### PR TITLE
Add repository content counter actor

### DIFF
--- a/src/Grace.Actors/Constants.Actor.fs
+++ b/src/Grace.Actors/Constants.Actor.fs
@@ -107,6 +107,9 @@ module Constants =
         let RepositoryPermission = "RepositoryPermissionActor"
 
         [<Literal>]
+        let RepositoryContentCounter = "RepositoryContentCounterActor"
+
+        [<Literal>]
         let User = "UserActor"
 
         [<Literal>]
@@ -187,6 +190,9 @@ module Constants =
 
         [<Literal>]
         let RepositoryPermission = "RepoPermission"
+
+        [<Literal>]
+        let RepositoryContentCounter = "RepoContentCounter"
 
         [<Literal>]
         let User = "User"

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -52,6 +52,7 @@
         <Compile Include="Artifact.Actor.fs" />
         <Compile Include="ContentBlockMetadata.Actor.fs" />
         <Compile Include="UploadSession.Actor.fs" />
+        <Compile Include="RepositoryContentCounter.Actor.fs" />
         <Compile Include="PromotionQueue.Actor.fs" />
         <Compile Include="Repository.Actor.fs" />
         <Compile Include="RepositoryName.Actor.fs" />

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -10,6 +10,7 @@ open Grace.Types.DirectoryVersion
 open Grace.Types.Reference
 open Grace.Types.Reminder
 open Grace.Types.Repository
+open Grace.Types.RepositoryContentCounter
 open Grace.Types.Organization
 open Grace.Types.Owner
 open Grace.Types.PersonalAccessToken
@@ -588,6 +589,23 @@ module Interfaces =
 
         /// Returns path permissions for this repository.
         abstract member GetPathPermissions: pathFilter: RelativePath option -> correlationId: CorrelationId -> Task<PathPermission list>
+
+    /// Defines the operations for the RepositoryContentCounter actor.
+    [<Interface>]
+    type IRepositoryContentCounterActor =
+        inherit IGrainWithStringKey
+
+        /// Returns true if this repository content counter has been initialized.
+        abstract member Exists: correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the current repository-local count for this manifest.
+        abstract member Get: correlationId: CorrelationId -> Task<RepositoryContentCounterDto>
+
+        /// Returns the events handled by this repository content counter.
+        abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<RepositoryContentCounterEvent>>
+
+        /// Validates incoming commands and converts them to persisted events and zero-crossing intents.
+        abstract member Handle: command: RepositoryContentCounterCommand -> eventMetadata: EventMetadata -> Task<GraceResult<RepositoryContentCounterDecision>>
 
     /// Defines the operations for the RepositoryName actor.
     [<Interface>]

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -39,9 +39,14 @@ module RepositoryContentCounter =
         | RepositoryContentCounterEventType.ReferenceAdded (operationId, _, _) -> operationId
         | RepositoryContentCounterEventType.ReferenceRemoved operationId -> operationId
 
-    let private hasAppliedOperationId (events: seq<RepositoryContentCounterEvent>) operationId =
+    let private eventCommandName counterEvent =
+        match counterEvent.Event with
+        | RepositoryContentCounterEventType.ReferenceAdded _ -> "AddReference"
+        | RepositoryContentCounterEventType.ReferenceRemoved _ -> "RemoveReference"
+
+    let private tryFindAppliedOperation (events: seq<RepositoryContentCounterEvent>) operationId =
         events
-        |> Seq.exists (fun counterEvent -> eventOperationId counterEvent = operationId)
+        |> Seq.tryFind (fun counterEvent -> eventOperationId counterEvent = operationId)
 
     let private applyEvents (events: RepositoryContentCounterEvent list) (counter: RepositoryContentCounterDto) =
         events
@@ -92,37 +97,44 @@ module RepositoryContentCounter =
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the grain key.")
         elif targetMismatch counter repositoryId manifestAddress then
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
-        elif hasAppliedOperationId events operationId then
-            okDecision counter operationId [] [] true "Repository content counter command replayed."
         else
