### PR TITLE
Add manifest reconstruction validation

### DIFF
--- a/src/Grace.SDK/LocalPlanner.SDK.fs
+++ b/src/Grace.SDK/LocalPlanner.SDK.fs
@@ -136,7 +136,7 @@ module LocalPlanner =
             if contentBlocks.Length = 0 then
                 None
             else
-                Some(ContentAddress.computeManifestAddress expectedSize contentBlocks)
+                Some(ContentAddress.computeManifestAddress options.ChunkingSuiteId fileContentHash expectedSize contentBlocks)
 
         let keyChunks =
             chunks

--- a/src/Grace.Shared/ContentAddress.Shared.fs
+++ b/src/Grace.Shared/ContentAddress.Shared.fs
@@ -83,14 +83,21 @@ module ContentAddress =
         |> computeBlake3Hex
         |> ContentBlockAddress
 
-    /// Builds the path-independent preimage for a manifest from its ordered logical blocks.
-    let manifestPreimage (size: int64) (blocks: ContentBlock seq) =
+    /// Builds the path-independent preimage for a manifest from its content hash and ordered logical blocks.
+    let manifestPreimage (chunkingSuiteId: ChunkingSuiteId) (fileContentHash: FileContentHash) (size: int64) (blocks: ContentBlock seq) =
+        if String.IsNullOrWhiteSpace(chunkingSuiteId) then
+            invalidArg (nameof chunkingSuiteId) "Chunking suite id is required."
+
+        let fileContentHash = requireValidAddress (nameof fileContentHash) fileContentHash
+
         ensureNonNegative (nameof size) size
 
         let blockArray = requireNonEmptySequence (nameof blocks) blocks
         let builder = StringBuilder()
 
         appendLine builder FileManifestPreimageHeader
+        appendLine builder $"chunking-suite:{chunkingSuiteId}"
+        appendLine builder $"file-content-hash:{fileContentHash}"
         appendLine builder $"size:{size}"
         appendLine builder $"block-count:{blockArray.Length}"
 
@@ -107,8 +114,14 @@ module ContentAddress =
         builder.ToString()
 
     /// Computes the manifest address from its path-independent logical block preimage.
-    let computeManifestAddress size blocks : ManifestAddress =
-        manifestPreimage size blocks
+    let computeManifestAddress chunkingSuiteId fileContentHash size blocks : ManifestAddress =
+        manifestPreimage chunkingSuiteId fileContentHash size blocks
         |> System.Text.Encoding.UTF8.GetBytes
         |> computeBlake3Hex
         |> ManifestAddress
+
+    /// Computes the manifest address from the stable fields carried by a FileManifest.
+    let computeManifestAddressForManifest (manifest: FileManifest) : ManifestAddress =
+        if isNull (box manifest) then nullArg (nameof manifest)
+
+        computeManifestAddress manifest.ChunkingSuiteId manifest.FileContentHash manifest.Size manifest.Blocks

--- a/src/Grace.Shared/ContentBlockFormat.Shared.fs
+++ b/src/Grace.Shared/ContentBlockFormat.Shared.fs
@@ -180,7 +180,7 @@ module ContentBlockFormat =
                         |> Array.map (fun chunk -> chunk.Address)
                         |> ContentAddress.computeContentBlockAddress FormatName
 
-                    Ok { Address = address; Payload = payload; Chunks = metadata }
+                    Ok({ Address = address; Payload = payload; Chunks = metadata }: EncodedContentBlock)
 
     let private parseTrailer (trailer: byte array) =
         if trailer.Length < TrailerHeaderLength then
@@ -300,7 +300,7 @@ module ContentBlockFormat =
                                     |> Array.map (fun chunk -> chunk.Address)
                                     |> ContentAddress.computeContentBlockAddress FormatName
 
-                                Ok { Address = address; Payload = copyRange payload 0 trailerStart; Chunks = chunks }
+                                Ok({ Address = address; Payload = copyRange payload 0 trailerStart; Chunks = chunks }: DecodedContentBlock)
 
     let validateAddress expectedAddress decodedBlock =
         if expectedAddress = decodedBlock.Address then

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -27,6 +27,7 @@
         <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="ContentAddress.Shared.fs" />
         <Compile Include="ContentBlockFormat.Shared.fs" />
