### PR TITLE
Add BLAKE3 content address helpers

### DIFF
--- a/src/Grace.Shared/ContentAddress.Shared.fs
+++ b/src/Grace.Shared/ContentAddress.Shared.fs
@@ -1,0 +1,114 @@
+namespace Grace.Shared
+
+open Blake3
+open Grace.Types.Types
+open System
+open System.Text
+open System.Text.RegularExpressions
+
+module ContentAddress =
+    [<Literal>]
+    let AddressHexLength = 64
+
+    [<Literal>]
+    let private ContentBlockPreimageHeader = "grace.cas.v1.content-block"
+
+    [<Literal>]
+    let private FileManifestPreimageHeader = "grace.cas.v1.file-manifest"
+
+    let private lowercaseAddressRegex =
+        Regex(
+            "^[0-9a-f]{64}$",
+            RegexOptions.Compiled
+            ||| RegexOptions.CultureInvariant
+        )
+
+    let private appendLine (builder: StringBuilder) (value: string) = builder.Append(value).Append('\n') |> ignore
+
+    let private ensureNonNegative name value =
+        if value < 0L then
+            invalidArg name "Content address preimage values cannot be negative."
+
+    let private requireValidAddress name (address: string) =
+        if lowercaseAddressRegex.IsMatch(address) then
+            address
+        else
+            invalidArg name "Content addresses must be lowercase 64-character hexadecimal BLAKE3 values."
+
+    let private requireNonEmptySequence name values =
+        if isNull (box values) then nullArg name
+
+        let valuesArray = values |> Seq.toArray
+
+        if valuesArray.Length = 0 then
+            invalidArg name "Content address preimages require at least one entry."
+
+        valuesArray
+
+    /// Computes the lowercase 64-hex BLAKE3 address for a byte payload.
+    let computeBlake3Hex (bytes: byte array) =
+        if isNull bytes then nullArg (nameof bytes)
+
+        Hasher.Hash(bytes).ToString().ToLowerInvariant()
+
+    /// Returns true when the supplied address is exactly lowercase 64-hex.
+    let isValidAddress (address: string) =
+        not (String.IsNullOrEmpty(address))
+        && lowercaseAddressRegex.IsMatch(address)
+
+    /// Computes the content address for one physical chunk payload.
+    let computeChunkAddress (bytes: byte array) : ChunkAddress = ChunkAddress(computeBlake3Hex bytes)
+
+    /// Builds the path-independent preimage for a content block from its ordered chunk addresses.
+    let contentBlockPreimage (blockFormat: string) (chunkAddresses: ChunkAddress seq) =
+        if String.IsNullOrWhiteSpace(blockFormat) then
+            invalidArg (nameof blockFormat) "Content block format is required."
+
+        let chunks = requireNonEmptySequence (nameof chunkAddresses) chunkAddresses
+        let builder = StringBuilder()
+
+        appendLine builder ContentBlockPreimageHeader
+        appendLine builder $"format:{blockFormat}"
+        appendLine builder $"chunk-count:{chunks.Length}"
+
+        chunks
+        |> Array.iteri (fun index address -> appendLine builder $"chunk:{index}:{requireValidAddress (nameof chunkAddresses) address}")
+
+        builder.ToString()
+
+    /// Computes the content address for a content block preimage.
+    let computeContentBlockAddress blockFormat chunkAddresses : ContentBlockAddress =
+        contentBlockPreimage blockFormat chunkAddresses
+        |> System.Text.Encoding.UTF8.GetBytes
+        |> computeBlake3Hex
+        |> ContentBlockAddress
+
+    /// Builds the path-independent preimage for a manifest from its ordered logical blocks.
+    let manifestPreimage (size: int64) (blocks: ContentBlock seq) =
+        ensureNonNegative (nameof size) size
+
+        let blockArray = requireNonEmptySequence (nameof blocks) blocks
+        let builder = StringBuilder()
+
+        appendLine builder FileManifestPreimageHeader
+        appendLine builder $"size:{size}"
+        appendLine builder $"block-count:{blockArray.Length}"
+
+        blockArray
+        |> Array.iteri (fun index block ->
+            if isNull (box block) then nullArg (nameof blocks)
+
+            ensureNonNegative (nameof block.Offset) block.Offset
+            ensureNonNegative (nameof block.Size) block.Size
+
+            let address = requireValidAddress (nameof block.Address) block.Address
+            appendLine builder $"block:{index}:{address}:{block.Offset}:{block.Size}")
+
+        builder.ToString()
+
+    /// Computes the manifest address from its path-independent logical block preimage.
+    let computeManifestAddress size blocks : ManifestAddress =
+        manifestPreimage size blocks
+        |> System.Text.Encoding.UTF8.GetBytes
+        |> computeBlake3Hex
+        |> ManifestAddress

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -25,6 +25,7 @@
         <Compile Include="Combinators.fs" />
         <Compile Include="Utilities.Shared.fs" />
         <Compile Include="StorageKeys.Shared.fs" />
