### PR TITLE
Add manifest eligibility policy evaluator

### DIFF
--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -28,6 +28,7 @@
         <Compile Include="Authorization.Shared.fs" />
         <Compile Include="Converters\BranchDtoConverter.Shared.fs" />
         <Compile Include="Services.Shared.fs" />
+        <Compile Include="ManifestEligibility.Shared.fs" />
         <Compile Include="Diff.Shared.fs" />
         <Compile Include="Evidence.Shared.fs" />
         <Compile Include="ReviewNotes.Shared.fs" />

--- a/src/Grace.Shared/ManifestEligibility.Shared.fs
+++ b/src/Grace.Shared/ManifestEligibility.Shared.fs
@@ -1,0 +1,52 @@
+namespace Grace.Shared
+
+open Grace.Types.Types
+open System
+open System.IO
+open System.IO.Compression
+
+module ManifestEligibility =
+    let private normalizedScanBytes (policy: ManifestEligibilityPolicy) contentLength = Math.Min(Math.Max(policy.BinaryScanBytes, 0), contentLength)
+
+    /// Detects binary content by scanning only the configured prefix for a NUL byte.
+    let detectBinaryContent (policy: ManifestEligibilityPolicy) (content: byte array) =
+        ArgumentNullException.ThrowIfNull(content)
+
+        let bytesToScan = normalizedScanBytes policy content.Length
+        let mutable isBinary = false
+        let mutable index = 0
+
+        while index < bytesToScan && not isBinary do
+            if content[index] = 0uy then isBinary <- true
+
+            index <- index + 1
+
+        isBinary
+
+    /// Returns the byte count produced by Grace's gzip settings for text content.
+    let getGraceGzipCompressedSize (content: byte array) =
+        ArgumentNullException.ThrowIfNull(content)
+
+        use compressed = new MemoryStream()
+
+        do
+            use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
+
+            gzipStream.Write(content, 0, content.Length)
+
+        compressed.Length
+
+    /// Evaluates whether content should remain whole-file content or be stored through a file manifest.
+    let evaluateContentReferenceType (policy: ManifestEligibilityPolicy) (content: byte array) =
+        ArgumentNullException.ThrowIfNull(content)
+
+        let measuredSize =
+            if detectBinaryContent policy content then
+                int64 content.Length
+            else
+                getGraceGzipCompressedSize content
+
+        if measuredSize >= policy.ThresholdBytes then
+            FileContentReferenceType.FileManifest
+        else
+            FileContentReferenceType.WholeFileContent

--- a/src/Grace.Types.Tests/Types.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Types.Types.Tests.fs
@@ -3,8 +3,11 @@ namespace Grace.Types.Tests
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Types
+open Grace.Types.Repository
 open MessagePack
 open NUnit.Framework
+open System.IO
+open System.IO.Compression
 
 [<MessagePackObject>]
 type LegacyFileVersion =
@@ -25,8 +28,96 @@ type LegacyFileVersion =
         BlobUri: string
     }
 
+module ManifestEligibilityTestData =
+    let thresholdBytes = 1024 * 1024
+
+    let private gzipSize (content: byte array) =
+        use compressed = new MemoryStream()
+
+        use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
+
+        gzipStream.Write(content, 0, content.Length)
+        gzipStream.Dispose()
+        compressed.Length
+
+    let private pseudoRandomTextBytes length =
+        let mutable state = 0x6C8E9CF5u
+
+        Array.init length (fun _ ->
+            state <- (state * 1664525u) + 1013904223u
+            byte ((state >>> 16) % 255u + 1u))
+
+    let binaryBelowThreshold =
+        let bytes = Array.create (thresholdBytes - 1) 0xFFuy
+        bytes[0] <- 0uy
+        bytes
+
+    let binaryAtThreshold =
+        let bytes = Array.create thresholdBytes 0xFFuy
+        bytes[0] <- 0uy
+        bytes
+
+    let textCompressesBelowThreshold = Array.create thresholdBytes (byte 'a')
+
+    let textCompressesAtOrAboveThreshold =
+        let bytes = pseudoRandomTextBytes thresholdBytes
+        Assert.That(gzipSize bytes, Is.GreaterThanOrEqualTo(int64 thresholdBytes))
+        bytes
+
+    let nulAtLastScannedByte =
+        let bytes = Array.create (thresholdBytes - 1) 0xFFuy
+        bytes[8191] <- 0uy
+        bytes
+
+    let nulAfterScanWindow =
+        let bytes = Array.create thresholdBytes (byte 'a')
+        bytes[8192] <- 0uy
+        bytes
+
+    let eligibilityCases =
+        [|
+            "binary below threshold stays whole-file", binaryBelowThreshold, FileContentReferenceType.WholeFileContent
+            "binary at threshold becomes manifest-backed", binaryAtThreshold, FileContentReferenceType.FileManifest
+            "text at uncompressed threshold stays whole-file when Grace gzip size is below threshold",
+            textCompressesBelowThreshold,
+            FileContentReferenceType.WholeFileContent
+            "text becomes manifest-backed when Grace gzip size reaches threshold", textCompressesAtOrAboveThreshold, FileContentReferenceType.FileManifest
+        |]
+
+    let binaryDetectionCases =
+        [|
+            "NUL at byte 8191 is binary", nulAtLastScannedByte, true
+            "NUL at byte 8192 is outside the scan window", nulAfterScanWindow, false
+        |]
+
 [<Parallelizable(ParallelScope.All)>]
 type TypesTypesTests() =
