### PR TITLE
Implement reuse range claims

### DIFF
--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -38,9 +38,11 @@ module UploadSession =
     let operationId command =
         match command with
         | UploadSessionCommand.Start start -> start.OperationId
+        | UploadSessionCommand.IssueDedupeDiscovery discovery when isNull (box discovery) -> String.Empty
         | UploadSessionCommand.IssueDedupeDiscovery discovery -> discovery.OperationId
         | UploadSessionCommand.RegisterBlockUploadIntent intent -> intent.OperationId
         | UploadSessionCommand.ConfirmBlockUploaded confirmation -> confirmation.OperationId
+        | UploadSessionCommand.ClaimReuseRanges claim when isNull (box claim) -> String.Empty
         | UploadSessionCommand.ClaimReuseRanges claim -> claim.OperationId
         | UploadSessionCommand.FinalizeManifest (operationId, _) -> operationId
         | UploadSessionCommand.Abandon operationId -> operationId

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -158,6 +158,9 @@ module UploadSession =
         && left.OrdinalCount = right.OrdinalCount
         && left.MetadataVersion = right.MetadataVersion
 
+    let private claimedRangeKey (range: ClaimedReuseRange) =
+        $"{range.StoragePoolId}|{range.ContentBlockAddress}|{range.OrdinalStart}|{range.OrdinalCount}|{range.MetadataVersion}"
+
     let private issueDedupeDiscovery (session: UploadSessionDto) (discovery: IssueDedupeDiscovery) (metadata: EventMetadata) =
         if discovery.MinimumReuseRunLength <= 0 then
             Error(graceError metadata.CorrelationId "MinimumReuseRunLength must be greater than zero.")
@@ -252,14 +255,21 @@ module UploadSession =
                 Error(graceError metadata.CorrelationId "At least one reuse range claim is required.")
             else
                 let claimedRanges = ResizeArray<ClaimedReuseRange>()
+
+                let claimedRangeKeys =
+                    session.ClaimedReuseRanges
+                    |> Array.map claimedRangeKey
+                    |> HashSet<string>
+
                 let mutable error = None
                 let mutable index = 0
 
                 while error.IsNone && index < claim.Ranges.Length do
                     match claimReuseRange metadata.CorrelationId metadata.Timestamp discovery claim.Ranges[index] with
-                    | Ok claimedRange ->
+                    | Ok claimedRange when claimedRangeKeys.Add(claimedRangeKey claimedRange) ->
                         claimedRanges.Add(claimedRange)
                         index <- index + 1
+                    | Ok _ -> error <- Some(graceError metadata.CorrelationId "Reuse range hint has already been claimed.")
                     | Error claimError -> error <- Some claimError
 
                 match error with

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -38,10 +38,10 @@ module UploadSession =
     let operationId command =
         match command with
         | UploadSessionCommand.Start start -> start.OperationId
-        | UploadSessionCommand.IssueDedupeDiscovery operationId -> operationId
+        | UploadSessionCommand.IssueDedupeDiscovery discovery -> discovery.OperationId
         | UploadSessionCommand.RegisterBlockUploadIntent intent -> intent.OperationId
         | UploadSessionCommand.ConfirmBlockUploaded confirmation -> confirmation.OperationId
-        | UploadSessionCommand.ClaimReuseRanges operationId -> operationId
+        | UploadSessionCommand.ClaimReuseRanges claim -> claim.OperationId
         | UploadSessionCommand.FinalizeManifest (operationId, _) -> operationId
         | UploadSessionCommand.Abandon operationId -> operationId
         | UploadSessionCommand.Expire operationId -> operationId
@@ -68,6 +68,8 @@ module UploadSession =
         | UploadSessionEventType.PhysicalStateDeleted operationId -> operationId
         | UploadSessionEventType.BlockUploadIntentRegistered (operationId, _) -> operationId
         | UploadSessionEventType.BlockUploadConfirmed (operationId, _) -> operationId
+        | UploadSessionEventType.DedupeDiscoveryIssued (operationId, _) -> operationId
+        | UploadSessionEventType.ReuseRangesClaimed (operationId, _) -> operationId
 
     let private hasAppliedOperationId (events: seq<UploadSessionEvent>) operationId =
         events
