### PR TITLE
Add ContentBlockMetadata actor

### DIFF
--- a/src/Grace.Actors/AGENTS.md
+++ b/src/Grace.Actors/AGENTS.md
@@ -23,6 +23,8 @@ Start with `../AGENTS.md` for global rules before working on Orleans code.
    entire implementation.
 4. `UploadSessionActor` cleanup reminders delete only temporary upload coordination state after finalization, abandon, or
    expiration. They must not delete accepted manifests, content blocks, block metadata, or contribution accounting.
+5. `ContentBlockMetadataActor` is keyed by the StoragePoolId and ContentBlockAddress composite key. Preserve whole-record
+   MetadataVersion concurrency and exact range presence semantics; do not introduce per-chunk actor or grain state.
 
 ## Validation
 

--- a/src/Grace.Actors/Constants.Actor.fs
+++ b/src/Grace.Actors/Constants.Actor.fs
@@ -86,6 +86,9 @@ module Constants =
         let Artifact = "ArtifactActor"
 
         [<Literal>]
+        let ContentBlockMetadata = "ContentBlockMetadataActor"
+
+        [<Literal>]
         let UploadSession = "UploadSessionActor"
 
         [<Literal>]
@@ -166,6 +169,9 @@ module Constants =
 
         [<Literal>]
         let Artifact = "Artifact"
