### PR TITLE
Add manifest contribution workflow actor

### DIFF
--- a/src/Grace.Actors/AGENTS.md
+++ b/src/Grace.Actors/AGENTS.md
@@ -25,6 +25,9 @@ Start with `../AGENTS.md` for global rules before working on Orleans code.
    expiration. They must not delete accepted manifests, content blocks, block metadata, or contribution accounting.
 5. `ContentBlockMetadataActor` is keyed by the StoragePoolId and ContentBlockAddress composite key. Preserve whole-record
    MetadataVersion concurrency and exact range presence semantics; do not introduce per-chunk actor or grain state.
+6. `ManifestContributionWorkflowActor` is keyed by RepositoryId and ManifestAddress. It owns only durable fan-out progress
+   for active range-count contribution; repository-local reference counts stay in `RepositoryContentCounterActor`, and
+   physical range metadata stays in `ContentBlockMetadataActor`.
 
 ## Validation
 

--- a/src/Grace.Actors/Constants.Actor.fs
+++ b/src/Grace.Actors/Constants.Actor.fs
@@ -110,6 +110,9 @@ module Constants =
         let RepositoryContentCounter = "RepositoryContentCounterActor"
 
         [<Literal>]
+        let ManifestContributionWorkflow = "ManifestContributionWorkflowActor"
+
+        [<Literal>]
         let User = "UserActor"
 
         [<Literal>]
@@ -193,6 +196,9 @@ module Constants =
 
         [<Literal>]
         let RepositoryContentCounter = "RepoContentCounter"
+
+        [<Literal>]
+        let ManifestContributionWorkflow = "ManifestContributionWorkflow"
 
         [<Literal>]
         let User = "User"

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -53,6 +53,7 @@
         <Compile Include="ContentBlockMetadata.Actor.fs" />
         <Compile Include="UploadSession.Actor.fs" />
         <Compile Include="RepositoryContentCounter.Actor.fs" />
+        <Compile Include="ManifestContributionWorkflow.Actor.fs" />
         <Compile Include="PromotionQueue.Actor.fs" />
         <Compile Include="Repository.Actor.fs" />
         <Compile Include="RepositoryName.Actor.fs" />

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -11,6 +11,7 @@ open Grace.Types.Reference
 open Grace.Types.Reminder
 open Grace.Types.Repository
 open Grace.Types.RepositoryContentCounter
+open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.Organization
 open Grace.Types.Owner
 open Grace.Types.PersonalAccessToken
@@ -606,6 +607,30 @@ module Interfaces =
 
         /// Validates incoming commands and converts them to persisted events and zero-crossing intents.
         abstract member Handle: command: RepositoryContentCounterCommand -> eventMetadata: EventMetadata -> Task<GraceResult<RepositoryContentCounterDecision>>
