### PR TITLE
Update Aspire packages to 13.3.5

### DIFF
--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -200,8 +200,7 @@ public partial class Program
                     var azuriteQueueHostAndPort = azuriteQueueEndpoint.Property(EndpointProperty.HostAndPort);
                     var azuriteTableHostAndPort = azuriteTableEndpoint.Property(EndpointProperty.HostAndPort);
 
-                    // Cosmos emulator (your existing approach)
-                    const string cosmosKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+                    // Cosmos emulator
                     var cosmosDatabaseName = configuration[getConfigKey(EnvironmentVariables.AzureCosmosDBDatabaseName)] ?? "grace-dev";
                     var cosmosDbContainerName = configuration[getConfigKey(EnvironmentVariables.AzureCosmosDBContainerName)] ?? "grace-events";
                     const int cosmosGatewayHostPort = 8081;
@@ -232,7 +231,7 @@ public partial class Program
 
                     _ = cosmos.AddCosmosDatabase(cosmosDatabaseName)
                         .AddContainer(cosmosDbContainerName, "/PartitionKey");
-                    var cosmosConnStr = BuildCosmosEmulatorConnectionString(cosmos, cosmosKey);
+                    var cosmosConnStr = cosmos.Resource.ConnectionStringExpression;
 
                     graceServer
                         .WithParentRelationship(azurite)
@@ -584,47 +583,6 @@ public partial class Program
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
         return port;
-    }
-
-    private static ReferenceExpression BuildCosmosEmulatorConnectionString(
-        IResourceBuilder<AzureCosmosDBResource> cosmos,
-        string accountKey)
-    {
-            if (cosmos.Resource is IResourceWithEndpoints cosmosWithEndpoints)
-            {
-                EndpointReference? selected = null;
-
-            foreach (var endpoint in cosmosWithEndpoints.GetEndpoints())
-            {
-                if (endpoint.EndpointAnnotation.TargetPort == 8081)
-                {
-                    selected = endpoint;
-                    break;
-                }
-
-                if (endpoint.IsHttps)
-                {
-                    selected = endpoint;
-                    break;
-                }
-
-                selected ??= endpoint;
-            }
-
-                if (selected is not null)
-                {
-                    var scheme = selected.EndpointAnnotation.UriScheme;
-                    if (string.IsNullOrWhiteSpace(scheme))
-                    {
-                        scheme = selected.IsHttps ? "https" : "http";
-                    }
-
-                var hostAndPort = selected.Property(EndpointProperty.HostAndPort);
-                return ReferenceExpression.Create($"AccountEndpoint={scheme}://{hostAndPort}/;AccountKey={accountKey};DisableServerCertificateValidation=True;");
-            }
-        }
-
-        return cosmos.Resource.ConnectionStringExpression;
     }
 
     private static readonly JsonSerializerOptions jsonOptions = new()

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -219,6 +219,7 @@ public partial class Program
                                 .WithEnvironment("AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE", "127.0.0.1")
                                 .WithEnvironment("ENABLE_OTLP_EXPORTER", "true")
                                 .WithEnvironment("LOG_LEVEL", "info")
+                                .WithArgs("--protocol", "https")
                                 .WithDataExplorer(1234)
                                 .WithGatewayPort(cosmosGatewayHostPort);
 

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -942,7 +942,7 @@ module AspireTestHost =
             match cosmosResourceName with
             | Some name ->
                 Console.WriteLine($"Cosmos emulator resource detected: {name}")
-                do! waitForResourceHealthyAsync notificationService app name cts.Token
+                Console.WriteLine("Cosmos functional readiness probe will verify emulator access.")
             | None -> Console.WriteLine("Cosmos emulator resource not found in model.")
 
             if not (shouldSkipServiceBus ()) then

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -486,11 +486,78 @@ module AspireTestHost =
                 None)
         |> Option.defaultValue "<missing>"
 
+    let private replaceConnValue (prefix: string) (replacement: string) (value: string) =
+        let mutable replaced = false
+
+        let segments =
+            value.Split(';', StringSplitOptions.RemoveEmptyEntries)
+            |> Array.map (fun segment ->
+                if segment.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) then
+                    replaced <- true
+                    $"{prefix}{replacement}"
+                else
+                    segment)
+
+        if replaced then (String.Join(";", segments)) + ";" else value
+
     let private tryGetCosmosEndpointUri (connectionString: string) =
         let value = tryGetConnValue "AccountEndpoint=" connectionString
         let mutable uri = Unchecked.defaultof<Uri>
 
         if Uri.TryCreate(value, UriKind.Absolute, &uri) then Some uri else None
