### PR TITLE
Require PRs to state tests added or no-test rationale

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,15 @@ Closes #
 - RED evidence or docs-only waiver:
 - Focused validation:
 
+## Test coverage changes
+
+Choose one:
+
+- [ ] Tests added or updated; list the test files and covered behavior below.
+- [ ] No tests added; explain why new tests were not required for this change.
+
+Details:
+
 ## Reviewer pass
 
 - [ ] Owned paths and forbidden paths reviewed against the issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ impact and skipped validation.
 - Use `pwsh ./scripts/validate.ps1 -Full` when Aspire, emulators, storage, Service Bus, Cosmos DB, Redis,
   deployment/runtime behavior, or cross-service integration is affected.
 - Commit after each completed slice and keep pull requests focused and reviewable.
+- Open normal ready-for-review pull requests. Do not open draft pull requests unless the user explicitly asks for a
+  draft.
 - Update README, CONTRIBUTING, nearby `AGENTS.md`, and other docs when behavior, commands, APIs, or workflow changes.
 
 ## Markdown Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ This repo is primarily **F#** and targets **.NET 10**.
   editing.
 - Use a focused branch for each issue. Maintainers and agents should use issue-owned worktrees for repo-local work.
 - Prefer vertical slices with focused validation and a commit after each completed slice.
+- Open normal ready-for-review pull requests unless a maintainer explicitly asks for a draft pull request.
 - Add or update tests when changing behavior.
 - Please add any useful AI prompts you used for diagnosis or implementation to the PR description.
 

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -61,7 +61,7 @@ Validation:
 Definition of done:
 - Behavior changed
 - Tests or docs updated
-- Pull request opened and linked
+- Ready-for-review pull request opened and linked
 - Validation recorded
 - Review evidence prepared
 - Follow-ups named
@@ -223,6 +223,9 @@ Before opening or updating a pull request, include:
 - residual risk
 - rollback or recovery notes when the change touches runtime or data
 - useful AI prompts used for diagnosis or implementation, when contributing externally
+
+Open normal ready-for-review pull requests for Grace implementation work. Do not open draft pull requests unless the
+maintainer explicitly asks for a draft.
 
 Grace's product model uses promotion candidates, queues, gates, attestations, and review reports. Today's repository
 still uses normal GitHub pull requests, but changes should be prepared so they are easy to audit in either system.

--- a/prompts/Grace pull request summary.md
+++ b/prompts/Grace pull request summary.md
@@ -25,6 +25,7 @@ If items 4 or 5 are not true, stop and output only:
 - Branch or diff to summarize.
 - Work item or issue reference (if applicable).
 - Validation results (tests/build/lint/manual checks).
+- Test files added or updated, or the reason no new tests were required.
 
 If any input is unavailable, state that explicitly and continue with what is verifiable.
 
@@ -34,6 +35,7 @@ If any input is unavailable, state that explicitly and continue with what is ver
 2. Summarize behavior-level change, not just line edits.
 3. Map each changed file to what was accomplished.
 4. Include evidence from validation results.
+5. Identify test coverage changes separately from validation commands.
 
 Use evidence anchors for every major claim in sections 4 through 7.
 
@@ -116,6 +118,8 @@ For each changed file, include:
 
 Include exactly what was run and what happened:
 
+- Test coverage changes: list test files added or updated and the behavior covered,
+  or explain why no new tests were required.
 - Build/test/lint commands
 - Manual verification steps
 - Results and any known gaps


### PR DESCRIPTION
## Linked issue

Closes #73

## Summary

Updates the Grace PR authoring flow so every PR has to state whether tests were added or updated, or explain why no new tests were required. The companion PR-summary prompt now asks agents to report test coverage changes separately from validation commands.

Also updates Grace contributor and agent guidance to make the PR state expectation explicit: implementation PRs should be opened as normal ready-for-review PRs, not draft PRs, unless the user or maintainer explicitly asks for a draft.

## Touched paths

- `.github/PULL_REQUEST_TEMPLATE.md`
- `prompts/Grace pull request summary.md`
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/Development process.md`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths or the follow-up issue comment expanding guidance paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: docs-only
- Public behavior or docs-only validation target: PR descriptions must explicitly capture test coverage changes or a no-test rationale, and Grace process guidance must direct agents to open ready-for-review PRs by default.
- RED evidence or docs-only waiver: Prior template only asked for focused validation and validation runs, so authors could list commands without saying whether test coverage changed. Repo guidance did not explicitly override generic draft-PR defaults.
- Focused validation: MarkdownLint on the changed Markdown files and `git diff --check`.

## Test coverage changes

Choose one:

- [ ] Tests added or updated; list the test files and covered behavior below.
- [x] No tests added; explain why new tests were not required for this change.

Details: This is a docs/template-only workflow change. The changed behavior is the PR form text, prompt guidance, and contributor/agent process wording, validated with MarkdownLint and whitespace checks rather than .NET test coverage.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue and follow-up maintainer direction.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [ ] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [ ] Focused tests: command
- [x] Formatting/linting: `npx --yes markdownlint-cli2 --config .markdownlint.jsonc AGENTS.md CONTRIBUTING.md docs/'Development process.md' .github/PULL_REQUEST_TEMPLATE.md "prompts/Grace pull request summary.md"` - passed, 0 errors
- [x] Manual validation: `git diff --check` - passed

## Validation not run

- `pwsh ./scripts/validate.ps1 -Fast` was not run because this change is limited to Markdown PR workflow templates, prompt guidance, and process docs.
- `pwsh ./scripts/validate.ps1 -Full` was not run because no Aspire, emulator, runtime, or cross-service behavior changed.

## Residual risks

Reviewers still need to enforce the template content during review; this change makes the requirement visible but does not add automated PR body validation.

The ready-for-review PR guidance now exists in repo docs, but external agent/plugin defaults outside this repository may still need to be overridden by the repo guidance when working in Grace.

## Rollback or recovery notes

Revert commits `89b181d` and `0df1539` to restore the previous PR template, PR-summary prompt, and process guidance.

## Docs follow-up required

None.