### PR TITLE
ADR-0001: decrement manifest contributions on save expiry

### DIFF
--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -109,6 +109,10 @@ module Reference =
 
                 { plan with CounterCommand = RepositoryContentCounterCommand.RemoveReference(operationId, repositoryId, plan.Manifest.ManifestAddress) }))
 
+    let shouldApplySaveExpiryBoundary (referenceDto: ReferenceDto) =
+        referenceDto.ReferenceId <> ReferenceId.Empty
+        && referenceDto.ReferenceType = ReferenceType.Save
+
     let tryCreateManifestContributionStart plan intent =
         match intent with
         | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, manifestAddress) when
@@ -295,15 +299,18 @@ module Reference =
 
                         let! boundaryResult =
                             task {
-                                match
-                                    planManifestSaveExpiryBoundary
-                                        physicalDeletionReminderState.RepositoryId
-                                        referenceId
-                                        directoryVersionDto.DirectoryVersion
-                                        this.correlationId
-                                    with
-                                | Error graceError -> return Error graceError
-                                | Ok plans -> return! applyManifestContributionBoundary plans (EventMetadata.New this.correlationId "GraceSystem")
+                                if shouldApplySaveExpiryBoundary referenceDto then
+                                    match
+                                        planManifestSaveExpiryBoundary
+                                            physicalDeletionReminderState.RepositoryId
+                                            referenceId
+                                            directoryVersionDto.DirectoryVersion
+                                            this.correlationId
+                                        with
+                                    | Error graceError -> return Error graceError
+                                    | Ok plans -> return! applyManifestContributionBoundary plans (EventMetadata.New this.correlationId "GraceSystem")
+                                else
+                                    return Ok()
                             }
 
                         match boundaryResult with

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -51,6 +51,11 @@ module Reference =
 
     let private manifestContributionWorkflowPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
 
+    let private counterCommandDirection command =
+        match command with
+        | RepositoryContentCounterCommand.AddReference _ -> ManifestContributionDirection.Increment
+        | RepositoryContentCounterCommand.RemoveReference _ -> ManifestContributionDirection.Decrement
+
     let private workflowRangesForManifest (manifest: FileManifest) =
         let ranges = ResizeArray<ManifestContributionWorkflowRange>()
         let mutable index = 0
@@ -70,7 +75,7 @@ module Reference =
                 OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress
                 RepositoryId = plan.RepositoryId
                 ManifestAddress = plan.Manifest.ManifestAddress
-                Direction = ManifestContributionDirection.Increment
+                Direction = counterCommandDirection plan.CounterCommand
                 Ranges = plan.WorkflowRanges
             }
 
@@ -91,35 +96,58 @@ module Reference =
                 })
             |> Ok
 
+    let planManifestSaveExpiryBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
+        planManifestSaveBoundary repositoryId referenceId directoryVersion correlationId
+        |> Result.map (fun plans ->
+            plans
+            |> List.map (fun plan ->
+                let operationId = RepositoryContentCounterOperationId $"save-expiry:{referenceId:N}:{plan.Manifest.ManifestAddress}"
+
+                { plan with CounterCommand = RepositoryContentCounterCommand.RemoveReference(operationId, repositoryId, plan.Manifest.ManifestAddress) }))
+
     let tryCreateManifestContributionStart plan intent =
         match intent with
         | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, manifestAddress) when
             repositoryId = plan.RepositoryId
             && manifestAddress = plan.Manifest.ManifestAddress
+            && counterCommandDirection plan.CounterCommand = ManifestContributionDirection.Increment
+            ->
+            Some(workflowStartCommandForPlan plan)
+        | RepositoryContentCounterIntent.DecrementManifestReferenceCount (repositoryId, manifestAddress) when
+            repositoryId = plan.RepositoryId
+            && manifestAddress = plan.Manifest.ManifestAddress
+            && counterCommandDirection plan.CounterCommand = ManifestContributionDirection.Decrement
             ->
             Some(workflowStartCommandForPlan plan)
         | _ -> None
 
-    let private addReferenceOperationId command =
+    let private counterCommandOperationId command =
         match command with
