### PR TITLE
Add ADR-0001 CAS contract shells

### DIFF
--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />
     <Compile Include="Validation.Types.Tests.fs" />
+    <Compile Include="Types.Types.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Types.Tests/Types.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Types.Types.Tests.fs
@@ -82,6 +82,7 @@ type TypesTypesTests() =
             )
 
         let fileVersion = FileVersion.Create "src/large.bin" "abc123" "https://example.test/blob" true 4096L
+        fileVersion.CreatedAt <- NodaTime.Instant.FromUtc(2025, 1, 1, 0, 0)
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
 
         let jsonRoundTrip = deserialize<FileVersion> (serialize fileVersion)
@@ -90,3 +91,16 @@ type TypesTypesTests() =
 
         Assert.That(jsonRoundTrip.ContentReference, Is.EqualTo(FileContentReference.FileManifest manifest))
         Assert.That(messagePackRoundTrip.ContentReference, Is.EqualTo(FileContentReference.FileManifest manifest))
+        Assert.That(jsonRoundTrip.ContentReference, Is.EqualTo(fileVersion.ContentReference))
+        Assert.That(jsonRoundTrip.ContentReference = fileVersion.ContentReference, Is.True)
+        Assert.That(jsonRoundTrip.Class, Is.EqualTo(fileVersion.Class))
+        Assert.That(jsonRoundTrip.RelativePath, Is.EqualTo(fileVersion.RelativePath))
+        Assert.That(jsonRoundTrip.Sha256Hash, Is.EqualTo(fileVersion.Sha256Hash))
+        Assert.That(jsonRoundTrip.IsBinary, Is.EqualTo(fileVersion.IsBinary))
+        Assert.That(jsonRoundTrip.Size, Is.EqualTo(fileVersion.Size))
+        Assert.That(jsonRoundTrip.CreatedAt, Is.EqualTo(fileVersion.CreatedAt))
+        Assert.That(jsonRoundTrip.BlobUri, Is.EqualTo(fileVersion.BlobUri))
+        Assert.That(jsonRoundTrip.Equals(fileVersion), Is.True)
+        Assert.That(messagePackRoundTrip.Equals(fileVersion), Is.True)
+        Assert.That(jsonRoundTrip.GetHashCode(), Is.EqualTo(fileVersion.GetHashCode()))
+        Assert.That(messagePackRoundTrip.GetHashCode(), Is.EqualTo(fileVersion.GetHashCode()))