+        <Compile Include="ManifestValidation.Shared.fs" />
         <Compile Include="RabinChunking.Shared.fs" />
         <Compile Include="BuildInfo.Shared.fs" />
         <Compile Include="Authorization.Shared.fs" />

--- a/src/Grace.Shared/ManifestValidation.Shared.fs
+++ b/src/Grace.Shared/ManifestValidation.Shared.fs
@@ -1,0 +1,171 @@
+namespace Grace.Shared
+
+open Grace.Types.Types
+open System
+open System.Collections.Generic
+open System.IO
+
+/// Pure FileManifest reconstruction and validation helpers.
+///
+/// Validation does not read storage. Callers provide the physical ContentBlock payloads they already loaded. The helper
+/// rejects manifests whose block ranges are not ordered, positive, contiguous from offset zero, and exactly
+/// size-covering; it also checks the pinned chunking suite, each ContentBlock payload address, the reconstructed file
+/// content hash, and the stable ManifestAddress.
+module ManifestValidation =
+    type ManifestBlockPayload = { Address: ContentBlockAddress; Payload: byte array }
+
+    type ManifestValidationError =
+        | NullManifest
+        | NullBlockPayloadSequence
+        | NullBlockPayload of index: int
+        | NullBlockPayloadBytes of address: ContentBlockAddress
+        | EmptyManifest
+        | InvalidManifestSize
+        | InvalidChunkingSuiteId of chunkingSuiteId: ChunkingSuiteId
+        | InvalidFileContentHash of fileContentHash: FileContentHash
+        | InvalidManifestAddress of manifestAddress: ManifestAddress
+        | NullContentBlock of index: int
+        | InvalidContentBlockAddress of index: int * address: ContentBlockAddress
+        | ChunkingSuiteMismatch of expected: ChunkingSuiteId * actual: ChunkingSuiteId
+        | ManifestAddressMismatch of expected: ManifestAddress * actual: ManifestAddress
+        | BlockRangeOutOfOrder of index: int
+        | BlockRangeNotPositive of index: int
+        | MissingContentBlockPayload of index: int * address: ContentBlockAddress
+        | ContentBlockPayloadInvalid of address: ContentBlockAddress * error: ContentBlockFormat.ContentBlockFormatError
+        | ContentBlockPayloadSizeMismatch of index: int * expected: int64 * actual: int64
+        | FileContentHashMismatch of expected: FileContentHash * actual: FileContentHash
+        | ManifestSizeMismatch of expected: int64 * actual: int64
+
+    let createBlockPayload address payload = { Address = address; Payload = payload }
+
+    let private copyBytes (bytes: byte array) =
+        let copy = Array.zeroCreate<byte> bytes.Length
+        Array.Copy(bytes, copy, bytes.Length)
+        copy
+
+    let private decodePayloads (payloads: ManifestBlockPayload seq) =
+        if isNull (box payloads) then
+            Error NullBlockPayloadSequence
+        else
+            let payloadArray = payloads |> Seq.toArray
+            let decoded = Dictionary<ContentBlockAddress, ContentBlockFormat.DecodedContentBlock>()
+            let mutable error = None
+            let mutable index = 0
+
+            while index < payloadArray.Length && Option.isNone error do
+                let payload = payloadArray[index]
+
+                if isNull (box payload) then
+                    error <- Some(NullBlockPayload index)
+                elif isNull payload.Payload then
+                    error <- Some(NullBlockPayloadBytes payload.Address)
+                else
+                    match ContentBlockFormat.decode payload.Payload with
+                    | Error decodeError -> error <- Some(ContentBlockPayloadInvalid(payload.Address, decodeError))
+                    | Ok decodedBlock ->
+                        match ContentBlockFormat.validateAddress payload.Address decodedBlock with
+                        | Error addressError -> error <- Some(ContentBlockPayloadInvalid(payload.Address, addressError))
+                        | Ok () -> decoded[payload.Address] <- decodedBlock
+
+                index <- index + 1
+
+            match error with
+            | Some error -> Error error
+            | None -> Ok decoded
+
+    let private validateManifestShape expectedChunkingSuiteId (manifest: FileManifest) =
+        if isNull (box manifest) then
+            Error NullManifest
+        elif String.IsNullOrWhiteSpace(expectedChunkingSuiteId) then
+            Error(InvalidChunkingSuiteId expectedChunkingSuiteId)
+        elif manifest.Size <= 0L then
+            Error InvalidManifestSize
+        elif isNull manifest.Blocks
+             || manifest.Blocks.Count = 0 then
+            Error EmptyManifest
+        elif String.IsNullOrWhiteSpace(manifest.ChunkingSuiteId) then
+            Error(InvalidChunkingSuiteId manifest.ChunkingSuiteId)
+        elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
+            Error(InvalidFileContentHash manifest.FileContentHash)
+        elif not (ContentAddress.isValidAddress manifest.ManifestAddress) then
+            Error(InvalidManifestAddress manifest.ManifestAddress)
+        elif manifest.ChunkingSuiteId
+             <> expectedChunkingSuiteId then
+            Error(ChunkingSuiteMismatch(expectedChunkingSuiteId, manifest.ChunkingSuiteId))
+        else
+            Ok()
+
+    let private validateRanges (manifest: FileManifest) =
+        let mutable expectedOffset = 0L
+        let mutable error = None
+        let mutable index = 0
+
+        while index < manifest.Blocks.Count
+              && Option.isNone error do
+            let block = manifest.Blocks[index]
+
+            if isNull (box block) then
+                error <- Some(NullContentBlock index)
+            elif not (ContentAddress.isValidAddress block.Address) then
+                error <- Some(InvalidContentBlockAddress(index, block.Address))
+            elif block.Size <= 0L then
+                error <- Some(BlockRangeNotPositive index)
+            elif block.Offset <> expectedOffset then
+                error <- Some(BlockRangeOutOfOrder index)
+            else
+                expectedOffset <- expectedOffset + block.Size
+
+            index <- index + 1
+
+        match error with
+        | Some error -> Error error
+        | None when expectedOffset <> manifest.Size -> Error(ManifestSizeMismatch(manifest.Size, expectedOffset))
+        | None -> Ok()
+
+    let private validateManifestAddress (manifest: FileManifest) =
+        let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+        if manifest.ManifestAddress <> expectedAddress then
+            Error(ManifestAddressMismatch(expectedAddress, manifest.ManifestAddress))
+        else
+            Ok()
+
+    let private reconstructBytes (manifest: FileManifest) (payloads: Dictionary<ContentBlockAddress, ContentBlockFormat.DecodedContentBlock>) =
+        use stream = new MemoryStream()
+        let mutable error = None
+        let mutable index = 0
+
+        while index < manifest.Blocks.Count
+              && Option.isNone error do
+            let block = manifest.Blocks[index]
+
+            match payloads.TryGetValue(block.Address) with
+            | false, _ -> error <- Some(MissingContentBlockPayload(index, block.Address))
+            | true, decodedBlock ->
+                let actualSize = int64 decodedBlock.Payload.Length
+
+                if actualSize <> block.Size then
+                    error <- Some(ContentBlockPayloadSizeMismatch(index, block.Size, actualSize))
+                else
+                    stream.Write(decodedBlock.Payload, 0, decodedBlock.Payload.Length)
+
+            index <- index + 1
+
+        match error with
+        | Some error -> Error error
+        | None -> Ok(stream.ToArray())
+
+    /// Validates and reconstructs a manifest-backed file from supplied ContentBlock payloads.
+    let validate expectedChunkingSuiteId (manifest: FileManifest) payloads =
+        validateManifestShape expectedChunkingSuiteId manifest
+        |> Result.bind (fun () -> validateRanges manifest)
+        |> Result.bind (fun () -> validateManifestAddress manifest)
+        |> Result.bind (fun () -> decodePayloads payloads)
+        |> Result.bind (fun decodedPayloads -> reconstructBytes manifest decodedPayloads)
+        |> Result.bind (fun reconstructedBytes ->
+            let actualHash = FileContentHash(ContentAddress.computeBlake3Hex reconstructedBytes)
+
+            if manifest.FileContentHash <> actualHash then
+                Error(FileContentHashMismatch(manifest.FileContentHash, actualHash))
+            else
+                Ok(copyBytes reconstructedBytes))

