### PR TITLE
Add GC safety decisions for manifest ranges

### DIFF
--- a/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -109,6 +109,34 @@ type ContentBlockMetadataActorTests() =
         Assert.That(ContentBlockMetadataTypes.rangePresence metadata { OrdinalStart = 12; OrdinalCount = 4 }, Is.EqualTo(ContentBlockRangePresence.Absent))
 
     [<Test>]
+    member _.RangeGcSafetyRetainsActiveOrClaimedRangesAndReclaimsOnlyUnclaimedZeroActiveRanges() =
+        let retainActive =
+            ContentBlockMetadataTypes.rangeGcSafety
+                { Presence = ContentBlockRangePresence.Active; HasPendingContributionWorkflow = false; HasActiveReuseClaim = false }
+
+        let retainPendingWorkflow =
+            ContentBlockMetadataTypes.rangeGcSafety
+                { Presence = ContentBlockRangePresence.Reclaimable; HasPendingContributionWorkflow = true; HasActiveReuseClaim = false }
+
+        let retainActiveClaim =
+            ContentBlockMetadataTypes.rangeGcSafety
+                { Presence = ContentBlockRangePresence.Reclaimable; HasPendingContributionWorkflow = false; HasActiveReuseClaim = true }
+
+        let reclaimZeroActive =
+            ContentBlockMetadataTypes.rangeGcSafety
+                { Presence = ContentBlockRangePresence.Reclaimable; HasPendingContributionWorkflow = false; HasActiveReuseClaim = false }
+
+        let absent =
+            ContentBlockMetadataTypes.rangeGcSafety
+                { Presence = ContentBlockRangePresence.Absent; HasPendingContributionWorkflow = false; HasActiveReuseClaim = false }
+
+        Assert.That(retainActive, Is.EqualTo(ContentBlockRangeGcSafety.RetainActiveRange))
+        Assert.That(retainPendingWorkflow, Is.EqualTo(ContentBlockRangeGcSafety.RetainPendingContributionWorkflow))
+        Assert.That(retainActiveClaim, Is.EqualTo(ContentBlockRangeGcSafety.RetainActiveReuseClaim))
+        Assert.That(reclaimZeroActive, Is.EqualTo(ContentBlockRangeGcSafety.Reclaimable))
+        Assert.That(absent, Is.EqualTo(ContentBlockRangeGcSafety.Absent))
+
+    [<Test>]
     member _.RangePresenceAggregatesDuplicateOrdinalRangesAsActiveWhenAnyPhysicalCopyIsActive() =
         let activePhysicalCopy = { reclaimableRange with ActiveManifestCount = 1; PhysicalOffset = 2048L }
 

--- a/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/UploadSession.Actor.Tests.fs
@@ -288,6 +288,24 @@ type UploadSessionActorTests() =
         | Error error -> Assert.That(error.Error, Is.EqualTo("UploadSession is finalized and cannot be changed by Abandon."))
 
     [<Test>]