+        <Compile Include="ContentAddress.Shared.fs" />
         <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />
         <Compile Include="Converters\BranchDtoConverter.Shared.fs" />
@@ -71,6 +72,7 @@
 
     <ItemGroup>
         <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
+        <PackageReference Include="Blake3" Version="2.2.1" />
         <PackageReference Include="DiffPlex" Version="1.9.0" />
         <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />

--- a/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
@@ -1,0 +1,100 @@
+namespace Grace.Types.Tests
+
+open System.Text
+open Grace.Shared
+open Grace.Types.Types
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type ContentAddressTypesTests() =
+    [<Test>]
+    member _.Blake3KnownVectorsPass() =
+        Assert.That(ContentAddress.computeBlake3Hex Array.empty, Is.EqualTo("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"))
+
+        Assert.That(
+            ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes("abc")),
+            Is.EqualTo("6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85")
+        )
+
+    [<Test>]
+    member _.AddressValidationRequiresLowercaseSixtyFourHexCharacters() =
+        Assert.That(ContentAddress.isValidAddress ("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"), Is.True)
+
+        Assert.That(ContentAddress.isValidAddress ("AF1349B9F5F9A1A6A0404DEA36DCC9499BCB25C9ADC112B7CC9A93CAE41F3262"), Is.False)
+
+        Assert.That(ContentAddress.isValidAddress ("af1349"), Is.False)
+        Assert.That(ContentAddress.isValidAddress ("gf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"), Is.False)
+        Assert.That(ContentAddress.isValidAddress (null), Is.False)
+
+    [<Test>]
+    member _.ChunkAddressFromBytesUsesLowercaseBlake3Hex() =
+        let address = ContentAddress.computeChunkAddress (Encoding.UTF8.GetBytes("BLAKE3"))
+
+        Assert.That(address, Is.EqualTo(ChunkAddress "f890484173e516bfd935ef3d22b912dc9738de38743993cfedf2c9473b3216a4"))
+        Assert.That(ContentAddress.isValidAddress address, Is.True)
+
+    [<Test>]
+    member _.ContentBlockPreimageAndAddressAreStableAndPathIndependent() =
+        let chunkA = ContentAddress.computeChunkAddress (Encoding.UTF8.GetBytes("alpha chunk"))
+        let chunkB = ContentAddress.computeChunkAddress (Encoding.UTF8.GetBytes("beta chunk"))
+
+        let expectedPreimage =
+            [
+                "grace.cas.v1.content-block"
+                "format:raw-chunks"
+                "chunk-count:2"
+                $"chunk:0:{chunkA}"
+                $"chunk:1:{chunkB}"
+            ]
+            |> String.concat "\n"
+            |> fun value -> value + "\n"
+
+        let preimage = ContentAddress.contentBlockPreimage "raw-chunks" [ chunkA; chunkB ]
+        let address = ContentAddress.computeContentBlockAddress "raw-chunks" [ chunkA; chunkB ]
+
+        Assert.That(preimage, Is.EqualTo(expectedPreimage))
+        Assert.That(address, Is.EqualTo(ContentBlockAddress "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f"))
+        Assert.That(ContentAddress.isValidAddress address, Is.True)
+
+        let sameContentFromDifferentPath = ContentAddress.contentBlockPreimage "raw-chunks" [ chunkA; chunkB ]
+        let reversedContent = ContentAddress.contentBlockPreimage "raw-chunks" [ chunkB; chunkA ]
+
+        Assert.That(sameContentFromDifferentPath, Is.EqualTo(preimage))
+        Assert.That(reversedContent, Is.Not.EqualTo(preimage))
+
+    [<Test>]
+    member _.ManifestPreimageAndAddressAreStableAndPathIndependent() =
+        let blockAddress = ContentBlockAddress "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f"
+
+        let blocks =
+            [
+                ContentBlock.Create(blockAddress, 0L, 4096L)
+                ContentBlock.Create(blockAddress, 4096L, 4096L)
+            ]
+
+        let manifest = FileManifest.Create(ManifestAddress "", 8192L, blocks)
+
+        let expectedPreimage =
+            [
+                "grace.cas.v1.file-manifest"
+                "size:8192"
+                "block-count:2"
+                $"block:0:{blockAddress}:0:4096"
+                $"block:1:{blockAddress}:4096:4096"
+            ]
+            |> String.concat "\n"
+            |> fun value -> value + "\n"
+
+        let preimage = ContentAddress.manifestPreimage manifest.Size manifest.Blocks
+        let address = ContentAddress.computeManifestAddress manifest.Size manifest.Blocks
+
+        let firstPath = FileVersion.Create "src/assets/movie.bin" "abc123" "https://example.test/a" true manifest.Size
+        firstPath.ContentReference <- FileContentReference.FileManifest { manifest with ManifestAddress = address }
+
+        let secondPath = FileVersion.Create "other/path/movie.bin" "abc123" "https://example.test/b" true manifest.Size
+        secondPath.ContentReference <- FileContentReference.FileManifest { manifest with ManifestAddress = address }
+
+        Assert.That(preimage, Is.EqualTo(expectedPreimage))
+        Assert.That(address, Is.EqualTo(ManifestAddress "ac308ff0b0f4f8c6dc0046d8c3a8bb268d73d425b33c51ff7aa93b50da4d12fd"))
+        Assert.That(ContentAddress.isValidAddress address, Is.True)
+        Assert.That(firstPath.ContentReference, Is.EqualTo(secondPath.ContentReference))

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Types.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
+    <Compile Include="ContentAddress.Types.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -119,6 +119,9 @@ module Types =
     /// A SHA-256 hash value.
     type Sha256Hash = string
 