@@ -130,6 +132,145 @@ module UploadSession =
             Some(graceError correlationId "StoragePlacement.ObjectKey is required.")
         else
             None
+
+    let private normalizeHints (hints: ContentBlockReuseRangeHint array) = if isNull hints then Array.empty else hints
+
+    let private validateReuseHint correlationId (hint: ContentBlockReuseRangeHint) =
+        if isNull (box hint) then
+            Some(graceError correlationId "Reuse range hint is required.")
+        elif String.IsNullOrWhiteSpace hint.StoragePoolId then
+            Some(graceError correlationId "Reuse range hint StoragePoolId is required.")
+        elif String.IsNullOrWhiteSpace hint.ContentBlockAddress then
+            Some(graceError correlationId "Reuse range hint ContentBlockAddress is required.")
+        elif hint.OrdinalStart < 0 then
+            Some(graceError correlationId "Reuse range hint OrdinalStart must be zero or greater.")
+        elif hint.OrdinalCount <= 0 then
+            Some(graceError correlationId "Reuse range hint OrdinalCount must be greater than zero.")
+        elif hint.MetadataVersion <= 0L then
+            Some(graceError correlationId "Reuse range hint MetadataVersion must be greater than zero.")
+        else
+            None
+
+    let private sameHint (left: ContentBlockReuseRangeHint) (right: ContentBlockReuseRangeHint) =
+        left.StoragePoolId = right.StoragePoolId
+        && left.ContentBlockAddress = right.ContentBlockAddress
+        && left.OrdinalStart = right.OrdinalStart
+        && left.OrdinalCount = right.OrdinalCount
+        && left.MetadataVersion = right.MetadataVersion
+
+    let private issueDedupeDiscovery (session: UploadSessionDto) (discovery: IssueDedupeDiscovery) (metadata: EventMetadata) =
+        if discovery.MinimumReuseRunLength <= 0 then
+            Error(graceError metadata.CorrelationId "MinimumReuseRunLength must be greater than zero.")
+        elif discovery.ExpiresAt <= metadata.Timestamp then
+            Error(graceError metadata.CorrelationId "Dedupe discovery ExpiresAt must be later than the issue timestamp.")
+        else
+            let hints = normalizeHints discovery.Hints
+
+            match
+                hints
+                |> Array.tryPick (validateReuseHint metadata.CorrelationId)
+                with
+            | Some error -> Error error
+            | None ->
+                let snapshot: DedupeDiscoverySnapshot =
+                    {
+                        OperationId = discovery.OperationId
+                        ExpiresAt = discovery.ExpiresAt
+                        MinimumReuseRunLength = discovery.MinimumReuseRunLength
+                        Hints = hints
+                    }
+
+                let events =
+                    [
+                        { Event = UploadSessionEventType.DedupeDiscoveryIssued(discovery.OperationId, snapshot); Metadata = metadata }
+                    ]
+
+                okDecision session discovery.OperationId events false "Dedupe discovery issued."
+
+    let private claimReuseRange correlationId timestamp (discovery: DedupeDiscoverySnapshot) (claimRange: ClaimReuseRange) =
+        if isNull (box claimRange) then
+            Error(graceError correlationId "Reuse range claim is required.")
+        else
+            match validateReuseHint correlationId claimRange.Hint with
+            | Some error -> Error error
+            | None ->
+                let hint = claimRange.Hint
+
+                if hint.OrdinalCount < discovery.MinimumReuseRunLength then
+                    Error(graceError correlationId $"Reuse range is shorter than the minimum reuse run length {discovery.MinimumReuseRunLength}.")
+                elif discovery.Hints
+                     |> Array.exists (sameHint hint)
+                     |> not then
+                    Error(graceError correlationId "Reuse range hint was not issued by the active discovery.")
+                elif isNull (box claimRange.Metadata) then
+                    Error(graceError correlationId "Authoritative ContentBlockMetadata is required.")
+                elif claimRange.Metadata.StoragePoolId
+                     <> hint.StoragePoolId then
+                    Error(graceError correlationId "Authoritative ContentBlockMetadata StoragePoolId does not match the reuse range hint.")
+                elif claimRange.Metadata.ContentBlockAddress
+                     <> hint.ContentBlockAddress then
+                    Error(graceError correlationId "Authoritative ContentBlockMetadata ContentBlockAddress does not match the reuse range hint.")
+                elif claimRange.Metadata.MetadataVersion
+                     <> hint.MetadataVersion then
+                    Error(
+                        graceError
+                            correlationId
+                            $"stale reuse range hint rejected. Hinted MetadataVersion {hint.MetadataVersion}, authoritative MetadataVersion {claimRange.Metadata.MetadataVersion}."
+                    )
+                elif isNull claimRange.Metadata.Ranges then
+                    Error(graceError correlationId "Authoritative ContentBlockMetadata range is absent; reuse range cannot be claimed.")
+                else
+                    match
+                        Grace.Types.ContentBlockMetadata.tryFindRange claimRange.Metadata { OrdinalStart = hint.OrdinalStart; OrdinalCount = hint.OrdinalCount }
+                        with
+                    | None -> Error(graceError correlationId "Authoritative ContentBlockMetadata range is absent; reuse range cannot be claimed.")
+                    | Some physicalRange ->
+                        Ok
+                            {
+                                StoragePoolId = hint.StoragePoolId
+                                ContentBlockAddress = hint.ContentBlockAddress
+                                OrdinalStart = hint.OrdinalStart
+                                OrdinalCount = hint.OrdinalCount
+                                PhysicalOffset = physicalRange.PhysicalOffset
+                                PhysicalLength = physicalRange.PhysicalLength
+                                MetadataVersion = claimRange.Metadata.MetadataVersion
+                                ClaimedAt = timestamp
+                            }
+
+    let private claimReuseRanges (session: UploadSessionDto) (claim: ClaimReuseRanges) (metadata: EventMetadata) =
+        match session.DedupeDiscovery with
+        | None -> Error(graceError metadata.CorrelationId "Dedupe discovery must be issued before reuse ranges can be claimed.")
+        | Some discovery when
+            discovery.OperationId
+            <> claim.DiscoveryOperationId
+            ->
+            Error(graceError metadata.CorrelationId "ClaimReuseRanges DiscoveryOperationId does not match the active discovery.")
+        | Some discovery when metadata.Timestamp >= discovery.ExpiresAt ->
+            Error(graceError metadata.CorrelationId "Dedupe discovery has expired; reuse ranges cannot be claimed.")
+        | Some discovery ->
+            if isNull claim.Ranges || claim.Ranges.Length = 0 then
+                Error(graceError metadata.CorrelationId "At least one reuse range claim is required.")
+            else
+                let claimedRanges = ResizeArray<ClaimedReuseRange>()
+                let mutable error = None
+                let mutable index = 0
+
+                while error.IsNone && index < claim.Ranges.Length do
+                    match claimReuseRange metadata.CorrelationId metadata.Timestamp discovery claim.Ranges[index] with
+                    | Ok claimedRange ->
+                        claimedRanges.Add(claimedRange)
+                        index <- index + 1
+                    | Error claimError -> error <- Some claimError
+
+                match error with
+                | Some claimError -> Error claimError
+                | None ->
+                    let events =
+                        [
+                            { Event = UploadSessionEventType.ReuseRangesClaimed(claim.OperationId, claimedRanges.ToArray()); Metadata = metadata }
+                        ]
+
+                    okDecision session claim.OperationId events false "Reuse ranges claimed."
 
     let private findBlockIntents (session: UploadSessionDto) contentBlockAddress =
         session.BlockUploadIntents
