### PR TITLE
Fix upload session retention cleanup

### DIFF
--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -67,7 +67,7 @@ module UploadSession =
         | UploadSessionEventType.Abandoned operationId -> operationId
         | UploadSessionEventType.Expired operationId -> operationId
         | UploadSessionEventType.Finalized (operationId, _) -> operationId
-        | UploadSessionEventType.CleanupReminderScheduled (operationId, _) -> operationId
+        | UploadSessionEventType.CleanupReminderScheduled _ -> String.Empty
         | UploadSessionEventType.PhysicalStateDeleted operationId -> operationId
         | UploadSessionEventType.BlockUploadIntentRegistered (operationId, _) -> operationId
         | UploadSessionEventType.BlockUploadConfirmed (operationId, _) -> operationId
@@ -81,6 +81,22 @@ module UploadSession =
     let private applyEvents (events: UploadSessionEvent list) (session: UploadSessionDto) =
         events
         |> List.fold (fun current event -> UploadSessionDto.UpdateDto event current) session
+
+    let compactEventsForPhysicalStateCleanup (events: seq<UploadSessionEvent>) =
+        events
+        |> Seq.filter (fun uploadSessionEvent ->
+            match uploadSessionEvent.Event with
+            | UploadSessionEventType.Started _
+            | UploadSessionEventType.Abandoned _
+            | UploadSessionEventType.Expired _
+            | UploadSessionEventType.Finalized _
+            | UploadSessionEventType.CleanupReminderScheduled _
+            | UploadSessionEventType.PhysicalStateDeleted _ -> true
+            | UploadSessionEventType.BlockUploadIntentRegistered _
+            | UploadSessionEventType.BlockUploadConfirmed _
+            | UploadSessionEventType.DedupeDiscoveryIssued _
+            | UploadSessionEventType.ReuseRangesClaimed _ -> false)
+        |> Seq.toList
 
     let private okDecision (session: UploadSessionDto) operationId (events: UploadSessionEvent list) wasReplay message =
         Ok { Session = applyEvents events session; OperationId = operationId; Events = events; WasIdempotentReplay = wasReplay; Message = message }
@@ -643,6 +659,28 @@ module UploadSession =
                 uploadSessionDto <- applyEvents events uploadSessionDto
             }
 
