### PR TITLE
Add upload session actor skeleton

### DIFF
--- a/src/Grace.Actors/AGENTS.md
+++ b/src/Grace.Actors/AGENTS.md
@@ -3,21 +3,30 @@
 Start with `../AGENTS.md` for global rules before working on Orleans code.
 
 ## Purpose
+
 - Define Orleans grain interfaces and implementations that orchestrate stateful workflows in Grace.
 - Persist state through domain events and records defined in `Grace.Types`.
 
 ## Key Patterns
+
 - Follow standard Orleans activation patterns; keep grain constructors light and rely on dependency injection.
 - Drive state changes through explicit events or commands; keep transitions deterministic and idempotent.
 - Use domain types from `Grace.Types` directly to avoid duplication and guarantee serialization compatibility.
 - Separate orchestration (grains) from external service or SDK calls by delegating to helper modules/services.
 
 ## Project Rules
-1. When adding new grain types or serializer changes, ensure `Grace.Orleans.CodeGen` stays in sync and regenerates as needed.
+
+1. When adding new grain types or serializer changes, ensure `Grace.Orleans.CodeGen` stays in sync and regenerates as
+   needed.
 2. Keep grain state mutations safe for retries—idempotent transitions make distributed recovery predictable.
-3. Document non-obvious activation, reminder, or timer behavior here so future agents can reason without scanning the entire implementation.
+3. Document non-obvious activation, reminder, or timer behavior here so future agents can reason without scanning the
+   entire implementation.
+4. `UploadSessionActor` cleanup reminders delete only temporary upload coordination state after finalization, abandon, or
+   expiration. They must not delete accepted manifests, content blocks, block metadata, or contribution accounting.
 
 ## Validation
+
 - Add activation and idempotency tests for new grains or state transitions.
-- Run `dotnet test --no-build` focusing on actor-related fixtures, then smoke `dotnet build --configuration Release` for the solution.
+- Run `dotnet test --no-build` focusing on actor-related fixtures, then smoke `dotnet build --configuration Release`
+  for the solution.
 - Confirm code generation outputs (if applicable) before finalizing a PR.

--- a/src/Grace.Actors/ActorProxy.Extensions.Actor.fs
+++ b/src/Grace.Actors/ActorProxy.Extensions.Actor.fs
@@ -289,6 +289,19 @@ module ActorProxy =
             memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
             grain
 
+    module UploadSession =
+        open Grace.Types.UploadSession
+
+        /// Creates an ActorProxy for an UploadSession actor, and adds the correlationId to the server's MemoryCache so
+        ///   it's available in the OnActivateAsync() method.
+        let CreateActorProxy (uploadSessionId: UploadSessionId) (repositoryId: RepositoryId) (correlationId: string) =
+            let grain = orleansClient.CreateActorProxyWithCorrelationId<IUploadSessionActor>(uploadSessionId, correlationId)
+            let orleansContext = Dictionary<string, obj>()
+            orleansContext.Add(nameof RepositoryId, repositoryId)
+            orleansContext.Add(Constants.ActorNameProperty, ActorName.UploadSession)
+            memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
+            grain
+
     module Policy =
         open Grace.Types.Policy
 

--- a/src/Grace.Actors/Constants.Actor.fs
+++ b/src/Grace.Actors/Constants.Actor.fs
@@ -86,6 +86,9 @@ module Constants =
         let Artifact = "ArtifactActor"
 
         [<Literal>]
+        let UploadSession = "UploadSessionActor"
+
+        [<Literal>]
         let Reference = "ReferenceActor"
 
         [<Literal>]
@@ -163,6 +166,9 @@ module Constants =
 
         [<Literal>]
         let Artifact = "Artifact"
+
+        [<Literal>]
+        let UploadSession = "UploadSession"
 
         [<Literal>]
         let Reference = "Ref"

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -50,6 +50,7 @@
         <Compile Include="ValidationSet.Actor.fs" />
         <Compile Include="ValidationResult.Actor.fs" />
         <Compile Include="Artifact.Actor.fs" />
+        <Compile Include="UploadSession.Actor.fs" />
         <Compile Include="PromotionQueue.Actor.fs" />
         <Compile Include="Repository.Actor.fs" />
         <Compile Include="RepositoryName.Actor.fs" />

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -18,6 +18,7 @@ open Grace.Types.Review
 open Grace.Types.Queue
 open Grace.Types.Validation
 open Grace.Types.Artifact
+open Grace.Types.UploadSession
 open Grace.Types.WorkItem
 open Grace.Types.Types
 open Grace.Shared.Utilities
@@ -468,6 +469,23 @@ module Interfaces =
 
         /// Validates incoming commands and converts them to events that are stored in the database.
         abstract member Handle: command: ArtifactCommand -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+    /// Defines the operations for the UploadSession actor.
+    [<Interface>]
+    type IUploadSessionActor =
+        inherit IGraceReminderWithGuidKey
+
+        /// Returns true if this upload session already exists in the database.
+        abstract member Exists: correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the current upload session state.
+        abstract member Get: correlationId: CorrelationId -> Task<UploadSessionDto>
+
+        /// Returns the events handled by this upload session.
+        abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<UploadSessionEvent>>
+
+        /// Validates incoming commands and converts them to persisted events.
+        abstract member Handle: command: UploadSessionCommand -> eventMetadata: EventMetadata -> Task<GraceResult<UploadSessionDecision>>
 
     /// Defines the operations for the WorkItemNumber actor.
     [<Interface>]

