### PR TITLE
Implement Rabin chunking suite

### DIFF
--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -26,6 +26,7 @@
         <Compile Include="Utilities.Shared.fs" />
         <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="ContentAddress.Shared.fs" />
+        <Compile Include="RabinChunking.Shared.fs" />
         <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />
         <Compile Include="Converters\BranchDtoConverter.Shared.fs" />

--- a/src/Grace.Shared/RabinChunking.Shared.fs
+++ b/src/Grace.Shared/RabinChunking.Shared.fs
@@ -72,7 +72,10 @@ module RabinChunking =
         && (fingerprint &&& cutMask) = cutValue
 
     let private findChunkEnd (bytes: byte array) start =
-        let limit = Math.Min(bytes.Length, start + MaximumChunkSize)
+        let limit =
+            start
+            + Math.Min(bytes.Length - start, MaximumChunkSize)
+
         let mutable fingerprint = 0UL
         let mutable windowBytes = 0
         let mutable index = start

--- a/src/Grace.Shared/RabinChunking.Shared.fs
+++ b/src/Grace.Shared/RabinChunking.Shared.fs
@@ -1,0 +1,131 @@
+namespace Grace.Shared
+
+open Grace.Types.Types
+open System
+
+/// Pure content-defined chunking for the pinned grace-rabin-blake3-64k-v1 suite.
+module RabinChunking =
+    /// Stable suite identifier used by clients and manifests that implement this exact chunking recipe.
+    [<Literal>]
+    let SuiteName = "grace-rabin-blake3-64k-v1"
+
+    /// Minimum natural chunk size. Boundary candidates before this size are ignored.
+    [<Literal>]
+    let MinimumChunkSize = 8 * 1024
+
+    /// Target average chunk size. The boundary mask is derived from this power-of-two target.
+    [<Literal>]
+    let TargetChunkSize = 64 * 1024
+
+    /// Maximum chunk size. A cut is forced here when no natural Rabin boundary appears first.
+    [<Literal>]
+    let MaximumChunkSize = 128 * 1024
+
+    /// Rolling Rabin window size in bytes.
+    [<Literal>]
+    let WindowSize = 64
+
+    /// Reduction polynomial for the 64-bit rolling Rabin fingerprint.
+    [<Literal>]
+    let Polynomial = 0x3DA3358B4DC173UL
+
+    /// One logical chunk produced by the pinned suite.
+    type Chunk =
+        {
+            /// Byte offset of the chunk in the original payload.
+            Offset: int64
+
+            /// Chunk length in bytes.
+            Length: int
+
+            /// Lowercase 64-hex BLAKE3 address of this chunk payload.
+            Address: ChunkAddress
+        }
+
+    let private cutMask = uint64 TargetChunkSize - 1UL
+    let private cutValue = cutMask
+    let private topFingerprintBit = 0x8000000000000000UL
+
+    let private appendByte (fingerprint: uint64) (value: byte) =
+        let mutable candidate = fingerprint
+        let input = uint64 value
+
+        for bit in 7..-1..0 do
+            let reduce = candidate &&& topFingerprintBit <> 0UL
+            candidate <- (candidate <<< 1) ||| ((input >>> bit) &&& 1UL)
+
+            if reduce then candidate <- candidate ^^^ Polynomial
+
+        candidate
+
+    let private outgoingByteTable =
+        Array.init 256 (fun value ->
+            let mutable fingerprint = appendByte 0UL (byte value)
+
+            for _ in 1..WindowSize do
+                fingerprint <- appendByte fingerprint 0uy
+
+            fingerprint)
+
+    let private isNaturalBoundary fingerprint =
+        fingerprint <> 0UL
+        && (fingerprint &&& cutMask) = cutValue
+
+    let private findChunkEnd (bytes: byte array) start =
+        let limit = Math.Min(bytes.Length, start + MaximumChunkSize)
+        let mutable fingerprint = 0UL
+        let mutable windowBytes = 0
+        let mutable index = start
+        let mutable chunkEnd = limit
+        let mutable foundNaturalBoundary = false
+
+        while index < limit && not foundNaturalBoundary do
+            let nextByte = bytes[index]
+
+            if windowBytes < WindowSize then
+                fingerprint <- appendByte fingerprint nextByte
+                windowBytes <- windowBytes + 1
+            else
+                let outgoingByte = bytes[index - WindowSize]
+
+                fingerprint <-
+                    (appendByte fingerprint nextByte)
+                    ^^^ outgoingByteTable[int outgoingByte]
+
+            let chunkLength = index - start + 1
+
+            if chunkLength >= MinimumChunkSize
+               && isNaturalBoundary fingerprint then
+                chunkEnd <- index + 1
+                foundNaturalBoundary <- true
+
+            index <- index + 1
+
+        chunkEnd
+
+    let private copyRange (bytes: byte array) offset length =
+        let chunkBytes = Array.zeroCreate<byte> length
+        Array.Copy(bytes, offset, chunkBytes, 0, length)
+        chunkBytes
+
+    /// Chunks bytes with grace-rabin-blake3-64k-v1.
+    ///
+    /// Natural boundaries are checked only after the 8 KiB minimum by evaluating the current 64-byte Rabin window with
+    /// polynomial 0x3DA3358B4DC173. A boundary is selected when the non-zero fingerprint matches the 64 KiB target mask;
+    /// otherwise a cut is forced at 128 KiB. Each returned chunk is addressed with lowercase BLAKE3.
+    let chunkBytes (bytes: byte array) : Chunk array =
+        if isNull bytes then nullArg (nameof bytes)
+
+        let chunks = ResizeArray<Chunk>()
+        let mutable offset = 0
+
+        while offset < bytes.Length do
+            let chunkEnd = findChunkEnd bytes offset
+            let chunkLength = chunkEnd - offset
+            let chunkPayload = copyRange bytes offset chunkLength
+
+            chunks.Add({ Offset = int64 offset; Length = chunkLength; Address = ContentAddress.computeChunkAddress chunkPayload })
+
+            offset <- chunkEnd
+
+        chunks.ToArray()

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Types.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />
+    <Compile Include="RabinChunking.Shared.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />
     <Compile Include="Program.fs" />