+    [<Test>]
+    member _.ManifestEligibilityPolicyDefaultUsesOneMiBThresholdAndEightKiBScanWindow() =
+        let policy = ManifestEligibilityPolicy.Default
+
+        Assert.That(policy.ThresholdBytes, Is.EqualTo(int64 ManifestEligibilityTestData.thresholdBytes))
+        Assert.That(policy.BinaryScanBytes, Is.EqualTo(8 * 1024))
+        Assert.That(RepositoryDto.Default.ManifestEligibilityPolicy, Is.EqualTo(policy))
+
+    [<Test>]
+    member _.ManifestEligibilityEvaluatorUsesThresholdAndCompressionPolicyTable() =
+        let policy = ManifestEligibilityPolicy.Default
+
+        for caseName, content, expectedReferenceType in ManifestEligibilityTestData.eligibilityCases do
+            let actualReferenceType = ManifestEligibility.evaluateContentReferenceType policy content
+
+            Assert.That(actualReferenceType, Is.EqualTo(expectedReferenceType), caseName)
+
+    [<Test>]
+    member _.ManifestEligibilityBinaryDetectorScansOnlyTheFirstEightKiBForNul() =
+        let policy = ManifestEligibilityPolicy.Default
+
+        for caseName, content, expectedIsBinary in ManifestEligibilityTestData.binaryDetectionCases do
+            let actualIsBinary = ManifestEligibility.detectBinaryContent policy content
+
+            Assert.That(actualIsBinary, Is.EqualTo(expectedIsBinary), caseName)
+
     [<Test>]
     member _.FileVersionCreateDefaultsContentReferenceToWholeFileContent() =
         let fileVersion = FileVersion.Create "src/app.fs" "abc123" "https://example.test/blob" false 123L

--- a/src/Grace.Types/Repository.Types.fs
+++ b/src/Grace.Types/Repository.Types.fs
@@ -115,6 +115,7 @@ module Repository =
             Description: string
             RecordSaves: bool
             ConflictResolutionPolicy: ConflictResolutionPolicy
+            ManifestEligibilityPolicy: ManifestEligibilityPolicy
             CreatedAt: Instant
             InitializedAt: Instant option
             UpdatedAt: Instant option
@@ -146,6 +147,7 @@ module Repository =
                 Description = String.Empty
                 RecordSaves = true
                 ConflictResolutionPolicy = ConflictResolutionPolicy.ConflictsAllowed 0.8f
+                ManifestEligibilityPolicy = ManifestEligibilityPolicy.Default
                 CreatedAt = Constants.DefaultTimestamp
                 InitializedAt = None
                 UpdatedAt = None

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -226,6 +226,23 @@ module Types =
         static member New correlationId principal =
             { Timestamp = getCurrentInstant (); CorrelationId = correlationId; Principal = principal; Properties = Dictionary<string, string>() }
 
+    /// Repository-level creation policy for choosing whole-file content or manifest-backed content.
+    ///
+    /// The policy is a creation-time gate. Grace stores the resulting content reference shape rather than a separate
+    /// mutable eligibility decision.
+    [<CLIMutable; MessagePackObject; GenerateSerializer>]
+    type ManifestEligibilityPolicy =
+        {
+            [<Key(0)>]
+            Class: string
+            [<Key(1)>]
+            ThresholdBytes: int64
+            [<Key(2)>]
+            BinaryScanBytes: int
+        }
+
+        static member Default = { Class = nameof ManifestEligibilityPolicy; ThresholdBytes = 1024L * 1024L; BinaryScanBytes = 8 * 1024 }
+
     /// A content block is an inert CAS contract shell for a contiguous byte range inside manifest-backed file content.
     [<CLIMutable; MessagePackObject; GenerateSerializer>]
     type ContentBlock =


### PR DESCRIPTION
Closes #84.

## Summary

- Added the canonical `ManifestEligibilityPolicy` contract with repository defaults for a 1 MiB threshold and 8 KiB binary scan window.
- Added a pure `Grace.Shared.ManifestEligibility` evaluator that chooses `WholeFileContent` or `FileManifest` from bytes.
- Covered binary and text threshold behavior with focused table tests.

## TDD Evidence

- RED: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter FullyQualifiedName~Grace.Types.Tests.TypesTypesTests` failed before implementation with FS0039 for missing `ManifestEligibilityPolicy`, repository policy field, and `ManifestEligibility` module.
- GREEN: same focused test passed after implementation: 7 passed, 0 failed.

## Validation

- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter FullyQualifiedName~Grace.Types.Tests.TypesTypesTests` - passed, 7/7.
- `dotnet tool run fantomas Grace.Types/Types.Types.fs Grace.Types/Repository.Types.fs Grace.Shared/ManifestEligibility.Shared.fs Grace.Types.Tests/Types.Types.Tests.fs` from `./src` - completed; targeted to owned touched files to avoid sibling churn.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed; build 0 warnings/0 errors, Authorization 21/21, CLI 194 passed/1 skipped, Types 23/23.

## Docs Impact

- Updated XML/type comments on `ManifestEligibilityPolicy` to capture policy immutability and inferred decision semantics.
- No README/AGENTS workflow docs changed because commands, workflow, and public CLI/API behavior are unchanged.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not touch Aspire, emulators, storage runtime behavior, Service Bus, Cosmos DB, Redis, or cross-service integration.

## Residual Risk

- Low. The evaluator is pure and covered at the contract boundary; downstream consumers compile, but no runtime caller is wired in this DAG slice.

## Follow-ups

- Downstream DAG issues can call the evaluator when creating `FileContentReference` values for actual content upload/planning flows.