-        | RepositoryContentCounterCommand.AddReference (operationId, _, _) -> Some operationId
-        | _ -> None
+        | RepositoryContentCounterCommand.AddReference (operationId, _, _)
+        | RepositoryContentCounterCommand.RemoveReference (operationId, _, _) -> Some operationId
 
-    let private referenceAddedFromZero operationId events =
+    let private commandCrossedZero operationId command events =
         let mutable referenceCount = 0L
-        let mutable addedFromZero = false
+        let mutable crossedZero = false
 
         for counterEvent in events do
             match counterEvent.Event with
             | RepositoryContentCounterEventType.ReferenceAdded (eventOperationId, _, _) ->
                 if eventOperationId = operationId
-                   && referenceCount = 0L then
-                    addedFromZero <- true
+                   && referenceCount = 0L
+                   && counterCommandDirection command = ManifestContributionDirection.Increment then
+                    crossedZero <- true
 
                 referenceCount <- referenceCount + 1L
-            | RepositoryContentCounterEventType.ReferenceRemoved _ -> referenceCount <- max 0L (referenceCount - 1L)
+            | RepositoryContentCounterEventType.ReferenceRemoved eventOperationId ->
+                if eventOperationId = operationId
+                   && referenceCount = 1L
+                   && counterCommandDirection command = ManifestContributionDirection.Decrement then
+                    crossedZero <- true
 
-        addedFromZero
+                referenceCount <- max 0L (referenceCount - 1L)
+
+        crossedZero
 
     let tryCreateManifestContributionStartForCounterDecision plan (decision: RepositoryContentCounterDecision) events =
         let startFromIntent =
@@ -129,9 +157,10 @@ module Reference =
         match startFromIntent with
         | Some startCommand -> Some startCommand
         | None when decision.WasIdempotentReplay ->
-            match addReferenceOperationId plan.CounterCommand with
-            | Some operationId when referenceAddedFromZero operationId events -> Some(workflowStartCommandForPlan plan)
-            | _ -> None
+            match counterCommandOperationId plan.CounterCommand with
+            | Some operationId when commandCrossedZero operationId plan.CounterCommand events -> Some(workflowStartCommandForPlan plan)
+            | None
+            | Some _ -> None
         | None -> None
 
     let private createRepositoryContentCounterActor repositoryId manifestAddress correlationId =
@@ -159,6 +188,38 @@ module Reference =
         orleansContext.Add(Constants.ActorNameProperty, ActorName.ManifestContributionWorkflow)
         memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
         grain
+
+    let private applyManifestContributionBoundary (plans: ManifestSaveContributionPlan list) (metadata: EventMetadata) =
+        task {
+            let planArray = plans |> List.toArray
+            let mutable planIndex = 0
+            let mutable error: GraceError option = None
+
+            while planIndex < planArray.Length && error.IsNone do
+                let plan = planArray[planIndex]
+
+                let counterActor = createRepositoryContentCounterActor plan.RepositoryId plan.Manifest.ManifestAddress metadata.CorrelationId
+
+                match! counterActor.Handle plan.CounterCommand metadata with
+                | Error graceError -> error <- Some graceError
+                | Ok counterReturnValue ->
+                    let! counterEvents = counterActor.GetEvents metadata.CorrelationId
+
+                    match tryCreateManifestContributionStartForCounterDecision plan counterReturnValue.ReturnValue counterEvents with
+                    | None -> ()
+                    | Some startCommand ->
+                        let workflowActor = createManifestContributionWorkflowActor plan.RepositoryId plan.Manifest.ManifestAddress metadata.CorrelationId
+
+                        match! workflowActor.Handle startCommand metadata with
+                        | Ok _ -> ()
+                        | Error graceError -> error <- Some graceError
+
+                planIndex <- planIndex + 1
+
+            match error with
+            | Some graceError -> return Error graceError
+            | None -> return Ok()
+        }
 
     type ReferenceActor([<PersistentState(StateName.Reference, Constants.GraceActorStorage)>] state: IPersistentState<List<ReferenceEvent>>) =
         inherit Grain()
