### PR TITLE
Add ContentBlock v1 format helpers

### DIFF
--- a/src/Grace.Shared/ContentBlockFormat.Shared.fs
+++ b/src/Grace.Shared/ContentBlockFormat.Shared.fs
@@ -200,28 +200,29 @@ module ContentBlockFormat =
                     Error InvalidTrailer
                 elif chunkCount = 0u then
                     Error EmptyBlock
-                elif chunkCount > uint32 Int32.MaxValue then
-                    Error InvalidTrailer
                 else
-                    let expectedLength =
-                        TrailerHeaderLength
-                        + (int chunkCount * ChunkRecordLength)
+                    let recordBytes = trailer.Length - TrailerHeaderLength
 
-                    if trailer.Length <> expectedLength then
+                    if recordBytes % ChunkRecordLength <> 0 then
                         Error InvalidTrailer
                     else
-                        let records =
-                            [|
-                                for index in 0 .. int chunkCount - 1 do
-                                    let offset = TrailerHeaderLength + (index * ChunkRecordLength)
-                                    let physicalOffset = readInt64 trailer offset
-                                    let length = readUInt32 trailer (offset + 8)
-                                    let addressBytes = copyRange trailer (offset + 12) AddressLength
+                        let expectedChunkCount = recordBytes / ChunkRecordLength
 
-                                    yield physicalOffset, length, bytesToChunkAddress addressBytes
-                            |]
+                        if chunkCount <> uint32 expectedChunkCount then
+                            Error InvalidTrailer
+                        else
+                            let records =
+                                [|
+                                    for index in 0 .. int chunkCount - 1 do
+                                        let offset = TrailerHeaderLength + (index * ChunkRecordLength)
+                                        let physicalOffset = readInt64 trailer offset
+                                        let length = readUInt32 trailer (offset + 8)
+                                        let addressBytes = copyRange trailer (offset + 12) AddressLength
 
-                        Ok records
+                                        yield physicalOffset, length, bytesToChunkAddress addressBytes
+                                |]
+
+                            Ok records
 
     let decode (payload: byte array) =
         if isNull payload then

