### PR TITLE
Integrate manifest save boundary accounting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,10 +1,11 @@
 name: .NET Restore / Build / Test
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,8 +3,6 @@ name: Validate
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main, agent/** ]
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
@@ -29,7 +27,7 @@ jobs:
         run: pwsh ./scripts/validate.ps1 -Fast
 
   full:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       GraceBuildKind: ci

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -107,6 +107,115 @@ module DirectoryVersion =
         else
             newFiles.ToArray()
 
+    let private normalizeContentReference (fileVersion: FileVersion) =
+        if isNull (box fileVersion.ContentReference) then
+            FileContentReference.WholeFileContent
+        else
+            fileVersion.ContentReference
+
+    let private isWholeFileContentReference (fileVersion: FileVersion) =
+        (normalizeContentReference fileVersion)
+            .ReferenceType = FileContentReferenceType.WholeFileContent
+
+    let getFilesToValidateForSaveBoundary (newFiles: List<FileVersion>) (previouslyValidatedFiles: List<FileVersion>) : FileVersion array =
+        getFilesToValidate newFiles previouslyValidatedFiles
+        |> Array.filter isWholeFileContentReference
+
+    let private manifestValidationError correlationId (fileVersion: FileVersion) message =
+        GraceError.Create $"FileManifest reference for '{fileVersion.RelativePath}' {message}" correlationId
+
+    let private validateManifestBlocks correlationId (fileVersion: FileVersion) (manifest: FileManifest) =
+        if
+            isNull (box manifest.Blocks)
+            || manifest.Blocks.Count = 0
+        then
+            Error(manifestValidationError correlationId fileVersion "must include at least one ContentBlock before Save.")
+        else
+            let mutable expectedOffset = 0L
+            let mutable index = 0
+            let mutable error: GraceError option = None
+
+            while index < manifest.Blocks.Count && error.IsNone do
+                let block = manifest.Blocks[index]
+
+                if isNull (box block) then
+                    error <- Some(manifestValidationError correlationId fileVersion $"has a null ContentBlock at index {index}.")
+                elif not (ContentAddress.isValidAddress block.Address) then
+                    error <- Some(manifestValidationError correlationId fileVersion $"has an invalid ContentBlockAddress at index {index}.")
+                elif block.Offset <> expectedOffset then
+                    error <- Some(manifestValidationError correlationId fileVersion $"must have contiguous ContentBlock offsets before Save.")
+                elif block.Size <= 0L then
+                    error <- Some(manifestValidationError correlationId fileVersion $"has a non-positive ContentBlock size at index {index}.")
+                else
+                    expectedOffset <- expectedOffset + block.Size
+
+                index <- index + 1
+
+            match error with
+            | Some error -> Error error
+            | None when expectedOffset <> manifest.Size ->
+                Error(manifestValidationError correlationId fileVersion "must have ContentBlocks that cover the full manifest size before Save.")
+            | None -> Ok()
+
+    let validateManifestBackedFileForSaveBoundary correlationId (fileVersion: FileVersion) (manifest: FileManifest) =
+        try
+            if isNull (box manifest) then
+                Error(manifestValidationError correlationId fileVersion "is required before Save.")
+            elif String.IsNullOrWhiteSpace manifest.ManifestAddress then
+                Error(manifestValidationError correlationId fileVersion "must be finalized before Save.")
+            elif not (ContentAddress.isValidAddress manifest.ManifestAddress) then
+                Error(manifestValidationError correlationId fileVersion "has an invalid ManifestAddress before Save.")
+            elif String.IsNullOrWhiteSpace manifest.ChunkingSuiteId then
+                Error(manifestValidationError correlationId fileVersion "must include a ChunkingSuiteId before Save.")
+            elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
+                Error(manifestValidationError correlationId fileVersion "has an invalid FileContentHash before Save.")
+            elif manifest.Size <= 0L then
+                Error(manifestValidationError correlationId fileVersion "must have a positive size before Save.")
+            elif fileVersion.Size <> manifest.Size then
+                Error(manifestValidationError correlationId fileVersion "must match the FileVersion size before Save.")
+            else
+                validateManifestBlocks correlationId fileVersion manifest
+                |> Result.bind (fun () ->
+                    let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+                    if expectedAddress <> manifest.ManifestAddress then
+                        Error(
+                            manifestValidationError
+                                correlationId
+                                fileVersion
+                                "must have a finalized ManifestAddress that matches its reconstruction contract before Save."
+                        )
+                    else
+                        Ok())
+        with
+        | ex -> Error(GraceError.CreateWithException ex $"FileManifest reference for '{fileVersion.RelativePath}' is invalid before Save." correlationId)
+
+    let getManifestReferencesForSaveBoundary (directoryVersion: DirectoryVersion) correlationId =
+        let manifests = Dictionary<ManifestAddress, FileManifest>()
+        let mutable index = 0
+        let mutable error: GraceError option = None
+
+        while index < directoryVersion.Files.Count
+              && error.IsNone do
+            let fileVersion = directoryVersion.Files[index]
+            let contentReference = normalizeContentReference fileVersion
+
+            if contentReference.ReferenceType = FileContentReferenceType.FileManifest then
+                match contentReference.Manifest with
+                | None -> error <- Some(manifestValidationError correlationId fileVersion "is required before Save.")
+                | Some manifest ->
+                    match validateManifestBackedFileForSaveBoundary correlationId fileVersion manifest with
+                    | Ok () ->
+                        if not (manifests.ContainsKey manifest.ManifestAddress) then
+                            manifests.Add(manifest.ManifestAddress, manifest)
+                    | Error graceError -> error <- Some graceError
+
+            index <- index + 1
+
+        match error with
+        | Some graceError -> Error graceError
+        | None -> Ok(manifests.Values |> Seq.toList)
+
     type DirectoryVersionActor
         (
             [<PersistentState(StateName.DirectoryVersion, Constants.GraceActorStorage)>] state: IPersistentState<List<DirectoryVersionEvent>>
@@ -549,7 +658,7 @@ module DirectoryVersion =
                                 BlockBlobOpenWriteOptions(Tags = tags, HttpHeaders = BlobHttpHeaders(ContentType = "application/msgpack"))
 
                             let conditionsSummary =
-                                let conditionsProperty = typeof<BlockBlobOpenWriteOptions>.GetProperty("Conditions")
+                                let conditionsProperty = typeof<BlockBlobOpenWriteOptions>.GetProperty ("Conditions")
 
                                 if isNull conditionsProperty then
                                     "not supported"
@@ -646,186 +755,191 @@ module DirectoryVersion =
                                 task {
                                     match command with
                                     | Create (directoryVersion, repositoryDto) ->
-                                        // Determine which files need validation using incremental validation logic.
-                                        let! mostRecentDirectoryVersion =
-                                            getMostRecentDirectoryVersionByRelativePath
-                                                repositoryDto.RepositoryId
-                                                directoryVersion.RelativePath
-                                                metadata.CorrelationId
+                                        match getManifestReferencesForSaveBoundary directoryVersion metadata.CorrelationId with
+                                        | Error graceError -> return Error graceError
+                                        | Ok _ ->
+                                            // Determine which whole-file entries need validation using incremental validation logic.
+                                            // Manifest-backed files were already accepted by UploadSession finalization; WholeFileContent remains unchanged.
+                                            let! mostRecentDirectoryVersion =
+                                                getMostRecentDirectoryVersionByRelativePath
+                                                    repositoryDto.RepositoryId
+                                                    directoryVersion.RelativePath
+                                                    metadata.CorrelationId
 
-                                        let filesToValidate =
-                                            match mostRecentDirectoryVersion with
-                                            | Some previousDirectoryVersion -> getFilesToValidate directoryVersion.Files previousDirectoryVersion.Files
-                                            | None -> getFilesToValidate directoryVersion.Files (List<FileVersion>())
+                                            let filesToValidate =
+                                                match mostRecentDirectoryVersion with
+                                                | Some previousDirectoryVersion ->
+                                                    getFilesToValidateForSaveBoundary directoryVersion.Files previousDirectoryVersion.Files
+                                                | None -> getFilesToValidateForSaveBoundary directoryVersion.Files (List<FileVersion>())
 
-                                        log.LogDebug(
-                                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting SHA-256 validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
-                                            getCurrentInstantExtended (),
-                                            getMachineName,
-                                            metadata.CorrelationId,
-                                            directoryVersion.DirectoryVersionId,
-                                            directoryVersion.RelativePath,
-                                            directoryVersion.Files.Count,
-                                            filesToValidate.Length
-                                        )
-
-                                        let validationResults = ConcurrentQueue<FileValidationResult>()
-
-                                        // Validate files in parallel
-                                        do!
-                                            Parallel.ForEachAsync(
-                                                filesToValidate,
-                                                Constants.ParallelOptions,
-                                                (fun fileVersion ct ->
-                                                    ValueTask(
-                                                        task {
-                                                            let! result = validateFileSha256 repositoryDto fileVersion metadata.CorrelationId
-                                                            validationResults.Enqueue result
-                                                        }
-                                                    ))
-                                            )
-
-                                        let validationResults = validationResults.ToArray()
-
-                                        // Collect failures
-                                        let failures =
-                                            validationResults
-                                            |> Array.filter (fun result ->
-                                                match result with
-                                                | Valid _ -> false
-                                                | _ -> true)
-                                            |> Array.toList
-
-                                        let validCount =
-                                            validationResults
-                                            |> Array.filter (fun result ->
-                                                match result with
-                                                | Valid _ -> true
-                                                | _ -> false)
-                                            |> Array.length
-
-                                        let totalElapsedMs =
-                                            validationResults
-                                            |> Array.sumBy (fun result ->
-                                                match result with
-                                                | Valid (_, _, ms) -> ms
-                                                | HashMismatch (_, _, _, ms) -> ms
-                                                | MissingInStorage (_, ms) -> ms
-                                                | ValidationError (_, _, ms) -> ms)
-
-                                        // Log validation results
-                                        for result in validationResults do
-                                            match result with
-                                            | Valid (fv, computedHash, elapsedMs) ->
-                                                log.LogDebug(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation passed; File: {RelativePath}; Hash: {Hash}; ElapsedMs: {ElapsedMs}.",
-                                                    getCurrentInstantExtended (),
-                                                    getMachineName,
-                                                    metadata.CorrelationId,
-                                                    fv.RelativePath,
-                                                    computedHash,
-                                                    elapsedMs
-                                                )
-                                            | HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
-                                                log.LogWarning(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
-                                                    getCurrentInstantExtended (),
-                                                    getMachineName,
-                                                    metadata.CorrelationId,
-                                                    fv.RelativePath,
-                                                    expectedHash,
-                                                    computedHash,
-                                                    elapsedMs
-                                                )
-                                            | MissingInStorage (fv, elapsedMs) ->
-                                                log.LogWarning(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; File not found in object storage; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ElapsedMs: {ElapsedMs}.",
-                                                    getCurrentInstantExtended (),
-                                                    getMachineName,
-                                                    metadata.CorrelationId,
-                                                    fv.RelativePath,
-                                                    fv.Sha256Hash,
-                                                    elapsedMs
-                                                )
-                                            | ValidationError (fv, errorMessage, elapsedMs) ->
-                                                log.LogError(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation error; File: {RelativePath}; Error: {ErrorMessage}; ElapsedMs: {ElapsedMs}.",
-                                                    getCurrentInstantExtended (),
-                                                    getMachineName,
-                                                    metadata.CorrelationId,
-                                                    fv.RelativePath,
-                                                    errorMessage,
-                                                    elapsedMs
-                                                )
-
-                                        // Check if any validation failed
-                                        if failures.Length > 0 then
-                                            // Build error message with details about failures
-                                            let errorDetails =
-                                                failures
-                                                |> List.map (fun failure ->
-                                                    match failure with
-                                                    | HashMismatch (fv, expected, computed, _) ->
-                                                        $"File '{fv.RelativePath}': hash mismatch (expected: {expected}, computed: {computed})"
-                                                    | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
-                                                    | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
-                                                    | _ -> "Unknown error")
-                                                |> String.concat "; "
-
-                                            log.LogWarning(
-                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                            log.LogDebug(
+                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting SHA-256 validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
                                                 getCurrentInstantExtended (),
                                                 getMachineName,
                                                 metadata.CorrelationId,
                                                 directoryVersion.DirectoryVersionId,
                                                 directoryVersion.RelativePath,
-                                                failures.Length,
-                                                validCount,
-                                                totalElapsedMs
+                                                directoryVersion.Files.Count,
+                                                filesToValidate.Length
                                             )
 
-                                            // Determine the appropriate error type
-                                            let hasHashMismatch =
-                                                failures
-                                                |> List.exists (fun f ->
-                                                    match f with
-                                                    | HashMismatch _ -> true
+                                            let validationResults = ConcurrentQueue<FileValidationResult>()
+
+                                            // Validate files in parallel
+                                            do!
+                                                Parallel.ForEachAsync(
+                                                    filesToValidate,
+                                                    Constants.ParallelOptions,
+                                                    (fun fileVersion ct ->
+                                                        ValueTask(
+                                                            task {
+                                                                let! result = validateFileSha256 repositoryDto fileVersion metadata.CorrelationId
+                                                                validationResults.Enqueue result
+                                                            }
+                                                        ))
+                                                )
+
+                                            let validationResults = validationResults.ToArray()
+
+                                            // Collect failures
+                                            let failures =
+                                                validationResults
+                                                |> Array.filter (fun result ->
+                                                    match result with
+                                                    | Valid _ -> false
+                                                    | _ -> true)
+                                                |> Array.toList
+
+                                            let validCount =
+                                                validationResults
+                                                |> Array.filter (fun result ->
+                                                    match result with
+                                                    | Valid _ -> true
                                                     | _ -> false)
+                                                |> Array.length
 
-                                            let hasMissing =
-                                                failures
-                                                |> List.exists (fun f ->
-                                                    match f with
-                                                    | MissingInStorage _ -> true
-                                                    | _ -> false)
+                                            let totalElapsedMs =
+                                                validationResults
+                                                |> Array.sumBy (fun result ->
+                                                    match result with
+                                                    | Valid (_, _, ms) -> ms
+                                                    | HashMismatch (_, _, _, ms) -> ms
+                                                    | MissingInStorage (_, ms) -> ms
+                                                    | ValidationError (_, _, ms) -> ms)
 
-                                            let errorMessage =
-                                                if hasMissing then
-                                                    DirectoryVersionError.getErrorMessage DirectoryVersionError.FileNotFoundInObjectStorage
-                                                    + " "
-                                                    + errorDetails
-                                                elif hasHashMismatch then
-                                                    DirectoryVersionError.getErrorMessage DirectoryVersionError.FileSha256HashDoesNotMatch
-                                                    + " "
-                                                    + errorDetails
-                                                else
-                                                    $"File integrity check failed: {errorDetails}"
+                                            // Log validation results
+                                            for result in validationResults do
+                                                match result with
+                                                | Valid (fv, computedHash, elapsedMs) ->
+                                                    log.LogDebug(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation passed; File: {RelativePath}; Hash: {Hash}; ElapsedMs: {ElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        fv.RelativePath,
+                                                        computedHash,
+                                                        elapsedMs
+                                                    )
+                                                | HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
+                                                    log.LogWarning(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        fv.RelativePath,
+                                                        expectedHash,
+                                                        computedHash,
+                                                        elapsedMs
+                                                    )
+                                                | MissingInStorage (fv, elapsedMs) ->
+                                                    log.LogWarning(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; File not found in object storage; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ElapsedMs: {ElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        fv.RelativePath,
+                                                        fv.Sha256Hash,
+                                                        elapsedMs
+                                                    )
+                                                | ValidationError (fv, errorMessage, elapsedMs) ->
+                                                    log.LogError(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation error; File: {RelativePath}; Error: {ErrorMessage}; ElapsedMs: {ElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        fv.RelativePath,
+                                                        errorMessage,
+                                                        elapsedMs
+                                                    )
 
-                                            return Error(GraceError.Create errorMessage metadata.CorrelationId)
-                                        else
-                                            log.LogInformation(
-                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
-                                                getCurrentInstantExtended (),
-                                                getMachineName,
-                                                metadata.CorrelationId,
-                                                directoryVersion.DirectoryVersionId,
-                                                directoryVersion.RelativePath,
-                                                validCount,
-                                                totalElapsedMs
-                                            )
+                                            // Check if any validation failed
+                                            if failures.Length > 0 then
+                                                // Build error message with details about failures
+                                                let errorDetails =
+                                                    failures
+                                                    |> List.map (fun failure ->
+                                                        match failure with
+                                                        | HashMismatch (fv, expected, computed, _) ->
+                                                            $"File '{fv.RelativePath}': hash mismatch (expected: {expected}, computed: {computed})"
+                                                        | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
+                                                        | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
+                                                        | _ -> "Unknown error")
+                                                    |> String.concat "; "
 
-                                            let newDirectoryVersion = { directoryVersion with HashesValidated = true }
-                                            return Ok(Created newDirectoryVersion)
+                                                log.LogWarning(
+                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                    getCurrentInstantExtended (),
+                                                    getMachineName,
+                                                    metadata.CorrelationId,
+                                                    directoryVersion.DirectoryVersionId,
+                                                    directoryVersion.RelativePath,
+                                                    failures.Length,
+                                                    validCount,
+                                                    totalElapsedMs
+                                                )
+
+                                                // Determine the appropriate error type
+                                                let hasHashMismatch =
+                                                    failures
+                                                    |> List.exists (fun f ->
+                                                        match f with
+                                                        | HashMismatch _ -> true
+                                                        | _ -> false)
+
+                                                let hasMissing =
+                                                    failures
+                                                    |> List.exists (fun f ->
+                                                        match f with
+                                                        | MissingInStorage _ -> true
+                                                        | _ -> false)
+
+                                                let errorMessage =
+                                                    if hasMissing then
+                                                        DirectoryVersionError.getErrorMessage DirectoryVersionError.FileNotFoundInObjectStorage
+                                                        + " "
+                                                        + errorDetails
+                                                    elif hasHashMismatch then
+                                                        DirectoryVersionError.getErrorMessage DirectoryVersionError.FileSha256HashDoesNotMatch
+                                                        + " "
+                                                        + errorDetails
+                                                    else
+                                                        $"File integrity check failed: {errorDetails}"
+
+                                                return Error(GraceError.Create errorMessage metadata.CorrelationId)
+                                            else
+                                                log.LogInformation(
+                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                    getCurrentInstantExtended (),
+                                                    getMachineName,
+                                                    metadata.CorrelationId,
+                                                    directoryVersion.DirectoryVersionId,
+                                                    directoryVersion.RelativePath,
+                                                    validCount,
+                                                    totalElapsedMs
+                                                )
+
+                                                let newDirectoryVersion = { directoryVersion with HashesValidated = true }
+                                                return Ok(Created newDirectoryVersion)
                                     | SetRecursiveSize recursiveSize -> return Ok(RecursiveSizeSet recursiveSize)
                                     | DeleteLogical deleteReason ->
                                         let repositoryActorProxy =

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -58,7 +58,7 @@ module Reference =
         while index < manifest.Blocks.Count do
             let block = manifest.Blocks[index]
 
-            ranges.Add({ StoragePoolId = StoragePoolId DefaultStoragePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = 1 })
+            ranges.Add({ StoragePoolId = StoragePoolId DefaultStoragePoolId; ContentBlockAddress = block.Address; OrdinalStart = index; OrdinalCount = 1 })
 
             index <- index + 1
 

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -64,6 +64,16 @@ module Reference =
 
         ranges.ToArray()
 
+    let private workflowStartCommandForPlan plan =
+        ManifestContributionWorkflowCommand.Start
+            {
+                OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress
+                RepositoryId = plan.RepositoryId
+                ManifestAddress = plan.Manifest.ManifestAddress
+                Direction = ManifestContributionDirection.Increment
+                Ranges = plan.WorkflowRanges
+            }
+
     let planManifestSaveBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
         match DirectoryVersion.getManifestReferencesForSaveBoundary directoryVersion correlationId with
         | Error graceError -> Error graceError
@@ -87,17 +97,42 @@ module Reference =
             repositoryId = plan.RepositoryId
             && manifestAddress = plan.Manifest.ManifestAddress
             ->
-            Some(
-                ManifestContributionWorkflowCommand.Start
-                    {
-                        OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress
-                        RepositoryId = plan.RepositoryId
-                        ManifestAddress = plan.Manifest.ManifestAddress
-                        Direction = ManifestContributionDirection.Increment
-                        Ranges = plan.WorkflowRanges
-                    }
-            )
+            Some(workflowStartCommandForPlan plan)
         | _ -> None
+
+    let private addReferenceOperationId command =
+        match command with
+        | RepositoryContentCounterCommand.AddReference (operationId, _, _) -> Some operationId
+        | _ -> None
+
+    let private referenceAddedFromZero operationId events =
+        let mutable referenceCount = 0L
+        let mutable addedFromZero = false
+
+        for counterEvent in events do
+            match counterEvent.Event with
+            | RepositoryContentCounterEventType.ReferenceAdded (eventOperationId, _, _) ->
+                if eventOperationId = operationId
+                   && referenceCount = 0L then
+                    addedFromZero <- true
+
+                referenceCount <- referenceCount + 1L
+            | RepositoryContentCounterEventType.ReferenceRemoved _ -> referenceCount <- max 0L (referenceCount - 1L)
+
+        addedFromZero
+
+    let tryCreateManifestContributionStartForCounterDecision plan (decision: RepositoryContentCounterDecision) events =
+        let startFromIntent =
+            decision.Intents
+            |> List.tryPick (tryCreateManifestContributionStart plan)
+
+        match startFromIntent with
+        | Some startCommand -> Some startCommand
+        | None when decision.WasIdempotentReplay ->
+            match addReferenceOperationId plan.CounterCommand with
+            | Some operationId when referenceAddedFromZero operationId events -> Some(workflowStartCommandForPlan plan)
+            | _ -> None
+        | None -> None
 
     let private createRepositoryContentCounterActor repositoryId manifestAddress correlationId =
         let grain =
@@ -387,27 +422,20 @@ module Reference =
                                         match! counterActor.Handle plan.CounterCommand metadata with
                                         | Error graceError -> error <- Some graceError
                                         | Ok counterReturnValue ->
-                                            let intents =
-                                                counterReturnValue.ReturnValue.Intents
-                                                |> List.toArray
+                                            let! counterEvents = counterActor.GetEvents metadata.CorrelationId
 
-                                            let mutable intentIndex = 0
+                                            match tryCreateManifestContributionStartForCounterDecision plan counterReturnValue.ReturnValue counterEvents with
+                                            | None -> ()
+                                            | Some startCommand ->
+                                                let workflowActor =
+                                                    createManifestContributionWorkflowActor
+                                                        plan.RepositoryId
+                                                        plan.Manifest.ManifestAddress
+                                                        metadata.CorrelationId
 
-                                            while intentIndex < intents.Length && error.IsNone do
-                                                match tryCreateManifestContributionStart plan intents[intentIndex] with
-                                                | None -> ()
-                                                | Some startCommand ->
-                                                    let workflowActor =
-                                                        createManifestContributionWorkflowActor
-                                                            plan.RepositoryId
-                                                            plan.Manifest.ManifestAddress
-                                                            metadata.CorrelationId
-
-                                                    match! workflowActor.Handle startCommand metadata with
-                                                    | Ok _ -> ()
-                                                    | Error graceError -> error <- Some graceError
-
-                                                intentIndex <- intentIndex + 1
+                                                match! workflowActor.Handle startCommand metadata with
+                                                | Ok _ -> ()
+                                                | Error graceError -> error <- Some graceError
 
                                         planIndex <- planIndex + 1
 

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -13,8 +13,10 @@ open Grace.Shared.Constants
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Events
+open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.Reference
 open Grace.Types.Reminder
+open Grace.Types.RepositoryContentCounter
 open Grace.Types.Types
 open Microsoft.Extensions.Logging
 open NodaTime
@@ -26,6 +28,102 @@ open System.Globalization
 open System.Threading.Tasks
 
 module Reference =
+
+    [<Literal>]
+    let private DefaultStoragePoolId = "default"
+
+    type ManifestSaveContributionPlan =
+        {
+            RepositoryId: RepositoryId
+            ReferenceId: ReferenceId
+            Manifest: FileManifest
+            CounterCommand: RepositoryContentCounterCommand
+            WorkflowRanges: ManifestContributionWorkflowRange array
+        }
+
+    let private manifestContributionOperationId (referenceId: ReferenceId) (manifestAddress: ManifestAddress) =
+        RepositoryContentCounterOperationId $"save:{referenceId:N}:{manifestAddress}"
+
+    let private workflowOperationId (referenceId: ReferenceId) (manifestAddress: ManifestAddress) =
+        ManifestContributionWorkflowOperationId $"save:{referenceId:N}:{manifestAddress}:fanout"
+
+    let private repositoryContentCounterPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
+
+    let private manifestContributionWorkflowPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
+
+    let private workflowRangesForManifest (manifest: FileManifest) =
+        let ranges = ResizeArray<ManifestContributionWorkflowRange>()
+        let mutable index = 0
+
+        while index < manifest.Blocks.Count do
+            let block = manifest.Blocks[index]
+
+            ranges.Add({ StoragePoolId = StoragePoolId DefaultStoragePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = 1 })
+
+            index <- index + 1
+
+        ranges.ToArray()
+
+    let planManifestSaveBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
+        match DirectoryVersion.getManifestReferencesForSaveBoundary directoryVersion correlationId with
+        | Error graceError -> Error graceError
+        | Ok manifests ->
+            manifests
+            |> List.map (fun manifest ->
+                let operationId = manifestContributionOperationId referenceId manifest.ManifestAddress
+
+                {
+                    RepositoryId = repositoryId
+                    ReferenceId = referenceId
+                    Manifest = manifest
+                    CounterCommand = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, manifest.ManifestAddress)
+                    WorkflowRanges = workflowRangesForManifest manifest
+                })
+            |> Ok
+
+    let tryCreateManifestContributionStart plan intent =
+        match intent with
+        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, manifestAddress) when
+            repositoryId = plan.RepositoryId
+            && manifestAddress = plan.Manifest.ManifestAddress
+            ->
+            Some(
+                ManifestContributionWorkflowCommand.Start
+                    {
+                        OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress
+                        RepositoryId = plan.RepositoryId
+                        ManifestAddress = plan.Manifest.ManifestAddress
+                        Direction = ManifestContributionDirection.Increment
+                        Ranges = plan.WorkflowRanges
+                    }
+            )
+        | _ -> None
+
+    let private createRepositoryContentCounterActor repositoryId manifestAddress correlationId =
+        let grain =
+            orleansClient.CreateActorProxyWithCorrelationId<IRepositoryContentCounterActor>(
+                repositoryContentCounterPrimaryKey repositoryId manifestAddress,
+                correlationId
+            )
+
+        let orleansContext = Dictionary<string, obj>()
+        orleansContext.Add(nameof RepositoryId, repositoryId)
+        orleansContext.Add(Constants.ActorNameProperty, ActorName.RepositoryContentCounter)
+        memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
+        grain
+
+    let private createManifestContributionWorkflowActor repositoryId manifestAddress correlationId =
+        let grain =
+            orleansClient.CreateActorProxyWithCorrelationId<IManifestContributionWorkflowActor>(
+                manifestContributionWorkflowPrimaryKey repositoryId manifestAddress,
+                correlationId
+            )
+
+        let orleansContext = Dictionary<string, obj>()
+        orleansContext.Add(nameof RepositoryId, repositoryId)
+        orleansContext.Add(Constants.ActorNameProperty, ActorName.ManifestContributionWorkflow)
+        memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
+        grain
 
     type ReferenceActor([<PersistentState(StateName.Reference, Constants.GraceActorStorage)>] state: IPersistentState<List<ReferenceEvent>>) =
         inherit Grain()
@@ -265,8 +363,61 @@ module Reference =
                     }
 
                 let processCommand (command: ReferenceCommand) (metadata: EventMetadata) =
+                    let applySaveManifestBoundary referenceId repositoryId directoryId referenceType =
+                        task {
+                            if referenceType <> ReferenceType.Save then
+                                return Ok()
+                            else
+                                let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
+                                let! directoryVersionDto = directoryVersionActorProxy.Get metadata.CorrelationId
+
+                                match planManifestSaveBoundary repositoryId referenceId directoryVersionDto.DirectoryVersion metadata.CorrelationId with
+                                | Error graceError -> return Error graceError
+                                | Ok plans ->
+                                    let planArray = plans |> List.toArray
+                                    let mutable planIndex = 0
+                                    let mutable error: GraceError option = None
+
+                                    while planIndex < planArray.Length && error.IsNone do
+                                        let plan = planArray[planIndex]
+
+                                        let counterActor =
+                                            createRepositoryContentCounterActor plan.RepositoryId plan.Manifest.ManifestAddress metadata.CorrelationId
+
+                                        match! counterActor.Handle plan.CounterCommand metadata with
+                                        | Error graceError -> error <- Some graceError
+                                        | Ok counterReturnValue ->
+                                            let intents =
+                                                counterReturnValue.ReturnValue.Intents
+                                                |> List.toArray
+
+                                            let mutable intentIndex = 0
+
+                                            while intentIndex < intents.Length && error.IsNone do
+                                                match tryCreateManifestContributionStart plan intents[intentIndex] with
+                                                | None -> ()
+                                                | Some startCommand ->
+                                                    let workflowActor =
+                                                        createManifestContributionWorkflowActor
+                                                            plan.RepositoryId
+                                                            plan.Manifest.ManifestAddress
+                                                            metadata.CorrelationId
+
+                                                    match! workflowActor.Handle startCommand metadata with
+                                                    | Ok _ -> ()
+                                                    | Error graceError -> error <- Some graceError
+
+                                                intentIndex <- intentIndex + 1
+
+                                        planIndex <- planIndex + 1
+
+                                    match error with
+                                    | Some graceError -> return Error graceError
+                                    | None -> return Ok()
+                        }
+
                     task {
-                        let! referenceEventType =
+                        let! (referenceEventTypeResult: Result<ReferenceEventType, GraceError>) =
                             task {
                                 match command with
                                 | Create (referenceId,
@@ -279,21 +430,26 @@ module Reference =
                                           referenceType,
                                           referenceText,
                                           links) ->
-                                    return
-                                        Created(
-                                            referenceId,
-                                            ownerId,
-                                            organizationId,
-                                            repositoryId,
-                                            branchId,
-                                            directoryId,
-                                            sha256Hash,
-                                            referenceType,
-                                            referenceText,
-                                            links
-                                        )
-                                | AddLink link -> return LinkAdded link
-                                | RemoveLink link -> return LinkRemoved link
+                                    match! applySaveManifestBoundary referenceId repositoryId directoryId referenceType with
+                                    | Ok () ->
+                                        return
+                                            Ok(
+                                                Created(
+                                                    referenceId,
+                                                    ownerId,
+                                                    organizationId,
+                                                    repositoryId,
+                                                    branchId,
+                                                    directoryId,
+                                                    sha256Hash,
+                                                    referenceType,
+                                                    referenceText,
+                                                    links
+                                                )
+                                            )
+                                    | Error graceError -> return Error graceError
+                                | AddLink link -> return Ok(LinkAdded link)
+                                | RemoveLink link -> return Ok(LinkRemoved link)
                                 | DeleteLogical (force, deleteReason) ->
                                     let tryGetLogicalDeleteDaysFromMetadata () =
                                         match metadata.Properties.TryGetValue("RepositoryLogicalDeleteDays") with
@@ -336,19 +492,21 @@ module Reference =
                                             (ReminderState.ReferencePhysicalDeletion reminderState)
                                             metadata.CorrelationId
 
-                                    return LogicalDeleted(force, deleteReason)
+                                    return Ok(LogicalDeleted(force, deleteReason))
                                 | DeletePhysical ->
                                     // Delete the actor state and mark the actor as deactivated.
                                     do! state.ClearStateAsync()
                                     this.DeactivateOnIdle()
-                                    return PhysicalDeleted
-                                | Undelete -> return Undeleted
+                                    return Ok PhysicalDeleted
+                                | Undelete -> return Ok Undeleted
                             }
 
-                        let referenceEvent = { Event = referenceEventType; Metadata = metadata }
-                        let! returnValue = this.ApplyEvent referenceEvent
-
-                        return returnValue
+                        match referenceEventTypeResult with
+                        | Ok referenceEventType ->
+                            let referenceEvent: ReferenceEvent = { Event = referenceEventType; Metadata = metadata }
+                            let! returnValue = this.ApplyEvent referenceEvent
+                            return returnValue
+                        | Error graceError -> return Error graceError
                     }
 
                 task {

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
+    <Compile Include="SaveBoundary.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -27,8 +27,9 @@ type SaveBoundaryActorTests() =
 
     let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
 
-    let finalizedManifest () : FileManifest =
+    let finalizedManifestWithBlockCopies blockCopies : FileManifest =
         let bytes = Encoding.UTF8.GetBytes($"large manifest-backed file {Guid.NewGuid():N}")
+        let fileBytes = Array.concat (List.replicate blockCopies bytes)
 
         let block =
             match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
@@ -41,14 +42,17 @@ type SaveBoundaryActorTests() =
             FileManifest.Create(
                 ManifestAddress String.Empty,
                 RabinChunking.SuiteName,
-                FileContentHash(ContentAddress.computeBlake3Hex bytes),
-                int64 bytes.Length,
+                FileContentHash(ContentAddress.computeBlake3Hex fileBytes),
+                int64 fileBytes.Length,
                 [
-                    ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+                    for index in 0 .. blockCopies - 1 do
+                        ContentBlock.Create(block.Address, int64 (index * bytes.Length), int64 bytes.Length)
                 ]
             )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let finalizedManifest () = finalizedManifestWithBlockCopies 1
 
     let manifestFile (manifest: FileManifest) =
         let fileVersion = FileVersion.Create "/large.bin" "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" String.Empty true manifest.Size
@@ -140,4 +144,29 @@ type SaveBoundaryActorTests() =
                 Assert.That(decision.Workflow.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
                 Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(manifest.Blocks.Count))
             | Error error -> Assert.Fail($"Expected contribution workflow start to succeed, got {error.Error}.")
+        | None -> Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")
+
+    [<Test>]
+    member _.SaveBoundaryStartsContributionWorkflowForRepeatedManifestBlockOccurrences() =
+        let manifest = finalizedManifestWithBlockCopies 2
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let plan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-repeated-block"
+            |> expectPlan
+
+        Assert.That(plan.WorkflowRanges, Has.Length.EqualTo(2))
+        Assert.That(plan.WorkflowRanges[0].ContentBlockAddress, Is.EqualTo(plan.WorkflowRanges[1].ContentBlockAddress))
+        Assert.That(plan.WorkflowRanges[0].OrdinalStart, Is.Not.EqualTo(plan.WorkflowRanges[1].OrdinalStart))
+
+        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifest.ManifestAddress)
+
+        match ReferenceActor.tryCreateManifestContributionStart plan intent with
+        | Some startCommand ->
+            let workflowDecision =
+                ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-repeated-workflow")
+
+            match workflowDecision with
+            | Ok decision -> Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(2))
+            | Error error -> Assert.Fail($"Expected repeated block occurrences to start contribution workflow, got {error.Error}.")
         | None -> Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -1,0 +1,143 @@
+namespace Grace.Server.Tests
+
+open Grace.Shared
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.RepositoryContentCounter
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Text
+
+module DirectoryVersionActor = Grace.Actors.DirectoryVersion
+module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
+module ReferenceActor = Grace.Actors.Reference
+module RepositoryContentCounterActor = Grace.Actors.RepositoryContentCounter
+
+[<Parallelizable(ParallelScope.All)>]
+type SaveBoundaryActorTests() =
+
+    let timestamp = Instant.FromUtc(2026, 5, 24, 16, 0)
+    let ownerId = Guid.Parse("06fed2a6-8de5-4ef2-86b7-e465448cf77d")
+    let organizationId = Guid.Parse("5a602145-3f0a-47c8-bc7c-f6618425c07f")
+    let repositoryId = Guid.Parse("e34f8949-6306-4fb1-89ca-e9eb831022b0")
+    let directoryVersionId = Guid.Parse("29e93e9b-3e5f-4b6e-b8c3-2a964d8d33f3")
+    let referenceId = Guid.Parse("9b26f91a-fd44-46b3-9cc7-17645bb388a2")
+
+    let metadata correlationId = { Timestamp = timestamp; CorrelationId = correlationId; Principal = "tester"; Properties = Dictionary<string, string>() }
+
+    let finalizedManifest () : FileManifest =
+        let bytes = Encoding.UTF8.GetBytes($"large manifest-backed file {Guid.NewGuid():N}")
+
+        let block =
+            match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
+            | Ok block -> block
+            | Error error ->
+                Assert.Fail($"Expected content block encoding to succeed, got {error}.")
+                Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex bytes),
+                int64 bytes.Length,
+                [
+                    ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+                ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let manifestFile (manifest: FileManifest) =
+        let fileVersion = FileVersion.Create "/large.bin" "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" String.Empty true manifest.Size
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+        fileVersion
+
+    let wholeFile () = FileVersion.Create "/small.txt" "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" String.Empty false 42L
+
+    let directoryWith (files: FileVersion seq) =
+        let fileList = List<FileVersion>(files)
+
+        Grace.Types.Types.DirectoryVersion.Create
+            directoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            (RelativePath "/")
+            (Sha256Hash "fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcba")
+            (List<DirectoryVersionId>())
+            fileList
+            (fileList
+             |> Seq.sumBy (fun fileVersion -> fileVersion.Size))
+
+    let expectPlan result =
+        match result with
+        | Ok plans -> plans |> Seq.exactlyOne
+        | Error error ->
+            Assert.Fail($"Expected save boundary plan to succeed, got {error.Error}.")
+            Unchecked.defaultof<ReferenceActor.ManifestSaveContributionPlan>
+
+    [<Test>]
+    member _.SaveBoundaryRejectsUnfinalizedManifestReferences() =
+        let unfinalizedManifest = { finalizedManifest () with ManifestAddress = ManifestAddress String.Empty }
+        let directoryVersion = directoryWith [ manifestFile unfinalizedManifest ]
+
+        let result = ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-unfinalized"
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected an unfinalized manifest reference to reject before save publication.")
+        | Error error -> Assert.That(error.Error, Does.Contain("must be finalized before Save"))
+
+    [<Test>]
+    member _.DirectoryVersionWholeFileValidationSetIgnoresFinalizedManifestBackedFiles() =
+        let manifest = finalizedManifest ()
+        let wholeFile = wholeFile ()
+        let files = List<FileVersion>([ wholeFile; manifestFile manifest ])
+
+        let filesToValidate = DirectoryVersionActor.getFilesToValidateForSaveBoundary files (List<FileVersion>())
+
+        Assert.That(filesToValidate, Has.Length.EqualTo(1))
+        Assert.That(filesToValidate[0].RelativePath, Is.EqualTo(wholeFile.RelativePath))
+
+    [<Test>]
+    member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let plan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-finalized"
+            |> expectPlan
+
+        let counterDecision = RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default plan.CounterCommand (metadata "corr-counter")
+
+        match counterDecision with
+        | Ok decision ->
+            Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(1L))
+            Assert.That(decision.Intents, Has.Length.EqualTo(1))
+            Assert.That(decision.Intents[0], Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifest.ManifestAddress)))
+        | Error error -> Assert.Fail($"Expected repository content counter increment to succeed, got {error.Error}.")
+
+    [<Test>]
+    member _.SaveBoundaryStartsPendingContributionWorkflowWithoutWaitingForRangeCompletion() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let plan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-fanout"
+            |> expectPlan
+
+        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifest.ManifestAddress)
+
+        match ReferenceActor.tryCreateManifestContributionStart plan intent with
+        | Some startCommand ->
+            let workflowDecision =
+                ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-workflow")
+
+            match workflowDecision with
+            | Ok decision ->
+                Assert.That(decision.Workflow.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
+                Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(manifest.Blocks.Count))
+            | Error error -> Assert.Fail($"Expected contribution workflow start to succeed, got {error.Error}.")
+        | None -> Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -124,6 +124,48 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected repository content counter increment to succeed, got {error.Error}.")
 
     [<Test>]
+    member _.SaveBoundaryRestartsContributionWorkflowAfterCounterReplay() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let plan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-replay"
+            |> expectPlan
+
+        let firstCounterDecision =
+            match RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default plan.CounterCommand (metadata "corr-counter-first") with
+            | Ok decision -> decision
+            | Error error ->
+                Assert.Fail($"Expected first repository content counter increment to succeed, got {error.Error}.")
+                Unchecked.defaultof<RepositoryContentCounterDecision>
+
+        let replayDecision =
+            match
+                RepositoryContentCounterActor.decideCommand
+                    firstCounterDecision.Events
+                    firstCounterDecision.Counter
+                    plan.CounterCommand
+                    (metadata "corr-counter-replay")
+                with
+            | Ok decision -> decision
+            | Error error ->
+                Assert.Fail($"Expected repository content counter replay to succeed, got {error.Error}.")
+                Unchecked.defaultof<RepositoryContentCounterDecision>
+
+        Assert.That(replayDecision.WasIdempotentReplay, Is.True)
+        Assert.That(replayDecision.Intents, Is.Empty)
+
+        match ReferenceActor.tryCreateManifestContributionStartForCounterDecision plan replayDecision firstCounterDecision.Events with
+        | Some startCommand ->
+            let workflowDecision =
+                ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-workflow-replay")
+
+            match workflowDecision with
+            | Ok decision -> Assert.That(decision.Workflow.LifecycleState, Is.EqualTo(ManifestContributionWorkflowLifecycleState.InProgress))
+            | Error error -> Assert.Fail($"Expected replayed counter boundary to restart contribution workflow, got {error.Error}.")
+        | None -> Assert.Fail("Expected replayed zero-crossing counter operation to restart manifest contribution workflow fan-out.")
+
+    [<Test>]
     member _.SaveBoundaryStartsPendingContributionWorkflowWithoutWaitingForRangeCompletion() =
         let manifest = finalizedManifest ()
         let directoryVersion = directoryWith [ manifestFile manifest ]

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -481,6 +481,8 @@ module Branch =
             }
 
     /// Creates a save reference pointing to the current root directory version in the branch.
+    /// Manifest-backed files are accepted only after repository-local manifest accounting is durably incremented;
+    /// WholeFileContent save behavior continues to use the existing directory-version validation path.
     let Save: HttpHandler =
         fun (next: HttpFunc) (context: HttpContext) ->
             task {


### PR DESCRIPTION
Closes #97.

## Summary
- Added save-boundary actor tests covering unfinalized manifest rejection, finalized manifest acceptance after durable repository content-counter intent, and async fan-out workflow start without waiting for range completion.
- Added DirectoryVersion save-boundary validation for manifest-backed files while keeping WholeFileContent SHA validation on the existing path.
- Integrated save reference creation with repository content-counter accounting and manifest contribution workflow start before the save reference is created.
- Added a Branch.Server save-flow comment documenting the manifest-backed publication boundary.

## Owned paths / scope
- Stayed inside the claimed #97 write set:
  - `src/Grace.Actors/DirectoryVersion.Actor.fs`
  - `src/Grace.Actors/Reference.Actor.fs`
  - `src/Grace.Server/Branch.Server.fs`
  - `src/Grace.Server.Tests/Grace.Server.Tests.fsproj`
  - `src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs`

## TDD / RED evidence
- Added save-boundary tests first. Initial focused run failed to compile because the production/test hooks did not exist yet:
  - `ManifestSaveContributionPlan` was not defined.
  - `ReferenceActor.planManifestSaveBoundary` was not defined.
  - `DirectoryVersionActor.getFilesToValidateForSaveBoundary` was not defined.
  - `ReferenceActor.tryCreateManifestContributionStart` was not defined.

## Validation
- Focused #97 tests: `dotnet test .\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter FullyQualifiedName~SaveBoundary` -> 4 passed, 0 failed.
- Focused related actor slice before merge from `origin/main`: SaveBoundary + RepositoryContentCounter + ManifestContributionWorkflow + UploadSession -> 55 passed, 0 failed.
- Targeted Fantomas: `dotnet tool run fantomas Grace.Actors/DirectoryVersion.Actor.fs Grace.Actors/Reference.Actor.fs Grace.Server/Branch.Server.fs Grace.Server.Tests/SaveBoundary.Actor.Tests.fs` -> passed after fixing the test shorthand that Fantomas surfaced.
- `git diff --check` before commit -> passed.
- `git diff --check origin/main...HEAD` after merge from latest `origin/main` -> passed.
- `pwsh .\scripts\validate.ps1 -Fast` after merge from latest `origin/main` -> passed: build clean, Authorization 21/21, CLI 200 passed / 1 suite-defined skip, Types 49/49.
- `pwsh .\scripts\validate.ps1 -Full` before merge from latest `origin/main` -> passed: build clean, Authorization 21/21, CLI 200 passed / 1 suite-defined skip, Types 49/49, Server 295/295.
- `pwsh .\scripts\validate.ps1 -Full` after merge from latest `origin/main` was rerun and failed in unrelated server integration tests with Orleans activation timeouts while parallel Grace work was active on the machine. The run reached Server tests and ended 271 passed / 24 failed. Failures were outside the #97 touched paths and routed through repository/service activation or unrelated endpoint setup, for example `Grace.Actors.Services.repositoryExists` activation cancellation and Owner/Access/Storage/WorkItem endpoint setup 400/500s. A post-failure focused #97 rerun passed 4/4, and the post-merge `-Fast` gate passed.

## Docs impact
- Updated the save-flow implementation comment in `Branch.Server.fs` because manifest-backed files now publish through durable manifest accounting before async fan-out completion.
- No Markdown files were changed by #97, so MarkdownLint was not run.

## Skipped validation / caveats
- MarkdownLint skipped: no #97 Markdown changes.
- Post-merge full-suite rerun is not green due the shared Orleans/Aspire activation-timeout failure described above; pre-merge full passed and post-merge fast plus focused #97 tests passed.

## Residual risk
- Manifest contribution workflow start uses the current default storage-pool boundary because storage-pool identity is not surfaced through the owned save-boundary contracts in this slice.
- Fan-out completion remains asynchronous by design; this PR only requires durable increment intent plus workflow start before accepting the save.

## Follow-ups
- Expiry/decrement integration remains for the later ADR-0001 DAG slices.
- Manifest default enablement remains separate from this save-boundary integration slice.
