### PR TITLE
Track API client identity in metadata

### DIFF
--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -466,3 +466,55 @@ module RootHelpGroupingTests =
 
                 for heading in expectation.Headings do
                     output |> should contain heading)
+
+
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.Types.Types
+open NUnit.Framework
+open System
+
+[<NonParallelizable>]
+module ClientIdentityTests =
+
+    [<Test>]
+    let ``configureSdkClientIdentity stamps CLI client type with assembly file version`` () =
+        Grace.SDK.ClientIdentity.clear ()
+
+        try
+            Services.configureSdkClientIdentity ()
+
+            match Grace.SDK.ClientIdentity.tryGetConfiguredClientType () with
+            | Some (ClientType.CLI version) ->
+                String.IsNullOrWhiteSpace version
+                |> should equal false
+
+                version
+                |> should equal (Services.getCliAssemblyFileVersion ())
+            | other -> Assert.Fail($"Expected CLI client identity, got {other}.")
+        finally
+            Grace.SDK.ClientIdentity.clear ()
+
+    [<Test>]
+    let ``configured SDK client identity adds Grace client headers`` () =
+        Grace.SDK.ClientIdentity.clear ()
+
+        try
+            Grace.SDK.ClientIdentity.configure (ClientType.CLI "1.2.3")
+
+            use httpClient = Grace.SDK.ClientIdentity.getHttpClient "corr-client"
+
+            httpClient.DefaultRequestHeaders.Contains(Grace.Shared.Constants.ClientTypeHeaderKey)
+            |> should equal true
+
+            httpClient.DefaultRequestHeaders.GetValues(Grace.Shared.Constants.ClientTypeHeaderKey)
+            |> Seq.exactlyOne
+            |> should equal "CLI"
+
+            httpClient.DefaultRequestHeaders.GetValues(Grace.Shared.Constants.ClientVersionHeaderKey)
+            |> Seq.exactlyOne
+            |> should equal "1.2.3"
+        finally
+            Grace.SDK.ClientIdentity.clear ()

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -27,6 +27,7 @@ open System.IO.Compression
 open System.IO.Enumeration
 open System.IO.Pipelines
 open System.Linq
+open System.Reflection
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
@@ -91,6 +92,23 @@ module Services =
     let mutable private invocationCorrelationId: CorrelationId option = None
 
     let resetInvocationCorrelationId () = invocationCorrelationId <- None
+
+    let getCliAssemblyFileVersion () =
+        let assembly = Assembly.GetExecutingAssembly()
+
+        if String.IsNullOrWhiteSpace assembly.Location then
+            $"{assembly.GetName().Version}"
+        else
+            let fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion
+
+            if String.IsNullOrWhiteSpace fileVersion then
+                $"{assembly.GetName().Version}"
+            else
+                fileVersion
+
+    let getCliClientType () = ClientType.CLI(getCliAssemblyFileVersion ())
+
+    let configureSdkClientIdentity () = Grace.SDK.ClientIdentity.configure (getCliClientType ())
 
     // Extension methods for dealing with local file changes.
     type DirectoryVersion with

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -720,6 +720,7 @@ module GraceCommand =
     let main args =
         let startTime = getCurrentInstant ()
         Auth.configureSdkAuth ()
+        Services.configureSdkClientIdentity ()
         Services.resetInvocationCorrelationId ()
 
         // Create a MemoryCache instance.

--- a/src/Grace.SDK/AGENTS.md
+++ b/src/Grace.SDK/AGENTS.md
@@ -46,3 +46,7 @@ Consult `../AGENTS.md` for global policies before modifying the SDK.
   (January 6, 2026).
 - Added `Auth.getOidcClientConfig` for fetching server-provided OIDC client
   configuration (January 8, 2026).
+- `ClientIdentity.SDK.fs` owns the process-wide client identity headers
+  (`X-Grace-Client-Type` and `X-Grace-Client-Version`). CLI startup configures
+  it with `ClientType.CLI(<Grace CLI assembly file version>)`; other clients
+  should configure their own identity before making SDK API calls.

--- a/src/Grace.SDK/Auth.SDK.fs
+++ b/src/Grace.SDK/Auth.SDK.fs
@@ -48,7 +48,7 @@ module Auth =
             parameters.CorrelationId <- correlationId
 
             try
