### PR TITLE
Update GitHub Actions Node runtime pins

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
     - name: Install .NET Aspire workload

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,9 +14,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
       - name: Install .NET Aspire workload
@@ -28,9 +28,9 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
       - name: Install .NET Aspire workload


### PR DESCRIPTION
## Summary

- Updates Grace workflow uses of `actions/checkout` from `v4` to `v5`.
- Updates Grace workflow uses of `actions/setup-dotnet` from `v4` to `v5`.
- Avoids temporary Node runtime escape hatches so the workflows use the maintained Node 24-compatible action majors directly.

Closes #67

## Touched Paths

- `.github/workflows/dotnet.yml`
- `.github/workflows/validate.yml`

## Validation

- `rg -n "actions/(checkout|setup-dotnet)@|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" .github\workflows`
- `npx --yes yaml-lint .github/workflows/dotnet.yml .github/workflows/validate.yml`
- `git diff --check`
- `pwsh ./scripts/validate.ps1 -Fast`

## Broader Validation

- `pwsh ./scripts/validate.ps1 -Full` not run locally. This change is limited to workflow action version pins and does not touch Aspire, emulator, storage, Service Bus, Cosmos DB, Redis, or source behavior. The PR and push workflow runs are the meaningful live validation surface.

## Docs Impact

- No docs updates. The workflows continue to use GitHub-hosted `ubuntu-latest` runners. If `arc-runner-set` is re-enabled later, validate the self-hosted runner version supports Node 24 actions before switching.

## Residual Risk

- Low for GitHub-hosted runners. Main residual risk is action-major compatibility, which should be covered by the live PR workflow runs.