### PR TITLE
Implement upload session manifest finalization

### DIFF
--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -44,7 +44,8 @@ module UploadSession =
         | UploadSessionCommand.ConfirmBlockUploaded confirmation -> confirmation.OperationId
         | UploadSessionCommand.ClaimReuseRanges claim when isNull (box claim) -> String.Empty
         | UploadSessionCommand.ClaimReuseRanges claim -> claim.OperationId
-        | UploadSessionCommand.FinalizeManifest (operationId, _) -> operationId
+        | UploadSessionCommand.FinalizeManifest finalize when isNull (box finalize) -> String.Empty
+        | UploadSessionCommand.FinalizeManifest finalize -> finalize.OperationId
         | UploadSessionCommand.Abandon operationId -> operationId
         | UploadSessionCommand.Expire operationId -> operationId
         | UploadSessionCommand.DeletePhysicalState operationId -> operationId
@@ -299,6 +300,127 @@ module UploadSession =
         decodedBlock.Chunks
         |> Array.sumBy (fun chunk -> int64 chunk.Length)
 
+    let private manifestValidationErrorMessage error =
+        match error with
+        | ManifestValidation.NullManifest -> "FileManifest is required."
+        | ManifestValidation.NullBlockPayloadSequence -> "FinalizeManifest BlockPayloads are required."
+        | ManifestValidation.NullBlockPayload index -> $"FinalizeManifest BlockPayloads[{index}] is required."
+        | ManifestValidation.NullBlockPayloadBytes address -> $"FinalizeManifest BlockPayloads for ContentBlockAddress {address} must include payload bytes."
+        | ManifestValidation.EmptyManifest -> "FileManifest must include at least one ContentBlock."
+        | ManifestValidation.InvalidManifestSize -> "FileManifest Size must be greater than zero."
+        | ManifestValidation.InvalidChunkingSuiteId chunkingSuiteId -> $"FileManifest ChunkingSuiteId is invalid: {chunkingSuiteId}."
+        | ManifestValidation.InvalidFileContentHash fileContentHash -> $"FileManifest FileContentHash is invalid: {fileContentHash}."
+        | ManifestValidation.InvalidManifestAddress manifestAddress -> $"FileManifest ManifestAddress is invalid: {manifestAddress}."
+        | ManifestValidation.NullContentBlock index -> $"FileManifest Blocks[{index}] is required."
+        | ManifestValidation.InvalidContentBlockAddress (index, address) -> $"FileManifest Blocks[{index}] ContentBlockAddress is invalid: {address}."
+        | ManifestValidation.ChunkingSuiteMismatch (expected, actual) -> $"FileManifest ChunkingSuiteId mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.ManifestAddressMismatch (expected, actual) -> $"FileManifest ManifestAddress mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.BlockRangeOutOfOrder index -> $"FileManifest Blocks[{index}] must be contiguous and ordered by logical offset."
+        | ManifestValidation.BlockRangeNotPositive index -> $"FileManifest Blocks[{index}] Size must be greater than zero."
+        | ManifestValidation.MissingContentBlockPayload (index, address) -> $"FileManifest Blocks[{index}] ContentBlockAddress {address} is missing a payload."
+        | ManifestValidation.ContentBlockPayloadInvalid (address, payloadError) -> $"ContentBlock payload for {address} is invalid: {payloadError}."
+        | ManifestValidation.ContentBlockPayloadSizeMismatch (index, expected, actual) ->
+            $"FileManifest Blocks[{index}] payload size mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.FileContentHashMismatch (expected, actual) -> $"FileManifest FileContentHash mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.ManifestSizeMismatch (expected, actual) -> $"FileManifest Size mismatch. Expected {expected}, actual {actual}."
+
+    let private blockWasUploaded (session: UploadSessionDto) (block: ContentBlock) =
+        session.ConfirmedBlockUploads
+        |> Array.exists (fun confirmedBlock -> confirmedBlock.ContentBlockAddress = block.Address)
+        && session.BlockUploadIntents
+           |> Array.exists (fun intent ->
+               intent.ContentBlockAddress = block.Address
+               && intent.LogicalOffset = block.Offset
+               && intent.LogicalLength = block.Size)
+
+    let private blockWasClaimed (session: UploadSessionDto) (block: ContentBlock) =
+        session.ClaimedReuseRanges
+        |> Array.exists (fun claimedRange ->
+            claimedRange.ContentBlockAddress = block.Address
+            && claimedRange.PhysicalLength = block.Size)
+
+    let private validateManifestBlockPresence correlationId (session: UploadSessionDto) (manifest: FileManifest) =
+        if isNull (box manifest) then
+            Error(graceError correlationId "FileManifest is required.")
+        elif isNull manifest.Blocks then
+            Error(graceError correlationId "FileManifest must include at least one ContentBlock.")
+        else
+            let mutable error = None
+            let mutable index = 0
+
+            while index < manifest.Blocks.Count
+                  && Option.isNone error do
+                let block = manifest.Blocks[index]
+
+                if isNull (box block) then
+                    error <- Some(graceError correlationId $"FileManifest Blocks[{index}] is required.")
+                elif blockWasUploaded session block
+                     || blockWasClaimed session block then
+                    index <- index + 1
+                else
+                    error <-
+                        Some(
+                            graceError
+                                correlationId
+                                $"FileManifest Blocks[{index}] ContentBlockAddress {block.Address} was not uploaded or claimed by this UploadSession."
+                        )
+
+            match error with
+            | Some error -> Error error
+            | None -> Ok()
+
+    let private validateFinalizeSessionFields correlationId (session: UploadSessionDto) (manifest: FileManifest) =
+        if isNull (box manifest) then
+            Error(graceError correlationId "FileManifest is required.")
+        elif manifest.Size <> session.ExpectedSize then
+            Error(graceError correlationId $"FileManifest Size must match UploadSession ExpectedSize. Expected {session.ExpectedSize}, actual {manifest.Size}.")
+        elif manifest.FileContentHash
+             <> session.FileContentHash then
+            Error(
+                graceError
+                    correlationId
+                    $"FileManifest FileContentHash must match UploadSession FileContentHash. Expected {session.FileContentHash}, actual {manifest.FileContentHash}."
+            )
+        elif manifest.ChunkingSuiteId
+             <> session.ChunkingSuiteId then
+            Error(
+                graceError
+                    correlationId
+                    $"FileManifest ChunkingSuiteId must match UploadSession ChunkingSuiteId. Expected {session.ChunkingSuiteId}, actual {manifest.ChunkingSuiteId}."
+            )
+        else
+            Ok()
+
+    let private finalizeBlockPayload (payload: FinalizeManifestBlockPayload) =
+        if isNull (box payload) then
+            Unchecked.defaultof<ManifestValidation.ManifestBlockPayload>
+        else
+            ManifestValidation.createBlockPayload payload.Address payload.Payload
+
+    let private finalizeManifest (session: UploadSessionDto) (finalize: FinalizeManifest) (metadata: EventMetadata) =
+        if isNull (box finalize) then
+            Error(graceError metadata.CorrelationId "FinalizeManifest payload is required.")
+        else
+            validateFinalizeSessionFields metadata.CorrelationId session finalize.Manifest
+            |> Result.bind (fun () -> validateManifestBlockPresence metadata.CorrelationId session finalize.Manifest)
+            |> Result.bind (fun () ->
+                let blockPayloads =
+                    if isNull finalize.BlockPayloads then
+                        Unchecked.defaultof<ManifestValidation.ManifestBlockPayload array>
+                    else
+                        finalize.BlockPayloads
+                        |> Array.map finalizeBlockPayload
+
+                match ManifestValidation.validate session.ChunkingSuiteId finalize.Manifest blockPayloads with
+                | Ok _ ->
+                    let events =
+                        [
+                            { Event = UploadSessionEventType.Finalized(finalize.OperationId, finalize.Manifest.ManifestAddress); Metadata = metadata }
+                        ]
+
+                    okDecision session finalize.OperationId events false "Upload session manifest finalized."
+                | Error error -> Error(graceError metadata.CorrelationId (manifestValidationErrorMessage error)))
+
     let private confirmBlockUpload (session: UploadSessionDto) (confirmation: ConfirmBlockUploaded) (metadata: EventMetadata) =
         if String.IsNullOrWhiteSpace confirmation.ContentBlockAddress then
             Error(graceError metadata.CorrelationId "ContentBlockAddress is required.")