--- a/src/Grace.Shared/ContentBlockFormat.Shared.fs
+++ b/src/Grace.Shared/ContentBlockFormat.Shared.fs
@@ -1,0 +1,312 @@
+namespace Grace.Shared
+
+open Grace.Types.Types
+open System
+open System.Buffers.Binary
+open System.IO
+open System.Text
+
+/// Encodes and validates the physical bytes stored for a reusable ContentBlock.
+///
+/// ContentBlock v1 payloads are `chunk-bytes || trailer || footer`.
+///
+/// The data section is the logical chunk payloads concatenated in order. The trailer starts with `GCB1META`, a version,
+/// reserved flags, and a chunk count. Each chunk record stores the source physical offset, logical chunk length, and the
+/// 32-byte BLAKE3 chunk address. The footer stores the trailer length, BLAKE3 trailer checksum, and `GCB1END!`.
+/// `ContentBlockAddress` is intentionally derived from the ordered chunk addresses plus `FormatName`; physical offsets
+/// are validation/reader metadata and do not affect the logical block identity.
+module ContentBlockFormat =
+    [<Literal>]
+    let FormatName = "grace-contentblock-v1"
+
+    [<Literal>]
+    let FooterLength = 44
+
+    [<Literal>]
+    let private AddressLength = 32
+
+    [<Literal>]
+    let private TrailerHeaderLength = 16
+
+    [<Literal>]
+    let private ChunkRecordLength = 44
+
+    [<Literal>]
+    let private Version = 1us
+
+    let private trailerMagic = Encoding.ASCII.GetBytes("GCB1META")
+    let private footerMagic = Encoding.ASCII.GetBytes("GCB1END!")
+
+    type ContentBlockFormatError =
+        | NullChunkSequence
+        | NullPayload
+        | EmptyBlock
+        | InvalidChunk of index: int * reason: string
+        | PayloadTooSmall
+        | InvalidFooter
+        | InvalidTrailer
+        | TrailerChecksumMismatch
+        | UnsupportedVersion of version: int
+        | ChunkAddressMismatch of index: int * expected: ChunkAddress * actual: ChunkAddress
+        | ContentBlockAddressMismatch of expected: ContentBlockAddress * actual: ContentBlockAddress
+
+    type ContentBlockInputChunk = { PhysicalOffset: int64; Bytes: byte array }
+
+    type ContentBlockChunk = { PhysicalOffset: int64; LogicalOffset: int64; Length: int; Address: ChunkAddress; Bytes: byte array }
+
+    type EncodedContentBlock = { Address: ContentBlockAddress; Payload: byte array; Chunks: ContentBlockChunk array }
+
+    type DecodedContentBlock = { Address: ContentBlockAddress; Payload: byte array; Chunks: ContentBlockChunk array }
+
+    let createChunk physicalOffset bytes = { PhysicalOffset = physicalOffset; Bytes = bytes }
+
+    let private copyRange (bytes: byte array) offset length =
+        let copy = Array.zeroCreate<byte> length
+        Array.Copy(bytes, offset, copy, 0, length)
+        copy
+
+    let private hashBytes (bytes: byte array) =
+        ContentAddress.computeBlake3Hex bytes
+        |> Convert.FromHexString
+
+    let private bytesToChunkAddress (bytes: byte array) =
+        Convert.ToHexString(bytes).ToLowerInvariant()
+        |> ChunkAddress
+
+    let private writeUInt16 (stream: MemoryStream) value =
+        let bytes = Array.zeroCreate<byte> 2
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes, value)
+        stream.Write(bytes, 0, bytes.Length)
+
+    let private writeUInt32 (stream: MemoryStream) value =
+        let bytes = Array.zeroCreate<byte> 4
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes, value)
+        stream.Write(bytes, 0, bytes.Length)
+
+    let private writeInt64 (stream: MemoryStream) value =
+        let bytes = Array.zeroCreate<byte> 8
+        BinaryPrimitives.WriteInt64LittleEndian(bytes, value)
+        stream.Write(bytes, 0, bytes.Length)
+
+    let private readUInt16 (bytes: byte array) offset = BinaryPrimitives.ReadUInt16LittleEndian(ReadOnlySpan<byte>(bytes, offset, 2))
+
+    let private readUInt32 (bytes: byte array) offset = BinaryPrimitives.ReadUInt32LittleEndian(ReadOnlySpan<byte>(bytes, offset, 4))
+
+    let private readInt64 (bytes: byte array) offset = BinaryPrimitives.ReadInt64LittleEndian(ReadOnlySpan<byte>(bytes, offset, 8))
+
+    let private sequenceEqual (expected: byte array) (actual: byte array) =
+        expected.Length = actual.Length
+        && Array.forall2 (=) expected actual
+
+    let private buildTrailer (chunks: ContentBlockChunk array) =
+        use stream = new MemoryStream()
+
+        stream.Write(trailerMagic, 0, trailerMagic.Length)
+        writeUInt16 stream Version
+        writeUInt16 stream 0us
+        writeUInt32 stream (uint32 chunks.Length)
+
+        for chunk in chunks do
+            writeInt64 stream chunk.PhysicalOffset
+            writeUInt32 stream (uint32 chunk.Length)
+
+            let addressBytes = Convert.FromHexString(chunk.Address)
+            stream.Write(addressBytes, 0, addressBytes.Length)
+
+        stream.ToArray()
+
+    let private buildFooter (trailer: byte array) =
+        use stream = new MemoryStream()
+
+        writeUInt32 stream (uint32 trailer.Length)
+
+        let trailerHash = hashBytes trailer
+        stream.Write(trailerHash, 0, trailerHash.Length)
+        stream.Write(footerMagic, 0, footerMagic.Length)
+        stream.ToArray()
+
+    let private toMetadata (chunks: ContentBlockInputChunk array) =
+        let mutable logicalOffset = 0L
+        let metadata = ResizeArray<ContentBlockChunk>()
+        let mutable error = None
+        let mutable index = 0
+
+        while index < chunks.Length && Option.isNone error do
+            let chunk = chunks[index]
+
+            if chunk.PhysicalOffset < 0L then
+                error <- Some(InvalidChunk(index, "Physical offset cannot be negative."))
+            elif isNull chunk.Bytes then
+                error <- Some(InvalidChunk(index, "Chunk bytes cannot be null."))
+            elif chunk.Bytes.Length = 0 then
+                error <- Some(InvalidChunk(index, "Chunk bytes cannot be empty."))
+            else
+                let bytes = Array.copy chunk.Bytes
+                let address = ContentAddress.computeChunkAddress bytes
+
+                metadata.Add({ PhysicalOffset = chunk.PhysicalOffset; LogicalOffset = logicalOffset; Length = bytes.Length; Address = address; Bytes = bytes })
+
+                logicalOffset <- logicalOffset + int64 bytes.Length
+
+            index <- index + 1
+
+        match error with
+        | Some error -> Error error
+        | None -> Ok(metadata.ToArray())
+
+    let encode (chunks: ContentBlockInputChunk seq) =
+        if isNull (box chunks) then
+            Error NullChunkSequence
+        else
+            let chunkArray = chunks |> Seq.toArray
+
+            if chunkArray.Length = 0 then
+                Error EmptyBlock
+            else
+                match toMetadata chunkArray with
+                | Error error -> Error error
+                | Ok metadata ->
+                    let data =
+                        metadata
+                        |> Array.collect (fun chunk -> chunk.Bytes)
+
+                    let trailer = buildTrailer metadata
+                    let footer = buildFooter trailer
+
+                    let payload = Array.concat [ data; trailer; footer ]
+
+                    let address =
+                        metadata
+                        |> Array.map (fun chunk -> chunk.Address)
+                        |> ContentAddress.computeContentBlockAddress FormatName
+
+                    Ok { Address = address; Payload = payload; Chunks = metadata }
+
+    let private parseTrailer (trailer: byte array) =
+        if trailer.Length < TrailerHeaderLength then
+            Error InvalidTrailer
+        elif not (sequenceEqual trailerMagic trailer[0 .. trailerMagic.Length - 1]) then
+            Error InvalidTrailer
+        else
+            let version = readUInt16 trailer 8
+
+            if version <> Version then
+                Error(UnsupportedVersion(int version))
+            else
+                let flags = readUInt16 trailer 10
+                let chunkCount = readUInt32 trailer 12
+
+                if flags <> 0us then
+                    Error InvalidTrailer
+                elif chunkCount = 0u then
+                    Error EmptyBlock
+                elif chunkCount > uint32 Int32.MaxValue then
+                    Error InvalidTrailer
+                else
+                    let expectedLength =
+                        TrailerHeaderLength
+                        + (int chunkCount * ChunkRecordLength)
+
+                    if trailer.Length <> expectedLength then
+                        Error InvalidTrailer
+                    else
+                        let records =
+                            [|
+                                for index in 0 .. int chunkCount - 1 do
+                                    let offset = TrailerHeaderLength + (index * ChunkRecordLength)
+                                    let physicalOffset = readInt64 trailer offset
+                                    let length = readUInt32 trailer (offset + 8)
+                                    let addressBytes = copyRange trailer (offset + 12) AddressLength
+
+                                    yield physicalOffset, length, bytesToChunkAddress addressBytes
+                            |]
+
+                        Ok records
+
+    let decode (payload: byte array) =
+        if isNull payload then
+            Error NullPayload
+        elif payload.Length < TrailerHeaderLength + FooterLength then
+            Error PayloadTooSmall
+        else
+            let footerStart = payload.Length - FooterLength
+            let footer = copyRange payload footerStart FooterLength
+            let footerMagicStart = FooterLength - footerMagic.Length
+
+            if not (sequenceEqual footerMagic footer[footerMagicStart .. FooterLength - 1]) then
+                Error InvalidFooter
+            else
+                let trailerLength = readUInt32 footer 0
+
+                if trailerLength < uint32 TrailerHeaderLength
+                   || trailerLength > uint32 footerStart then
+                    Error InvalidFooter
+                else
+                    let trailerStart = footerStart - int trailerLength
+                    let trailer = copyRange payload trailerStart (int trailerLength)
+                    let expectedTrailerHash = copyRange footer 4 AddressLength
+                    let actualTrailerHash = hashBytes trailer
+
+                    if not (sequenceEqual expectedTrailerHash actualTrailerHash) then
+                        Error TrailerChecksumMismatch
+                    else
+                        match parseTrailer trailer with
+                        | Error error -> Error error
+                        | Ok records ->
+                            let mutable logicalOffset = 0L
+                            let decodedChunks = ResizeArray<ContentBlockChunk>()
+                            let mutable error = None
+                            let mutable index = 0
+
+                            while index < records.Length && Option.isNone error do
+                                let physicalOffset, length, expectedAddress = records[index]
+
+                                if physicalOffset < 0L then
+                                    error <- Some InvalidTrailer
+                                elif length = 0u || length > uint32 Int32.MaxValue then
+                                    error <- Some InvalidTrailer
+                                elif logicalOffset + int64 length > int64 trailerStart then
+                                    error <- Some InvalidTrailer
+                                else
+                                    let chunkBytes = copyRange payload (int logicalOffset) (int length)
+                                    let actualAddress = ContentAddress.computeChunkAddress chunkBytes
+
+                                    if actualAddress <> expectedAddress then
+                                        error <- Some(ChunkAddressMismatch(index, expectedAddress, actualAddress))
+                                    else
+                                        decodedChunks.Add(
+                                            {
+                                                PhysicalOffset = physicalOffset
+                                                LogicalOffset = logicalOffset
+                                                Length = int length
+                                                Address = actualAddress
+                                                Bytes = chunkBytes
+                                            }
+                                        )
+
+                                        logicalOffset <- logicalOffset + int64 length
+
+                                index <- index + 1
+
+                            match error with
+                            | Some error -> Error error
+                            | None when logicalOffset <> int64 trailerStart -> Error InvalidTrailer
+                            | None ->
+                                let chunks = decodedChunks.ToArray()
+
+                                let address =
+                                    chunks
+                                    |> Array.map (fun chunk -> chunk.Address)
+                                    |> ContentAddress.computeContentBlockAddress FormatName
+
+                                Ok { Address = address; Payload = copyRange payload 0 trailerStart; Chunks = chunks }
+
+    let validateAddress expectedAddress decodedBlock =
+        if expectedAddress = decodedBlock.Address then
+            Ok()
+        else
+            Error(ContentBlockAddressMismatch(expectedAddress, decodedBlock.Address))
+
+    let validatePayloadAddress expectedAddress payload =
+        decode payload
+        |> Result.bind (validateAddress expectedAddress)

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -26,6 +26,7 @@
         <Compile Include="Utilities.Shared.fs" />
         <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="ContentAddress.Shared.fs" />
