### PR TITLE
Implement block upload intent confirmation

### DIFF
--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -78,7 +78,9 @@ module ContentBlockMetadata =
             |> Array.tryPick (validateRange correlationId)
 
     let private validateStoragePlacement correlationId (placement: ContentBlockStoragePlacement) =
-        if String.IsNullOrWhiteSpace placement.ObjectKey then
+        if isNull (box placement) then
+            Some(graceError correlationId "StoragePlacement is required.")
+        elif String.IsNullOrWhiteSpace placement.ObjectKey then
             Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
         else
             None

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -119,10 +119,17 @@ module ContentBlockMetadata =
         |> Array.append [| 0L |]
         |> Array.max
 
-    let private activePhysicalBytes ranges =
+    let private activePhysicalBytes correlationId ranges =
         ranges
         |> Array.filter (fun range -> range.ActiveManifestCount > 0)
-        |> Array.sumBy (fun range -> range.PhysicalLength)
+        |> Array.fold
+            (fun total range ->
+                match total with
+                | Error error -> Error error
+                | Ok current when range.PhysicalLength > Int64.MaxValue - current ->
+                    Error(graceError correlationId "ActivePhysicalBytes cannot exceed Int64.MaxValue.")
+                | Ok current -> Ok(current + range.PhysicalLength))
+            (Ok 0L)
 
     let private rangeKey (range: ContentBlockMetadataRange) = $"{range.OrdinalStart}:{range.OrdinalCount}:{range.PhysicalOffset}:{range.PhysicalLength}"
 
@@ -213,26 +220,29 @@ module ContentBlockMetadata =
                 match mergeRanges existingRanges merge.Ranges with
                 | Error error -> Error error
                 | Ok ranges ->
-                    let metadataVersion =
-                        currentMetadata
-                        |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
-                        |> Option.defaultValue 1L
+                    match activePhysicalBytes correlationId ranges with
+                    | Error error -> Error error
+                    | Ok activePhysicalBytes ->
+                        let metadataVersion =
+                            currentMetadata
+                            |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
+                            |> Option.defaultValue 1L
 
-                    let metadata: ContentBlockMetadata =
-                        {
-                            Class = nameof ContentBlockMetadata
-                            StoragePoolId = merge.StoragePoolId
-                            ContentBlockAddress = merge.ContentBlockAddress
-                            BlockFormatVersion = merge.BlockFormatVersion
-                            StoragePlacement = merge.StoragePlacement
-                            Ranges = ranges
-                            TotalPhysicalBytes = totalPhysicalBytes ranges
-                            ActivePhysicalBytes = activePhysicalBytes ranges
-                            MetadataVersion = metadataVersion
-                            UpdatedAt = timestamp
-                        }
+                        let metadata: ContentBlockMetadata =
+                            {
+                                Class = nameof ContentBlockMetadata
+                                StoragePoolId = merge.StoragePoolId
+                                ContentBlockAddress = merge.ContentBlockAddress
+                                BlockFormatVersion = merge.BlockFormatVersion
+                                StoragePlacement = merge.StoragePlacement
+                                Ranges = ranges
+                                TotalPhysicalBytes = totalPhysicalBytes ranges
+                                ActivePhysicalBytes = activePhysicalBytes
+                                MetadataVersion = metadataVersion
+                                UpdatedAt = timestamp
+                            }
 
-                    Ok metadata
+                        Ok metadata
 
     let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
 

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -223,26 +223,31 @@ module ContentBlockMetadata =
                     match activePhysicalBytes correlationId ranges with
                     | Error error -> Error error
                     | Ok activePhysicalBytes ->
-                        let metadataVersion =
-                            currentMetadata
-                            |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
-                            |> Option.defaultValue 1L
+                        let totalPhysicalBytes = totalPhysicalBytes ranges
 
-                        let metadata: ContentBlockMetadata =
-                            {
-                                Class = nameof ContentBlockMetadata
-                                StoragePoolId = merge.StoragePoolId
-                                ContentBlockAddress = merge.ContentBlockAddress
-                                BlockFormatVersion = merge.BlockFormatVersion
-                                StoragePlacement = merge.StoragePlacement
-                                Ranges = ranges
-                                TotalPhysicalBytes = totalPhysicalBytes ranges
-                                ActivePhysicalBytes = activePhysicalBytes
-                                MetadataVersion = metadataVersion
-                                UpdatedAt = timestamp
-                            }
+                        if activePhysicalBytes > totalPhysicalBytes then
+                            Error(graceError correlationId "ActivePhysicalBytes cannot exceed TotalPhysicalBytes.")
+                        else
+                            let metadataVersion =
+                                currentMetadata
+                                |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
+                                |> Option.defaultValue 1L
 
-                        Ok metadata
+                            let metadata: ContentBlockMetadata =
+                                {
+                                    Class = nameof ContentBlockMetadata
+                                    StoragePoolId = merge.StoragePoolId
+                                    ContentBlockAddress = merge.ContentBlockAddress
+                                    BlockFormatVersion = merge.BlockFormatVersion
+                                    StoragePlacement = merge.StoragePlacement
+                                    Ranges = ranges
+                                    TotalPhysicalBytes = totalPhysicalBytes
+                                    ActivePhysicalBytes = activePhysicalBytes
+                                    MetadataVersion = metadataVersion
+                                    UpdatedAt = timestamp
+                                }
+
+                            Ok metadata
 
     let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
 

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -175,6 +175,15 @@ module ContentBlockMetadata =
                         correlationId
                         $"ContentBlockMetadata BlockFormatVersion mismatch. Existing {existing.BlockFormatVersion}, requested {merge.BlockFormatVersion}."
                 )
+            | Some existing when
+                existing.StoragePlacement.ObjectKey
+                <> merge.StoragePlacement.ObjectKey
+                ->
+                Error(
+                    graceError
+                        correlationId
+                        $"ContentBlockMetadata StoragePlacement.ObjectKey mismatch. Existing {existing.StoragePlacement.ObjectKey}, requested {merge.StoragePlacement.ObjectKey}."
+                )
             | _ ->
                 let existingRanges =
                     currentMetadata

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -57,6 +57,8 @@ module ContentBlockMetadata =
             Some(graceError correlationId "ContentBlockMetadataRange.PhysicalOffset must be zero or greater.")
         elif range.PhysicalLength <= 0L then
             Some(graceError correlationId "ContentBlockMetadataRange.PhysicalLength must be greater than zero.")
+        elif range.PhysicalOffset > Int64.MaxValue - range.PhysicalLength then
+            Some(graceError correlationId "ContentBlockMetadataRange.PhysicalOffset plus PhysicalLength must not exceed Int64.MaxValue.")
         else
             None
 
@@ -82,6 +84,14 @@ module ContentBlockMetadata =
             Some(graceError correlationId "StoragePlacement is required.")
         elif String.IsNullOrWhiteSpace placement.ObjectKey then
             Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
+        else
+            None
+
+    let private validateExistingStoragePlacement correlationId (placement: ContentBlockStoragePlacement) =
+        if isNull (box placement) then
+            Some(graceError correlationId "Existing StoragePlacement is required.")
+        elif String.IsNullOrWhiteSpace placement.ObjectKey then
+            Some(graceError correlationId "Existing StoragePlacement.ObjectKey is required.")
         else
             None
 
@@ -176,6 +186,14 @@ module ContentBlockMetadata =
                     graceError
                         correlationId
                         $"ContentBlockMetadata BlockFormatVersion mismatch. Existing {existing.BlockFormatVersion}, requested {merge.BlockFormatVersion}."
+                )
+            | Some existing when
+                validateExistingStoragePlacement correlationId existing.StoragePlacement
+                |> Option.isSome
+                ->
+                Error(
+                    validateExistingStoragePlacement correlationId existing.StoragePlacement
+                    |> Option.get
                 )
             | Some existing when
                 existing.StoragePlacement.ObjectKey

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -112,11 +112,10 @@ module ContentBlockMetadata =
         |> Array.filter (fun range -> range.ActiveManifestCount > 0)
         |> Array.sumBy (fun range -> range.PhysicalLength)
 
-    let private rangeKey (range: ContentBlockMetadataRange) = $"{range.OrdinalStart}:{range.OrdinalCount}"
+    let private rangeKey (range: ContentBlockMetadataRange) = $"{range.OrdinalStart}:{range.OrdinalCount}:{range.PhysicalOffset}:{range.PhysicalLength}"
 
-    let private mergeRanges correlationId existingRanges incomingRanges =
+    let private mergeRanges existingRanges incomingRanges =
         let merged = Dictionary<string, ContentBlockMetadataRange>()
-        let mutable error = None
 
         let addRange preserveActiveCount range =
             let key = rangeKey range
@@ -124,22 +123,13 @@ module ContentBlockMetadata =
             if merged.ContainsKey key then
                 let existing = merged[key]
 
