### PR TITLE
Add SDK local upload planner

### DIFF
--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Queue.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
+    <Compile Include="LocalPlanner.SDK.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -51,6 +52,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 	</ItemGroup>
 

--- a/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
@@ -1,0 +1,152 @@
+namespace Grace.CLI.Tests
+
+open Grace.SDK
+open Grace.Shared
+open Grace.Types.Types
+open NUnit.Framework
+open System
+open System.IO
+open System.Text
+
+[<Parallelizable(ParallelScope.All)>]
+type LocalPlannerSdkTests() =
+    static member private PseudoRandomBytes length =
+        let bytes = Array.zeroCreate<byte> length
+        let mutable state = 0x12345678u
+
+        for index in 0 .. length - 1 do
+            state <- state ^^^ (state <<< 13)
+            state <- state ^^^ (state >>> 17)
+            state <- state ^^^ (state <<< 5)
+            bytes[index] <- byte (state &&& 0xffu)
+
+        bytes
+
+    static member private BinaryPolicy thresholdBytes = { ManifestEligibilityPolicy.Default with ThresholdBytes = thresholdBytes; BinaryScanBytes = 16 }
+
+    [<Test>]
+    member _.FallbackPlanAlwaysCarriesTheOriginalBytes() =
+        let payload = Encoding.UTF8.GetBytes("small source file")
+        let options = { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 1024L }
+
+        let plan = LocalPlanner.analyzeBytes options payload
+
+        Assert.That(plan.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
+        Assert.That(plan.FileContentHash, Is.EqualTo(FileContentHash(ContentAddress.computeBlake3Hex payload)))
+        Assert.That(plan.FallbackUpload, Is.Not.Null)
+        Assert.That(plan.FallbackUpload.Value.Bytes = payload, Is.True)
+        Assert.That(plan.Chunks, Is.Empty)
+        Assert.That(plan.Blocks, Is.Empty)
+        Assert.That(plan.ContentBlockUploads, Is.Empty)
+
+    [<Test>]
+    member _.EligibleBinaryPayloadPlansDeterministicChunksBlocksAndManifest() =
+        let payload = LocalPlannerSdkTests.PseudoRandomBytes 220000
+        payload[0] <- 0uy
+
+        let options = { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 1024L }
+
+        let firstPlan = LocalPlanner.analyzeBytes options payload
+        let secondPlan = LocalPlanner.analyzeBytes options payload
+
+        Assert.That(firstPlan.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
+        Assert.That(firstPlan.FileContentHash, Is.EqualTo(secondPlan.FileContentHash))
+        Assert.That(firstPlan.ManifestAddress, Is.EqualTo(secondPlan.ManifestAddress))
+        Assert.That(firstPlan.FallbackUpload, Is.EqualTo(None))
+        Assert.That(firstPlan.ChunkingSuiteId, Is.EqualTo(ChunkingSuiteId RabinChunking.SuiteName))
+
+        Assert.That(
+            (firstPlan.Chunks
+             |> Array.map (fun chunk -> chunk.Address)) =
+                (secondPlan.Chunks
+                 |> Array.map (fun chunk -> chunk.Address)),
+            Is.True
+        )
+
+        Assert.That(
+            (firstPlan.Blocks
+             |> Array.map (fun block -> block.Address)) =
+                (secondPlan.Blocks
+                 |> Array.map (fun block -> block.Address)),
+            Is.True
+        )
+
+        let expectedChunks = RabinChunking.chunkBytes payload
+
+        Assert.That(
+            (firstPlan.Chunks
+             |> Array.map (fun chunk -> chunk.Offset)) =
+                (expectedChunks
+                 |> Array.map (fun chunk -> chunk.Offset)),
+            Is.True
+        )
+
+        Assert.That(
+            (firstPlan.Chunks
+             |> Array.map (fun chunk -> chunk.Length)) =
+                (expectedChunks
+                 |> Array.map (fun chunk -> chunk.Length)),
+            Is.True
+        )
+
+        Assert.That(
+            (firstPlan.Chunks
+             |> Array.map (fun chunk -> chunk.Address)) =
+                (expectedChunks
+                 |> Array.map (fun chunk -> chunk.Address)),
+            Is.True
+        )
+
+        Assert.That(
+            (firstPlan.Blocks
+             |> Array.map (fun block -> block.Offset)) =
+                (expectedChunks
+                 |> Array.map (fun chunk -> chunk.Offset)),
+            Is.True
+        )
+
+        Assert.That(
+            (firstPlan.Blocks
+             |> Array.map (fun block -> block.Size)) =
+                (expectedChunks
+                 |> Array.map (fun chunk -> int64 chunk.Length)),
+            Is.True
+        )
+
+    [<Test>]
+    member _.DuplicateLocalChunksProduceOneUploadPlanAndOneKeyChunk() =
+        let payload = Array.zeroCreate<byte> (RabinChunking.MaximumChunkSize * 2)
+        let options = { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 1024L }
+
+        let plan = LocalPlanner.analyzeBytes options payload
+
+        Assert.That(plan.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
+        Assert.That(plan.Chunks, Has.Length.EqualTo(2))
+        Assert.That(plan.Chunks[0].Address, Is.EqualTo(plan.Chunks[1].Address))
+        Assert.That(plan.Chunks[0].IsKeyChunk, Is.True)
+        Assert.That(plan.Chunks[1].IsKeyChunk, Is.False)
+        Assert.That(plan.KeyChunks, Has.Length.EqualTo(1))
+        Assert.That(plan.KeyChunks[0].ChunkIndex, Is.EqualTo(0))
+        Assert.That(plan.ContentBlockUploads, Has.Length.EqualTo(1))
+        Assert.That(plan.ContentBlockUploads[0].BlockAddress, Is.EqualTo(plan.Blocks[0].Address))
+        Assert.That(plan.Blocks[0].Address, Is.EqualTo(plan.Blocks[1].Address))
+
+    [<Test>]
+    member _.AnalyzeFileUsesFileBytesWithoutServerState() =
+        let tempPath = Path.Combine(Path.GetTempPath(), $"grace-local-planner-{Guid.NewGuid():N}.bin")
+        let payload = LocalPlannerSdkTests.PseudoRandomBytes 160000
+        payload[0] <- 0uy
+
+        try
+            File.WriteAllBytes(tempPath, payload)
+
+            let options = { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 1024L }
+
+            let plan = LocalPlanner.analyzeFile options tempPath
+
+            Assert.That(plan.ExpectedSize, Is.EqualTo(int64 payload.Length))
+            Assert.That(plan.FileContentHash, Is.EqualTo(FileContentHash(ContentAddress.computeBlake3Hex payload)))
+            Assert.That(plan.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
+            Assert.That(plan.ContentBlockUploads, Is.Not.Empty)
+        finally
+            if File.Exists(tempPath) then File.Delete(tempPath)

--- a/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
@@ -40,6 +40,21 @@ type LocalPlannerSdkTests() =
         Assert.That(plan.ContentBlockUploads, Is.Empty)
 
     [<Test>]
+    member _.EmptyPayloadFallsBackEvenWhenThresholdWouldAllowManifest() =
+        let payload = Array.empty<byte>
+        let options = { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 0L }
+
+        let plan = LocalPlanner.analyzeBytes options payload
+
+        Assert.That(plan.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
+        Assert.That(plan.ManifestAddress, Is.EqualTo(None))
+        Assert.That(plan.FallbackUpload, Is.Not.Null)
+        Assert.That(plan.FallbackUpload.Value.Bytes = payload, Is.True)
+        Assert.That(plan.Chunks, Is.Empty)
+        Assert.That(plan.Blocks, Is.Empty)
+        Assert.That(plan.ContentBlockUploads, Is.Empty)
+
+    [<Test>]
     member _.EligibleBinaryPayloadPlansDeterministicChunksBlocksAndManifest() =
         let payload = LocalPlannerSdkTests.PseudoRandomBytes 220000
         payload[0] <- 0uy

--- a/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs
@@ -55,6 +55,23 @@ type LocalPlannerSdkTests() =
         Assert.That(plan.ContentBlockUploads, Is.Empty)
 
     [<Test>]
+    member _.ManifestPlanningRejectsUnsupportedChunkingSuite() =
+        let payload = LocalPlannerSdkTests.PseudoRandomBytes 160000
+        payload[0] <- 0uy
+
+        let options =
+            { LocalPlanner.Options.Default with EligibilityPolicy = LocalPlannerSdkTests.BinaryPolicy 1024L; ChunkingSuiteId = ChunkingSuiteId "other-suite" }
+
+        let ex =
+            Assert.Throws<ArgumentException>(
+                Action (fun () ->
+                    LocalPlanner.analyzeBytes options payload
+                    |> ignore)
+            )
+
+        Assert.That(ex.ParamName, Is.EqualTo("ChunkingSuiteId"))
+
+    [<Test>]
     member _.EligibleBinaryPayloadPlansDeterministicChunksBlocksAndManifest() =
         let payload = LocalPlannerSdkTests.PseudoRandomBytes 220000
         payload[0] <- 0uy

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -20,6 +20,7 @@
         <Compile Include="Auth.SDK.fs" />
         <Compile Include="Common.SDK.fs" />
         <Compile Include="PersonalAccessToken.SDK.fs" />
+        <Compile Include="LocalPlanner.SDK.fs" />
         <Compile Include="Storage.SDK.fs" />
 		<Compile Include="Branch.SDK.fs" />
 		<Compile Include="Owner.SDK.fs" />

--- a/src/Grace.SDK/LocalPlanner.SDK.fs
+++ b/src/Grace.SDK/LocalPlanner.SDK.fs
@@ -1,0 +1,176 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Types.Types
+open System
+open System.Collections.Generic
+open System.IO
+
+/// Pure local planning for manifest-backed file uploads.
+module LocalPlanner =
+    [<Literal>]
+    let DefaultBlockFormat = "grace-content-block-v1"
+
+    type Options =
+        {
+            EligibilityPolicy: ManifestEligibilityPolicy
+            ChunkingSuiteId: ChunkingSuiteId
+            BlockFormat: string
+        }
+
+        static member Default =
+            {
+                EligibilityPolicy = ManifestEligibilityPolicy.Default
+                ChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
+                BlockFormat = DefaultBlockFormat
+            }
+
+    type FallbackUploadPlan = { Bytes: byte array }
+
+    type LocalChunkPlan = { ChunkIndex: int; Offset: int64; Length: int; Address: ChunkAddress; IsKeyChunk: bool }
+
+    type KeyChunkPlan = { ChunkIndex: int; Offset: int64; Length: int; Address: ChunkAddress }
+
+    type ContentBlockPlan =
+        {
+            BlockIndex: int
+            Offset: int64
+            Size: int64
+            Address: ContentBlockAddress
+            ChunkIndexes: int array
+            ChunkAddresses: ChunkAddress array
+            KeyChunkAddress: ChunkAddress
+            DuplicateOfBlockIndex: int option
+        }
+
+    type ContentBlockUploadPlan = { BlockIndex: int; BlockAddress: ContentBlockAddress; Bytes: byte array }
+
+    type LocalFilePlan =
+        {
+            ReferenceType: FileContentReferenceType
+            FileContentHash: FileContentHash
+            ExpectedSize: int64
+            ChunkingSuiteId: ChunkingSuiteId
+            ManifestAddress: ManifestAddress option
+            Chunks: LocalChunkPlan array
+            KeyChunks: KeyChunkPlan array
+            Blocks: ContentBlockPlan array
+            ContentBlockUploads: ContentBlockUploadPlan array
+            FallbackUpload: FallbackUploadPlan option
+        }
+
+    let private copyRange (bytes: byte array) offset length =
+        let copied = Array.zeroCreate<byte> length
+        Array.Copy(bytes, offset, copied, 0, length)
+        copied
+
+    let private fallbackPlan (options: Options) (fileContentHash: FileContentHash) expectedSize bytes =
+        {
+            ReferenceType = FileContentReferenceType.WholeFileContent
+            FileContentHash = fileContentHash
+            ExpectedSize = expectedSize
+            ChunkingSuiteId = options.ChunkingSuiteId
+            ManifestAddress = None
+            Chunks = Array.empty
+            KeyChunks = Array.empty
+            Blocks = Array.empty
+            ContentBlockUploads = Array.empty
+            FallbackUpload = Some { Bytes = Array.copy bytes }
+        }
+
+    let private planManifest (options: Options) (fileContentHash: FileContentHash) expectedSize (bytes: byte array) =
+        let firstChunkIndexesByAddress = Dictionary<ChunkAddress, int>()
+        let firstBlockIndexesByAddress = Dictionary<ContentBlockAddress, int>()
+        let uploadPlans = ResizeArray<ContentBlockUploadPlan>()
+
+        let chunks =
+            RabinChunking.chunkBytes bytes
+            |> Array.mapi (fun index chunk ->
+                let isKeyChunk =
+                    if firstChunkIndexesByAddress.ContainsKey(chunk.Address) then
+                        false
+                    else
+                        firstChunkIndexesByAddress[chunk.Address] <- index
+                        true
+
+                { ChunkIndex = index; Offset = chunk.Offset; Length = chunk.Length; Address = chunk.Address; IsKeyChunk = isKeyChunk })
+
+        let blocks =
+            chunks
+            |> Array.mapi (fun index chunk ->
+                let blockAddress = ContentAddress.computeContentBlockAddress options.BlockFormat [| chunk.Address |]
+
+                let duplicateOfBlockIndex =
+                    if firstBlockIndexesByAddress.ContainsKey(blockAddress) then
+                        Some firstBlockIndexesByAddress[blockAddress]
+                    else
+                        firstBlockIndexesByAddress[blockAddress] <- index
+
+                        uploadPlans.Add({ BlockIndex = index; BlockAddress = blockAddress; Bytes = copyRange bytes (int chunk.Offset) chunk.Length })
+
+                        None
+
+                {
+                    BlockIndex = index
+                    Offset = chunk.Offset
+                    Size = int64 chunk.Length
+                    Address = blockAddress
+                    ChunkIndexes = [| chunk.ChunkIndex |]
+                    ChunkAddresses = [| chunk.Address |]
+                    KeyChunkAddress = chunk.Address
+                    DuplicateOfBlockIndex = duplicateOfBlockIndex
+                })
+
+        let contentBlocks =
+            blocks
+            |> Array.map (fun block -> ContentBlock.Create(block.Address, block.Offset, block.Size))
+
+        let manifestAddress =
+            if contentBlocks.Length = 0 then
+                None
+            else
+                Some(ContentAddress.computeManifestAddress expectedSize contentBlocks)
+
+        let keyChunks =
+            chunks
+            |> Array.choose (fun chunk ->
+                if chunk.IsKeyChunk then
+                    Some { ChunkIndex = chunk.ChunkIndex; Offset = chunk.Offset; Length = chunk.Length; Address = chunk.Address }
+                else
+                    None)
+
+        {
+            ReferenceType = FileContentReferenceType.FileManifest
+            FileContentHash = fileContentHash
+            ExpectedSize = expectedSize
+            ChunkingSuiteId = options.ChunkingSuiteId
+            ManifestAddress = manifestAddress
+            Chunks = chunks
+            KeyChunks = keyChunks
+            Blocks = blocks
+            ContentBlockUploads = uploadPlans.ToArray()
+            FallbackUpload = None
+        }
+
+    /// Analyzes local bytes and returns the deterministic upload plan without contacting Grace Server.
+    let analyzeBytes (options: Options) (bytes: byte array) =
+        ArgumentNullException.ThrowIfNull(bytes)
+
+        if String.IsNullOrWhiteSpace(options.BlockFormat) then
+            invalidArg (nameof options.BlockFormat) "Content block format is required."
+
+        let fileContentHash = FileContentHash(ContentAddress.computeBlake3Hex bytes)
+        let expectedSize = int64 bytes.Length
+
+        match ManifestEligibility.evaluateContentReferenceType options.EligibilityPolicy bytes with
+        | FileContentReferenceType.WholeFileContent -> fallbackPlan options fileContentHash expectedSize bytes
+        | FileContentReferenceType.FileManifest -> planManifest options fileContentHash expectedSize bytes
+        | unexpected -> invalidOp $"Unsupported file content reference type: {unexpected}."
+
+    /// Analyzes a local file and returns the deterministic upload plan without contacting Grace Server.
+    let analyzeFile options filePath =
+        if String.IsNullOrWhiteSpace(filePath) then
+            invalidArg (nameof filePath) "File path is required."
+
+        File.ReadAllBytes(filePath)
+        |> analyzeBytes options

--- a/src/Grace.SDK/LocalPlanner.SDK.fs
+++ b/src/Grace.SDK/LocalPlanner.SDK.fs
@@ -78,7 +78,14 @@ module LocalPlanner =
             FallbackUpload = Some { Bytes = Array.copy bytes }
         }
 
+    let private ensureSupportedChunkingSuite (options: Options) =
+        if options.ChunkingSuiteId
+           <> ChunkingSuiteId RabinChunking.SuiteName then
+            invalidArg "ChunkingSuiteId" $"Only {RabinChunking.SuiteName} is supported by the local planner."
+
     let private planManifest (options: Options) (fileContentHash: FileContentHash) expectedSize (bytes: byte array) =
+        ensureSupportedChunkingSuite options
+
         let firstChunkIndexesByAddress = Dictionary<ChunkAddress, int>()
         let firstBlockIndexesByAddress = Dictionary<ContentBlockAddress, int>()
         let uploadPlans = ResizeArray<ContentBlockUploadPlan>()

--- a/src/Grace.SDK/LocalPlanner.SDK.fs
+++ b/src/Grace.SDK/LocalPlanner.SDK.fs
@@ -162,10 +162,11 @@ module LocalPlanner =
         let fileContentHash = FileContentHash(ContentAddress.computeBlake3Hex bytes)
         let expectedSize = int64 bytes.Length
 
-        match ManifestEligibility.evaluateContentReferenceType options.EligibilityPolicy bytes with
-        | FileContentReferenceType.WholeFileContent -> fallbackPlan options fileContentHash expectedSize bytes
-        | FileContentReferenceType.FileManifest -> planManifest options fileContentHash expectedSize bytes
-        | unexpected -> invalidOp $"Unsupported file content reference type: {unexpected}."
+        match bytes.Length, ManifestEligibility.evaluateContentReferenceType options.EligibilityPolicy bytes with
+        | 0, _ -> fallbackPlan options fileContentHash expectedSize bytes
+        | _, FileContentReferenceType.WholeFileContent -> fallbackPlan options fileContentHash expectedSize bytes
+        | _, FileContentReferenceType.FileManifest -> planManifest options fileContentHash expectedSize bytes
+        | _, unexpected -> invalidOp $"Unsupported file content reference type: {unexpected}."
 
     /// Analyzes a local file and returns the deterministic upload plan without contacting Grace Server.
     let analyzeFile options filePath =


### PR DESCRIPTION
## Summary

- Adds pure `Grace.SDK.LocalPlanner` byte/file analysis for manifest eligibility, BLAKE3 whole-file hashing, Rabin chunking, first-occurrence key chunk selection, local duplicate block upload dedupe, and manifest/block planning.
- Adds focused `Grace.CLI.Tests` coverage for whole-file fallback uploads, deterministic large-file manifest plans, duplicate local chunk dedupe, and file-path analysis without server state.

Closes #99.

## Changed Files

- `src/Grace.SDK/LocalPlanner.SDK.fs`
- `src/Grace.SDK/Grace.SDK.fsproj`
- `src/Grace.CLI.Tests/LocalPlanner.SDK.Tests.fs`
- `src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`

## Validation

- RED: `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter LocalPlanner` failed before implementation because `Grace.SDK.LocalPlanner` and the planned fields did not exist.
- GREEN focused: `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter LocalPlanner` - passed, 4 tests.
- Broader focused: `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` - passed, 199 tests.
- Formatting: `dotnet tool run fantomas Grace.SDK\LocalPlanner.SDK.fs Grace.CLI.Tests\LocalPlanner.SDK.Tests.fs` from `./src` - passed.
- Hygiene: `git diff --check` - passed.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast` - passed; build clean, Authorization 21, CLI 199, Types 40.

## Docs Impact

- No docs updates. This adds SDK local planning surface and tests without introducing new visible CLI options or command help.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run locally because this slice is pure SDK local analysis plus unit tests and does not touch Aspire, Azurite/blob storage, Cosmos DB, Service Bus, Redis, deployment/runtime behavior, or cross-service integration.

## Residual Risk

- Content-block planning is intentionally minimal for CL1: one Rabin logical chunk maps to one content block, with local duplicate chunk/block addresses deduped to one upload payload plan. Later DAG nodes can expand upload/session orchestration without changing server behavior in this slice.

## Follow-ups

- #100 can consume the local plan to implement manifest upload without global dedupe.