@@ -479,10 +601,18 @@ module UploadSession =
                 match requireStartedSession session command metadata.CorrelationId with
                 | Some error -> Error error
                 | None -> claimReuseRanges session claim metadata
-            | UploadSessionCommand.FinalizeManifest _ ->
+            | UploadSessionCommand.FinalizeManifest finalize ->
                 match terminalMutationError session command metadata.CorrelationId with
                 | Some error -> Error error
-                | None -> Error(graceError metadata.CorrelationId $"UploadSession command {commandName command} is not implemented in this skeleton.")
+                | None ->
+                    match session.LifecycleState with
+                    | UploadSessionLifecycleState.Started
+                    | UploadSessionLifecycleState.Discovering
+                    | UploadSessionLifecycleState.UploadingBlocks
+                    | UploadSessionLifecycleState.ClaimingRanges -> finalizeManifest session finalize metadata
+                    | UploadSessionLifecycleState.NotStarted ->
+                        Error(graceError metadata.CorrelationId "UploadSession must be started before FinalizeManifest.")
+                    | _ -> Error(graceError metadata.CorrelationId $"UploadSession cannot FinalizeManifest from {session.LifecycleState}.")
 
     type UploadSessionActor([<PersistentState(StateName.UploadSession, Constants.GraceActorStorage)>] state: IPersistentState<List<UploadSessionEvent>>) =
         inherit Grain()

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -417,6 +417,7 @@ module UploadSession =
                         [
                             { Event = UploadSessionEventType.Finalized(finalize.OperationId, finalize.Manifest.ManifestAddress); Metadata = metadata }
                         ]
