### PR TITLE
Add safe content block discovery endpoint

### DIFF
--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -397,3 +397,30 @@ module Storage =
                 logToConsole $"exception: {exceptionResponse.ToString()}"
                 return Error(GraceError.Create (exceptionResponse.ToString()) parameters.CorrelationId)
         }
+
+    /// Discovers reusable ContentBlock candidates for key chunks without treating empty results as absence.
+    let DiscoverContentBlocks (parameters: DiscoverContentBlocksParameters) =
+        task {
+            let correlationId = parameters.CorrelationId
+
+            try
+                let httpClient = getHttpClient correlationId
+                do! Auth.addAuthorizationHeader httpClient
+                let serviceUrl = $"{Current().ServerUri}/storage/discoverContentBlocks"
+                let jsonContent = createJsonContent parameters
+                let! response = httpClient.PostAsync(serviceUrl, jsonContent)
+
+                if response.IsSuccessStatusCode then
+                    let! discoveryResult = response.Content.ReadFromJsonAsync<GraceReturnValue<DiscoverContentBlocksResult>>(Constants.JsonSerializerOptions)
+
+                    return Ok discoveryResult
+                else
+                    let! errorMessage = response.Content.ReadAsStringAsync()
+
+                    return Error(GraceError.Create $"Failed to discover ContentBlocks; {errorMessage}" correlationId)
+            with
+            | ex ->
+                let exceptionResponse = ExceptionResponse.Create ex
+                logToConsole $"exception: {exceptionResponse.ToString()}"
+                return Error(GraceError.Create (exceptionResponse.ToString()) correlationId)
+        }

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -12,6 +12,7 @@ open System.Reflection
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
+open System.Net.Http.Headers
 
 [<NonParallelizable>]
 type StorageWholeFileCompatibility() =
@@ -220,6 +221,181 @@ type StorageContentBlockSasRoutes() =
             do! assertSuccessSasForContentBlock allowedDownload parameters.ContentBlockAddress
         }
 
