### PR TITLE
Add whole-file storage compatibility metadata

### DIFF
--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
+    <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -1,0 +1,112 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open NUnit.Framework
+open System
+open System.Net
+open System.Security.Cryptography
+open System.Text
+open System.Text.Json
+
+[<NonParallelizable>]
+type StorageWholeFileCompatibility() =
+
+    let computeSha256Hash (bytes: byte array) =
+        let hash = SHA256.HashData(bytes)
+        byteArrayToString (hash.AsSpan())
+
+    let tryGetJsonProperty (name: string) (element: JsonElement) =
+        element.EnumerateObject()
+        |> Seq.tryFind (fun property -> property.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+        |> Option.map (fun property -> property.Value)
+
+    let requireJsonProperty (name: string) (element: JsonElement) =
+        match tryGetJsonProperty name element with
+        | Some value -> value
+        | None ->
+            Assert.Fail($"Expected JSON property '{name}'.")
+            Unchecked.defaultof<JsonElement>
+
+    let assertWholeFileContentReference (metadata: JsonElement) =
+        let contentReference = requireJsonProperty "ContentReference" metadata
+        let referenceType = requireJsonProperty "ReferenceType" contentReference
+
+        match referenceType.ValueKind with
+        | JsonValueKind.Number -> Assert.That(referenceType.GetInt32(), Is.EqualTo(int FileContentReferenceType.WholeFileContent))
+        | JsonValueKind.String -> Assert.That(referenceType.GetString(), Is.EqualTo("WholeFileContent").IgnoreCase)
+        | _ -> Assert.Fail($"Unexpected ContentReference.ReferenceType JSON kind: {referenceType.ValueKind}.")
+
+        match tryGetJsonProperty "Manifest" contentReference with
+        | Some manifest -> Assert.That(manifest.ValueKind, Is.EqualTo(JsonValueKind.Null))
+        | None -> ()
+
+    let getUploadMetadataJson (content: string) =
+        use document = JsonDocument.Parse(content)
+        let root = document.RootElement.Clone()
+        let returnValue = requireJsonProperty "ReturnValue" root
+        returnValue.EnumerateArray() |> Seq.exactlyOne
+
+    let createUploadParameters repositoryId fileVersion =
+        let parameters = Parameters.Storage.GetUploadMetadataForFilesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.FileVersions <- [| fileVersion |]
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let createDownloadParameters repositoryId fileVersion =
+        let parameters = Parameters.Storage.GetDownloadUriParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.FileVersion <- fileVersion
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    [<Test>]
+    member _.SmallWholeFileContentPopulatesContentReferenceWithoutChangingEndpointMetadata() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let relativeDirectory = $"wholefile-compatibility/{Guid.NewGuid():N}"
+            let relativePath = $"{relativeDirectory}/small.bin"
+            let payload = Encoding.UTF8.GetBytes($"Grace whole-file compatibility {Guid.NewGuid():N}")
+            let sha256Hash = computeSha256Hash payload
+            let fileVersion = FileVersion.Create relativePath sha256Hash String.Empty true (int64 payload.Length)
+
+            let! uploadResponse = Client.PostAsync("/storage/getUploadMetadataForFiles", createJsonContent (createUploadParameters repositoryId fileVersion))
+            let! uploadContent = uploadResponse.Content.ReadAsStringAsync()
+            Assert.That(uploadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadContent)
+
+            let metadata = getUploadMetadataJson uploadContent
+
+            Assert.That(
+                (requireJsonProperty "RelativePath" metadata)
+                    .GetString(),
+                Is.EqualTo(relativePath)
+            )
+
+            Assert.That(
+                (requireJsonProperty "Sha256Hash" metadata)
+                    .GetString(),
+                Is.EqualTo(sha256Hash)
+            )
+
+            assertWholeFileContentReference metadata
+
+            let blobUri =
+                Uri(
+                    (requireJsonProperty "BlobUriWithSasToken" metadata)
+                        .GetString()
+                )
+
+            Assert.That(blobUri.IsAbsoluteUri, Is.True)
+
+            let! downloadResponse = Client.PostAsync("/storage/getDownloadUri", createJsonContent (createDownloadParameters repositoryId fileVersion))
+            let! downloadUri = downloadResponse.Content.ReadAsStringAsync()
+            Assert.That(downloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), downloadUri)
+            Assert.That(downloadUri, Does.Contain(fileVersion.GetObjectFileName))
+        }

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -32,16 +32,50 @@ open System.Diagnostics
 open System.Reflection.Metadata
 open System.Net.Http.Json
 