--- a/src/Grace.Actors/Reminder.Actor.fs
+++ b/src/Grace.Actors/Reminder.Actor.fs
@@ -167,6 +167,9 @@ module Reminder =
                         | ActorName.Reference ->
                             let referenceActorProxy = Reference.CreateActorProxy actorId reminderDto.RepositoryId correlationId
                             return! referenceActorProxy.ReceiveReminderAsync reminderDto
+                        | ActorName.UploadSession ->
+                            let uploadSessionActorProxy = UploadSession.CreateActorProxy actorId reminderDto.RepositoryId correlationId
+                            return! uploadSessionActorProxy.ReceiveReminderAsync reminderDto
                         | ActorName.Diff ->
                             // Example reminderDto.ActorId: "diffactor/15b50c95-7306-4ecb-9850-a0a5dc7419cf*1e7b6f83-4715-42f8-ba0b-9b0262356f08"
                             let directoryVersionIds = reminderDto.ActorId.Split("/").[1].Split("*")

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -160,6 +160,8 @@ module UploadSession =
                     | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot Expire from {session.LifecycleState}.")
             | UploadSessionCommand.DeletePhysicalState operationId ->
                 match session.LifecycleState with
+                | UploadSessionLifecycleState.NotStarted
+                | UploadSessionLifecycleState.StateDeleted -> okDecision session operationId [] true "Upload session physical state was already deleted."
                 | UploadSessionLifecycleState.RetentionPending ->
                     let events =
                         [
@@ -237,7 +239,8 @@ module UploadSession =
 
                         match decideCommand state.State uploadSessionDto command metadata with
                         | Ok decision ->
-                            do! this.ApplyEvents decision.Events
+                            if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
                             do! state.ClearStateAsync()
                             this.DeactivateOnIdle()
                             return Ok()

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -276,11 +276,10 @@ module UploadSession =
 
                     match decideCommand state.State uploadSessionDto command metadata with
                     | Ok decision ->
-                        do! this.ApplyEvents decision.Events
+                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
 
                         match command with
-                        | UploadSessionCommand.Abandon operationId
-                        | UploadSessionCommand.Expire operationId ->
+                        | UploadSessionCommand.Abandon operationId when not decision.WasIdempotentReplay ->
                             let reminderState =
                                 createCleanupReminderState decision.Session.UploadSessionId decision.Session.RepositoryId operationId metadata.CorrelationId
 
@@ -291,7 +290,18 @@ module UploadSession =
                                     DefaultPhysicalDeletionReminderDuration
                                     (ReminderState.UploadSessionPhysicalDeletion reminderState)
                                     metadata.CorrelationId
-                        | UploadSessionCommand.DeletePhysicalState _ ->
+                        | UploadSessionCommand.Expire operationId when not decision.WasIdempotentReplay ->
+                            let reminderState =
+                                createCleanupReminderState decision.Session.UploadSessionId decision.Session.RepositoryId operationId metadata.CorrelationId
+
+                            do!
+                                (this :> IGraceReminderWithGuidKey)
+                                    .ScheduleReminderAsync
+                                    ReminderTypes.PhysicalDeletion
+                                    DefaultPhysicalDeletionReminderDuration
+                                    (ReminderState.UploadSessionPhysicalDeletion reminderState)
+                                    metadata.CorrelationId
+                        | UploadSessionCommand.DeletePhysicalState _ when not decision.WasIdempotentReplay ->
                             do! state.ClearStateAsync()
                             this.DeactivateOnIdle()
                         | _ -> ()

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -1,0 +1,318 @@
+namespace Grace.Actors
+
+open Grace.Actors.Constants
+open Grace.Actors.Context
+open Grace.Actors.Interfaces
+open Grace.Actors.Services
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types.Reminder
+open Grace.Types.Types
+open Grace.Types.UploadSession
+open Microsoft.Extensions.Logging
+open NodaTime
+open Orleans
+open Orleans.Runtime
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module UploadSession =
+
+    let private actorName = ActorName.UploadSession
+
+    let commandName command =
+        match command with
+        | UploadSessionCommand.Start _ -> "Start"
+        | UploadSessionCommand.IssueDedupeDiscovery _ -> "IssueDedupeDiscovery"
+        | UploadSessionCommand.RegisterBlockUploadIntent _ -> "RegisterBlockUploadIntent"
+        | UploadSessionCommand.ConfirmBlockUploaded _ -> "ConfirmBlockUploaded"
+        | UploadSessionCommand.ClaimReuseRanges _ -> "ClaimReuseRanges"
+        | UploadSessionCommand.FinalizeManifest _ -> "FinalizeManifest"
+        | UploadSessionCommand.Abandon _ -> "Abandon"
+        | UploadSessionCommand.Expire _ -> "Expire"
+        | UploadSessionCommand.DeletePhysicalState _ -> "DeletePhysicalState"
+
+    let operationId command =
+        match command with
+        | UploadSessionCommand.Start start -> start.OperationId
+        | UploadSessionCommand.IssueDedupeDiscovery operationId -> operationId
+        | UploadSessionCommand.RegisterBlockUploadIntent (operationId, _) -> operationId
+        | UploadSessionCommand.ConfirmBlockUploaded (operationId, _) -> operationId
+        | UploadSessionCommand.ClaimReuseRanges operationId -> operationId
+        | UploadSessionCommand.FinalizeManifest (operationId, _) -> operationId
+        | UploadSessionCommand.Abandon operationId -> operationId
+        | UploadSessionCommand.Expire operationId -> operationId
+        | UploadSessionCommand.DeletePhysicalState operationId -> operationId
+
+    let createCleanupOperationId operationId = $"{operationId}:cleanup"
+
+    let createCleanupReminderState uploadSessionId repositoryId operationId correlationId =
+        {
+            UploadSessionId = uploadSessionId
+            RepositoryId = repositoryId
+            OperationId = createCleanupOperationId operationId
+            DeleteReason = "UploadSession coordination state retention window elapsed."
+            CorrelationId = correlationId
+        }
+
+    let private eventOperationId uploadSessionEvent =
+        match uploadSessionEvent.Event with
+        | UploadSessionEventType.Started start -> start.OperationId
+        | UploadSessionEventType.Abandoned operationId -> operationId
+        | UploadSessionEventType.Expired operationId -> operationId
+        | UploadSessionEventType.Finalized (operationId, _) -> operationId
+        | UploadSessionEventType.CleanupReminderScheduled (operationId, _) -> operationId
+        | UploadSessionEventType.PhysicalStateDeleted operationId -> operationId
+
+    let private hasAppliedOperationId (events: seq<UploadSessionEvent>) operationId =
+        events
+        |> Seq.exists (fun uploadSessionEvent -> eventOperationId uploadSessionEvent = operationId)
+
+    let private applyEvents (events: UploadSessionEvent list) (session: UploadSessionDto) =
+        events
+        |> List.fold (fun current event -> UploadSessionDto.UpdateDto event current) session
+
+    let private okDecision (session: UploadSessionDto) operationId (events: UploadSessionEvent list) wasReplay message =
+        Ok { Session = applyEvents events session; OperationId = operationId; Events = events; WasIdempotentReplay = wasReplay; Message = message }
+
+    let private graceError correlationId message = GraceError.Create message correlationId
+
+    let private cleanupEvents (session: UploadSessionDto) operationId (metadata: EventMetadata) =
+        let cleanupOperationId = createCleanupOperationId operationId
+        let reminderTime = metadata.Timestamp.Plus(DefaultPhysicalDeletionReminderDuration)
+
+        [
+            { Event = UploadSessionEventType.CleanupReminderScheduled(cleanupOperationId, reminderTime); Metadata = metadata }
+        ]
+
+    let private terminalMutationError (session: UploadSessionDto) command correlationId =
+        match session.LifecycleState with
+        | UploadSessionLifecycleState.Finalized -> Some(graceError correlationId $"UploadSession is finalized and cannot be changed by {commandName command}.")
+        | UploadSessionLifecycleState.RetentionPending ->
+            Some(graceError correlationId $"UploadSession is waiting for cleanup and cannot be changed by {commandName command}.")
+        | UploadSessionLifecycleState.StateDeleted ->
+            Some(graceError correlationId $"UploadSession physical state has been deleted and cannot be changed by {commandName command}.")
+        | _ -> None
+
+    let decideCommand (events: seq<UploadSessionEvent>) (session: UploadSessionDto) (command: UploadSessionCommand) (metadata: EventMetadata) =
+        let operationId = operationId command
+
+        if String.IsNullOrWhiteSpace operationId then
+            Error(graceError metadata.CorrelationId "UploadSession command requires a non-empty operation id.")
+        elif hasAppliedOperationId events operationId then
+            okDecision session operationId [] true "Upload session command replayed."
+        else
+            match command with
+            | UploadSessionCommand.Start start ->
+                if session.LifecycleState
+                   <> UploadSessionLifecycleState.NotStarted then
+                    Error(graceError metadata.CorrelationId "UploadSession has already been started.")
+                elif start.UploadSessionId = UploadSessionId.Empty then
+                    Error(graceError metadata.CorrelationId "UploadSessionId must be a non-empty Guid.")
+                elif start.RepositoryId = RepositoryId.Empty then
+                    Error(graceError metadata.CorrelationId "RepositoryId must be a non-empty Guid.")
+                elif start.ExpectedSize <= 0L then
+                    Error(graceError metadata.CorrelationId "ExpectedSize must be greater than zero.")
+                else
+                    let events =
+                        [
+                            { Event = UploadSessionEventType.Started start; Metadata = metadata }
+                        ]
+
+                    okDecision session operationId events false "Upload session started."
+            | UploadSessionCommand.Abandon operationId ->
+                match terminalMutationError session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None ->
+                    match session.LifecycleState with
+                    | UploadSessionLifecycleState.Started
+                    | UploadSessionLifecycleState.Discovering
+                    | UploadSessionLifecycleState.UploadingBlocks
+                    | UploadSessionLifecycleState.ClaimingRanges ->
+                        let events =
+                            [
+                                { Event = UploadSessionEventType.Abandoned operationId; Metadata = metadata }
+                            ]
+                            @ cleanupEvents session operationId metadata
+
+                        okDecision session operationId events false "Upload session abandoned."
+                    | UploadSessionLifecycleState.NotStarted -> Error(graceError metadata.CorrelationId "UploadSession must be started before Abandon.")
+                    | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot Abandon from {session.LifecycleState}.")
+            | UploadSessionCommand.Expire operationId ->
+                match terminalMutationError session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None ->
+                    match session.LifecycleState with
+                    | UploadSessionLifecycleState.Started
+                    | UploadSessionLifecycleState.Discovering
+                    | UploadSessionLifecycleState.UploadingBlocks
+                    | UploadSessionLifecycleState.ClaimingRanges ->
+                        let events =
+                            [
+                                { Event = UploadSessionEventType.Expired operationId; Metadata = metadata }
+                            ]
+                            @ cleanupEvents session operationId metadata
+
+                        okDecision session operationId events false "Upload session expired."
+                    | UploadSessionLifecycleState.NotStarted -> Error(graceError metadata.CorrelationId "UploadSession must be started before Expire.")
+                    | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot Expire from {session.LifecycleState}.")
+            | UploadSessionCommand.DeletePhysicalState operationId ->
+                match session.LifecycleState with
+                | UploadSessionLifecycleState.RetentionPending ->
+                    let events =
+                        [
+                            { Event = UploadSessionEventType.PhysicalStateDeleted operationId; Metadata = metadata }
+                        ]
+
+                    okDecision session operationId events false "Upload session physical state deleted."
+                | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot DeletePhysicalState from {session.LifecycleState}.")
+            | UploadSessionCommand.IssueDedupeDiscovery _
+            | UploadSessionCommand.RegisterBlockUploadIntent _
+            | UploadSessionCommand.ConfirmBlockUploaded _
+            | UploadSessionCommand.ClaimReuseRanges _
+            | UploadSessionCommand.FinalizeManifest _ ->
+                match terminalMutationError session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None -> Error(graceError metadata.CorrelationId $"UploadSession command {commandName command} is not implemented in this skeleton.")
+
+    type UploadSessionActor([<PersistentState(StateName.UploadSession, Constants.GraceActorStorage)>] state: IPersistentState<List<UploadSessionEvent>>) =
+        inherit Grain()
+
+        let log = loggerFactory.CreateLogger("UploadSession.Actor")
+        let mutable uploadSessionDto = UploadSessionDto.Default
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override this.OnActivateAsync(ct) =
+            let activateStartTime = getCurrentInstant ()
+
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+
+            uploadSessionDto <-
+                state.State
+                |> Seq.fold (fun dto event -> UploadSessionDto.UpdateDto event dto) UploadSessionDto.Default
+
+            Task.CompletedTask
+
+        member private this.ApplyEvents(events: UploadSessionEvent list) =
+            task {
+                for uploadSessionEvent in events do
+                    state.State.Add(uploadSessionEvent)
+
+                do! state.WriteStateAsync()
+
+                uploadSessionDto <- applyEvents events uploadSessionDto
+            }
+
+        interface IGraceReminderWithGuidKey with
+            member this.ScheduleReminderAsync reminderType delay reminderState correlationId =
+                task {
+                    let reminder =
+                        ReminderDto.Create
+                            actorName
+                            $"{this.IdentityString}"
+                            uploadSessionDto.OwnerId
+                            uploadSessionDto.OrganizationId
+                            uploadSessionDto.RepositoryId
+                            reminderType
+                            (getFutureInstant delay)
+                            reminderState
+                            correlationId
+
+                    do! createReminder reminder
+                }
+                :> Task
+
+            member this.ReceiveReminderAsync(reminder: ReminderDto) : Task<Result<unit, GraceError>> =
+                task {
+                    this.correlationId <- reminder.CorrelationId
+
+                    match reminder.ReminderType, reminder.State with
+                    | ReminderTypes.PhysicalDeletion, ReminderState.UploadSessionPhysicalDeletion reminderState ->
+                        this.correlationId <- reminderState.CorrelationId
+
+                        let metadata = EventMetadata.New reminderState.CorrelationId "system"
+                        let command = UploadSessionCommand.DeletePhysicalState reminderState.OperationId
+
+                        match decideCommand state.State uploadSessionDto command metadata with
+                        | Ok decision ->
+                            do! this.ApplyEvents decision.Events
+                            do! state.ClearStateAsync()
+                            this.DeactivateOnIdle()
+                            return Ok()
+                        | Error error -> return Error error
+                    | reminderType, reminderState ->
+                        return
+                            Error(
+                                GraceError.Create
+                                    $"{actorName} does not process reminder type {getDiscriminatedUnionCaseName reminderType} with state {getDiscriminatedUnionCaseName reminderState}."
+                                    this.correlationId
+                            )
+                }
+
+        interface IUploadSessionActor with
+            member this.Exists correlationId =
+                this.correlationId <- correlationId
+
+                (uploadSessionDto.UploadSessionId
+                 <> UploadSessionId.Empty)
+                |> returnTask
+
+            member this.Get correlationId =
+                this.correlationId <- correlationId
+                uploadSessionDto |> returnTask
+
+            member this.GetEvents correlationId =
+                this.correlationId <- correlationId
+
+                (state.State :> IReadOnlyList<UploadSessionEvent>)
+                |> returnTask
+
+            member this.Handle command metadata =
+                task {
+                    this.correlationId <- metadata.CorrelationId
+                    RequestContext.Set(Constants.CurrentCommandProperty, commandName command)
+
+                    match decideCommand state.State uploadSessionDto command metadata with
+                    | Ok decision ->
+                        do! this.ApplyEvents decision.Events
+
+                        match command with
+                        | UploadSessionCommand.Abandon operationId
+                        | UploadSessionCommand.Expire operationId ->
+                            let reminderState =
+                                createCleanupReminderState decision.Session.UploadSessionId decision.Session.RepositoryId operationId metadata.CorrelationId
+
+                            do!
+                                (this :> IGraceReminderWithGuidKey)
+                                    .ScheduleReminderAsync
+                                    ReminderTypes.PhysicalDeletion
+                                    DefaultPhysicalDeletionReminderDuration
+                                    (ReminderState.UploadSessionPhysicalDeletion reminderState)
+                                    metadata.CorrelationId
+                        | UploadSessionCommand.DeletePhysicalState _ ->
+                            do! state.ClearStateAsync()
+                            this.DeactivateOnIdle()
+                        | _ -> ()
+
+                        let returnValue =
+                            (GraceReturnValue.Create decision metadata.CorrelationId)
+                                .enhance(nameof RepositoryId, decision.Session.RepositoryId)
+                                .enhance(nameof UploadSessionId, decision.Session.UploadSessionId)
+                                .enhance(nameof UploadSessionOperationId, decision.OperationId)
+                                .enhance (nameof UploadSessionLifecycleState, decision.Session.LifecycleState)
+
+                        return Ok returnValue
+                    | Error error ->
+                        log.LogWarning(
+                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected UploadSession command {Command}. Error: {Error}",
+                            getCurrentInstantExtended (),
+                            getMachineName,
+                            metadata.CorrelationId,
+                            commandName command,
+                            error.Error
+                        )
+
+                        return Error error
+                }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
+    <Compile Include="UploadSession.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -86,6 +86,35 @@ type UploadSessionActorTests() =
         | Error error -> Assert.Fail($"Expected abandon to succeed, got {error.Error}.")
 
     [<Test>]
+    member _.AbandonWithSameOperationIdIsIdempotentReplayWithoutCleanupEvent() =
+        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
+
+        let startedDto, startEvents =
+            match startDecision with
+            | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let abandon = UploadSessionActor.decideCommand startEvents startedDto (UploadSessionCommand.Abandon "op-abandon") (metadata "corr-abandon")
+
+        let retainedDto, retainedEvents =
+            match abandon with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected abandon to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let replay = UploadSessionActor.decideCommand retainedEvents retainedDto (UploadSessionCommand.Abandon "op-abandon") (metadata "corr-abandon-retry")
+
+        match replay with
+        | Ok replayDecision ->
+            Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+            Assert.That(replayDecision.Events, Is.Empty)
+            Assert.That(replayDecision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-abandon:cleanup"))
+        | Error error -> Assert.Fail($"Expected abandon replay to succeed, got {error.Error}.")
+
+    [<Test>]
     member _.ExpireMovesStartedSessionToRetentionPendingAndSchedulesCleanup() =
         let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
 

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -191,3 +191,19 @@ type UploadSessionActorTests() =
         match state with
         | ReminderState.UploadSessionPhysicalDeletion uploadSessionState -> Assert.That(uploadSessionState.OperationId, Is.EqualTo("op-abandon:cleanup"))
         | _ -> Assert.Fail("Expected UploadSessionPhysicalDeletion reminder state.")
+
+    [<Test>]
+    member _.DeletePhysicalStateRetryAfterStateClearedDrainsAsIdempotentReplay() =
+        let result =
+            UploadSessionActor.decideCommand
+                []
+                UploadSessionDto.Default
+                (UploadSessionCommand.DeletePhysicalState "op-abandon:cleanup")
+                (metadata "corr-cleanup-retry")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.True)
+            Assert.That(decision.Events, Is.Empty)
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.NotStarted))
+        | Error error -> Assert.Fail($"Expected cleanup retry to drain, got {error.Error}.")

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -1,0 +1,164 @@
+namespace Grace.Server.Tests
+
+open Grace.Types.Reminder
+open Grace.Types.Types
+open Grace.Types.UploadSession
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+module UploadSessionActor = Grace.Actors.UploadSession
+
+[<Parallelizable(ParallelScope.All)>]
+type UploadSessionActorTests() =
+
+    let timestamp = Instant.FromUtc(2026, 5, 24, 12, 0)
+
+    let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+
+    let sessionId = Guid.Parse("ab6fd828-87a3-4b7a-9c2e-5a83f5e8b1b0")
+    let ownerId = Guid.Parse("4f512f0d-d6b0-488a-934c-db16840d2a8d")
+    let organizationId = Guid.Parse("2b4ffda8-1129-47df-9c0c-76371153a807")
+    let repositoryId = Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5")
+
+    let start operationId =
+        {
+            UploadSessionId = sessionId
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            AuthorizedScope = "/src"
+            FileContentHash = "blake3:file"
+            ExpectedSize = 1_048_576L
+            ChunkingSuiteId = "rabin-blake3-v1"
+            SamplingPolicySnapshot = "sparse-key-v1"
+            OperationId = operationId
+        }
+
+    let apply event dto = UploadSessionDto.UpdateDto event dto
+
+    let applyAll events dto =
+        events
+        |> List.fold (fun current event -> apply event current) dto
+
+    [<Test>]
+    member _.StartWithSameOperationIdIsIdempotentReplay() =
+        let command = UploadSessionCommand.Start(start "op-start")
+        let first = UploadSessionActor.decideCommand [] UploadSessionDto.Default command (metadata "corr-start-1")
+
+        match first with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Events.Length, Is.EqualTo(1))
+
+            let dto = applyAll decision.Events UploadSessionDto.Default
+            let replay = UploadSessionActor.decideCommand decision.Events dto command (metadata "corr-start-2")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Session.UploadSessionId, Is.EqualTo(sessionId))
+                Assert.That(replayDecision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Started))
+            | Error error -> Assert.Fail($"Expected idempotent replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected start to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.AbandonMovesStartedSessionToRetentionPendingAndSchedulesCleanup() =
+        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
+
+        let started =
+            match startDecision with
+            | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let (startedDto, existingEvents) = started
+        let abandon = UploadSessionActor.decideCommand existingEvents startedDto (UploadSessionCommand.Abandon "op-abandon") (metadata "corr-abandon")
+
+        match abandon with
+        | Ok decision ->
+            Assert.That(decision.Events.Length, Is.EqualTo(2))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
+            Assert.That(decision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-abandon:cleanup"))
+        | Error error -> Assert.Fail($"Expected abandon to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ExpireMovesStartedSessionToRetentionPendingAndSchedulesCleanup() =
+        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
+
+        let started =
+            match startDecision with
+            | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let (startedDto, existingEvents) = started
+        let expire = UploadSessionActor.decideCommand existingEvents startedDto (UploadSessionCommand.Expire "op-expire") (metadata "corr-expire")
+
+        match expire with
+        | Ok decision ->
+            Assert.That(decision.Events.Length, Is.EqualTo(2))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
+            Assert.That(decision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-expire:cleanup"))
+        | Error error -> Assert.Fail($"Expected expire to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizedSessionRejectsLifecycleMutation() =
+        let finalized =
+            { UploadSessionDto.Default with
+                UploadSessionId = sessionId
+                OwnerId = ownerId
+                OrganizationId = organizationId
+                RepositoryId = repositoryId
+                LifecycleState = UploadSessionLifecycleState.Finalized
+                FinalizedManifestAddress = Some "manifest-blake3-final"
+            }
+
+        let result = UploadSessionActor.decideCommand [] finalized (UploadSessionCommand.Abandon "op-abandon") (metadata "corr-finalized")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected finalized session to reject abandon.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession is finalized and cannot be changed by Abandon."))
+
+    [<Test>]
+    member _.BlockUploadAndFinalizeCommandsRemainUnimplementedForSkeleton() =
+        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
+
+        let started =
+            match startDecision with
+            | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let (startedDto, existingEvents) = started
+
+        let result =
+            UploadSessionActor.decideCommand
+                existingEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent("op-block", "block-blake3"))
+                (metadata "corr-block")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected block upload intent to remain unimplemented in the skeleton.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession command RegisterBlockUploadIntent is not implemented in this skeleton."))
+
+    [<Test>]
+    member _.CleanupReminderStateCarriesDeletePhysicalStateOperationId() =
+        let reminderState = UploadSessionActor.createCleanupReminderState sessionId repositoryId "op-abandon" "corr-abandon"
+
+        Assert.That(reminderState.OperationId, Is.EqualTo("op-abandon:cleanup"))
+        Assert.That(reminderState.UploadSessionId, Is.EqualTo(sessionId))
+        Assert.That(reminderState.RepositoryId, Is.EqualTo(repositoryId))
+        Assert.That(reminderState.CorrelationId, Is.EqualTo("corr-abandon"))
+
+        let state = ReminderState.UploadSessionPhysicalDeletion reminderState
+
+        match state with
+        | ReminderState.UploadSessionPhysicalDeletion uploadSessionState -> Assert.That(uploadSessionState.OperationId, Is.EqualTo("op-abandon:cleanup"))
+        | _ -> Assert.Fail("Expected UploadSessionPhysicalDeletion reminder state.")

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -39,6 +39,7 @@
         <Compile Include="Validation.Types.fs" />
         <Compile Include="Diff.Types.fs" />
         <Compile Include="DirectoryVersion.Types.fs" />
+        <Compile Include="UploadSession.Types.fs" />
         <Compile Include="Reminder.Types.fs" />
         <Compile Include="Events.Types.fs" />
     </ItemGroup>

--- a/src/Grace.Types/Reminder.Types.fs
+++ b/src/Grace.Types/Reminder.Types.fs
@@ -9,6 +9,7 @@ open Grace.Types.Owner
 open Grace.Types.Reference
 open Grace.Types.Repository
 open Grace.Types.Types
+open Grace.Types.UploadSession
 open NodaTime
 open Orleans
 open System
@@ -27,6 +28,7 @@ module Reminder =
         | DirectoryVersionDeleteCachedState of DirectoryVersion.PhysicalDeletionReminderState
         | DirectoryVersionDeleteZipFile of DirectoryVersion.PhysicalDeletionReminderState
         | DiffDeleteCachedState of Diff.DeleteCachedStateReminderState
+        | UploadSessionPhysicalDeletion of UploadSession.PhysicalDeletionReminderState
 
     /// Defines all reminders used in Grace.
     type ReminderDto =

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -125,6 +125,18 @@ module Types =
     /// The content-addressed identifier for a file manifest.
     type ManifestAddress = string
 
+    /// The Id of an upload session.
+    type UploadSessionId = Guid
+
+    /// Caller-supplied retry identity for upload-session commands.
+    type UploadSessionOperationId = string
+
+    /// The content-derived hash for a complete manifest-backed file.
+    type FileContentHash = string
+
+    /// The versioned chunking suite used for a manifest-backed file.
+    type ChunkingSuiteId = string
+
     type StorageAccountName = string
     type StorageConnectionString = string
     type StorageContainerName = string

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -1,0 +1,178 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open NodaTime
+open Orleans
+open System
+open System.Runtime.Serialization
+
+module UploadSession =
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type UploadSessionLifecycleState =
+        | NotStarted
+        | Started
+        | Discovering
+        | UploadingBlocks
+        | ClaimingRanges
+        | FinalizingManifest
+        | Finalized
+        | Abandoned
+        | Expired
+        | RetentionPending
+        | StateDeleted
+
+        static member GetKnownTypes() = GetKnownTypes<UploadSessionLifecycleState>()
+
+    [<GenerateSerializer>]
+    type StartUploadSession =
+        {
+            UploadSessionId: UploadSessionId
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            AuthorizedScope: RelativePath
+            FileContentHash: FileContentHash
+            ExpectedSize: int64
+            ChunkingSuiteId: ChunkingSuiteId
+            SamplingPolicySnapshot: string
+            OperationId: UploadSessionOperationId
+        }
+
+    [<KnownType("GetKnownTypes")>]
+    type UploadSessionCommand =
+        | Start of start: StartUploadSession
+        | IssueDedupeDiscovery of operationId: UploadSessionOperationId
+        | RegisterBlockUploadIntent of operationId: UploadSessionOperationId * contentBlockAddress: ContentBlockAddress
+        | ConfirmBlockUploaded of operationId: UploadSessionOperationId * contentBlockAddress: ContentBlockAddress
+        | ClaimReuseRanges of operationId: UploadSessionOperationId
+        | FinalizeManifest of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
+        | Abandon of operationId: UploadSessionOperationId
+        | Expire of operationId: UploadSessionOperationId
+        | DeletePhysicalState of operationId: UploadSessionOperationId
+
+        static member GetKnownTypes() = GetKnownTypes<UploadSessionCommand>()
+
+    [<KnownType("GetKnownTypes")>]
+    type UploadSessionEventType =
+        | Started of start: StartUploadSession
+        | Abandoned of operationId: UploadSessionOperationId
+        | Expired of operationId: UploadSessionOperationId
+        | Finalized of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
+        | CleanupReminderScheduled of operationId: UploadSessionOperationId * reminderTime: Instant
+        | PhysicalStateDeleted of operationId: UploadSessionOperationId
+
+        static member GetKnownTypes() = GetKnownTypes<UploadSessionEventType>()
+
+    type UploadSessionEvent = { Event: UploadSessionEventType; Metadata: EventMetadata }
+
+    [<GenerateSerializer>]
+    type UploadSessionDto =
+        {
+            Class: string
+            UploadSessionId: UploadSessionId
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            AuthorizedScope: RelativePath
+            FileContentHash: FileContentHash
+            ExpectedSize: int64
+            ChunkingSuiteId: ChunkingSuiteId
+            SamplingPolicySnapshot: string
+            LifecycleState: UploadSessionLifecycleState
+            StartedAt: Instant
+            CompletedAt: Instant option
+            FinalizedManifestAddress: ManifestAddress option
+            CleanupReminderScheduledAt: Instant option
+            CleanupReminderOperationId: UploadSessionOperationId option
+            LastOperationId: UploadSessionOperationId option
+        }
+
+        static member Default =
+            {
+                Class = nameof UploadSessionDto
+                UploadSessionId = UploadSessionId.Empty
+                OwnerId = OwnerId.Empty
+                OrganizationId = OrganizationId.Empty
+                RepositoryId = RepositoryId.Empty
+                AuthorizedScope = RelativePath String.Empty
+                FileContentHash = FileContentHash String.Empty
+                ExpectedSize = 0L
+                ChunkingSuiteId = ChunkingSuiteId String.Empty
+                SamplingPolicySnapshot = String.Empty
+                LifecycleState = UploadSessionLifecycleState.NotStarted
+                StartedAt = Constants.DefaultTimestamp
+                CompletedAt = None
+                FinalizedManifestAddress = None
+                CleanupReminderScheduledAt = None
+                CleanupReminderOperationId = None
+                LastOperationId = None
+            }
+
+        static member UpdateDto uploadSessionEvent current =
+            match uploadSessionEvent.Event with
+            | UploadSessionEventType.Started start ->
+                { UploadSessionDto.Default with
+                    UploadSessionId = start.UploadSessionId
+                    OwnerId = start.OwnerId
+                    OrganizationId = start.OrganizationId
+                    RepositoryId = start.RepositoryId
+                    AuthorizedScope = start.AuthorizedScope
+                    FileContentHash = start.FileContentHash
+                    ExpectedSize = start.ExpectedSize
+                    ChunkingSuiteId = start.ChunkingSuiteId
+                    SamplingPolicySnapshot = start.SamplingPolicySnapshot
+                    LifecycleState = UploadSessionLifecycleState.Started
+                    StartedAt = uploadSessionEvent.Metadata.Timestamp
+                    LastOperationId = Some start.OperationId
+                }
+            | UploadSessionEventType.Abandoned operationId ->
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.Abandoned
+                    CompletedAt = Some uploadSessionEvent.Metadata.Timestamp
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.Expired operationId ->
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.Expired
+                    CompletedAt = Some uploadSessionEvent.Metadata.Timestamp
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.Finalized (operationId, manifestAddress) ->
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.Finalized
+                    FinalizedManifestAddress = Some manifestAddress
+                    CompletedAt = Some uploadSessionEvent.Metadata.Timestamp
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.CleanupReminderScheduled (operationId, reminderTime) ->
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.RetentionPending
+                    CleanupReminderScheduledAt = Some reminderTime
+                    CleanupReminderOperationId = Some operationId
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.PhysicalStateDeleted operationId ->
+                { current with LifecycleState = UploadSessionLifecycleState.StateDeleted; LastOperationId = Some operationId }
+
+    [<GenerateSerializer>]
+    type UploadSessionDecision =
+        {
+            Session: UploadSessionDto
+            OperationId: UploadSessionOperationId
+            Events: UploadSessionEvent list
+            WasIdempotentReplay: bool
+            Message: string
+        }
+
+    [<GenerateSerializer>]
+    type PhysicalDeletionReminderState =
+        {
+            UploadSessionId: UploadSessionId
+            RepositoryId: RepositoryId
+            OperationId: UploadSessionOperationId
+            DeleteReason: DeleteReason
+            CorrelationId: CorrelationId
+        }


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #89

## Summary

- Adds `UploadSession` domain contracts for GUID-keyed session state, operation-id commands/events, lifecycle states, decision results, and cleanup reminder payloads.
- Adds `UploadSessionActor` skeleton handling start, abandon, expire, delete-physical-state, idempotent operation replay, finalized/terminal rejection, and cleanup reminder scheduling/dispatch.
- Adds focused UploadSession actor tests for retry-safe lifecycle behavior while keeping block upload/finalize behavior explicitly unimplemented.

## Touched paths

- `src/Grace.Types/*`
- `src/Grace.Actors/*`
- `src/Grace.Server.Tests/*`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `actor-workflow`
- Public behavior or docs-only validation target: Upload session lifecycle transitions are deterministic and retry-safe; block upload/finalize remains unimplemented.
- RED evidence or docs-only waiver: Initial focused test run failed because `Grace.Types.UploadSession`, `UploadSessionCommand`, `UploadSessionDto`, and `ReminderState.UploadSessionPhysicalDeletion` did not exist yet.
- Focused validation: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"`

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Added `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs` covering idempotent start replay, abandon and expire transition to retention pending, finalized-state rejection, unimplemented block-upload behavior, and cleanup reminder state.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [x] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

Updated `src/Grace.Actors/AGENTS.md` with UploadSession cleanup reminder semantics.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"`
- [x] Formatting/linting: `dotnet tool run fantomas Grace.Actors/ActorProxy.Extensions.Actor.fs Grace.Actors/Constants.Actor.fs Grace.Actors/Interfaces.Actor.fs Grace.Actors/Reminder.Actor.fs Grace.Actors/UploadSession.Actor.fs Grace.Server.Tests/UploadSession.Actor.Tests.fs Grace.Types/Reminder.Types.fs Grace.Types/Types.Types.fs Grace.Types/UploadSession.Types.fs`
- [x] Formatting/linting: `npx --yes markdownlint-cli2 "src/Grace.Actors/AGENTS.md"`
- [x] Formatting/linting: `git diff --check`
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full` was not run because this skeleton does not exercise Aspire, emulators, storage, Service Bus, Redis, deployment/runtime behavior, or cross-service integration.

## Residual risks

- UploadSession block intent, dedupe discovery, range claim, and manifest finalization commands are contract placeholders that intentionally return not implemented in this skeleton.
- Cleanup reminder scheduling uses the existing default physical-deletion delay until repository-configured upload-session retention is introduced by a later slice.

## Rollback or recovery notes

- Reverting this PR removes the new UploadSession actor/contracts/tests and leaves existing upload behavior unchanged.

## Docs follow-up required

- Later upload-session implementation slices should document public API/SDK/CLI behavior when those surfaces are added.