--- a/src/Grace.Types.Tests/Types.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Types.Types.Tests.fs
@@ -1,0 +1,92 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open MessagePack
+open NUnit.Framework
+
+[<MessagePackObject>]
+type LegacyFileVersion =
+    {
+        [<Key(0)>]
+        Class: string
+        [<Key(1)>]
+        RelativePath: RelativePath
+        [<Key(2)>]
+        Sha256Hash: Sha256Hash
+        [<Key(3)>]
+        IsBinary: bool
+        [<Key(4)>]
+        Size: int64
+        [<Key(5)>]
+        CreatedAt: NodaTime.Instant
+        [<Key(6)>]
+        BlobUri: string
+    }
+
+[<Parallelizable(ParallelScope.All)>]
+type TypesTypesTests() =
+    [<Test>]
+    member _.FileVersionCreateDefaultsContentReferenceToWholeFileContent() =
+        let fileVersion = FileVersion.Create "src/app.fs" "abc123" "https://example.test/blob" false 123L
+
+        Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+
+    [<Test>]
+    member _.FileVersionJsonWithoutContentReferenceDefaultsToWholeFileContent() =
+        let legacyJson =
+            """
+{
+  "Class": "FileVersion",
+  "RelativePath": "src/app.fs",
+  "Sha256Hash": "abc123",
+  "IsBinary": false,
+  "Size": 123,
+  "CreatedAt": "2025-01-01T00:00:00Z",
+  "BlobUri": "https://example.test/blob"
+}
+"""
+
+        let fileVersion = deserialize<FileVersion> legacyJson
+
+        Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+
+    [<Test>]
+    member _.FileVersionMessagePackWithoutContentReferenceDefaultsToWholeFileContent() =
+        let legacyFileVersion =
+            {
+                Class = "FileVersion"
+                RelativePath = "src/app.fs"
+                Sha256Hash = "abc123"
+                IsBinary = false
+                Size = 123L
+                CreatedAt = NodaTime.Instant.FromUtc(2025, 1, 1, 0, 0)
+                BlobUri = "https://example.test/blob"
+            }
+
+        let bytes = MessagePackSerializer.Serialize(legacyFileVersion, Constants.messagePackSerializerOptions)
+        let fileVersion = MessagePackSerializer.Deserialize<FileVersion>(bytes, Constants.messagePackSerializerOptions)
+
+        Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+
+    [<Test>]
+    member _.FileVersionManifestContentReferenceRoundTripsThroughJsonAndMessagePack() =
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress "manifest-blake3-abc123",
+                4096L,
+                [
+                    ContentBlock.Create(ContentBlockAddress "block-blake3-def456", 0L, 4096L)
+                ]
+            )
+
+        let fileVersion = FileVersion.Create "src/large.bin" "abc123" "https://example.test/blob" true 4096L
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let jsonRoundTrip = deserialize<FileVersion> (serialize fileVersion)
+        let messagePackBytes = MessagePackSerializer.Serialize(fileVersion, Constants.messagePackSerializerOptions)
+        let messagePackRoundTrip = MessagePackSerializer.Deserialize<FileVersion>(messagePackBytes, Constants.messagePackSerializerOptions)
+
+        Assert.That(jsonRoundTrip.ContentReference, Is.EqualTo(FileContentReference.FileManifest manifest))
+        Assert.That(messagePackRoundTrip.ContentReference, Is.EqualTo(FileContentReference.FileManifest manifest))

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -119,6 +119,12 @@ module Types =
     /// A SHA-256 hash value.
     type Sha256Hash = string
 
+    /// The content-addressed identifier for a reusable content block.
+    type ContentBlockAddress = string
+
+    /// The content-addressed identifier for a file manifest.
+    type ManifestAddress = string
+
     type StorageAccountName = string
     type StorageConnectionString = string
     type StorageContainerName = string
@@ -220,28 +226,95 @@ module Types =
         static member New correlationId principal =
             { Timestamp = getCurrentInstant (); CorrelationId = correlationId; Principal = principal; Properties = Dictionary<string, string>() }
 
-    /// A FileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
-    ///
-    /// It is the server-side representation of the LocalFileVersion type, used for the local object cache.
+    /// A content block is an inert CAS contract shell for a contiguous byte range inside manifest-backed file content.
     [<CLIMutable; MessagePackObject; GenerateSerializer>]
-    type FileVersion =
+    type ContentBlock =
         {
             [<Key(0)>]
             Class: string
-            //RepositoryId: RepositoryId
             [<Key(1)>]
-            RelativePath: RelativePath
+            Address: ContentBlockAddress
             [<Key(2)>]
-            Sha256Hash: Sha256Hash
+            Offset: int64
             [<Key(3)>]
-            IsBinary: bool
-            [<Key(4)>]
             Size: int64
-            [<Key(5)>]
-            CreatedAt: Instant
-            [<Key(6)>]
-            BlobUri: string
         }