@@ -214,29 +275,59 @@ module Reference =
 
                         this.correlationId <- physicalDeletionReminderState.CorrelationId
 
-                        // Mark the branch as needing to update its latest references.
-                        let branchActorProxy =
-                            Branch.CreateActorProxy physicalDeletionReminderState.BranchId physicalDeletionReminderState.RepositoryId this.correlationId
+                        let referenceId =
+                            if referenceDto.ReferenceId = ReferenceId.Empty then
+                                this.GetPrimaryKey()
+                            else
+                                referenceDto.ReferenceId
 
-                        do! branchActorProxy.MarkForRecompute physicalDeletionReminderState.CorrelationId
+                        let directoryVersionActorProxy =
+                            DirectoryVersion.CreateActorProxy
+                                physicalDeletionReminderState.DirectoryVersionId
+                                physicalDeletionReminderState.RepositoryId
+                                this.correlationId
 
-                        // Delete saved state for this actor.
-                        do! state.ClearStateAsync()
+                        let! directoryVersionDto = directoryVersionActorProxy.Get this.correlationId
 
-                        log.LogInformation(
-                            "{CurrentInstant}: Node: {hostName}; CorrelationId: {correlationId}; Deleted physical state for reference; RepositoryId: {RepositoryId}; BranchId: {BranchId}; ReferenceId: {ReferenceId}; DirectoryVersionId: {DirectoryVersionId}; deleteReason: {deleteReason}.",
-                            getCurrentInstantExtended (),
-                            getMachineName,
-                            physicalDeletionReminderState.CorrelationId,
-                            physicalDeletionReminderState.RepositoryId,
-                            physicalDeletionReminderState.BranchId,
-                            referenceDto.ReferenceId,
-                            physicalDeletionReminderState.DirectoryVersionId,
-                            physicalDeletionReminderState.DeleteReason
-                        )
+                        let! boundaryResult =
+                            task {
+                                match
+                                    planManifestSaveExpiryBoundary
+                                        physicalDeletionReminderState.RepositoryId
+                                        referenceId
+                                        directoryVersionDto.DirectoryVersion
+                                        this.correlationId
+                                    with
+                                | Error graceError -> return Error graceError
+                                | Ok plans -> return! applyManifestContributionBoundary plans (EventMetadata.New this.correlationId "GraceSystem")
+                            }
 
-                        this.DeactivateOnIdle()
-                        return Ok()
+                        match boundaryResult with
+                        | Error graceError -> return Error graceError
+                        | Ok () ->
+                            // Mark the branch as needing to update its latest references.
+                            let branchActorProxy =
+                                Branch.CreateActorProxy physicalDeletionReminderState.BranchId physicalDeletionReminderState.RepositoryId this.correlationId
+
+                            do! branchActorProxy.MarkForRecompute physicalDeletionReminderState.CorrelationId
+
+                            // Delete saved state for this actor.
+                            do! state.ClearStateAsync()
+
+                            log.LogInformation(
+                                "{CurrentInstant}: Node: {hostName}; CorrelationId: {correlationId}; Deleted physical state for reference; RepositoryId: {RepositoryId}; BranchId: {BranchId}; ReferenceId: {ReferenceId}; DirectoryVersionId: {DirectoryVersionId}; deleteReason: {deleteReason}.",
+                                getCurrentInstantExtended (),
+                                getMachineName,
+                                physicalDeletionReminderState.CorrelationId,
+                                physicalDeletionReminderState.RepositoryId,
+                                physicalDeletionReminderState.BranchId,
+                                referenceId,
+                                physicalDeletionReminderState.DirectoryVersionId,
+                                physicalDeletionReminderState.DeleteReason
+                            )
+
+                            this.DeactivateOnIdle()
+                            return Ok()
                     | reminderType, state ->
                         return
                             Error(
@@ -408,40 +499,20 @@ module Reference =
 
                                 match planManifestSaveBoundary repositoryId referenceId directoryVersionDto.DirectoryVersion metadata.CorrelationId with
                                 | Error graceError -> return Error graceError
-                                | Ok plans ->
-                                    let planArray = plans |> List.toArray
-                                    let mutable planIndex = 0
-                                    let mutable error: GraceError option = None
+                                | Ok plans -> return! applyManifestContributionBoundary plans metadata
+                        }
 