@@ -318,8 +459,14 @@ module UploadSession =
                 match requireStartedSession session command metadata.CorrelationId with
                 | Some error -> Error error
                 | None -> confirmBlockUpload session confirmation metadata
-            | UploadSessionCommand.IssueDedupeDiscovery _
-            | UploadSessionCommand.ClaimReuseRanges _
+            | UploadSessionCommand.IssueDedupeDiscovery discovery ->
+                match requireStartedSession session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None -> issueDedupeDiscovery session discovery metadata
+            | UploadSessionCommand.ClaimReuseRanges claim ->
+                match requireStartedSession session command metadata.CorrelationId with
+                | Some error -> Error error
+                | None -> claimReuseRanges session claim metadata
             | UploadSessionCommand.FinalizeManifest _ ->
                 match terminalMutationError session command metadata.CorrelationId with
                 | Some error -> Error error

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -67,6 +67,51 @@ type UploadSessionActorTests() =
     let confirmWithPlacement operationId blockAddress payload placement : ConfirmBlockUploaded =
         { OperationId = operationId; ContentBlockAddress = blockAddress; Payload = payload; StoragePlacement = placement }
 
+    let storagePoolId = StoragePoolId "pool-main"
+    let reuseBlockAddress = ContentBlockAddress "block-blake3-reuse"
+    let discoveryExpiresAt = timestamp.Plus(Duration.FromMinutes(10L))
+    let minimumReuseRunLength = 4
+
+    let reusableMetadataRange = { OrdinalStart = 0; OrdinalCount = 4; ActiveManifestCount = 0; PhysicalOffset = 0L; PhysicalLength = 4096L }
+
+    let reuseMetadata metadataVersion ranges : ContentBlockMetadata =
+        {
+            Class = nameof ContentBlockMetadata
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = reuseBlockAddress
+            BlockFormatVersion = 1s
+            StoragePlacement = { ObjectKey = $"cas/content-blocks/{reuseBlockAddress}"; ETag = Some "etag-reuse" }
+            Ranges = ranges
+            TotalPhysicalBytes = 4096L
+            ActivePhysicalBytes = 0L
+            MetadataVersion = metadataVersion
+            UpdatedAt = timestamp
+        }
+
+    let reuseHint =
+        {
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = reuseBlockAddress
+            OrdinalStart = reusableMetadataRange.OrdinalStart
+            OrdinalCount = reusableMetadataRange.OrdinalCount
+            MetadataVersion = 7L
+        }
+
+    let discovery operationId hints =
+        UploadSessionCommand.IssueDedupeDiscovery
+            { OperationId = operationId; ExpiresAt = discoveryExpiresAt; MinimumReuseRunLength = minimumReuseRunLength; Hints = hints }
+
+    let claim operationId hint metadata =
+        UploadSessionCommand.ClaimReuseRanges
+            {
+                OperationId = operationId
+                DiscoveryOperationId = "op-discovery"
+                Ranges =
+                    [|
+                        { Hint = hint; Metadata = metadata }
+                    |]
+            }
+
     let apply event dto = UploadSessionDto.UpdateDto event dto
 
     let applyAll events dto =