-                if existing.PhysicalOffset <> range.PhysicalOffset
-                   || existing.PhysicalLength <> range.PhysicalLength then
-                    error <-
-                        Some(
-                            graceError
-                                correlationId
-                                $"Conflicting physical metadata range for OrdinalStart {range.OrdinalStart}, OrdinalCount {range.OrdinalCount}."
-                        )
-                else
-                    let activeManifestCount =
-                        if preserveActiveCount then
-                            max existing.ActiveManifestCount range.ActiveManifestCount
-                        else
-                            range.ActiveManifestCount
+                let activeManifestCount =
+                    if preserveActiveCount then
+                        max existing.ActiveManifestCount range.ActiveManifestCount
+                    else
+                        range.ActiveManifestCount
 
-                    merged[key] <- { existing with ActiveManifestCount = activeManifestCount }
+                merged[key] <- { existing with ActiveManifestCount = activeManifestCount }
             else
                 merged[key] <- range
 
@@ -147,13 +137,10 @@ module ContentBlockMetadata =
 
         incomingRanges |> Array.iter (addRange true)
 
-        match error with
-        | Some error -> Error error
-        | None ->
-            merged.Values
-            |> Seq.sortBy (fun range -> range.OrdinalStart, range.OrdinalCount)
-            |> Seq.toArray
-            |> Ok
+        merged.Values
+        |> Seq.sortBy (fun range -> range.OrdinalStart, range.OrdinalCount, range.PhysicalOffset, range.PhysicalLength)
+        |> Seq.toArray
+        |> Ok
 
     let private createMergedMetadata
         correlationId
@@ -194,7 +181,7 @@ module ContentBlockMetadata =
                     |> Option.map (fun metadata -> metadata.Ranges)
                     |> Option.defaultValue Array.empty
 
-                match mergeRanges correlationId existingRanges merge.Ranges with
+                match mergeRanges existingRanges merge.Ranges with
                 | Error error -> Error error
                 | Ok ranges ->
                     let metadataVersion =

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -24,14 +24,17 @@ module ContentBlockMetadata =
     let commandName command =
         match command with
         | ContentBlockMetadataCommand.ReplaceWholeRecord _ -> "ReplaceWholeRecord"
+        | ContentBlockMetadataCommand.MergePhysicalRanges _ -> "MergePhysicalRanges"
 
     let operationId command =
         match command with
         | ContentBlockMetadataCommand.ReplaceWholeRecord replace -> replace.OperationId
+        | ContentBlockMetadataCommand.MergePhysicalRanges merge -> merge.OperationId
 
     let private eventOperationId metadataEvent =
         match metadataEvent.Event with
         | ContentBlockMetadataEventType.WholeRecordReplaced (operationId, _) -> operationId
+        | ContentBlockMetadataEventType.PhysicalRangesMerged (operationId, _) -> operationId
 
     let private hasAppliedOperationId (events: seq<ContentBlockMetadataEvent>) operationId =
         events
@@ -73,6 +76,147 @@ module ContentBlockMetadata =
         else
             metadata.Ranges
             |> Array.tryPick (validateRange correlationId)
+
+    let private validateStoragePlacement correlationId (placement: ContentBlockStoragePlacement) =
+        if String.IsNullOrWhiteSpace placement.ObjectKey then
+            Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
+        else
+            None
+
+    let private validateMergePhysicalRanges correlationId (merge: MergeContentBlockPhysicalRanges) =
+        if String.IsNullOrWhiteSpace merge.StoragePoolId then
+            Some(graceError correlationId "StoragePoolId is required.")
+        elif String.IsNullOrWhiteSpace merge.ContentBlockAddress then
+            Some(graceError correlationId "ContentBlockAddress is required.")
+        elif merge.BlockFormatVersion <= 0s then
+            Some(graceError correlationId "BlockFormatVersion must be greater than zero.")
+        elif isNull merge.Ranges || merge.Ranges.Length = 0 then
+            Some(graceError correlationId "At least one ContentBlockMetadataRange is required.")
+        else
+            match validateStoragePlacement correlationId merge.StoragePlacement with
+            | Some error -> Some error
+            | None ->
+                merge.Ranges
+                |> Array.tryPick (validateRange correlationId)
+
+    let private physicalEnd (range: ContentBlockMetadataRange) = range.PhysicalOffset + range.PhysicalLength
+
+    let private totalPhysicalBytes ranges =
+        ranges
+        |> Array.map physicalEnd
+        |> Array.append [| 0L |]
+        |> Array.max
+
+    let private activePhysicalBytes ranges =
+        ranges
+        |> Array.filter (fun range -> range.ActiveManifestCount > 0)
+        |> Array.sumBy (fun range -> range.PhysicalLength)
+
+    let private rangeKey (range: ContentBlockMetadataRange) = $"{range.OrdinalStart}:{range.OrdinalCount}"
+
+    let private mergeRanges correlationId existingRanges incomingRanges =
+        let merged = Dictionary<string, ContentBlockMetadataRange>()
+        let mutable error = None
+
+        let addRange preserveActiveCount range =
+            let key = rangeKey range
+
+            if merged.ContainsKey key then
+                let existing = merged[key]
+
+                if existing.PhysicalOffset <> range.PhysicalOffset
+                   || existing.PhysicalLength <> range.PhysicalLength then
+                    error <-
+                        Some(
+                            graceError
+                                correlationId
+                                $"Conflicting physical metadata range for OrdinalStart {range.OrdinalStart}, OrdinalCount {range.OrdinalCount}."
+                        )
+                else
+                    let activeManifestCount =
+                        if preserveActiveCount then
+                            max existing.ActiveManifestCount range.ActiveManifestCount
+                        else
+                            range.ActiveManifestCount
+
+                    merged[key] <- { existing with ActiveManifestCount = activeManifestCount }
+            else
+                merged[key] <- range
+
+        existingRanges |> Array.iter (addRange true)
+
+        incomingRanges |> Array.iter (addRange true)
+
+        match error with
+        | Some error -> Error error
+        | None ->
+            merged.Values
+            |> Seq.sortBy (fun range -> range.OrdinalStart, range.OrdinalCount)
+            |> Seq.toArray
+            |> Ok
+
+    let private createMergedMetadata
+        correlationId
+        (currentMetadata: ContentBlockMetadata option)
+        (merge: MergeContentBlockPhysicalRanges)
+        timestamp
+        : Result<ContentBlockMetadata, GraceError>
+        =
+        match validateMergePhysicalRanges correlationId merge with
+        | Some error -> Error error
+        | None ->
+            match currentMetadata with
+            | Some existing when existing.StoragePoolId <> merge.StoragePoolId ->
+                Error(
+                    graceError correlationId $"ContentBlockMetadata StoragePoolId mismatch. Existing {existing.StoragePoolId}, requested {merge.StoragePoolId}."
+                )
+            | Some existing when
+                existing.ContentBlockAddress
+                <> merge.ContentBlockAddress
+                ->
+                Error(
+                    graceError
+                        correlationId
+                        $"ContentBlockMetadata ContentBlockAddress mismatch. Existing {existing.ContentBlockAddress}, requested {merge.ContentBlockAddress}."
+                )
+            | Some existing when
+                existing.BlockFormatVersion
+                <> merge.BlockFormatVersion
+                ->
+                Error(
+                    graceError
+                        correlationId
+                        $"ContentBlockMetadata BlockFormatVersion mismatch. Existing {existing.BlockFormatVersion}, requested {merge.BlockFormatVersion}."
+                )
+            | _ ->
+                let existingRanges =
+                    currentMetadata
+                    |> Option.map (fun metadata -> metadata.Ranges)
+                    |> Option.defaultValue Array.empty
+
+                match mergeRanges correlationId existingRanges merge.Ranges with
+                | Error error -> Error error
+                | Ok ranges ->
+                    let metadataVersion =
+                        currentMetadata
+                        |> Option.map (fun metadata -> metadata.MetadataVersion + 1L)
+                        |> Option.defaultValue 1L
+
+                    let metadata: ContentBlockMetadata =
+                        {
+                            Class = nameof ContentBlockMetadata
+                            StoragePoolId = merge.StoragePoolId
+                            ContentBlockAddress = merge.ContentBlockAddress
+                            BlockFormatVersion = merge.BlockFormatVersion
+                            StoragePlacement = merge.StoragePlacement
+                            Ranges = ranges
+                            TotalPhysicalBytes = totalPhysicalBytes ranges
+                            ActivePhysicalBytes = activePhysicalBytes ranges
+                            MetadataVersion = metadataVersion
+                            UpdatedAt = timestamp
+                        }
+
+                    Ok metadata
 
     let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
 
@@ -124,6 +268,16 @@ module ContentBlockMetadata =
                             ]
 
                         okDecision metadata operationId events false "ContentBlockMetadata whole record replaced."