-            match command with
-            | RepositoryContentCounterCommand.AddReference _ ->
-                let counterEvent = { Event = RepositoryContentCounterEventType.ReferenceAdded(operationId, repositoryId, manifestAddress); Metadata = metadata }
-
-                let intents =
-                    if counter.ReferenceCount = 0L then
-                        [
-                            RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifestAddress)
-                        ]
-                    else
-                        []
-
-                okDecision counter operationId [ counterEvent ] intents false "Repository content reference added."
-            | RepositoryContentCounterCommand.RemoveReference _ ->
-                if counter.ReferenceCount = 0L then
-                    Error(graceError metadata.CorrelationId "RepositoryContentCounter cannot remove a reference when the local count is already zero.")
-                else
-                    let counterEvent = { Event = RepositoryContentCounterEventType.ReferenceRemoved operationId; Metadata = metadata }
+            match tryFindAppliedOperation events operationId with
+            | Some counterEvent when
+                eventCommandName counterEvent
+                <> commandName command
+                ->
+                Error(graceError metadata.CorrelationId "RepositoryContentCounter operation id was already used for a different command.")
+            | Some _ -> okDecision counter operationId [] [] true "Repository content counter command replayed."
+            | None ->
+                match command with
+                | RepositoryContentCounterCommand.AddReference _ ->
+                    let counterEvent =
+                        { Event = RepositoryContentCounterEventType.ReferenceAdded(operationId, repositoryId, manifestAddress); Metadata = metadata }
 
                     let intents =
-                        if counter.ReferenceCount = 1L then
+                        if counter.ReferenceCount = 0L then
                             [
-                                RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifestAddress)
+                                RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifestAddress)
                             ]
                         else
                             []
 
-                    okDecision counter operationId [ counterEvent ] intents false "Repository content reference removed."
+                    okDecision counter operationId [ counterEvent ] intents false "Repository content reference added."
+                | RepositoryContentCounterCommand.RemoveReference _ ->
+                    if counter.ReferenceCount = 0L then
+                        Error(graceError metadata.CorrelationId "RepositoryContentCounter cannot remove a reference when the local count is already zero.")
+                    else
+                        let counterEvent = { Event = RepositoryContentCounterEventType.ReferenceRemoved operationId; Metadata = metadata }
+
+                        let intents =
+                            if counter.ReferenceCount = 1L then
+                                [
+                                    RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifestAddress)
+                                ]
+                            else
+                                []
+
+                        okDecision counter operationId [ counterEvent ] intents false "Repository content reference removed."
 
     let decideCommand events counter command metadata = decideCommandForKey None events counter command metadata
 

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -66,7 +66,13 @@ module RepositoryContentCounter =
         || (not (String.IsNullOrWhiteSpace counter.ManifestAddress)
             && counter.ManifestAddress <> manifestAddress)
 
-    let decideCommand
+    let private expectedPrimaryKeyMismatch expectedPrimaryKey repositoryId manifestAddress =
+        match expectedPrimaryKey with
+        | Some expectedPrimaryKey -> not (String.Equals(expectedPrimaryKey, primaryKey repositoryId manifestAddress, StringComparison.Ordinal))
+        | None -> false
+
+    let decideCommandForKey
+        (expectedPrimaryKey: string option)
         (events: seq<RepositoryContentCounterEvent>)
         (counter: RepositoryContentCounterDto)
         (command: RepositoryContentCounterCommand)
@@ -82,10 +88,12 @@ module RepositoryContentCounter =
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty RepositoryId.")
         elif String.IsNullOrWhiteSpace manifestAddress then
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty ManifestAddress.")
-        elif hasAppliedOperationId events operationId then
-            okDecision counter operationId [] [] true "Repository content counter command replayed."
+        elif expectedPrimaryKeyMismatch expectedPrimaryKey repositoryId manifestAddress then
+            Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the grain key.")
         elif targetMismatch counter repositoryId manifestAddress then
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
+        elif hasAppliedOperationId events operationId then
+            okDecision counter operationId [] [] true "Repository content counter command replayed."
         else
             match command with
             | RepositoryContentCounterCommand.AddReference _ ->
@@ -115,6 +123,8 @@ module RepositoryContentCounter =
                             []
 
                     okDecision counter operationId [ counterEvent ] intents false "Repository content reference removed."