@@ -25,6 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="FsUnit" Version="7.1.1" />
+    <PackageReference Include="FsCheck" Version="3.3.3" />
+    <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />

--- a/src/Grace.Types.Tests/RabinChunking.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/RabinChunking.Shared.Tests.fs
@@ -1,0 +1,108 @@
+namespace Grace.Types.Tests
+
+open FsCheck
+open Grace.Shared
+open NUnit.Framework
+open System
+
+[<Parallelizable(ParallelScope.All)>]
+type RabinChunkingSharedTests() =
+    static member private PseudoRandomBytes length =
+        let bytes = Array.zeroCreate<byte> length
+        let mutable state = 0x12345678u
+
+        for index in 0 .. length - 1 do
+            state <- state ^^^ (state <<< 13)
+            state <- state ^^^ (state >>> 17)
+            state <- state ^^^ (state <<< 5)
+            bytes[index] <- byte (state &&& 0xffu)
+
+        bytes
+
+    [<Test>]
+    member _.PinnedSuiteExposesConstantsForClientImplementations() =
+        Assert.That(RabinChunking.SuiteName, Is.EqualTo("grace-rabin-blake3-64k-v1"))
+        Assert.That(RabinChunking.MinimumChunkSize, Is.EqualTo(8 * 1024))
+        Assert.That(RabinChunking.TargetChunkSize, Is.EqualTo(64 * 1024))
+        Assert.That(RabinChunking.MaximumChunkSize, Is.EqualTo(128 * 1024))
+        Assert.That(RabinChunking.WindowSize, Is.EqualTo(64))
+        Assert.That(RabinChunking.Polynomial, Is.EqualTo(0x3DA3358B4DC173UL))
+
+    [<Test>]
+    member _.EmptyPayloadHasNoChunks() = Assert.That(RabinChunking.chunkBytes Array.empty, Is.Empty)
+
+    [<Test>]
+    member _.PayloadBelowMinimumEmitsOneChunkWithItsBlake3Address() =
+        let payload = RabinChunkingSharedTests.PseudoRandomBytes 4096
+        let chunks = RabinChunking.chunkBytes payload
+
+        Assert.That(chunks, Has.Length.EqualTo(1))
+        Assert.That(chunks[0].Offset, Is.EqualTo(0L))
+        Assert.That(chunks[0].Length, Is.EqualTo(payload.Length))
+        Assert.That(chunks[0].Address, Is.EqualTo(ContentAddress.computeChunkAddress payload))
+
+    [<Test>]
+    member _.ForcedMaximumCutsWhenNoNaturalBoundaryAppears() =
+        let payload = Array.zeroCreate<byte> ((128 * 1024) + 17)
+        let chunks = RabinChunking.chunkBytes payload
+
+        Assert.That((chunks |> Array.map (fun chunk -> chunk.Length)) = [| 128 * 1024; 17 |], Is.True)
+        Assert.That((chunks |> Array.map (fun chunk -> chunk.Offset)) = [| 0L; 128L * 1024L |], Is.True)
+
+    [<Test>]
+    member _.SeededPayloadHasPinnedChunkBoundaries() =
+        let payload = RabinChunkingSharedTests.PseudoRandomBytes 220000
+        let chunks = RabinChunking.chunkBytes payload
+
+        Assert.That((chunks |> Array.map (fun chunk -> chunk.Offset)) = [| 0L; 119720L; 128931L; 210902L |], Is.True)
+        Assert.That((chunks |> Array.map (fun chunk -> chunk.Length)) = [| 119720; 9211; 81971; 9098 |], Is.True)
+
+        let expectedAddresses =
+            [|
+                "112f66f6756ae61adf847406c2a9e435278c6d29814a537347bf690e99c4e15b"
+                "455d9abeff18abb4a12a1af098191009a42e2a0bc313e525d40740d88e57bf91"
+                "d7507a7baa204fcd27ef724c9657af25ae879f6bde31fc0007782e7546eaf0a2"
+                "73c207c781be308ce9b38d173c3d09cf53cb2922f181ae6d1af214837df402e0"
+            |]
+
+        Assert.That((chunks |> Array.map (fun chunk -> chunk.Address)) = expectedAddresses, Is.True)
+
+    [<Test>]
+    member _.ChunkingIsDeterministic() =
+        let payload = RabinChunkingSharedTests.PseudoRandomBytes 220000
+
+        Assert.That(RabinChunking.chunkBytes payload = RabinChunking.chunkBytes payload, Is.True)
+
+    [<Test>]
+    member _.FsCheckPropertiesHoldForChunkCoverageAndSizing() =
+        let property (NonNegativeInt requestedLength) =
+            let length = Math.Min(requestedLength, 512 * 1024)
+            let payload = RabinChunkingSharedTests.PseudoRandomBytes length
+            let chunks = RabinChunking.chunkBytes payload
+
+            let lengths = chunks |> Array.map (fun chunk -> chunk.Length)
+            let offsets = chunks |> Array.map (fun chunk -> chunk.Offset)
+
+            let reconstructed =
+                chunks
+                |> Array.collect (fun chunk -> payload[int chunk.Offset .. int chunk.Offset + chunk.Length - 1])
+
+            let expectedOffsets =
+                lengths
+                |> Array.scan (fun offset length -> offset + int64 length) 0L
+                |> Array.take chunks.Length
+
+            (length = 0 && chunks.Length = 0
+             || (chunks.Length > 0
+                 && (lengths |> Array.sum) = length
+                 && offsets = expectedOffsets
+                 && reconstructed = payload
+                 && (chunks
+                     |> Array.forall (fun chunk ->
+                         chunk.Length > 0
+                         && chunk.Length <= RabinChunking.MaximumChunkSize))
+                 && (chunks
+                     |> Array.truncate (Math.Max(0, chunks.Length - 1))
+                     |> Array.forall (fun chunk -> chunk.Length >= RabinChunking.MinimumChunkSize))))
+
+        Check.QuickThrowOnFailure property