+            | ContentBlockMetadataCommand.MergePhysicalRanges merge ->
+                match createMergedMetadata eventMetadata.CorrelationId current.Metadata merge eventMetadata.Timestamp with
+                | Error error -> Error error
+                | Ok metadata ->
+                    let events =
+                        [
+                            { Event = ContentBlockMetadataEventType.PhysicalRangesMerged(operationId, metadata); Metadata = eventMetadata }
+                        ]
+
+                    okDecision metadata operationId events false "ContentBlockMetadata physical ranges merged."
 
     type ContentBlockMetadataActor
         (

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -7,6 +7,7 @@ open Grace.Actors.Services
 open Grace.Shared
 open Grace.Shared.Constants
 open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Reminder
 open Grace.Types.Types
 open Grace.Types.UploadSession
@@ -38,8 +39,8 @@ module UploadSession =
         match command with
         | UploadSessionCommand.Start start -> start.OperationId
         | UploadSessionCommand.IssueDedupeDiscovery operationId -> operationId
-        | UploadSessionCommand.RegisterBlockUploadIntent (operationId, _) -> operationId
-        | UploadSessionCommand.ConfirmBlockUploaded (operationId, _) -> operationId
+        | UploadSessionCommand.RegisterBlockUploadIntent intent -> intent.OperationId
+        | UploadSessionCommand.ConfirmBlockUploaded confirmation -> confirmation.OperationId
         | UploadSessionCommand.ClaimReuseRanges operationId -> operationId
         | UploadSessionCommand.FinalizeManifest (operationId, _) -> operationId
         | UploadSessionCommand.Abandon operationId -> operationId
@@ -65,6 +66,8 @@ module UploadSession =
         | UploadSessionEventType.Finalized (operationId, _) -> operationId
         | UploadSessionEventType.CleanupReminderScheduled (operationId, _) -> operationId
         | UploadSessionEventType.PhysicalStateDeleted operationId -> operationId
+        | UploadSessionEventType.BlockUploadIntentRegistered (operationId, _) -> operationId
+        | UploadSessionEventType.BlockUploadConfirmed (operationId, _) -> operationId
 
     let private hasAppliedOperationId (events: seq<UploadSessionEvent>) operationId =
         events
@@ -95,6 +98,93 @@ module UploadSession =
         | UploadSessionLifecycleState.StateDeleted ->
             Some(graceError correlationId $"UploadSession physical state has been deleted and cannot be changed by {commandName command}.")
         | _ -> None
+
+    let private requireStartedSession (session: UploadSessionDto) command correlationId =
+        match terminalMutationError session command correlationId with
+        | Some error -> Some error
+        | None ->
+            match session.LifecycleState with
+            | UploadSessionLifecycleState.Started
+            | UploadSessionLifecycleState.Discovering
+            | UploadSessionLifecycleState.UploadingBlocks
+            | UploadSessionLifecycleState.ClaimingRanges -> None
+            | UploadSessionLifecycleState.NotStarted -> Some(graceError correlationId $"UploadSession must be started before {commandName command}.")
+            | _ -> Some(graceError correlationId $"UploadSession cannot {commandName command} from {session.LifecycleState}.")
+
+    let private validateIntent correlationId (intent: RegisterBlockUploadIntent) =
+        if String.IsNullOrWhiteSpace intent.ContentBlockAddress then
+            Some(graceError correlationId "ContentBlockAddress is required.")
+        elif intent.LogicalOffset < 0L then
+            Some(graceError correlationId "LogicalOffset must be zero or greater.")
+        elif intent.LogicalLength <= 0L then
+            Some(graceError correlationId "LogicalLength must be greater than zero.")
+        elif intent.ExpectedPayloadLength <= 0L then
+            Some(graceError correlationId "ExpectedPayloadLength must be greater than zero.")
+        else
+            None
+
+    let private validateStoragePlacement correlationId (placement: ContentBlockStoragePlacement) =
+        if String.IsNullOrWhiteSpace placement.ObjectKey then
+            Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
+        else
+            None
+
+    let private findBlockIntent (session: UploadSessionDto) contentBlockAddress =
+        session.BlockUploadIntents
+        |> Array.tryFind (fun intent -> intent.ContentBlockAddress = contentBlockAddress)
+
+    let private contentBlockError error = $"ContentBlock payload is invalid: {error}."
+
+    let private physicalRangesFromDecodedBlock (decodedBlock: ContentBlockFormat.DecodedContentBlock) =
+        decodedBlock.Chunks
+        |> Array.mapi (fun index chunk ->
+            { OrdinalStart = index; OrdinalCount = 1; ActiveManifestCount = 0; PhysicalOffset = chunk.PhysicalOffset; PhysicalLength = int64 chunk.Length })
+
+    let private confirmBlockUpload (session: UploadSessionDto) (confirmation: ConfirmBlockUploaded) (metadata: EventMetadata) =
+        if String.IsNullOrWhiteSpace confirmation.ContentBlockAddress then
+            Error(graceError metadata.CorrelationId "ContentBlockAddress is required.")
+        elif isNull confirmation.Payload then
+            Error(graceError metadata.CorrelationId "ContentBlock payload is required.")
+        elif confirmation.Payload.LongLength = 0L then
+            Error(graceError metadata.CorrelationId "ContentBlock payload must not be empty.")
+        else
+            match validateStoragePlacement metadata.CorrelationId confirmation.StoragePlacement with
+            | Some error -> Error error
+            | None ->
+                match findBlockIntent session confirmation.ContentBlockAddress with
+                | None ->
+                    Error(graceError metadata.CorrelationId $"Block upload intent does not exist for ContentBlockAddress {confirmation.ContentBlockAddress}.")
+                | Some intent when
+                    intent.ExpectedPayloadLength
+                    <> confirmation.Payload.LongLength
+                    ->
+                    Error(
+                        graceError
+                            metadata.CorrelationId
+                            $"ContentBlock payload length mismatch. Expected {intent.ExpectedPayloadLength}, actual {confirmation.Payload.LongLength}."
+                    )
+                | Some _ ->
+                    match ContentBlockFormat.decode confirmation.Payload with
+                    | Error error -> Error(graceError metadata.CorrelationId (contentBlockError error))
+                    | Ok decodedBlock ->
+                        match ContentBlockFormat.validateAddress confirmation.ContentBlockAddress decodedBlock with
+                        | Error error -> Error(graceError metadata.CorrelationId (contentBlockError error))
+                        | Ok () ->
+                            let confirmedBlock =
+                                {
+                                    ContentBlockAddress = confirmation.ContentBlockAddress
+                                    PayloadLength = confirmation.Payload.LongLength
+                                    StoragePlacement = confirmation.StoragePlacement
+                                    Ranges = physicalRangesFromDecodedBlock decodedBlock
+                                    ConfirmedAt = metadata.Timestamp
+                                }
+
+                            let events =
+                                [
+                                    { Event = UploadSessionEventType.BlockUploadConfirmed(confirmation.OperationId, confirmedBlock); Metadata = metadata }
+                                ]
+
+                            okDecision session confirmation.OperationId events false "ContentBlock upload confirmed."
 
     let decideCommand (events: seq<UploadSessionEvent>) (session: UploadSessionDto) (command: UploadSessionCommand) (metadata: EventMetadata) =
         let operationId = operationId command
@@ -170,9 +260,33 @@ module UploadSession =
 
                     okDecision session operationId events false "Upload session physical state deleted."
                 | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot DeletePhysicalState from {session.LifecycleState}.")
+            | UploadSessionCommand.RegisterBlockUploadIntent intent ->
+                match requireStartedSession session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None ->
+                    match validateIntent metadata.CorrelationId intent with
+                    | Some error -> Error error
+                    | None ->
+                        let blockUploadIntent =
+                            {
+                                ContentBlockAddress = intent.ContentBlockAddress
+                                LogicalOffset = intent.LogicalOffset
+                                LogicalLength = intent.LogicalLength
+                                ExpectedPayloadLength = intent.ExpectedPayloadLength
+                                RegisteredAt = metadata.Timestamp
+                            }
+
+                        let events =
+                            [
+                                { Event = UploadSessionEventType.BlockUploadIntentRegistered(intent.OperationId, blockUploadIntent); Metadata = metadata }
+                            ]
+
+                        okDecision session intent.OperationId events false "Block upload intent registered."
+            | UploadSessionCommand.ConfirmBlockUploaded confirmation ->
+                match requireStartedSession session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None -> confirmBlockUpload session confirmation metadata
             | UploadSessionCommand.IssueDedupeDiscovery _
-            | UploadSessionCommand.RegisterBlockUploadIntent _
-            | UploadSessionCommand.ConfirmBlockUploaded _
             | UploadSessionCommand.ClaimReuseRanges _
             | UploadSessionCommand.FinalizeManifest _ ->
                 match terminalMutationError session command metadata.CorrelationId with

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -142,6 +142,10 @@ module UploadSession =
         |> Array.mapi (fun index chunk ->
             { OrdinalStart = index; OrdinalCount = 1; ActiveManifestCount = 0; PhysicalOffset = chunk.PhysicalOffset; PhysicalLength = int64 chunk.Length })
 
+    let private decodedLogicalLength (decodedBlock: ContentBlockFormat.DecodedContentBlock) =
+        decodedBlock.Chunks
+        |> Array.sumBy (fun chunk -> int64 chunk.Length)
+
     let private confirmBlockUpload (session: UploadSessionDto) (confirmation: ConfirmBlockUploaded) (metadata: EventMetadata) =
         if String.IsNullOrWhiteSpace confirmation.ContentBlockAddress then
             Error(graceError metadata.CorrelationId "ContentBlockAddress is required.")
@@ -178,21 +182,41 @@ module UploadSession =
                         match ContentBlockFormat.validateAddress confirmation.ContentBlockAddress decodedBlock with
                         | Error error -> Error(graceError metadata.CorrelationId (contentBlockError error))
                         | Ok () ->
-                            let confirmedBlock =
-                                {
-                                    ContentBlockAddress = confirmation.ContentBlockAddress
-                                    PayloadLength = confirmation.Payload.LongLength
-                                    StoragePlacement = confirmation.StoragePlacement
-                                    Ranges = physicalRangesFromDecodedBlock decodedBlock
-                                    ConfirmedAt = metadata.Timestamp
-                                }
+                            let logicalLength = decodedLogicalLength decodedBlock
 
-                            let events =
-                                [
-                                    { Event = UploadSessionEventType.BlockUploadConfirmed(confirmation.OperationId, confirmedBlock); Metadata = metadata }
-                                ]
+                            let matchingLogicalLength =
+                                findBlockIntents session confirmation.ContentBlockAddress
+                                |> Array.filter (fun intent -> intent.ExpectedPayloadLength = confirmation.Payload.LongLength)
 
-                            okDecision session confirmation.OperationId events false "ContentBlock upload confirmed."
+                            if matchingLogicalLength
+                               |> Array.exists (fun intent -> intent.LogicalLength = logicalLength)
+                               |> not then
+                                let expectedLengths =
+                                    matchingLogicalLength
+                                    |> Array.map (fun intent -> intent.LogicalLength.ToString())
+                                    |> String.concat ", "
+
+                                Error(
+                                    graceError
+                                        metadata.CorrelationId
+                                        $"ContentBlock logical length mismatch. Expected one of [{expectedLengths}], actual {logicalLength}."
+                                )
+                            else
+                                let confirmedBlock =
+                                    {
+                                        ContentBlockAddress = confirmation.ContentBlockAddress
+                                        PayloadLength = confirmation.Payload.LongLength
+                                        StoragePlacement = confirmation.StoragePlacement
+                                        Ranges = physicalRangesFromDecodedBlock decodedBlock
+                                        ConfirmedAt = metadata.Timestamp
+                                    }
+
+                                let events =
+                                    [
+                                        { Event = UploadSessionEventType.BlockUploadConfirmed(confirmation.OperationId, confirmedBlock); Metadata = metadata }
+                                    ]
+
+                                okDecision session confirmation.OperationId events false "ContentBlock upload confirmed."
 
     let decideCommand (events: seq<UploadSessionEvent>) (session: UploadSessionDto) (command: UploadSessionCommand) (metadata: EventMetadata) =
         let operationId = operationId command

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -124,14 +124,16 @@ module UploadSession =
             None
 
     let private validateStoragePlacement correlationId (placement: ContentBlockStoragePlacement) =
-        if String.IsNullOrWhiteSpace placement.ObjectKey then
+        if isNull (box placement) then
+            Some(graceError correlationId "StoragePlacement is required.")
+        elif String.IsNullOrWhiteSpace placement.ObjectKey then
             Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
         else
             None
 
-    let private findBlockIntent (session: UploadSessionDto) contentBlockAddress =
+    let private findBlockIntents (session: UploadSessionDto) contentBlockAddress =
         session.BlockUploadIntents
-        |> Array.tryFind (fun intent -> intent.ContentBlockAddress = contentBlockAddress)
+        |> Array.filter (fun intent -> intent.ContentBlockAddress = contentBlockAddress)
 
     let private contentBlockError error = $"ContentBlock payload is invalid: {error}."
 
@@ -151,19 +153,25 @@ module UploadSession =
             match validateStoragePlacement metadata.CorrelationId confirmation.StoragePlacement with
             | Some error -> Error error
             | None ->
-                match findBlockIntent session confirmation.ContentBlockAddress with
-                | None ->
+                match findBlockIntents session confirmation.ContentBlockAddress with
+                | intents when intents.Length = 0 ->
                     Error(graceError metadata.CorrelationId $"Block upload intent does not exist for ContentBlockAddress {confirmation.ContentBlockAddress}.")
-                | Some intent when
-                    intent.ExpectedPayloadLength
-                    <> confirmation.Payload.LongLength
+                | intents when
+                    intents
+                    |> Array.exists (fun intent -> intent.ExpectedPayloadLength = confirmation.Payload.LongLength)
+                    |> not
                     ->
+                    let expectedLengths =
+                        intents
+                        |> Array.map (fun intent -> intent.ExpectedPayloadLength.ToString())
+                        |> String.concat ", "
+
                     Error(
                         graceError
                             metadata.CorrelationId
-                            $"ContentBlock payload length mismatch. Expected {intent.ExpectedPayloadLength}, actual {confirmation.Payload.LongLength}."
+                            $"ContentBlock payload length mismatch. Expected one of [{expectedLengths}], actual {confirmation.Payload.LongLength}."
                     )
-                | Some _ ->
+                | _ ->
                     match ContentBlockFormat.decode confirmation.Payload with
                     | Error error -> Error(graceError metadata.CorrelationId (contentBlockError error))
                     | Ok decodedBlock ->

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -168,6 +168,34 @@ type ContentBlockMetadataActorTests() =
         | Error error -> Assert.That(error.Error, Is.EqualTo("StoragePlacement is required."))
 
     [<Test>]
+    member _.MergePhysicalRangesRejectsExistingNullStoragePlacementAsGraceError() =
+        let existing =
+            { ContentBlockMetadataDto.Empty with
+                Metadata = Some { record [| activeRange |] with StoragePlacement = Unchecked.defaultof<ContentBlockStoragePlacement> }
+            }
+
+        let result = ContentBlockMetadataActor.decideCommand [] existing (merge "op-merge" [| reclaimableRange |]) (metadata "corr-merge")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected null existing storage placement to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("Existing StoragePlacement is required."))
+
+    [<Test>]
+    member _.MergePhysicalRangesRejectsPhysicalEndOverflow() =
+        let overflowingRange = { reclaimableRange with PhysicalOffset = Int64.MaxValue - 5L; PhysicalLength = 10L }
+
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                ContentBlockMetadataDto.Empty
+                (merge "op-merge-overflow" [| overflowingRange |])
+                (metadata "corr-merge-overflow")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected physical range overflow to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ContentBlockMetadataRange.PhysicalOffset plus PhysicalLength must not exceed Int64.MaxValue."))
+
+    [<Test>]
     member _.MergePhysicalRangesAddsMissingRangesWithoutDuplicatingExistingOnReplay() =
         let created =
             match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -43,16 +43,18 @@ type ContentBlockMetadataActorTests() =
     let replace operationId expectedVersion ranges =
         ContentBlockMetadataCommand.ReplaceWholeRecord { OperationId = operationId; ExpectedMetadataVersion = expectedVersion; Metadata = record ranges }
 