+[<NonParallelizable>]
+type StorageContentBlockDiscoveryRoutes() =
+
+    let maxDiscoveryKeyChunkAddresses = 256
+
+    let createClientWithUserId (userId: string) =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    let createUnauthenticatedClient () =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client
+
+    let grantRoleAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId principalId roleId =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- scopeKind
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+        }
+
+    let createDiscoveryJson repositoryId (keyChunkAddresses: string array) =
+        let encodedAddresses =
+            keyChunkAddresses
+            |> Array.map JsonSerializer.Serialize
+            |> String.concat ","
+
+        String.Concat(
+            "{",
+            "\"OwnerId\":",
+            JsonSerializer.Serialize ownerId,
+            ",\"OrganizationId\":",
+            JsonSerializer.Serialize organizationId,
+            ",\"RepositoryId\":",
+            JsonSerializer.Serialize repositoryId,
+            ",\"CorrelationId\":",
+            JsonSerializer.Serialize(generateCorrelationId ()),
+            ",\"KeyChunkAddresses\":[",
+            encodedAddresses,
+            "]}"
+        )
+
+    let createJsonContentFromString (json: string) =
+        let content = new StringContent(json, Encoding.UTF8)
+        content.Headers.ContentType <- MediaTypeHeaderValue("application/json")
+        content
+
+    let tryGetJsonProperty (name: string) (element: JsonElement) =
+        element.EnumerateObject()
+        |> Seq.tryFind (fun property -> property.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+        |> Option.map (fun property -> property.Value)
+
+    let requireJsonProperty (name: string) (element: JsonElement) =
+        match tryGetJsonProperty name element with
+        | Some value -> value
+        | None ->
+            Assert.Fail($"Expected JSON property '{name}'.")
+            Unchecked.defaultof<JsonElement>
+
+    let postDiscoveryAsync (client: HttpClient) repositoryId keyChunkAddresses =
+        client.PostAsync("/storage/discoverContentBlocks", createJsonContentFromString (createDiscoveryJson repositoryId keyChunkAddresses))
+
+    [<Test>]
+    member _.DiscoveryRequiresRepositoryReadAndReturnsSafeEmptyNonAuthoritativeResults() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let repoReader = $"{Guid.NewGuid()}"
+
+            let requestedChunkAddresses =
+                [|
+                    $"chunk-{Guid.NewGuid():N}"
+                    $"chunk-{Guid.NewGuid():N}"
+                |]
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use unauthClient = createUnauthenticatedClient ()
+            use readerClient = createClientWithUserId repoReader
+            use unprivilegedClient = createClientWithUserId $"{Guid.NewGuid()}"
+
+            let! unauthDiscovery = postDiscoveryAsync unauthClient repositoryId requestedChunkAddresses
+            Assert.That(unauthDiscovery.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
+
+            let! deniedDiscovery = postDiscoveryAsync unprivilegedClient repositoryId requestedChunkAddresses
+            Assert.That(deniedDiscovery.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! allowedDiscovery = postDiscoveryAsync readerClient repositoryId requestedChunkAddresses
+            let! body = allowedDiscovery.Content.ReadAsStringAsync()
+            Assert.That(allowedDiscovery.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+
+            for requestedChunkAddress in requestedChunkAddresses do
+                Assert.That(body, Does.Not.Contain(requestedChunkAddress), "Discovery must not echo per-chunk existence probes.")
+
+            use document = JsonDocument.Parse(body)
+            let returnValue = requireJsonProperty "ReturnValue" document.RootElement
+            let policy = requireJsonProperty "Policy" returnValue
+            let candidates = requireJsonProperty "CandidateContentBlocks" returnValue
+
+            Assert.That(
+                (requireJsonProperty "MaxKeyChunkAddresses" policy)
+                    .GetInt32(),
+                Is.EqualTo(maxDiscoveryKeyChunkAddresses)
+            )
+
+            Assert.That(
+                (requireJsonProperty "PositiveCandidatesEnabled" policy)
+                    .GetBoolean(),
+                Is.False
+            )
+
+            Assert.That(
+                (requireJsonProperty "EmptyResponseMeansAbsent" policy)
+                    .GetBoolean(),
+                Is.False
+            )
+
+            Assert.That(
+                (requireJsonProperty "IsAuthoritative" policy)
+                    .GetBoolean(),
+                Is.False
+            )
+
+            Assert.That(
+                (requireJsonProperty "RequestedKeyChunkCount" returnValue)
+                    .GetInt32(),
+                Is.EqualTo(requestedChunkAddresses.Length)
+            )
+
+            Assert.That(
+                (requireJsonProperty "AcceptedKeyChunkCount" returnValue)
+                    .GetInt32(),
+                Is.EqualTo(requestedChunkAddresses.Length)
+            )
+
+            Assert.That(
+                (requireJsonProperty "IsPartial" returnValue)
+                    .GetBoolean(),
+                Is.True
+            )
+
+            Assert.That(candidates.GetArrayLength(), Is.EqualTo(0))
+        }
+
+    [<Test>]
+    member _.DiscoveryRejectsRequestsAboveMaxKeyChunkLimit() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let repoReader = $"{Guid.NewGuid()}"
+            let requestedChunkAddresses = Array.init (maxDiscoveryKeyChunkAddresses + 1) (fun index -> $"chunk-{index}-{Guid.NewGuid():N}")
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use readerClient = createClientWithUserId repoReader
+            let! response = postDiscoveryAsync readerClient repositoryId requestedChunkAddresses
+            let! body = response.Content.ReadAsStringAsync()
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain("KeyChunkAddresses"))
+            Assert.That(body, Does.Contain($"{maxDiscoveryKeyChunkAddresses}"))
+        }
+
 [<Parallelizable(ParallelScope.All)>]
 type StorageContentBlockSdkContract() =
 
@@ -256,3 +432,12 @@ type StorageContentBlockSdkContract() =
     member _.ContentBlockSasSdkMethodsMatchSharedParameterContracts() =
         assertSdkMethod "GetContentBlockUploadUri" "GetContentBlockUploadUriParameters"
         assertSdkMethod "GetContentBlockDownloadUri" "GetContentBlockDownloadUriParameters"
+
+    [<Test>]
+    member _.ContentBlockDiscoverySdkMethodMatchesSharedParameterContract() =
+        let parameterType = getStorageParameterType "DiscoverContentBlocksParameters"
+        Assert.That(parameterType, Is.Not.Null)
+        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
+        Assert.That(parameterType.GetProperty("KeyChunkAddresses"), Is.Not.Null)
+        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Null)
+        assertSdkMethod "DiscoverContentBlocks" "DiscoverContentBlocksParameters"

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -175,6 +175,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/review/report/get" Authenticated
             endpoint "POST" "/review/resolve" Authenticated
             endpoint "POST" "/storage/getDownloadUri" (Authorized(PathRead, Path))