+
+    let decideCommand events counter command metadata = decideCommandForKey None events counter command metadata
 
     type RepositoryContentCounterActor
         (
@@ -166,7 +176,7 @@ module RepositoryContentCounter =
                     this.correlationId <- metadata.CorrelationId
                     RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
 
-                    match decideCommand state.State counter command metadata with
+                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) state.State counter command metadata with
                     | Ok decision ->
                         if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
 

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -1,0 +1,192 @@
+namespace Grace.Actors
+
+open Grace.Actors.Constants
+open Grace.Actors.Context
+open Grace.Actors.Interfaces
+open Grace.Actors.Services
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types.RepositoryContentCounter
+open Grace.Types.Types
+open Microsoft.Extensions.Logging
+open Orleans
+open Orleans.Runtime
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module RepositoryContentCounter =
+
+    let primaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
+
+    let commandName command =
+        match command with
+        | RepositoryContentCounterCommand.AddReference _ -> "AddReference"
+        | RepositoryContentCounterCommand.RemoveReference _ -> "RemoveReference"
+
+    let operationId command =
+        match command with
+        | RepositoryContentCounterCommand.AddReference (operationId, _, _) -> operationId
+        | RepositoryContentCounterCommand.RemoveReference (operationId, _, _) -> operationId
+
+    let private commandTarget command =
+        match command with
+        | RepositoryContentCounterCommand.AddReference (_, repositoryId, manifestAddress)
+        | RepositoryContentCounterCommand.RemoveReference (_, repositoryId, manifestAddress) -> repositoryId, manifestAddress
+
+    let private eventOperationId counterEvent =
+        match counterEvent.Event with
+        | RepositoryContentCounterEventType.ReferenceAdded (operationId, _, _) -> operationId
+        | RepositoryContentCounterEventType.ReferenceRemoved operationId -> operationId
+
+    let private hasAppliedOperationId (events: seq<RepositoryContentCounterEvent>) operationId =
+        events
+        |> Seq.exists (fun counterEvent -> eventOperationId counterEvent = operationId)
+
+    let private applyEvents (events: RepositoryContentCounterEvent list) (counter: RepositoryContentCounterDto) =
+        events
+        |> List.fold (fun current event -> RepositoryContentCounterDto.UpdateDto event current) counter
+
+    let private okDecision counter operationId events intents wasReplay message =
+        Ok
+            {
+                Counter = applyEvents events counter
+                OperationId = operationId
+                Events = events
+                Intents = intents
+                WasIdempotentReplay = wasReplay
+                Message = message
+            }
+
+    let private graceError correlationId message = GraceError.Create message correlationId
+
+    let private targetMismatch (counter: RepositoryContentCounterDto) repositoryId manifestAddress =
+        (counter.RepositoryId <> RepositoryId.Empty
+         && counter.RepositoryId <> repositoryId)
+        || (not (String.IsNullOrWhiteSpace counter.ManifestAddress)
+            && counter.ManifestAddress <> manifestAddress)
+
+    let decideCommand
+        (events: seq<RepositoryContentCounterEvent>)
+        (counter: RepositoryContentCounterDto)
+        (command: RepositoryContentCounterCommand)
+        (metadata: EventMetadata)
+        : Result<RepositoryContentCounterDecision, GraceError>
+        =
+        let operationId = operationId command
+        let repositoryId, manifestAddress = commandTarget command
+
+        if String.IsNullOrWhiteSpace operationId then
+            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty operation id.")
+        elif repositoryId = RepositoryId.Empty then
+            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty RepositoryId.")
+        elif String.IsNullOrWhiteSpace manifestAddress then
+            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty ManifestAddress.")
+        elif hasAppliedOperationId events operationId then
+            okDecision counter operationId [] [] true "Repository content counter command replayed."
+        elif targetMismatch counter repositoryId manifestAddress then
+            Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
+        else
+            match command with
+            | RepositoryContentCounterCommand.AddReference _ ->
+                let counterEvent = { Event = RepositoryContentCounterEventType.ReferenceAdded(operationId, repositoryId, manifestAddress); Metadata = metadata }
+
+                let intents =
+                    if counter.ReferenceCount = 0L then
+                        [
+                            RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifestAddress)
+                        ]
+                    else
+                        []
+
+                okDecision counter operationId [ counterEvent ] intents false "Repository content reference added."
+            | RepositoryContentCounterCommand.RemoveReference _ ->
+                if counter.ReferenceCount = 0L then
+                    Error(graceError metadata.CorrelationId "RepositoryContentCounter cannot remove a reference when the local count is already zero.")
+                else
+                    let counterEvent = { Event = RepositoryContentCounterEventType.ReferenceRemoved operationId; Metadata = metadata }
+
+                    let intents =
+                        if counter.ReferenceCount = 1L then
+                            [
+                                RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifestAddress)
+                            ]
+                        else
+                            []
+
+                    okDecision counter operationId [ counterEvent ] intents false "Repository content reference removed."
+
+    type RepositoryContentCounterActor
+        (
+            [<PersistentState(StateName.RepositoryContentCounter, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<List<RepositoryContentCounterEvent>>
+        ) =
+        inherit Grain()
+
+        let log = loggerFactory.CreateLogger("RepositoryContentCounter.Actor")
+        let mutable counter = RepositoryContentCounterDto.Default
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override this.OnActivateAsync(ct) =
+            let activateStartTime = getCurrentInstant ()
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+
+            counter <-
+                state.State
+                |> Seq.fold (fun dto event -> RepositoryContentCounterDto.UpdateDto event dto) RepositoryContentCounterDto.Default
+
+            Task.CompletedTask
+
+        member private this.ApplyEvents(events: RepositoryContentCounterEvent list) =
+            task {
+                state.State.AddRange(events)
+                do! state.WriteStateAsync()
+                counter <- applyEvents events counter
+            }
+
+        interface IRepositoryContentCounterActor with
+            member this.Exists correlationId =
+                this.correlationId <- correlationId
+
+                (counter.RepositoryId <> RepositoryId.Empty
+                 && not (String.IsNullOrWhiteSpace counter.ManifestAddress))
+                |> returnTask
+
+            member this.Get correlationId =
+                this.correlationId <- correlationId
+                counter |> returnTask
+
+            member this.GetEvents correlationId =
+                this.correlationId <- correlationId
+
+                (state.State :> IReadOnlyList<RepositoryContentCounterEvent>)
+                |> returnTask
+
+            member this.Handle command metadata =
+                task {
+                    this.correlationId <- metadata.CorrelationId
+                    RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
+
+                    match decideCommand state.State counter command metadata with
+                    | Ok decision ->
+                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
+                        let returnValue =
+                            (GraceReturnValue.Create decision metadata.CorrelationId)
+                                .enhance(nameof RepositoryId, decision.Counter.RepositoryId)
+                                .enhance(nameof ManifestAddress, decision.Counter.ManifestAddress)
+                                .enhance(nameof ReferenceCount, decision.Counter.ReferenceCount)
+                                .enhance (nameof RepositoryContentCounterLifecycleState, decision.Counter.LifecycleState)
+
+                        return Ok returnValue
+                    | Error error ->
+                        log.LogWarning(
+                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected RepositoryContentCounter command {Command}. Error: {Error}",
+                            getCurrentInstantExtended (),
+                            getMachineName,
+                            metadata.CorrelationId,
+                            commandName command,
+                            error.Error
+                        )
+
+                        return Error error
+                }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="UploadSession.Actor.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
+    <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -14,7 +14,9 @@ type RepositoryContentCounterActorTests() =
 
     let timestamp = Instant.FromUtc(2026, 5, 24, 13, 0)
     let repositoryId = Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5")
+    let otherRepositoryId = Guid.Parse("41ff01d0-8f4c-41e7-875d-1c4f7b519c11")
     let manifestAddress = "manifest:blake3:alpha"
+    let otherManifestAddress = "manifest:blake3:beta"
 
     let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
 
@@ -127,3 +129,32 @@ type RepositoryContentCounterActorTests() =
             Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(0L))
             Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.NotReferenced))
         | Error error -> Assert.Fail($"Expected remove replay to be idempotent, got {error.Error}.")