-    let merge operationId ranges =
+    let mergeWithObjectKey operationId objectKey ranges =
         ContentBlockMetadataCommand.MergePhysicalRanges
             {
                 OperationId = operationId
                 StoragePoolId = storagePoolId
                 ContentBlockAddress = contentBlockAddress
                 BlockFormatVersion = 1s
-                StoragePlacement = { ObjectKey = "cas/content-blocks/block-blake3-0001"; ETag = Some "etag-1" }
+                StoragePlacement = { ObjectKey = objectKey; ETag = Some "etag-1" }
                 Ranges = ranges
             }
+
+    let merge operationId ranges = mergeWithObjectKey operationId "cas/content-blocks/block-blake3-0001" ranges
 
     let applyAll events current =
         events
@@ -103,6 +105,16 @@ type ContentBlockMetadataActorTests() =
         Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 8; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Reclaimable))
 
         Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 12; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Absent))
+
+    [<Test>]
+    member _.RangePresenceAggregatesDuplicateOrdinalRangesAsActiveWhenAnyPhysicalCopyIsActive() =
+        let activePhysicalCopy = { reclaimableRange with ActiveManifestCount = 1; PhysicalOffset = 2048L }
+
+        let metadata =
+            record [| reclaimableRange
+                      activePhysicalCopy |]
+
+        Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 8; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Active))
 
     [<Test>]
     member _.SameOperationIdIsIdempotentReplayWithoutVersionBump() =