+
+    /// Defines the operations for the ManifestContributionWorkflow actor.
+    [<Interface>]
+    type IManifestContributionWorkflowActor =
+        inherit IGrainWithStringKey
+
+        /// Returns true if this manifest contribution workflow has been initialized.
+        abstract member Exists: correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the current workflow state.
+        abstract member Get: correlationId: CorrelationId -> Task<ManifestContributionWorkflowDto>
+
+        /// Returns the ranges that still need active-count fan-out.
+        abstract member GetPendingRanges: correlationId: CorrelationId -> Task<ManifestContributionWorkflowRange array>
+
+        /// Returns true when this workflow still owns pending work for the range.
+        abstract member BlocksUnsafeDeletion: range: ManifestContributionWorkflowRange -> correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the events handled by this manifest contribution workflow.
+        abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<ManifestContributionWorkflowEvent>>
+
+        /// Validates incoming commands and converts them to persisted workflow progress and fan-out intents.
+        abstract member Handle:
+            command: ManifestContributionWorkflowCommand -> eventMetadata: EventMetadata -> Task<GraceResult<ManifestContributionWorkflowDecision>>
 
     /// Defines the operations for the RepositoryName actor.
     [<Interface>]

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -1,0 +1,273 @@
+namespace Grace.Actors
+
+open Grace.Actors.Constants
+open Grace.Actors.Context
+open Grace.Actors.Interfaces
+open Grace.Actors.Services
+open Grace.Shared.Utilities
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.Types
+open Microsoft.Extensions.Logging
+open Orleans
+open Orleans.Runtime
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module ManifestContributionWorkflow =
+
+    let primaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
+
+    let commandName command =
+        match command with
+        | ManifestContributionWorkflowCommand.Start _ -> "Start"
+        | ManifestContributionWorkflowCommand.RecordRangeSucceeded _ -> "RecordRangeSucceeded"
+        | ManifestContributionWorkflowCommand.RecordRangeFailed _ -> "RecordRangeFailed"
+
+    let operationId command =
+        match command with
+        | ManifestContributionWorkflowCommand.Start start -> start.OperationId
+        | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, _) -> operationId
+        | ManifestContributionWorkflowCommand.RecordRangeFailed (operationId, _, _) -> operationId
+
+    let private eventOperationId workflowEvent =
+        match workflowEvent.Event with
+        | ManifestContributionWorkflowEventType.WorkflowStarted start -> start.OperationId
+        | ManifestContributionWorkflowEventType.RangeSucceeded (operationId, _) -> operationId
+        | ManifestContributionWorkflowEventType.RangeFailed (operationId, _, _) -> operationId
+
+    let private eventCommandName workflowEvent =
+        match workflowEvent.Event with
+        | ManifestContributionWorkflowEventType.WorkflowStarted _ -> "Start"
+        | ManifestContributionWorkflowEventType.RangeSucceeded _ -> "RecordRangeSucceeded"
+        | ManifestContributionWorkflowEventType.RangeFailed _ -> "RecordRangeFailed"
+
+    let private tryFindAppliedOperation (events: seq<ManifestContributionWorkflowEvent>) operationId =
+        events
+        |> Seq.tryFind (fun workflowEvent -> eventOperationId workflowEvent = operationId)
+
+    let private applyEvents (events: ManifestContributionWorkflowEvent list) (workflow: ManifestContributionWorkflowDto) =
+        events
+        |> List.fold (fun current event -> ManifestContributionWorkflowDto.UpdateDto event current) workflow
+
+    let pendingRanges (workflow: ManifestContributionWorkflowDto) =
+        workflow.Ranges
+        |> Array.filter (fun range -> not (workflow.CompletedRanges.ContainsKey range))
+
+    let blocksUnsafeDeletion (workflow: ManifestContributionWorkflowDto) range =
+        workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress
+        && pendingRanges workflow |> Array.exists ((=) range)
+
+    let private isKnownRange (workflow: ManifestContributionWorkflowDto) range = workflow.Ranges |> Array.exists ((=) range)
+
+    let private targetMismatch (workflow: ManifestContributionWorkflowDto) (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) =
+        (workflow.RepositoryId <> RepositoryId.Empty
+         && workflow.RepositoryId <> repositoryId)
+        || (not (String.IsNullOrWhiteSpace workflow.ManifestAddress)
+            && workflow.ManifestAddress <> manifestAddress)
+
+    let private expectedPrimaryKeyMismatch expectedPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) =
+        match expectedPrimaryKey with
+        | Some expectedPrimaryKey -> not (String.Equals(expectedPrimaryKey, primaryKey repositoryId manifestAddress, StringComparison.Ordinal))
+        | None -> false
+
+    let private activeCountDelta direction =
+        match direction with
+        | ManifestContributionDirection.Increment -> 1
+        | ManifestContributionDirection.Decrement -> -1
+
+    let private okDecision workflow operationId events intents wasReplay message =
+        Ok
+            {
+                Workflow = applyEvents events workflow
+                OperationId = operationId
+                Events = events
+                Intents = intents
+                WasIdempotentReplay = wasReplay
+                Message = message
+            }
+
+    let private graceError correlationId message = GraceError.Create message correlationId
+
+    let private validateRange correlationId range =
+        if String.IsNullOrWhiteSpace range.StoragePoolId then
+            Some(graceError correlationId "ManifestContributionWorkflow range requires a non-empty StoragePoolId.")
+        elif String.IsNullOrWhiteSpace range.ContentBlockAddress then
+            Some(graceError correlationId "ManifestContributionWorkflow range requires a non-empty ContentBlockAddress.")
+        elif range.OrdinalStart < 0 then
+            Some(graceError correlationId "ManifestContributionWorkflow range OrdinalStart must be zero or greater.")
+        elif range.OrdinalCount <= 0 then
+            Some(graceError correlationId "ManifestContributionWorkflow range OrdinalCount must be greater than zero.")
+        else
+            None
+
+    let private validateStart
+        expectedPrimaryKey
+        (workflow: ManifestContributionWorkflowDto)
+        (start: StartManifestContributionWorkflow)
+        (metadata: EventMetadata)
+        =
+        if start.RepositoryId = RepositoryId.Empty then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires a non-empty RepositoryId.")
+        elif String.IsNullOrWhiteSpace start.ManifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires a non-empty ManifestAddress.")
+        elif expectedPrimaryKeyMismatch expectedPrimaryKey start.RepositoryId start.ManifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the grain key.")
+        elif targetMismatch workflow start.RepositoryId start.ManifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the initialized workflow.")
+        elif
+            workflow.LifecycleState
+            <> ManifestContributionWorkflowLifecycleState.NotStarted
+            && not (String.IsNullOrWhiteSpace workflow.ManifestAddress)
+        then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow has already been started.")
+        elif Array.isEmpty start.Ranges then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires at least one range.")
+        else
+            start.Ranges
+            |> Array.tryPick (validateRange metadata.CorrelationId)
+
+    let decideCommandForKey
+        (expectedPrimaryKey: string option)
+        (events: seq<ManifestContributionWorkflowEvent>)
+        (workflow: ManifestContributionWorkflowDto)
+        (command: ManifestContributionWorkflowCommand)
+        (metadata: EventMetadata)
+        : Result<ManifestContributionWorkflowDecision, GraceError>
+        =
+        let operationId = operationId command
+
+        if String.IsNullOrWhiteSpace operationId then
+            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow command requires a non-empty operation id.")
+        else
+            match tryFindAppliedOperation events operationId with
+            | Some workflowEvent when
+                eventCommandName workflowEvent
+                <> commandName command
+                ->
+                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used for a different command.")
+            | Some _ -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
+            | None ->
+                match command with
+                | ManifestContributionWorkflowCommand.Start start ->
+                    match validateStart expectedPrimaryKey workflow start metadata with
+                    | Some error -> Error error
+                    | None ->
+                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
+                        okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
+                | ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, range) ->
+                    if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                    elif not (isKnownRange workflow range) then
+                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                    elif workflow.CompletedRanges.ContainsKey range then
+                        okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                    else
+                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded(operationId, range); Metadata = metadata }
+
+                        let intents =
+                            [
+                                ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range, activeCountDelta workflow.Direction)
+                            ]
+
+                        okDecision workflow operationId [ workflowEvent ] intents false "Manifest contribution workflow range completed."
+                | ManifestContributionWorkflowCommand.RecordRangeFailed (_, range, message) ->
+                    if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                    elif not (isKnownRange workflow range) then
+                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                    elif workflow.CompletedRanges.ContainsKey range then
+                        okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                    else
+                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed(operationId, range, message); Metadata = metadata }
+
+                        okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow range failure recorded."
+
+    let decideCommand events workflow command metadata = decideCommandForKey None events workflow command metadata
+
+    type ManifestContributionWorkflowActor
+        (
+            [<PersistentState(StateName.ManifestContributionWorkflow, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<List<ManifestContributionWorkflowEvent>>
+        ) =
+        inherit Grain()
+
+        let log = loggerFactory.CreateLogger("ManifestContributionWorkflow.Actor")
+        let mutable workflow = ManifestContributionWorkflowDto.Default
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override this.OnActivateAsync(ct) =
+            let activateStartTime = getCurrentInstant ()
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+
+            workflow <-
+                state.State
+                |> Seq.fold (fun dto event -> ManifestContributionWorkflowDto.UpdateDto event dto) ManifestContributionWorkflowDto.Default
+
+            Task.CompletedTask
+
+        member private this.ApplyEvents(events: ManifestContributionWorkflowEvent list) =
+            task {
+                state.State.AddRange(events)
+                do! state.WriteStateAsync()
+                workflow <- applyEvents events workflow
+            }
+
+        interface IHasRepositoryId with
+            member this.GetRepositoryId correlationId =
+                this.correlationId <- correlationId
+                workflow.RepositoryId |> returnTask
+
+        interface IManifestContributionWorkflowActor with
+            member this.Exists correlationId =
+                this.correlationId <- correlationId
+
+                (workflow.RepositoryId <> RepositoryId.Empty
+                 && not (String.IsNullOrWhiteSpace workflow.ManifestAddress))
+                |> returnTask
+
+            member this.Get correlationId =
+                this.correlationId <- correlationId
+                workflow |> returnTask
+
+            member this.GetPendingRanges correlationId =
+                this.correlationId <- correlationId
+                pendingRanges workflow |> returnTask
+
+            member this.BlocksUnsafeDeletion range correlationId =
+                this.correlationId <- correlationId
+                blocksUnsafeDeletion workflow range |> returnTask
+
+            member this.GetEvents correlationId =
+                this.correlationId <- correlationId
+
+                (state.State :> IReadOnlyList<ManifestContributionWorkflowEvent>)
+                |> returnTask
+
+            member this.Handle command metadata =
+                task {
+                    this.correlationId <- metadata.CorrelationId
+                    RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
+
+                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) state.State workflow command metadata with
+                    | Ok decision ->
+                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
+                        let returnValue =
+                            (GraceReturnValue.Create decision metadata.CorrelationId)
+                                .enhance(nameof RepositoryId, decision.Workflow.RepositoryId)
+                                .enhance(nameof ManifestAddress, decision.Workflow.ManifestAddress)
+                                .enhance (nameof ManifestContributionWorkflowLifecycleState, decision.Workflow.LifecycleState)
+
+                        return Ok returnValue
+                    | Error error ->
+                        log.LogWarning(
+                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected ManifestContributionWorkflow command {Command}. Error: {Error}",
+                            getCurrentInstantExtended (),
+                            getMachineName,
+                            metadata.CorrelationId,
+                            commandName command,
+                            error.Error
+                        )
+
+                        return Error error
+                }

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -42,6 +42,27 @@ module ManifestContributionWorkflow =
         | ManifestContributionWorkflowEventType.RangeSucceeded _ -> "RecordRangeSucceeded"
         | ManifestContributionWorkflowEventType.RangeFailed _ -> "RecordRangeFailed"
 
+    let private rangesEqual left right =
+        Array.length left = Array.length right
+        && Seq.forall2 (=) left right
+
+    let private startMatches (existing: StartManifestContributionWorkflow) (candidate: StartManifestContributionWorkflow) =
+        existing.RepositoryId = candidate.RepositoryId
+        && existing.ManifestAddress = candidate.ManifestAddress
+        && existing.Direction = candidate.Direction
+        && rangesEqual existing.Ranges candidate.Ranges
+
+    let private eventMatchesCommand workflowEvent command =
+        match workflowEvent.Event, command with
+        | ManifestContributionWorkflowEventType.WorkflowStarted existing, ManifestContributionWorkflowCommand.Start candidate -> startMatches existing candidate
+        | ManifestContributionWorkflowEventType.RangeSucceeded (_, existingRange), ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, candidateRange) ->
+            existingRange = candidateRange
+        | ManifestContributionWorkflowEventType.RangeFailed (_, existingRange, existingMessage),
+          ManifestContributionWorkflowCommand.RecordRangeFailed (_, candidateRange, candidateMessage) ->
+            existingRange = candidateRange
+            && existingMessage = candidateMessage
+        | _ -> false
+
     let private tryFindAppliedOperation (events: seq<ManifestContributionWorkflowEvent>) operationId =
         events
         |> Seq.tryFind (fun workflowEvent -> eventOperationId workflowEvent = operationId)