-                                    while planIndex < planArray.Length && error.IsNone do
-                                        let plan = planArray[planIndex]
+                    let applySaveExpiryManifestBoundary referenceId repositoryId directoryId referenceType =
+                        task {
+                            if referenceType <> ReferenceType.Save then
+                                return Ok()
+                            else
+                                let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
+                                let! directoryVersionDto = directoryVersionActorProxy.Get metadata.CorrelationId
 
-                                        let counterActor =
-                                            createRepositoryContentCounterActor plan.RepositoryId plan.Manifest.ManifestAddress metadata.CorrelationId
-
-                                        match! counterActor.Handle plan.CounterCommand metadata with
-                                        | Error graceError -> error <- Some graceError
-                                        | Ok counterReturnValue ->
-                                            let! counterEvents = counterActor.GetEvents metadata.CorrelationId
-
-                                            match tryCreateManifestContributionStartForCounterDecision plan counterReturnValue.ReturnValue counterEvents with
-                                            | None -> ()
-                                            | Some startCommand ->
-                                                let workflowActor =
-                                                    createManifestContributionWorkflowActor
-                                                        plan.RepositoryId
-                                                        plan.Manifest.ManifestAddress
-                                                        metadata.CorrelationId
-
-                                                match! workflowActor.Handle startCommand metadata with
-                                                | Ok _ -> ()
-                                                | Error graceError -> error <- Some graceError
-
-                                        planIndex <- planIndex + 1
-
-                                    match error with
-                                    | Some graceError -> return Error graceError
-                                    | None -> return Ok()
+                                match planManifestSaveExpiryBoundary repositoryId referenceId directoryVersionDto.DirectoryVersion metadata.CorrelationId with
+                                | Error graceError -> return Error graceError
+                                | Ok plans -> return! applyManifestContributionBoundary plans metadata
                         }
 
                     task {
@@ -522,10 +593,19 @@ module Reference =
 
                                     return Ok(LogicalDeleted(force, deleteReason))
                                 | DeletePhysical ->
-                                    // Delete the actor state and mark the actor as deactivated.
-                                    do! state.ClearStateAsync()
-                                    this.DeactivateOnIdle()
-                                    return Ok PhysicalDeleted
+                                    match!
+                                        applySaveExpiryManifestBoundary
+                                            referenceDto.ReferenceId
+                                            referenceDto.RepositoryId
+                                            referenceDto.DirectoryId
+                                            referenceDto.ReferenceType
+                                        with
+                                    | Ok () ->
+                                        // Delete the actor state and mark the actor as deactivated.
+                                        do! state.ClearStateAsync()
+                                        this.DeactivateOnIdle()
+                                        return Ok PhysicalDeleted
+                                    | Error graceError -> return Error graceError
                                 | Undelete -> return Ok Undeleted
                             }
 

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -44,9 +44,6 @@ module Reference =
     let private manifestContributionOperationId (referenceId: ReferenceId) (manifestAddress: ManifestAddress) =
         RepositoryContentCounterOperationId $"save:{referenceId:N}:{manifestAddress}"
 
-    let private workflowOperationId (referenceId: ReferenceId) (manifestAddress: ManifestAddress) =
-        ManifestContributionWorkflowOperationId $"save:{referenceId:N}:{manifestAddress}:fanout"
-
     let private repositoryContentCounterPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
 
     let private manifestContributionWorkflowPrimaryKey (repositoryId: RepositoryId) (manifestAddress: ManifestAddress) = $"{repositoryId:N}|{manifestAddress}"
@@ -55,6 +52,11 @@ module Reference =
         match command with
         | RepositoryContentCounterCommand.AddReference _ -> ManifestContributionDirection.Increment
         | RepositoryContentCounterCommand.RemoveReference _ -> ManifestContributionDirection.Decrement
