### PR TITLE
Centralize build versioning and runtime build identity

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,10 @@ jobs:
   build:
     #runs-on: arc-runner-set
     runs-on: ubuntu-latest
+    env:
+      GraceBuildKind: ci
+      GraceBuildNumber: ${{ github.run_number }}
+      GraceSourceRevisionId: ${{ github.sha }}
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,10 @@ jobs:
   fast:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      GraceBuildKind: ci
+      GraceBuildNumber: ${{ github.run_number }}
+      GraceSourceRevisionId: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup .NET
@@ -27,6 +31,10 @@ jobs:
   full:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      GraceBuildKind: ci
+      GraceBuildNumber: ${{ github.run_number }}
+      GraceSourceRevisionId: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup .NET

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ impact and skipped validation.
   deployment/runtime behavior, or cross-service integration is affected.
 - Commit after each completed slice and keep pull requests focused and reviewable.
 - Update README, CONTRIBUTING, nearby `AGENTS.md`, and other docs when behavior, commands, APIs, or workflow changes.
+- When the user asks to address a code review comment, review comment, PR feedback, or similar, treat that as a complete
+  review-thread workflow: evaluate the comment, make the appropriate fix or explicitly explain why no code change is
+  needed, validate the result, commit and push the branch, reply to the GitHub review comment with the outcome and
+  evidence, and resolve the GitHub conversation when the feedback has been satisfied.
 
 ## Markdown Guidelines
 

--- a/docs/Build versioning.md
+++ b/docs/Build versioning.md
@@ -7,11 +7,16 @@ versions unless a future release process explicitly documents an exception.
 
 The product base version is `0.2.0`.
 
-Local builds default to a development prerelease version:
+Local validation builds default to a development prerelease version:
 
 ```text
 0.2.0-dev.<yyyyMMddHHmmss>
 ```
+
+`scripts/validate.ps1` computes that timestamp once and passes it to the solution build so every project built in that
+invocation receives the same local build identity. Direct `dotnet build` invocations can pass the same properties
+explicitly; if they do not, MSBuild falls back to `0.2.0-dev.local` rather than computing independent per-project
+timestamps.
 
 CI builds pass a monotonic run number and use:
 

--- a/docs/Build versioning.md
+++ b/docs/Build versioning.md
@@ -1,0 +1,83 @@
+# Build versioning
+
+Grace uses one build-version source in `src/Directory.Build.props`. Project files should not declare their own product
+versions unless a future release process explicitly documents an exception.
+
+## Version shape
+
+The product base version is `0.2.0`.
+
+Local builds default to a development prerelease version:
+
+```text
+0.2.0-dev.<yyyyMMddHHmmss>
+```
+
+CI builds pass a monotonic run number and use:
+
+```text
+0.2.0-ci.<run number>
+```
+
+When a source revision is available, `AssemblyInformationalVersion` appends short commit metadata:
+
+```text
+0.2.0-ci.1234+abcdef1
+```
+
+`AssemblyVersion` remains `0.2.0.0` for the `0.2.x` line. `FileVersion` stays numeric-only so Windows assembly metadata
+remains valid. Container image tags use the exact prerelease build version without `+` metadata, for example
+`0.2.0-ci.1234`, plus `latest` where Grace already publishes `latest`.
+
+## CI inputs
+
+GitHub Actions sets these MSBuild properties through job environment variables:
+
+- `GraceBuildKind=ci`
+- `GraceBuildNumber=${{ github.run_number }}`
+- `GraceSourceRevisionId=${{ github.sha }}`
+
+You can validate the CI version locally with explicit MSBuild properties.
+
+PowerShell:
+
+```powershell
+dotnet build ./src/Grace.slnx --configuration Release -p:GraceBuildKind=ci -p:GraceBuildNumber=1234 -p:GraceSourceRevisionId=abcdef1234567890
+```
+
+bash / zsh:
+
+```bash
+dotnet build ./src/Grace.slnx --configuration Release -p:GraceBuildKind=ci -p:GraceBuildNumber=1234 -p:GraceSourceRevisionId=abcdef1234567890
+```
+
+## Runtime identity
+
+Runtime code should read build identity through `Grace.Shared.BuildInfo` instead of reading `AssemblyName.Version` or
+`FileVersionInfo` directly. The helper prefers `AssemblyInformationalVersion`, then falls back to product/file/assembly
+metadata, and finally to a safe non-empty value.
+
+Current runtime surfaces:
+
+- CLI history records store the informational build identity in `graceVersion`.
+- Grace Server startup output logs the informational build identity.
+- The root Grace Server hello endpoint displays the same informational build identity.
+
+`Constants.CurrentConfigurationVersion` remains the local configuration schema version. Do not change it as part of a
+product build-version bump unless there is an actual configuration schema migration.
+
+## Audit
+
+Run the static audit after changing project or container metadata:
+
+PowerShell:
+
+```powershell
+pwsh ./scripts/test-versioning.ps1
+```
+
+bash / zsh:
+
+```bash
+pwsh ./scripts/test-versioning.ps1
+```

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -227,6 +227,26 @@ Before opening or updating a pull request, include:
 Grace's product model uses promotion candidates, queues, gates, attestations, and review reports. Today's repository
 still uses normal GitHub pull requests, but changes should be prepared so they are easy to audit in either system.
 