+    member _.FinalizedSessionRetainsLiveManifestForGcSafety() =
+        let manifestAddress = ManifestAddress "manifest-blake3-final"
+
+        let finalized =
+            { UploadSessionDto.Default with
+                UploadSessionId = sessionId
+                RepositoryId = repositoryId
+                LifecycleState = UploadSessionLifecycleState.StateDeleted
+                FinalizedManifestAddress = Some manifestAddress
+            }
+
+        let abandoned = { finalized with LifecycleState = UploadSessionLifecycleState.StateDeleted; FinalizedManifestAddress = None }
+
+        Assert.That(retainsFinalizedManifest manifestAddress finalized, Is.True)
+        Assert.That(retainsFinalizedManifest manifestAddress abandoned, Is.False)
+        Assert.That(retainsFinalizedManifest (ManifestAddress String.Empty) finalized, Is.False)
+
+    [<Test>]
     member _.BlockUploadIntentMovesStartedSessionToUploadingBlocks() =
         let block = encodedBlock (Text.Encoding.UTF8.GetBytes("hello world"))
         let startedDto, existingEvents = startedSession ()

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -34,6 +34,19 @@ module ContentBlockMetadata =
 
         static member GetKnownTypes() = GetKnownTypes<ContentBlockRangePresence>()
 
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ContentBlockRangeGcSafety =
+        | RetainActiveRange
+        | RetainPendingContributionWorkflow
+        | RetainActiveReuseClaim
+        | Reclaimable
+        | Absent
+
+        static member GetKnownTypes() = GetKnownTypes<ContentBlockRangeGcSafety>()
+
+    [<CLIMutable; GenerateSerializer>]
+    type ContentBlockRangeGcSafetyContext = { Presence: ContentBlockRangePresence; HasPendingContributionWorkflow: bool; HasActiveReuseClaim: bool }
+
     [<CLIMutable; GenerateSerializer>]
     type ContentBlockMetadata =
         {
@@ -142,3 +155,11 @@ module ContentBlockMetadata =
             ContentBlockRangePresence.Reclaimable
         else
             ContentBlockRangePresence.Absent
+
+    let rangeGcSafety context =
+        match context.Presence with
+        | ContentBlockRangePresence.Absent -> ContentBlockRangeGcSafety.Absent
+        | ContentBlockRangePresence.Active -> ContentBlockRangeGcSafety.RetainActiveRange
+        | ContentBlockRangePresence.Reclaimable when context.HasPendingContributionWorkflow -> ContentBlockRangeGcSafety.RetainPendingContributionWorkflow
+        | ContentBlockRangePresence.Reclaimable when context.HasActiveReuseClaim -> ContentBlockRangeGcSafety.RetainActiveReuseClaim
+        | ContentBlockRangePresence.Reclaimable -> ContentBlockRangeGcSafety.Reclaimable

--- a/src/Grace.Types/UploadSession.Types.fs
+++ b/src/Grace.Types/UploadSession.Types.fs
@@ -310,6 +310,10 @@ module UploadSession =
             Message: string
         }
 
+    let retainsFinalizedManifest manifestAddress (session: UploadSessionDto) =
+        not (String.IsNullOrWhiteSpace manifestAddress)
+        && session.FinalizedManifestAddress = Some manifestAddress
+
     [<GenerateSerializer>]
     type PhysicalDeletionReminderState =
         {


### PR DESCRIPTION
Closes #105.

## Summary

- Add a serializable `ContentBlockRangeGcSafety` decision surface for exact ContentBlock metadata ranges.
- Retain active ranges, pending contribution workflow ranges, and active reuse claims before allowing zero-active ranges to become reclaimable.
- Add a finalized-manifest retention helper so upload-session cleanup preserves the live manifest safety signal.

## TDD / RED Evidence

- Added `RangeGcSafetyRetainsActiveOrClaimedRangesAndReclaimsOnlyUnclaimedZeroActiveRanges` first.
- RED failed as expected because `rangeGcSafety` and `ContentBlockRangeGcSafety` were not defined.

## Validation

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "Name~RangeGcSafety"` - passed, 1 test.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "Name~FinalizedSessionRetainsLiveManifestForGcSafety"` - passed, 1 test after rerun; an earlier parallel invocation hit a Windows DLL lock from another testhost.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ContentBlockMetadataActorTests|FullyQualifiedName~UploadSessionActorTests|FullyQualifiedName~ManifestContributionWorkflowActorTests"` - passed, 62 tests.
- `dotnet tool run fantomas --recurse .` from `src` - run; unrelated formatting churn was discarded, leaving only issue-owned files.
- `pwsh ./scripts/validate.ps1 -Fast` - passed. Build 0 warnings/errors; Authorization 21 passed; CLI 200 passed, 1 skipped; Types 49 passed.
- `pwsh ./scripts/validate.ps1 -Full` - passed. Build 0 warnings/errors; Authorization 21 passed; CLI 200 passed, 1 skipped; Types 49 passed; Server 317 passed.
- `git diff --check` - passed.

## Docs Impact

- No docs changed. The issue-owned paths exclude docs, and this slice adds internal safety contracts plus focused tests without changing a public command/API surface.

## Residual Risk

- This PR defines the conservative GC safety decision surface; #106 still owns compaction candidate selection and metadata rewrite behavior.

## Follow-ups

- #106 can consume `ContentBlockRangeGcSafety` when selecting compaction candidates.