+
+    let private workflowOperationId (referenceId: ReferenceId) (manifestAddress: ManifestAddress) direction =
+        match direction with
+        | ManifestContributionDirection.Increment -> ManifestContributionWorkflowOperationId $"save:{referenceId:N}:{manifestAddress}:fanout"
+        | ManifestContributionDirection.Decrement -> ManifestContributionWorkflowOperationId $"save-expiry:{referenceId:N}:{manifestAddress}:fanout"
 
     let private workflowRangesForManifest (manifest: FileManifest) =
         let ranges = ResizeArray<ManifestContributionWorkflowRange>()
@@ -70,12 +72,14 @@ module Reference =
         ranges.ToArray()
 
     let private workflowStartCommandForPlan plan =
+        let direction = counterCommandDirection plan.CounterCommand
+
         ManifestContributionWorkflowCommand.Start
             {
-                OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress
+                OperationId = workflowOperationId plan.ReferenceId plan.Manifest.ManifestAddress direction
                 RepositoryId = plan.RepositoryId
                 ManifestAddress = plan.Manifest.ManifestAddress
-                Direction = counterCommandDirection plan.CounterCommand
+                Direction = direction
                 Ranges = plan.WorkflowRanges
             }
 

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -247,6 +247,65 @@ type SaveBoundaryActorTests() =
         | None -> Assert.Fail("Expected decrement intent to start manifest contribution workflow fan-out.")
 
     [<Test>]
+    member _.SaveExpiryDecrementWorkflowUsesDistinctOperationIdAfterIncrementWorkflow() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let savePlan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-expiry-operation-plan"
+            |> expectPlan
+
+        let incrementStart =
+            match
+                ReferenceActor.tryCreateManifestContributionStart
+                    savePlan
+                    (RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifest.ManifestAddress))
+                with
+            | Some command -> command
+            | None ->
+                Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")
+                Unchecked.defaultof<ManifestContributionWorkflowCommand>
+
+        let incrementDecision =
+            match ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default incrementStart (metadata "corr-increment-start")
+                with
+            | Ok decision -> decision
+            | Error error ->
+                Assert.Fail($"Expected increment workflow to start, got {error.Error}.")
+                Unchecked.defaultof<ManifestContributionWorkflowDecision>
+
+        let decrementPlan =
+            { savePlan with
+                CounterCommand =
+                    RepositoryContentCounterCommand.RemoveReference(
+                        RepositoryContentCounterOperationId $"save-expiry:{referenceId:N}:{manifest.ManifestAddress}",
+                        repositoryId,
+                        manifest.ManifestAddress
+                    )
+            }
+
+        let decrementStart =
+            match
+                ReferenceActor.tryCreateManifestContributionStart
+                    decrementPlan
+                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifest.ManifestAddress))
+                with
+            | Some command -> command
+            | None ->
+                Assert.Fail("Expected decrement intent to start manifest contribution workflow fan-out.")
+                Unchecked.defaultof<ManifestContributionWorkflowCommand>
+
+        let completedIncrementWorkflow = { incrementDecision.Workflow with LifecycleState = ManifestContributionWorkflowLifecycleState.Completed }
+
+        match
+            ManifestContributionWorkflowActor.decideCommand incrementDecision.Events completedIncrementWorkflow decrementStart (metadata "corr-decrement-start")
+            with
+        | Ok decision ->
+            Assert.That(decision.Workflow.Direction, Is.EqualTo(ManifestContributionDirection.Decrement))
+            Assert.That(decision.OperationId, Is.Not.EqualTo(incrementDecision.OperationId))
+        | Error error -> Assert.Fail($"Expected decrement workflow to start after increment workflow, got {error.Error}.")
+
+    [<Test>]
     member _.SaveExpiryCounterReplayRestartsDecrementWorkflowWithoutSecondCounterEvent() =
         let manifest = finalizedManifest ()
         let directoryVersion = directoryWith [ manifestFile manifest ]

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -61,6 +61,14 @@ type SaveBoundaryActorTests() =
 
     let wholeFile () = FileVersion.Create "/small.txt" "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" String.Empty false 42L
 