### PR DESCRIPTION
## Summary

- Implements pure `Grace.Shared.RabinChunking` support for the pinned `grace-rabin-blake3-64k-v1` suite.
- Exposes the client-visible constants: 8 KiB minimum, 64 KiB target, 128 KiB maximum, 64-byte Rabin window, polynomial `0x3DA3358B4DC173`, and suite name.
- Returns deterministic chunk offsets, lengths, and lowercase BLAKE3 chunk addresses.

## Linked Issue

Closes #81.

## TDD Evidence

- RED: `dotnet test --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj` failed with `FS0039: The value, namespace, type or module 'RabinChunking' is not defined` after adding the chunk boundary examples and FsCheck coverage.
- GREEN: the same focused test project passes after adding the shared implementation.

## Changed Files

- `src/Grace.Shared/RabinChunking.Shared.fs`
- `src/Grace.Shared/Grace.Shared.fsproj`
- `src/Grace.Types.Tests/RabinChunking.Shared.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

- `dotnet test --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj` - passed, 40 tests.
- `dotnet tool run fantomas Grace.Shared\RabinChunking.Shared.fs Grace.Types.Tests\RabinChunking.Shared.Tests.fs` from `./src` - passed.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed; Release build clean, Authorization tests passed, CLI tests passed with the existing 1 skipped test, Types tests passed.

## Docs Impact

- Suite constants and the boundary rule are recorded in XML comments on the public shared module and constants so clients can implement the same suite.
- No separate ADR/docs file was updated because #81 owns only shared logic and tests.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice is pure shared chunking logic and does not touch Aspire, emulators, storage, Service Bus, Cosmos DB, Redis, deployment/runtime behavior, or cross-service integration.

## Residual Risk

- The Rabin suite is now pinned by examples and FsCheck invariants, but downstream upload/manifest planners still need their DAG issues to adopt it.

## Follow-ups

- #82 and #99 can consume `RabinChunking.chunkBytes` once this merges.
