### PR TITLE
Add ContentBlock SAS storage routes

### DIFF
--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -349,3 +349,51 @@ module Storage =
                 logToConsole $"exception: {exceptionResponse.ToString()}"
                 return Error(GraceError.Create (exceptionResponse.ToString()) parameters.CorrelationId)
         }
+
+    /// Gets an upload URI with a SAS token for uploading a ContentBlock payload to object storage.
+    let GetContentBlockUploadUri (parameters: GetContentBlockUploadUriParameters) =
+        task {
+            try
+                match Current().ObjectStorageProvider with
+                | ObjectStorageProvider.Unknown -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+                | ObjectStorageProvider.AzureBlobStorage ->
+                    let httpClient = getHttpClient parameters.CorrelationId
+                    do! Auth.addAuthorizationHeader httpClient
+                    let serviceUrl = $"{Current().ServerUri}/storage/getContentBlockUploadUri"
+                    let jsonContent = createJsonContent parameters
+                    let! response = httpClient.PostAsync(serviceUrl, jsonContent)
+                    let! blobUriWithSasToken = response.Content.ReadAsStringAsync()
+                    return Ok(GraceReturnValue.Create blobUriWithSasToken parameters.CorrelationId)
+                | ObjectStorageProvider.AWSS3 -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+                | ObjectStorageProvider.GoogleCloudStorage ->
+                    return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+            with
+            | ex ->
+                let exceptionResponse = ExceptionResponse.Create ex
+                logToConsole $"exception: {exceptionResponse.ToString()}"
+                return Error(GraceError.Create (exceptionResponse.ToString()) parameters.CorrelationId)
+        }
+
+    /// Gets a download URI with a SAS token for downloading a ContentBlock payload from object storage.
+    let GetContentBlockDownloadUri (parameters: GetContentBlockDownloadUriParameters) =
+        task {
+            try
+                match Current().ObjectStorageProvider with
+                | ObjectStorageProvider.Unknown -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+                | ObjectStorageProvider.AzureBlobStorage ->
+                    let httpClient = getHttpClient parameters.CorrelationId
+                    do! Auth.addAuthorizationHeader httpClient
+                    let serviceUrl = $"{Current().ServerUri}/storage/getContentBlockDownloadUri"
+                    let jsonContent = createJsonContent parameters
+                    let! response = httpClient.PostAsync(serviceUrl, jsonContent)
+                    let! blobUriWithSasToken = response.Content.ReadAsStringAsync()
+                    return Ok(GraceReturnValue.Create blobUriWithSasToken parameters.CorrelationId)
+                | ObjectStorageProvider.AWSS3 -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+                | ObjectStorageProvider.GoogleCloudStorage ->
+                    return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
+            with
+            | ex ->
+                let exceptionResponse = ExceptionResponse.Create ex
+                logToConsole $"exception: {exceptionResponse.ToString()}"
+                return Error(GraceError.Create (exceptionResponse.ToString()) parameters.CorrelationId)
+        }

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -153,14 +153,12 @@ type StorageContentBlockSasRoutes() =
     let createContentBlockUploadParameters repositoryId =
         let parameters = Parameters.Storage.GetContentBlockUploadUriParameters()
         setContentBlockParameters parameters repositoryId
-        parameters.RelativePath <- "large-assets/never-uploaded.bin"
         parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
         parameters
 
     let createContentBlockDownloadParameters repositoryId =
         let parameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
         setContentBlockParameters parameters repositoryId
-        parameters.RelativePath <- "large-assets/never-uploaded.bin"
         parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
         parameters
 
@@ -232,7 +230,7 @@ type StorageContentBlockSdkContract() =
         let parameterType = getStorageParameterType typeName
         Assert.That(parameterType, Is.Not.Null, $"{typeName} should be defined in Grace.Shared.Parameters.Storage.")
         Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
-        Assert.That(parameterType.GetProperty("RelativePath"), Is.Not.Null)
+        Assert.That(parameterType.GetProperty("RelativePath"), Is.Null)
         Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Not.Null)
 
     let assertSdkMethod methodName parameterTypeName =