+module StorageParameterContracts = Grace.Shared.Parameters.Storage
+
 module Storage =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Storage.Server")
+
+    let private normalizeWholeFileContentReference (fileVersion: FileVersion) =
+        if isNull (box fileVersion.ContentReference) then
+            FileContentReference.WholeFileContent
+        else
+            match fileVersion.ContentReference.ReferenceType with
+            | FileContentReferenceType.WholeFileContent -> fileVersion.ContentReference
+            | FileContentReferenceType.FileManifest ->
+                invalidOp "FileManifest content references are not supported by the current storage compatibility endpoints."
+            | unsupported -> invalidOp $"Unsupported file content reference type: {unsupported}."
+
+    let private getWholeFileContentObjectKey (fileVersion: FileVersion) =
+        normalizeWholeFileContentReference fileVersion
+        |> ignore
+
+        StorageKeys.wholeFileContentObjectKey fileVersion
+
+    let private resolveStorageIds (graceIds: GraceIds) (parameters: StorageParameters) =
+        let organizationId =
+            if graceIds.OrganizationId <> OrganizationId.Empty then
+                graceIds.OrganizationId
+            else
+                OrganizationId.Parse parameters.OrganizationId
+
+        let repositoryId =
+            if graceIds.RepositoryId <> RepositoryId.Empty then
+                graceIds.RepositoryId
+            else
+                RepositoryId.Parse parameters.RepositoryId
+
+        organizationId, repositoryId
 
     /// Gets the metadata stored in the object storage provider for the specified file.
     let getFileMetadata (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (context: HttpContext) =
         task {
             match repositoryDto.ObjectStorageProvider with
             | AzureBlobStorage ->
-                let! blobClient = getAzureBlobClientForFileVersion repositoryDto fileVersion (getCorrelationId context)
+                let blobName = getWholeFileContentObjectKey fileVersion
+                let! blobClient = getAzureBlobClient repositoryDto blobName (getCorrelationId context)
                 let! azureResponse = blobClient.GetPropertiesAsync()
                 let blobProperties = azureResponse.Value
                 return Ok(blobProperties.Metadata :?> IReadOnlyDictionary<string, string>)
@@ -64,10 +98,12 @@ module Storage =
 
                 try
                     let! parameters = context.BindJsonAsync<GetDownloadUriParameters>()
-                    let repositoryActor = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
+                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
                     let! repositoryDto = repositoryActor.Get correlationId
 
-                    let! downloadUri = getUriWithReadSharedAccessSignatureForFileVersion repositoryDto parameters.FileVersion correlationId
+                    let blobName = getWholeFileContentObjectKey parameters.FileVersion
+                    let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
                     context.SetStatusCode StatusCodes.Status200OK
                     //log.LogTrace("fileVersion: {fileVersion.RelativePath}; downloadUri: {downloadUri}", [| parameters.FileVersion.RelativePath, downloadUri |])
                     return! context.WriteStringAsync $"{downloadUri}"
@@ -87,11 +123,13 @@ module Storage =
 
                 try
                     let! parameters = context.BindJsonAsync<GetUploadUriParameters>()
-                    let repositoryActor = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
+                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
                     let! repositoryDto = repositoryActor.Get correlationId
 
                     for fileVersion in parameters.FileVersions do
-                        let! uploadUri = getUriWithWriteSharedAccessSignatureForFileVersion repositoryDto fileVersion correlationId
+                        let blobName = getWholeFileContentObjectKey fileVersion
+                        let! uploadUri = getUriWithWriteSharedAccessSignature repositoryDto blobName correlationId
                         uris.Add(fileVersion.RelativePath, uploadUri)
 
                     if log.IsEnabled(LogLevel.Debug) then
@@ -130,10 +168,11 @@ module Storage =
                     |> ignore
 
                     if parameters.FileVersions.Length > 0 then
-                        let repositoryActor = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
+                        let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                        let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
                         let! repositoryDto = repositoryActor.Get correlationId
 
-                        let uploadMetadata = ConcurrentQueue<UploadMetadata>()
+                        let uploadMetadata = ConcurrentQueue<StorageParameterContracts.UploadMetadata>()
 
                         do!
                             Parallel.ForEachAsync(
@@ -145,16 +184,20 @@ module Storage =
                                             //let! fileExists = fileExists repositoryDto fileVersion context
 
                                             //if not <| fileExists then
-                                            let! blobUriWithSasToken =
-                                                getUriWithWriteSharedAccessSignatureForFileVersion repositoryDto fileVersion correlationId
+                                            let contentReference = normalizeWholeFileContentReference fileVersion
+                                            let blobName = getWholeFileContentObjectKey fileVersion
 
-                                            uploadMetadata.Enqueue(
+                                            let! blobUriWithSasToken = getUriWithWriteSharedAccessSignature repositoryDto blobName correlationId
+
+                                            let metadata: StorageParameterContracts.UploadMetadata =
                                                 {
                                                     RelativePath = fileVersion.RelativePath
                                                     BlobUriWithSasToken = blobUriWithSasToken
                                                     Sha256Hash = fileVersion.Sha256Hash
+                                                    ContentReference = contentReference
                                                 }
-                                            )
+
+                                            uploadMetadata.Enqueue(metadata)
                                         }
                                     ))
                             )

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -29,6 +29,8 @@ module Storage =
         inherit StorageParameters()
         member val public FileVersion = FileVersion.Default with get, set
 