@@ -547,3 +592,133 @@ type UploadSessionActorTests() =
             Assert.That(decision.Events, Is.Empty)
             Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.NotStarted))
         | Error error -> Assert.Fail($"Expected cleanup retry to drain, got {error.Error}.")
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsStaleDiscoveryHintVersion() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let staleMetadata = reuseMetadata 8L [| reusableMetadataRange |]
+
+        let result = UploadSessionActor.decideCommand discoveryEvents discoveredDto (claim "op-claim" reuseHint staleMetadata) (metadata "corr-claim")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected stale discovery hint to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("stale"))
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsExpiredDiscovery() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                discoveryEvents
+                discoveredDto
+                (claim "op-claim" reuseHint (reuseMetadata 7L [| reusableMetadataRange |]))
+                { metadata "corr-claim" with Timestamp = discoveryExpiresAt }
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected expired discovery to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("expired"))
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsMissingAuthoritativePhysicalRange() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let metadataWithoutRange =
+            reuseMetadata
+                7L
+                [|
+                    { reusableMetadataRange with OrdinalStart = 8; PhysicalOffset = 8192L }
+                |]
+
+        let result = UploadSessionActor.decideCommand discoveryEvents discoveredDto (claim "op-claim" reuseHint metadataWithoutRange) (metadata "corr-claim")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected absent authoritative physical range to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("absent"))
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsRunsBelowMinimumReuseLength() =
+        let shortHint = { reuseHint with OrdinalCount = minimumReuseRunLength - 1 }
+        let shortRange = { reusableMetadataRange with OrdinalCount = minimumReuseRunLength - 1 }
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| shortHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand
+                discoveryEvents
+                discoveredDto
+                (claim "op-claim" shortHint (reuseMetadata 7L [| shortRange |]))
+                (metadata "corr-claim")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected too-short reuse run to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("minimum reuse run"))
+
+    [<Test>]
+    member _.ClaimReuseRangesWithSameOperationIdIsStableIdempotentReplay() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let command = claim "op-claim" reuseHint (reuseMetadata 7L [| reusableMetadataRange |])
+        let first = UploadSessionActor.decideCommand discoveryEvents discoveredDto command (metadata "corr-claim")
+
+        match first with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.ClaimingRanges))
+            Assert.That(decision.Session.ClaimedReuseRanges.Length, Is.EqualTo(1))
+
+            let replay = UploadSessionActor.decideCommand (discoveryEvents @ decision.Events) decision.Session command (metadata "corr-claim-replay")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Session.ClaimedReuseRanges.Length, Is.EqualTo(decision.Session.ClaimedReuseRanges.Length))
+                Assert.That(replayDecision.Session.ClaimedReuseRanges[0], Is.EqualTo(decision.Session.ClaimedReuseRanges[0]))
+            | Error error -> Assert.Fail($"Expected idempotent claim replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected claim to succeed, got {error.Error}.")

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -789,3 +789,33 @@ type UploadSessionActorTests() =
         match second with
         | Ok _ -> Assert.Fail("Expected already claimed reuse hint to be rejected.")
         | Error error -> Assert.That(error.Error, Does.Contain("already been claimed"))