+        member private this.CompactPhysicalStateEvents() =
+            task {
+                let retainedEvents =
+                    state.State
+                    |> compactEventsForPhysicalStateCleanup
+                    |> List.toArray
+
+                state.State.Clear()
+
+                let mutable index = 0
+
+                while index < retainedEvents.Length do
+                    state.State.Add(retainedEvents[index])
+                    index <- index + 1
+
+                do! state.WriteStateAsync()
+
+                uploadSessionDto <-
+                    state.State
+                    |> Seq.fold (fun dto event -> UploadSessionDto.UpdateDto event dto) UploadSessionDto.Default
+            }
+
         interface IGraceReminderWithGuidKey with
             member this.ScheduleReminderAsync reminderType delay reminderState correlationId =
                 task {
@@ -677,7 +715,7 @@ module UploadSession =
                         | Ok decision ->
                             if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
 
-                            do! state.ClearStateAsync()
+                            do! this.CompactPhysicalStateEvents()
                             this.DeactivateOnIdle()
                             return Ok()
                         | Error error -> return Error error
@@ -755,8 +793,8 @@ module UploadSession =
                                     DefaultPhysicalDeletionReminderDuration
                                     (ReminderState.UploadSessionPhysicalDeletion reminderState)
                                     metadata.CorrelationId
-                        | UploadSessionCommand.DeletePhysicalState _ when not decision.WasIdempotentReplay ->
-                            do! state.ClearStateAsync()
+                        | UploadSessionCommand.DeletePhysicalState _ ->
+                            do! this.CompactPhysicalStateEvents()
                             this.DeactivateOnIdle()
                         | _ -> ()
 

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -169,6 +169,13 @@ type UploadSessionActorTests() =
             Assert.Fail($"Expected start to succeed, got {error.Error}.")
             UploadSessionDto.Default, []
 
+    let decisionOrFail message result =
+        match result with
+        | Ok decision -> decision
+        | Error error ->
+            Assert.Fail($"{message}, got {error.Error}.")
+            Unchecked.defaultof<_>
+
     [<Test>]
     member _.StartWithSameOperationIdIsIdempotentReplay() =
         let command = UploadSessionCommand.Start(start "op-start")
@@ -932,6 +939,202 @@ type UploadSessionActorTests() =
         match state with
         | ReminderState.UploadSessionPhysicalDeletion uploadSessionState -> Assert.That(uploadSessionState.OperationId, Is.EqualTo("op-abandon:cleanup"))
         | _ -> Assert.Fail("Expected UploadSessionPhysicalDeletion reminder state.")
+
+    [<Test>]
+    member _.DeletePhysicalStateAfterFinalizePreservesManifestEvidenceAndClearsUploadCoordination() =
+        let fileBytes = Text.Encoding.UTF8.GetBytes("hello world")
+        let block = encodedBlock fileBytes
+        let manifest = manifestFor fileBytes [| block |]
+
+        let startDecision =
+            UploadSessionActor.decideCommand
+                []
+                UploadSessionDto.Default
+                (UploadSessionCommand.Start(startForManifest "op-start" fileBytes))
+                (metadata "corr-start")
+            |> decisionOrFail "Expected start to succeed"
+
+        let intentDecision =
+            UploadSessionActor.decideCommand
+                startDecision.Events
+                startDecision.Session
+                (UploadSessionCommand.RegisterBlockUploadIntent(intentForBlock "op-block-intent" block 0L))
+                (metadata "corr-block-intent")
+            |> decisionOrFail "Expected block upload intent to succeed"
+
+        let intentEvents = startDecision.Events @ intentDecision.Events
+
+        let confirmedDecision =
+            UploadSessionActor.decideCommand
+                intentEvents
+                intentDecision.Session
+                (UploadSessionCommand.ConfirmBlockUploaded(confirm "op-block-confirm" block.Address block.Payload))
+                (metadata "corr-block-confirm")
+            |> decisionOrFail "Expected block upload confirmation to succeed"
+
+        let confirmedEvents = intentEvents @ confirmedDecision.Events
+
+        let finalizedDecision =
+            UploadSessionActor.decideCommand
+                confirmedEvents
+                confirmedDecision.Session
+                (finalize "op-finalize" manifest [| payloadFor block |])
+                (metadata "corr-finalize")
+            |> decisionOrFail "Expected finalize to succeed"
+
+        Assert.That(finalizedDecision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+        Assert.That(finalizedDecision.Session.BlockUploadIntents, Is.Not.Empty)
+        Assert.That(finalizedDecision.Session.ConfirmedBlockUploads, Is.Not.Empty)
+        Assert.That(finalizedDecision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-finalize:cleanup"))
+
+        let finalizedEvents = confirmedEvents @ finalizedDecision.Events
+
+        let cleanupDecision =
+            UploadSessionActor.decideCommand
+                finalizedEvents
+                finalizedDecision.Session
+                (UploadSessionCommand.DeletePhysicalState "op-finalize:cleanup")
+                (metadata "corr-cleanup")
+            |> decisionOrFail "Expected cleanup to succeed"
+
+        Assert.That(cleanupDecision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.StateDeleted))
+        Assert.That(cleanupDecision.Session.UploadSessionId, Is.EqualTo(sessionId))
+        Assert.That(cleanupDecision.Session.RepositoryId, Is.EqualTo(repositoryId))
+        Assert.That(cleanupDecision.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+        Assert.That(cleanupDecision.Session.CompletedAt, Is.EqualTo(finalizedDecision.Session.CompletedAt))
+        Assert.That(cleanupDecision.Session.BlockUploadIntents, Is.Empty)
+        Assert.That(cleanupDecision.Session.ConfirmedBlockUploads, Is.Empty)
+        Assert.That(cleanupDecision.Session.DedupeDiscovery, Is.EqualTo(None))
+        Assert.That(cleanupDecision.Session.ClaimedReuseRanges, Is.Empty)
+        Assert.That(cleanupDecision.Session.CleanupReminderScheduledAt, Is.EqualTo(None))
+        Assert.That(cleanupDecision.Session.CleanupReminderOperationId, Is.EqualTo(None))
+
+    [<Test>]
+    member _.DeletePhysicalStateAfterAbandonReleasesTemporaryReuseClaims() =
+        let startedDto, startEvents = startedSession ()
+
+        let issuedDecision =
+            UploadSessionActor.decideCommand startEvents startedDto (discovery "op-discovery" [| reuseHint |]) (metadata "corr-discovery")
+            |> decisionOrFail "Expected discovery to succeed"
+
+        let discoveryEvents = startEvents @ issuedDecision.Events
+
+        let claimedDecision =
+            UploadSessionActor.decideCommand
+                discoveryEvents
+                issuedDecision.Session
+                (claim "op-claim" reuseHint (reuseMetadata 7L [| reusableMetadataRange |]))
+                (metadata "corr-claim")
+            |> decisionOrFail "Expected claim to succeed"
+
+        let claimedEvents = discoveryEvents @ claimedDecision.Events
+
+        let abandonedDecision =
+            UploadSessionActor.decideCommand claimedEvents claimedDecision.Session (UploadSessionCommand.Abandon "op-abandon") (metadata "corr-abandon")
+            |> decisionOrFail "Expected abandon to succeed"
+
+        Assert.That(abandonedDecision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
+        Assert.That(abandonedDecision.Session.DedupeDiscovery.IsSome, Is.True)
+        Assert.That(abandonedDecision.Session.ClaimedReuseRanges, Is.Not.Empty)
+        Assert.That(abandonedDecision.Session.CleanupReminderOperationId, Is.EqualTo(Some "op-abandon:cleanup"))
+
+        let abandonedEvents = claimedEvents @ abandonedDecision.Events
+
+        let cleanupDecision =
+            UploadSessionActor.decideCommand
+                abandonedEvents
+                abandonedDecision.Session
+                (UploadSessionCommand.DeletePhysicalState "op-abandon:cleanup")
+                (metadata "corr-cleanup")
+            |> decisionOrFail "Expected cleanup to succeed"
+
+        Assert.That(cleanupDecision.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.StateDeleted))
+        Assert.That(cleanupDecision.Session.FinalizedManifestAddress, Is.EqualTo(None))
+        Assert.That(cleanupDecision.Session.DedupeDiscovery, Is.EqualTo(None))
+        Assert.That(cleanupDecision.Session.ClaimedReuseRanges, Is.Empty)
+        Assert.That(cleanupDecision.Session.BlockUploadIntents, Is.Empty)
+        Assert.That(cleanupDecision.Session.ConfirmedBlockUploads, Is.Empty)
+        Assert.That(cleanupDecision.Session.CleanupReminderScheduledAt, Is.EqualTo(None))
+        Assert.That(cleanupDecision.Session.CleanupReminderOperationId, Is.EqualTo(None))
+
+    [<Test>]
+    member _.PhysicalCleanupCompactsPersistedEventsToTombstoneAndDropsCoordinationPayloads() =
+        let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
+        let manifestAddress = ManifestAddress "manifest-blake3-final"
+        let cleanupReminderTime = timestamp.Plus(Duration.FromMinutes(5L))
+
+        let blockIntent =
+            {
+                ContentBlockAddress = block.Address
+                LogicalOffset = 0L
+                LogicalLength = 11L
+                ExpectedPayloadLength = block.Payload.LongLength
+                RegisteredAt = timestamp
+            }
+
+        let confirmedBlock =
+            {
+                ContentBlockAddress = block.Address
+                PayloadLength = block.Payload.LongLength
+                StoragePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some "etag-confirmed" }
+                Ranges =
+                    [|
+                        { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 0; PhysicalOffset = 0L; PhysicalLength = 11L }
+                    |]
+                ConfirmedAt = timestamp
+            }
+
+        let discoverySnapshot: DedupeDiscoverySnapshot =
+            { OperationId = "op-discovery"; ExpiresAt = discoveryExpiresAt; MinimumReuseRunLength = minimumReuseRunLength; Hints = [| reuseHint |] }
+
+        let claimedRange =
+            {
+                StoragePoolId = storagePoolId
+                ContentBlockAddress = reuseBlockAddress
+                OrdinalStart = 0
+                OrdinalCount = 4
+                PhysicalOffset = 0L
+                PhysicalLength = 4096L
+                MetadataVersion = 7L
+                ClaimedAt = timestamp
+            }
+
+        let eventStream =
+            [
+                { Event = UploadSessionEventType.Started(start "op-start"); Metadata = metadata "corr-start" }
+                { Event = UploadSessionEventType.BlockUploadIntentRegistered("op-intent", blockIntent); Metadata = metadata "corr-intent" }
+                { Event = UploadSessionEventType.BlockUploadConfirmed("op-confirm", confirmedBlock); Metadata = metadata "corr-confirm" }
+                { Event = UploadSessionEventType.DedupeDiscoveryIssued("op-discovery", discoverySnapshot); Metadata = metadata "corr-discovery" }
+                { Event = UploadSessionEventType.ReuseRangesClaimed("op-claim", [| claimedRange |]); Metadata = metadata "corr-claim" }
+                { Event = UploadSessionEventType.Finalized("op-finalize", manifestAddress); Metadata = metadata "corr-finalize" }
+                { Event = UploadSessionEventType.CleanupReminderScheduled("op-finalize:cleanup", cleanupReminderTime); Metadata = metadata "corr-retention" }
+                { Event = UploadSessionEventType.PhysicalStateDeleted "op-finalize:cleanup"; Metadata = metadata "corr-cleanup" }
+            ]
+
+        let compacted = UploadSessionActor.compactEventsForPhysicalStateCleanup eventStream
+
+        Assert.That(compacted.Length, Is.EqualTo(4))
+
+        Assert.That(
+            compacted
+            |> List.exists (fun uploadSessionEvent ->
+                match uploadSessionEvent.Event with
+                | UploadSessionEventType.BlockUploadIntentRegistered _
+                | UploadSessionEventType.BlockUploadConfirmed _
+                | UploadSessionEventType.DedupeDiscoveryIssued _
+                | UploadSessionEventType.ReuseRangesClaimed _ -> true
+                | _ -> false),
+            Is.False
+        )
+
+        let rehydrated = applyAll compacted UploadSessionDto.Default
+
+        Assert.That(rehydrated.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.StateDeleted))
+        Assert.That(rehydrated.FinalizedManifestAddress, Is.EqualTo(Some manifestAddress))
+        Assert.That(rehydrated.BlockUploadIntents, Is.Empty)
+        Assert.That(rehydrated.ConfirmedBlockUploads, Is.Empty)
+        Assert.That(rehydrated.DedupeDiscovery, Is.EqualTo(None))
+        Assert.That(rehydrated.ClaimedReuseRanges, Is.Empty)
 
     [<Test>]
     member _.DeletePhysicalStateRetryAfterStateClearedDrainsAsIdempotentReplay() =

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -263,7 +263,16 @@ module UploadSession =
                     LastOperationId = Some operationId
                 }
             | UploadSessionEventType.PhysicalStateDeleted operationId ->