+                        @ cleanupEvents session finalize.OperationId metadata
 
                     okDecision session finalize.OperationId events false "Upload session manifest finalized."
                 | Error error -> Error(graceError metadata.CorrelationId (manifestValidationErrorMessage error)))
@@ -731,6 +732,21 @@ module UploadSession =
                         | UploadSessionCommand.Expire operationId when not decision.WasIdempotentReplay ->
                             let reminderState =
                                 createCleanupReminderState decision.Session.UploadSessionId decision.Session.RepositoryId operationId metadata.CorrelationId
+
+                            do!
+                                (this :> IGraceReminderWithGuidKey)
+                                    .ScheduleReminderAsync
+                                    ReminderTypes.PhysicalDeletion
+                                    DefaultPhysicalDeletionReminderDuration
+                                    (ReminderState.UploadSessionPhysicalDeletion reminderState)
+                                    metadata.CorrelationId
+                        | UploadSessionCommand.FinalizeManifest finalize when not decision.WasIdempotentReplay ->
+                            let reminderState =
+                                createCleanupReminderState
+                                    decision.Session.UploadSessionId
+                                    decision.Session.RepositoryId
+                                    finalize.OperationId
+                                    metadata.CorrelationId
 
                             do!
                                 (this :> IGraceReminderWithGuidKey)

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -33,10 +33,13 @@ type UploadSessionActorTests() =
             AuthorizedScope = "/src"
             FileContentHash = "blake3:file"
             ExpectedSize = 1_048_576L
-            ChunkingSuiteId = "rabin-blake3-v1"
+            ChunkingSuiteId = RabinChunking.SuiteName
             SamplingPolicySnapshot = "sparse-key-v1"
             OperationId = operationId
         }
+
+    let startForManifest operationId (fileBytes: byte array) =
+        { start operationId with FileContentHash = FileContentHash(ContentAddress.computeBlake3Hex fileBytes); ExpectedSize = int64 fileBytes.Length }
 
     let encodedBlock bytes =
         match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
@@ -45,16 +48,25 @@ type UploadSessionActorTests() =
             Assert.Fail($"Expected test content block to encode, got {error}.")
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
-    let intentAt operationId blockAddress payloadLength logicalOffset : RegisterBlockUploadIntent =
+    let intentAtWithLength operationId blockAddress payloadLength logicalOffset logicalLength : RegisterBlockUploadIntent =
         {
             OperationId = operationId
             ContentBlockAddress = blockAddress
             LogicalOffset = logicalOffset
-            LogicalLength = 11L
+            LogicalLength = logicalLength
             ExpectedPayloadLength = payloadLength
         }
 
+    let intentAt operationId blockAddress payloadLength logicalOffset = intentAtWithLength operationId blockAddress payloadLength logicalOffset 11L
+
     let intent operationId blockAddress payloadLength = intentAt operationId blockAddress payloadLength 0L