+
+    [<Test>]
+    member _.IssueDedupeDiscoveryNullPayloadReturnsGraceError() =
+        let startedDto, startEvents = startedSession ()
+
+        let result =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.IssueDedupeDiscovery Unchecked.defaultof<IssueDedupeDiscovery>)
+                (metadata "corr-null-discovery")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected null discovery payload to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("requires a non-empty operation id"))
+
+    [<Test>]
+    member _.ClaimReuseRangesNullPayloadReturnsGraceError() =
+        let startedDto, startEvents = startedSession ()
+
+        let result =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.ClaimReuseRanges Unchecked.defaultof<ClaimReuseRanges>)
+                (metadata "corr-null-claim")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected null claim payload to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("requires a non-empty operation id"))

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -722,3 +722,70 @@ type UploadSessionActorTests() =
                 Assert.That(replayDecision.Session.ClaimedReuseRanges[0], Is.EqualTo(decision.Session.ClaimedReuseRanges[0]))
             | Error error -> Assert.Fail($"Expected idempotent claim replay, got {error.Error}.")
         | Error error -> Assert.Fail($"Expected claim to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsDuplicateHintsInSameCommand() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let authoritativeMetadata = reuseMetadata 7L [| reusableMetadataRange |]
+
+        let duplicateClaim =
+            UploadSessionCommand.ClaimReuseRanges
+                {
+                    OperationId = "op-claim"
+                    DiscoveryOperationId = "op-discovery"
+                    Ranges =
+                        [|
+                            { Hint = reuseHint; Metadata = authoritativeMetadata }
+                            { Hint = reuseHint; Metadata = authoritativeMetadata }
+                        |]
+                }
+
+        let result = UploadSessionActor.decideCommand discoveryEvents discoveredDto duplicateClaim (metadata "corr-claim")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected duplicate reuse hint claims to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("already been claimed"))
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsAlreadyClaimedHintWithNewOperationId() =
+        let startedDto, startEvents = startedSession ()
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let command = claim "op-claim" reuseHint (reuseMetadata 7L [| reusableMetadataRange |])
+        let first = UploadSessionActor.decideCommand discoveryEvents discoveredDto command (metadata "corr-claim")
+
+        let claimedDto, claimedEvents =
+            match first with
+            | Ok decision -> decision.Session, discoveryEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected first claim to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let second =
+            UploadSessionActor.decideCommand
+                claimedEvents
+                claimedDto
+                (claim "op-claim-again" reuseHint (reuseMetadata 7L [| reusableMetadataRange |]))
+                (metadata "corr-claim-again")
+
+        match second with
+        | Ok _ -> Assert.Fail("Expected already claimed reuse hint to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("already been claimed"))

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -281,7 +281,7 @@ module UploadSession =
             | UploadSessionEventType.ReuseRangesClaimed (operationId, claimedRanges) ->
                 { current with
                     LifecycleState = UploadSessionLifecycleState.ClaimingRanges
-                    ClaimedReuseRanges = claimedRanges
+                    ClaimedReuseRanges = Array.append current.ClaimedReuseRanges claimedRanges
                     LastOperationId = Some operationId
                 }
 

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -81,13 +81,63 @@ module UploadSession =
             ConfirmedAt: Instant
         }
 