--- a/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
@@ -73,10 +73,14 @@ type ContentAddressTypesTests() =
             ]
 
         let manifest = FileManifest.Create(ManifestAddress "", 8192L, blocks)
+        let fileContentHash = FileContentHash "fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae"
+        let manifest = FileManifest.Create(ManifestAddress "", RabinChunking.SuiteName, fileContentHash, manifest.Size, blocks)
 
         let expectedPreimage =
             [
                 "grace.cas.v1.file-manifest"
+                $"chunking-suite:{RabinChunking.SuiteName}"
+                $"file-content-hash:{fileContentHash}"
                 "size:8192"
                 "block-count:2"
                 $"block:0:{blockAddress}:0:4096"
@@ -85,8 +89,8 @@ type ContentAddressTypesTests() =
             |> String.concat "\n"
             |> fun value -> value + "\n"
 
-        let preimage = ContentAddress.manifestPreimage manifest.Size manifest.Blocks
-        let address = ContentAddress.computeManifestAddress manifest.Size manifest.Blocks
+        let preimage = ContentAddress.manifestPreimage manifest.ChunkingSuiteId manifest.FileContentHash manifest.Size manifest.Blocks
+        let address = ContentAddress.computeManifestAddressForManifest manifest
 
         let firstPath = FileVersion.Create "src/assets/movie.bin" "abc123" "https://example.test/a" true manifest.Size
         firstPath.ContentReference <- FileContentReference.FileManifest { manifest with ManifestAddress = address }
@@ -95,6 +99,6 @@ type ContentAddressTypesTests() =
         secondPath.ContentReference <- FileContentReference.FileManifest { manifest with ManifestAddress = address }
 
         Assert.That(preimage, Is.EqualTo(expectedPreimage))
-        Assert.That(address, Is.EqualTo(ManifestAddress "ac308ff0b0f4f8c6dc0046d8c3a8bb268d73d425b33c51ff7aa93b50da4d12fd"))
+        Assert.That(address, Is.EqualTo(ManifestAddress "5dd11fdb1534c0f1c4fecca3c07498f9b59a7dff26d69fe78e43f7ce50d90895"))
         Assert.That(ContentAddress.isValidAddress address, Is.True)
         Assert.That(firstPath.ContentReference, Is.EqualTo(secondPath.ContentReference))

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />
     <Compile Include="ContentBlockFormat.Shared.Tests.fs" />
+    <Compile Include="ManifestValidation.Shared.Tests.fs" />
     <Compile Include="RabinChunking.Shared.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/ManifestValidation.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/ManifestValidation.Shared.Tests.fs
@@ -1,0 +1,238 @@
+namespace Grace.Types.Tests
+
+open FsCheck
+open Grace.Shared
+open Grace.Types.Types
+open NUnit.Framework
+open System
+open System.Text
+
+[<Parallelizable(ParallelScope.All)>]
+type ManifestValidationSharedTests() =
+    static member private Bytes(value: string) = Encoding.UTF8.GetBytes(value)
+
+    static member private ExpectEncodedOk(result: Result<ContentBlockFormat.EncodedContentBlock, ContentBlockFormat.ContentBlockFormatError>) =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected Ok but got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    static member private ContentBlockPayload physicalOffset bytes : ContentBlockFormat.EncodedContentBlock =
+        ContentBlockFormat.encode [ ContentBlockFormat.createChunk physicalOffset bytes ]
+        |> ManifestValidationSharedTests.ExpectEncodedOk
+
+    static member private BuildManifest chunkingSuiteId bytes (blockPayloads: ContentBlockFormat.EncodedContentBlock array) =
+        let mutable offset = 0L
+
+        let blocks =
+            blockPayloads
+            |> Array.map (fun payload ->
+                let contentLength =
+                    payload.Chunks
+                    |> Array.sumBy (fun chunk -> chunk.Length)
+                    |> int64
+
+                let block = ContentBlock.Create(payload.Address, offset, contentLength)
+                offset <- offset + contentLength
+                block)
+            |> Array.toList
+
+        let fileContentHash = FileContentHash(ContentAddress.computeBlake3Hex bytes)
+
+        let manifest = FileManifest.Create(ManifestAddress String.Empty, chunkingSuiteId, fileContentHash, int64 bytes.Length, blocks)
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    static member private PayloadReference(block: ContentBlockFormat.EncodedContentBlock) = ManifestValidation.createBlockPayload block.Address block.Payload
+
+    [<Test>]
+    member _.ValidManifestReconstructsBytesAndValidatesStableAddress() =
+        let alpha = ManifestValidationSharedTests.Bytes "alpha logical range"
+        let beta = ManifestValidationSharedTests.Bytes "beta logical range"
+        let fileBytes = Array.concat [ alpha; beta ]
+
+        let alphaBlock = ManifestValidationSharedTests.ContentBlockPayload 4096L alpha
+        let betaBlock = ManifestValidationSharedTests.ContentBlockPayload 8192L beta
+
+        let manifest = ManifestValidationSharedTests.BuildManifest RabinChunking.SuiteName fileBytes [| alphaBlock; betaBlock |]
+
+        let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+        let validation =
+            ManifestValidation.validate
+                RabinChunking.SuiteName
+                manifest
+                [
+                    ManifestValidationSharedTests.PayloadReference alphaBlock
+                    ManifestValidationSharedTests.PayloadReference betaBlock
+                ]
+
+        match validation with
+        | Ok reconstructed ->
+            Assert.That((reconstructed = fileBytes), Is.True)
+            Assert.That(manifest.ManifestAddress, Is.EqualTo(expectedAddress))
+            Assert.That(ContentAddress.isValidAddress (manifest.ManifestAddress), Is.True)
+        | Error error -> Assert.Fail($"Expected valid manifest but got {error}.")
+
+    [<Test>]
+    member _.InvalidManifestInvariantsAreRejected() =
+        let alpha = ManifestValidationSharedTests.Bytes "alpha"
+        let beta = ManifestValidationSharedTests.Bytes "beta"
+        let fileBytes = Array.concat [ alpha; beta ]
+
+        let alphaBlock = ManifestValidationSharedTests.ContentBlockPayload 0L alpha
+        let betaBlock = ManifestValidationSharedTests.ContentBlockPayload 1024L beta
+
+        let validManifest = ManifestValidationSharedTests.BuildManifest RabinChunking.SuiteName fileBytes [| alphaBlock; betaBlock |]
+
+        let payloads =
+            [
+                ManifestValidationSharedTests.PayloadReference alphaBlock
+                ManifestValidationSharedTests.PayloadReference betaBlock
+            ]
+
+        let withAddress manifest = { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+        let unordered =
+            { validManifest with
+                Blocks =
+                    [
+                        ContentBlock.Create(betaBlock.Address, int64 alpha.Length, int64 beta.Length)
+                        ContentBlock.Create(alphaBlock.Address, 0L, int64 alpha.Length)
+                    ]
+                    |> System.Collections.Generic.List<ContentBlock>
+            }
+            |> withAddress
+
+        let zeroSized =
+            { validManifest with
+                Blocks =
+                    [
+                        ContentBlock.Create(alphaBlock.Address, 0L, 0L)
+                        ContentBlock.Create(betaBlock.Address, 0L, int64 beta.Length)
+                    ]
+                    |> System.Collections.Generic.List<ContentBlock>
+            }
+            |> withAddress
+
+        let gap =
+            { validManifest with
+                Blocks =
+                    [
+                        ContentBlock.Create(alphaBlock.Address, 0L, int64 alpha.Length)
+                        ContentBlock.Create(betaBlock.Address, int64 alpha.Length + 1L, int64 beta.Length)
+                    ]
+                    |> System.Collections.Generic.List<ContentBlock>
+            }
+            |> withAddress
+
+        let undersized =
+            { validManifest with Size = validManifest.Size + 1L }
+            |> withAddress
+
+        let wrongSuite =
+            { validManifest with ChunkingSuiteId = ChunkingSuiteId "different-suite" }
+            |> withAddress
+
+        let wrongHash =
+            { validManifest with FileContentHash = FileContentHash(ContentAddress.computeBlake3Hex (ManifestValidationSharedTests.Bytes "wrong")) }
+            |> withAddress
+
+        let cases =
+            [
+                "unordered", unordered, ManifestValidation.BlockRangeOutOfOrder 0
+                "zero-sized", zeroSized, ManifestValidation.BlockRangeNotPositive 0
+                "gap", gap, ManifestValidation.BlockRangeOutOfOrder 1
+                "undersized", undersized, ManifestValidation.ManifestSizeMismatch(undersized.Size, validManifest.Size)
+                "wrong-suite", wrongSuite, ManifestValidation.ChunkingSuiteMismatch(RabinChunking.SuiteName, wrongSuite.ChunkingSuiteId)
+                "wrong-hash", wrongHash, ManifestValidation.FileContentHashMismatch(wrongHash.FileContentHash, validManifest.FileContentHash)
+            ]
+
+        for name, manifest, expectedError in cases do
+            match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
+            | Error error -> Assert.That(error, Is.EqualTo(expectedError), $"{name}")
+            | Ok _ -> Assert.Fail($"Expected {name} manifest to be rejected.")
+
+    [<Test>]
+    member _.MalformedManifestFieldsReturnValidationErrors() =
+        let bytes = ManifestValidationSharedTests.Bytes "payload"
+        let block = ManifestValidationSharedTests.ContentBlockPayload 0L bytes
+        let validManifest = ManifestValidationSharedTests.BuildManifest RabinChunking.SuiteName bytes [| block |]
+
+        let payloads =
+            [
+                ManifestValidationSharedTests.PayloadReference block
+            ]
+
+        let invalidManifestAddress = { validManifest with ManifestAddress = ManifestAddress "not-a-blake3-address" }
+
+        let invalidFileHash = { validManifest with FileContentHash = FileContentHash "not-a-blake3-address" }
+
+        let invalidBlockAddress =
+            { validManifest with
+                Blocks =
+                    [
+                        ContentBlock.Create(ContentBlockAddress "not-a-blake3-address", 0L, int64 bytes.Length)
+                    ]
+                    |> System.Collections.Generic.List<ContentBlock>
+            }
+
+        let nullBlock =
+            { validManifest with
+                Blocks =
+                    [ Unchecked.defaultof<ContentBlock> ]
+                    |> System.Collections.Generic.List<ContentBlock>
+            }
+
+        let cases =
+            [
+                "empty-expected-suite", ChunkingSuiteId String.Empty, validManifest, ManifestValidation.InvalidChunkingSuiteId(ChunkingSuiteId String.Empty)
+                "invalid-manifest-address",
+                RabinChunking.SuiteName,
+                invalidManifestAddress,
+                ManifestValidation.InvalidManifestAddress invalidManifestAddress.ManifestAddress
+                "invalid-file-hash", RabinChunking.SuiteName, invalidFileHash, ManifestValidation.InvalidFileContentHash invalidFileHash.FileContentHash
+                "invalid-block-address",
+                RabinChunking.SuiteName,
+                invalidBlockAddress,
+                ManifestValidation.InvalidContentBlockAddress(0, ContentBlockAddress "not-a-blake3-address")
+                "null-block", RabinChunking.SuiteName, nullBlock, ManifestValidation.NullContentBlock 0
+            ]
+
+        for name, suite, manifest, expectedError in cases do
+            match ManifestValidation.validate suite manifest payloads with
+            | Error error -> Assert.That(error, Is.EqualTo(expectedError), $"{name}")
+            | Ok _ -> Assert.Fail($"Expected {name} manifest to be rejected.")
+
+    [<Test>]
+    member _.FsCheckReconstructionAndAddressPropertiesHold() =
+        let property (NonNegativeInt requestedLength) =
+            let length = Math.Min(requestedLength, 256 * 1024)
+            let bytes = Array.init length (fun index -> byte ((index * 31 + length) % 251))
+
+            let blockPayloads =
+                RabinChunking.chunkBytes bytes
+                |> Array.map (fun chunk ->
+                    let chunkBytes = bytes[int chunk.Offset .. int chunk.Offset + chunk.Length - 1]
+                    ManifestValidationSharedTests.ContentBlockPayload chunk.Offset chunkBytes)
+
+            if length = 0 then
+                blockPayloads.Length = 0
+            else
+                let manifest = ManifestValidationSharedTests.BuildManifest RabinChunking.SuiteName bytes blockPayloads
+
+                let rerunManifest = ManifestValidationSharedTests.BuildManifest RabinChunking.SuiteName bytes blockPayloads
+
+                let payloads =
+                    blockPayloads
+                    |> Array.rev
+                    |> Array.map ManifestValidationSharedTests.PayloadReference
+
+                match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
+                | Ok reconstructed ->
+                    reconstructed = bytes
+                    && manifest.ManifestAddress = rerunManifest.ManifestAddress
+                | Error _ -> false
+
+        Check.QuickThrowOnFailure property

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -277,7 +277,11 @@ module Types =
 
         static member Default = ContentBlock.Create(String.Empty, 0L, 0L)
 
-    /// A file manifest is an inert CAS contract shell for content assembled from one or more content blocks.
+    /// A file manifest is a CAS contract shell for content assembled from one or more content blocks.
+    ///
+    /// Validation reconstructs bytes by reading `Blocks` in order. Each block range must be positive, contiguous from
+    /// offset zero, and cover exactly `Size`. `ChunkingSuiteId`, `FileContentHash`, and the ordered block ranges are
+    /// included in the stable manifest address preimage.
     [<CLIMutable; MessagePackObject; GenerateSerializer; CustomEquality; NoComparison>]
     type FileManifest =
         {
@@ -289,10 +293,31 @@ module Types =
             Size: int64
             [<Key(3)>]
             Blocks: List<ContentBlock>
+            [<Key(4)>]
+            ChunkingSuiteId: ChunkingSuiteId
+            [<Key(5)>]
+            FileContentHash: FileContentHash
         }
 
+        static member Create
+            (
+                manifestAddress: ManifestAddress,
+                chunkingSuiteId: ChunkingSuiteId,
+                fileContentHash: FileContentHash,
+                size: int64,
+                blocks: ContentBlock list
+            ) =
+            {
+                Class = "FileManifest"
+                ManifestAddress = manifestAddress
+                Size = size
+                Blocks = List<ContentBlock>(blocks)
+                ChunkingSuiteId = chunkingSuiteId
+                FileContentHash = fileContentHash
+            }
+
         static member Create(manifestAddress: ManifestAddress, size: int64, blocks: ContentBlock list) =
-            { Class = "FileManifest"; ManifestAddress = manifestAddress; Size = size; Blocks = List<ContentBlock>(blocks) }
+            FileManifest.Create(manifestAddress, ChunkingSuiteId String.Empty, FileContentHash String.Empty, size, blocks)
 
         static member Default = FileManifest.Create(String.Empty, 0L, [])
 
@@ -302,6 +327,8 @@ module Types =
                 this.Class = otherManifest.Class
                 && this.ManifestAddress = otherManifest.ManifestAddress
                 && this.Size = otherManifest.Size
+                && this.ChunkingSuiteId = otherManifest.ChunkingSuiteId
+                && this.FileContentHash = otherManifest.FileContentHash
                 && this.Blocks.Count = otherManifest.Blocks.Count
                 && Seq.forall2 (=) this.Blocks otherManifest.Blocks
             | _ -> false
@@ -311,6 +338,8 @@ module Types =
             hashCode.Add(this.Class)
             hashCode.Add(this.ManifestAddress)
             hashCode.Add(this.Size)
+            hashCode.Add(this.ChunkingSuiteId)
+            hashCode.Add(this.FileContentHash)
 
             for block in this.Blocks do
                 hashCode.Add(block)


### PR DESCRIPTION
## Linked issue

Closes #83

## Summary

- Add stable manifest address preimages that pin the chunking suite id and full-file BLAKE3 content hash alongside ordered content block ranges.
- Add pure `ManifestValidation` helpers that validate manifest shape/ranges, suite match, content block payload addresses, reconstructed bytes, file hash, and manifest address before returning reconstructed file bytes.
- Update `FileManifest` to carry `ChunkingSuiteId` and `FileContentHash`, and keep equality/hash code aligned with those stable fields.
- Update the SDK local planner call site introduced on `origin/main` so it computes manifest addresses with the new stable preimage contract.

## Touched paths

- `src/Grace.Shared/ContentAddress.Shared.fs`
- `src/Grace.Shared/ContentBlockFormat.Shared.fs`
- `src/Grace.Shared/Grace.Shared.fsproj`
- `src/Grace.Shared/ManifestValidation.Shared.fs`
- `src/Grace.Types/Types.Types.fs`
- `src/Grace.Types.Tests/ContentAddress.Types.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`
- `src/Grace.Types.Tests/ManifestValidation.Shared.Tests.fs`
- `src/Grace.SDK/LocalPlanner.SDK.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths, except the SDK expansion noted below.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

`src/Grace.SDK/LocalPlanner.SDK.fs` was added after an issue comment scope update: merging current `origin/main` brought in PR #119, whose local planner still called the old manifest address API. The SDK edit is a one-line compatibility update to the new issue #83 contract.

## Validation profile and public-boundary evidence

- Validation profile: domain-contract.
- Public behavior or docs-only validation target: manifest ranges must be ordered, positive, size-covering, suite-matching, and hash-valid against reconstructed bytes; manifest address must be stable from chunking suite, file content hash, size, and ordered logical block ranges.
- RED evidence or docs-only waiver: captured in disposable worktree `C:\Source\Grace-gh-83-red-20260524050758` at base `9ce0db4`; focused test `ManifestPreimagePinsChunkingSuiteAndFileContentHash` failed because the old manifest preimage lacked `chunking-suite:` and `file-content-hash:`.
- Focused validation: manifest/content-address contract tests and SDK local planner tests passed.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.Types.Tests/ContentAddress.Types.Tests.fs`: updated manifest preimage/address stability expectations for suite and full-file hash pinning.
- `src/Grace.Types.Tests/ManifestValidation.Shared.Tests.fs`: added valid reconstruction, invalid invariant, malformed field, and FsCheck property coverage for reconstruction/address stability.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [x] Server or API contract
- [ ] Orleans actor behavior
- [x] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

Details: validation invariants are documented near `FileManifest` and `ManifestValidation`; no broader README/CONTRIBUTING changes were needed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet test --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj --filter "FullyQualifiedName~ManifestValidationSharedTests|FullyQualifiedName~ContentAddressTypesTests"`
- [x] Focused tests: `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~LocalPlanner"`
- [x] Formatting/linting: `dotnet tool run fantomas -- Grace.Shared\ContentAddress.Shared.fs Grace.Shared\ContentBlockFormat.Shared.fs Grace.Shared\ManifestValidation.Shared.fs Grace.Types\Types.Types.fs Grace.Types.Tests\ContentAddress.Types.Tests.fs Grace.Types.Tests\ManifestValidation.Shared.Tests.fs`
- [x] Formatting/linting: `dotnet tool run fantomas -- Grace.SDK\LocalPlanner.SDK.fs`
- [x] Formatting/linting: `git diff --check origin/main...HEAD`
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full`: not run because this slice is pure contract/helper/local planner logic and does not touch Aspire, emulators, blob storage runtime, Cosmos DB, Service Bus, Redis, deployment, or cross-service integration behavior.

## Residual risks

- `FileManifest` has additive serialized fields; callers still using legacy `FileManifest.Create(manifestAddress, size, blocks)` receive empty suite/hash placeholders and must move to the new overload before using strict manifest validation.

## Rollback or recovery notes

- Revert this PR to restore the old manifest-address preimage and remove pure manifest validation helpers.

## Docs follow-up required

None.