+            endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepoRead, Repository))
             endpoint "POST" "/storage/getContentBlockDownloadUri" (Authorized(PathRead, Path))
             endpoint "POST" "/storage/getContentBlockUploadUri" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getUploadMetadataForFiles" (Authorized(PathWrite, Path))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1259,6 +1259,9 @@ module Application =
                         POST [ route "/getUploadMetadataForFiles" (composeHandlers requirePathWrite Storage.GetUploadMetadataForFiles)
                                |> addMetadata typeof<Storage.GetUploadMetadataForFilesParameters>
 
+                               route "/discoverContentBlocks" (composeHandlers requireRepoRead Storage.DiscoverContentBlocks)
+                               |> addMetadata typeof<Storage.DiscoverContentBlocksParameters>
+
                                route "/getDownloadUri" (composeHandlers requirePathRead Storage.GetDownloadUri)
                                |> addMetadata typeof<Storage.GetDownloadUriParameters>
 

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -71,6 +71,24 @@ module Storage =
 
         organizationId, repositoryId
 
+    let private createDiscoveryPolicy () : StorageParameterContracts.ContentBlockDiscoveryPolicy =
+        {
+            MaxKeyChunkAddresses = StorageParameterContracts.MaxDiscoveryKeyChunkAddresses
+            PositiveCandidatesEnabled = false
+            EmptyResponseMeansAbsent = false
+            IsAuthoritative = false
+        }
+
+    let private createEmptyDiscoveryResult requestedKeyChunkCount : StorageParameterContracts.DiscoverContentBlocksResult =
+        {
+            RequestedKeyChunkCount = requestedKeyChunkCount
+            AcceptedKeyChunkCount = requestedKeyChunkCount
+            Policy = createDiscoveryPolicy ()
+            CandidateContentBlocks = Array.empty
+            IsPartial = true
+            Message = "No positive ContentBlock candidates are returned yet. Empty discovery results are non-authoritative and do not prove absence."
+        }
+
     /// Gets the metadata stored in the object storage provider for the specified file.
     let getFileMetadata (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (context: HttpContext) =
         task {
@@ -163,6 +181,45 @@ module Storage =
                     logToConsole $"Exception in GetContentBlockDownloadUri: {(ExceptionResponse.Create ex)}"
 
                     return! context.WriteTextAsync $"{getCurrentInstantExtended ()} Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
+            }
+
+    /// Discovers reusable ContentBlocks for key chunks without exposing a per-chunk existence oracle.
+    let DiscoverContentBlocks: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+
+                try
+                    let! parameters = context.BindJsonAsync<DiscoverContentBlocksParameters>()
+
+                    let keyChunkAddresses =
+                        if isNull parameters.KeyChunkAddresses then
+                            Array.empty
+                        else
+                            parameters.KeyChunkAddresses
+
+                    Activity.Current.SetTag("keyChunkAddresses.Count", $"{keyChunkAddresses.Length}")
+                    |> ignore
+
+                    if keyChunkAddresses.Length > StorageParameterContracts.MaxDiscoveryKeyChunkAddresses then
+                        return!
+                            context
+                            |> result400BadRequest (
+                                GraceError.Create
+                                    $"KeyChunkAddresses must contain no more than {StorageParameterContracts.MaxDiscoveryKeyChunkAddresses} items."
+                                    correlationId
+                            )
+                    else
+                        return!
+                            context
+                            |> result200Ok (GraceReturnValue.Create (createEmptyDiscoveryResult keyChunkAddresses.Length) correlationId)
+                with
+                | ex ->
+                    logToConsole $"Exception in DiscoverContentBlocks: {(ExceptionResponse.Create ex)}"
+
+                    return!
+                        context
+                        |> result500ServerError (GraceError.Create (getErrorMessage StorageError.ObjectStorageException) correlationId)
             }
 
     /// Gets an upload URI for the specified file version that can be used by a Grace client.

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -6,6 +6,10 @@ open System
 
 module Storage =
 
+    /// Maximum number of key chunks accepted by the ContentBlock discovery endpoint in a single request.
+    [<Literal>]
+    let MaxDiscoveryKeyChunkAddresses = 256
+
     /// Parameters used by multiple endpoints in the /diff path.
     type StorageParameters() =
         inherit CommonParameters()
@@ -36,6 +40,37 @@ module Storage =
     type GetContentBlockDownloadUriParameters() =
         inherit StorageParameters()
         member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
+
+    /// Parameters for /storage/discoverContentBlocks.
+    ///
+    /// Discovery is intentionally bounded and non-authoritative in this phase. The server accepts at most
+    /// MaxDiscoveryKeyChunkAddresses key chunks and must not answer per-chunk existence questions.
+    type DiscoverContentBlocksParameters() =
+        inherit StorageParameters()
+        member val public KeyChunkAddresses = Array.empty<ChunkAddress> with get, set
+
+    /// Policy returned with ContentBlock discovery results so clients know the bounded, non-authoritative semantics.
+    type ContentBlockDiscoveryPolicy = { MaxKeyChunkAddresses: int; PositiveCandidatesEnabled: bool; EmptyResponseMeansAbsent: bool; IsAuthoritative: bool }
+
+    /// A possible ContentBlock reuse candidate.
+    ///
+    /// The initial discovery implementation returns no positive candidates yet; this DTO is reserved for later
+    /// index-backed discovery without changing the endpoint shape.
+    type ContentBlockDiscoveryCandidate = { ContentBlockAddress: ContentBlockAddress; MatchingKeyChunkCount: int }
+
+    /// Result for /storage/discoverContentBlocks.
+    ///
+    /// Empty CandidateContentBlocks values are safe hints only. They are never proof that requested chunks or future
+    /// ContentBlocks are absent.
+    type DiscoverContentBlocksResult =
+        {
+            RequestedKeyChunkCount: int
+            AcceptedKeyChunkCount: int
+            Policy: ContentBlockDiscoveryPolicy
+            CandidateContentBlocks: ContentBlockDiscoveryCandidate array
+            IsPartial: bool
+            Message: string
+        }
 
     type UploadMetadata = { RelativePath: RelativePath; BlobUriWithSasToken: Uri; Sha256Hash: Sha256Hash; ContentReference: FileContentReference }
 


### PR DESCRIPTION
Closes #91.

## Summary

- Adds `/storage/discoverContentBlocks` as the U3 discovery-empty-safe slice.
- Returns bounded discovery policy/config with safe empty, non-authoritative results and no positive candidates yet.
- Adds the shared request/response DTOs and SDK method for the discovery contract.
- Requires repository read authorization and records the endpoint in the authorization manifest.

## Changed files

- `src/Grace.Shared/Parameters/Storage.Parameters.fs`
- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.Server/Startup.Server.fs`
- `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs`
- `src/Grace.SDK/Storage.SDK.fs`
- `src/Grace.Server.Tests/Storage.Server.Tests.fs`

## Validation

- RED: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "StorageContentBlockDiscovery"` failed with `404 NotFound` for the missing discovery endpoint.
- GREEN focused: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "StorageContentBlockDiscovery|StorageContentBlockSdkContract"` passed, 5/5.
- Storage focused: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "Storage"` passed, 14/14.
- Formatting: `dotnet tool run fantomas Grace.Server/Storage.Server.fs Grace.Server/Startup.Server.fs Grace.Server/Security/EndpointAuthorizationManifest.Server.fs Grace.Shared/Parameters/Storage.Parameters.fs Grace.SDK/Storage.SDK.fs Grace.Server.Tests/Storage.Server.Tests.fs` passed.
- Whitespace: `git diff --check` passed.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast` passed: build clean; authorization tests 21/21; CLI tests 200 passed, 1 suite-defined skip; types tests 49/49.

## Docs impact

- Discovery limits and non-authoritative empty-response semantics are documented in the shared API/OpenAPI DTO comments.

## Skipped validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not touch hosted storage behavior, Aspire wiring, emulators, Service Bus, Cosmos DB, Redis, GC, compaction, or cross-service runtime behavior.

## Residual risk

- The discovery response intentionally returns no positive candidates until the later index-backed DAG slice, so clients must treat empty responses as hints only.

## Follow-ups

- Later DAG slices should populate positive candidates and claim/range behavior without changing the safe empty-response contract.