+    let referenceDto referenceType =
+        { Grace.Types.Reference.ReferenceDto.Default with
+            ReferenceId = referenceId
+            RepositoryId = repositoryId
+            DirectoryId = directoryVersionId
+            ReferenceType = referenceType
+        }
+
     let directoryWith (files: FileVersion seq) =
         let fileList = List<FileVersion>(files)
 
@@ -439,3 +447,9 @@ type SaveBoundaryActorTests() =
         match ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-whole-file-expiry" with
         | Ok plans -> Assert.That(plans, Is.Empty)
         | Error error -> Assert.Fail($"Expected whole-file save expiry planning to remain a no-op, got {error.Error}.")
+
+    [<Test>]
+    member _.PhysicalDeletionReminderAppliesExpiryBoundaryOnlyForLiveSaveReferences() =
+        Assert.That(ReferenceActor.shouldApplySaveExpiryBoundary (referenceDto ReferenceType.Save), Is.True)
+        Assert.That(ReferenceActor.shouldApplySaveExpiryBoundary (referenceDto ReferenceType.Checkpoint), Is.False)
+        Assert.That(ReferenceActor.shouldApplySaveExpiryBoundary Grace.Types.Reference.ReferenceDto.Default, Is.False)

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -275,8 +275,7 @@ type SaveBoundaryActorTests() =
                     )
             }
 
-        let removeDecision =
-            RepositoryContentCounterActor.decideCommand addEvents addedDto decrementPlan.CounterCommand (metadata "corr-expiry-remove")
+        let removeDecision = RepositoryContentCounterActor.decideCommand addEvents addedDto decrementPlan.CounterCommand (metadata "corr-expiry-remove")
 
         let removedDto, allEvents =
             match removeDecision with
@@ -288,8 +287,7 @@ type SaveBoundaryActorTests() =
                 Assert.Fail($"Expected save expiry counter decrement to succeed, got {error.Error}.")
                 RepositoryContentCounterDto.Default, []
 
-        let replayDecision =
-            RepositoryContentCounterActor.decideCommand allEvents removedDto decrementPlan.CounterCommand (metadata "corr-expiry-retry")
+        let replayDecision = RepositoryContentCounterActor.decideCommand allEvents removedDto decrementPlan.CounterCommand (metadata "corr-expiry-retry")
 
         match replayDecision with
         | Ok decision ->
@@ -336,7 +334,7 @@ type SaveBoundaryActorTests() =
                 ReferenceActor.tryCreateManifestContributionStart
                     decrementPlan
                     (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifest.ManifestAddress))
-            with
+                with
             | Some command -> command
             | None ->
                 Assert.Fail("Expected decrement intent to start manifest contribution workflow fan-out.")
@@ -367,7 +365,7 @@ type SaveBoundaryActorTests() =
                     started
                     (ManifestContributionWorkflowCommand.RecordRangeSucceeded progress)
                     (metadata "corr-expiry-gc-range")
-            with
+                with
             | Ok decision -> decision.Workflow
             | Error error ->
                 Assert.Fail($"Expected decrement range completion to succeed, got {error.Error}.")

--- a/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/SaveBoundary.Actor.Tests.fs
@@ -212,3 +212,173 @@ type SaveBoundaryActorTests() =
             | Ok decision -> Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(2))
             | Error error -> Assert.Fail($"Expected repeated block occurrences to start contribution workflow, got {error.Error}.")
         | None -> Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")