+    type UploadMetadata = { RelativePath: RelativePath; BlobUriWithSasToken: Uri; Sha256Hash: Sha256Hash; ContentReference: FileContentReference }
+
     type GetUploadMetadataForFilesParameters() =
         inherit StorageParameters()
         member val public FileVersions = Array.empty<FileVersion> with get, set


### PR DESCRIPTION
## Summary

- Routes the current storage upload/download compatibility path through `FileContentReference.WholeFileContent` while preserving the existing relative path, SHA-256, and SAS metadata fields.
- Adds `ContentReference` to storage upload metadata so clients can observe the content reference selected for the file version.
- Adds a focused server compatibility test that first failed on missing `ContentReference`, then passed after the implementation.

Fixes #86.

## Touched Paths

- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.Shared/Parameters/Storage.Parameters.fs`
- `src/Grace.Server.Tests/Storage.Server.Tests.fs`
- `src/Grace.Server.Tests/Grace.Server.Tests.fsproj`

## Validation

- RED: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~StorageWholeFileCompatibility.SmallWholeFileContentPopulatesContentReferenceWithoutChangingEndpointMetadata"` initially failed because upload metadata did not include `ContentReference`.
- GREEN focused: same command passed after implementation.
- Formatting: `dotnet tool run fantomas Grace.Server/Storage.Server.fs Grace.Shared/Parameters/Storage.Parameters.fs Grace.SDK/Storage.SDK.fs Grace.Server.Tests/Storage.Server.Tests.fs` from `src` (reran targeted test-file formatting after replacing unsupported shorthand).
- Rebased onto latest `origin/main`, then reran focused test: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after final rebase.
- `pwsh ./scripts/validate.ps1 -Full`: passed after final rebase.
- `git diff --check`: passed.

## Docs Impact

No docs changes. The existing storage endpoint behavior and CLI-facing fields remain compatible; this PR adds metadata to the response contract rather than changing commands or workflow guidance.

## Skipped Validation

None intentionally skipped. The repo validation script's format stage reports as skipped because it is temporarily disabled by the script; targeted Fantomas was run manually for touched F# files.

## Residual Risk

- This keeps manifest-backed file content out of the legacy storage endpoint path for now. `FileManifest` references still raise as unsupported in the compatibility endpoint path, matching this slice's WholeFileContent-only scope.
- The test verifies endpoint metadata and download URI generation. It does not upload through the returned SAS URI because local Azurite SAS authorization exposed unrelated emulator/account-shape behavior during development; full server validation still passes.

## Follow-ups

- Future ADR DAG slices can add manifest-backed upload/download behavior once manifest creation is enabled by the later nodes.
