### PR TITLE
Update NuGet packages to clear security audit

### DIFF
--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -66,23 +66,23 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-        <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-        <PackageReference Include="Azure.Storage.Blobs.Batch" Version="12.23.0" />
-        <PackageReference Include="Azure.Storage.Common" Version="12.25.0" />
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
+        <PackageReference Include="Azure.Storage.Blobs.Batch" Version="12.25.0" />
+        <PackageReference Include="Azure.Storage.Common" Version="12.27.0" />
         <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-        <PackageReference Include="FSharpPlus" Version="1.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Core" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Runtime" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
+        <PackageReference Include="FSharpPlus" Version="1.9.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.10" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Orleans.Core" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-        <PackageReference Include="NodaTime" Version="3.2.2" />
-        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
+        <PackageReference Include="NodaTime" Version="3.3.2" />
+        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
     </ItemGroup>
 
     <ItemGroup>
@@ -95,7 +95,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.0.100" />
+        <PackageReference Update="FSharp.Core" Version="10.1.300" />
     </ItemGroup>
 
 </Project>

--- a/src/Grace.Actors/Services.Actor.fs
+++ b/src/Grace.Actors/Services.Actor.fs
@@ -5,6 +5,7 @@ open Azure.Identity
 open Azure.Messaging.ServiceBus
 open Azure.Storage
 open Azure.Storage.Blobs
+open Azure.Storage.Blobs.Models
 open Azure.Storage.Blobs.Specialized
 open Azure.Storage.Sas
 open Grace.Actors.Constants
@@ -303,11 +304,13 @@ module Services =
                         // For managed identity, we need to get a user delegation key first
                         let blobServiceClient = blobContainerClient.GetParentBlobServiceClient()
 
-                        let! userDelegationKey =
-                            blobServiceClient.GetUserDelegationKeyAsync(
-                                DateTimeOffset.UtcNow,
-                                DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(SharedAccessSignatureExpiration))
+                        let userDelegationKeyOptions =
+                            BlobGetUserDelegationKeyOptions(
+                                DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(SharedAccessSignatureExpiration)),
+                                StartsOn = DateTimeOffset.UtcNow
                             )
+
+                        let! userDelegationKey = blobServiceClient.GetUserDelegationKeyAsync(userDelegationKeyOptions)
 
                         let sasQueryParameters = blobSasBuilder.ToSasQueryParameters(userDelegationKey.Value, blobServiceClient.AccountName)
                         return Uri($"{blobContainerClient.Uri}/{blobName}?{sasQueryParameters}")
@@ -318,8 +321,7 @@ module Services =
                         | Some credential ->
                             let sasQueryParameters = blobSasBuilder.ToSasQueryParameters(credential)
                             return Uri($"{blobContainerClient.Uri}/{blobName}?{sasQueryParameters}")