+
+    [<Test>]
+    member _.SaveExpiryStartsDecrementContributionWorkflow() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let savePlan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-expiry-plan"
+            |> expectPlan
+
+        let decrementPlan =
+            { savePlan with
+                CounterCommand =
+                    RepositoryContentCounterCommand.RemoveReference(
+                        RepositoryContentCounterOperationId $"save-expiry:{referenceId:N}:{manifest.ManifestAddress}",
+                        repositoryId,
+                        manifest.ManifestAddress
+                    )
+            }
+
+        let intent = RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifest.ManifestAddress)
+
+        match ReferenceActor.tryCreateManifestContributionStart decrementPlan intent with
+        | Some startCommand ->
+            let workflowDecision =
+                ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-expiry-workflow")
+
+            match workflowDecision with
+            | Ok decision ->
+                Assert.That(decision.Workflow.Direction, Is.EqualTo(ManifestContributionDirection.Decrement))
+                Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(manifest.Blocks.Count))
+            | Error error -> Assert.Fail($"Expected save expiry decrement workflow to start, got {error.Error}.")
+        | None -> Assert.Fail("Expected decrement intent to start manifest contribution workflow fan-out.")
+
+    [<Test>]
+    member _.SaveExpiryCounterReplayRestartsDecrementWorkflowWithoutSecondCounterEvent() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let savePlan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-expiry-replay-plan"
+            |> expectPlan
+
+        let addDecision =
+            RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default savePlan.CounterCommand (metadata "corr-add-before-expiry")
+
+        let addedDto, addEvents =
+            match addDecision with
+            | Ok decision -> decision.Counter, decision.Events
+            | Error error ->
+                Assert.Fail($"Expected save counter increment to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let decrementPlan =
+            { savePlan with
+                CounterCommand =
+                    RepositoryContentCounterCommand.RemoveReference(
+                        RepositoryContentCounterOperationId $"save-expiry:{referenceId:N}:{manifest.ManifestAddress}",
+                        repositoryId,
+                        manifest.ManifestAddress
+                    )
+            }
+
+        let removeDecision =
+            RepositoryContentCounterActor.decideCommand addEvents addedDto decrementPlan.CounterCommand (metadata "corr-expiry-remove")
+
+        let removedDto, allEvents =
+            match removeDecision with
+            | Ok decision ->
+                Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(0L))
+                Assert.That(decision.Intents, Has.Length.EqualTo(1))
+                decision.Counter, addEvents @ decision.Events
+            | Error error ->
+                Assert.Fail($"Expected save expiry counter decrement to succeed, got {error.Error}.")
+                RepositoryContentCounterDto.Default, []
+
+        let replayDecision =
+            RepositoryContentCounterActor.decideCommand allEvents removedDto decrementPlan.CounterCommand (metadata "corr-expiry-retry")
+
+        match replayDecision with
+        | Ok decision ->
+            Assert.That(decision.WasIdempotentReplay, Is.True)
+            Assert.That(decision.Events, Is.Empty)
+            Assert.That(decision.Intents, Is.Empty)
+
+            match ReferenceActor.tryCreateManifestContributionStartForCounterDecision decrementPlan decision allEvents with
+            | Some startCommand ->
+                let workflowDecision =
+                    ManifestContributionWorkflowActor.decideCommand
+                        []
+                        ManifestContributionWorkflowDto.Default
+                        startCommand
+                        (metadata "corr-expiry-retry-workflow")
+
+                match workflowDecision with
+                | Ok workflowDecision -> Assert.That(workflowDecision.Workflow.Direction, Is.EqualTo(ManifestContributionDirection.Decrement))
+                | Error error -> Assert.Fail($"Expected replayed expiry decrement to restart workflow, got {error.Error}.")
+            | None -> Assert.Fail("Expected replayed zero-crossing counter removal to restart decrement workflow fan-out.")
+        | Error error -> Assert.Fail($"Expected save expiry counter retry to be idempotent, got {error.Error}.")
+
+    [<Test>]
+    member _.PendingSaveExpiryDecrementBlocksUnsafeGcUntilRangeCompletes() =
+        let manifest = finalizedManifest ()
+        let directoryVersion = directoryWith [ manifestFile manifest ]
+
+        let savePlan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-expiry-gc-plan"
+            |> expectPlan
+
+        let decrementPlan =
+            { savePlan with
+                CounterCommand =
+                    RepositoryContentCounterCommand.RemoveReference(
+                        RepositoryContentCounterOperationId $"save-expiry:{referenceId:N}:{manifest.ManifestAddress}",
+                        repositoryId,
+                        manifest.ManifestAddress
+                    )
+            }
+
+        let startCommand =
+            match
+                ReferenceActor.tryCreateManifestContributionStart
+                    decrementPlan
+                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, manifest.ManifestAddress))
+            with
+            | Some command -> command
+            | None ->
+                Assert.Fail("Expected decrement intent to start manifest contribution workflow fan-out.")
+                Unchecked.defaultof<ManifestContributionWorkflowCommand>
+
+        let started =
+            match ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-expiry-gc-start") with
+            | Ok decision -> decision.Workflow
+            | Error error ->
+                Assert.Fail($"Expected decrement workflow start to succeed, got {error.Error}.")
+                ManifestContributionWorkflowDto.Default
+
+        let range = decrementPlan.WorkflowRanges[0]
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion started range, Is.True)
+
+        let progress =
+            {
+                OperationId = ManifestContributionWorkflowOperationId "range-expiry-done"
+                RepositoryId = repositoryId
+                ManifestAddress = manifest.ManifestAddress
+                Range = range
+            }
+
+        let completed =
+            match
+                ManifestContributionWorkflowActor.decideCommand
+                    []
+                    started
+                    (ManifestContributionWorkflowCommand.RecordRangeSucceeded progress)
+                    (metadata "corr-expiry-gc-range")
+            with
+            | Ok decision -> decision.Workflow
+            | Error error ->
+                Assert.Fail($"Expected decrement range completion to succeed, got {error.Error}.")
+                started
+
+        Assert.That(ManifestContributionWorkflowActor.blocksUnsafeDeletion completed range, Is.False)
+
+    [<Test>]
+    member _.SaveExpiryPlanningKeepsWholeFileCleanupAsNoOp() =
+        let directoryVersion = directoryWith [ wholeFile () ]
+
+        match ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-whole-file-expiry" with
+        | Ok plans -> Assert.That(plans, Is.Empty)
+        | Error error -> Assert.Fail($"Expected whole-file save expiry planning to remain a no-op, got {error.Error}.")