@@ -101,6 +122,12 @@ module ManifestContributionWorkflow =
         else
             None
 
+    let private hasDuplicateRanges ranges =
+        let seen = HashSet<ManifestContributionWorkflowRange>()
+
+        ranges
+        |> Array.exists (fun range -> not (seen.Add range))
+
     let private validateStart
         expectedPrimaryKey
         (workflow: ManifestContributionWorkflowDto)
@@ -123,6 +150,8 @@ module ManifestContributionWorkflow =
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow has already been started.")
         elif Array.isEmpty start.Ranges then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires at least one range.")
+        elif hasDuplicateRanges start.Ranges then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow ranges must be unique.")
         else
             start.Ranges
             |> Array.tryPick (validateRange metadata.CorrelationId)
@@ -146,6 +175,8 @@ module ManifestContributionWorkflow =
                 <> commandName command
                 ->
                 Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used for a different command.")
+            | Some workflowEvent when not (eventMatchesCommand workflowEvent command) ->
+                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used with a different payload.")
             | Some _ -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
             | None ->
                 match command with

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -27,14 +27,14 @@ module ManifestContributionWorkflow =
     let operationId command =
         match command with
         | ManifestContributionWorkflowCommand.Start start -> start.OperationId
-        | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, _) -> operationId
-        | ManifestContributionWorkflowCommand.RecordRangeFailed (operationId, _, _) -> operationId
+        | ManifestContributionWorkflowCommand.RecordRangeSucceeded progress -> progress.OperationId
+        | ManifestContributionWorkflowCommand.RecordRangeFailed failure -> failure.OperationId
 
     let private eventOperationId workflowEvent =
         match workflowEvent.Event with
         | ManifestContributionWorkflowEventType.WorkflowStarted start -> start.OperationId
-        | ManifestContributionWorkflowEventType.RangeSucceeded (operationId, _) -> operationId
-        | ManifestContributionWorkflowEventType.RangeFailed (operationId, _, _) -> operationId
+        | ManifestContributionWorkflowEventType.RangeSucceeded progress -> progress.OperationId
+        | ManifestContributionWorkflowEventType.RangeFailed failure -> failure.OperationId
 
     let private eventCommandName workflowEvent =
         match workflowEvent.Event with
@@ -55,12 +55,9 @@ module ManifestContributionWorkflow =
     let private eventMatchesCommand workflowEvent command =
         match workflowEvent.Event, command with
         | ManifestContributionWorkflowEventType.WorkflowStarted existing, ManifestContributionWorkflowCommand.Start candidate -> startMatches existing candidate