@@ -196,6 +208,28 @@ type ContentBlockMetadataActorTests() =
             Assert.That(decision.Metadata.Ranges[1].PhysicalOffset, Is.EqualTo(4096L))
             Assert.That(decision.Metadata.TotalPhysicalBytes, Is.EqualTo(5120L))
         | Error error -> Assert.Fail($"Expected relocated physical range to merge, got {error.Error}.")
+
+    [<Test>]
+    member _.MergePhysicalRangesRejectsStoragePlacementObjectKeyChanges() =
+        let created =
+            match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with
+            | Ok decision -> applyAll decision.Events ContentBlockMetadataDto.Empty, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected create to succeed, got {error.Error}.")
+                ContentBlockMetadataDto.Empty, []
+
+        let createdDto, createdEvents = created
+
+        let changedPlacement =
+            ContentBlockMetadataActor.decideCommand
+                createdEvents
+                createdDto
+                (mergeWithObjectKey "op-moved" "cas/content-blocks/other-object" [| reclaimableRange |])
+                (metadata "corr-moved")
+
+        match changedPlacement with
+        | Ok _ -> Assert.Fail("Expected object key change to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("StoragePlacement.ObjectKey mismatch"))
 
     [<Test>]
     member _.MetadataActorUsesOneCompositeStringKeyAndDoesNotIntroduceChunkActorState() =

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -43,6 +43,17 @@ type ContentBlockMetadataActorTests() =
     let replace operationId expectedVersion ranges =
         ContentBlockMetadataCommand.ReplaceWholeRecord { OperationId = operationId; ExpectedMetadataVersion = expectedVersion; Metadata = record ranges }
 
+    let merge operationId ranges =
+        ContentBlockMetadataCommand.MergePhysicalRanges
+            {
+                OperationId = operationId
+                StoragePoolId = storagePoolId
+                ContentBlockAddress = contentBlockAddress
+                BlockFormatVersion = 1s
+                StoragePlacement = { ObjectKey = "cas/content-blocks/block-blake3-0001"; ETag = Some "etag-1" }
+                Ranges = ranges
+            }
+
     let applyAll events current =
         events
         |> List.fold (fun state event -> ContentBlockMetadataDto.UpdateDto event state) current
@@ -110,6 +121,58 @@ type ContentBlockMetadataActorTests() =
                 Assert.That(replayDecision.Metadata.MetadataVersion, Is.EqualTo(1L))
             | Error error -> Assert.Fail($"Expected idempotent replay, got {error.Error}.")
         | Error error -> Assert.Fail($"Expected create to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.MergePhysicalRangesCreatesAuthoritativeMetadata() =
+        let result = ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-merge" [| reclaimableRange |]) (metadata "corr-merge")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Metadata.MetadataVersion, Is.EqualTo(1L))
+            Assert.That(decision.Metadata.Ranges.Length, Is.EqualTo(1))
+            Assert.That(decision.Metadata.TotalPhysicalBytes, Is.EqualTo(1536L))
+            Assert.That(decision.Metadata.ActivePhysicalBytes, Is.EqualTo(0L))
+
+            Assert.That(
+                ContentBlockMetadataTypes.rangePresence decision.Metadata { OrdinalStart = 8; OrdinalCount = 4 },
+                Is.EqualTo(ContentBlockRangePresence.Reclaimable)
+            )
+        | Error error -> Assert.Fail($"Expected physical range merge to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.MergePhysicalRangesAddsMissingRangesWithoutDuplicatingExistingOnReplay() =
+        let created =
+            match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with
+            | Ok decision -> applyAll decision.Events ContentBlockMetadataDto.Empty, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected create to succeed, got {error.Error}.")
+                ContentBlockMetadataDto.Empty, []
+
+        let createdDto, createdEvents = created
+
+        let updated =
+            ContentBlockMetadataActor.decideCommand createdEvents createdDto (merge "op-append" [| activeRange; reclaimableRange |]) (metadata "corr-append")
+
+        match updated with
+        | Ok decision ->
+            Assert.That(decision.Metadata.MetadataVersion, Is.EqualTo(2L))
+            Assert.That(decision.Metadata.Ranges.Length, Is.EqualTo(2))
+
+            let replay =
+                ContentBlockMetadataActor.decideCommand
+                    (createdEvents @ decision.Events)
+                    (applyAll decision.Events createdDto)
+                    (merge "op-append" [| activeRange; reclaimableRange |])
+                    (metadata "corr-replay")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Metadata.MetadataVersion, Is.EqualTo(2L))
+                Assert.That(replayDecision.Metadata.Ranges.Length, Is.EqualTo(2))
+            | Error error -> Assert.Fail($"Expected idempotent replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected append merge to succeed, got {error.Error}.")
 
     [<Test>]
     member _.MetadataActorUsesOneCompositeStringKeyAndDoesNotIntroduceChunkActorState() =

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -43,16 +43,18 @@ type ContentBlockMetadataActorTests() =
     let replace operationId expectedVersion ranges =
         ContentBlockMetadataCommand.ReplaceWholeRecord { OperationId = operationId; ExpectedMetadataVersion = expectedVersion; Metadata = record ranges }
 
-    let mergeWithObjectKey operationId objectKey ranges =
+    let mergeWithPlacement operationId placement ranges =
         ContentBlockMetadataCommand.MergePhysicalRanges
             {
                 OperationId = operationId
                 StoragePoolId = storagePoolId
                 ContentBlockAddress = contentBlockAddress
                 BlockFormatVersion = 1s
-                StoragePlacement = { ObjectKey = objectKey; ETag = Some "etag-1" }
+                StoragePlacement = placement
                 Ranges = ranges
             }
+
+    let mergeWithObjectKey operationId objectKey ranges = mergeWithPlacement operationId { ObjectKey = objectKey; ETag = Some "etag-1" } ranges
 
     let merge operationId ranges = mergeWithObjectKey operationId "cas/content-blocks/block-blake3-0001" ranges
 
@@ -151,6 +153,19 @@ type ContentBlockMetadataActorTests() =
                 Is.EqualTo(ContentBlockRangePresence.Reclaimable)
             )
         | Error error -> Assert.Fail($"Expected physical range merge to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.MergePhysicalRangesRejectsNullStoragePlacementAsGraceError() =
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                ContentBlockMetadataDto.Empty
+                (mergeWithPlacement "op-merge-null-placement" Unchecked.defaultof<ContentBlockStoragePlacement> [| reclaimableRange |])
+                (metadata "corr-merge-null-placement")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected null storage placement to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("StoragePlacement is required."))
 
     [<Test>]
     member _.MergePhysicalRangesAddsMissingRangesWithoutDuplicatingExistingOnReplay() =

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -218,6 +218,28 @@ type ContentBlockMetadataActorTests() =
         | Error error -> Assert.That(error.Error, Is.EqualTo("ActivePhysicalBytes cannot exceed Int64.MaxValue."))
 
     [<Test>]
+    member _.MergePhysicalRangesRejectsActivePhysicalBytesGreaterThanTotalPhysicalBytes() =
+        let firstActiveRange = { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 1; PhysicalOffset = 0L; PhysicalLength = 10L }
+
+        let overlappingActiveRange = { firstActiveRange with OrdinalStart = 1; PhysicalOffset = 5L }
+
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                ContentBlockMetadataDto.Empty
+                (merge
+                    "op-merge-active-exceeds-total"
+                    [|
+                        firstActiveRange
+                        overlappingActiveRange
+                    |])
+                (metadata "corr-merge-active-exceeds-total")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected active bytes greater than total bytes to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ActivePhysicalBytes cannot exceed TotalPhysicalBytes."))
+
+    [<Test>]
     member _.MergePhysicalRangesAddsMissingRangesWithoutDuplicatingExistingOnReplay() =
         let created =
             match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -175,6 +175,29 @@ type ContentBlockMetadataActorTests() =
         | Error error -> Assert.Fail($"Expected append merge to succeed, got {error.Error}.")
 
     [<Test>]
+    member _.MergePhysicalRangesAllowsSameOrdinalAtDifferentPhysicalOffsets() =
+        let relocatedRange = { activeRange with PhysicalOffset = 4096L; PhysicalLength = activeRange.PhysicalLength; ActiveManifestCount = 0 }
+
+        let created =
+            match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with
+            | Ok decision -> applyAll decision.Events ContentBlockMetadataDto.Empty, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected create to succeed, got {error.Error}.")
+                ContentBlockMetadataDto.Empty, []
+
+        let createdDto, createdEvents = created
+
+        let updated = ContentBlockMetadataActor.decideCommand createdEvents createdDto (merge "op-relocated" [| relocatedRange |]) (metadata "corr-relocated")
+
+        match updated with
+        | Ok decision ->
+            Assert.That(decision.Metadata.Ranges.Length, Is.EqualTo(2))
+            Assert.That(decision.Metadata.Ranges[0].PhysicalOffset, Is.EqualTo(0L))
+            Assert.That(decision.Metadata.Ranges[1].PhysicalOffset, Is.EqualTo(4096L))
+            Assert.That(decision.Metadata.TotalPhysicalBytes, Is.EqualTo(5120L))
+        | Error error -> Assert.Fail($"Expected relocated physical range to merge, got {error.Error}.")
+
+    [<Test>]
     member _.MetadataActorUsesOneCompositeStringKeyAndDoesNotIntroduceChunkActorState() =
         let key = ContentBlockMetadataActorKey.Create storagePoolId contentBlockAddress
 

--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -196,6 +196,28 @@ type ContentBlockMetadataActorTests() =
         | Error error -> Assert.That(error.Error, Is.EqualTo("ContentBlockMetadataRange.PhysicalOffset plus PhysicalLength must not exceed Int64.MaxValue."))
 
     [<Test>]
+    member _.MergePhysicalRangesRejectsActivePhysicalBytesOverflow() =
+        let firstActiveRange = { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 1; PhysicalOffset = 0L; PhysicalLength = (Int64.MaxValue / 2L) + 1L }
+
+        let secondActiveRange = { firstActiveRange with OrdinalStart = 1; PhysicalOffset = 8L }
+
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                ContentBlockMetadataDto.Empty
+                (merge
+                    "op-merge-active-overflow"
+                    [|
+                        firstActiveRange
+                        secondActiveRange
+                    |])
+                (metadata "corr-merge-active-overflow")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected active physical byte overflow to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ActivePhysicalBytes cannot exceed Int64.MaxValue."))
+
+    [<Test>]
     member _.MergePhysicalRangesAddsMissingRangesWithoutDuplicatingExistingOnReplay() =
         let created =
             match ContentBlockMetadataActor.decideCommand [] ContentBlockMetadataDto.Empty (merge "op-create" [| activeRange |]) (metadata "corr-create") with

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -64,6 +64,9 @@ type UploadSessionActorTests() =
             StoragePlacement = { ObjectKey = $"cas/content-blocks/{blockAddress}"; ETag = Some "etag-confirmed" }
         }
 