-                use httpClient = getHttpClient correlationId
+                use httpClient = ClientIdentity.getHttpClient correlationId
                 let startTime = getCurrentInstant ()
 
                 let graceServerUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)

--- a/src/Grace.SDK/ClientIdentity.SDK.fs
+++ b/src/Grace.SDK/ClientIdentity.SDK.fs
@@ -1,0 +1,37 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Types.Types
+open System.Net.Http
+
+module ClientIdentity =
+
+    let mutable private configuredClientType: ClientType option = None
+
+    let configure (clientType: ClientType) = configuredClientType <- Some clientType
+
+    let clear () = configuredClientType <- None
+
+    let tryGetConfiguredClientType () = configuredClientType
+
+    let private toHeaderValues clientType =
+        match clientType with
+        | ClientType.CLI version -> "CLI", version
+
+    let applyHeaders (httpClient: HttpClient) =
+        match configuredClientType with
+        | Some clientType ->
+            let clientTypeName, clientVersion = toHeaderValues clientType
+
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ClientTypeHeaderKey, clientTypeName)
+            |> ignore
+
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ClientVersionHeaderKey, clientVersion)
+            |> ignore
+        | None -> ()
+
+        httpClient
+
+    let getHttpClient correlationId =
+        Grace.Shared.Utilities.getHttpClient correlationId
+        |> applyHeaders