+
+    [<Test>]
+    member _.FirstWriteRejectsCommandTargetThatDoesNotMatchGrainKey() =
+        let wrongKey = RepositoryContentCounterActor.primaryKey otherRepositoryId manifestAddress
+
+        let result =
+            RepositoryContentCounterActor.decideCommandForKey (Some wrongKey) [] RepositoryContentCounterDto.Default (add "op-add-1") (metadata "corr-key")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected target mismatch to reject the first write.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("RepositoryContentCounter command target does not match the grain key."))
+
+    [<Test>]
+    member _.ReusedOperationIdWithDifferentTargetRejectsInsteadOfReplaying() =
+        let first = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-1") (metadata "corr-add-1")
+
+        let afterFirst, firstEvents =
+            match first with
+            | Ok decision -> decision.Counter, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected add to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let mismatchedCommand = RepositoryContentCounterCommand.AddReference("op-add-1", repositoryId, otherManifestAddress)
+        let replay = RepositoryContentCounterActor.decideCommand firstEvents afterFirst mismatchedCommand (metadata "corr-add-reused")
+
+        match replay with
+        | Ok _ -> Assert.Fail("Expected reused operation id with a different target to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("RepositoryContentCounter command target does not match the initialized counter."))

--- a/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -158,3 +158,20 @@ type RepositoryContentCounterActorTests() =
         match replay with
         | Ok _ -> Assert.Fail("Expected reused operation id with a different target to reject.")
         | Error error -> Assert.That(error.Error, Is.EqualTo("RepositoryContentCounter command target does not match the initialized counter."))
+
+    [<Test>]
+    member _.ReusedOperationIdWithDifferentCommandRejectsInsteadOfReplaying() =
+        let first = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-shared") (metadata "corr-add")
+
+        let afterFirst, firstEvents =
+            match first with
+            | Ok decision -> decision.Counter, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected add to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let reused = RepositoryContentCounterActor.decideCommand firstEvents afterFirst (remove "op-shared") (metadata "corr-remove")
+
+        match reused with
+        | Ok _ -> Assert.Fail("Expected reused operation id with a different command to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("RepositoryContentCounter operation id was already used for a different command."))

--- a/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -1,0 +1,129 @@
+namespace Grace.Server.Tests
+
+open Grace.Types.RepositoryContentCounter
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+module RepositoryContentCounterActor = Grace.Actors.RepositoryContentCounter
+
+[<Parallelizable(ParallelScope.All)>]
+type RepositoryContentCounterActorTests() =
+
+    let timestamp = Instant.FromUtc(2026, 5, 24, 13, 0)
+    let repositoryId = Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5")
+    let manifestAddress = "manifest:blake3:alpha"
+
+    let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+
+    let add operationId = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, manifestAddress)
+
+    let remove operationId = RepositoryContentCounterCommand.RemoveReference(operationId, repositoryId, manifestAddress)
+
+    let applyAll events dto =
+        events
+        |> List.fold (fun current event -> RepositoryContentCounterDto.UpdateDto event current) dto
+
+    [<Test>]
+    member _.ZeroToOneEmitsIncrementIntentAndRetryIsIdempotent() =
+        let first = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-1") (metadata "corr-add-1")
+
+        match first with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(1L))
+            Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.Referenced))
+            Assert.That(decision.Events.Length, Is.EqualTo(1))
+            Assert.That(decision.Intents.Length, Is.EqualTo(1))
+            Assert.That(decision.Intents[0], Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifestAddress)))
+
+            let dto = applyAll decision.Events RepositoryContentCounterDto.Default
+            let replay = RepositoryContentCounterActor.decideCommand decision.Events dto (add "op-add-1") (metadata "corr-add-retry")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Intents, Is.Empty)
+                Assert.That(replayDecision.Counter.ReferenceCount, Is.EqualTo(1L))
+            | Error error -> Assert.Fail($"Expected add replay to be idempotent, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected add to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.NToNTransitionsDoNotEmitIntentAndOneToZeroEmitsDecrementIntent() =
+        let first = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-1") (metadata "corr-add-1")
+
+        let afterFirst, firstEvents =
+            match first with
+            | Ok decision -> decision.Counter, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected first add to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let second = RepositoryContentCounterActor.decideCommand firstEvents afterFirst (add "op-add-2") (metadata "corr-add-2")
+
+        let afterSecond, secondEvents =
+            match second with
+            | Ok decision ->
+                Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(2L))
+                Assert.That(decision.Intents, Is.Empty)
+                decision.Counter, firstEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected second add to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let firstRemove = RepositoryContentCounterActor.decideCommand secondEvents afterSecond (remove "op-remove-1") (metadata "corr-remove-1")
+
+        let afterFirstRemove, removeEvents =
+            match firstRemove with
+            | Ok decision ->
+                Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(1L))
+                Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.Referenced))
+                Assert.That(decision.Intents, Is.Empty)
+                decision.Counter, secondEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected first remove to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let finalRemove = RepositoryContentCounterActor.decideCommand removeEvents afterFirstRemove (remove "op-remove-2") (metadata "corr-remove-2")
+
+        match finalRemove with
+        | Ok decision ->
+            Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(0L))
+            Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.NotReferenced))
+            Assert.That(decision.Intents.Length, Is.EqualTo(1))
+            Assert.That(decision.Intents[0], Is.EqualTo(RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifestAddress)))
+        | Error error -> Assert.Fail($"Expected final remove to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.OneToZeroRetryIsIdempotentWithoutSecondDecrementIntent() =
+        let addDecision = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-1") (metadata "corr-add-1")
+
+        let addedDto, addEvents =
+            match addDecision with
+            | Ok decision -> decision.Counter, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected add to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let removeDecision = RepositoryContentCounterActor.decideCommand addEvents addedDto (remove "op-remove-1") (metadata "corr-remove-1")
+
+        let removedDto, allEvents =
+            match removeDecision with
+            | Ok decision -> decision.Counter, addEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected remove to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let replay = RepositoryContentCounterActor.decideCommand allEvents removedDto (remove "op-remove-1") (metadata "corr-remove-retry")
+
+        match replay with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.True)
+            Assert.That(decision.Events, Is.Empty)
+            Assert.That(decision.Intents, Is.Empty)
+            Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(0L))
+            Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.NotReferenced))
+        | Error error -> Assert.Fail($"Expected remove replay to be idempotent, got {error.Error}.")

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -41,6 +41,7 @@
         <Compile Include="Diff.Types.fs" />
         <Compile Include="DirectoryVersion.Types.fs" />
         <Compile Include="UploadSession.Types.fs" />