+    let confirmWithPlacement operationId blockAddress payload placement : ConfirmBlockUploaded =
+        { OperationId = operationId; ContentBlockAddress = blockAddress; Payload = payload; StoragePlacement = placement }
+
     let apply event dto = UploadSessionDto.UpdateDto event dto
 
     let applyAll events dto =
@@ -309,6 +312,81 @@ type UploadSessionActorTests() =
                 Is.EqualTo(11L)
             )
         | Error error -> Assert.Fail($"Expected block upload confirmation to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ConfirmBlockUploadedRejectsNullStoragePlacementAsGraceError() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent(intent "op-block-intent" block.Address block.Payload.LongLength))
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(
+                    confirmWithPlacement "op-block-confirm" block.Address block.Payload Unchecked.defaultof<ContentBlockStoragePlacement>
+                ))
+                (metadata "corr-block-confirm")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected null storage placement to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("StoragePlacement is required."))
+
+    [<Test>]
+    member _.ConfirmBlockUploadedMatchesAnyCompatibleDuplicateIntent() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let first =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentAt "op-block-intent-1" block.Address (block.Payload.LongLength + 1L) 0L))
+                (metadata "corr-block-intent-1")
+
+        let firstDto, firstEvents =
+            match first with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected first intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let second =
+            UploadSessionActor.decideCommand
+                firstEvents
+                firstDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentAt "op-block-intent-2" block.Address block.Payload.LongLength 4096L))
+                (metadata "corr-block-intent-2")
+
+        let secondDto, secondEvents =
+            match second with
+            | Ok decision -> decision.Session, firstEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected second intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                secondEvents
+                secondDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        match result with
+        | Ok decision -> Assert.That(decision.Session.ConfirmedBlockUploads.Length, Is.EqualTo(1))
+        | Error error -> Assert.Fail($"Expected confirmation to match compatible duplicate intent, got {error.Error}.")
 
     [<Test>]
     member _.ConfirmBlockUploadedRejectsCorruptPayloadWithoutConsumingOperationId() =

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -1,5 +1,7 @@
 namespace Grace.Server.Tests
 
+open Grace.Shared
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Reminder
 open Grace.Types.Types
 open Grace.Types.UploadSession
@@ -36,11 +38,38 @@ type UploadSessionActorTests() =
             OperationId = operationId
         }
 