+
+        [<Literal>]
+        let ContentBlockMetadata = "ContentBlockMetadata"
 
         [<Literal>]
         let UploadSession = "UploadSession"

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -1,0 +1,211 @@
+namespace Grace.Actors
+
+open Grace.Actors.Constants
+open Grace.Actors.Context
+open Grace.Actors.Interfaces
+open Grace.Actors.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.Types
+open Microsoft.Extensions.Logging
+open Orleans
+open Orleans.Runtime
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module ContentBlockMetadataActorKey =
+
+    let Create (storagePoolId: StoragePoolId) (contentBlockAddress: ContentBlockAddress) = $"{storagePoolId}|{contentBlockAddress}"
+
+module ContentBlockMetadata =
+
+    let commandName command =
+        match command with
+        | ContentBlockMetadataCommand.ReplaceWholeRecord _ -> "ReplaceWholeRecord"
+
+    let operationId command =
+        match command with
+        | ContentBlockMetadataCommand.ReplaceWholeRecord replace -> replace.OperationId
+
+    let private eventOperationId metadataEvent =
+        match metadataEvent.Event with
+        | ContentBlockMetadataEventType.WholeRecordReplaced (operationId, _) -> operationId
+
+    let private hasAppliedOperationId (events: seq<ContentBlockMetadataEvent>) operationId =
+        events
+        |> Seq.exists (fun metadataEvent -> eventOperationId metadataEvent = operationId)
+
+    let applyEvents (events: ContentBlockMetadataEvent list) (current: ContentBlockMetadataDto) =
+        events
+        |> List.fold (fun dto event -> ContentBlockMetadataDto.UpdateDto event dto) current
+
+    let private graceError correlationId message = GraceError.Create message correlationId
+
+    let private validateRange correlationId (range: ContentBlockMetadataRange) =
+        if range.OrdinalStart < 0 then
+            Some(graceError correlationId "ContentBlockMetadataRange.OrdinalStart must be zero or greater.")
+        elif range.OrdinalCount <= 0 then
+            Some(graceError correlationId "ContentBlockMetadataRange.OrdinalCount must be greater than zero.")
+        elif range.ActiveManifestCount < 0 then
+            Some(graceError correlationId "ContentBlockMetadataRange.ActiveManifestCount must be zero or greater.")
+        elif range.PhysicalOffset < 0L then
+            Some(graceError correlationId "ContentBlockMetadataRange.PhysicalOffset must be zero or greater.")
+        elif range.PhysicalLength <= 0L then
+            Some(graceError correlationId "ContentBlockMetadataRange.PhysicalLength must be greater than zero.")
+        else
+            None
+
+    let private validateMetadata correlationId (metadata: ContentBlockMetadata) =
+        if String.IsNullOrWhiteSpace metadata.StoragePoolId then
+            Some(graceError correlationId "StoragePoolId is required.")
+        elif String.IsNullOrWhiteSpace metadata.ContentBlockAddress then
+            Some(graceError correlationId "ContentBlockAddress is required.")
+        elif metadata.BlockFormatVersion <= 0s then
+            Some(graceError correlationId "BlockFormatVersion must be greater than zero.")
+        elif metadata.TotalPhysicalBytes < 0L then
+            Some(graceError correlationId "TotalPhysicalBytes must be zero or greater.")
+        elif metadata.ActivePhysicalBytes < 0L then
+            Some(graceError correlationId "ActivePhysicalBytes must be zero or greater.")
+        elif metadata.ActivePhysicalBytes > metadata.TotalPhysicalBytes then
+            Some(graceError correlationId "ActivePhysicalBytes cannot exceed TotalPhysicalBytes.")
+        else
+            metadata.Ranges
+            |> Array.tryPick (validateRange correlationId)
+
+    let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
+
+    let private okDecision metadata operationId events wasReplay message =
+        Ok { Metadata = metadata; OperationId = operationId; Events = events; WasIdempotentReplay = wasReplay; Message = message }
+
+    let decideCommand
+        (events: seq<ContentBlockMetadataEvent>)
+        (current: ContentBlockMetadataDto)
+        (command: ContentBlockMetadataCommand)
+        (eventMetadata: EventMetadata)
+        =
+        let operationId = operationId command
+
+        if String.IsNullOrWhiteSpace operationId then
+            Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata command requires a non-empty operation id.")
+        elif hasAppliedOperationId events operationId then
+            match current.Metadata with
+            | Some metadata -> okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
+            | None -> Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation was replayed but no metadata state is available.")
+        else
+            match command with
+            | ContentBlockMetadataCommand.ReplaceWholeRecord replace ->
+                match validateMetadata eventMetadata.CorrelationId replace.Metadata with
+                | Some error -> Error error
+                | None ->
+                    match current.Metadata, replace.ExpectedMetadataVersion with
+                    | None, Some expectedVersion ->
+                        Error(graceError eventMetadata.CorrelationId $"ContentBlockMetadata does not exist; expected MetadataVersion {expectedVersion}.")
+                    | Some _, None ->
+                        Error(graceError eventMetadata.CorrelationId "ExpectedMetadataVersion is required when replacing existing ContentBlockMetadata.")
+                    | Some existing, Some expectedVersion when existing.MetadataVersion <> expectedVersion ->
+                        Error(
+                            graceError
+                                eventMetadata.CorrelationId
+                                $"Stale ContentBlockMetadata update rejected. Expected MetadataVersion {expectedVersion}, current MetadataVersion {existing.MetadataVersion}."
+                        )
+                    | currentState, _ ->
+                        let nextVersion =
+                            currentState
+                            |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
+                            |> Option.defaultValue 1L
+
+                        let metadata = stampMetadata replace.Metadata nextVersion eventMetadata.Timestamp
+
+                        let events =
+                            [
+                                { Event = ContentBlockMetadataEventType.WholeRecordReplaced(operationId, metadata); Metadata = eventMetadata }
+                            ]
+
+                        okDecision metadata operationId events false "ContentBlockMetadata whole record replaced."
+
+    type ContentBlockMetadataActor
+        (
+            [<PersistentState(StateName.ContentBlockMetadata, Constants.GraceActorStorage)>] state: IPersistentState<List<ContentBlockMetadataEvent>>
+        ) =
+        inherit Grain()
+
+        let log = loggerFactory.CreateLogger("ContentBlockMetadata.Actor")
+        let mutable metadataDto = ContentBlockMetadataDto.Empty
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override this.OnActivateAsync(ct) =
+            let activateStartTime = getCurrentInstant ()
+
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+
+            metadataDto <-
+                state.State
+                |> Seq.fold (fun dto event -> ContentBlockMetadataDto.UpdateDto event dto) ContentBlockMetadataDto.Empty
+
+            Task.CompletedTask
+
+        member private this.ApplyEvents(events: ContentBlockMetadataEvent list) =
+            task {
+                for metadataEvent in events do
+                    state.State.Add(metadataEvent)
+
+                do! state.WriteStateAsync()
+
+                metadataDto <- applyEvents events metadataDto
+            }
+
+        interface IContentBlockMetadataActor with
+            member this.Exists correlationId =
+                this.correlationId <- correlationId
+
+                metadataDto.Metadata.IsSome |> returnTask
+
+            member this.Get correlationId =
+                this.correlationId <- correlationId
+
+                metadataDto.Metadata |> returnTask
+
+            member this.GetEvents correlationId =
+                this.correlationId <- correlationId
+
+                (state.State :> IReadOnlyList<ContentBlockMetadataEvent>)
+                |> returnTask
+
+            member this.GetRangePresence query correlationId =
+                this.correlationId <- correlationId
+
+                match metadataDto.Metadata with
+                | Some metadata -> Grace.Types.ContentBlockMetadata.rangePresence metadata query
+                | None -> ContentBlockRangePresence.Absent
+                |> returnTask
+
+            member this.Handle command eventMetadata =
+                task {
+                    this.correlationId <- eventMetadata.CorrelationId
+                    RequestContext.Set(Constants.CurrentCommandProperty, commandName command)
+
+                    match decideCommand state.State metadataDto command eventMetadata with
+                    | Ok decision ->
+                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
+                        let returnValue =
+                            (GraceReturnValue.Create decision eventMetadata.CorrelationId)
+                                .enhance(nameof StoragePoolId, decision.Metadata.StoragePoolId)
+                                .enhance(nameof ContentBlockAddress, decision.Metadata.ContentBlockAddress)
+                                .enhance (nameof MetadataVersion, decision.Metadata.MetadataVersion)
+
+                        return Ok returnValue
+                    | Error error ->
+                        log.LogWarning(
+                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected ContentBlockMetadata command {Command}. Error: {Error}",
+                            getCurrentInstantExtended (),
+                            getMachineName,
+                            eventMetadata.CorrelationId,
+                            commandName command,
+                            error.Error
+                        )
+
+                        return Error error
+                }

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -50,6 +50,7 @@
         <Compile Include="ValidationSet.Actor.fs" />
         <Compile Include="ValidationResult.Actor.fs" />
         <Compile Include="Artifact.Actor.fs" />