--- a/src/Grace.SDK/Common.SDK.fs
+++ b/src/Grace.SDK/Common.SDK.fs
@@ -39,7 +39,7 @@ module Common =
         task {
             try
                 //checkMemoryCache ()
-                use httpClient = getHttpClient parameters.CorrelationId
+                use httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                 do! Auth.addAuthorizationHeader httpClient
                 let startTime = getCurrentInstant ()
 
@@ -81,7 +81,7 @@ module Common =
         task {
             try
                 //checkMemoryCache ()
-                use httpClient = getHttpClient parameters.CorrelationId
+                use httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                 do! Auth.addAuthorizationHeader httpClient
                 let serverUriWithRoute = Uri($"{Current().ServerUri}/{route}")
                 let startTime = getCurrentInstant ()

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -17,6 +17,7 @@
 	</PropertyGroup>
 	<ItemGroup>
         <None Include="instructions.md" />
+        <Compile Include="ClientIdentity.SDK.fs" />
         <Compile Include="Auth.SDK.fs" />
         <Compile Include="Common.SDK.fs" />
         <Compile Include="PersonalAccessToken.SDK.fs" />

--- a/src/Grace.SDK/PersonalAccessToken.SDK.fs
+++ b/src/Grace.SDK/PersonalAccessToken.SDK.fs
@@ -20,7 +20,7 @@ module PersonalAccessToken =
         task {
             try
                 let parameters = Common.ensureCorrelationIdIsSet parameters
-                use httpClient = getHttpClient parameters.CorrelationId
+                use httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                 do! Auth.addAuthorizationHeader httpClient
                 let startTime = getCurrentInstant ()
 

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -40,7 +40,7 @@ module Storage =
                 match Current().ObjectStorageProvider with
                 | AzureBlobStorage ->
                     // Get the URI to use when downloading the file. This includes a SAS token.
-                    let httpClient = getHttpClient correlationId
+                    let httpClient = ClientIdentity.getHttpClient correlationId
                     do! Auth.addAuthorizationHeader httpClient
                     let serviceUrl = $"{Current().ServerUri}/storage/getDownloadUri"
                     let jsonContent = createJsonContent getDownloadUriParameters
@@ -117,7 +117,7 @@ module Storage =
                 if parameters.FileVersions.Length > 0 then
                     match Current().ObjectStorageProvider with
                     | AzureBlobStorage ->
-                        let httpClient = getHttpClient correlationId
+                        let httpClient = ClientIdentity.getHttpClient correlationId
                         do! Auth.addAuthorizationHeader httpClient
                         let serviceUrl = $"{Current().ServerUri}/storage/getUploadMetadataForFiles"
                         let jsonContent = createJsonContent parameters
@@ -180,7 +180,7 @@ module Storage =
                 | ObjectStorageProvider.AzureBlobStorage ->
                     try
                         // Creating an HttpClientTransport so we can use our custom HttpClientFactory here.
-                        use transport = new HttpClientTransport(getHttpClient correlationId)
+                        use transport = new HttpClientTransport(ClientIdentity.getHttpClient correlationId)
 
                         let blobClientOptions = BlobClientOptions(Transport = transport)
                         // I might regret this setting. Time will tell.
@@ -307,7 +307,7 @@ module Storage =
                 match Current().ObjectStorageProvider with
                 | ObjectStorageProvider.Unknown -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
                 | ObjectStorageProvider.AzureBlobStorage ->
-                    let httpClient = getHttpClient parameters.CorrelationId
+                    let httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                     do! Auth.addAuthorizationHeader httpClient
                     let serviceUrl = $"{Current().ServerUri}/storage/getUploadUri"
                     let jsonContent = createJsonContent parameters
@@ -332,7 +332,7 @@ module Storage =
                 match Current().ObjectStorageProvider with
                 | ObjectStorageProvider.Unknown -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
                 | ObjectStorageProvider.AzureBlobStorage ->
-                    let httpClient = getHttpClient parameters.CorrelationId
+                    let httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                     do! Auth.addAuthorizationHeader httpClient
                     let serviceUrl = $"{Current().ServerUri}/storage/getDownloadUri"
                     let jsonContent = createJsonContent parameters

--- a/src/Grace.Server.Tests/Eventing.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Eventing.Server.Tests.fs
@@ -22,7 +22,13 @@ type AutomationEventingTests() =
         let properties = Dictionary<string, string>()
         properties[nameof RepositoryId] <- $"{repositoryId}"
 
-        { Timestamp = Instant.FromUtc(2026, 2, 18, 0, 0); CorrelationId = correlationId; Principal = "tester"; Properties = properties }
+        {
+            Timestamp = Instant.FromUtc(2026, 2, 18, 0, 0)
+            CorrelationId = correlationId
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = properties
+        }
 
     [<Test>]
     member _.ReferencePromotionWithTerminalLinkMapsToPromotionSetApplied() =

--- a/src/Grace.Server.Tests/General.Server.Tests.fs
+++ b/src/Grace.Server.Tests/General.Server.Tests.fs
@@ -3,10 +3,12 @@ namespace Grace.Server.Tests
 open Grace.Shared
 open Grace.Shared.Utilities
 open NUnit.Framework
+open Microsoft.AspNetCore.Http
 open System
 open System.Net
 open System.Net.Http
 open System.Net.Http.Json
+open System.Security.Claims
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
@@ -63,6 +65,35 @@ module Services =
     let logToTestConsole (message: string) = Console.WriteLine(message)
 
 open Services
+
+[<TestFixture>]
+module MetadataCreationTests =
+
+    let private createContext () =
+        let context = DefaultHttpContext()
+        context.Items[ Constants.CorrelationId ] <- "corr-server"
+        context.User <- ClaimsPrincipal(ClaimsIdentity([| Claim(ClaimTypes.Name, "tester") |], "test"))
+        context
+
+    [<Test>]
+    let ``createMetadata maps Grace client headers to CLI client type`` () =
+        let context = createContext ()
+        context.Request.Headers[ Constants.ClientTypeHeaderKey ] <- "CLI"
+        context.Request.Headers[ Constants.ClientVersionHeaderKey ] <- "0.1.2.3"
+
+        let metadata = Grace.Server.Services.createMetadata context
+
+        match metadata.ClientType with
+        | Some (ClientType.CLI version) -> Assert.That(version, Is.EqualTo("0.1.2.3"))
+        | other -> Assert.Fail($"Expected CLI client metadata, got {other}.")
+
+    [<Test>]
+    let ``createMetadata leaves client type unset when headers are absent`` () =
+        let context = createContext ()
+
+        let metadata = Grace.Server.Services.createMetadata context
+
+        Assert.That(metadata.ClientType, Is.EqualTo(Microsoft.FSharp.Core.Option.None))
 
 /// Defines the setup and teardown for all tests in the Grace.Server.Tests namespace.
 [<SetUpFixture>]

--- a/src/Grace.Server.Tests/Policy.Validation.Derived.Tests.fs
+++ b/src/Grace.Server.Tests/Policy.Validation.Derived.Tests.fs
@@ -14,7 +14,13 @@ open System.Collections.Generic
 [<Parallelizable(ParallelScope.All)>]
 type PolicyValidationDerivedTests() =
     let metadata correlationId timestamp =
-        { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+        {
+            Timestamp = timestamp
+            CorrelationId = correlationId
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     [<Test>]
     member _.ValidationResultRejectsDuplicateCorrelationIds() =

--- a/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
@@ -13,7 +13,13 @@ open System.Collections.Generic
 type PromotionSetCommandValidationTests() =
 
     let createMetadata correlationId =
-        { Timestamp = Instant.FromUtc(2026, 2, 21, 11, 0); CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+        {
+            Timestamp = Instant.FromUtc(2026, 2, 21, 11, 0)
+            CorrelationId = correlationId
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     let existingPromotionSet status computationStatus =
         { PromotionSetDto.Default with

--- a/src/Grace.Server.Tests/WorkItem.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Server.Tests.fs
@@ -16,7 +16,14 @@ open System.Collections.Generic
 
 [<Parallelizable(ParallelScope.All)>]
 type WorkItemServerUnitTests() =
-    let metadata timestamp = { Timestamp = timestamp; CorrelationId = "corr-work-item"; Principal = "tester"; Properties = Dictionary<string, string>() }
+    let metadata timestamp =
+        {
+            Timestamp = timestamp
+            CorrelationId = "corr-work-item"
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     let runValidation (validation: Threading.Tasks.ValueTask<Result<unit, WorkItemError>>) =
         validation.AsTask()

--- a/src/Grace.Server/Services.Server.fs
+++ b/src/Grace.Server/Services.Server.fs
@@ -46,6 +46,21 @@ module Services =
         else
             GraceIds.Default
 
+    let private tryGetHeader (context: HttpContext) headerName =
+        match context.Request.Headers.TryGetValue headerName with
+        | true, values when
+            values.Count > 0
+            && not (String.IsNullOrWhiteSpace values[0])
+            ->
+            Some(values[ 0 ].ToString())
+        | _ -> None
+
+    let private tryCreateClientType (context: HttpContext) =
+        match tryGetHeader context Constants.ClientTypeHeaderKey with
+        | Some clientType when clientType.Equals("CLI", StringComparison.OrdinalIgnoreCase) ->
+            Some(ClientType.CLI(defaultArg (tryGetHeader context Constants.ClientVersionHeaderKey) String.Empty))
+        | _ -> None
+
     /// Creates common metadata for Grace events.
     let createMetadata (context: HttpContext) : EventMetadata =
         let metadata =
@@ -56,6 +71,7 @@ module Services =
                         .Items[ Constants.CorrelationId ]
                         .ToString()
                 Principal = context.User.Identity.Name
+                ClientType = tryCreateClientType context
                 Properties = new Dictionary<string, string>()
             }
 

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -188,6 +188,14 @@ module Constants =
     [<Literal>]
     let ServerApiVersionHeaderKey = "X-Api-Version"
 
+    /// The request header that identifies the Grace client type.
+    [<Literal>]
+    let ClientTypeHeaderKey = "X-Grace-Client-Type"
+
+    /// The request header that identifies the Grace client version.
+    [<Literal>]
+    let ClientVersionHeaderKey = "X-Grace-Client-Version"
+
     /// Environment variables used by Grace.
     module EnvironmentVariables =
         /// The environment variable that contains the Application Insights connection string.

--- a/src/Grace.Types.Tests/EventMetadata.Types.Tests.fs
+++ b/src/Grace.Types.Tests/EventMetadata.Types.Tests.fs
@@ -1,0 +1,38 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System.Collections.Generic
+
+[<TestFixture>]
+type EventMetadataTypesTests() =
+
+    [<Test>]
+    member _.NewLeavesClientTypeUnsetForInternalMetadata() =
+        let metadata = EventMetadata.New "corr-internal" "GraceSystem"
+
+        Assert.That(metadata.CorrelationId, Is.EqualTo("corr-internal"))
+        Assert.That(metadata.Principal, Is.EqualTo("GraceSystem"))
+        Assert.That(metadata.ClientType, Is.EqualTo(Microsoft.FSharp.Core.Option.None))
+
+    [<Test>]
+    member _.ClientTypeRoundTripsThroughGraceJsonSerialization() =
+        let metadata =
+            {
+                Timestamp = Instant.FromUtc(2026, 5, 21, 12, 0)
+                CorrelationId = "corr-cli"
+                Principal = "tester"
+                ClientType = Some(ClientType.CLI "0.1.2.3")
+                Properties = Dictionary<string, string>()
+            }
+
+        let roundTrip =
+            metadata
+            |> serialize
+            |> deserialize<EventMetadata>
+
+        match roundTrip.ClientType with
+        | Some (ClientType.CLI version) -> Assert.That(version, Is.EqualTo("0.1.2.3"))
+        | other -> Assert.Fail($"Expected CLI client type, got {other}.")

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="EventMetadata.Types.Tests.fs" />
     <Compile Include="Automation.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/PromotionSet.Types.Tests.fs
+++ b/src/Grace.Types.Tests/PromotionSet.Types.Tests.fs
@@ -11,7 +11,13 @@ open System.Collections.Generic
 type PromotionSetDeterminismTests() =
 
     let createMetadata correlationId principal timestamp =
-        { Timestamp = timestamp; CorrelationId = correlationId; Principal = principal; Properties = Dictionary<string, string>() }
+        {
+            Timestamp = timestamp
+            CorrelationId = correlationId
+            Principal = principal
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     let createPromotionSetDto timestamp =
         let createdEvent: PromotionSetEvent =

--- a/src/Grace.Types.Tests/Queue.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Queue.Types.Tests.fs
@@ -11,7 +11,13 @@ open System.Collections.Generic
 [<Parallelizable(ParallelScope.All)>]
 type QueueTypesTests() =
     let metadata (timestamp: Instant) : EventMetadata =
-        { Timestamp = timestamp; CorrelationId = "corr-queue"; Principal = "tester"; Properties = Dictionary<string, string>() }
+        {
+            Timestamp = timestamp
+            CorrelationId = "corr-queue"
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     [<Test>]
     member _.PromotionQueueDtoUpdatesDeterministically() =

--- a/src/Grace.Types.Tests/Validation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Validation.Types.Tests.fs
@@ -9,7 +9,14 @@ open System.Collections.Generic
 
 [<Parallelizable(ParallelScope.All)>]
 type ValidationQuickScanDeterminism() =
-    let metadata timestamp = { Timestamp = timestamp; CorrelationId = "corr-1"; Principal = "tester"; Properties = Dictionary<string, string>() }
+    let metadata timestamp =
+        {
+            Timestamp = timestamp
+            CorrelationId = "corr-1"
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     [<Test>]
     member _.UpdateUsesEventPayloadAndTimestamp() =

--- a/src/Grace.Types.Tests/WorkItem.Types.Tests.fs
+++ b/src/Grace.Types.Tests/WorkItem.Types.Tests.fs
@@ -9,7 +9,14 @@ open System.Collections.Generic
 
 [<Parallelizable(ParallelScope.All)>]
 type WorkItemTypesTests() =
-    let metadata timestamp = { Timestamp = timestamp; CorrelationId = "corr-work-item"; Principal = "tester"; Properties = Dictionary<string, string>() }
+    let metadata timestamp =
+        {
+            Timestamp = timestamp
+            CorrelationId = "corr-work-item"
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
 
     [<Test>]
     member _.UpdateDtoPreservesCreatedFields() =

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -34,6 +34,15 @@ module Types =
     /// The CorrelationId used during a Grace operation.
     type CorrelationId = string
 
+    /// Identifies the Grace client that initiated an API request.
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ClientType =
+        | CLI of Version: string
+
+        override this.ToString() = getDiscriminatedUnionFullName this
+
+        static member GetKnownTypes() = GetKnownTypes<ClientType>()
+
     /// The reason given for deleting a branch or reference.
     type DeleteReason = string
 
@@ -212,13 +221,20 @@ module Types =
             Timestamp: Instant
             CorrelationId: CorrelationId
             Principal: string
+            ClientType: ClientType option
             Properties: Dictionary<string, string>
         }
 
         override this.ToString() = serialize this
 
         static member New correlationId principal =
-            { Timestamp = getCurrentInstant (); CorrelationId = correlationId; Principal = principal; Properties = Dictionary<string, string>() }
+            {
+                Timestamp = getCurrentInstant ()
+                CorrelationId = correlationId
+                Principal = principal
+                ClientType = Microsoft.FSharp.Core.Option.None
+                Properties = Dictionary<string, string>()
+            }
 
     /// A FileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
     ///

--- a/src/OpenAPI/Shared.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Shared.Components.OpenAPI.yaml
@@ -187,10 +187,21 @@ components:
           type: string
         Principal:
           type: string
+        ClientType:
+          $ref: '#/components/schemas/ClientType'
         Properties:
           type: object
           additionalProperties:
             type: string
+
+    ClientType:
+      description: Identifies the Grace client that initiated an API request.
+      type: object
+      additionalProperties: false
+      properties:
+        CLI:
+          description: The Grace CLI assembly file version.
+          type: string
 
     GraceReturnValue:
       type: object


### PR DESCRIPTION
## Linked issue

Closes #72

## Summary

- Adds `ClientType` with `CLI(version)` and stores optional client identity on `EventMetadata`.
- Adds SDK client identity configuration plus `X-Grace-Client-Type` and `X-Grace-Client-Version` headers on SDK HTTP calls.
- Configures Grace CLI startup to stamp SDK calls with the CLI assembly file version.
- Reads client identity headers into server-created `EventMetadata` and updates OpenAPI/docs.
- Adds focused type, CLI, and server metadata coverage and updates existing metadata fixtures.

## Touched paths

- `src/Grace.Types/Types.Types.fs`
- `src/Grace.Types.Tests/*`
- `src/Grace.Shared/Constants.Shared.fs`
- `src/Grace.SDK/*`
- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI/Program.CLI.fs`
- `src/Grace.CLI.Tests/*`
- `src/Grace.Server/Services.Server.fs`
- `src/Grace.Server.Tests/*`
- `src/OpenAPI/Shared.Components.OpenAPI.yaml`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: domain-contract
- Public behavior or docs-only validation target: shared `EventMetadata` plus SDK-to-server client identity headers.
- RED evidence or docs-only waiver: original issue requested focused tests for metadata/client identity behavior; this branch adds the failing-boundary coverage with the implementation.
- Focused validation: Release build, Grace.Types tests, filtered Grace.CLI client identity tests, SDK AGENTS MarkdownLint, and diff whitespace checks all passed after rebasing onto current `origin/main`.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Added `src/Grace.Types.Tests/EventMetadata.Types.Tests.fs` for `EventMetadata` default client identity and JSON round-trip behavior.
- Added `ClientIdentityTests` in `src/Grace.CLI.Tests/Program.CLI.Tests.fs` for CLI SDK identity stamping and SDK client header emission.
- Added server metadata header coverage in `src/Grace.Server.Tests/General.Server.Tests.fs`.
- Updated existing metadata fixture construction across affected type and server tests.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [x] Server or API contract
- [ ] Orleans actor behavior
- [x] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

Docs updated:

- `src/Grace.SDK/AGENTS.md` documents the client identity header pattern.
- `src/OpenAPI/Shared.Components.OpenAPI.yaml` includes `ClientType` on `EventMetadata`.

## Validation run

- [ ] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet build src\Grace.slnx -c Release --no-restore`
- [x] Focused tests: `dotnet test src\Grace.Types.Tests\Grace.Types.Tests.fsproj -c Release --no-build`
- [x] Focused tests: `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj -c Release --no-build --filter FullyQualifiedName~ClientIdentityTests`
- [x] Formatting/linting: `npx --yes markdownlint-cli2 src\Grace.SDK\AGENTS.md`
- [x] Formatting/linting: `git diff --check`
- [x] Formatting/linting: `git diff --cached --check`

## Validation not run

- `pwsh ./scripts/validate.ps1 -Fast` was not rerun in this publish pass. The earlier issue completion comment reported it built successfully and then the unfiltered `Grace.CLI.Tests` runner did not return promptly; this pass reran the focused validation after rebasing the stranded commit onto current `origin/main`.
- `pwsh ./scripts/validate.ps1 -Full` was not run because this change does not touch Aspire, emulators, storage providers, Service Bus, Cosmos DB, Redis, deployment, or runtime emulator behavior.

## Residual risks

- The SDK client identity configuration is process-wide mutable state. The focused tests clear it around assertions, but reviewers should confirm this remains acceptable for concurrent non-CLI SDK consumers.
- Broader server test execution was not rerun in this publish pass.

## Rollback or recovery notes

Revert this PR to remove the client identity metadata contract, SDK header emission, CLI stamping, and OpenAPI/docs updates.

## Docs follow-up required

None expected beyond the SDK AGENTS note and OpenAPI component update included here.