+    let encodedBlock bytes =
+        match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
+        | Ok block -> block
+        | Error error ->
+            Assert.Fail($"Expected test content block to encode, got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    let intent operationId blockAddress payloadLength : RegisterBlockUploadIntent =
+        { OperationId = operationId; ContentBlockAddress = blockAddress; LogicalOffset = 0L; LogicalLength = 11L; ExpectedPayloadLength = payloadLength }
+
+    let confirm operationId blockAddress payload : ConfirmBlockUploaded =
+        {
+            OperationId = operationId
+            ContentBlockAddress = blockAddress
+            Payload = payload
+            StoragePlacement = { ObjectKey = $"cas/content-blocks/{blockAddress}"; ETag = Some "etag-confirmed" }
+        }
+
     let apply event dto = UploadSessionDto.UpdateDto event dto
 
     let applyAll events dto =
         events
         |> List.fold (fun current event -> apply event current) dto
+
+    let startedSession () =
+        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
+
+        match startDecision with
+        | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
+        | Error error ->
+            Assert.Fail($"Expected start to succeed, got {error.Error}.")
+            UploadSessionDto.Default, []
 
     [<Test>]
     member _.StartWithSameOperationIdIsIdempotentReplay() =
@@ -154,28 +183,180 @@ type UploadSessionActorTests() =
         | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession is finalized and cannot be changed by Abandon."))
 
     [<Test>]
-    member _.BlockUploadAndFinalizeCommandsRemainUnimplementedForSkeleton() =
-        let startDecision = UploadSessionActor.decideCommand [] UploadSessionDto.Default (UploadSessionCommand.Start(start "op-start")) (metadata "corr-start")
-
-        let started =
-            match startDecision with
-            | Ok decision -> applyAll decision.Events UploadSessionDto.Default, decision.Events
-            | Error error ->
-                Assert.Fail($"Expected start to succeed, got {error.Error}.")
-                UploadSessionDto.Default, []
-
-        let (startedDto, existingEvents) = started
+    member _.BlockUploadIntentMovesStartedSessionToUploadingBlocks() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, existingEvents = startedSession ()
 
         let result =
             UploadSessionActor.decideCommand
                 existingEvents
                 startedDto
-                (UploadSessionCommand.RegisterBlockUploadIntent("op-block", "block-blake3"))
-                (metadata "corr-block")
+                (UploadSessionCommand.RegisterBlockUploadIntent(intent "op-block-intent" block.Address block.Payload.LongLength))
+                (metadata "corr-block-intent")
 
         match result with
-        | Ok _ -> Assert.Fail("Expected block upload intent to remain unimplemented in the skeleton.")
-        | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession command RegisterBlockUploadIntent is not implemented in this skeleton."))
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Events.Length, Is.EqualTo(1))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.UploadingBlocks))
+            Assert.That(decision.Session.BlockUploadIntents.Length, Is.EqualTo(1))
+
+            Assert.That(
+                decision.Session.BlockUploadIntents[0]
+                    .ContentBlockAddress,
+                Is.EqualTo(block.Address)
+            )
+        | Error error -> Assert.Fail($"Expected block upload intent to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ConfirmBlockUploadedValidatesPayloadAndRecordsPhysicalRanges() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let intentDecision =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intent "op-block-intent" block.Address block.Payload.LongLength))
+                (metadata "corr-block-intent")
+
+        let intentDto, intentEvents =
+            match intentDecision with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Session.ConfirmedBlockUploads.Length, Is.EqualTo(1))
+
+            Assert.That(
+                decision.Session.ConfirmedBlockUploads[0]
+                    .ContentBlockAddress,
+                Is.EqualTo(block.Address)
+            )
+
+            Assert.That(
+                decision.Session.ConfirmedBlockUploads[0]
+                    .Ranges
+                    .Length,
+                Is.EqualTo(1)
+            )
+
+            Assert.That(
+                decision.Session.ConfirmedBlockUploads[0].Ranges[0]
+                    .PhysicalLength,
+                Is.EqualTo(11L)
+            )
+        | Error error -> Assert.Fail($"Expected block upload confirmation to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ConfirmBlockUploadedRejectsCorruptPayloadWithoutConsumingOperationId() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let corruptPayload = Array.copy block.Payload
+        corruptPayload[0] <- corruptPayload[0] ^^^ 0xffuy
+        let startedDto, startEvents = startedSession ()
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent(intent "op-block-intent" block.Address block.Payload.LongLength))
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let corrupt =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address corruptPayload))
+                (metadata "corr-block-confirm-corrupt")
+
+        match corrupt with
+        | Ok _ -> Assert.Fail("Expected corrupt ContentBlock payload to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("ContentBlock payload is invalid"))
+
+        let retry =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm-retry")
+
+        match retry with
+        | Ok decision -> Assert.That(decision.Session.ConfirmedBlockUploads.Length, Is.EqualTo(1))
+        | Error error -> Assert.Fail($"Expected retry after corrupt payload to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ConfirmBlockUploadedWithSameOperationIdIsIdempotentReplay() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent(intent "op-block-intent" block.Address block.Payload.LongLength))
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let first =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        match first with
+        | Ok decision ->
+            let replay =
+                UploadSessionActor.decideCommand
+                    (intentEvents @ decision.Events)
+                    decision.Session
+                    (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                    (metadata "corr-block-confirm-replay")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Session.ConfirmedBlockUploads.Length, Is.EqualTo(1))
+            | Error error -> Assert.Fail($"Expected idempotent replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected first confirmation to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizeCommandRemainsUnimplementedForSkeleton() =
+        let startedDto, existingEvents = startedSession ()
+
+        let result =
+            UploadSessionActor.decideCommand
+                existingEvents
+                startedDto
+                (UploadSessionCommand.FinalizeManifest("op-finalize", "manifest-blake3"))
+                (metadata "corr-finalize")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected finalize to remain unimplemented in this slice.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession command FinalizeManifest is not implemented in this skeleton."))
 
     [<Test>]
     member _.CleanupReminderStateCarriesDeletePhysicalStateOperationId() =

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -389,6 +389,36 @@ type UploadSessionActorTests() =
         | Error error -> Assert.Fail($"Expected confirmation to match compatible duplicate intent, got {error.Error}.")
 
     [<Test>]
+    member _.ConfirmBlockUploadedRejectsIntentLogicalLengthMismatch() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent
+                        { intentAt "op-block-intent" block.Address block.Payload.LongLength 0L with LogicalLength = 10L })
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected logical length mismatch to be rejected.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ContentBlock logical length mismatch. Expected one of [10], actual 11."))
+
+    [<Test>]
     member _.ConfirmBlockUploadedRejectsCorruptPayloadWithoutConsumingOperationId() =
         let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
         let corruptPayload = Array.copy block.Payload

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -45,8 +45,16 @@ type UploadSessionActorTests() =
             Assert.Fail($"Expected test content block to encode, got {error}.")
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
-    let intent operationId blockAddress payloadLength : RegisterBlockUploadIntent =
-        { OperationId = operationId; ContentBlockAddress = blockAddress; LogicalOffset = 0L; LogicalLength = 11L; ExpectedPayloadLength = payloadLength }
+    let intentAt operationId blockAddress payloadLength logicalOffset : RegisterBlockUploadIntent =
+        {
+            OperationId = operationId
+            ContentBlockAddress = blockAddress
+            LogicalOffset = logicalOffset
+            LogicalLength = 11L
+            ExpectedPayloadLength = payloadLength
+        }
+
+    let intent operationId blockAddress payloadLength = intentAt operationId blockAddress payloadLength 0L
 
     let confirm operationId blockAddress payload : ConfirmBlockUploaded =
         {
@@ -207,6 +215,49 @@ type UploadSessionActorTests() =
                 Is.EqualTo(block.Address)
             )
         | Error error -> Assert.Fail($"Expected block upload intent to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.BlockUploadIntentPreservesRepeatedBlockAddressAtDifferentLogicalOffsets() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let startedDto, startEvents = startedSession ()
+
+        let first =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentAt "op-block-intent-1" block.Address block.Payload.LongLength 0L))
+                (metadata "corr-block-intent-1")
+
+        let firstDto, firstEvents =
+            match first with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected first intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let second =
+            UploadSessionActor.decideCommand
+                firstEvents
+                firstDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentAt "op-block-intent-2" block.Address block.Payload.LongLength 4096L))
+                (metadata "corr-block-intent-2")
+
+        match second with
+        | Ok decision ->
+            Assert.That(decision.Session.BlockUploadIntents.Length, Is.EqualTo(2))
+
+            Assert.That(
+                decision.Session.BlockUploadIntents[0]
+                    .LogicalOffset,
+                Is.EqualTo(0L)
+            )
+
+            Assert.That(
+                decision.Session.BlockUploadIntents[1]
+                    .LogicalOffset,
+                Is.EqualTo(4096L)
+            )
+        | Error error -> Assert.Fail($"Expected repeated block address intent to succeed, got {error.Error}.")
 
     [<Test>]
     member _.ConfirmBlockUploadedValidatesPayloadAndRecordsPhysicalRanges() =

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -118,17 +118,27 @@ module ContentBlockMetadata =
             Message: string
         }
 
-    let tryFindRange (metadata: ContentBlockMetadata) query =
+    let findRanges (metadata: ContentBlockMetadata) query =
         if query.OrdinalCount <= 0 then
-            None
+            Array.empty
         else
             metadata.Ranges
-            |> Array.tryFind (fun range ->
+            |> Array.filter (fun range ->
                 range.OrdinalStart = query.OrdinalStart
                 && range.OrdinalCount = query.OrdinalCount)
 
+    let tryFindRange metadata query =
+        findRanges metadata query
+        |> Array.sortByDescending (fun range -> range.ActiveManifestCount)
+        |> Array.tryHead
+
     let rangePresence metadata query =
-        match tryFindRange metadata query with
-        | Some range when range.ActiveManifestCount > 0 -> ContentBlockRangePresence.Active
-        | Some _ -> ContentBlockRangePresence.Reclaimable
-        | None -> ContentBlockRangePresence.Absent
+        let ranges = findRanges metadata query
+
+        if ranges
+           |> Array.exists (fun range -> range.ActiveManifestCount > 0) then
+            ContentBlockRangePresence.Active
+        elif ranges.Length > 0 then
+            ContentBlockRangePresence.Reclaimable
+        else
+            ContentBlockRangePresence.Absent

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -66,15 +66,28 @@ module ContentBlockMetadata =
     [<GenerateSerializer>]
     type ReplaceContentBlockMetadata = { OperationId: string; ExpectedMetadataVersion: MetadataVersion option; Metadata: ContentBlockMetadata }
 
+    [<GenerateSerializer>]
+    type MergeContentBlockPhysicalRanges =
+        {
+            OperationId: string
+            StoragePoolId: StoragePoolId
+            ContentBlockAddress: ContentBlockAddress
+            BlockFormatVersion: int16
+            StoragePlacement: ContentBlockStoragePlacement
+            Ranges: ContentBlockMetadataRange array
+        }
+
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockMetadataCommand =
         | ReplaceWholeRecord of replace: ReplaceContentBlockMetadata
+        | MergePhysicalRanges of merge: MergeContentBlockPhysicalRanges
 
         static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataCommand>()
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockMetadataEventType =
         | WholeRecordReplaced of operationId: string * metadata: ContentBlockMetadata
+        | PhysicalRangesMerged of operationId: string * metadata: ContentBlockMetadata
 
         static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataEventType>()
 
@@ -93,6 +106,7 @@ module ContentBlockMetadata =
         static member UpdateDto event _current =
             match event.Event with
             | ContentBlockMetadataEventType.WholeRecordReplaced (operationId, metadata) -> { Metadata = Some metadata; LastOperationId = Some operationId }
+            | ContentBlockMetadataEventType.PhysicalRangesMerged (operationId, metadata) -> { Metadata = Some metadata; LastOperationId = Some operationId }
 
     [<GenerateSerializer>]
     type ContentBlockMetadataDecision =

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -2,6 +2,7 @@ namespace Grace.Types
 
 open Grace.Shared
 open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Types
 open NodaTime
 open Orleans
@@ -41,12 +42,51 @@ module UploadSession =
             OperationId: UploadSessionOperationId
         }
 