-                        | None when blobContainerClient.CanGenerateSasUri ->
-                            return blobContainerClient.GenerateSasUri(blobSasBuilder)
+                        | None when blobContainerClient.CanGenerateSasUri -> return blobContainerClient.GenerateSasUri(blobSasBuilder)
                         | None ->
                             return
                                 raise (
@@ -2721,6 +2723,7 @@ module Services =
 
                     if iterator.HasMoreResults then
                         let! results = iterator.ReadNextAsync()
+
                         let actorId =
                             results.Resource
                             |> Seq.tryHead

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.4">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -177,6 +177,12 @@ public partial class Program
                     var azuriteContainerName = runSuffix is null ? "azurite" : $"azurite-{runSuffix}";
                     var azurite = builder.AddContainer("azurite", "mcr.microsoft.com/azure-storage/azurite", "latest")
                         .WithContainerName(azuriteContainerName)
+                        .WithArgs(
+                            "azurite",
+                            "--skipApiVersionCheck",
+                            "--blobHost", "0.0.0.0",
+                            "--queueHost", "0.0.0.0",
+                            "--tableHost", "0.0.0.0")
                         .WithBindMount(azuriteDataPath, "/data")
                         //.WithLifetime(ContainerLifetime.Session)
                         .WithEnvironment("AZURITE_ACCOUNTS", "gracevcsdevelopment:Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
@@ -607,7 +613,10 @@ public partial class Program
 
                 if (selected is not null)
                 {
-                    var scheme = selected.EndpointAnnotation.UriScheme;
+                    var scheme =
+                        selected.EndpointAnnotation.TargetPort == 8081
+                            ? "https"
+                            : selected.EndpointAnnotation.UriScheme;
                     if (string.IsNullOrWhiteSpace(scheme))
                     {
                         scheme = selected.IsHttps ? "https" : "http";

--- a/src/Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj
+++ b/src/Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj
@@ -13,14 +13,14 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0-rc.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0-rc.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.13.0-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
+++ b/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -22,16 +22,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="FsCheck" Version="3.3.0" />
-    <PackageReference Include="FsCheck.NUnit" Version="3.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="FsCheck" Version="3.3.3" />
+    <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.100" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
+++ b/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.100" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 </Project>

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -31,17 +31,17 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FsCheck" Version="3.2.0" />
-		<PackageReference Include="FsCheck.NUnit" Version="3.2.0" />
+		<PackageReference Include="FsCheck" Version="3.3.3" />
+		<PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
 		<PackageReference Include="FsUnit" Version="7.1.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="NUnit" Version="4.4.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="NUnit" Version="4.6.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+		<PackageReference Include="NUnit.Analyzers" Version="4.13.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -54,6 +54,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.0.100" />
+		<PackageReference Update="FSharp.Core" Version="10.1.300" />
 	</ItemGroup>
 </Project>

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -53,19 +53,14 @@ module LocalStateDbTests =
         if not (Directory.Exists(graceDir)) then
             Directory.CreateDirectory(graceDir) |> ignore
 
-        if not (File.Exists(configPath)) then
-            File.WriteAllText(configPath, "{}")
+        if not (File.Exists(configPath)) then File.WriteAllText(configPath, "{}")
 
     let private withTempDir (action: string -> GraceConfiguration -> Task<'T>) =
         task {
             let root = Path.Combine(Path.GetTempPath(), $"grace-tests-{Guid.NewGuid()}")
             Directory.CreateDirectory(root) |> ignore
             let previousDirectory = Environment.CurrentDirectory
-            let previousConfiguration =
-                if configurationFileExists () then
-                    Some(Current())
-                else
-                    None
+            let previousConfiguration = if configurationFileExists () then Some(Current()) else None
 
             try
                 Environment.CurrentDirectory <- root
@@ -680,7 +675,8 @@ module LocalStateDbTests =
                 let ticks = getCurrentInstant().ToUnixTimeTicks()
                 let status = createTestStatus rootId rootHash ticks
 
-                let operation = fun () -> task { do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile status Seq.empty Seq.empty } :> Task
+                let operation =
+                    Func<Task>(fun () -> task { do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile status Seq.empty Seq.empty } :> Task)
 
                 Assert.ThrowsAsync<SqliteException>(operation)
                 |> ignore
@@ -734,7 +730,7 @@ module LocalStateDbTests =
                         LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(999L)
                     }
 
-                let operation = fun () -> task { do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusB } :> Task
+                let operation = Func<Task>(fun () -> task { do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusB } :> Task)
 
                 Assert.ThrowsAsync<SqliteException>(operation)
                 |> ignore
@@ -794,7 +790,8 @@ module LocalStateDbTests =
                     ]
 
                 let operation =
-                    fun () -> task { do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile updatedStatus [ updatedSrc ] differences } :> Task
+                    Func<Task> (fun () ->
+                        task { do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile updatedStatus [ updatedSrc ] differences } :> Task)
 
                 Assert.ThrowsAsync<SqliteException>(operation)
                 |> ignore
@@ -1109,7 +1106,7 @@ module LocalStateDbTests =
                 let orphanId = Guid.NewGuid()
 
                 Assert.Throws<SqliteException>(
-                    TestDelegate(fun () ->
+                    Action (fun () ->
                         executeNonQuery
                             connection
                             $"INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('orphan.txt', 'missing', '{orphanId}', 'hash', 0, 1, 0, 0, 0);")
@@ -1287,11 +1284,15 @@ module LocalStateDbTests =
                 rootRead.Files.Count |> should equal 2
 
                 rootRead.Files
-                |> Seq.exists (fun file -> file.RelativePath = "LICENSE.md" && file.Sha256Hash = "license-hash-2")
+                |> Seq.exists (fun file ->
+                    file.RelativePath = "LICENSE.md"
+                    && file.Sha256Hash = "license-hash-2")
                 |> should equal true
 
                 rootRead.Files
-                |> Seq.exists (fun file -> file.RelativePath = "README.md" && file.Sha256Hash = "readme-hash-1")
+                |> Seq.exists (fun file ->
+                    file.RelativePath = "README.md"
+                    && file.Sha256Hash = "readme-hash-1")
                 |> should equal true
             })
 
@@ -1396,7 +1397,7 @@ module LocalStateDbTests =
 
                 let parentDir = createDirectoryVersion configuration parentId "src" "parent-hash" [| missingChildId |] [||] 0L lastWrite
 
-                let operation = fun () -> task { do! LocalStateDb.upsertObjectCache configuration.GraceStatusFile [ parentDir ] } :> Task
+                let operation = Func<Task>(fun () -> task { do! LocalStateDb.upsertObjectCache configuration.GraceStatusFile [ parentDir ] } :> Task)
 
                 Assert.ThrowsAsync<InvalidOperationException>(operation)
                 |> ignore
@@ -1459,16 +1460,7 @@ module LocalStateDbTests =
 
                 let childFile = createFileVersion "src/child/file.txt" "child-file-hash-v2" false 2L now lastWrite
 
-                let childDirV2 =
-                    createDirectoryVersion
-                        configuration
-                        childId
-                        "src/child"
-                        "child-hash-v2"
-                        [||]
-                        [| childFile |]
-                        childFile.Size
-                        lastWrite
+                let childDirV2 = createDirectoryVersion configuration childId "src/child" "child-hash-v2" [||] [| childFile |] childFile.Size lastWrite
 
                 do! LocalStateDb.upsertObjectCache configuration.GraceStatusFile [ childDirV2 ]
 
@@ -1481,10 +1473,7 @@ module LocalStateDbTests =
 
                 childLinkCount |> should equal 1
 
-                let childHash =
-                    executeScalarString
-                        connection
-                        $"SELECT sha256_hash FROM object_cache_directories WHERE directory_version_id = '{childId}';"
+                let childHash = executeScalarString connection $"SELECT sha256_hash FROM object_cache_directories WHERE directory_version_id = '{childId}';"
 
                 childHash |> should equal "child-hash-v2"
 
@@ -1558,7 +1547,7 @@ module LocalStateDbTests =
 
                 do! LocalStateDb.upsertObjectCache configuration.GraceStatusFile [ childDir; parentDir ]
 
-                let operation = fun () -> task { do! LocalStateDb.removeObjectCacheDirectory configuration.GraceStatusFile childId } :> Task
+                let operation = Func<Task>(fun () -> task { do! LocalStateDb.removeObjectCacheDirectory configuration.GraceStatusFile childId } :> Task)
 
                 Assert.ThrowsAsync<SqliteException>(operation)
                 |> ignore

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -136,7 +136,7 @@ module Watch =
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
 
-    let fileDeleted filePath = logToConsole $"In Delete: filePath: {filePath}"   
+    let fileDeleted filePath = logToConsole $"In Delete: filePath: {filePath}"
 
     let isNotDirectory path = not <| Directory.Exists(path)
     let updateInProgress () = File.Exists(updateInProgressFileName ())
@@ -144,10 +144,8 @@ module Watch =
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
-        | Ok(Some token) when not (String.IsNullOrWhiteSpace token) -> Ok token
-        | Ok _ ->
-            Error
-                $"No access token is available. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
+        | Ok (Some token) when not (String.IsNullOrWhiteSpace token) -> Ok token
+        | Ok _ -> Error $"No access token is available. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
         | Error message -> Error $"Unable to acquire an access token for SignalR notifications: {message}"
 
     let private getSignalRAccessToken () =
@@ -165,7 +163,7 @@ module Watch =
                     options.Transports <- HttpTransportType.ServerSentEvents
 
                     options.AccessTokenProvider <-
-                        Func<Task<string>>(fun () ->
+                        Func<Task<string>> (fun () ->
                             task {
                                 let! accessTokenResult = getSignalRAccessToken ()
 
@@ -178,6 +176,7 @@ module Watch =
 
     let private isGraceStatusArtifact (fullPath: string) =
         let statusFile = Current().GraceStatusFile
+
         fullPath.Equals(statusFile, StringComparison.InvariantCultureIgnoreCase)
         || fullPath.Equals(statusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
         || fullPath.Equals(statusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
@@ -287,8 +286,7 @@ module Watch =
                 $"{getDiscriminatedUnionCaseName difference.DifferenceType} for {getDiscriminatedUnionCaseName difference.FileSystemEntryType} {difference.RelativePath}"
 
     /// Update the Grace Object Cache file with the new DirectoryVersions.
-    let updateObjectCacheFile (newDirectoryVersions: List<LocalDirectoryVersion>) =
-        task { do! upsertObjectCache newDirectoryVersions }
+    let updateObjectCacheFile (newDirectoryVersions: List<LocalDirectoryVersion>) = task { do! upsertObjectCache newDirectoryVersions }
 
     /// Updates the Grace Status file's Index with updates detected from the file system.
     let updateGraceStatus graceStatus correlationId =
@@ -347,8 +345,7 @@ module Watch =
                 if (differences.Count > 0) then
                     match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
                     | Ok returnValue ->
-                        let newGraceStatusWithUpdatedTime =
-                            { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
+                        let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
                         // Apply incremental changes to the Grace Status DB.
                         do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
                         //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
@@ -412,8 +409,7 @@ module Watch =
             graceStatus <- GraceStatus.Default
         }
 
-    let updateGraceStatusDirectoryIds (status: GraceStatus) =
-        graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
+    let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
     /// Processes any changed files since the last timer tick.
     let processChangedFiles () =
@@ -464,6 +460,7 @@ module Watch =
                     if filesToProcess.IsEmpty then
                         let! graceStatusSnapshot = readGraceStatusFile ()
                         graceStatus <- graceStatusSnapshot
+
                         match! (updateGraceStatus graceStatus correlationId) with
                         | Some newGraceStatus -> graceStatus <- newGraceStatus
                         | None ->
@@ -749,7 +746,7 @@ module Watch =
                           && not (cancellationToken.IsCancellationRequested) do
                         // Grace Status may have changed from branch switch, or other commands.
                         if graceStatusHasChanged then
-                            let! updatedGraceStatus = readGraceStatusFile ()    
+                            let! updatedGraceStatus = readGraceStatusFile ()
                             graceStatus <- updatedGraceStatus
                             updateGraceStatusDirectoryIds graceStatus
                             do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
@@ -784,21 +781,27 @@ module Watch =
                 with
                 | :? HttpRequestException as httpEx when
                     httpEx.StatusCode.HasValue
-                    && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized ->
+                    && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
+                    ->
                     logToAnsiConsole
                         Colors.Error
                         $"SignalR negotiation failed with 401 Unauthorized. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
+
                     return -1
-                | :? InvalidOperationException as invalidOperationException
-                    when invalidOperationException.Message.Contains("access token", StringComparison.OrdinalIgnoreCase) ->
+                | :? InvalidOperationException as invalidOperationException when
+                    invalidOperationException.Message.Contains
+                        (
+                            "access token",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    ->
                     logToAnsiConsole Colors.Error $"{Markup.Escape(invalidOperationException.Message)}"
                     return -1
                 | ex ->
                     //let exceptionMarkup = Markup.Escape($"{ExceptionResponse.Create ex}").Replace("\\\\", @"\").Replace("\r\n", Environment.NewLine)
                     //logToAnsiConsole Colors.Error $"{exceptionMarkup}"
-                    let exceptionSettings = ExceptionSettings()
+                    let exceptionSettings = ExceptionSettings(Format = ExceptionFormats.Default)
                     // Need to fill in some exception styles here.
-                    exceptionSettings.Format <- ExceptionFormats.Default
                     AnsiConsole.WriteException(ex, exceptionSettings)
                     return -1
             }

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -56,30 +56,30 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.0" />
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
+		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.8" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="MessagePack" Version="3.1.4" />
 		<PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
 		<PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-		<PackageReference Include="MessagePack.NodaTime" Version="3.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
-		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.2" />
-		<PackageReference Include="NodaTime" Version="3.2.2" />
-		<PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-		<PackageReference Include="OpenTelemetry" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
-		<PackageReference Include="Polly" Version="8.6.5" />
-		<PackageReference Include="Spectre.Console" Version="0.54.0" />
-		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.54.0" />
-		<PackageReference Include="Spectre.Console.Json" Version="0.54.0" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0" />
+		<PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.1" />
+		<PackageReference Include="NodaTime" Version="3.3.2" />
+		<PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
+		<PackageReference Include="OpenTelemetry" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+		<PackageReference Include="Polly" Version="8.6.6" />
+		<PackageReference Include="Spectre.Console" Version="0.55.2" />
+		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.55.2" />
+		<PackageReference Include="Spectre.Console.Json" Version="0.55.2" />
+		<PackageReference Include="System.CommandLine" Version="2.0.8" />
 		<PackageReference Include="System.Reactive" Version="6.1.0" />
 	</ItemGroup>
 	<ItemGroup>
@@ -88,7 +88,7 @@
 		<ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.100" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Grace.CLI.Tests" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -79,14 +79,12 @@ module GraceCommand =
     let printAliases () =
         let table = Table(Border = TableBorder.DoubleEdge)
 
-        table
-            .LeftAligned()
-            .AddColumns(
-                [|
-                    TableColumn($"[{Colors.Important}]Alias[/]")
-                    TableColumn($"[{Colors.Important}]Grace command[/]")
-                |]
-            )
+        table.AddColumns(
+            [|
+                TableColumn($"[{Colors.Important}]Alias[/]")
+                TableColumn($"[{Colors.Important}]Grace command[/]")
+            |]
+        )
         |> ignore
 
         aliases

--- a/src/Grace.Load/Grace.Load.fsproj
+++ b/src/Grace.Load/Grace.Load.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -18,8 +18,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-	  <PackageReference Include="Spectre.Console" Version="0.54.0" />
-	  <PackageReference Include="Spectre.Console.Json" Version="0.54.0" />
+	  <PackageReference Include="Spectre.Console" Version="0.55.2" />
+	  <PackageReference Include="Spectre.Console.Json" Version="0.55.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -28,7 +28,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.0.100" />
+		<PackageReference Update="FSharp.Core" Version="10.1.300" />
 	</ItemGroup>
 
 </Project>

--- a/src/Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj
+++ b/src/Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="9.2.1" />
+		<PackageReference Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -41,9 +41,9 @@
         </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-		<PackageReference Include="Polly" Version="8.6.5" />
+		<PackageReference Include="Polly" Version="8.6.6" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -52,7 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.0.100" />
+		<PackageReference Update="FSharp.Core" Version="10.1.300" />
 	</ItemGroup>
 
 </Project>

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -44,19 +44,19 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.0" />
-    <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
-    <PackageReference Include="FsCheck" Version="3.2.0" />
-    <PackageReference Include="FsCheck.NUnit" Version="3.2.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.3.4" />
+    <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
+    <PackageReference Include="FsCheck" Version="3.3.3" />
+    <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
     <PackageReference Include="FsUnit" Version="7.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.100" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -115,49 +115,49 @@
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
-		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+		<PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
+		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-		<PackageReference Include="Azure.Storage.Blobs.Batch" Version="12.23.0" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
+		<PackageReference Include="Azure.Storage.Blobs.Batch" Version="12.25.0" />
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-		<PackageReference Include="dotenv.net" Version="4.0.0" />
+		<PackageReference Include="dotenv.net" Version="4.0.2" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
 		<PackageReference Include="Giraffe" Version="8.2.0" />
 		<PackageReference Include="MessagePack" Version="3.1.4" />
 		<PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
-		<PackageReference Include="MessagePack.NodaTime" Version="3.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
-		<PackageReference Include="Microsoft.OpenApi" Version="3.0.1" />
-		<PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1" />
-		<PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
-		<PackageReference Include="OpenTelemetry" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.1-beta.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-		<PackageReference Include="Orleans.Serialization.NodaTime" Version="0.0.4-beta" />
+		<PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
+		<PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Server" Version="10.1.0" />
+		<PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.1.0" />
+		<PackageReference Include="OpenTelemetry" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+		<PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+		<PackageReference Include="Orleans.Serialization.NodaTime" Version="1.0.0" />
 		<PackageReference Include="OrleansDashboard" Version="8.2.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.0.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.0.100" />
+		<PackageReference Update="FSharp.Core" Version="10.1.300" />
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="Grace.Server.Tests" />

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -71,25 +71,25 @@
     <ItemGroup>
         <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
         <PackageReference Include="DiffPlex" Version="1.9.0" />
-        <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
+        <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
-        <PackageReference Include="FSharpPlus" Version="1.8.0" />
+        <PackageReference Include="FSharpPlus" Version="1.9.1" />
         <PackageReference Include="MessagePack" Version="3.1.4" />
         <PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-        <PackageReference Include="MessagePack.NodaTime" Version="3.5.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Core" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="9.2.1" />
+        <PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Orleans.Core" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.1.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.1.0" />
         <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
         <PackageReference Include="MimeTypes" Version="2.5.2" />
         <PackageReference Include="Nanoid" Version="3.1.0" />
-        <PackageReference Include="NodaTime" Version="3.2.2" />
-        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-        <PackageReference Include="Polly" Version="8.6.5" />
+        <PackageReference Include="NodaTime" Version="3.3.2" />
+        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
+        <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 
@@ -98,7 +98,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.0.100" />
+        <PackageReference Update="FSharp.Core" Version="10.1.300" />
     </ItemGroup>
 
 </Project>

--- a/src/Grace.Types.Tests/Automation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Automation.Types.Tests.fs
@@ -10,24 +10,28 @@ open System
 type AutomationTypesTests() =
     [<Test>]
     member _.AutomationEventTypeIncludesAgentLifecycleCases() =
-        let eventTypes = Utilities.listCases<AutomationEventType>() |> Set.ofArray
+        let eventTypes =
+            Utilities.listCases<AutomationEventType> ()
+            |> Set.ofArray
 
-        Assert.Multiple(fun () ->
-            Assert.That(eventTypes.Contains("AgentWorkStarted"), Is.True)
-            Assert.That(eventTypes.Contains("AgentWorkStopped"), Is.True)
-            Assert.That(eventTypes.Contains("AgentSummaryAdded"), Is.True)
-            Assert.That(eventTypes.Contains("AgentBootstrapped"), Is.True)
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(eventTypes.Contains("AgentWorkStarted"), Is.True)
+                Assert.That(eventTypes.Contains("AgentWorkStopped"), Is.True)
+                Assert.That(eventTypes.Contains("AgentSummaryAdded"), Is.True)
+                Assert.That(eventTypes.Contains("AgentBootstrapped"), Is.True))
         )
 
     [<Test>]
     member _.StartAgentSessionParametersDefaultRequiredFieldsAreEmpty() =
         let parameters = StartAgentSessionParameters()
 
-        Assert.Multiple(fun () ->
-            Assert.That(parameters.CorrelationId, Is.EqualTo(String.Empty))
-            Assert.That(parameters.WorkItemIdOrNumber, Is.EqualTo(String.Empty))
-            Assert.That(parameters.OperationId, Is.EqualTo(String.Empty))
-            Assert.That(parameters.AgentId, Is.EqualTo(String.Empty))
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(parameters.CorrelationId, Is.EqualTo(String.Empty))
+                Assert.That(parameters.WorkItemIdOrNumber, Is.EqualTo(String.Empty))
+                Assert.That(parameters.OperationId, Is.EqualTo(String.Empty))
+                Assert.That(parameters.AgentId, Is.EqualTo(String.Empty)))
         )
 
     [<Test>]
@@ -47,9 +51,10 @@ type AutomationTypesTests() =
         let json = Utilities.serialize parameters
         let deserialized = Utilities.deserialize<StartAgentSessionParameters> json
 
-        Assert.Multiple(fun () ->
-            Assert.That(deserialized.CorrelationId, Is.EqualTo("corr-session-start"))
-            Assert.That(deserialized.WorkItemIdOrNumber, Is.EqualTo("42"))
-            Assert.That(deserialized.PromotionSetId, Is.EqualTo("promotion-set-9"))
-            Assert.That(deserialized.OperationId, Is.EqualTo("operation-123"))
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(deserialized.CorrelationId, Is.EqualTo("corr-session-start"))
+                Assert.That(deserialized.WorkItemIdOrNumber, Is.EqualTo("42"))
+                Assert.That(deserialized.PromotionSetId, Is.EqualTo("promotion-set-9"))
+                Assert.That(deserialized.OperationId, Is.EqualTo("operation-123")))
         )

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -22,15 +22,15 @@
 
   <ItemGroup>
     <PackageReference Include="FsUnit" Version="7.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -42,6 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.100" />
+    <PackageReference Update="FSharp.Core" Version="10.1.300" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -47,28 +47,28 @@
     <ItemGroup>
         <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
         <PackageReference Include="DiffPlex" Version="1.9.0" />
-        <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
+        <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
-        <PackageReference Include="FSharpPlus" Version="1.8.0" />
+        <PackageReference Include="FSharpPlus" Version="1.9.1" />
         <PackageReference Include="MessagePack" Version="3.1.4" />
         <PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-        <PackageReference Include="MessagePack.NodaTime" Version="3.5.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
+        <PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
         <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
         <PackageReference Include="MimeTypes" Version="2.5.2" />
         <PackageReference Include="Nanoid" Version="3.1.0" />
-        <PackageReference Include="NodaTime" Version="3.2.2" />
-        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-        <PackageReference Include="Orleans.Serialization.NodaTime" Version="0.0.4-beta" />
-        <PackageReference Include="Polly" Version="8.6.5" />
+        <PackageReference Include="NodaTime" Version="3.3.2" />
+        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
+        <PackageReference Include="Orleans.Serialization.NodaTime" Version="1.0.0" />
+        <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.0.100" />
+        <PackageReference Update="FSharp.Core" Version="10.1.300" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #63.

## Summary

- Updated Grace's direct NuGet package references to current safe versions for `net10.0`, including OpenTelemetry 1.15.x, Orleans 10.1.0, Aspire 13.3.4, Azure Storage/Cosmos patches, test infrastructure, CLI packages, and related runtime/library patches.
- Kept NuGet audit and warnings-as-errors enabled; no `NU1902` suppression or warning-policy weakening.
- Applied narrow compatibility fixes for updated APIs:
  - Azure Blob user-delegation key options in managed-identity SAS generation.
  - Azurite local emulator startup with `--skipApiVersionCheck` for the newer Azure Storage API version.
  - Cosmos emulator connection string uses HTTPS for the gateway endpoint.
  - NUnit 4.6 delegate overloads use explicit `Action` / `Func<Task>`.
  - Spectre.Console 0.55 initializer/alignment changes.

## Validation

- `dotnet restore .\src\Grace.slnx` passed with normal NuGet audit and warnings-as-errors enabled.
- `dotnet restore .\src\Grace.Aspire.ServiceDefaults\Grace.Aspire.ServiceDefaults.csproj` passed with normal NuGet audit and warnings-as-errors enabled.
- `dotnet list .\src\Grace.slnx package --no-restore --vulnerable --include-transitive` reported no vulnerable packages.
- `dotnet list .\src\Grace.Aspire.ServiceDefaults\Grace.Aspire.ServiceDefaults.csproj package --no-restore --vulnerable --include-transitive` reported no vulnerable packages.
- `dotnet build .\src\Grace.slnx -c Release --no-restore` passed with 0 warnings and 0 errors.
- `dotnet build .\src\Grace.Aspire.ServiceDefaults\Grace.Aspire.ServiceDefaults.csproj -c Release --no-restore` passed with 0 warnings and 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast` passed. Format step is skipped by the script as currently disabled; tests: Authorization 21 passed, CLI 188 passed / 1 skipped, Types 16 passed.
- `pwsh ./scripts/validate.ps1 -Full` passed after the emulator compatibility fix. Tests: Authorization 21 passed, CLI 188 passed / 1 skipped, Types 16 passed, Server 217 passed.
- `git diff --check` passed.
- Focused repro before the emulator fix: `dotnet test .\src\Grace.Server.Tests\Grace.Server.Tests.fsproj -c Release --no-build --filter FullyQualifiedName~BootstrapSeedsSystemAdminWhenConfigured --logger "console;verbosity=normal"` passed after the HTTPS/Azurite changes.

## Notes

- `dotnet list --outdated` still reports the prerelease-only OpenTelemetry Prometheus exporter and gRPC instrumentation packages as `Not found at the sources` unless prerelease is included. Explicit prerelease inventory showed they are on the current prerelease versions used by NuGet.
- The one skipped CLI test is the existing guarded `multi-process writers do not crash or corrupt database` test, skipped by its own worker-binary guard during the validation script.
- Full validation used local emulators/containers only; no `DebugAzure`, managed identity, real Cosmos DB, real Blob Storage, real Service Bus, Azure Monitor ingestion, or cloud-backed secrets were used as acceptance evidence.