+    /// Non-authoritative discovery evidence that may be used once, before expiry, to request reuse of an exact range.
+    [<GenerateSerializer>]
+    type ContentBlockReuseRangeHint =
+        {
+            StoragePoolId: StoragePoolId
+            ContentBlockAddress: ContentBlockAddress
+            OrdinalStart: int
+            OrdinalCount: int
+            MetadataVersion: MetadataVersion
+        }
+
+    /// Records the bounded policy returned by discovery so later claims can fail safely when hints age out.
+    [<GenerateSerializer>]
+    type DedupeDiscoverySnapshot =
+        {
+            OperationId: UploadSessionOperationId
+            ExpiresAt: Instant
+            MinimumReuseRunLength: int
+            Hints: ContentBlockReuseRangeHint array
+        }
+
+    [<GenerateSerializer>]
+    type IssueDedupeDiscovery =
+        {
+            OperationId: UploadSessionOperationId
+            ExpiresAt: Instant
+            MinimumReuseRunLength: int
+            Hints: ContentBlockReuseRangeHint array
+        }
+
+    /// Claim request for a reuse range. Metadata must be the authoritative ContentBlockMetadata read at claim time.
+    [<GenerateSerializer>]
+    type ClaimReuseRange = { Hint: ContentBlockReuseRangeHint; Metadata: ContentBlockMetadata }
+
+    [<GenerateSerializer>]
+    type ClaimReuseRanges = { OperationId: UploadSessionOperationId; DiscoveryOperationId: UploadSessionOperationId; Ranges: ClaimReuseRange array }
+
+    [<GenerateSerializer>]
+    type ClaimedReuseRange =
+        {
+            StoragePoolId: StoragePoolId
+            ContentBlockAddress: ContentBlockAddress
+            OrdinalStart: int
+            OrdinalCount: int
+            PhysicalOffset: int64
+            PhysicalLength: int64
+            MetadataVersion: MetadataVersion
+            ClaimedAt: Instant
+        }
+
     [<KnownType("GetKnownTypes")>]
     type UploadSessionCommand =
         | Start of start: StartUploadSession
-        | IssueDedupeDiscovery of operationId: UploadSessionOperationId
+        | IssueDedupeDiscovery of discovery: IssueDedupeDiscovery
         | RegisterBlockUploadIntent of intent: RegisterBlockUploadIntent
         | ConfirmBlockUploaded of confirmation: ConfirmBlockUploaded
-        | ClaimReuseRanges of operationId: UploadSessionOperationId
+        | ClaimReuseRanges of claim: ClaimReuseRanges
         | FinalizeManifest of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
         | Abandon of operationId: UploadSessionOperationId
         | Expire of operationId: UploadSessionOperationId
@@ -105,6 +155,8 @@ module UploadSession =
         | PhysicalStateDeleted of operationId: UploadSessionOperationId
         | BlockUploadIntentRegistered of operationId: UploadSessionOperationId * intent: BlockUploadIntent
         | BlockUploadConfirmed of operationId: UploadSessionOperationId * confirmedBlock: ConfirmedBlockUpload
+        | DedupeDiscoveryIssued of operationId: UploadSessionOperationId * discovery: DedupeDiscoverySnapshot
+        | ReuseRangesClaimed of operationId: UploadSessionOperationId * claimedRanges: ClaimedReuseRange array
 
         static member GetKnownTypes() = GetKnownTypes<UploadSessionEventType>()
 
@@ -129,6 +181,8 @@ module UploadSession =
             FinalizedManifestAddress: ManifestAddress option
             BlockUploadIntents: BlockUploadIntent array
             ConfirmedBlockUploads: ConfirmedBlockUpload array