+    /// The content-addressed identifier for one chunk of manifest-backed file content.
+    type ChunkAddress = string
+
     /// The content-addressed identifier for a reusable content block.
     type ContentBlockAddress = string
 


### PR DESCRIPTION
Closes #80.

## Summary

- Adds `ChunkAddress` as the canonical contract alias alongside `ContentBlockAddress` and `ManifestAddress`.
- Adds shared BLAKE3 content-address helpers for chunk bytes, content-block preimages, manifest preimages, and lowercase 64-hex validation.
- Adds focused contract tests for known BLAKE3 vectors, address validation, and golden preimage/address behavior that does not depend on repository paths.

## TDD Evidence

- RED: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter ContentAddressTypesTests` failed because `ContentAddress` and `ChunkAddress` did not exist yet.
- GREEN: same focused command passed with 5 tests after implementation.

## Validation

- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter ContentAddressTypesTests` - passed, 5 tests.
- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj` - passed, 25 tests.
- `dotnet tool run fantomas --recurse .` from `./src` - ran; unrelated whole-tree formatter churn was restored, leaving only #80 files.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed in 00:03:41; build clean, authorization tests passed, CLI tests passed, Types tests passed.

## Docs Impact

- No docs update. The address framing is documented on the helper functions and covered by golden preimage tests.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this change is a pure domain-contract/helper slice and does not touch Aspire, storage emulators, Cosmos DB, Service Bus, Redis, deployment/runtime behavior, GC, or compaction.

## Residual Risk

- Downstream storage/server consumers are not wired to these helpers yet; this PR only establishes the deterministic address contract for later DAG nodes.

## Follow-ups

- #81 can build Rabin chunking on top of `computeChunkAddress` and the block/manifest preimage helpers.