+
+        static member Create(address: ContentBlockAddress, offset: int64, size: int64) =
+            { Class = "ContentBlock"; Address = address; Offset = offset; Size = size }
+
+        static member Default = ContentBlock.Create(String.Empty, 0L, 0L)
+
+    /// A file manifest is an inert CAS contract shell for content assembled from one or more content blocks.
+    [<CLIMutable; MessagePackObject; GenerateSerializer>]
+    type FileManifest =
+        {
+            [<Key(0)>]
+            Class: string
+            [<Key(1)>]
+            ManifestAddress: ManifestAddress
+            [<Key(2)>]
+            Size: int64
+            [<Key(3)>]
+            Blocks: List<ContentBlock>
+        }
+
+        static member Create(manifestAddress: ManifestAddress, size: int64, blocks: ContentBlock list) =
+            { Class = "FileManifest"; ManifestAddress = manifestAddress; Size = size; Blocks = List<ContentBlock>(blocks) }
+
+        static member Default = FileManifest.Create(String.Empty, 0L, [])
+
+    /// Identifies the shape of a FileVersion content reference.
+    type FileContentReferenceType =
+        | WholeFileContent = 0
+        | FileManifest = 1
+
+    /// Identifies how a FileVersion refers to its file bytes.
+    [<CLIMutable; MessagePackObject; GenerateSerializer>]
+    type FileContentReference =
+        {
+            [<Key(0)>]
+            Class: string
+            [<Key(1)>]
+            ReferenceType: FileContentReferenceType
+            [<Key(2)>]
+            Manifest: FileManifest option
+        }
+
+        static member WholeFileContent = { Class = "FileContentReference"; ReferenceType = FileContentReferenceType.WholeFileContent; Manifest = None }
+
+        static member FileManifest manifest =
+            { Class = "FileContentReference"; ReferenceType = FileContentReferenceType.FileManifest; Manifest = Some manifest }
+
+    /// A FileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
+    ///
+    /// It is the server-side representation of the LocalFileVersion type, used for the local object cache.
+    [<MessagePackObject; GenerateSerializer>]
+    type FileVersion() =
+        [<Key(0)>]
+        member val Class: string = "FileVersion" with get, set
+
+        //RepositoryId: RepositoryId
+        [<Key(1)>]
+        member val RelativePath: RelativePath = String.Empty with get, set
+
+        [<Key(2)>]
+        member val Sha256Hash: Sha256Hash = String.Empty with get, set
+
+        [<Key(3)>]
+        member val IsBinary: bool = false with get, set
+
+        [<Key(4)>]
+        member val Size: int64 = 0L with get, set
+
+        [<Key(5)>]
+        member val CreatedAt: Instant = getCurrentInstant () with get, set
+
+        [<Key(6)>]
+        member val BlobUri: string = String.Empty with get, set
+
+        [<Key(7)>]
+        member val ContentReference: FileContentReference = FileContentReference.WholeFileContent with get, set
 
         static member Create
             //(repositoryId: RepositoryId)
@@ -251,16 +324,17 @@ module Types =
             (isBinary: bool)
             (size: int64)
             =
-            {
-                Class = "FileVersion"
-                //RepositoryId = repositoryId
-                RelativePath = RelativePath(normalizeFilePath $"{relativePath}")
-                Sha256Hash = sha256Hash
-                BlobUri = blobUri
-                IsBinary = isBinary
-                Size = size
-                CreatedAt = getCurrentInstant ()
-            }
+            let fileVersion = FileVersion()
+            fileVersion.Class <- "FileVersion"
+            //fileVersion.RepositoryId <- repositoryId
+            fileVersion.RelativePath <- RelativePath(normalizeFilePath $"{relativePath}")
+            fileVersion.Sha256Hash <- sha256Hash
+            fileVersion.BlobUri <- blobUri
+            fileVersion.IsBinary <- isBinary
+            fileVersion.Size <- size
+            fileVersion.CreatedAt <- getCurrentInstant ()
+            fileVersion.ContentReference <- FileContentReference.WholeFileContent
+            fileVersion
 
         static member Default = FileVersion.Create String.Empty String.Empty String.Empty false 0L
 
@@ -275,6 +349,22 @@ module Types =
         /// Gets the relative directory path of the file. Example: "/dir/subdir/file.js" -> "/dir/subdir/".
         [<IgnoreMember>]
         member this.RelativeDirectory = getRelativeDirectory $"{this.RelativePath}" ""
+
+        override this.Equals(other) =
+            match other with
+            | :? FileVersion as otherFileVersion ->
+                this.Class = otherFileVersion.Class
+                && this.RelativePath = otherFileVersion.RelativePath
+                && this.Sha256Hash = otherFileVersion.Sha256Hash
+                && this.IsBinary = otherFileVersion.IsBinary
+                && this.Size = otherFileVersion.Size
+                && this.CreatedAt = otherFileVersion.CreatedAt
+                && this.BlobUri = otherFileVersion.BlobUri
+                && this.ContentReference = otherFileVersion.ContentReference
+            | _ -> false
+
+        override this.GetHashCode() =
+            HashCode.Combine(this.Class, this.RelativePath, this.Sha256Hash, this.IsBinary, this.Size, this.CreatedAt, this.BlobUri, this.ContentReference)
 
     /// A LocalFileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
     ///

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -246,7 +246,7 @@ module Types =
         static member Default = ContentBlock.Create(String.Empty, 0L, 0L)
 
     /// A file manifest is an inert CAS contract shell for content assembled from one or more content blocks.
