### PR TITLE
Update checkout action to v6

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
## Summary

- Updates Grace workflow uses of `actions/checkout` from `v5` to `v6`.
- Leaves `actions/setup-dotnet@v5` unchanged.
- Adds no temporary Node runtime escape hatches.

Closes #69

## Touched Paths

- `.github/workflows/dotnet.yml`
- `.github/workflows/validate.yml`

## Validation

- `rg -n "actions/(checkout|setup-dotnet)@|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" .github\workflows`
- `npx --yes yaml-lint .github/workflows/dotnet.yml .github/workflows/validate.yml`
- `git diff --check`
- `pwsh ./scripts/validate.ps1 -Fast`

## Broader Validation

- `pwsh ./scripts/validate.ps1 -Full` not run locally. This change is limited to workflow action version pins and does not touch Aspire, emulator, storage, Service Bus, Cosmos DB, Redis, or source behavior. The PR and branch-push workflow runs are the meaningful live validation surface.

## Docs Impact

- No docs updates. The workflows continue to use GitHub-hosted `ubuntu-latest` runners. If `arc-runner-set` is re-enabled later, validate the self-hosted runner version supports `actions/checkout@v6` before switching.

## Residual Risk

- Low for GitHub-hosted runners. Main residual risk is `actions/checkout@v6` major-version compatibility, which should be covered by live PR workflow runs.