@@ -250,7 +248,7 @@ type StorageContentBlockSdkContract() =
         Assert.That(parameters[0].ParameterType, Is.EqualTo(parameterType))
 
     [<Test>]
-    member _.ContentBlockSasParametersExposePathContextAndAddress() =
+    member _.ContentBlockSasParametersExposeAddressWithoutCallerSuppliedPath() =
         assertContentBlockParameterShape "GetContentBlockUploadUriParameters"
         assertContentBlockParameterShape "GetContentBlockDownloadUriParameters"
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -7,6 +7,8 @@ open Grace.Types.Types
 open NUnit.Framework
 open System
 open System.Net
+open System.Net.Http
+open System.Reflection
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
@@ -110,3 +112,149 @@ type StorageWholeFileCompatibility() =
             Assert.That(downloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), downloadUri)
             Assert.That(downloadUri, Does.Contain(fileVersion.GetObjectFileName))
         }
+
+[<NonParallelizable>]
+type StorageContentBlockSasRoutes() =
+
+    let createClientWithUserId (userId: string) =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    let createUnauthenticatedClient () =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client
+
+    let grantRoleAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId principalId roleId =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- scopeKind
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+        }
+
+    let setContentBlockParameters (parameters: Parameters.Storage.StorageParameters) repositoryId =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+    let createContentBlockUploadParameters repositoryId =
+        let parameters = Parameters.Storage.GetContentBlockUploadUriParameters()
+        setContentBlockParameters parameters repositoryId
+        parameters.RelativePath <- "large-assets/never-uploaded.bin"
+        parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
+        parameters
+
+    let createContentBlockDownloadParameters repositoryId =
+        let parameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
+        setContentBlockParameters parameters repositoryId
+        parameters.RelativePath <- "large-assets/never-uploaded.bin"
+        parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
+        parameters
+
+    let assertSuccessSasForContentBlock (response: HttpResponseMessage) (contentBlockAddress: ContentBlockAddress) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            Assert.That(body, Does.Contain("cas/content-blocks"))
+            Assert.That(body, Does.Contain(contentBlockAddress))
+        }
+
+    [<Test>]
+    member _.ContentBlockUploadUriRequiresPathWriteAndDoesNotProbeBlockExistence() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathWriter = $"{Guid.NewGuid()}"
+
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepoContributor"
+            Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use unauthClient = createUnauthenticatedClient ()
+            use writerClient = createClientWithUserId pathWriter
+            use unprivilegedClient = createClientWithUserId $"{Guid.NewGuid()}"
+
+            let parameters = createContentBlockUploadParameters repositoryId
+
+            let! unauthUpload = unauthClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            Assert.That(unauthUpload.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
+
+            let! deniedUpload = unprivilegedClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            Assert.That(deniedUpload.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! allowedUpload = writerClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            do! assertSuccessSasForContentBlock allowedUpload parameters.ContentBlockAddress
+        }
+
+    [<Test>]
+    member _.ContentBlockDownloadUriRequiresPathReadAndDoesNotProbeBlockExistence() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathReader = $"{Guid.NewGuid()}"
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepoReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use unauthClient = createUnauthenticatedClient ()
+            use readerClient = createClientWithUserId pathReader
+            use unprivilegedClient = createClientWithUserId $"{Guid.NewGuid()}"
+
+            let parameters = createContentBlockDownloadParameters repositoryId
+
+            let! unauthDownload = unauthClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            Assert.That(unauthDownload.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
+
+            let! deniedDownload = unprivilegedClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            Assert.That(deniedDownload.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! allowedDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            do! assertSuccessSasForContentBlock allowedDownload parameters.ContentBlockAddress
+        }
+
+[<Parallelizable(ParallelScope.All)>]
+type StorageContentBlockSdkContract() =
+
+    let getStorageParameterType typeName =
+        typeof<Parameters.Storage.StorageParameters>.Assembly.GetType ($"Grace.Shared.Parameters.Storage+{typeName}", throwOnError = false)
+
+    let assertContentBlockParameterShape typeName =
+        let parameterType = getStorageParameterType typeName
+        Assert.That(parameterType, Is.Not.Null, $"{typeName} should be defined in Grace.Shared.Parameters.Storage.")
+        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
+        Assert.That(parameterType.GetProperty("RelativePath"), Is.Not.Null)
+        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Not.Null)
+
+    let assertSdkMethod methodName parameterTypeName =
+        let parameterType = getStorageParameterType parameterTypeName
+        Assert.That(parameterType, Is.Not.Null)
+
+        let storageType = typeof<Grace.SDK.AgentSession>.Assembly.GetType ("Grace.SDK.Storage", throwOnError = false)
+        Assert.That(storageType, Is.Not.Null, "Grace.SDK.Storage should be available as an SDK module.")
+
+        let methodInfo: MethodInfo = storageType.GetMethod(methodName, BindingFlags.Public ||| BindingFlags.Static)
+
+        Assert.That(methodInfo, Is.Not.Null, $"Grace.SDK.Storage.{methodName} should be a public SDK method.")
+        let parameters: ParameterInfo array = methodInfo.GetParameters()
+        Assert.That(parameters, Has.Length.EqualTo(1))
+        Assert.That(parameters[0].ParameterType, Is.EqualTo(parameterType))
+
+    [<Test>]
+    member _.ContentBlockSasParametersExposePathContextAndAddress() =
+        assertContentBlockParameterShape "GetContentBlockUploadUriParameters"
+        assertContentBlockParameterShape "GetContentBlockDownloadUriParameters"
+
+    [<Test>]
+    member _.ContentBlockSasSdkMethodsMatchSharedParameterContracts() =
+        assertSdkMethod "GetContentBlockUploadUri" "GetContentBlockUploadUriParameters"
+        assertSdkMethod "GetContentBlockDownloadUri" "GetContentBlockDownloadUriParameters"

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -175,6 +175,8 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/review/report/get" Authenticated
             endpoint "POST" "/review/resolve" Authenticated
             endpoint "POST" "/storage/getDownloadUri" (Authorized(PathRead, Path))
+            endpoint "POST" "/storage/getContentBlockDownloadUri" (Authorized(PathRead, Path))
+            endpoint "POST" "/storage/getContentBlockUploadUri" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getUploadMetadataForFiles" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getUploadUri" (Authorized(PathWrite, Path))
             endpoint "POST" "/work/create" (Authorized(RepoWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -202,7 +202,13 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.RelativePath)
+                return
+                    Resource.Path(
+                        graceIds.OwnerId,
+                        graceIds.OrganizationId,
+                        graceIds.RepositoryId,
+                        StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
+                    )
             }
 
         let contentBlockDownloadPathResourceFromContext (context: HttpContext) =
@@ -215,7 +221,13 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.RelativePath)
+                return
+                    Resource.Path(
+                        graceIds.OwnerId,
+                        graceIds.OrganizationId,
+                        graceIds.RepositoryId,
+                        StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
+                    )
             }
 
         let composeHandlers (first: HttpHandler) (second: HttpHandler) : HttpHandler = fun next context -> first (second next) context

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -192,6 +192,32 @@ module Application =
                 return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.FileVersion.RelativePath)
             }
 