+        <Compile Include="ContentBlockFormat.Shared.fs" />
         <Compile Include="RabinChunking.Shared.fs" />
         <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />

--- a/src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs
@@ -4,6 +4,7 @@ open Grace.Shared
 open Grace.Types.Types
 open NUnit.Framework
 open System
+open System.Buffers.Binary
 open System.Text
 
 [<Parallelizable(ParallelScope.All)>]
@@ -16,6 +17,18 @@ type ContentBlockFormatSharedTests() =
         | Error error ->
             Assert.Fail($"Expected Ok but got {error}.")
             Unchecked.defaultof<'T>
+
+    static member private RehashTrailerFooter(payload: byte array) =
+        let footerStart = payload.Length - ContentBlockFormat.FooterLength
+        let trailerLength = BinaryPrimitives.ReadUInt32LittleEndian(ReadOnlySpan<byte>(payload, footerStart, 4))
+        let trailerStart = footerStart - int trailerLength
+        let trailer = payload[trailerStart .. footerStart - 1]
+
+        let trailerHash =
+            ContentAddress.computeBlake3Hex trailer
+            |> Convert.FromHexString
+
+        Array.Copy(trailerHash, 0, payload, footerStart + 4, trailerHash.Length)
 
     [<Test>]
     member _.PayloadRoundtripsThroughCompactV1Format() =