+        <Compile Include="RepositoryContentCounter.Types.fs" />
         <Compile Include="Reminder.Types.fs" />
         <Compile Include="Events.Types.fs" />
     </ItemGroup>

--- a/src/Grace.Types/RepositoryContentCounter.Types.fs
+++ b/src/Grace.Types/RepositoryContentCounter.Types.fs
@@ -1,0 +1,103 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open Orleans
+open System
+open System.Runtime.Serialization
+
+module RepositoryContentCounter =
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type RepositoryContentCounterLifecycleState =
+        | NotReferenced
+        | Referenced
+
+        static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterLifecycleState>()
+
+    [<KnownType("GetKnownTypes")>]
+    type RepositoryContentCounterCommand =
+        | AddReference of operationId: RepositoryContentCounterOperationId * repositoryId: RepositoryId * manifestAddress: ManifestAddress
+        | RemoveReference of operationId: RepositoryContentCounterOperationId * repositoryId: RepositoryId * manifestAddress: ManifestAddress
+
+        static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterCommand>()
+
+    [<KnownType("GetKnownTypes")>]
+    type RepositoryContentCounterEventType =
+        | ReferenceAdded of operationId: RepositoryContentCounterOperationId * repositoryId: RepositoryId * manifestAddress: ManifestAddress
+        | ReferenceRemoved of operationId: RepositoryContentCounterOperationId
+
+        static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterEventType>()
+
+    [<KnownType("GetKnownTypes")>]
+    type RepositoryContentCounterIntent =
+        | IncrementManifestReferenceCount of repositoryId: RepositoryId * manifestAddress: ManifestAddress
+        | DecrementManifestReferenceCount of repositoryId: RepositoryId * manifestAddress: ManifestAddress
+
+        static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterIntent>()
+
+    type RepositoryContentCounterEvent = { Event: RepositoryContentCounterEventType; Metadata: EventMetadata }
+
+    [<GenerateSerializer>]
+    type RepositoryContentCounterDto =
+        {
+            Class: string
+            RepositoryId: RepositoryId
+            ManifestAddress: ManifestAddress
+            ReferenceCount: ReferenceCount
+            LifecycleState: RepositoryContentCounterLifecycleState
+            LastOperationId: RepositoryContentCounterOperationId option
+        }
+
+        static member Default =
+            {
+                Class = nameof RepositoryContentCounterDto
+                RepositoryId = RepositoryId.Empty
+                ManifestAddress = String.Empty
+                ReferenceCount = 0L
+                LifecycleState = RepositoryContentCounterLifecycleState.NotReferenced
+                LastOperationId = None
+            }
+
+        static member UpdateDto counterEvent current =
+            match counterEvent.Event with
+            | RepositoryContentCounterEventType.ReferenceAdded (operationId, repositoryId, manifestAddress) ->
+                { current with
+                    RepositoryId =
+                        if current.RepositoryId = RepositoryId.Empty then
+                            repositoryId
+                        else
+                            current.RepositoryId
+                    ManifestAddress =
+                        if String.IsNullOrWhiteSpace current.ManifestAddress then
+                            manifestAddress
+                        else
+                            current.ManifestAddress
+                    ReferenceCount = current.ReferenceCount + 1L
+                    LifecycleState = RepositoryContentCounterLifecycleState.Referenced
+                    LastOperationId = Some operationId
+                }
+            | RepositoryContentCounterEventType.ReferenceRemoved operationId ->
+                let nextReferenceCount = max 0L (current.ReferenceCount - 1L)
+
+                { current with
+                    ReferenceCount = nextReferenceCount
+                    LifecycleState =
+                        if nextReferenceCount = 0L then
+                            RepositoryContentCounterLifecycleState.NotReferenced
+                        else
+                            RepositoryContentCounterLifecycleState.Referenced
+                    LastOperationId = Some operationId
+                }
+
+    [<GenerateSerializer>]
+    type RepositoryContentCounterDecision =
+        {
+            Counter: RepositoryContentCounterDto
+            OperationId: RepositoryContentCounterOperationId
+            Events: RepositoryContentCounterEvent list
+            Intents: RepositoryContentCounterIntent list
+            WasIdempotentReplay: bool
+            Message: string
+        }

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -140,6 +140,12 @@ module Types =
     /// Caller-supplied retry identity for upload-session commands.
     type UploadSessionOperationId = string
 