+    [<GenerateSerializer>]
+    type RegisterBlockUploadIntent =
+        {
+            OperationId: UploadSessionOperationId
+            ContentBlockAddress: ContentBlockAddress
+            LogicalOffset: int64
+            LogicalLength: int64
+            ExpectedPayloadLength: int64
+        }
+
+    [<GenerateSerializer>]
+    type ConfirmBlockUploaded =
+        {
+            OperationId: UploadSessionOperationId
+            ContentBlockAddress: ContentBlockAddress
+            Payload: byte array
+            StoragePlacement: ContentBlockStoragePlacement
+        }
+
+    [<GenerateSerializer>]
+    type BlockUploadIntent =
+        {
+            ContentBlockAddress: ContentBlockAddress
+            LogicalOffset: int64
+            LogicalLength: int64
+            ExpectedPayloadLength: int64
+            RegisteredAt: Instant
+        }
+
+    [<GenerateSerializer>]
+    type ConfirmedBlockUpload =
+        {
+            ContentBlockAddress: ContentBlockAddress
+            PayloadLength: int64
+            StoragePlacement: ContentBlockStoragePlacement
+            Ranges: ContentBlockMetadataRange array
+            ConfirmedAt: Instant
+        }
+
     [<KnownType("GetKnownTypes")>]
     type UploadSessionCommand =
         | Start of start: StartUploadSession
         | IssueDedupeDiscovery of operationId: UploadSessionOperationId
-        | RegisterBlockUploadIntent of operationId: UploadSessionOperationId * contentBlockAddress: ContentBlockAddress
-        | ConfirmBlockUploaded of operationId: UploadSessionOperationId * contentBlockAddress: ContentBlockAddress
+        | RegisterBlockUploadIntent of intent: RegisterBlockUploadIntent
+        | ConfirmBlockUploaded of confirmation: ConfirmBlockUploaded
         | ClaimReuseRanges of operationId: UploadSessionOperationId
         | FinalizeManifest of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
         | Abandon of operationId: UploadSessionOperationId
@@ -63,6 +103,8 @@ module UploadSession =
         | Finalized of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
         | CleanupReminderScheduled of operationId: UploadSessionOperationId * reminderTime: Instant
         | PhysicalStateDeleted of operationId: UploadSessionOperationId
+        | BlockUploadIntentRegistered of operationId: UploadSessionOperationId * intent: BlockUploadIntent
+        | BlockUploadConfirmed of operationId: UploadSessionOperationId * confirmedBlock: ConfirmedBlockUpload
 
         static member GetKnownTypes() = GetKnownTypes<UploadSessionEventType>()
 
@@ -85,6 +127,8 @@ module UploadSession =
             StartedAt: Instant
             CompletedAt: Instant option
             FinalizedManifestAddress: ManifestAddress option
+            BlockUploadIntents: BlockUploadIntent array
+            ConfirmedBlockUploads: ConfirmedBlockUpload array
             CleanupReminderScheduledAt: Instant option
             CleanupReminderOperationId: UploadSessionOperationId option
             LastOperationId: UploadSessionOperationId option
@@ -106,6 +150,8 @@ module UploadSession =
                 StartedAt = Constants.DefaultTimestamp
                 CompletedAt = None
                 FinalizedManifestAddress = None
+                BlockUploadIntents = Array.empty
+                ConfirmedBlockUploads = Array.empty
                 CleanupReminderScheduledAt = None
                 CleanupReminderOperationId = None
                 LastOperationId = None
@@ -156,6 +202,30 @@ module UploadSession =
                 }
             | UploadSessionEventType.PhysicalStateDeleted operationId ->
                 { current with LifecycleState = UploadSessionLifecycleState.StateDeleted; LastOperationId = Some operationId }
+            | UploadSessionEventType.BlockUploadIntentRegistered (operationId, intent) ->
+                let existing =
+                    current.BlockUploadIntents
+                    |> Array.filter (fun existingIntent ->
+                        existingIntent.ContentBlockAddress
+                        <> intent.ContentBlockAddress)
+
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.UploadingBlocks
+                    BlockUploadIntents = Array.append existing [| intent |]
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.BlockUploadConfirmed (operationId, confirmedBlock) ->
+                let existing =
+                    current.ConfirmedBlockUploads
+                    |> Array.filter (fun existingBlock ->
+                        existingBlock.ContentBlockAddress
+                        <> confirmedBlock.ContentBlockAddress)
+
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.UploadingBlocks
+                    ConfirmedBlockUploads = Array.append existing [| confirmedBlock |]
+                    LastOperationId = Some operationId
+                }
 
     [<GenerateSerializer>]
     type UploadSessionDecision =

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -203,15 +203,9 @@ module UploadSession =
             | UploadSessionEventType.PhysicalStateDeleted operationId ->
                 { current with LifecycleState = UploadSessionLifecycleState.StateDeleted; LastOperationId = Some operationId }
             | UploadSessionEventType.BlockUploadIntentRegistered (operationId, intent) ->
-                let existing =
-                    current.BlockUploadIntents
-                    |> Array.filter (fun existingIntent ->
-                        existingIntent.ContentBlockAddress
-                        <> intent.ContentBlockAddress)
-
                 { current with
                     LifecycleState = UploadSessionLifecycleState.UploadingBlocks
-                    BlockUploadIntents = Array.append existing [| intent |]
+                    BlockUploadIntents = Array.append current.BlockUploadIntents [| intent |]
                     LastOperationId = Some operationId
                 }
             | UploadSessionEventType.BlockUploadConfirmed (operationId, confirmedBlock) ->


### PR DESCRIPTION
## Summary

Implements ADR-0001 U2 block upload intents and confirmation through `UploadSession` and authoritative physical metadata range merging through `ContentBlockMetadata`.

- Adds upload-session intent registration, block confirmation, payload/address validation, and idempotent operation replay.
- Adds content-block physical range merge commands/events, preserving duplicate physical placements and rejecting incompatible metadata placement changes.
- Adds actor tests for RED/GREEN coverage, corruption checks, idempotency, repeated intents, duplicate intent confirmation, logical-length validation, null placement validation, physical range overflow, active-byte overflow, active/total invariant enforcement, relocated physical ranges, range-presence aggregation, and storage object-key mismatch rejection.

Closes #90.

## Changed files

- `src/Grace.Types/UploadSession.Types.fs`
- `src/Grace.Types/ContentBlockMetadata.Types.fs`
- `src/Grace.Actors/UploadSession.Actor.fs`
- `src/Grace.Actors/ContentBlockMetadata.Actor.fs`
- `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs`
- `src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs`

## Validation

- RED evidence: focused actor tests failed before implementation because U2 contracts/state were missing (`RegisterBlockUploadIntent`, `ConfirmBlockUploaded`, upload-session intent/confirmation state, and `ContentBlockMetadataCommand.MergePhysicalRanges`). Later review RED evidence covered null placement faults, duplicate-intent confirmation selecting the wrong intent, null existing metadata placement, physical end overflow, active byte aggregation overflow, active bytes exceeding total bytes, and logical-length mismatch.
- `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests|FullyQualifiedName~ContentBlockMetadataActorTests"` - passed, 31/31.
- `dotnet tool run fantomas Grace.Types/UploadSession.Types.fs Grace.Types/ContentBlockMetadata.Types.fs Grace.Actors/UploadSession.Actor.fs Grace.Actors/ContentBlockMetadata.Actor.fs Grace.Server.Tests/UploadSession.Actor.Tests.fs Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs` - passed.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed.
- `pwsh ./scripts/validate.ps1 -Full` - passed, 21 authorization tests, 200 CLI tests plus 1 skipped, 49 types tests, 253 server tests.

## Docs impact

No public route or OpenAPI surface was added; this is actor/type behavior only, so no route docs were updated.

## Review feedback addressed

- Preserved repeated upload intents for the same content block at different logical offsets.
- Allowed relocated physical range merges by treating physical placement as part of range identity.
- Aggregated duplicate ordinal ranges so any active physical copy reports active presence.
- Rejected object-key changes when merging into existing content-block metadata.
- Returned domain `GraceError` results for null upload-confirm and metadata-merge storage placements.
- Matched confirmations against any compatible duplicate intent for the content block address.
- Returned a domain `GraceError` when existing metadata has a null storage placement during merge.
- Rejected physical ranges whose `PhysicalOffset + PhysicalLength` would overflow `Int64.MaxValue`.
- Rejected active physical byte aggregation that would overflow `Int64.MaxValue`.
- Rejected merge results where active physical bytes exceed total physical bytes.
- Rejected confirmations whose decoded logical length does not match a compatible intent.

## Skipped validation

None. Earlier local validation attempts hit infrastructure/process issues outside the code path: one stale `testhost` lock and one Service Bus emulator startup timeout. After clearing/retrying, focused tests, fast, and full all passed.

## Residual risk

The confirm behavior is currently exercised at the actor/type layer. No public HTTP endpoint is exposed in this slice, so API-client integration remains for a future public route slice if one is added.

## Follow-ups

- Wire these actor commands into a public confirm endpoint if a later ADR DAG issue introduces that service surface.