-        | ManifestContributionWorkflowEventType.RangeSucceeded (_, existingRange), ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, candidateRange) ->
-            existingRange = candidateRange
-        | ManifestContributionWorkflowEventType.RangeFailed (_, existingRange, existingMessage),
-          ManifestContributionWorkflowCommand.RecordRangeFailed (_, candidateRange, candidateMessage) ->
-            existingRange = candidateRange
-            && existingMessage = candidateMessage
+        | ManifestContributionWorkflowEventType.RangeSucceeded existing, ManifestContributionWorkflowCommand.RecordRangeSucceeded candidate ->
+            existing = candidate
+        | ManifestContributionWorkflowEventType.RangeFailed existing, ManifestContributionWorkflowCommand.RecordRangeFailed candidate -> existing = candidate
         | _ -> false
 
     let private tryFindAppliedOperation (events: seq<ManifestContributionWorkflowEvent>) operationId =
@@ -142,11 +139,7 @@ module ManifestContributionWorkflow =
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the grain key.")
         elif targetMismatch workflow start.RepositoryId start.ManifestAddress then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the initialized workflow.")
-        elif
-            workflow.LifecycleState
-            <> ManifestContributionWorkflowLifecycleState.NotStarted
-            && not (String.IsNullOrWhiteSpace workflow.ManifestAddress)
-        then
+        elif workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow has already been started.")
         elif Array.isEmpty start.Ranges then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires at least one range.")
@@ -155,6 +148,18 @@ module ManifestContributionWorkflow =
         else
             start.Ranges
             |> Array.tryPick (validateRange metadata.CorrelationId)
+
+    let private validateProgressTarget expectedPrimaryKey (workflow: ManifestContributionWorkflowDto) repositoryId manifestAddress (metadata: EventMetadata) =
+        if repositoryId = RepositoryId.Empty then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires a non-empty RepositoryId.")
+        elif String.IsNullOrWhiteSpace manifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires a non-empty ManifestAddress.")
+        elif expectedPrimaryKeyMismatch expectedPrimaryKey repositoryId manifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the grain key.")
+        elif targetMismatch workflow repositoryId manifestAddress then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the initialized workflow.")
+        else
+            None
 
     let decideCommandForKey
         (expectedPrimaryKey: string option)
@@ -186,33 +191,39 @@ module ManifestContributionWorkflow =
                     | None ->
                         let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
                         okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
-                | ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, range) ->
-                    if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
-                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
-                    elif not (isKnownRange workflow range) then
-                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                    elif workflow.CompletedRanges.ContainsKey range then
-                        okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
-                    else
-                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded(operationId, range); Metadata = metadata }
+                | ManifestContributionWorkflowCommand.RecordRangeSucceeded progress ->
+                    match validateProgressTarget expectedPrimaryKey workflow progress.RepositoryId progress.ManifestAddress metadata with
+                    | Some error -> Error error
+                    | None ->
+                        if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                        elif not (isKnownRange workflow progress.Range) then
+                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                        elif workflow.CompletedRanges.ContainsKey progress.Range then
+                            okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                        else
+                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded progress; Metadata = metadata }
 
-                        let intents =
-                            [
-                                ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range, activeCountDelta workflow.Direction)
-                            ]
+                            let intents =
+                                [
+                                    ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(progress.Range, activeCountDelta workflow.Direction)
+                                ]
 
-                        okDecision workflow operationId [ workflowEvent ] intents false "Manifest contribution workflow range completed."
-                | ManifestContributionWorkflowCommand.RecordRangeFailed (_, range, message) ->
-                    if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
-                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
-                    elif not (isKnownRange workflow range) then
-                        Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                    elif workflow.CompletedRanges.ContainsKey range then
-                        okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
-                    else
-                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed(operationId, range, message); Metadata = metadata }
+                            okDecision workflow operationId [ workflowEvent ] intents false "Manifest contribution workflow range completed."
+                | ManifestContributionWorkflowCommand.RecordRangeFailed failure ->
+                    match validateProgressTarget expectedPrimaryKey workflow failure.RepositoryId failure.ManifestAddress metadata with
+                    | Some error -> Error error
+                    | None ->
+                        if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                        elif not (isKnownRange workflow failure.Range) then
+                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                        elif workflow.CompletedRanges.ContainsKey failure.Range then
+                            okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                        else
+                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed failure; Metadata = metadata }
 
-                        okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow range failure recorded."
+                            okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow range failure recorded."
 
     let decideCommand events workflow command metadata = decideCommandForKey None events workflow command metadata
 

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="UploadSession.Actor.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
+    <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -22,15 +22,11 @@ type ManifestContributionWorkflowActorTests() =
 
     let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
 
-    let start direction =
+    let startWithRanges direction ranges =
         ManifestContributionWorkflowCommand.Start
-            {
-                OperationId = "workflow-start"
-                RepositoryId = repositoryId
-                ManifestAddress = manifestAddress
-                Direction = direction
-                Ranges = [| range0; range1 |]
-            }
+            { OperationId = "workflow-start"; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Direction = direction; Ranges = ranges }
+
+    let start direction = startWithRanges direction [| range0; range1 |]
 
     let succeeded operationId range = ManifestContributionWorkflowCommand.RecordRangeSucceeded(operationId, range)
 
@@ -52,6 +48,60 @@ type ManifestContributionWorkflowActorTests() =
         let key = ManifestContributionWorkflowActor.primaryKey repositoryId manifestAddress
 
         Assert.That(key, Is.EqualTo("a6c6b60ad4d240f68362258dbe75a5bf|manifest:blake3:alpha"))