+        let contentBlockUploadPathResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Storage.GetContentBlockUploadUriParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let graceIds = Services.getGraceIds context
+
+                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.RelativePath)
+            }
+
+        let contentBlockDownloadPathResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Storage.GetContentBlockDownloadUriParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let graceIds = Services.getGraceIds context
+
+                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.RelativePath)
+            }
+
         let composeHandlers (first: HttpHandler) (second: HttpHandler) : HttpHandler = fun next context -> first (second next) context
 
         let requireSystemAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.SystemAdmin (fun _ -> task { return Resource.System })
@@ -221,6 +247,12 @@ module Application =
         let requirePathWriteForUploadUri: HttpHandler = AuthorizationMiddleware.requiresPermissions Operation.PathWrite uploadUriResourcesFromContext
 
         let requirePathRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.PathRead downloadPathResourceFromContext
+
+        let requirePathWriteForContentBlockUploadUri: HttpHandler =
+            AuthorizationMiddleware.requiresPermission Operation.PathWrite contentBlockUploadPathResourceFromContext
+
+        let requirePathReadForContentBlockDownloadUri: HttpHandler =
+            AuthorizationMiddleware.requiresPermission Operation.PathRead contentBlockDownloadPathResourceFromContext
 
         let activeAgentSessionsByAgentKey = ConcurrentDictionary<string, AgentSessionInfo>()
         let activeAgentSessionsBySessionId = ConcurrentDictionary<string, string>()