+            DedupeDiscovery: DedupeDiscoverySnapshot option
+            ClaimedReuseRanges: ClaimedReuseRange array
             CleanupReminderScheduledAt: Instant option
             CleanupReminderOperationId: UploadSessionOperationId option
             LastOperationId: UploadSessionOperationId option
@@ -152,6 +206,8 @@ module UploadSession =
                 FinalizedManifestAddress = None
                 BlockUploadIntents = Array.empty
                 ConfirmedBlockUploads = Array.empty
+                DedupeDiscovery = None
+                ClaimedReuseRanges = Array.empty
                 CleanupReminderScheduledAt = None
                 CleanupReminderOperationId = None
                 LastOperationId = None
@@ -218,6 +274,14 @@ module UploadSession =
                 { current with
                     LifecycleState = UploadSessionLifecycleState.UploadingBlocks
                     ConfirmedBlockUploads = Array.append existing [| confirmedBlock |]
+                    LastOperationId = Some operationId
+                }
+            | UploadSessionEventType.DedupeDiscoveryIssued (operationId, discovery) ->
+                { current with LifecycleState = UploadSessionLifecycleState.Discovering; DedupeDiscovery = Some discovery; LastOperationId = Some operationId }
+            | UploadSessionEventType.ReuseRangesClaimed (operationId, claimedRanges) ->
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.ClaimingRanges
+                    ClaimedReuseRanges = claimedRanges
                     LastOperationId = Some operationId
                 }
 


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #92

## Summary

- Adds UploadSession discovery snapshots with TTL, minimum reuse-run policy, and non-authoritative range hints.
- Implements ClaimReuseRanges against authoritative ContentBlockMetadata supplied at claim time.
- Rejects stale metadata-version hints, expired discovery windows, absent physical ranges, and too-short reuse runs; same-operation claim retries replay stably.

## Touched paths

- `src/Grace.Types/UploadSession.Types.fs`
- `src/Grace.Actors/UploadSession.Actor.fs`
- `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: actor-workflow
- Public behavior or docs-only validation target: UploadSession range-claim decisions against authoritative ContentBlockMetadata.
- RED evidence or docs-only waiver: Initial focused `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~UploadSessionActorTests` failed because the range-claim contract did not exist yet (`ExpiresAt`, `MinimumReuseRunLength`, `Hints`, `DiscoveryOperationId`, and `ClaimedReuseRanges` missing).
- Focused validation:
  - `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~UploadSessionActorTests` passed, 21/21.
  - `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~ContentBlockMetadataActorTests` passed, 15/15.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs` covers stale hint rejection, expired discovery rejection, absent authoritative physical range rejection, minimum reuse-run enforcement, and idempotent claim replay stability.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [x] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - no public docs changed; API/contract comments were added in `UploadSession.Types.fs` for claim/discovery semantics.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast` passed; build clean; Authorization 21/21; CLI 200 passed, 1 skipped; Types 49/49; elapsed 00:03:49.
- [x] `pwsh ./scripts/validate.ps1 -Full` passed; build clean; Authorization 21/21; CLI 200 passed, 1 skipped; Types 49/49; Server 279/279; elapsed 00:04:38.
- [x] Focused tests: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~UploadSessionActorTests` passed, 21/21; `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~ContentBlockMetadataActorTests` passed, 15/15.
- [x] Formatting/linting: `dotnet tool run fantomas -- Grace.Types/UploadSession.Types.fs Grace.Actors/UploadSession.Actor.fs Grace.Server.Tests/UploadSession.Actor.Tests.fs`; `git diff --check` passed.
- [ ] Manual validation: command or steps

## Validation not run

- Manual validation not run; pure actor decision coverage plus Fast/Full automated gates covered this slice.

## Residual risks

- This PR records claim decisions in UploadSession state only. Later DAG nodes still need to consume the claimed ranges during manifest finalization/contribution workflows.
- Positive discovery remains bounded by the caller-provided hints in this actor slice; server-side positive discovery/indexing remains outside #92.

## Rollback or recovery notes

- Revert this PR to return IssueDedupeDiscovery and ClaimReuseRanges to the prior skeleton behavior.

## Docs follow-up required

- None for this slice.