+
+    [<Test>]
+    member _.StartRejectsDuplicateRanges() =
+        let duplicateStart = startWithRanges ManifestContributionDirection.Increment [| range0; range0 |]
+
+        let result = ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default duplicateStart (metadata "corr-duplicate")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected duplicate ranges to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow ranges must be unique."))
+
+    [<Test>]
+    member _.ReusedStartOperationIdWithDifferentPayloadRejectsInsteadOfReplaying() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+        let mismatchedStart = startWithRanges ManifestContributionDirection.Increment [| range0 |]
+
+        let replay = ManifestContributionWorkflowActor.decideCommand started.Events afterStart mismatchedStart (metadata "corr-start-reused")
+
+        match replay with
+        | Ok _ -> Assert.Fail("Expected reused start operation id with different payload to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow operation id was already used with a different payload."))
+
+    [<Test>]
+    member _.ReusedRangeSuccessOperationIdWithDifferentRangeRejectsInsteadOfReplaying() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let firstSuccess =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-shared" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        let allEvents = started.Events @ firstSuccess.Events
+        let afterSuccess = applyAll firstSuccess.Events afterStart
+
+        let replay = ManifestContributionWorkflowActor.decideCommand allEvents afterSuccess (succeeded "range-shared" range1) (metadata "corr-range-reused")
+
+        match replay with
+        | Ok _ -> Assert.Fail("Expected reused range operation id with different range to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow operation id was already used with a different payload."))
 
     [<Test>]
     member _.ActivationResumeReturnsOnlyUncompletedRanges() =

--- a/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -26,11 +26,23 @@ type ManifestContributionWorkflowActorTests() =
         ManifestContributionWorkflowCommand.Start
             { OperationId = "workflow-start"; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Direction = direction; Ranges = ranges }
 
+    let startWithOperation operationId direction ranges =
+        ManifestContributionWorkflowCommand.Start
+            { OperationId = operationId; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Direction = direction; Ranges = ranges }
+
     let start direction = startWithRanges direction [| range0; range1 |]
 
-    let succeeded operationId range = ManifestContributionWorkflowCommand.RecordRangeSucceeded(operationId, range)
+    let progress operationId range = { OperationId = operationId; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Range = range }
 
-    let failed operationId range message = ManifestContributionWorkflowCommand.RecordRangeFailed(operationId, range, message)
+    let succeeded operationId range = ManifestContributionWorkflowCommand.RecordRangeSucceeded(progress operationId range)
+
+    let succeededFor repositoryId manifestAddress operationId range =
+        ManifestContributionWorkflowCommand.RecordRangeSucceeded
+            { OperationId = operationId; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Range = range }
+
+    let failed operationId range message =
+        ManifestContributionWorkflowCommand.RecordRangeFailed
+            { OperationId = operationId; RepositoryId = repositoryId; ManifestAddress = manifestAddress; Range = range; Message = message }
 
     let applyAll events current =
         events
@@ -102,6 +114,100 @@ type ManifestContributionWorkflowActorTests() =
         match replay with
         | Ok _ -> Assert.Fail("Expected reused range operation id with different range to reject.")
         | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow operation id was already used with a different payload."))