@@ -1217,6 +1249,14 @@ module Application =
 
                                route "/getDownloadUri" (composeHandlers requirePathRead Storage.GetDownloadUri)
                                |> addMetadata typeof<Storage.GetDownloadUriParameters>
+
+                               route "/getContentBlockUploadUri" (composeHandlers requirePathWriteForContentBlockUploadUri Storage.GetContentBlockUploadUri)
+                               |> addMetadata typeof<Storage.GetContentBlockUploadUriParameters>
+
+                               route
+                                   "/getContentBlockDownloadUri"
+                                   (composeHandlers requirePathReadForContentBlockDownloadUri Storage.GetContentBlockDownloadUri)
+                               |> addMetadata typeof<Storage.GetContentBlockDownloadUriParameters>
 
                                route "/getUploadUri" (composeHandlers requirePathWriteForUploadUri Storage.GetUploadUris)
                                |> addMetadata typeof<Storage.GetUploadUriParameters> ]

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -54,6 +54,8 @@ module Storage =
 
         StorageKeys.wholeFileContentObjectKey fileVersion
 
+    let private getContentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = StorageKeys.contentBlockObjectKey contentBlockAddress
+
     let private resolveStorageIds (graceIds: GraceIds) (parameters: StorageParameters) =
         let organizationId =
             if graceIds.OrganizationId <> OrganizationId.Empty then
@@ -111,6 +113,56 @@ module Storage =
                 | ex ->
                     context.SetStatusCode StatusCodes.Status500InternalServerError
                     return! context.WriteTextAsync $"Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
+            }
+
+    /// Gets an upload URI for the specified ContentBlock payload without probing whether the blob already exists.
+    let GetContentBlockUploadUri: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+                let graceIds = getGraceIds context
+
+                try
+                    let! parameters = context.BindJsonAsync<GetContentBlockUploadUriParameters>()
+                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
+                    let! repositoryDto = repositoryActor.Get correlationId
+
+                    let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
+                    let! uploadUri = getUriWithWriteSharedAccessSignature repositoryDto blobName correlationId
+                    context.SetStatusCode StatusCodes.Status200OK
+                    return! context.WriteStringAsync $"{uploadUri}"
+                with
+                | ex ->
+                    context.SetStatusCode StatusCodes.Status500InternalServerError
+                    logToConsole $"Exception in GetContentBlockUploadUri: {(ExceptionResponse.Create ex)}"
+
+                    return! context.WriteTextAsync $"{getCurrentInstantExtended ()} Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
+            }
+
+    /// Gets a download URI for the specified ContentBlock payload without probing whether the blob already exists.
+    let GetContentBlockDownloadUri: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+                let graceIds = getGraceIds context
+
+                try
+                    let! parameters = context.BindJsonAsync<GetContentBlockDownloadUriParameters>()
+                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
+                    let! repositoryDto = repositoryActor.Get correlationId
+
+                    let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
+                    let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
+                    context.SetStatusCode StatusCodes.Status200OK
+                    return! context.WriteStringAsync $"{downloadUri}"
+                with
+                | ex ->
+                    context.SetStatusCode StatusCodes.Status500InternalServerError
+                    logToConsole $"Exception in GetContentBlockDownloadUri: {(ExceptionResponse.Create ex)}"
+
+                    return! context.WriteTextAsync $"{getCurrentInstantExtended ()} Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
             }
 
     /// Gets an upload URI for the specified file version that can be used by a Grace client.

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -29,6 +29,16 @@ module Storage =
         inherit StorageParameters()
         member val public FileVersion = FileVersion.Default with get, set
 