+## Review Feedback
+
+When the user asks an agent to address a code review comment, review comment, PR feedback, or similar wording, treat the
+request as a complete review-thread workflow.
+
+The agent should:
+
+1. Inspect the GitHub review thread or PR feedback directly and separate actionable feedback from informational comments.
+2. Evaluate whether the feedback is correct and identify the smallest appropriate fix, or state why no code change is
+   needed.
+3. Make the fix in the issue-owned branch/worktree and keep the change traceable to the review thread.
+4. Run focused validation for the changed behavior or docs, and broader validation when the feedback touches shared or
+   risky surfaces.
+5. Commit the fix and push the branch.
+6. Reply to the GitHub review comment with the outcome, changed commit, and validation evidence.
+7. Resolve the GitHub conversation after the feedback has been satisfied.
+
+If the comment is ambiguous, conflicts with another requirement, or would cause a behavioral regression, ask for
+clarification or reply with the trade-off instead of resolving the thread prematurely.
+
 ## Cleanup
 
 After merge or promotion:

--- a/scripts/test-versioning.ps1
+++ b/scripts/test-versioning.ps1
@@ -1,0 +1,39 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$src = Join-Path $Root 'src'
+$violations = [System.Collections.Generic.List[string]]::new()
+
+$projectFiles = Get-ChildItem -LiteralPath $src -Recurse -File -Include '*.fsproj', '*.csproj'
+
+foreach ($file in $projectFiles) {
+    $text = Get-Content -LiteralPath $file.FullName -Raw
+    $relativePath = [System.IO.Path]::GetRelativePath($Root, $file.FullName)
+
+    if ($text -match '<Version>\s*0\.1\s*</Version>') {
+        $violations.Add("${relativePath}: contains a project-level <Version>0.1</Version> declaration.")
+    }
+
+    if ($text -match '<ContainerImageTags>\s*0\.1;latest\s*</ContainerImageTags>') {
+        $violations.Add("${relativePath}: contains hard-coded 0.1;latest container tags.")
+    }
+}
+
+$configSchemaFile = Join-Path $src 'Grace.Shared\Constants.Shared.fs'
+$configSchemaText = Get-Content -LiteralPath $configSchemaFile -Raw
+
+if ($configSchemaText -notmatch 'CurrentConfigurationVersion\s*=\s*"0\.1"') {
+    $violations.Add('src/Grace.Shared/Constants.Shared.fs: CurrentConfigurationVersion changed; confirm this is an intentional configuration schema migration.')
+}
+
+if ($violations.Count -gt 0) {
+    $violations | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host 'Grace versioning audit passed.'

--- a/scripts/test-versioning.ps1
+++ b/scripts/test-versioning.ps1
@@ -31,6 +31,13 @@ if ($configSchemaText -notmatch 'CurrentConfigurationVersion\s*=\s*"0\.1"') {
     $violations.Add('src/Grace.Shared/Constants.Shared.fs: CurrentConfigurationVersion changed; confirm this is an intentional configuration schema migration.')
 }
 
+$directoryBuildProps = Join-Path $src 'Directory.Build.props'
+$directoryBuildPropsText = Get-Content -LiteralPath $directoryBuildProps -Raw
+
+if ($directoryBuildPropsText -match 'UtcNow') {
+    $violations.Add('src/Directory.Build.props: local build numbers must be supplied once per invocation, not computed per project with UtcNow.')
+}
+
 if ($violations.Count -gt 0) {
     $violations | ForEach-Object { Write-Error $_ }
     exit 1

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -15,6 +15,40 @@ $startTime = Get-Date
 $exitCode = 0
 $formatDisabled = $true
 
+function Get-GraceBuildProperties {
+    $buildKind = $env:GraceBuildKind
+    if ([string]::IsNullOrWhiteSpace($buildKind)) {
+        $buildKind = "dev"
+    }
+
+    $buildNumber = $env:GraceBuildNumber
+    if ([string]::IsNullOrWhiteSpace($buildNumber)) {
+        $buildNumber = [DateTime]::UtcNow.ToString("yyyyMMddHHmmss", [Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    $sourceRevision = $env:GraceSourceRevisionId
+    if ([string]::IsNullOrWhiteSpace($sourceRevision)) {
+        $git = Get-Command git -ErrorAction SilentlyContinue
+        if ($null -ne $git) {
+            $sourceRevision = (& git rev-parse HEAD 2>$null)
+            if ($LASTEXITCODE -ne 0) {
+                $sourceRevision = $null
+            }
+        }
+    }
+
+    $properties = @(
+        "-p:GraceBuildKind=$buildKind",
+        "-p:GraceBuildNumber=$buildNumber"
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($sourceRevision)) {
+        $properties += "-p:GraceSourceRevisionId=$sourceRevision"
+    }
+
+    [string[]]$properties
+}
+
 function Write-Section([string]$Title) {
     Write-Host ""
     Write-Host ("== {0} ==" -f $Title)
@@ -180,9 +214,11 @@ try {
         Write-Host "Skipped (-SkipFormat)."
     }
 
+    $graceBuildProperties = Get-GraceBuildProperties
+
     if (-not $SkipBuild) {
         Write-Section "Build"
-        Invoke-External "Grace solution build" { dotnet build "src/Grace.slnx" -c $Configuration }
+        Invoke-External "Grace solution build" { dotnet build "src/Grace.slnx" -c $Configuration @graceBuildProperties }
     } else {
         Write-Section "Build"
         Write-Host "Skipped (-SkipBuild)."

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -29,6 +29,10 @@ update the issue before editing the new paths.
 - Resolve all compilation errors before considering a task complete.
 - Run impacted tests for each task and fix failures introduced by your changes.
 - Create a new git commit after each completed task to keep review scope clear.
+- When the user asks to address a code review comment, review comment, PR feedback, or similar, complete the full
+  review-thread workflow: evaluate the comment, make the appropriate fix or explicitly explain why no code change is
+  needed, validate the result, commit and push the branch, reply to the GitHub review comment with the outcome and
+  evidence, and resolve the GitHub conversation when the feedback has been satisfied.
 - Record skipped validation, docs impact, residual risk, and follow-ups in the task record or pull request.
 - Write tests for new features and bug fixes; prioritize critical paths.
 - Document new public APIs with XML comments and update nearby `AGENTS.md`/docs when behavior changes.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
         <GraceBuildKind Condition="'$(GraceBuildKind)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">ci</GraceBuildKind>
         <GraceBuildKind Condition="'$(GraceBuildKind)' == ''">dev</GraceBuildKind>
         <GraceBuildNumber Condition="'$(GraceBuildNumber)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">$(GITHUB_RUN_NUMBER)</GraceBuildNumber>
+        <GraceBuildNumber Condition="'$(GraceBuildNumber)' == '' and '$(GraceBuildKind)' == 'ci'">0</GraceBuildNumber>
         <GraceBuildNumber Condition="'$(GraceBuildNumber)' == ''">local</GraceBuildNumber>
         <GraceBuildVersion Condition="'$(GraceBuildKind)' == 'release'">$(GraceVersionPrefix)</GraceBuildVersion>
         <GraceBuildVersion Condition="'$(GraceBuildVersion)' == ''">$(GraceVersionPrefix)-$(GraceBuildKind).$(GraceBuildNumber)</GraceBuildVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,26 @@
 <Project>
     <PropertyGroup>
+        <GraceVersionPrefix Condition="'$(GraceVersionPrefix)' == ''">0.2.0</GraceVersionPrefix>
+        <GraceBuildKind Condition="'$(GraceBuildKind)' == ''">dev</GraceBuildKind>
+        <GraceBuildNumber Condition="'$(GraceBuildNumber)' == ''">$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</GraceBuildNumber>
+        <GraceBuildVersion Condition="'$(GraceBuildKind)' == 'release'">$(GraceVersionPrefix)</GraceBuildVersion>
+        <GraceBuildVersion Condition="'$(GraceBuildVersion)' == ''">$(GraceVersionPrefix)-$(GraceBuildKind).$(GraceBuildNumber)</GraceBuildVersion>
+        <GraceSourceRevisionId Condition="'$(GraceSourceRevisionId)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</GraceSourceRevisionId>
+        <GraceShortSourceRevisionId Condition="'$(GraceSourceRevisionId)' != '' and $([System.String]::Copy('$(GraceSourceRevisionId)').Length) &gt;= 7">$([System.String]::Copy('$(GraceSourceRevisionId)').Substring(0, 7))</GraceShortSourceRevisionId>
+        <GraceShortSourceRevisionId Condition="'$(GraceSourceRevisionId)' != '' and '$(GraceShortSourceRevisionId)' == ''">$(GraceSourceRevisionId)</GraceShortSourceRevisionId>
+        <VersionPrefix>$(GraceVersionPrefix)</VersionPrefix>
+        <VersionSuffix Condition="'$(GraceBuildKind)' != 'release'">$(GraceBuildKind).$(GraceBuildNumber)</VersionSuffix>
+        <Version>$(GraceBuildVersion)</Version>
+        <PackageVersion>$(GraceBuildVersion)</PackageVersion>
+        <ProductVersion>$(GraceBuildVersion)</ProductVersion>
+        <AssemblyVersion>0.2.0.0</AssemblyVersion>
+        <GraceFileVersionRevision Condition="'$(GraceFileVersionRevision)' == '' and '$(GraceBuildKind)' == 'ci'">$([MSBuild]::Modulo($(GraceBuildNumber), 65535))</GraceFileVersionRevision>
+        <GraceFileVersionRevision Condition="'$(GraceFileVersionRevision)' == ''">0</GraceFileVersionRevision>
+        <FileVersion>0.2.0.$(GraceFileVersionRevision)</FileVersion>
+        <InformationalVersion Condition="'$(GraceShortSourceRevisionId)' != ''">$(GraceBuildVersion)+$(GraceShortSourceRevisionId)</InformationalVersion>
+        <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(GraceBuildVersion)</InformationalVersion>
+        <AssemblyInformationalVersion>$(InformationalVersion)</AssemblyInformationalVersion>
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,10 @@
 <Project>
     <PropertyGroup>
         <GraceVersionPrefix Condition="'$(GraceVersionPrefix)' == ''">0.2.0</GraceVersionPrefix>
+        <GraceBuildKind Condition="'$(GraceBuildKind)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">ci</GraceBuildKind>
         <GraceBuildKind Condition="'$(GraceBuildKind)' == ''">dev</GraceBuildKind>
-        <GraceBuildNumber Condition="'$(GraceBuildNumber)' == ''">$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</GraceBuildNumber>
+        <GraceBuildNumber Condition="'$(GraceBuildNumber)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">$(GITHUB_RUN_NUMBER)</GraceBuildNumber>
+        <GraceBuildNumber Condition="'$(GraceBuildNumber)' == ''">local</GraceBuildNumber>
         <GraceBuildVersion Condition="'$(GraceBuildKind)' == 'release'">$(GraceVersionPrefix)</GraceBuildVersion>
         <GraceBuildVersion Condition="'$(GraceBuildVersion)' == ''">$(GraceVersionPrefix)-$(GraceBuildKind).$(GraceBuildNumber)</GraceBuildVersion>
         <GraceSourceRevisionId Condition="'$(GraceSourceRevisionId)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</GraceSourceRevisionId>

--- a/src/Grace.CLI.Tests/BuildInfo.Tests.fs
+++ b/src/Grace.CLI.Tests/BuildInfo.Tests.fs
@@ -1,0 +1,45 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.Shared
+open NUnit.Framework
+
+module BuildInfoTests =
+
+    [<Test>]
+    let ``createFromValues prefers informational version for display identity`` () =
+        let buildInfo = BuildInfo.createFromValues (Some "0.2.0-ci.1234+abcdef1") (Some "0.2.0-ci.1234") (Some "0.2.0.1234") (Some "0.2.0.0")
+
+        buildInfo.InformationalVersion
+        |> should equal "0.2.0-ci.1234+abcdef1"
+
+        buildInfo.SourceRevisionId
+        |> should equal (Some "abcdef1")
+
+    [<Test>]
+    let ``createFromValues falls back to product version when informational version is missing`` () =
+        let buildInfo = BuildInfo.createFromValues None (Some "0.2.0-dev.20260521220544") (Some "0.2.0.0") (Some "0.2.0.0")
+
+        buildInfo.InformationalVersion
+        |> should equal "0.2.0-dev.20260521220544"
+
+    [<Test>]
+    let ``createFromValues falls back to file version when product metadata is missing`` () =
+        let buildInfo = BuildInfo.createFromValues None None (Some "0.2.0.1234") (Some "0.2.0.0")
+
+        buildInfo.InformationalVersion
+        |> should equal "0.2.0.1234"
+
+    [<Test>]
+    let ``createFromValues falls back to assembly version when file metadata is missing`` () =
+        let buildInfo = BuildInfo.createFromValues None None None (Some "0.2.0.0")
+
+        buildInfo.InformationalVersion
+        |> should equal "0.2.0.0"
+
+    [<Test>]
+    let ``createFromValues returns safe non-empty identity when metadata is unavailable`` () =
+        let buildInfo = BuildInfo.createFromValues None None None None
+
+        buildInfo.InformationalVersion
+        |> should equal "unknown"

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Auth.Tests.fs" />
     <Compile Include="AuthTokenBundle.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
+    <Compile Include="BuildInfo.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />
     <Compile Include="HistoryStorage.CLI.Tests.fs" />
     <Compile Include="LocalStateDb.Tests.fs" />

--- a/src/Grace.CLI.Tests/HistoryStorage.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/HistoryStorage.CLI.Tests.fs
@@ -196,6 +196,39 @@ module HistoryStorageTests =
             | None -> Assert.Fail("Expected recordInvocation to return a history entry."))
 
     [<Test>]
+    let ``recordInvocation stores informational build identity`` () =
+        let configPath = UserConfiguration.getUserConfigurationPath ()
+
+        withFileBackup configPath (fun () ->
+            let configuration = UserConfiguration.UserConfiguration()
+            configuration.History.Enabled <- true
+
+            match UserConfiguration.saveUserConfiguration configuration with
+            | Ok _ -> ()
+            | Error error -> Assert.Fail(error)
+
+            let input: HistoryStorage.RecordInput =
+                {
+                    argvOriginal = [| "branch"; "status" |]
+                    argvNormalized = [| "branch"; "status" |]
+                    cwd = Environment.CurrentDirectory
+                    exitCode = 0
+                    durationMs = 5L
+                    parseSucceeded = true
+                    timestampUtc = getCurrentInstant ()
+                    source = None
+                }
+
+            match HistoryStorage.recordInvocation input with
+            | Some (entry, _) ->
+                entry.graceVersion
+                |> should equal (BuildInfo.current().InformationalVersion)
+
+                entry.graceVersion
+                |> should not' (equal "0.2.0.0")
+            | None -> Assert.Fail("Expected recordInvocation to return a history entry."))
+
+    [<Test>]
     let ``shouldRecord treats history command with leading source option as history`` () =
         let configuration = UserConfiguration.UserConfiguration()
         configuration.History.Enabled <- true

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -7,7 +7,6 @@
 		<OutputType>Exe</OutputType>
 		<!--<PublishAot>true</PublishAot>-->
 		<!--<RuntimeIdentifier>win10-x64</RuntimeIdentifier>-->
-		<Version>0.1</Version>
 		<Description>The command-line interface for Grace.</Description>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>

--- a/src/Grace.CLI/HistoryStorage.CLI.fs
+++ b/src/Grace.CLI/HistoryStorage.CLI.fs
@@ -9,7 +9,6 @@ open System
 open System.Collections.Generic
 open System.Diagnostics
 open System.IO
-open System.Reflection
 open System.Text
 open System.Text.Json
 open System.Text.RegularExpressions
@@ -88,12 +87,7 @@ module HistoryStorage =
 
     let private getGraceVersion () =
         try
-            let version = Assembly.GetEntryAssembly().GetName().Version
-
-            if isNull version then
-                Constants.CurrentConfigurationVersion
-            else
-                version.ToString()
+            BuildInfo.current().InformationalVersion
         with
         | _ -> Constants.CurrentConfigurationVersion
 

--- a/src/Grace.Server/ApplicationContext.Server.fs
+++ b/src/Grace.Server/ApplicationContext.Server.fs
@@ -74,11 +74,9 @@ module ApplicationContext =
 
     /// Sets the Application global configuration.
     let setConfiguration (config: IConfiguration) =
-        let assembly = Assembly.GetExecutingAssembly()
-        let version = assembly.GetName().Version
-        let fileInfo = FileInfo(assembly.Location)
+        let buildInfo = BuildInfo.fromAssembly (Assembly.GetExecutingAssembly())
 
-        logToConsole $"Grace Server version: {version}; build time (UTC): {fileInfo.LastWriteTimeUtc}."
+        logToConsole $"Grace Server build: {buildInfo.InformationalVersion}."
 
         configuration <- config
     //configuration.AsEnumerable() |> Seq.iter (fun kvp -> logToConsole $"{kvp.Key}: {kvp.Value}")

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-    <PropertyGroup>
-        <AssemblyInformationalVersion>0.1.0 (Build Time: $([System.DateTime]::UtcNow.ToString("u")))</AssemblyInformationalVersion>
-    </PropertyGroup>
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
         <ServerGarbageCollection>true</ServerGarbageCollection>
@@ -11,12 +8,11 @@
         <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
         <Platforms>AnyCPU;x64</Platforms>
 		<LangVersion>preview</LangVersion>
-		<Version>0.1</Version>
 		<Description>The server module for Grace Version Control System.</Description>
 		<UserSecretsId>f1167a88-7f15-49c3-8ea1-30c2608081c9</UserSecretsId>
         <TransformWebConfigEnabled>false</TransformWebConfigEnabled>
         <ContainerBaseImage>mcr.microsoft.com/dotnet/sdk:10.0</ContainerBaseImage>
-		<ContainerImageTags>0.1;latest</ContainerImageTags>
+		<ContainerImageTags>$(GraceBuildVersion);latest</ContainerImageTags>
 		<ContainerRepository>scottarbeit/grace-server</ContainerRepository>
         <EnableSdkContainerDebugging>true</EnableSdkContainerDebugging>
         <!--<IsPublishable>false</IsPublishable>-->

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -113,11 +113,11 @@ module Application =
         let mustBeLoggedIn = requiresAuthentication notLoggedIn
 
         let graceServerVersion =
-            FileVersionInfo
-                .GetVersionInfo(
-                    Assembly.GetExecutingAssembly().Location
+            BuildInfo
+                .fromAssembly(
+                    Assembly.GetExecutingAssembly()
                 )
-                .FileVersion
+                .InformationalVersion
 
         let repositoryResourceFromContext (context: HttpContext) =
             task {

--- a/src/Grace.Shared/BuildInfo.Shared.fs
+++ b/src/Grace.Shared/BuildInfo.Shared.fs
@@ -1,0 +1,114 @@
+namespace Grace.Shared
+
+open System
+open System.Diagnostics
+open System.IO
+open System.Reflection
+
+module BuildInfo =
+
+    type BuildIdentity = { ProductVersion: string; FileVersion: string; InformationalVersion: string; AssemblyVersion: string; SourceRevisionId: string option }
+
+    let private unknownVersion = "unknown"
+
+    let private clean value =
+        value
+        |> Option.bind (fun text -> if String.IsNullOrWhiteSpace text then None else Some(text.Trim()))
+
+    let private firstNonEmpty values =
+        values
+        |> List.tryPick clean
+        |> Option.defaultValue unknownVersion
+
+    let private trySourceRevisionId informationalVersion =
+        informationalVersion
+        |> clean
+        |> Option.bind (fun value ->
+            let plusIndex = value.IndexOf('+')
+
+            if plusIndex < 0 || plusIndex = value.Length - 1 then
+                None
+            else
+                Some(value.Substring(plusIndex + 1)))
+
+    let createFromValues informationalVersion productVersion fileVersion assemblyVersion =
+        let displayVersion =
+            firstNonEmpty [ informationalVersion
+                            productVersion
+                            fileVersion
+                            assemblyVersion ]
+
+        {
+            ProductVersion =
+                firstNonEmpty [ productVersion
+                                informationalVersion
+                                fileVersion
+                                assemblyVersion ]
+            FileVersion =
+                firstNonEmpty [ fileVersion
+                                productVersion
+                                informationalVersion
+                                assemblyVersion ]
+            InformationalVersion = displayVersion
+            AssemblyVersion =
+                firstNonEmpty [ assemblyVersion
+                                fileVersion
+                                productVersion
+                                informationalVersion ]
+            SourceRevisionId = trySourceRevisionId informationalVersion
+        }
+
+    let private tryFileVersionInfo (assembly: Assembly) =
+        try
+            let location = assembly.Location
+
+            if String.IsNullOrWhiteSpace location
+               || not <| File.Exists location then
+                None
+            else
+                Some(FileVersionInfo.GetVersionInfo location)
+        with
+        | _ -> None
+
+    let fromAssembly (assembly: Assembly) =
+        try
+            let informationalVersion =
+                try
+                    let attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+
+                    if isNull attribute then None else Some attribute.InformationalVersion
+                with
+                | _ -> None
+
+            let fileVersionInfo = tryFileVersionInfo assembly
+
+            let productVersion =
+                fileVersionInfo
+                |> Option.bind (fun info -> Some info.ProductVersion)
+
+            let fileVersion =
+                fileVersionInfo
+                |> Option.bind (fun info -> Some info.FileVersion)
+
+            let assemblyVersion =
+                try
+                    let version = assembly.GetName().Version
+
+                    if isNull version then None else Some(version.ToString())
+                with
+                | _ -> None
+
+            createFromValues informationalVersion productVersion fileVersion assemblyVersion
+        with
+        | _ -> createFromValues None None None None
+
+    let current () =
+        let assembly =
+            try
+                let entryAssembly = Assembly.GetEntryAssembly()
+
+                if isNull entryAssembly then Assembly.GetExecutingAssembly() else entryAssembly
+            with
+            | _ -> Assembly.GetExecutingAssembly()
+
+        fromAssembly assembly

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -3,7 +3,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <LangVersion>preview</LangVersion>
         <PublishReadyToRun>true</PublishReadyToRun>
-        <Version>0.1</Version>
         <Description>The shared core module for Grace.</Description>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
@@ -25,6 +24,7 @@
         <Compile Include="Resources\Utilities.Resources.fs" />
         <Compile Include="Combinators.fs" />
         <Compile Include="Utilities.Shared.fs" />
+        <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />
         <Compile Include="Converters\BranchDtoConverter.Shared.fs" />
         <Compile Include="Services.Shared.fs" />

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -4,7 +4,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <LangVersion>Preview</LangVersion>
         <PublishReadyToRun>true</PublishReadyToRun>
-        <Version>0.1</Version>
         <Description>The shared types module for Grace.</Description>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>


### PR DESCRIPTION
Closes #71

## Summary

- Centralizes Grace build metadata in `src/Directory.Build.props` with product base `0.2.0` and generated `dev.<timestamp>` / `ci.<run number>` prerelease identities.
- Removes duplicated project-level `0.1` versions from CLI, Server, Shared, and Types, and replaces the server container tag with `$(GraceBuildVersion);latest`.
- Adds `Grace.Shared.BuildInfo` and wires CLI history, server startup logging, and the root hello endpoint to the same informational build identity source.
- Adds focused build-info/history tests, a static version audit script, CI workflow build identity inputs, and build-versioning docs.

## Final audit against the supplied spec

- Authoritative version source: `src/Directory.Build.props` now owns `GraceVersionPrefix`, `GraceBuildKind`, `GraceBuildNumber`, `GraceBuildVersion`, assembly/package/product versions, and informational version metadata.
- Product base version: `0.2.0`.
- Local build identity: default local CLI build verified as `0.2.0-dev.20260521231312` with `AssemblyVersion=0.2.0.0` and `FileVersion=0.2.0.0`.
- CI build identity: explicit build verified CLI and Server metadata as `ProductVersion=0.2.0-ci.1234+abcdef1`, `AssemblyVersion=0.2.0.0`, `FileVersion=0.2.0.1234`.
- Runtime surfaces: CLI history uses `BuildInfo.current().InformationalVersion`; server startup and root hello endpoint use `BuildInfo.fromAssembly(...).InformationalVersion`.
- Container tags: `dotnet msbuild ./src/Grace.Server/Grace.Server.fsproj -getProperty:ContainerImageTags -p:GraceBuildKind=ci -p:GraceBuildNumber=1234 -p:GraceSourceRevisionId=abcdef1234567890` returned `0.2.0-ci.1234;latest`.
- Configuration schema: `Constants.CurrentConfigurationVersion` intentionally remains `0.1`; no config schema changed.
- Project-level static version audit: `pwsh ./scripts/test-versioning.ps1` passes and fails if `<Version>0.1</Version>` or `0.1;latest` container tags return.
- CodexPlan note: the downloaded spec asked for `CodexPlan.md`, but current Grace repo guidance uses the GitHub issue/PR as the single task record, so traceability and final audit are recorded here instead of reintroducing that retired file workflow.

## Validation

Passed:

- `dotnet build ./src/Grace.slnx --configuration Release -p:GraceBuildKind=ci -p:GraceBuildNumber=1234 -p:GraceSourceRevisionId=abcdef1234567890`
- `dotnet test ./src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --no-build --filter "BuildInfoTests|HistoryStorageTests"` - 20 passed
- `pwsh ./scripts/test-versioning.ps1`
- `dotnet msbuild ./src/Grace.Server/Grace.Server.fsproj -getProperty:ContainerImageTags -p:GraceBuildKind=ci -p:GraceBuildNumber=1234 -p:GraceSourceRevisionId=abcdef1234567890`
- Metadata inspection for CLI and Server assemblies: `AssemblyVersion=0.2.0.0`, `FileVersion=0.2.0.1234`, `ProductVersion=0.2.0-ci.1234+abcdef1`
- `pwsh ./scripts/validate.ps1 -Fast` - build passed; Authorization 21 passed; CLI 194 passed / 1 skipped; Types 16 passed
- `npx --yes markdownlint-cli2 --config <temp .markdownlint-cli2.jsonc> "docs/Build versioning.md"`
- `git diff --check`

Attempted / not passed:

- `dotnet test ./src/Grace.slnx --configuration Release --no-build` failed in `Grace.Server.Tests` global setup because the local Cosmos emulator never became ready: `Timed out waiting for Cosmos emulator`, with `HttpIOException: The response ended prematurely`. Non-emulator suites passed in the same run; `validate -Fast` passed afterward.
- Whole-repo MarkdownLint was attempted and failed on pre-existing markdown debt in unrelated files; the changed markdown file passes the lint check.

## Docs impact

- Added `docs/Build versioning.md` with version shape, CI inputs, runtime identity guidance, and audit command.

## Residual risk

- `FileVersion` uses a numeric, 16-bit-safe CI revision derived from the run number; the exact traceable build identity remains in product/informational version and container tags.
- Full server integration validation should be rerun when the local Cosmos emulator is healthy or in CI with working emulator startup.