### PR DESCRIPTION
## Summary

- Wires Save physical expiry / `DeletePhysical` through repository manifest contribution decrement planning before reference state is cleared.
- Extends the existing save-boundary contribution helpers so `RemoveReference` starts a decrement `ManifestContributionWorkflow` and retry replays can restart the workflow without emitting a second counter event.
- Keeps checkpoint and already-cleared reference physical deletion cleanup from attempting save-only manifest decrement accounting.
- Adds focused actor tests for save expiry decrement, retry idempotency, pending decrement GC blocking, whole-file cleanup no-op behavior, distinct increment/decrement workflow operation IDs, and checkpoint cleanup no-op behavior.

Closes #98.

## Validation

- RED focused test run before implementation: `dotnet test .\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~SaveBoundaryActorTests"` failed 3/10 on missing decrement workflow fan-out/replay.
- GREEN focused test run after the initial implementation: `dotnet test .\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~SaveBoundaryActorTests"` passed 10/10.
- Review-fix focused validation: `dotnet test .\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~SaveBoundaryActorTests" --blame-hang-timeout 90s` passed 12/12.
- Formatting: `dotnet tool run fantomas .\Grace.Actors\Reference.Actor.fs .\Grace.Server.Tests\SaveBoundary.Actor.Tests.fs` passed.
- Local Fast gate on final head: `pwsh ./scripts/validate.ps1 -Fast` passed; build clean, Authorization 21/21, CLI 200 passed + 1 skipped, Types 49/49.
- Local Full gate passed before review-fix commits: `pwsh ./scripts/validate.ps1 -Full` passed; build clean, Authorization 21/21, CLI 200 passed + 1 skipped, Types 49/49, Server 313/313.
- GitHub Fast gate on final head `1caeb71` passed in run `26378802506`.
- GitHub Full gate on final head `1caeb71` passed in run `26378802506`.

## Docs Impact

- No docs changes. This preserves the existing public save/checkpoint cleanup surface while adding the ADR-0001 manifest contribution accounting side effect for Save references.

## Residual Risk

- The change relies on existing manifest workflow progress handling to apply per-range active count decrements; no shared contract or workflow schema changes were made.
- Final local Full rerun after the second review fix was interrupted while recovering a corrupted local worktree and produced Aspire readiness fallout, so the final Full evidence is the successful GitHub Full gate on the final head.