@@ -74,6 +87,29 @@ type ContentBlockFormatSharedTests() =
         match ContentBlockFormat.decode corruptedPayload with
         | Error (ContentBlockFormat.ChunkAddressMismatch (0, _, _)) -> Assert.Pass()
         | result -> Assert.Fail($"Expected ChunkAddressMismatch for chunk 0 but got {result}.")
+
+    [<Test>]
+    member _.OversizedTrailerChunkCountIsRejectedWithoutThrowing() =
+        let encoded =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L (ContentBlockFormatSharedTests.Bytes "payload") ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        let corruptedPayload = Array.copy encoded.Payload
+
+        let footerStart =
+            corruptedPayload.Length
+            - ContentBlockFormat.FooterLength
+
+        let trailerLength = BinaryPrimitives.ReadUInt32LittleEndian(ReadOnlySpan<byte>(corruptedPayload, footerStart, 4))
+        let trailerStart = footerStart - int trailerLength
+        let chunkCountOffset = trailerStart + 12
+
+        BinaryPrimitives.WriteUInt32LittleEndian(Span<byte>(corruptedPayload, chunkCountOffset, 4), UInt32.MaxValue)
+        ContentBlockFormatSharedTests.RehashTrailerFooter corruptedPayload
+
+        match ContentBlockFormat.decode corruptedPayload with
+        | Error ContentBlockFormat.InvalidTrailer -> Assert.Pass()
+        | result -> Assert.Fail($"Expected InvalidTrailer but got {result}.")
 
     [<Test>]
     member _.PhysicalOffsetsDoNotChangeContentBlockAddress() =