+        <Compile Include="ContentBlockMetadata.Actor.fs" />
         <Compile Include="UploadSession.Actor.fs" />
         <Compile Include="PromotionQueue.Actor.fs" />
         <Compile Include="Repository.Actor.fs" />

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -4,6 +4,7 @@ open Grace.Actors.Types
 open Grace.Shared
 open Grace.Types.Authorization
 open Grace.Types.Branch
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Diff
 open Grace.Types.DirectoryVersion
 open Grace.Types.Reference
@@ -469,6 +470,26 @@ module Interfaces =
 
         /// Validates incoming commands and converts them to events that are stored in the database.
         abstract member Handle: command: ArtifactCommand -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+    /// Defines the operations for the StoragePool-scoped ContentBlock metadata actor.
+    [<Interface>]
+    type IContentBlockMetadataActor =
+        inherit IGrainWithStringKey
+
+        /// Returns true if metadata exists for this ContentBlock.
+        abstract member Exists: correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the current ContentBlock metadata, if it exists.
+        abstract member Get: correlationId: CorrelationId -> Task<ContentBlockMetadata option>
+
+        /// Returns the events handled by this ContentBlock metadata actor.
+        abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<ContentBlockMetadataEvent>>
+
+        /// Returns the authoritative physical presence for an exact logical range.
+        abstract member GetRangePresence: query: ContentBlockRangeQuery -> correlationId: CorrelationId -> Task<ContentBlockRangePresence>
+
+        /// Validates whole-record metadata updates and converts them to persisted events.
+        abstract member Handle: command: ContentBlockMetadataCommand -> eventMetadata: EventMetadata -> Task<GraceResult<ContentBlockMetadataDecision>>
 
     /// Defines the operations for the UploadSession actor.
     [<Interface>]

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -1,0 +1,139 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+
+module ContentBlockMetadataActor = Grace.Actors.ContentBlockMetadata
+module ContentBlockMetadataTypes = Grace.Types.ContentBlockMetadata
+
+[<Parallelizable(ParallelScope.All)>]
+type ContentBlockMetadataActorTests() =
+
+    let timestamp = Instant.FromUtc(2026, 5, 24, 13, 0)
+
+    let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+
+    let storagePoolId = StoragePoolId "pool-main"
+    let contentBlockAddress = ContentBlockAddress "block-blake3-0001"
+
+    let activeRange = { OrdinalStart = 0; OrdinalCount = 8; ActiveManifestCount = 2; PhysicalOffset = 0L; PhysicalLength = 1024L }
+
+    let reclaimableRange = { OrdinalStart = 8; OrdinalCount = 4; ActiveManifestCount = 0; PhysicalOffset = 1024L; PhysicalLength = 512L }
+
+    let record ranges =
+        {
+            Class = nameof ContentBlockMetadata
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = contentBlockAddress
+            BlockFormatVersion = 1s
+            StoragePlacement = { ObjectKey = "cas/content-blocks/block-blake3-0001"; ETag = Some "etag-1" }
+            Ranges = ranges
+            TotalPhysicalBytes = 1536L
+            ActivePhysicalBytes = 1024L
+            MetadataVersion = 0L
+            UpdatedAt = timestamp
+        }
+
+    let replace operationId expectedVersion ranges =
+        ContentBlockMetadataCommand.ReplaceWholeRecord { OperationId = operationId; ExpectedMetadataVersion = expectedVersion; Metadata = record ranges }
+
+    let applyAll events current =
+        events
+        |> List.fold (fun state event -> ContentBlockMetadataDto.UpdateDto event state) current
+
+    [<Test>]
+    member _.CreateWholeRecordStampsVersionAndReportsActivePresence() =
+        let result =
+            ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (replace "op-create" None [| activeRange |]) (metadata "corr-create")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Events.Length, Is.EqualTo(1))
+            Assert.That(decision.Metadata.MetadataVersion, Is.EqualTo(1L))
+            Assert.That(decision.Metadata.StoragePoolId, Is.EqualTo(storagePoolId))
+
+            let presence = ContentBlockMetadataTypes.rangePresence decision.Metadata { OrdinalStart = 0; OrdinalCount = 8 }
+
+            Assert.That(presence, Is.EqualTo(ContentBlockRangePresence.Active))
+        | Error error -> Assert.Fail($"Expected create to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.StaleWholeRecordUpdateIsRejected() =
+        let created =
+            match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (replace "op-create" None [| activeRange |]) (metadata "corr-create")
+                with
+            | Ok decision -> applyAll decision.Events ContentBlockMetadataDto.Empty
+            | Error error ->
+                Assert.Fail($"Expected create to succeed, got {error.Error}.")
+                ContentBlockMetadataDto.Empty
+
+        let staleUpdate =
+            ContentBlockMetadataActor.decideCommand [] created (replace "op-stale" (Some 0L) [| activeRange; reclaimableRange |]) (metadata "corr-stale")
+
+        match staleUpdate with
+        | Ok _ -> Assert.Fail("Expected stale whole-record update to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("MetadataVersion"))
+
+    [<Test>]
+    member _.RangePresenceDistinguishesActiveReclaimableAndAbsentRanges() =
+        let metadata =
+            record [| activeRange
+                      reclaimableRange |]
+
+        Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 0; OrdinalCount = 8 }, Is.EqualTo(ContentBlockRangePresence.Active))
+
+        Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 8; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Reclaimable))
+
+        Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 12; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Absent))
+
+    [<Test>]
+    member _.SameOperationIdIsIdempotentReplayWithoutVersionBump() =
+        let command = replace "op-create" None [| activeRange |]
+        let first = ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty command (metadata "corr-create")
+
+        match first with
+        | Ok decision ->
+            let current = applyAll decision.Events ContentBlockMetadataDto.Empty
+            let replay = ContentBlockMetadataActor.decideCommand decision.Events current command (metadata "corr-replay")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Metadata.MetadataVersion, Is.EqualTo(1L))
+            | Error error -> Assert.Fail($"Expected idempotent replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected create to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.MetadataActorUsesOneCompositeStringKeyAndDoesNotIntroduceChunkActorState() =
+        let key = ContentBlockMetadataActorKey.Create storagePoolId contentBlockAddress
+
+        Assert.That(key, Is.EqualTo("pool-main|block-blake3-0001"))
+
+        let repoRoot =
+            DirectoryInfo(
+                TestContext.CurrentContext.TestDirectory
+            )
+                .Parent
+                .Parent
+                .Parent
+                .Parent
+                .FullName
+
+        let actorsDirectory = Path.Combine(repoRoot, "Grace.Actors")
+        let actorFiles = Directory.EnumerateFiles(actorsDirectory, "*.fs", SearchOption.AllDirectories)
+
+        let contentChunkActorMentions =
+            actorFiles
+            |> Seq.collect (fun path -> File.ReadLines(path))
+            |> Seq.filter (fun line -> line.Contains("ContentChunkActor", StringComparison.Ordinal))
+            |> Seq.toArray
+
+        Assert.That(contentChunkActorMentions, Is.Empty)

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="UploadSession.Actor.Tests.fs" />
+    <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -1,0 +1,120 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open NodaTime
+open Orleans
+open System
+open System.Runtime.Serialization
+
+module ContentBlockMetadata =
+
+    [<CLIMutable; GenerateSerializer>]
+    type ContentBlockStoragePlacement =
+        {
+            ObjectKey: string
+            ETag: string option
+        }
+
+        static member Empty = { ObjectKey = String.Empty; ETag = None }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ContentBlockMetadataRange = { OrdinalStart: int; OrdinalCount: int; ActiveManifestCount: int; PhysicalOffset: int64; PhysicalLength: int64 }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ContentBlockRangeQuery = { OrdinalStart: int; OrdinalCount: int }
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ContentBlockRangePresence =
+        | Active
+        | Reclaimable
+        | Absent
+
+        static member GetKnownTypes() = GetKnownTypes<ContentBlockRangePresence>()
+
+    [<CLIMutable; GenerateSerializer>]
+    type ContentBlockMetadata =
+        {
+            Class: string
+            StoragePoolId: StoragePoolId
+            ContentBlockAddress: ContentBlockAddress
+            BlockFormatVersion: int16
+            StoragePlacement: ContentBlockStoragePlacement
+            Ranges: ContentBlockMetadataRange array
+            TotalPhysicalBytes: int64
+            ActivePhysicalBytes: int64
+            MetadataVersion: MetadataVersion
+            UpdatedAt: Instant
+        }
+
+        static member Empty =
+            {
+                Class = nameof ContentBlockMetadata
+                StoragePoolId = StoragePoolId String.Empty
+                ContentBlockAddress = ContentBlockAddress String.Empty
+                BlockFormatVersion = 0s
+                StoragePlacement = ContentBlockStoragePlacement.Empty
+                Ranges = Array.empty
+                TotalPhysicalBytes = 0L
+                ActivePhysicalBytes = 0L
+                MetadataVersion = 0L
+                UpdatedAt = DefaultTimestamp
+            }
+
+    [<GenerateSerializer>]
+    type ReplaceContentBlockMetadata = { OperationId: string; ExpectedMetadataVersion: MetadataVersion option; Metadata: ContentBlockMetadata }
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ContentBlockMetadataCommand =
+        | ReplaceWholeRecord of replace: ReplaceContentBlockMetadata
+
+        static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataCommand>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ContentBlockMetadataEventType =
+        | WholeRecordReplaced of operationId: string * metadata: ContentBlockMetadata
+
+        static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataEventType>()
+
+    [<GenerateSerializer>]
+    type ContentBlockMetadataEvent = { Event: ContentBlockMetadataEventType; Metadata: EventMetadata }
+
+    [<GenerateSerializer>]
+    type ContentBlockMetadataDto =
+        {
+            Metadata: ContentBlockMetadata option
+            LastOperationId: string option
+        }
+
+        static member Empty = { Metadata = None; LastOperationId = None }
+
+        static member UpdateDto event _current =
+            match event.Event with
+            | ContentBlockMetadataEventType.WholeRecordReplaced (operationId, metadata) -> { Metadata = Some metadata; LastOperationId = Some operationId }
+
+    [<GenerateSerializer>]
+    type ContentBlockMetadataDecision =
+        {
+            Metadata: ContentBlockMetadata
+            OperationId: string
+            Events: ContentBlockMetadataEvent list
+            WasIdempotentReplay: bool
+            Message: string
+        }
+
+    let tryFindRange (metadata: ContentBlockMetadata) query =
+        if query.OrdinalCount <= 0 then
+            None
+        else
+            metadata.Ranges
+            |> Array.tryFind (fun range ->
+                range.OrdinalStart = query.OrdinalStart
+                && range.OrdinalCount = query.OrdinalCount)
+
+    let rangePresence metadata query =
+        match tryFindRange metadata query with
+        | Some range when range.ActiveManifestCount > 0 -> ContentBlockRangePresence.Active
+        | Some _ -> ContentBlockRangePresence.Reclaimable
+        | None -> ContentBlockRangePresence.Absent

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -19,6 +19,7 @@
         <Compile Include="..\Grace.Shared\Constants.Shared.fs" Link="Constants.Shared.fs" />
         <Compile Include="..\Grace.Shared\Utilities.Shared.fs" Link="Utilities.Shared.fs" />
         <Compile Include="Types.Types.fs" />
+        <Compile Include="ContentBlockMetadata.Types.fs" />
         <Compile Include="Authorization.Types.fs" />
         <Compile Include="Auth.Types.fs" />
         <Compile Include="PersonalAccessToken.Types.fs" />

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -128,6 +128,12 @@ module Types =
     /// The content-addressed identifier for a file manifest.
     type ManifestAddress = string
 
+    /// The StoragePool-wide scope for manifest-backed content-addressed storage.
+    type StoragePoolId = string
+
+    /// Optimistic concurrency version for mutable content block metadata.
+    type MetadataVersion = int64
+
     /// The Id of an upload session.
     type UploadSessionId = Guid
 


### PR DESCRIPTION
## Summary

- Adds ContentBlockMetadata domain contracts, StoragePoolId/MetadataVersion aliases, and Orleans serializers for whole-record metadata events.
- Adds ContentBlockMetadataActor keyed by StoragePoolId + ContentBlockAddress, with whole-record replacement, operation-id replay handling, MetadataVersion concurrency checks, and exact range presence queries.
- Adds focused actor tests for create/version stamping, stale update rejection, active/reclaimable/absent presence, idempotent replay, and no per-chunk actor state; updates actor AGENTS guidance.

Closes #88

## TDD / recovery evidence

- Recovery started from an existing disconnected-agent worktree that already mixed tests and implementation.
- No prior RED evidence was present in issue comments; I preserved the useful recovered work instead of rewinding it.
- First focused recovery run failed before green due incomplete recovered setup:
  - `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~ContentBlockMetadataActorTests --no-restore`
  - Initial failures: missing `KnownType` open, missing actor context/logger open, and test namespace ambiguity.
- Final focused run is green on the rebased commit.

## Validation

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~ContentBlockMetadataActorTests --no-restore` - passed, 5 tests.
- `dotnet tool run fantomas src\Grace.Types\ContentBlockMetadata.Types.fs src\Grace.Actors\ContentBlockMetadata.Actor.fs src\Grace.Server.Tests\ContentBlockMetadata.Actor.Tests.fs src\Grace.Actors\Constants.Actor.fs src\Grace.Actors\Interfaces.Actor.fs src\Grace.Types\Types.Types.fs` - passed.
- `npx --yes markdownlint-cli2 src/Grace.Actors/AGENTS.md` - passed, 0 errors.
- `git diff --check origin/main...HEAD` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed on final rebased commit.
- `pwsh ./scripts/validate.ps1 -Full` - passed on final rebased commit.

## Docs impact

- Updated `src/Grace.Actors/AGENTS.md` with the ContentBlockMetadata keying/concurrency/no-per-chunk-state rule.

## Skipped validation / residual risk

- No required validation intentionally skipped.
- The repo validation script reports formatting as temporarily disabled internally, so targeted Fantomas was run explicitly for touched F# files.