+
+    [<Test>]
+    member _.CompletedWorkflowCanStartNextCycleForSameManifest() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let range0Done =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        let afterRange0 = applyAll range0Done.Events afterStart
+
+        let range1Done =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events @ range0Done.Events)
+                afterRange0
+                (succeeded "range-1" range1)
+                (metadata "corr-range-1")
+            |> expectOk
+
+        let completedEvents =
+            started.Events
+            @ range0Done.Events @ range1Done.Events
+
+        let restarted =
+            ManifestContributionWorkflowActor.decideCommand
+                completedEvents
+                range1Done.Workflow
+                (startWithOperation "workflow-restart" ManifestContributionDirection.Decrement [| range0 |])
+                (metadata "corr-restart")
+            |> expectOk
+
+        Assert.That(restarted.Workflow.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
+        Assert.That(restarted.Workflow.Direction, Is.EqualTo(ManifestContributionDirection.Decrement))
+        let restartedPending = ManifestContributionWorkflowActor.pendingRanges restarted.Workflow
+        Assert.That(restartedPending.Length, Is.EqualTo(1))
+        Assert.That(restartedPending[0], Is.EqualTo(range0))
+
+    [<Test>]
+    member _.RangeProgressRejectsWhenActorKeyDoesNotMatchWorkflowTarget() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+        let wrongKey = ManifestContributionWorkflowActor.primaryKey (Guid.Parse("24560efe-bb67-4be8-b0d1-1a11990e66b1")) manifestAddress
+
+        let result =
+            ManifestContributionWorkflowActor.decideCommandForKey
+                (Some wrongKey)
+                started.Events
+                afterStart
+                (succeeded "range-wrong-key" range0)
+                (metadata "corr-wrong-key")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected range progress for a mismatched grain key to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow command target does not match the grain key."))
+
+    [<Test>]
+    member _.RangeProgressRejectsWhenCommandTargetDoesNotMatchWorkflowTarget() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+        let wrongRepositoryId = Guid.Parse("24560efe-bb67-4be8-b0d1-1a11990e66b1")
+
+        let result =
+            ManifestContributionWorkflowActor.decideCommandForKey
+                (Some(ManifestContributionWorkflowActor.primaryKey repositoryId manifestAddress))
+                started.Events
+                afterStart
+                (succeededFor wrongRepositoryId manifestAddress "range-wrong-target" range0)
+                (metadata "corr-wrong-target")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected range progress for a mismatched command target to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow command target does not match the grain key."))
 
     [<Test>]
     member _.ActivationResumeReturnsOnlyUncompletedRanges() =

--- a/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -1,0 +1,213 @@
+namespace Grace.Server.Tests
+
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
+
+[<Parallelizable(ParallelScope.All)>]
+type ManifestContributionWorkflowActorTests() =
+
+    let timestamp = Instant.FromUtc(2026, 5, 24, 14, 0)
+    let repositoryId = Guid.Parse("a6c6b60a-d4d2-40f6-8362-258dbe75a5bf")
+    let manifestAddress = "manifest:blake3:alpha"
+
+    let range0 = { StoragePoolId = StoragePoolId "pool-main"; ContentBlockAddress = ContentBlockAddress "block-a"; OrdinalStart = 0; OrdinalCount = 8 }
+
+    let range1 = { StoragePoolId = StoragePoolId "pool-main"; ContentBlockAddress = ContentBlockAddress "block-b"; OrdinalStart = 8; OrdinalCount = 4 }
+
+    let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+
+    let start direction =
+        ManifestContributionWorkflowCommand.Start
+            {
+                OperationId = "workflow-start"
+                RepositoryId = repositoryId
+                ManifestAddress = manifestAddress
+                Direction = direction
+                Ranges = [| range0; range1 |]
+            }
+
+    let succeeded operationId range = ManifestContributionWorkflowCommand.RecordRangeSucceeded(operationId, range)
+
+    let failed operationId range message = ManifestContributionWorkflowCommand.RecordRangeFailed(operationId, range, message)
+
+    let applyAll events current =
+        events
+        |> List.fold (fun state event -> ManifestContributionWorkflowDto.UpdateDto event state) current
+
+    let expectOk result =
+        match result with
+        | Ok decision -> decision
+        | Error error ->
+            Assert.Fail($"Expected command to succeed, got {error.Error}.")
+            Unchecked.defaultof<ManifestContributionWorkflowDecision>
+
+    [<Test>]
+    member _.WorkflowPrimaryKeyCombinesRepositoryIdAndManifestAddress() =
+        let key = ManifestContributionWorkflowActor.primaryKey repositoryId manifestAddress
+
+        Assert.That(key, Is.EqualTo("a6c6b60ad4d240f68362258dbe75a5bf|manifest:blake3:alpha"))
+
+    [<Test>]
+    member _.ActivationResumeReturnsOnlyUncompletedRanges() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let completedRange0 =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        let allEvents = started.Events @ completedRange0.Events
+        let afterActivation = applyAll allEvents ManifestContributionWorkflowDto.Default
+
+        Assert.That(afterActivation.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
+        let pending = ManifestContributionWorkflowActor.pendingRanges afterActivation
+        Assert.That(pending.Length, Is.EqualTo(1))
+        Assert.That(pending[0], Is.EqualTo(range1))
+
+    [<Test>]
+    member _.PartialBatchFailureRetriesOnlyFailedRangeAndThenCompletes() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let range0Done =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        let afterRange0 = applyAll range0Done.Events afterStart
+
+        let range1Failed =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events @ range0Done.Events)
+                afterRange0
+                (failed "range-1-failed" range1 "transient")
+                (metadata "corr-range-1-failed")
+            |> expectOk
+
+        let afterFailure = applyAll range1Failed.Events afterRange0
+
+        Assert.That(afterFailure.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
+        let pendingAfterFailure = ManifestContributionWorkflowActor.pendingRanges afterFailure
+        Assert.That(pendingAfterFailure.Length, Is.EqualTo(1))
+        Assert.That(pendingAfterFailure[0], Is.EqualTo(range1))
+        Assert.That(afterFailure.FailedRanges.ContainsKey(range1), Is.True)
+
+        let retrySucceeded =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events
+                 @ range0Done.Events @ range1Failed.Events)
+                afterFailure
+                (succeeded "range-1-retry" range1)
+                (metadata "corr-range-1-retry")
+            |> expectOk
+
+        Assert.That(retrySucceeded.Workflow.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.Completed))
+        Assert.That(ManifestContributionWorkflowActor.pendingRanges retrySucceeded.Workflow, Is.Empty)
+
+    [<Test>]
+    member _.RangeSuccessEmitsOneActiveCountIntentAndReplayDoesNotEmitSecondIntent() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let firstSuccess =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        Assert.That(firstSuccess.Intents.Length, Is.EqualTo(1))
+        Assert.That(firstSuccess.Intents[0], Is.EqualTo(ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range0, 1)))
+
+        let allEvents = started.Events @ firstSuccess.Events
+        let afterSuccess = applyAll firstSuccess.Events afterStart
+
+        let replay =
+            ManifestContributionWorkflowActor.decideCommand allEvents afterSuccess (succeeded "range-0" range0) (metadata "corr-range-0-replay")
+            |> expectOk
+
+        Assert.That(replay.WasIdempotentReplay, Is.True)
+        Assert.That(replay.Events, Is.Empty)
+        Assert.That(replay.Intents, Is.Empty)
+
+    [<Test>]
+    member _.IncrementAndDecrementDirectionsProduceOppositeActiveRangeDeltas() =
+        let startAndSucceed direction =
+            let started =
+                ManifestContributionWorkflowActor.decideCommand
+                    []
+                    ManifestContributionWorkflowDto.Default
+                    (start direction)
+                    (metadata $"corr-start-{direction}")
+                |> expectOk
+
+            let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata $"corr-range-{direction}")
+            |> expectOk
+
+        let increment = startAndSucceed ManifestContributionDirection.Increment
+        let decrement = startAndSucceed ManifestContributionDirection.Decrement
+
+        Assert.That(increment.Intents.Length, Is.EqualTo(1))
+        Assert.That(increment.Intents[0], Is.EqualTo(ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range0, 1)))
+        Assert.That(decrement.Intents.Length, Is.EqualTo(1))
+        Assert.That(decrement.Intents[0], Is.EqualTo(ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range0, -1)))
+
+    [<Test>]
+    member _.PendingWorkflowBlocksUnsafeDeletionUntilAllRangesComplete() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Decrement)
+                (metadata "corr-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion afterStart range0, Is.True)
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion afterStart range1, Is.True)
+
+        let range0Done =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "range-0" range0) (metadata "corr-range-0")
+            |> expectOk
+
+        let afterRange0 = applyAll range0Done.Events afterStart
+
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion afterRange0 range0, Is.False)
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion afterRange0 range1, Is.True)
+
+        let range1Done =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events @ range0Done.Events)
+                afterRange0
+                (succeeded "range-1" range1)
+                (metadata "corr-range-1")
+            |> expectOk
+
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion range1Done.Workflow range0, Is.False)
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion range1Done.Workflow range1, Is.False)

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -42,6 +42,7 @@
         <Compile Include="DirectoryVersion.Types.fs" />
         <Compile Include="UploadSession.Types.fs" />
         <Compile Include="RepositoryContentCounter.Types.fs" />