+
+    let intentForBlock operationId (block: ContentBlockFormat.EncodedContentBlock) logicalOffset =
+        let logicalLength =
+            block.Chunks
+            |> Array.sumBy (fun chunk -> int64 chunk.Length)
+
+        intentAtWithLength operationId block.Address block.Payload.LongLength logicalOffset logicalLength
 
     let confirm operationId blockAddress payload : ConfirmBlockUploaded =
         {
@@ -66,6 +78,30 @@ type UploadSessionActorTests() =
 
     let confirmWithPlacement operationId blockAddress payload placement : ConfirmBlockUploaded =
         { OperationId = operationId; ContentBlockAddress = blockAddress; Payload = payload; StoragePlacement = placement }
+
+    let manifestFor (fileBytes: byte array) (blocks: ContentBlockFormat.EncodedContentBlock array) =
+        let contentBlocks = ResizeArray<ContentBlock>()
+        let mutable offset = 0L
+
+        for block in blocks do
+            let size =
+                block.Chunks
+                |> Array.sumBy (fun chunk -> int64 chunk.Length)
+
+            contentBlocks.Add(ContentBlock.Create(block.Address, offset, size))
+            offset <- offset + size
+
+        let fileContentHash = FileContentHash(ContentAddress.computeBlake3Hex fileBytes)
+
+        let manifest =
+            FileManifest.Create(ManifestAddress String.Empty, RabinChunking.SuiteName, fileContentHash, int64 fileBytes.Length, List.ofSeq contentBlocks)
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let payloadFor (block: ContentBlockFormat.EncodedContentBlock) : FinalizeManifestBlockPayload = { Address = block.Address; Payload = block.Payload }
+
+    let finalize operationId manifest payloads =
+        UploadSessionCommand.FinalizeManifest { OperationId = operationId; Manifest = manifest; BlockPayloads = payloads }
 
     let storagePoolId = StoragePoolId "pool-main"
     let reuseBlockAddress = ContentBlockAddress "block-blake3-reuse"
@@ -86,6 +122,12 @@ type UploadSessionActorTests() =
             ActivePhysicalBytes = 0L
             MetadataVersion = metadataVersion
             UpdatedAt = timestamp
+        }
+
+    let reuseMetadataFor contentBlockAddress metadataVersion ranges : ContentBlockMetadata =
+        { reuseMetadata metadataVersion ranges with
+            ContentBlockAddress = contentBlockAddress
+            StoragePlacement = { ObjectKey = $"cas/content-blocks/{contentBlockAddress}"; ETag = Some "etag-reuse" }
         }
 
     let reuseHint =
@@ -548,19 +590,330 @@ type UploadSessionActorTests() =
         | Error error -> Assert.Fail($"Expected first confirmation to succeed, got {error.Error}.")
 
     [<Test>]
