### PR TITLE
Add shared storage key builders

### DIFF
--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -24,6 +24,7 @@
         <Compile Include="Resources\Utilities.Resources.fs" />
         <Compile Include="Combinators.fs" />
         <Compile Include="Utilities.Shared.fs" />
+        <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />
         <Compile Include="Converters\BranchDtoConverter.Shared.fs" />

--- a/src/Grace.Shared/StorageKeys.Shared.fs
+++ b/src/Grace.Shared/StorageKeys.Shared.fs
@@ -1,0 +1,28 @@
+namespace Grace.Shared
+
+open Grace.Types.Types
+
+module StorageKeys =
+    [<Literal>]
+    let private CasPrefix = "cas"
+
+    [<Literal>]
+    let private ContentBlocksPrefix = "content-blocks"
+
+    [<Literal>]
+    let private FileManifestsPrefix = "file-manifests"
+
+    [<Literal>]
+    let private ContentBlockMetadataPrefix = "content-block-metadata"
+
+    /// Builds the current repository-scoped object key for whole-file content.
+    let wholeFileContentObjectKey (fileVersion: FileVersion) = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+
+    /// Builds the StoragePool-scoped object key for a content-addressed ContentBlock payload.
+    let contentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = $"{CasPrefix}/{ContentBlocksPrefix}/{contentBlockAddress}"
+
+    /// Builds the StoragePool-scoped object key for a content-addressed FileManifest record.
+    let fileManifestObjectKey (manifestAddress: ManifestAddress) = $"{CasPrefix}/{FileManifestsPrefix}/{manifestAddress}"
+
+    /// Builds the StoragePool-scoped object key for mutable ContentBlock metadata.
+    let contentBlockMetadataObjectKey (contentBlockAddress: ContentBlockAddress) = $"{CasPrefix}/{ContentBlockMetadataPrefix}/{contentBlockAddress}.json"

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="PromotionSet.Types.Tests.fs" />
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Types.Types.Tests.fs" />
+    <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
@@ -1,0 +1,60 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.Types
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type StorageKeysSharedTests() =
+    [<Test>]
+    member _.WholeFileContentObjectKeyMatchesExistingBlobKeyShape() =
+        let fileVersion =
+            FileVersion.Create
+                "src/Grace.Server/Storage.Server.fs"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                "https://example.test/blob"
+                false
+                1234L
+
+        let key = StorageKeys.wholeFileContentObjectKey fileVersion
+
+        Assert.That(key, Is.EqualTo("src/Grace.Server/Storage.Server.fs/Storage.Server_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.fs"))
+
+    [<Test>]
+    member _.WholeFileContentObjectKeyPreservesExtensionlessBlobKeyShape() =
+        let fileVersion = FileVersion.Create "Dockerfile" "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" "" false 2048L
+
+        let key = StorageKeys.wholeFileContentObjectKey fileVersion
+
+        Assert.That(key, Is.EqualTo("Dockerfile/Dockerfile_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"))
+
+    [<Test>]
+    member _.ContentBlockObjectKeyDependsOnlyOnContentBlockAddress() =
+        let address = ContentBlockAddress "block-blake3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+        let firstKey = StorageKeys.contentBlockObjectKey address
+        let secondKey = StorageKeys.contentBlockObjectKey address
+
+        Assert.That(firstKey, Is.EqualTo("cas/content-blocks/block-blake3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+        Assert.That(secondKey, Is.EqualTo(firstKey))
+
+    [<Test>]
+    member _.ManifestObjectKeyDependsOnlyOnManifestAddress() =
+        let address = ManifestAddress "manifest-blake3-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        let firstKey = StorageKeys.fileManifestObjectKey address
+        let secondKey = StorageKeys.fileManifestObjectKey address
+
+        Assert.That(firstKey, Is.EqualTo("cas/file-manifests/manifest-blake3-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+        Assert.That(secondKey, Is.EqualTo(firstKey))
+
+    [<Test>]
+    member _.ContentBlockMetadataObjectKeyDependsOnlyOnContentBlockAddress() =
+        let address = ContentBlockAddress "block-blake3-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+        let firstKey = StorageKeys.contentBlockMetadataObjectKey address
+        let secondKey = StorageKeys.contentBlockMetadataObjectKey address
+
+        Assert.That(firstKey, Is.EqualTo("cas/content-block-metadata/block-blake3-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc.json"))
+
+        Assert.That(secondKey, Is.EqualTo(firstKey))


### PR DESCRIPTION
## Linked issue

Closes #85

## Summary

- Added `Grace.Shared.StorageKeys` builders for whole-file content, content blocks, file manifests, and content-block metadata.
- Preserved the existing whole-file blob key shape: `{RelativePath}/{GetObjectFileName}`.
- Added golden tests proving whole-file compatibility and ADR-required repository/path independence for new CAS keys.

## Touched paths

- `src/Grace.Shared/Grace.Shared.fsproj`
- `src/Grace.Shared/StorageKeys.Shared.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`
- `src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: domain-contract
- Public behavior or docs-only validation target: storage object key builder compatibility and CAS key independence
- RED evidence or docs-only waiver: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter StorageKeysSharedTests` failed before implementation with `FS0039: The value, namespace, type or module 'StorageKeys' is not defined`.
- Focused validation: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter StorageKeysSharedTests` passed with 5 tests.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Added `src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs`.
- Covers existing whole-file key compatibility, extensionless whole-file keys, content-block keys, file-manifest keys, and content-block metadata keys.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [x] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast` passed in 00:03:37.3555531.
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter StorageKeysSharedTests` passed with 5 tests.
- [x] Focused tests: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj` passed with 25 tests.
- [x] Formatting/linting: `dotnet tool run fantomas --recurse .` from `./src` was run; it produced broad unrelated formatting churn, so those out-of-scope rewrites were restored. Targeted follow-up `dotnet tool run fantomas src/Grace.Shared/StorageKeys.Shared.fs src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs` reported both files unchanged.
- [x] Formatting/linting: `git diff --check` passed.
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice only adds pure shared key builders and focused contract tests. It does not change runtime blob storage, Aspire, emulators, Cosmos DB, Service Bus, Redis, GC, compaction, or cross-service behavior.

## Residual risks

- Runtime storage callers are not switched to these builders in this PR by design; follow-up storage-runtime slices must adopt the centralized helpers carefully.
- CAS key prefixes are now golden-tested as contract helpers, but ADR-0001 leaves exact object layout to implementation slices.

## Rollback or recovery notes

- Revert this PR to remove the helper module and its tests. No persisted data or runtime storage behavior changes are introduced.

## Docs follow-up required

- None for this helper-only slice.