+        <Compile Include="ManifestContributionWorkflow.Types.fs" />
         <Compile Include="Reminder.Types.fs" />
         <Compile Include="Events.Types.fs" />
     </ItemGroup>

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -65,19 +65,38 @@ module ManifestContributionWorkflow =
             Ranges: ManifestContributionWorkflowRange array
         }
 
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowRangeProgress =
+        {
+            OperationId: ManifestContributionWorkflowOperationId
+            RepositoryId: RepositoryId
+            ManifestAddress: ManifestAddress
+            Range: ManifestContributionWorkflowRange
+        }
+
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowRangeFailure =
+        {
+            OperationId: ManifestContributionWorkflowOperationId
+            RepositoryId: RepositoryId
+            ManifestAddress: ManifestAddress
+            Range: ManifestContributionWorkflowRange
+            Message: string
+        }
+
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ManifestContributionWorkflowCommand =
         | Start of StartManifestContributionWorkflow
-        | RecordRangeSucceeded of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange
-        | RecordRangeFailed of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange * message: string
+        | RecordRangeSucceeded of ManifestContributionWorkflowRangeProgress
+        | RecordRangeFailed of ManifestContributionWorkflowRangeFailure
 
         static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowCommand>()
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ManifestContributionWorkflowEventType =
         | WorkflowStarted of start: StartManifestContributionWorkflow
-        | RangeSucceeded of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange
-        | RangeFailed of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange * message: string
+        | RangeSucceeded of ManifestContributionWorkflowRangeProgress
+        | RangeFailed of ManifestContributionWorkflowRangeFailure
 
         static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowEventType>()
 
@@ -150,27 +169,27 @@ module ManifestContributionWorkflow =
                     LifecycleState = lifecycle
                     LastOperationId = Some start.OperationId
                 }
-            | ManifestContributionWorkflowEventType.RangeSucceeded (operationId, range) ->
+            | ManifestContributionWorkflowEventType.RangeSucceeded progress ->
                 let completed = ManifestContributionWorkflowDto.CloneCompleted current.CompletedRanges
-                completed[range] <- operationId
+                completed[progress.Range] <- progress.OperationId
 
                 let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
-                failed.Remove(range) |> ignore
+                failed.Remove(progress.Range) |> ignore
 
                 { current with
                     CompletedRanges = completed
                     FailedRanges = failed
                     LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges completed.Count
-                    LastOperationId = Some operationId
+                    LastOperationId = Some progress.OperationId
                 }
-            | ManifestContributionWorkflowEventType.RangeFailed (operationId, range, message) ->
+            | ManifestContributionWorkflowEventType.RangeFailed failure ->
                 let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
-                failed[range] <- message
+                failed[failure.Range] <- failure.Message
 
                 { current with
                     FailedRanges = failed
                     LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges current.CompletedRanges.Count
-                    LastOperationId = Some operationId
+                    LastOperationId = Some failure.OperationId
                 }
 
     [<GenerateSerializer>]

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -1,0 +1,185 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open Orleans
+open System
+open System.Collections.Generic
+open System.Runtime.Serialization
+
+module ManifestContributionWorkflow =
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ManifestContributionDirection =
+        | Increment
+        | Decrement
+
+        static member GetKnownTypes() = GetKnownTypes<ManifestContributionDirection>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ManifestContributionWorkflowLifecycleState =
+        | NotStarted
+        | InProgress
+        | Completed
+
+        static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowLifecycleState>()
+
+    [<CLIMutable; GenerateSerializer; CustomComparison; CustomEquality>]
+    type ManifestContributionWorkflowRange =
+        {
+            StoragePoolId: StoragePoolId
+            ContentBlockAddress: ContentBlockAddress
+            OrdinalStart: int
+            OrdinalCount: int
+        }
+
+        interface IComparable with
+            member this.CompareTo other =
+                match other with
+                | :? ManifestContributionWorkflowRange as otherRange ->
+                    compare
+                        (this.StoragePoolId, this.ContentBlockAddress, this.OrdinalStart, this.OrdinalCount)
+                        (otherRange.StoragePoolId, otherRange.ContentBlockAddress, otherRange.OrdinalStart, otherRange.OrdinalCount)
+                | _ -> invalidArg (nameof other) "Cannot compare ManifestContributionWorkflowRange with a different type."
+
+        override this.Equals(other: obj) =
+            match other with
+            | :? ManifestContributionWorkflowRange as otherRange ->
+                this.StoragePoolId = otherRange.StoragePoolId
+                && this.ContentBlockAddress = otherRange.ContentBlockAddress
+                && this.OrdinalStart = otherRange.OrdinalStart
+                && this.OrdinalCount = otherRange.OrdinalCount
+            | _ -> false
+
+        override this.GetHashCode() = HashCode.Combine(this.StoragePoolId, this.ContentBlockAddress, this.OrdinalStart, this.OrdinalCount)
+
+    [<GenerateSerializer>]
+    type StartManifestContributionWorkflow =
+        {
+            OperationId: ManifestContributionWorkflowOperationId
+            RepositoryId: RepositoryId
+            ManifestAddress: ManifestAddress
+            Direction: ManifestContributionDirection
+            Ranges: ManifestContributionWorkflowRange array
+        }
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ManifestContributionWorkflowCommand =
+        | Start of StartManifestContributionWorkflow
+        | RecordRangeSucceeded of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange
+        | RecordRangeFailed of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange * message: string
+
+        static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowCommand>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ManifestContributionWorkflowEventType =
+        | WorkflowStarted of start: StartManifestContributionWorkflow
+        | RangeSucceeded of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange
+        | RangeFailed of operationId: ManifestContributionWorkflowOperationId * range: ManifestContributionWorkflowRange * message: string
+
+        static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowEventType>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ManifestContributionWorkflowIntent =
+        | AdjustRangeActiveManifestCount of range: ManifestContributionWorkflowRange * delta: int
+
+        static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowIntent>()
+
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowEvent = { Event: ManifestContributionWorkflowEventType; Metadata: EventMetadata }
+
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowDto =
+        {
+            Class: string
+            RepositoryId: RepositoryId
+            ManifestAddress: ManifestAddress
+            Direction: ManifestContributionDirection
+            Ranges: ManifestContributionWorkflowRange array
+            CompletedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>
+            FailedRanges: Dictionary<ManifestContributionWorkflowRange, string>
+            LifecycleState: ManifestContributionWorkflowLifecycleState
+            LastOperationId: ManifestContributionWorkflowOperationId option
+        }
+
+        static member Default =
+            {
+                Class = nameof ManifestContributionWorkflowDto
+                RepositoryId = RepositoryId.Empty
+                ManifestAddress = String.Empty
+                Direction = ManifestContributionDirection.Increment
+                Ranges = Array.empty
+                CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
+                FailedRanges = Dictionary<ManifestContributionWorkflowRange, string>()
+                LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted
+                LastOperationId = None
+            }
+
+        static member private Lifecycle ranges completedRanges =
+            if Array.isEmpty ranges then
+                ManifestContributionWorkflowLifecycleState.NotStarted
+            elif completedRanges = Array.length ranges then
+                ManifestContributionWorkflowLifecycleState.Completed
+            else
+                ManifestContributionWorkflowLifecycleState.InProgress
+
+        static member private CloneCompleted(completedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>) =
+            Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>(completedRanges)
+
+        static member private CloneFailed(failedRanges: Dictionary<ManifestContributionWorkflowRange, string>) =
+            Dictionary<ManifestContributionWorkflowRange, string>(failedRanges)
+
+        static member UpdateDto workflowEvent current =
+            match workflowEvent.Event with
+            | ManifestContributionWorkflowEventType.WorkflowStarted start ->
+                let lifecycle =
+                    if Array.isEmpty start.Ranges then
+                        ManifestContributionWorkflowLifecycleState.Completed
+                    else
+                        ManifestContributionWorkflowLifecycleState.InProgress
+
+                { current with
+                    RepositoryId = start.RepositoryId
+                    ManifestAddress = start.ManifestAddress
+                    Direction = start.Direction
+                    Ranges = Array.copy start.Ranges
+                    CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
+                    FailedRanges = Dictionary<ManifestContributionWorkflowRange, string>()
+                    LifecycleState = lifecycle
+                    LastOperationId = Some start.OperationId
+                }
+            | ManifestContributionWorkflowEventType.RangeSucceeded (operationId, range) ->
+                let completed = ManifestContributionWorkflowDto.CloneCompleted current.CompletedRanges
+                completed[range] <- operationId
+
+                let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
+                failed.Remove(range) |> ignore
+
+                { current with
+                    CompletedRanges = completed
+                    FailedRanges = failed
+                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges completed.Count
+                    LastOperationId = Some operationId
+                }
+            | ManifestContributionWorkflowEventType.RangeFailed (operationId, range, message) ->
+                let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
+                failed[range] <- message
+
+                { current with
+                    FailedRanges = failed
+                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges current.CompletedRanges.Count
+                    LastOperationId = Some operationId
+                }
+
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowDecision =
+        {
+            Workflow: ManifestContributionWorkflowDto
+            OperationId: ManifestContributionWorkflowOperationId
+            Events: ManifestContributionWorkflowEvent list
+            Intents: ManifestContributionWorkflowIntent list
+            WasIdempotentReplay: bool
+            Message: string
+        }