+    type GetContentBlockUploadUriParameters() =
+        inherit StorageParameters()
+        member val public RelativePath: RelativePath = String.Empty with get, set
+        member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
+
+    type GetContentBlockDownloadUriParameters() =
+        inherit StorageParameters()
+        member val public RelativePath: RelativePath = String.Empty with get, set
+        member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
+
     type UploadMetadata = { RelativePath: RelativePath; BlobUriWithSasToken: Uri; Sha256Hash: Sha256Hash; ContentReference: FileContentReference }
 
     type GetUploadMetadataForFilesParameters() =

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -31,12 +31,10 @@ module Storage =
 
     type GetContentBlockUploadUriParameters() =
         inherit StorageParameters()
-        member val public RelativePath: RelativePath = String.Empty with get, set
         member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
 
     type GetContentBlockDownloadUriParameters() =
         inherit StorageParameters()
-        member val public RelativePath: RelativePath = String.Empty with get, set
         member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
 
     type UploadMetadata = { RelativePath: RelativePath; BlobUriWithSasToken: Uri; Sha256Hash: Sha256Hash; ContentReference: FileContentReference }


### PR DESCRIPTION
## Linked issue

Closes #87

## Summary

- Added shared ContentBlock SAS request parameters carrying `ContentBlockAddress` only; callers no longer supply an independent file path for ContentBlock SAS authorization.
- Added authorized `/storage/getContentBlockUploadUri` and `/storage/getContentBlockDownloadUri` routes that authorize and mint SAS URIs against the same `cas/content-blocks/{ContentBlockAddress}` object path without probing blob existence.
- Added matching SDK helpers and route/authorization manifest entries.
- Added focused server route tests for unauthenticated, forbidden, and allowed ContentBlock SAS flows plus SDK/contract reflection coverage.
- Addressed Codex review by binding authorization to the addressed block path instead of a separate caller-controlled path.

## Touched paths

- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.Server/Startup.Server.fs`
- `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs`
- `src/Grace.Shared/Parameters/Storage.Parameters.fs`
- `src/Grace.SDK/Storage.SDK.fs`
- `src/Grace.Server.Tests/Storage.Server.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: server-api + sdk-client.
- Public behavior or docs-only validation target: authorized ContentBlock upload/download SAS routes require path authorization on `cas/content-blocks/{ContentBlockAddress}` and return SAS URIs for that same object key without existence checks.
- RED evidence or docs-only waiver: recovered worktree already contained focused tests from the disconnected worker. First practical focused RED attempt (`dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "ContentBlock"`) failed before behavior execution because the Cosmos emulator exited 137 during setup. After implementation, the same focused slice passed.
- Focused validation: `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "ContentBlock"` passed after implementation, after merging latest `origin/main`, and after the Codex review fix.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.Server.Tests/Storage.Server.Tests.fs` covers ContentBlock SAS upload/download authorization outcomes and confirms SDK methods align to the shared parameter contracts.
- The SDK/contract test now verifies ContentBlock SAS request contracts expose `ContentBlockAddress` without a caller-supplied `RelativePath`.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [x] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [x] Server or API contract
- [ ] Orleans actor behavior
- [x] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [x] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast` - passed after the Codex review fix.
- [x] `pwsh ./scripts/validate.ps1 -Full` - passed after the Codex review fix.
- [x] Focused tests: `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "ContentBlock"` - passed after the Codex review fix.
- [x] Formatting/linting: `dotnet tool run fantomas ...` on touched F# files; `git diff --check` passed.
- [ ] Manual validation: command or steps

## Validation not run

- Manual validation beyond automated server integration tests was not run; the focused Aspire-backed route tests cover the changed public behavior.

## Residual risks

- The new SDK helpers follow the existing storage SDK pattern of returning the response body as the SAS value; they do not add additional non-success response shaping in this slice.

## Rollback or recovery notes

- Revert the storage route/SDK/parameter/test commits to remove the new ContentBlock SAS public surface.

## Docs follow-up required

- None.