### PR TITLE
Eliminate FS3511 warnings, document avoidance rules, and enable warnings-as-errors

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
         <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn);NETSDK1057</NoWarn>
         <PublishProfile>DefaultContainer</PublishProfile>
         <OtherFlags>$(OtherFlags) --test:GraphBasedChecking</OtherFlags>

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -640,7 +640,8 @@ module Connect =
 
                                                         let additionalEntries = ResizeArray<string>()
 
-                                                        for entry in zipArchive.Entries do
+                                                        zipArchive.Entries
+                                                        |> Seq.iter (fun entry ->
                                                             if not <| String.IsNullOrEmpty(entry.Name) then
                                                                 let entryRelativePath = normalizeFilePath entry.FullName
 
@@ -683,7 +684,7 @@ module Connect =
 
                                                                     if parseResult |> verbose then
                                                                         AnsiConsole.MarkupLine $"[{Colors.Important}]Wrote {fileVersion.RelativePath}.[/]"
-                                                                | false, _ -> additionalEntries.Add(entry.FullName)
+                                                                | false, _ -> additionalEntries.Add(entry.FullName))
 
                                                         if additionalEntries.Count > 0 && (parseResult |> verbose) then
                                                             AnsiConsole.MarkupLine

--- a/src/Grace.CLI/Command/History.CLI.fs
+++ b/src/Grace.CLI/Command/History.CLI.fs
@@ -636,8 +636,7 @@ module History =
                                             startInfo.RedirectStandardOutput <- false
                                             startInfo.RedirectStandardError <- false
 
-                                            for arg in argvToRun do
-                                                startInfo.ArgumentList.Add(arg)
+                                            argvToRun |> Array.iter startInfo.ArgumentList.Add
 
                                             use proc = new Process()
                                             proc.StartInfo <- startInfo


### PR DESCRIPTION
### Motivation

- Remove occurrences of F# compiler warning FS3511 (non-statically-compilable resumable state machines) by refactoring resumable computation expressions to be reducible.
- Add actionable guidance to the repository documentation to prevent future FS3511 regressions.
- Keep all refactors semantics-preserving and localized to avoid behavioral changes to CLI and server flows.
- Enable warnings-as-errors once FS3511 instances are eliminated to prevent regressions.

### Description

- Add an "Avoid FS3511" section to `src/AGENTS.md` with concrete bad/good snippets and a policy that FS3511 is treated as a regression.
- Refactor CLI resumable workflows: replace recursive `poll` in `pollDeviceCodeAsync` with a `while` loop, extract `applyRefreshToken` and `renderTokenList` in `Auth.CLI.fs`, and move heavy rendering/large record construction out of `task {}` blocks.
- Split large `task {}` bodies into small impl functions plus thin `try/with` wrappers across many CLI commands (e.g. `Branch.CLI.fs`, `WorkItem.CLI.fs`, `Review.CLI.fs`, `Admin.CLI.fs`), replace `for ... in` loops with `Seq.iter` where appropriate (e.g. `Connect.CLI.fs`, `Admin.CLI.fs`, `History.CLI.fs`), and add helpers like `buildEnqueueParameters` in `Queue.CLI.fs`.
- Improve server handlers by extracting permission parsing to `parseClaimPermissions` in `Access.Server.fs` and breaking up `GetVersion` in `Branch.Server.fs` into smaller helpers (`tryResolveRootDirectoryVersion` / `getVersionImpl`) to simplify resumable code.
- Turn on warnings-as-errors by adding `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to `src/Directory.Build.props`.

### Testing

- Ran formatting with `dotnet tool run fantomas --recurse .` but it could not be executed in this environment (failed: `dotnet` not available).
- Attempted `dotnet build --configuration Release` but the command could not be run here (failed: `dotnet` not available).
- Attempted `dotnet test --no-build`, but the command could not be run here (failed: `dotnet` not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623fc07a8483238e118454f0ee7c79)