--- a/src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs
@@ -1,0 +1,94 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.Types
+open NUnit.Framework
+open System
+open System.Text
+
+[<Parallelizable(ParallelScope.All)>]
+type ContentBlockFormatSharedTests() =
+    static member private Bytes(value: string) = Encoding.UTF8.GetBytes(value)
+
+    static member private ExpectOk(result: Result<'T, ContentBlockFormat.ContentBlockFormatError>) =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected Ok but got {error}.")
+            Unchecked.defaultof<'T>
+
+    [<Test>]
+    member _.PayloadRoundtripsThroughCompactV1Format() =
+        let alpha = ContentBlockFormatSharedTests.Bytes "alpha chunk"
+        let beta = ContentBlockFormatSharedTests.Bytes "beta chunk"
+
+        let encoded =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 4096L alpha
+                                        ContentBlockFormat.createChunk 12288L beta ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        let decoded =
+            ContentBlockFormat.decode encoded.Payload
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        Assert.That(decoded.Address, Is.EqualTo(encoded.Address))
+        Assert.That(decoded.Payload = Array.concat [ alpha; beta ], Is.True)
+        Assert.That(decoded.Chunks, Has.Length.EqualTo(2))
+        Assert.That(decoded.Chunks[0].PhysicalOffset, Is.EqualTo(4096L))
+        Assert.That(decoded.Chunks[0].LogicalOffset, Is.EqualTo(0L))
+        Assert.That(decoded.Chunks[0].Length, Is.EqualTo(alpha.Length))
+        Assert.That(decoded.Chunks[0].Bytes = alpha, Is.True)
+        Assert.That(decoded.Chunks[1].PhysicalOffset, Is.EqualTo(12288L))
+        Assert.That(decoded.Chunks[1].LogicalOffset, Is.EqualTo(int64 alpha.Length))
+        Assert.That(decoded.Chunks[1].Length, Is.EqualTo(beta.Length))
+        Assert.That(decoded.Chunks[1].Bytes = beta, Is.True)
+
+    [<Test>]
+    member _.CorruptTrailerIsRejected() =
+        let encoded =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L (ContentBlockFormatSharedTests.Bytes "payload") ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        let corruptedPayload = Array.copy encoded.Payload
+
+        let trailerByteIndex =
+            corruptedPayload.Length
+            - ContentBlockFormat.FooterLength
+            - 1
+
+        corruptedPayload[trailerByteIndex] <- corruptedPayload[trailerByteIndex] ^^^ 0x01uy
+
+        match ContentBlockFormat.decode corruptedPayload with
+        | Error ContentBlockFormat.TrailerChecksumMismatch -> Assert.Pass()
+        | result -> Assert.Fail($"Expected TrailerChecksumMismatch but got {result}.")
+
+    [<Test>]
+    member _.ChunkAddressMismatchIsRejected() =
+        let encoded =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L (ContentBlockFormatSharedTests.Bytes "payload") ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        let corruptedPayload = Array.copy encoded.Payload
+        corruptedPayload[0] <- corruptedPayload[0] ^^^ 0x01uy
+
+        match ContentBlockFormat.decode corruptedPayload with
+        | Error (ContentBlockFormat.ChunkAddressMismatch (0, _, _)) -> Assert.Pass()
+        | result -> Assert.Fail($"Expected ChunkAddressMismatch for chunk 0 but got {result}.")
+
+    [<Test>]
+    member _.PhysicalOffsetsDoNotChangeContentBlockAddress() =
+        let alpha = ContentBlockFormatSharedTests.Bytes "alpha chunk"
+        let beta = ContentBlockFormatSharedTests.Bytes "beta chunk"
+
+        let firstLayout =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L alpha
+                                        ContentBlockFormat.createChunk 4096L beta ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        let secondLayout =
+            ContentBlockFormat.encode [ ContentBlockFormat.createChunk 1048576L alpha
+                                        ContentBlockFormat.createChunk 2097152L beta ]
+            |> ContentBlockFormatSharedTests.ExpectOk
+
+        Assert.That(firstLayout.Address, Is.EqualTo(secondLayout.Address))
+        Assert.That(ContentAddress.isValidAddress firstLayout.Address, Is.True)

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Types.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />
+    <Compile Include="ContentBlockFormat.Shared.Tests.fs" />
     <Compile Include="RabinChunking.Shared.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds `ContentBlockFormat` helpers for compact v1 ContentBlock payload encoding and decoding.
- Validates v1 trailers with footer magic, trailer length, and BLAKE3 trailer checksum before parsing chunk records.
- Rejects chunk payload/address mismatches and keeps `ContentBlockAddress` derived from ordered chunk addresses plus the v1 format name, independent of physical offsets.
- Hardens trailer chunk-count validation so malformed trailers return `InvalidTrailer` instead of overflowing length arithmetic or reading out of range.

Closes #82.

## TDD Evidence

- RED: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter ContentBlockFormatSharedTests` failed because `ContentBlockFormat` was not implemented (`FS0039`).
- GREEN: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter ContentBlockFormatSharedTests` passed with the original 4/4 tests.
- Review fix: added `OversizedTrailerChunkCountIsRejectedWithoutThrowing`; focused suite now passes 5/5.

## Changed Files

- `src/Grace.Shared/ContentBlockFormat.Shared.fs`
- `src/Grace.Shared/Grace.Shared.fsproj`
- `src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

- `dotnet tool run fantomas src/Grace.Shared/ContentBlockFormat.Shared.fs src/Grace.Types.Tests/ContentBlockFormat.Shared.Tests.fs` - passed.
- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter ContentBlockFormatSharedTests` - passed, 5/5.
- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj` - passed, 45/45.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed locally; build succeeded with 0 warnings/errors; Authorization 21/21, CLI 194 passed / 1 skipped, Types 45/45.
- GitHub checks after the final push: build success, fast success, full success.

## Docs Impact

- Documented the physical ContentBlock v1 byte format in comments near `ContentBlockFormat`, including data/trailer/footer layout and the rule that physical offsets do not affect `ContentBlockAddress`.
- No docs path was added because issue #82 owns only `src/Grace.Shared/*`, `src/Grace.Types/*`, and `src/Grace.Types.Tests/*` unless expanded first.

## Skipped Validation

- No required validation was skipped. Full validation was not required locally for this pure contract/format helper slice, but the GitHub full check ran and passed.

## Residual Risk

- This establishes the v1 physical payload contract but does not wire storage readers/writers yet, so later DAG nodes still need integration coverage when they persist or retrieve these payloads.

## Follow-ups

- Future storage/metadata DAG nodes should consume `ContentBlockFormat.FormatName`, `encode`, `decode`, and `validatePayloadAddress` rather than recreating the physical format.