-                { current with LifecycleState = UploadSessionLifecycleState.StateDeleted; LastOperationId = Some operationId }
+                { current with
+                    LifecycleState = UploadSessionLifecycleState.StateDeleted
+                    BlockUploadIntents = Array.empty
+                    ConfirmedBlockUploads = Array.empty
+                    DedupeDiscovery = None
+                    ClaimedReuseRanges = Array.empty
+                    CleanupReminderScheduledAt = None
+                    CleanupReminderOperationId = None
+                    LastOperationId = Some operationId
+                }
             | UploadSessionEventType.BlockUploadIntentRegistered (operationId, intent) ->
                 { current with
                     LifecycleState = UploadSessionLifecycleState.UploadingBlocks


### PR DESCRIPTION
## Linked issue

Closes #104

## Summary

- Fix upload-session cleanup idempotency so the scheduled cleanup reminder does not consume the later `DeletePhysicalState` command operation id.
- Make `PhysicalStateDeleted` retain final diagnostic evidence while clearing upload coordination arrays, discovery snapshots, reuse claims, and cleanup reminder fields.
- Compact persisted upload-session events after cleanup so block upload, discovery, and reuse-claim payload events are removed while start/terminal/tombstone evidence remains.

## Touched paths

- `src/Grace.Actors/UploadSession.Actor.fs`
- `src/Grace.Types/UploadSession.Types.fs`
- `src/Grace.Server.Tests/UploadSession.Actor.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: actor-workflow
- Public behavior or docs-only validation target: finalized upload sessions preserve manifest evidence after cleanup; abandoned unfinalized sessions release temporary reuse claims; persisted event compaction drops upload coordination payloads.
- RED evidence or docs-only waiver: after adding the cleanup tests first, `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` failed because cleanup remained `RetentionPending` instead of reaching `StateDeleted`.
- Focused validation: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` passed 33/33.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Added upload-session actor tests for finalized cleanup survival, abandoned claim release, and persisted-event compaction to a tombstone stream.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [x] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - the retention boundary is already documented in `src/Grace.Actors/AGENTS.md`.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast` passed; build clean, Authorization 21/21, CLI 200/201 with one existing skip, Types 49/49.
- [x] `pwsh ./scripts/validate.ps1 -Full` passed; build clean, Authorization 21/21, CLI 200/201 with one existing skip, Types 49/49, Server 291/291.
- [x] Focused tests: `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~UploadSessionActorTests"` passed 33/33.
- [x] Formatting/linting: `dotnet tool run fantomas Grace.Actors/UploadSession.Actor.fs Grace.Types/UploadSession.Types.fs Grace.Server.Tests/UploadSession.Actor.Tests.fs`; `git diff --check`.
- [ ] Manual validation: command or steps

## Validation not run

- Manual validation not run; the actor workflow is covered by focused actor tests plus fast/full automated gates.

## Residual risks

- Existing deployments that already fully cleared upload-session state still retry as the prior empty-state idempotent path; new cleanup writes compact tombstone evidence going forward.

## Rollback or recovery notes

- Reverting this PR restores the previous behavior where cleanup reminders can be mistaken for already-applied delete operations and successful cleanup clears the actor state entirely.

## Docs follow-up required

- None.