-    member _.FinalizeCommandRemainsUnimplementedForSkeleton() =
+    member _.FinalizeManifestFromUploadedBlockValidatesReconstructionAndFinalizes() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let block = encodedBlock fileBytes
+        let manifest = manifestFor fileBytes [| block |]
+
+        let startDecision =
+            UploadSessionActor.decideCommand
+                []
+                UploadSessionDto.Default
+                (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                (metadata "corr-start")
+
+        let startedDto, startEvents =
+            match startDecision with
+            | Ok decision -> decision.Session, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let intentDecision =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentForBlock "op-block-intent" block 0L))
+                (metadata "corr-block-intent")
+
+        let intentDto, intentEvents =
+            match intentDecision with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let confirmDecision =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        let confirmedDto, confirmedEvents =
+            match confirmDecision with
+            | Ok decision -> decision.Session, intentEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected confirmation to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand confirmedEvents confirmedDto (finalize "op-finalize" manifest [| payloadFor block |]) (metadata "corr-finalize")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.False)
+            Assert.That(decision.Events.Length, Is.EqualTo(1))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+            Assert.That(decision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+        | Error error -> Assert.Fail($"Expected finalize to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizeManifestFromClaimedReuseRangeValidatesReconstructionAndFinalizes() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("reuse range bytes")
+        let block = encodedBlock fileBytes
+        let manifest = manifestFor fileBytes [| block |]
+
+        let claimedRange =
+            { StoragePoolId = storagePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = minimumReuseRunLength; MetadataVersion = 7L }
+
+        let metadataRange = { reusableMetadataRange with OrdinalStart = 0; OrdinalCount = minimumReuseRunLength; PhysicalLength = int64 fileBytes.Length }
+
+        let startDecision =
+            UploadSessionActor.decideCommand
+                []
+                UploadSessionDto.Default
+                (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                (metadata "corr-start")
+
+        let startedDto, startEvents =
+            match startDecision with
+            | Ok decision -> decision.Session, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let issued = UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| claimedRange |]) (metadata "corr-discovery")
+
+        let discoveredDto, discoveryEvents =
+            match issued with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected discovery to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let claimCommand = claim "op-claim" claimedRange (reuseMetadataFor block.Address 7L [| metadataRange |])
+        let claimed = UploadSessionActor.decideCommand discoveryEvents discoveredDto claimCommand (metadata "corr-claim")
+
+        let claimedDto, claimedEvents =
+            match claimed with
+            | Ok decision -> decision.Session, discoveryEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected range claim to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let result =
+            UploadSessionActor.decideCommand claimedEvents claimedDto (finalize "op-finalize" manifest [| payloadFor block |]) (metadata "corr-finalize")
+
+        match result with
+        | Ok decision ->
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+            Assert.That(decision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+        | Error error -> Assert.Fail($"Expected finalize from claimed range to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizeManifestRejectsMissingConfirmedOrClaimedBlockWithoutConsumingOperationId() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let block = encodedBlock fileBytes
+        let manifest = manifestFor fileBytes [| block |]
+
+        let startDecision =
+            UploadSessionActor.decideCommand
+                []
+                UploadSessionDto.Default
+                (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                (metadata "corr-start")
+
+        let startedDto, startEvents =
+            match startDecision with
+            | Ok decision -> decision.Session, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let missing =
+            UploadSessionActor.decideCommand startEvents startedDto (finalize "op-finalize" manifest [| payloadFor block |]) (metadata "corr-finalize-missing")
+
+        match missing with
+        | Ok _ -> Assert.Fail("Expected finalize to reject a manifest block that was not uploaded or claimed.")
+        | Error error -> Assert.That(error.Error, Does.Contain("not uploaded or claimed"))
+
+        let intentDecision =
+            UploadSessionActor.decideCommand
+                startEvents
+                startedDto
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentForBlock "op-block-intent" block 0L))
+                (metadata "corr-block-intent")
+
+        let intentDto, intentEvents =
+            match intentDecision with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let confirmDecision =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDto
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+
+        let confirmedDto, confirmedEvents =
+            match confirmDecision with
+            | Ok decision -> decision.Session, intentEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected confirmation to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let retry =
+            UploadSessionActor.decideCommand
+                confirmedEvents
+                confirmedDto
+                (finalize "op-finalize" manifest [| payloadFor block |])
+                (metadata "corr-finalize-retry")
+
+        match retry with
+        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+        | Error error -> Assert.Fail($"Expected retry after failed finalize to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizeManifestRejectsFileHashMismatchWithoutConsumingOperationId() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let wrongBytes = Text.Encoding.UTF8.GetBytes("wrong bytes")
+        let block = encodedBlock fileBytes
+        let validManifest = manifestFor fileBytes [| block |]
+        let wrongHashManifest = { validManifest with FileContentHash = FileContentHash(ContentAddress.computeBlake3Hex wrongBytes) }
+
+        let startedDto, startEvents =
+            match
+                UploadSessionActor.decideCommand
+                    []
+                    UploadSessionDto.Default
+                    (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                    (metadata "corr-start")
+                with
+            | Ok decision -> decision.Session, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent(intentForBlock "op-block-intent" block 0L))
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let confirmedDto, confirmedEvents =
+            match
+                UploadSessionActor.decideCommand
+                    intentEvents
+                    intentDto
+                    (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                    (metadata "corr-block-confirm")
+                with
+            | Ok decision -> decision.Session, intentEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected confirmation to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let mismatch =
+            UploadSessionActor.decideCommand
+                confirmedEvents
+                confirmedDto
+                (finalize "op-finalize" wrongHashManifest [| payloadFor block |])
+                (metadata "corr-finalize-mismatch")
+
+        match mismatch with
+        | Ok _ -> Assert.Fail("Expected file content hash mismatch to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("FileContentHash"))
+
+        let retry =
+            UploadSessionActor.decideCommand
+                confirmedEvents
+                confirmedDto
+                (finalize "op-finalize" validManifest [| payloadFor block |])
+                (metadata "corr-finalize-retry")
+
+        match retry with
+        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+        | Error error -> Assert.Fail($"Expected retry after failed hash validation to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.FinalizeManifestRejectsTotalSizeMismatch() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let block = encodedBlock fileBytes
+        let manifest = { manifestFor fileBytes [| block |] with Size = int64 fileBytes.Length + 1L }
         let startedDto, existingEvents = startedSession ()
 
         let result =
-            UploadSessionActor.decideCommand
-                existingEvents
-                startedDto
-                (UploadSessionCommand.FinalizeManifest("op-finalize", "manifest-blake3"))
-                (metadata "corr-finalize")
+            UploadSessionActor.decideCommand existingEvents startedDto (finalize "op-finalize" manifest [| payloadFor block |]) (metadata "corr-finalize-size")
 
         match result with
-        | Ok _ -> Assert.Fail("Expected finalize to remain unimplemented in this slice.")
-        | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession command FinalizeManifest is not implemented in this skeleton."))
+        | Ok _ -> Assert.Fail("Expected total size mismatch to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("ExpectedSize"))
+
+    [<Test>]
+    member _.FinalizeManifestWithSameOperationIdIsIdempotentReplay() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let block = encodedBlock fileBytes
+        let manifest = manifestFor fileBytes [| block |]
+
+        let startedDto, startEvents =
+            match
+                UploadSessionActor.decideCommand
+                    []
+                    UploadSessionDto.Default
+                    (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                    (metadata "corr-start")
+                with
+            | Ok decision -> decision.Session, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected start to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let intentDto, intentEvents =
+            match
+                UploadSessionActor.decideCommand
+                    startEvents
+                    startedDto
+                    (UploadSessionCommand.RegisterBlockUploadIntent(intentForBlock "op-block-intent" block 0L))
+                    (metadata "corr-block-intent")
+                with
+            | Ok decision -> decision.Session, startEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected intent to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let confirmedDto, confirmedEvents =
+            match
+                UploadSessionActor.decideCommand
+                    intentEvents
+                    intentDto
+                    (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                    (metadata "corr-block-confirm")
+                with
+            | Ok decision -> decision.Session, intentEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected confirmation to succeed, got {error.Error}.")
+                UploadSessionDto.Default, []
+
+        let first =
+            UploadSessionActor.decideCommand confirmedEvents confirmedDto (finalize "op-finalize" manifest [| payloadFor block |]) (metadata "corr-finalize")
+
+        match first with
+        | Ok decision ->
+            let replay =
+                UploadSessionActor.decideCommand
+                    (confirmedEvents @ decision.Events)
+                    decision.Session
+                    (finalize "op-finalize" manifest [| payloadFor block |])
+                    (metadata "corr-finalize-replay")
+
+            match replay with
+            | Ok replayDecision ->
+                Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+                Assert.That(replayDecision.Events, Is.Empty)
+                Assert.That(replayDecision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+            | Error error -> Assert.Fail($"Expected idempotent finalize replay, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected first finalize to succeed, got {error.Error}.")
 
     [<Test>]
     member _.CleanupReminderStateCarriesDeletePhysicalStateOperationId() =

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -643,9 +643,10 @@ type UploadSessionActorTests() =
         match result with
         | Ok decision ->
             Assert.That(decision.WasIdempotentReplay, Is.False)
-            Assert.That(decision.Events.Length, Is.EqualTo(1))
-            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+            Assert.That(decision.Events.Length, Is.EqualTo(2))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
             Assert.That(decision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+            Assert.That(decision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-finalize:cleanup"))
         | Error error -> Assert.Fail($"Expected finalize to succeed, got {error.Error}.")
 
     [<Test>]
@@ -697,8 +698,9 @@ type UploadSessionActorTests() =
 
         match result with
         | Ok decision ->
-            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+            Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
             Assert.That(decision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+            Assert.That(decision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-finalize:cleanup"))
         | Error error -> Assert.Fail($"Expected finalize from claimed range to succeed, got {error.Error}.")
 
     [<Test>]
@@ -764,7 +766,7 @@ type UploadSessionActorTests() =
                 (metadata "corr-finalize-retry")
 
         match retry with
-        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
         | Error error -> Assert.Fail($"Expected retry after failed finalize to succeed, got {error.Error}.")
 
     [<Test>]
@@ -833,7 +835,7 @@ type UploadSessionActorTests() =
                 (metadata "corr-finalize-retry")
 
         match retry with
-        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.Finalized))
+        | Ok decision -> Assert.That(decision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
         | Error error -> Assert.Fail($"Expected retry after failed hash validation to succeed, got {error.Error}.")
 
     [<Test>]
@@ -912,6 +914,7 @@ type UploadSessionActorTests() =
                 Assert.That(replayDecision.WasIdempotentReplay, Is.True)
                 Assert.That(replayDecision.Events, Is.Empty)
                 Assert.That(replayDecision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+                Assert.That(replayDecision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-finalize:cleanup"))
             | Error error -> Assert.Fail($"Expected idempotent finalize replay, got {error.Error}.")
         | Error error -> Assert.Fail($"Expected first finalize to succeed, got {error.Error}.")
 

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -131,6 +131,12 @@ module UploadSession =
             ClaimedAt: Instant
         }
 
+    [<GenerateSerializer>]
+    type FinalizeManifestBlockPayload = { Address: ContentBlockAddress; Payload: byte array }
+
+    [<GenerateSerializer>]
+    type FinalizeManifest = { OperationId: UploadSessionOperationId; Manifest: FileManifest; BlockPayloads: FinalizeManifestBlockPayload array }
+
     [<KnownType("GetKnownTypes")>]
     type UploadSessionCommand =
         | Start of start: StartUploadSession
@@ -138,7 +144,7 @@ module UploadSession =
         | RegisterBlockUploadIntent of intent: RegisterBlockUploadIntent
         | ConfirmBlockUploaded of confirmation: ConfirmBlockUploaded
         | ClaimReuseRanges of claim: ClaimReuseRanges
-        | FinalizeManifest of operationId: UploadSessionOperationId * manifestAddress: ManifestAddress
+        | FinalizeManifest of finalize: FinalizeManifest
         | Abandon of operationId: UploadSessionOperationId
         | Expire of operationId: UploadSessionOperationId
         | DeletePhysicalState of operationId: UploadSessionOperationId


### PR DESCRIPTION
## Summary

- Implements #93: UploadSession `FinalizeManifest` now accepts a manifest plus caller-loaded ContentBlock payloads and validates session size/hash/chunking suite, uploaded-or-claimed block presence, manifest reconstruction, file hash, and manifest address before persisting finalization.
- Keeps failed finalize attempts retryable by emitting no events on validation errors; successful finalize replays by operation id through the existing UploadSession idempotency path.
- Schedules the same physical-state cleanup reminder used by abandon/expire after successful finalization, leaving accepted manifest/block data untouched while upload coordination state enters retention cleanup.
- Adds focused UploadSession actor tests for uploaded-block success, claimed-range success, missing block presence, file hash mismatch retry, total size mismatch, cleanup scheduling, and finalize operation-id replay.

## Touched Paths

- `src/Grace.Types/UploadSession.Types.fs`
- `src/Grace.Actors/UploadSession.Actor.fs`
- `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs`

## Validation

- RED: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` failed on the new finalize tests with `UploadSession command FinalizeManifest is not implemented in this skeleton.`
- GREEN focused: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` passed: 30/30.
- Review-fix focused: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` passed: 30/30.
- Formatting: `dotnet tool run fantomas Grace.Actors/UploadSession.Actor.fs Grace.Types/UploadSession.Types.fs Grace.Server.Tests/UploadSession.Actor.Tests.fs` passed; changed files formatted.
- Whitespace: `git diff --check` passed.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast` passed before and after the review fix. Latest: build succeeded; Authorization 21/21, CLI 200 passed / 1 suite-defined skip, Types 49/49.
- Full gate: `pwsh ./scripts/validate.ps1 -Full` passed before and after the review fix. Latest: build succeeded; Authorization 21/21, CLI 200 passed / 1 suite-defined skip, Types 49/49, Server 288/288.

## Docs Impact

- No public HTTP endpoint or OpenAPI surface was introduced or changed in this slice; behavior is actor/contract/test scoped within the issue-owned paths.

## Skipped Validation

- No requested validation was skipped. The repo validation script reports its format phase as temporarily disabled; targeted Fantomas was run manually on the changed F# files.

## Residual Risk

- Finalize validates against payloads supplied to the command; the future server/API slice must ensure those payloads are loaded from the authoritative object store before calling the actor.
- Dedupe index publication remains intentionally out of scope for #93 and is left for the dependent DAG work.

## Follow-ups

- #94 should publish the dedupe index after finalize.
- #100 should align the SDK/client upload flow with the finalized actor contract.

Closes #93