-    [<CLIMutable; MessagePackObject; GenerateSerializer>]
+    [<CLIMutable; MessagePackObject; GenerateSerializer; CustomEquality; NoComparison>]
     type FileManifest =
         {
             [<Key(0)>]
@@ -263,6 +263,27 @@ module Types =
             { Class = "FileManifest"; ManifestAddress = manifestAddress; Size = size; Blocks = List<ContentBlock>(blocks) }
 
         static member Default = FileManifest.Create(String.Empty, 0L, [])
+
+        override this.Equals(other: obj) =
+            match other with
+            | :? FileManifest as otherManifest ->
+                this.Class = otherManifest.Class
+                && this.ManifestAddress = otherManifest.ManifestAddress
+                && this.Size = otherManifest.Size
+                && this.Blocks.Count = otherManifest.Blocks.Count
+                && Seq.forall2 (=) this.Blocks otherManifest.Blocks
+            | _ -> false
+
+        override this.GetHashCode() =
+            let mutable hashCode = HashCode()
+            hashCode.Add(this.Class)
+            hashCode.Add(this.ManifestAddress)
+            hashCode.Add(this.Size)
+
+            for block in this.Blocks do
+                hashCode.Add(block)
+
+            hashCode.ToHashCode()
 
     /// Identifies the shape of a FileVersion content reference.
     type FileContentReferenceType =
@@ -350,7 +371,7 @@ module Types =
         [<IgnoreMember>]
         member this.RelativeDirectory = getRelativeDirectory $"{this.RelativePath}" ""
 
-        override this.Equals(other) =
+        override this.Equals(other: obj) =
             match other with
             | :? FileVersion as otherFileVersion ->
                 this.Class = otherFileVersion.Class


### PR DESCRIPTION
## Summary

- Adds inert ADR-0001 CAS contract shells for `ContentBlock`, `FileManifest`, and `FileContentReference`.
- Adds additive `FileVersion.ContentReference`, defaulting current factory/new/legacy payload behavior to `WholeFileContent`.
- Adds focused contract tests for default behavior plus JSON and MessagePack compatibility/round-tripping.

Closes #79.

## Touched Paths

- `src/Grace.Types/Types.Types.fs`
- `src/Grace.Types.Tests/Types.Types.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

- RED evidence: `dotnet test src\Grace.Types.Tests\Grace.Types.Tests.fsproj -c Release` initially failed because `FileVersion.ContentReference`, `FileContentReference`, and the CAS shell types were not defined.
- GREEN focused: `dotnet test src\Grace.Types.Tests\Grace.Types.Tests.fsproj -c Release` passed: 20 passed, 0 failed, 0 skipped.
- Formatting: from `./src`, ran `dotnet tool run fantomas --recurse .`; reverted unrelated full-repo formatting churn, then ran targeted `dotnet tool run fantomas Grace.Types\Types.Types.fs Grace.Types.Tests\Types.Types.Tests.fs` / `Grace.Types.Tests\Types.Types.Tests.fs` for touched files.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast` passed. Build succeeded with 0 warnings/0 errors; Authorization tests 21 passed; CLI tests 194 passed, 1 skipped; Types tests 20 passed.

## Docs Impact

- No user-facing docs update. This is an inert contract shell and preserves current behavior by defaulting to `WholeFileContent`.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not change Aspire, storage runtime behavior, Service Bus, Cosmos DB, Redis, deployment, GC, or compaction behavior.

## Residual Risk

- `FileVersion` now uses a parameterless contract class rather than an F# record so legacy JSON/MessagePack payloads can retain the default `ContentReference`; equality/hash behavior is preserved explicitly, but this is still a shared contract shape worth review.

## Follow-ups

- Downstream ADR-0001 DAG nodes should add hash/address semantics, eligibility policy, storage key builders, and upload-session behavior in their own issue-owned branches.