+
+    let private tryGetEndpointNameForTargetPort (app: DistributedApplication) (resourceName: string) (targetPort: int) =
+        match tryFindResourceByName app resourceName with
+        | Some (:? IResourceWithEndpoints as resourceWithEndpoints) ->
+            resourceWithEndpoints.GetEndpoints()
+            |> Seq.tryFind (fun endpoint ->
+                endpoint.EndpointAnnotation.TargetPort.HasValue
+                && endpoint.EndpointAnnotation.TargetPort.Value = targetPort)
+            |> Option.map (fun endpoint -> endpoint.EndpointAnnotation.Name)
+        | _ -> None
+
+    let private tryFindResourceNameForTargetPort (app: DistributedApplication) (targetPort: int) =
+        let model = app.Services.GetRequiredService<DistributedApplicationModel>()
+
+        model.Resources
+        |> Seq.tryPick (fun resource ->
+            match resource with
+            | :? IResourceWithEndpoints as resourceWithEndpoints ->
+                let hasTargetPort =
+                    resourceWithEndpoints.GetEndpoints()
+                    |> Seq.exists (fun endpoint ->
+                        endpoint.EndpointAnnotation.TargetPort.HasValue
+                        && endpoint.EndpointAnnotation.TargetPort.Value = targetPort)
+
+                if hasTargetPort then Some resource.Name else None
+            | _ -> None)
+
+    let private tryGetRuntimeEndpoint (app: DistributedApplication) (resourceName: string) (targetPort: int) =
+        try
+            let endpointName =
+                tryGetEndpointNameForTargetPort app resourceName targetPort
+                |> Option.defaultWith (fun () -> getEndpointName app resourceName)
+
+            Some(app.GetEndpoint(resourceName, endpointName))
+        with
+        | ex ->
+            Console.WriteLine($"Unable to resolve runtime endpoint for {resourceName}: {ex.Message}")
+            None
+
+    let private resolveLocalCosmosConnectionString (app: DistributedApplication) (cosmosResourceName: string option) (connectionString: string) =
+        match cosmosResourceName with
+        | Some resourceName ->
+            match tryGetRuntimeEndpoint app resourceName 8081 with
+            | Some runtimeEndpoint ->
+                let endpoint = runtimeEndpoint.ToString().TrimEnd('/') + "/"
+                let configuredEndpoint = tryGetConnValue "AccountEndpoint=" connectionString
+
+                if not (endpoint.Equals(configuredEndpoint, StringComparison.OrdinalIgnoreCase)) then
+                    Console.WriteLine($"Cosmos readiness endpoint adjusted from {configuredEndpoint} to {endpoint}.")
+
+                replaceConnValue "AccountEndpoint=" endpoint connectionString
+            | None -> connectionString
+        | None -> connectionString
 
     let private formatExceptionChain (ex: exn) =
         let parts = ResizeArray<string>()
@@ -666,6 +733,12 @@ module AspireTestHost =
                 let isLocalCosmos =
                     connectionString.Contains("localhost", StringComparison.OrdinalIgnoreCase)
                     || connectionString.Contains("127.0.0.1", StringComparison.OrdinalIgnoreCase)
+
+                let connectionString =
+                    if isLocalCosmos then
+                        resolveLocalCosmosConnectionString app cosmosResourceName connectionString
+                    else
+                        connectionString
 
                 let options = createLocalCosmosClientOptions ()
 
@@ -862,7 +935,9 @@ module AspireTestHost =
             else
                 Console.WriteLine("Skipping Service Bus SQL readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
 
-            let cosmosResourceName = tryFindResourceName<AzureCosmosDBEmulatorResource> app
+            let cosmosResourceName =
+                tryFindResourceName<AzureCosmosDBEmulatorResource> app
+                |> Option.orElseWith (fun () -> tryFindResourceNameForTargetPort app 8081)
 
             match cosmosResourceName with
             | Some name ->

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.3.5" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
     <PackageReference Include="FsCheck" Version="3.3.3" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />


### PR DESCRIPTION
Closes #76

## Summary

- Update the Aspire AppHost SDK, Aspire hosting packages, and `Aspire.Hosting.Testing` from 13.3.4 to 13.3.5.
- Use Aspire's Cosmos emulator `ConnectionStringExpression` in the AppHost so dynamic local host ports stay aligned with the running emulator.
- Harden the Aspire-backed server test host so Cosmos readiness resolves the runtime endpoint when Aspire exposes the emulator through target port metadata.

## Validation

- `dotnet restore .\src\Grace.slnx`
- `dotnet build .\src\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj --configuration Release --no-restore`
- `dotnet build .\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-restore`
- `dotnet test .\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build` - 217 passed, 0 skipped
- `dotnet tool run fantomas .\Grace.Server.Tests\AspireTestHost.fs`
- `pwsh ./scripts/validate.ps1 -Fast` - build clean; Authorization 21 passed; CLI 188 passed, 1 skipped; Types 16 passed
- `pwsh ./scripts/validate.ps1 -Full` - build clean; Authorization 21 passed; CLI 188 passed, 1 skipped; Types 16 passed; Server 217 passed
- `git diff --check`
- `dotnet list .\src\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj package --outdated` - no updates
- `dotnet list .\src\Grace.Server.Tests\Grace.Server.Tests.fsproj package --outdated` - no updates

## Docs Impact

No documentation update is needed. This is a patch-level dependency update plus local Aspire emulator binding compatibility; commands and public behavior are unchanged.

## Residual Risk

Risk is limited to local Aspire emulator runtime binding. Full local emulator validation passed after the AppHost moved back to Aspire's generated Cosmos connection expression.