--- a/src/Grace.Types/Types.Types.fs
+++ b/src/Grace.Types/Types.Types.fs
@@ -143,6 +143,9 @@ module Types =
     /// Caller-supplied retry identity for repository-content-counter commands.
     type RepositoryContentCounterOperationId = string
 
+    /// Caller-supplied retry identity for manifest-contribution workflow commands.
+    type ManifestContributionWorkflowOperationId = string
+
     /// Repository-local count of live references to a manifest-backed file.
     type ReferenceCount = int64
 


### PR DESCRIPTION
Closes #96.

## Summary

- Adds `ManifestContributionWorkflow` contracts for repository/manifest-scoped range contribution progress.
- Adds `ManifestContributionWorkflowActor` keyed by `RepositoryId|ManifestAddress`, with activation replay, idempotent command handling, partial-failure progress, pending-range queries, and unsafe-deletion blocking for pending workflow ranges.
- Adds focused actor tests for primary key shape, activation resume, partial failure retry, exact-once active-count intents, increment/decrement deltas, and pending workflow deletion safety.
- Documents workflow state ownership in `src/Grace.Actors/AGENTS.md`.

## Touched paths / write-set expansion

- Stayed within the #96 owned paths: `src/Grace.Actors/*`, `src/Grace.Types/*`, and `src/Grace.Server.Tests/*`.
- No write-set expansion.

## RED evidence

- `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter ManifestContributionWorkflowActorTests` failed before implementation because `Grace.Types.ManifestContributionWorkflow` and `Grace.Actors.ManifestContributionWorkflow` did not exist yet.

## Validation

- `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter ManifestContributionWorkflowActorTests` - passed, 6 tests.
- `dotnet tool run fantomas Grace.Actors/Constants.Actor.fs Grace.Actors/Interfaces.Actor.fs Grace.Actors/ManifestContributionWorkflow.Actor.fs Grace.Types/Types.Types.fs Grace.Types/ManifestContributionWorkflow.Types.fs Grace.Server.Tests/ManifestContributionWorkflow.Actor.Tests.fs` - passed/unchanged after targeted formatting.
- `npx --yes markdownlint-cli2 "src/Grace.Actors/AGENTS.md"` - passed, 0 errors.
- `git diff --check` - passed.
- `pwsh ./scripts/validate.ps1 -Fast` - passed; build clean, Authorization/CLI/Types tests passed; existing CLI skip remained.
- `pwsh ./scripts/validate.ps1 -Full` - first run failed in shared Aspire HTTP readiness before server tests executed; immediate retry passed with all gates green, including 247 `Grace.Server.Tests`.

## Docs impact

- Updated `src/Grace.Actors/AGENTS.md` to make future agents aware that `ManifestContributionWorkflowActor` owns fan-out progress only; repository-local counts remain in `RepositoryContentCounterActor`, and physical range metadata remains in `ContentBlockMetadataActor`.

## Skipped validation

- None intentionally skipped.

## Residual risk

- The workflow currently returns `AdjustRangeActiveManifestCount` intents; integration into save/expiry boundaries and application to `ContentBlockMetadataActor` remains for downstream DAG issues.
- Local `-Full` showed one transient Aspire readiness failure before passing on retry, so CI should be watched for the same infrastructure flake.

## Follow-ups

- #97 should wire save-boundary integration to the durable increment workflow.
- #98/#105 should wire decrement and GC safety around completed/pending contribution workflows.