+    /// Caller-supplied retry identity for repository-content-counter commands.
+    type RepositoryContentCounterOperationId = string
+
+    /// Repository-local count of live references to a manifest-backed file.
+    type ReferenceCount = int64
+
     /// The content-derived hash for a complete manifest-backed file.
     type FileContentHash = string
 


### PR DESCRIPTION
## Summary

- Adds `RepositoryContentCounter` domain contracts for repository-local manifest reference counting, lifecycle state, events, and zero-crossing intents.
- Adds the Orleans actor interface/implementation keyed by `RepositoryId` + `ManifestAddress`, with idempotent operation-id replay handling.
- Adds focused actor decision tests covering zero-to-one increment intent, N-to-N no fan-out, one-to-zero decrement intent, and retry idempotency.

Closes #95.

## Validation

- RED: `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~RepositoryContentCounterActorTests"` initially failed behaviorally after compile scaffolding was fixed: count stayed `0`, intents were missing, and retry was not idempotent.
- GREEN/focused: `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~RepositoryContentCounterActorTests"` passed, 3/3.
- Formatting: `dotnet tool run fantomas -- src\Grace.Types\Types.Types.fs src\Grace.Types\RepositoryContentCounter.Types.fs src\Grace.Actors\Constants.Actor.fs src\Grace.Actors\Interfaces.Actor.fs src\Grace.Actors\RepositoryContentCounter.Actor.fs src\Grace.Server.Tests\RepositoryContentCounter.Actor.Tests.fs`.
- Formatting check: `dotnet tool run fantomas -- --check src\Grace.Types\Types.Types.fs src\Grace.Types\RepositoryContentCounter.Types.fs src\Grace.Actors\Constants.Actor.fs src\Grace.Actors\Interfaces.Actor.fs src\Grace.Actors\RepositoryContentCounter.Actor.fs src\Grace.Server.Tests\RepositoryContentCounter.Actor.Tests.fs` passed.
- Whitespace: `git diff --check` passed.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast` passed after rebasing onto `origin/main` at PR #121.
- Full gate: `pwsh ./scripts/validate.ps1 -Full` passed after rebasing onto `origin/main` at PR #121.

## Docs Impact

- No public CLI/API/docs changes. Code comments/type names carry the local counter semantics.

## Skipped Validation

- None.

## Residual Risk

- The actor returns increment/decrement intents but does not yet fan out manifest/block reference-count work; that remains owned by downstream DAG issue #96.
- A pre-final `validate -Full` attempt hit a transient Aspire HTTP readiness timeout; Docker had no leftover containers, the server log showed normal request handling, and subsequent full validation passed.

## Follow-ups

- #96 should consume the zero-crossing intents and own manifest contribution fan-out/batch progress.
