### PR TITLE
Implement manifest-backed downloads

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,26 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  fast:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    env:
-      GraceBuildKind: ci
-      GraceBuildNumber: ${{ github.run_number }}
-      GraceSourceRevisionId: ${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          global-json-file: global.json
-      - name: Install .NET Aspire workload
-        run: dotnet workload install aspire
-      - name: Validate (Fast)
-        run: pwsh ./scripts/validate.ps1 -Fast
-
   full:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       GraceBuildKind: ci
@@ -44,11 +25,38 @@ jobs:
       - name: Docker info
         run: docker info
       - name: Pre-pull Aspire images
+        shell: bash
         run: |
-          docker pull redis:latest
-          docker pull mcr.microsoft.com/azure-storage/azurite:latest
-          docker pull mcr.microsoft.com/mssql/server:2022-latest
-          docker pull mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
-          docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+          set -euo pipefail
+
+          images=(
+            "redis:latest"
+            "mcr.microsoft.com/azure-storage/azurite:latest"
+            "mcr.microsoft.com/mssql/server:2022-latest"
+            "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest"
+            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest"
+          )
+
+          pids=()
+          for image in "${images[@]}"; do
+            echo "Starting pull for ${image}"
+            docker pull "${image}" &
+            pids+=("$!")
+          done
+
+          failed=0
+          for index in "${!pids[@]}"; do
+            image="${images[$index]}"
+            pid="${pids[$index]}"
+
+            if wait "${pid}"; then
+              echo "Completed pull for ${image}"
+            else
+              echo "Failed pull for ${image}" >&2
+              failed=1
+            fi
+          done
+
+          exit "${failed}"
       - name: Validate (Full)
         run: pwsh ./scripts/validate.ps1 -Full

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,18 @@ jobs:
           global-json-file: global.json
       - name: Install .NET Aspire workload
         run: dotnet workload install aspire
+      - name: Format
+        run: echo "Skipped (temporarily disabled pending full repo formatting)."
+      - name: Restore
+        run: dotnet restore "src/Grace.slnx"
+      - name: Build
+        run: |
+          dotnet build "src/Grace.slnx" \
+            --configuration Release \
+            --no-restore \
+            -p:GraceBuildKind="${GraceBuildKind}" \
+            -p:GraceBuildNumber="${GraceBuildNumber}" \
+            -p:GraceSourceRevisionId="${GraceSourceRevisionId}"
       - name: Docker info
         run: docker info
       - name: Pre-pull Aspire images
@@ -58,5 +70,5 @@ jobs:
           done
 
           exit "${failed}"
-      - name: Validate (Full)
-        run: pwsh ./scripts/validate.ps1 -Full
+      - name: Test
+        run: dotnet test "src/Grace.slnx" --configuration Release --no-build --no-restore

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />
     <Compile Include="ManifestUpload.SDK.Tests.fs" />
+    <Compile Include="ManifestDownload.SDK.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -1,7 +1,10 @@
 namespace Grace.CLI.Tests
 
+open Grace.CLI
+open Grace.CLI.Services
 open Grace.SDK
 open Grace.Shared
+open Grace.Shared.Client.Configuration
 open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
@@ -9,6 +12,7 @@ open Grace.Types.Types
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.IO
 open System.Security.Cryptography
 open System.Threading.Tasks
 
@@ -67,6 +71,64 @@ type ManifestDownloadSdkTests() =
             FileVersion = fileVersion
             CorrelationId = correlationId
             ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
+        }
+
+    static member private ConfigureForRoot root =
+        let graceDirectory = System.IO.Path.Combine(root, Constants.GraceConfigDirectory)
+
+        System.IO.Directory.CreateDirectory(graceDirectory)
+        |> ignore
+
+        let graceConfigPath = System.IO.Path.Combine(graceDirectory, Constants.GraceConfigFileName)
+
+        if not (System.IO.File.Exists(graceConfigPath)) then
+            System.IO.File.WriteAllText(graceConfigPath, "{}")
+
+        let configuration = GraceConfiguration()
+        configuration.OwnerId <- Guid.Parse("22222222-2222-2222-2222-222222222222")
+        configuration.OwnerName <- "owner"
+        configuration.OrganizationId <- Guid.Parse("33333333-3333-3333-3333-333333333333")
+        configuration.OrganizationName <- "org"
+        configuration.RepositoryId <- Guid.Parse("11111111-1111-1111-1111-111111111111")
+        configuration.RepositoryName <- "repo"
+        configuration.RootDirectory <- root
+        configuration.StandardizedRootDirectory <- normalizeFilePath root
+        configuration.GraceDirectory <- graceDirectory
+        configuration.ObjectDirectory <- System.IO.Path.Combine(configuration.GraceDirectory, Constants.GraceObjectsDirectory)
+        configuration.ConfigurationDirectory <- configuration.GraceDirectory
+        configuration.ObjectStorageProvider <- ObjectStorageProvider.AzureBlobStorage
+        configuration.IsPopulated <- true
+        updateConfiguration configuration
+        configuration
+
+    static member private WithTempConfiguration(action: string -> Task<'T>) =
+        task {
+            let root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"grace-manifest-download-{Guid.NewGuid():N}")
+            let previousDirectory = Environment.CurrentDirectory
+            let previousConfiguration = if configurationFileExists () then Some(Current()) else None
+
+            try
+                System.IO.Directory.CreateDirectory(root)
+                |> ignore
+
+                Environment.CurrentDirectory <- root
+
+                ManifestDownloadSdkTests.ConfigureForRoot root
+                |> ignore
+
+                return! action root
+            finally
+                Environment.CurrentDirectory <- previousDirectory
+
+                match previousConfiguration with
+                | Some configuration -> updateConfiguration configuration
+                | None -> resetConfiguration ()
+
+                if System.IO.Directory.Exists(root) then
+                    try
+                        System.IO.Directory.Delete(root, true)
+                    with
+                    | _ -> ()
         }
 
     [<Test>]
@@ -146,6 +208,81 @@ type ManifestDownloadSdkTests() =
                 Assert.That(returnValue.ReturnValue.Bytes, Is.Empty)
                 Assert.That(returnValue.ReturnValue.DownloadedBlockCount, Is.EqualTo(0))
         }
+
+    [<Test>]
+    member _.CliObjectDownloadPreservesManifestReferenceBeforeChoosingDownloadPath() =
+        ManifestDownloadSdkTests.WithTempConfiguration (fun _ ->
+            task {
+                let payload = ManifestDownloadSdkTests.PseudoRandomBytes 220000
+                payload[0] <- 6uy
+
+                let plan =
+                    LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+                let manifest = ManifestDownloadSdkTests.ManifestFor plan
+                let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "cli-large.bin" payload manifest
+                let localFileVersion = fileVersion.ToLocalFileVersion DateTime.UtcNow
+                let downloadFile = Services.objectStorageDownloadFileFromFileVersion fileVersion
+
+                Assert.That(localFileVersion.ToFileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
+
+                Assert.That(
+                    (Services.fileVersionForObjectStorageDownload downloadFile)
+                        .ContentReference
+                        .ReferenceType,
+                    Is.EqualTo(FileContentReferenceType.FileManifest)
+                )
+
+                let getDownloadUriParameters =
+                    GetDownloadUriParameters(
+                        OwnerId = $"{Current().OwnerId}",
+                        OwnerName = Current().OwnerName,
+                        OrganizationId = $"{Current().OrganizationId}",
+                        OrganizationName = Current().OrganizationName,
+                        RepositoryId = $"{Current().RepositoryId}",
+                        RepositoryName = Current().RepositoryName,
+                        CorrelationId = "corr-cli-manifest-download"
+                    )
+
+                let mutable manifestPathTaken = false
+
+                let manifestDownload (request: ManifestDownload.ManifestDownloadRequest) =
+                    manifestPathTaken <- true
+                    Assert.That(request.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
+                    Assert.That(request.FileVersion.ContentReference.Manifest, Is.EqualTo(Some manifest))
+
+                    let result: ManifestDownload.ManifestDownloadResult =
+                        {
+                            FileVersion = request.FileVersion
+                            Manifest = Some manifest
+                            Bytes = payload
+                            DownloadedBlockCount = manifest.Blocks.Count
+                            UsedManifestDownload = true
+                        }
+
+                    Task.FromResult(Ok(GraceReturnValue.Create result request.CorrelationId))
+
+                let wholeFileDownload _ _ =
+                    Assert.Fail("Manifest-backed CLI downloads must not use the WholeFileContent object-storage path.")
+                    Task.FromResult(Error(GraceError.Create "unexpected whole-file download" getDownloadUriParameters.CorrelationId))
+
+                let! result =
+                    Services.downloadFilesFromObjectStorageWithClients
+                        manifestDownload
+                        wholeFileDownload
+                        getDownloadUriParameters
+                        [| downloadFile |]
+                        getDownloadUriParameters.CorrelationId
+
+                match result with
+                | Error error -> Assert.Fail(error)
+                | Ok () ->
+                    Assert.That(manifestPathTaken, Is.True)
+                    Assert.That(System.IO.File.Exists(localFileVersion.FullObjectPath), Is.True)
+                    let downloadedBytes = System.IO.File.ReadAllBytes(localFileVersion.FullObjectPath)
+                    Assert.That(downloadedBytes.Length, Is.EqualTo(payload.Length))
+                    Assert.That(Array.forall2 (=) downloadedBytes payload, Is.True)
+            })
 
     [<Test>]
     member _.ManifestDownloadRejectsOutOfOrderManifestRanges() =

--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -62,11 +62,11 @@ type ManifestDownloadSdkTests() =
 
     static member private CreateRequest fileVersion correlationId : ManifestDownload.ManifestDownloadRequest =
         {
-            OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            OwnerId = "22222222-2222-2222-2222-222222222222"
             OwnerName = "owner"
-            OrganizationId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            OrganizationId = "33333333-3333-3333-3333-333333333333"
             OrganizationName = "org"
-            RepositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            RepositoryId = "11111111-1111-1111-1111-111111111111"
             RepositoryName = "repo"
             FileVersion = fileVersion
             CorrelationId = correlationId
@@ -235,11 +235,11 @@ type ManifestDownloadSdkTests() =
 
                 let getDownloadUriParameters =
                     GetDownloadUriParameters(
-                        OwnerId = $"{Current().OwnerId}",
+                        OwnerId = String.Empty,
                         OwnerName = Current().OwnerName,
-                        OrganizationId = $"{Current().OrganizationId}",
+                        OrganizationId = String.Empty,
                         OrganizationName = Current().OrganizationName,
-                        RepositoryId = $"{Current().RepositoryId}",
+                        RepositoryId = String.Empty,
                         RepositoryName = Current().RepositoryName,
                         CorrelationId = "corr-cli-manifest-download"
                     )
@@ -248,6 +248,9 @@ type ManifestDownloadSdkTests() =
 
                 let manifestDownload (request: ManifestDownload.ManifestDownloadRequest) =
                     manifestPathTaken <- true
+                    Assert.That(request.OwnerId, Is.EqualTo(String.Empty))
+                    Assert.That(request.OrganizationId, Is.EqualTo(String.Empty))
+                    Assert.That(request.RepositoryId, Is.EqualTo(String.Empty))
                     Assert.That(request.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
                     Assert.That(request.FileVersion.ContentReference.Manifest, Is.EqualTo(Some manifest))
 

--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -69,6 +69,7 @@ type ManifestDownloadSdkTests() =
             RepositoryId = "11111111-1111-1111-1111-111111111111"
             RepositoryName = "repo"
             FileVersion = fileVersion
+            OutputStream = None
             CorrelationId = correlationId
             ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
         }
@@ -145,6 +146,7 @@ type ManifestDownloadSdkTests() =
             let requestedBlocks = ResizeArray<ContentBlockAddress>()
             let downloadedBlocks = ResizeArray<ContentBlockAddress>()
             let correlationId = "corr-sdk-manifest-download"
+            use outputStream = new MemoryStream()
 
             let client: ManifestDownload.ManifestDownloadClient =
                 {
@@ -159,25 +161,26 @@ type ManifestDownloadSdkTests() =
                             Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
                 }
 
-            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+            let request = { ManifestDownloadSdkTests.CreateRequest fileVersion correlationId with OutputStream = Some outputStream }
+
+            let! result = ManifestDownload.downloadFileWithClient client request
 
             match result with
             | Error error -> Assert.Fail(error.Error)
             | Ok returnValue ->
                 Assert.That(returnValue.ReturnValue.UsedManifestDownload, Is.True)
-                Assert.That(returnValue.ReturnValue.Bytes.Length, Is.EqualTo(payload.Length))
-                Assert.That(Array.forall2 (=) returnValue.ReturnValue.Bytes payload, Is.True)
+                Assert.That(returnValue.ReturnValue.BytesWritten, Is.EqualTo(payload.LongLength))
+                let downloadedBytes = outputStream.ToArray()
+                Assert.That(downloadedBytes.Length, Is.EqualTo(payload.Length))
+                Assert.That(Array.forall2 (=) downloadedBytes payload, Is.True)
 
-                Assert.That(
-                    requestedBlocks,
-                    Is.EquivalentTo(
-                        manifest.Blocks
-                        |> Seq.map (fun block -> block.Address)
-                        |> Seq.distinct
-                    )
-                )
+                let expectedBlocks =
+                    manifest.Blocks
+                    |> Seq.map (fun block -> block.Address)
+                    |> Seq.toArray
 
-                Assert.That(downloadedBlocks, Is.EquivalentTo(requestedBlocks))
+                Assert.That(requestedBlocks.ToArray() = expectedBlocks, Is.True)
+                Assert.That(downloadedBlocks.ToArray() = expectedBlocks, Is.True)
         }
 
     [<Test>]
@@ -205,7 +208,7 @@ type ManifestDownloadSdkTests() =
             | Error error -> Assert.Fail(error.Error)
             | Ok returnValue ->
                 Assert.That(returnValue.ReturnValue.UsedManifestDownload, Is.False)
-                Assert.That(returnValue.ReturnValue.Bytes, Is.Empty)
+                Assert.That(returnValue.ReturnValue.BytesWritten, Is.EqualTo(0L))
                 Assert.That(returnValue.ReturnValue.DownloadedBlockCount, Is.EqualTo(0))
         }
 
@@ -254,11 +257,15 @@ type ManifestDownloadSdkTests() =
                     Assert.That(request.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
                     Assert.That(request.FileVersion.ContentReference.Manifest, Is.EqualTo(Some manifest))
 
+                    match request.OutputStream with
+                    | None -> Assert.Fail("Manifest-backed CLI downloads must provide an output stream.")
+                    | Some outputStream -> outputStream.Write(payload, 0, payload.Length)
+
                     let result: ManifestDownload.ManifestDownloadResult =
                         {
                             FileVersion = request.FileVersion
                             Manifest = Some manifest
-                            Bytes = payload
+                            BytesWritten = payload.LongLength
                             DownloadedBlockCount = manifest.Blocks.Count
                             UsedManifestDownload = true
                         }
@@ -288,6 +295,69 @@ type ManifestDownloadSdkTests() =
             })
 
     [<Test>]
+    member _.CliManifestDownloadReportsObjectCacheWriteFailuresAsGraceErrors() =
+        ManifestDownloadSdkTests.WithTempConfiguration (fun root ->
+            task {
+                let payload = ManifestDownloadSdkTests.PseudoRandomBytes 220000
+                payload[0] <- 7uy
+
+                let plan =
+                    LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+                let manifest = ManifestDownloadSdkTests.ManifestFor plan
+                let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "cli-cache-write.bin" payload manifest
+                let downloadFile = Services.objectStorageDownloadFileFromFileVersion fileVersion
+
+                let objectCacheFile = Path.Combine(root, "object-cache-file")
+                File.WriteAllText(objectCacheFile, "not a directory")
+
+                let configuration = Current()
+                configuration.ObjectDirectory <- objectCacheFile
+                updateConfiguration configuration
+
+                let getDownloadUriParameters =
+                    GetDownloadUriParameters(
+                        OwnerId = String.Empty,
+                        OwnerName = Current().OwnerName,
+                        OrganizationId = String.Empty,
+                        OrganizationName = Current().OrganizationName,
+                        RepositoryId = String.Empty,
+                        RepositoryName = Current().RepositoryName,
+                        CorrelationId = "corr-cli-manifest-cache-write"
+                    )
+
+                let manifestDownload (request: ManifestDownload.ManifestDownloadRequest) =
+                    let result: ManifestDownload.ManifestDownloadResult =
+                        {
+                            FileVersion = request.FileVersion
+                            Manifest = Some manifest
+                            BytesWritten = payload.LongLength
+                            DownloadedBlockCount = manifest.Blocks.Count
+                            UsedManifestDownload = true
+                        }
+
+                    Task.FromResult(Ok(GraceReturnValue.Create result request.CorrelationId))
+
+                let wholeFileDownload _ _ =
+                    Assert.Fail("Manifest cache write failures must not fall back to WholeFileContent downloads.")
+                    Task.FromResult(Error(GraceError.Create "unexpected whole-file download" getDownloadUriParameters.CorrelationId))
+
+                let! result =
+                    Services.downloadFilesFromObjectStorageWithClients
+                        manifestDownload
+                        wholeFileDownload
+                        getDownloadUriParameters
+                        [| downloadFile |]
+                        getDownloadUriParameters.CorrelationId
+
+                match result with
+                | Ok () -> Assert.Fail("Expected object-cache write failure to be returned as GraceError.")
+                | Error error ->
+                    Assert.That(error, Does.Contain("Some files could not be downloaded from object storage."))
+                    Assert.That(error, Does.Contain("Failed writing manifest-backed file to object cache"))
+            })
+
+    [<Test>]
     member _.ManifestDownloadRejectsOutOfOrderManifestRanges() =
         task {
             let payload = Array.zeroCreate<byte> (RabinChunking.MaximumChunkSize * 2)
@@ -310,6 +380,7 @@ type ManifestDownloadSdkTests() =
 
             let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "out-of-order-large.bin" payload invalidManifest
             let correlationId = "corr-sdk-manifest-download-ranges"
+            use outputStream = new MemoryStream()
 
             let client: ManifestDownload.ManifestDownloadClient =
                 {
@@ -319,7 +390,9 @@ type ManifestDownloadSdkTests() =
                         fun contentBlockAddress _ -> Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
                 }
 
-            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+            let request = { ManifestDownloadSdkTests.CreateRequest fileVersion correlationId with OutputStream = Some outputStream }
+
+            let! result = ManifestDownload.downloadFileWithClient client request
 
             match result with
             | Error error ->
@@ -345,6 +418,7 @@ type ManifestDownloadSdkTests() =
 
             let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "corrupt-large.bin" payload manifest
             let correlationId = "corr-sdk-manifest-download-corrupt"
+            use outputStream = new MemoryStream()
 
             let client: ManifestDownload.ManifestDownloadClient =
                 {
@@ -354,7 +428,9 @@ type ManifestDownloadSdkTests() =
                         fun contentBlockAddress _ -> Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
                 }
 
-            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+            let request = { ManifestDownloadSdkTests.CreateRequest fileVersion correlationId with OutputStream = Some outputStream }
+
+            let! result = ManifestDownload.downloadFileWithClient client request
 
             match result with
             | Error error ->

--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -1,0 +1,224 @@
+namespace Grace.CLI.Tests
+
+open Grace.SDK
+open Grace.Shared
+open Grace.Shared.Parameters.Storage
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Types
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+open System.Threading.Tasks
+
+[<NonParallelizable>]
+type ManifestDownloadSdkTests() =
+    static member private PseudoRandomBytes length =
+        let bytes = Array.zeroCreate<byte> length
+        let mutable state = 0x7843ac21u
+
+        for index in 0 .. length - 1 do
+            state <- state ^^^ (state <<< 13)
+            state <- state ^^^ (state >>> 17)
+            state <- state ^^^ (state <<< 5)
+            bytes[index] <- byte (state &&& 0xffu)
+
+        bytes
+
+    static member private BinaryPolicy thresholdBytes = { ManifestEligibilityPolicy.Default with ThresholdBytes = thresholdBytes; BinaryScanBytes = 16 }
+
+    static member private ComputeSha256Hash(bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+
+    static member private ManifestFor(plan: LocalPlanner.LocalFilePlan) =
+        match plan.ManifestAddress with
+        | None -> failwith "Expected manifest-backed plan."
+        | Some manifestAddress ->
+            let blocks =
+                plan.Blocks
+                |> Array.map (fun block -> ContentBlock.Create(block.Address, block.Offset, block.Size))
+                |> List.ofArray
+
+            FileManifest.Create(manifestAddress, plan.ChunkingSuiteId, plan.FileContentHash, plan.ExpectedSize, blocks)
+
+    static member private EncodeBlocks(plan: LocalPlanner.LocalFilePlan) =
+        let blocks = Dictionary<ContentBlockAddress, byte array>()
+
+        for uploadPlan in plan.ContentBlockUploads do
+            match ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L uploadPlan.Bytes ] with
+            | Error error -> failwith $"Failed to encode test ContentBlock: {error}."
+            | Ok encodedBlock -> blocks[encodedBlock.Address] <- encodedBlock.Payload
+
+        blocks
+
+    static member private CreateManifestFileVersion relativePath payload manifest =
+        let fileVersion = FileVersion.Create relativePath (ManifestDownloadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+        fileVersion
+
+    static member private CreateRequest fileVersion correlationId : ManifestDownload.ManifestDownloadRequest =
+        {
+            OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            OwnerName = "owner"
+            OrganizationId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            OrganizationName = "org"
+            RepositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            RepositoryName = "repo"
+            FileVersion = fileVersion
+            CorrelationId = correlationId
+            ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
+        }
+
+    [<Test>]
+    member _.ManifestDownloadResolvesBlocksAndReconstructsOriginalBytes() =
+        task {
+            let payload = ManifestDownloadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 4uy
+
+            let plan = LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+            let manifest = ManifestDownloadSdkTests.ManifestFor plan
+            let blockPayloads = ManifestDownloadSdkTests.EncodeBlocks plan
+            let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "large.bin" payload manifest
+            let requestedBlocks = ResizeArray<ContentBlockAddress>()
+            let downloadedBlocks = ResizeArray<ContentBlockAddress>()
+            let correlationId = "corr-sdk-manifest-download"
+
+            let client: ManifestDownload.ManifestDownloadClient =
+                {
+                    GetContentBlockDownloadUri =
+                        fun parameters ->
+                            requestedBlocks.Add(parameters.ContentBlockAddress)
+                            Task.FromResult(Ok(GraceReturnValue.Create $"https://example.test/{parameters.ContentBlockAddress}" correlationId))
+                    DownloadContentBlock =
+                        fun contentBlockAddress uri ->
+                            Assert.That(uri.AbsoluteUri, Does.Contain(contentBlockAddress))
+                            downloadedBlocks.Add(contentBlockAddress)
+                            Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
+                }
+
+            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok returnValue ->
+                Assert.That(returnValue.ReturnValue.UsedManifestDownload, Is.True)
+                Assert.That(returnValue.ReturnValue.Bytes.Length, Is.EqualTo(payload.Length))
+                Assert.That(Array.forall2 (=) returnValue.ReturnValue.Bytes payload, Is.True)
+
+                Assert.That(
+                    requestedBlocks,
+                    Is.EquivalentTo(
+                        manifest.Blocks
+                        |> Seq.map (fun block -> block.Address)
+                        |> Seq.distinct
+                    )
+                )
+
+                Assert.That(downloadedBlocks, Is.EquivalentTo(requestedBlocks))
+        }
+
+    [<Test>]
+    member _.WholeFileContentDownloadUsesCompatibilityFallbackWithoutResolvingBlocks() =
+        task {
+            let payload = ManifestDownloadSdkTests.PseudoRandomBytes 128
+            let fileVersion = FileVersion.Create "small.txt" (ManifestDownloadSdkTests.ComputeSha256Hash payload) String.Empty false (int64 payload.Length)
+            let correlationId = "corr-sdk-manifest-download-whole-file"
+
+            let client: ManifestDownload.ManifestDownloadClient =
+                {
+                    GetContentBlockDownloadUri =
+                        fun _ ->
+                            Assert.Fail("WholeFileContent downloads must not resolve ContentBlock download URIs.")
+                            Task.FromResult(Error(GraceError.Create "unexpected" correlationId))
+                    DownloadContentBlock =
+                        fun _ _ ->
+                            Assert.Fail("WholeFileContent downloads must not download ContentBlock payloads.")
+                            Task.FromResult(Error(GraceError.Create "unexpected" correlationId))
+                }
+
+            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok returnValue ->
+                Assert.That(returnValue.ReturnValue.UsedManifestDownload, Is.False)
+                Assert.That(returnValue.ReturnValue.Bytes, Is.Empty)
+                Assert.That(returnValue.ReturnValue.DownloadedBlockCount, Is.EqualTo(0))
+        }
+
+    [<Test>]
+    member _.ManifestDownloadRejectsOutOfOrderManifestRanges() =
+        task {
+            let payload = Array.zeroCreate<byte> (RabinChunking.MaximumChunkSize * 2)
+
+            let plan = LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+            let validManifest = ManifestDownloadSdkTests.ManifestFor plan
+            let blockPayloads = ManifestDownloadSdkTests.EncodeBlocks plan
+
+            let invalidBlocks =
+                validManifest.Blocks
+                |> Seq.mapi (fun index block -> if index = 1 then ContentBlock.Create(block.Address, 0L, block.Size) else block)
+                |> List.ofSeq
+
+            let invalidManifestAddress =
+                ContentAddress.computeManifestAddress validManifest.ChunkingSuiteId validManifest.FileContentHash validManifest.Size invalidBlocks
+
+            let invalidManifest =
+                FileManifest.Create(invalidManifestAddress, validManifest.ChunkingSuiteId, validManifest.FileContentHash, validManifest.Size, invalidBlocks)
+
+            let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "out-of-order-large.bin" payload invalidManifest
+            let correlationId = "corr-sdk-manifest-download-ranges"
+
+            let client: ManifestDownload.ManifestDownloadClient =
+                {
+                    GetContentBlockDownloadUri =
+                        fun parameters -> Task.FromResult(Ok(GraceReturnValue.Create $"https://example.test/{parameters.ContentBlockAddress}" correlationId))
+                    DownloadContentBlock =
+                        fun contentBlockAddress _ -> Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
+                }
+
+            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+
+            match result with
+            | Error error ->
+                Assert.That(error.Error, Does.Contain("Manifest download reconstruction failed"))
+                Assert.That(error.Error, Does.Contain("BlockRangeOutOfOrder"))
+            | Ok _ -> Assert.Fail("Expected out-of-order manifest ranges to be rejected.")
+        }
+
+    [<Test>]
+    member _.ManifestDownloadRejectsCorruptContentBlockPayload() =
+        task {
+            let payload = ManifestDownloadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 5uy
+
+            let plan = LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+            let manifest = ManifestDownloadSdkTests.ManifestFor plan
+            let blockPayloads = ManifestDownloadSdkTests.EncodeBlocks plan
+            let firstAddress = plan.ContentBlockUploads[0].BlockAddress
+            let corruptPayload = Array.copy blockPayloads[firstAddress]
+            corruptPayload[0] <- corruptPayload[0] ^^^ 0xffuy
+            blockPayloads[firstAddress] <- corruptPayload
+
+            let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "corrupt-large.bin" payload manifest
+            let correlationId = "corr-sdk-manifest-download-corrupt"
+
+            let client: ManifestDownload.ManifestDownloadClient =
+                {
+                    GetContentBlockDownloadUri =
+                        fun parameters -> Task.FromResult(Ok(GraceReturnValue.Create $"https://example.test/{parameters.ContentBlockAddress}" correlationId))
+                    DownloadContentBlock =
+                        fun contentBlockAddress _ -> Task.FromResult(Ok(GraceReturnValue.Create blockPayloads[contentBlockAddress] correlationId))
+                }
+
+            let! result = ManifestDownload.downloadFileWithClient client (ManifestDownloadSdkTests.CreateRequest fileVersion correlationId)
+
+            match result with
+            | Error error ->
+                Assert.That(error.Error, Does.Contain("Manifest download reconstruction failed"))
+                Assert.That(error.Error, Does.Contain("ContentBlock payload is invalid"))
+            | Ok _ -> Assert.Fail("Expected corrupt ContentBlock payload to be rejected.")
+        }

--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -358,6 +358,58 @@ type ManifestDownloadSdkTests() =
             })
 
     [<Test>]
+    member _.CliManifestDownloadDeletesPartialObjectCacheFileOnFailure() =
+        ManifestDownloadSdkTests.WithTempConfiguration (fun _ ->
+            task {
+                let payload = ManifestDownloadSdkTests.PseudoRandomBytes 220000
+                payload[0] <- 8uy
+
+                let plan =
+                    LocalPlanner.analyzeBytes { LocalPlanner.Options.Default with EligibilityPolicy = ManifestDownloadSdkTests.BinaryPolicy 1024L } payload
+
+                let manifest = ManifestDownloadSdkTests.ManifestFor plan
+                let fileVersion = ManifestDownloadSdkTests.CreateManifestFileVersion "cli-partial-cache.bin" payload manifest
+                let downloadFile = Services.objectStorageDownloadFileFromFileVersion fileVersion
+                let localFileVersion = downloadFile.LocalFileVersion
+
+                let getDownloadUriParameters =
+                    GetDownloadUriParameters(
+                        OwnerId = String.Empty,
+                        OwnerName = Current().OwnerName,
+                        OrganizationId = String.Empty,
+                        OrganizationName = Current().OrganizationName,
+                        RepositoryId = String.Empty,
+                        RepositoryName = Current().RepositoryName,
+                        CorrelationId = "corr-cli-manifest-partial-cache"
+                    )
+
+                let manifestDownload (request: ManifestDownload.ManifestDownloadRequest) =
+                    match request.OutputStream with
+                    | None -> Assert.Fail("Manifest-backed CLI downloads must provide an output stream.")
+                    | Some outputStream -> outputStream.Write(payload, 0, 4096)
+
+                    Task.FromResult(Error(GraceError.Create "simulated manifest reconstruction failure" request.CorrelationId))
+
+                let wholeFileDownload _ _ =
+                    Assert.Fail("Manifest reconstruction failures must not fall back to WholeFileContent downloads.")
+                    Task.FromResult(Error(GraceError.Create "unexpected whole-file download" getDownloadUriParameters.CorrelationId))
+
+                let! result =
+                    Services.downloadFilesFromObjectStorageWithClients
+                        manifestDownload
+                        wholeFileDownload
+                        getDownloadUriParameters
+                        [| downloadFile |]
+                        getDownloadUriParameters.CorrelationId
+
+                match result with
+                | Ok () -> Assert.Fail("Expected manifest reconstruction failure to be returned as GraceError.")
+                | Error error ->
+                    Assert.That(error, Does.Contain("simulated manifest reconstruction failure"))
+                    Assert.That(File.Exists localFileVersion.FullObjectPath, Is.False)
+            })
+
+    [<Test>]
     member _.ManifestDownloadRejectsOutOfOrderManifestRanges() =
         task {
             let payload = Array.zeroCreate<byte> (RabinChunking.MaximumChunkSize * 2)

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2921,36 +2921,7 @@ module Branch =
                                                 directoryVersionDto.DirectoryVersion.Files
                                                 (getCorrelationId parseResult))
                                         with
-                                    | Ok _ ->
-                                        try
-                                            //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
-
-                                            // Write the UpdatesInProgress file to let grace watch know to ignore these changes.
-                                            // This file is deleted in the finally clause.
-                                            do! File.WriteAllTextAsync(updateInProgressFileName (), "`grace switch` is in progress.")
-
-                                            // Update working directory based on new GraceStatus.Index
-                                            do!
-                                                updateWorkingDirectory
-                                                    newGraceStatus
-                                                    graceStatusWithNewDirectoryVersionsFromServer
-                                                    newDirectoryVersionDtos
-                                                    (getCorrelationId parseResult)
-                                            //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
-
-                                            // Save the new Grace Status.
-                                            do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
-
-                                            // Update graceconfig.json.
-                                            let configuration = Current()
-                                            configuration.BranchId <- newBranch.BranchId
-                                            configuration.BranchName <- newBranch.BranchName
-                                            updateConfiguration configuration
-                                            t |> setProgressTaskValue showOutput 100.0
-                                        finally
-                                            // Delete the UpdatesInProgress file.
-                                            File.Delete(updateInProgressFileName ())
-
+                                    | Ok _ -> ()
                                     | Error error ->
                                         if parseResult |> verbose then
                                             logToAnsiConsole
@@ -2961,6 +2932,36 @@ module Branch =
                                         isError <- true
 
                                 if not <| isError then
+                                    try
+                                        //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
+
+                                        // Write the UpdatesInProgress file to let grace watch know to ignore these changes.
+                                        // This file is deleted in the finally clause.
+                                        do! File.WriteAllTextAsync(updateInProgressFileName (), "`grace switch` is in progress.")
+
+                                        // Update working directory based on new GraceStatus.Index
+                                        do!
+                                            updateWorkingDirectory
+                                                newGraceStatus
+                                                graceStatusWithNewDirectoryVersionsFromServer
+                                                newDirectoryVersionDtos
+                                                (getCorrelationId parseResult)
+                                        //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
+
+                                        // Save the new Grace Status.
+                                        do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
+
+                                        // Update graceconfig.json.
+                                        let configuration = Current()
+                                        configuration.BranchId <- newBranch.BranchId
+                                        configuration.BranchName <- newBranch.BranchName
+                                        updateConfiguration configuration
+                                        t |> setProgressTaskValue showOutput 100.0
+                                    finally
+                                        // Delete the UpdatesInProgress file.
+                                        if File.Exists(updateInProgressFileName ()) then
+                                            File.Delete(updateInProgressFileName ())
+
                                     newGraceStatus <- graceStatusWithNewDirectoryVersionsFromServer
                                     rootDirectoryId <- newGraceStatus.RootDirectoryId
                                     rootDirectorySha256Hash <- newGraceStatus.RootDirectorySha256Hash

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2915,8 +2915,12 @@ module Branch =
                                         CorrelationId = graceIds.CorrelationId
                                     )
 
-                                for directoryVersion in graceStatusWithNewDirectoryVersionsFromServer.Index.Values do
-                                    match! (downloadFilesFromObjectStorage getDownloadUriParameters directoryVersion.Files (getCorrelationId parseResult)) with
+                                for directoryVersionDto in newDirectoryVersionDtos do
+                                    match! (downloadFileVersionsFromObjectStorage
+                                                getDownloadUriParameters
+                                                directoryVersionDto.DirectoryVersion.Files
+                                                (getCorrelationId parseResult))
+                                        with
                                     | Ok _ ->
                                         try
                                             //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
@@ -2949,7 +2953,9 @@ module Branch =
 
                                     | Error error ->
                                         if parseResult |> verbose then
-                                            logToAnsiConsole Colors.Verbose $"Failed downloading files from object storage for {directoryVersion.RelativePath}."
+                                            logToAnsiConsole
+                                                Colors.Verbose
+                                                $"Failed downloading files from object storage for {directoryVersionDto.DirectoryVersion.RelativePath}."
 
                                         logToAnsiConsole Colors.Error $"{error}"
                                         isError <- true

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -701,8 +701,19 @@ module Services =
                             parameters.CorrelationId <- getDownloadUriParameters.CorrelationId
 
                             if fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest then
+                                let objectFilePath = localFileVersion.FullObjectPath
+
+                                let deletePartialManifestCacheFile () =
+                                    try
+                                        if File.Exists objectFilePath then File.Delete objectFilePath
+                                    with
+                                    | ex ->
+                                        logToAnsiConsole
+                                            Colors.Verbose
+                                            $"Failed to delete partial manifest cache file {objectFilePath}: {ExceptionResponse.Create ex}"
+
                                 try
-                                    let objectFileInfo = FileInfo(localFileVersion.FullObjectPath)
+                                    let objectFileInfo = FileInfo(objectFilePath)
 
                                     Directory.CreateDirectory(objectFileInfo.Directory.FullName)
                                     |> ignore
@@ -724,12 +735,20 @@ module Services =
                                         }
 
                                     match! manifestDownload manifestRequest with
-                                    | Error error -> return Error error
+                                    | Error error ->
+                                        outputStream.Dispose()
+                                        deletePartialManifestCacheFile ()
+                                        return Error error
                                     | Ok returnValue when returnValue.ReturnValue.UsedManifestDownload ->
                                         return Ok(GraceReturnValue.Create "Retrieved manifest-backed file from object storage." correlationId)
-                                    | Ok _ -> return! wholeFileDownload parameters correlationId
+                                    | Ok _ ->
+                                        outputStream.Dispose()
+                                        deletePartialManifestCacheFile ()
+                                        return! wholeFileDownload parameters correlationId
                                 with
                                 | ex ->
+                                    deletePartialManifestCacheFile ()
+
                                     return
                                         Error(
                                             GraceError.Create

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -658,17 +658,37 @@ module Services =
     let removeDirectoryFromObjectCache (directoryId: DirectoryVersionId) =
         task { do! LocalStateDb.removeObjectCacheDirectory (getLocalStateDbPath ()) directoryId }
 
-    /// Downloads files from object storage that aren't already present in the local object cache.
-    let downloadFilesFromObjectStorage (getDownloadUriParameters: GetDownloadUriParameters) (files: IEnumerable<LocalFileVersion>) (correlationId: string) =
+    type internal ObjectStorageDownloadFile = { LocalFileVersion: LocalFileVersion; SourceFileVersion: FileVersion option }
+
+    let internal objectStorageDownloadFileFromLocal localFileVersion = { LocalFileVersion = localFileVersion; SourceFileVersion = None }
+
+    let internal objectStorageDownloadFileFromFileVersion (fileVersion: FileVersion) =
+        { LocalFileVersion = fileVersion.ToLocalFileVersion DateTime.UtcNow; SourceFileVersion = Some fileVersion }
+
+    let internal fileVersionForObjectStorageDownload downloadFile =
+        match downloadFile.SourceFileVersion with
+        | Some fileVersion -> fileVersion
+        | None -> downloadFile.LocalFileVersion.ToFileVersion
+
+    let internal downloadFilesFromObjectStorageWithClients
+        (manifestDownload: ManifestDownload.ManifestDownloadRequest -> Task<GraceResult<ManifestDownload.ManifestDownloadResult>>)
+        (wholeFileDownload: GetDownloadUriParameters -> string -> Task<GraceResult<string>>)
+        (getDownloadUriParameters: GetDownloadUriParameters)
+        (files: IEnumerable<ObjectStorageDownloadFile>)
+        (correlationId: string)
+        =
         task {
             match Current().ObjectStorageProvider with
             | ObjectStorageProvider.Unknown -> return Ok()
             | AzureBlobStorage ->
                 let results =
                     files.ToArray()
-                    |> Array.where (fun f -> not <| File.Exists(f.FullObjectPath))
-                    |> Array.Parallel.map (fun f ->
+                    |> Array.where (fun f ->
+                        not
+                        <| File.Exists(f.LocalFileVersion.FullObjectPath))
+                    |> Array.Parallel.map (fun downloadFile ->
                         (task {
+                            let localFileVersion = downloadFile.LocalFileVersion
                             let parameters = GetDownloadUriParameters()
                             parameters.OwnerId <- getDownloadUriParameters.OwnerId
                             parameters.OwnerName <- getDownloadUriParameters.OwnerName
@@ -676,7 +696,7 @@ module Services =
                             parameters.OrganizationName <- getDownloadUriParameters.OrganizationName
                             parameters.RepositoryId <- getDownloadUriParameters.RepositoryId
                             parameters.RepositoryName <- getDownloadUriParameters.RepositoryName
-                            let fileVersion = f.ToFileVersion
+                            let fileVersion = fileVersionForObjectStorageDownload downloadFile
                             parameters.FileVersion <- fileVersion
                             parameters.CorrelationId <- getDownloadUriParameters.CorrelationId
 
@@ -694,19 +714,19 @@ module Services =
                                         ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
                                     }
 
-                                match! ManifestDownload.downloadFile manifestRequest with
+                                match! manifestDownload manifestRequest with
                                 | Error error -> return Error error
                                 | Ok returnValue when returnValue.ReturnValue.UsedManifestDownload ->
-                                    let objectFileInfo = FileInfo(f.FullObjectPath)
+                                    let objectFileInfo = FileInfo(localFileVersion.FullObjectPath)
 
                                     Directory.CreateDirectory(objectFileInfo.Directory.FullName)
                                     |> ignore
 
                                     do! File.WriteAllBytesAsync(objectFileInfo.FullName, returnValue.ReturnValue.Bytes)
                                     return Ok(GraceReturnValue.Create "Retrieved manifest-backed file from object storage." correlationId)
-                                | Ok _ -> return! Storage.GetFileFromObjectStorage parameters correlationId
+                                | Ok _ -> return! wholeFileDownload parameters correlationId
                             else
-                                return! Storage.GetFileFromObjectStorage parameters correlationId
+                                return! wholeFileDownload parameters correlationId
                         })
                             .Result)
 
@@ -740,6 +760,31 @@ module Services =
             | AWSS3 -> return Ok()
             | GoogleCloudStorage -> return Ok()
         }
+
+    /// Downloads files from object storage that aren't already present in the local object cache.
+    let downloadFilesFromObjectStorage (getDownloadUriParameters: GetDownloadUriParameters) (files: IEnumerable<LocalFileVersion>) (correlationId: string) =
+        let downloadFiles =
+            files
+            |> Seq.map objectStorageDownloadFileFromLocal
+
+        downloadFilesFromObjectStorageWithClients
+            ManifestDownload.downloadFile
+            Storage.GetFileFromObjectStorage
+            getDownloadUriParameters
+            downloadFiles
+            correlationId
+
+    let downloadFileVersionsFromObjectStorage (getDownloadUriParameters: GetDownloadUriParameters) (files: IEnumerable<FileVersion>) (correlationId: string) =
+        let downloadFiles =
+            files
+            |> Seq.map objectStorageDownloadFileFromFileVersion
+
+        downloadFilesFromObjectStorageWithClients
+            ManifestDownload.downloadFile
+            Storage.GetFileFromObjectStorage
+            getDownloadUriParameters
+            downloadFiles
+            correlationId
 
     let private uploadWholeFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
         task {
@@ -1429,9 +1474,15 @@ module Services =
                 let directoryInfo = Directory.CreateDirectory(newDirectoryVersion.FullName)
 
                 // Copy new and existing files into place.
-                let newLocalFileVersions = newDirectoryVersion.Files.Select(fun file -> file.ToLocalFileVersion DateTime.UtcNow)
+                let sourceFileVersions = newDirectoryVersion.Files.ToArray()
 
-                for fileVersion in newLocalFileVersions do
+                let newLocalFileVersions =
+                    sourceFileVersions
+                    |> Array.map (fun file -> file.ToLocalFileVersion DateTime.UtcNow)
+
+                for index in 0 .. newLocalFileVersions.Length - 1 do
+                    let sourceFileVersion = sourceFileVersions[index]
+                    let fileVersion = newLocalFileVersions[index]
                     let existingFileOnDisk = FileInfo(fileVersion.FullName)
                     let objectFile = FileInfo(fileVersion.FullObjectPath)
 
@@ -1449,7 +1500,7 @@ module Services =
                                 CorrelationId = correlationId
                             )
 
-                        match! downloadFilesFromObjectStorage getDownloadUriParameters [| fileVersion |] correlationId with
+                        match! downloadFileVersionsFromObjectStorage getDownloadUriParameters [| sourceFileVersion |] correlationId with
                         | Ok _ ->
                             logToAnsiConsole Colors.Verbose $"Downloaded {fileVersion.FullObjectPath} from the object storage provider."
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -701,30 +701,41 @@ module Services =
                             parameters.CorrelationId <- getDownloadUriParameters.CorrelationId
 
                             if fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest then
-                                let manifestRequest: ManifestDownload.ManifestDownloadRequest =
-                                    {
-                                        OwnerId = getDownloadUriParameters.OwnerId
-                                        OwnerName = getDownloadUriParameters.OwnerName
-                                        OrganizationId = getDownloadUriParameters.OrganizationId
-                                        OrganizationName = getDownloadUriParameters.OrganizationName
-                                        RepositoryId = getDownloadUriParameters.RepositoryId
-                                        RepositoryName = getDownloadUriParameters.RepositoryName
-                                        FileVersion = fileVersion
-                                        CorrelationId = getDownloadUriParameters.CorrelationId
-                                        ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
-                                    }
-
-                                match! manifestDownload manifestRequest with
-                                | Error error -> return Error error
-                                | Ok returnValue when returnValue.ReturnValue.UsedManifestDownload ->
+                                try
                                     let objectFileInfo = FileInfo(localFileVersion.FullObjectPath)
 
                                     Directory.CreateDirectory(objectFileInfo.Directory.FullName)
                                     |> ignore
 
-                                    do! File.WriteAllBytesAsync(objectFileInfo.FullName, returnValue.ReturnValue.Bytes)
-                                    return Ok(GraceReturnValue.Create "Retrieved manifest-backed file from object storage." correlationId)
-                                | Ok _ -> return! wholeFileDownload parameters correlationId
+                                    use outputStream = File.Open(objectFileInfo.FullName, fileStreamOptionsWrite)
+
+                                    let manifestRequest: ManifestDownload.ManifestDownloadRequest =
+                                        {
+                                            OwnerId = getDownloadUriParameters.OwnerId
+                                            OwnerName = getDownloadUriParameters.OwnerName
+                                            OrganizationId = getDownloadUriParameters.OrganizationId
+                                            OrganizationName = getDownloadUriParameters.OrganizationName
+                                            RepositoryId = getDownloadUriParameters.RepositoryId
+                                            RepositoryName = getDownloadUriParameters.RepositoryName
+                                            FileVersion = fileVersion
+                                            OutputStream = Some outputStream
+                                            CorrelationId = getDownloadUriParameters.CorrelationId
+                                            ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
+                                        }
+
+                                    match! manifestDownload manifestRequest with
+                                    | Error error -> return Error error
+                                    | Ok returnValue when returnValue.ReturnValue.UsedManifestDownload ->
+                                        return Ok(GraceReturnValue.Create "Retrieved manifest-backed file from object storage." correlationId)
+                                    | Ok _ -> return! wholeFileDownload parameters correlationId
+                                with
+                                | ex ->
+                                    return
+                                        Error(
+                                            GraceError.Create
+                                                $"Failed writing manifest-backed file to object cache: {ExceptionResponse.Create ex}"
+                                                correlationId
+                                        )
                             else
                                 return! wholeFileDownload parameters correlationId
                         })

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -703,11 +703,11 @@ module Services =
                             if fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest then
                                 let manifestRequest: ManifestDownload.ManifestDownloadRequest =
                                     {
-                                        OwnerId = Guid.Parse(getDownloadUriParameters.OwnerId)
+                                        OwnerId = getDownloadUriParameters.OwnerId
                                         OwnerName = getDownloadUriParameters.OwnerName
-                                        OrganizationId = Guid.Parse(getDownloadUriParameters.OrganizationId)
+                                        OrganizationId = getDownloadUriParameters.OrganizationId
                                         OrganizationName = getDownloadUriParameters.OrganizationName
-                                        RepositoryId = Guid.Parse(getDownloadUriParameters.RepositoryId)
+                                        RepositoryId = getDownloadUriParameters.RepositoryId
                                         RepositoryName = getDownloadUriParameters.RepositoryName
                                         FileVersion = fileVersion
                                         CorrelationId = getDownloadUriParameters.CorrelationId

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -676,10 +676,37 @@ module Services =
                             parameters.OrganizationName <- getDownloadUriParameters.OrganizationName
                             parameters.RepositoryId <- getDownloadUriParameters.RepositoryId
                             parameters.RepositoryName <- getDownloadUriParameters.RepositoryName
-                            parameters.FileVersion <- f.ToFileVersion
+                            let fileVersion = f.ToFileVersion
+                            parameters.FileVersion <- fileVersion
                             parameters.CorrelationId <- getDownloadUriParameters.CorrelationId
 
-                            return! Storage.GetFileFromObjectStorage parameters correlationId
+                            if fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest then
+                                let manifestRequest: ManifestDownload.ManifestDownloadRequest =
+                                    {
+                                        OwnerId = Guid.Parse(getDownloadUriParameters.OwnerId)
+                                        OwnerName = getDownloadUriParameters.OwnerName
+                                        OrganizationId = Guid.Parse(getDownloadUriParameters.OrganizationId)
+                                        OrganizationName = getDownloadUriParameters.OrganizationName
+                                        RepositoryId = Guid.Parse(getDownloadUriParameters.RepositoryId)
+                                        RepositoryName = getDownloadUriParameters.RepositoryName
+                                        FileVersion = fileVersion
+                                        CorrelationId = getDownloadUriParameters.CorrelationId
+                                        ExpectedChunkingSuiteId = ChunkingSuiteId RabinChunking.SuiteName
+                                    }
+
+                                match! ManifestDownload.downloadFile manifestRequest with
+                                | Error error -> return Error error
+                                | Ok returnValue when returnValue.ReturnValue.UsedManifestDownload ->
+                                    let objectFileInfo = FileInfo(f.FullObjectPath)
+
+                                    Directory.CreateDirectory(objectFileInfo.Directory.FullName)
+                                    |> ignore
+
+                                    do! File.WriteAllBytesAsync(objectFileInfo.FullName, returnValue.ReturnValue.Bytes)
+                                    return Ok(GraceReturnValue.Create "Retrieved manifest-backed file from object storage." correlationId)
+                                | Ok _ -> return! Storage.GetFileFromObjectStorage parameters correlationId
+                            else
+                                return! Storage.GetFileFromObjectStorage parameters correlationId
                         })
                             .Result)
 

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -22,6 +22,7 @@
         <Compile Include="PersonalAccessToken.SDK.fs" />
         <Compile Include="LocalPlanner.SDK.fs" />
         <Compile Include="Storage.SDK.fs" />
+        <Compile Include="ManifestDownload.SDK.fs" />
         <Compile Include="ManifestUpload.SDK.fs" />
 		<Compile Include="Branch.SDK.fs" />
 		<Compile Include="Owner.SDK.fs" />

--- a/src/Grace.SDK/ManifestDownload.SDK.fs
+++ b/src/Grace.SDK/ManifestDownload.SDK.fs
@@ -1,0 +1,156 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Shared.Parameters.Storage
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Types
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module ManifestDownload =
+    type ManifestDownloadRequest =
+        {
+            OwnerId: OwnerId
+            OwnerName: OwnerName
+            OrganizationId: OrganizationId
+            OrganizationName: OrganizationName
+            RepositoryId: RepositoryId
+            RepositoryName: RepositoryName
+            FileVersion: FileVersion
+            CorrelationId: CorrelationId
+            ExpectedChunkingSuiteId: ChunkingSuiteId
+        }
+
+    type ManifestDownloadResult =
+        {
+            FileVersion: FileVersion
+            Manifest: FileManifest option
+            Bytes: byte array
+            DownloadedBlockCount: int
+            UsedManifestDownload: bool
+        }
+
+    type ManifestDownloadClient =
+        {
+            GetContentBlockDownloadUri: GetContentBlockDownloadUriParameters -> Task<GraceResult<string>>
+            DownloadContentBlock: ContentBlockAddress -> Uri -> Task<GraceResult<byte array>>
+        }
+
+    let private setStorageParameters (request: ManifestDownloadRequest) (parameters: StorageParameters) =
+        parameters.OwnerId <- $"{request.OwnerId}"
+        parameters.OwnerName <- request.OwnerName
+        parameters.OrganizationId <- $"{request.OrganizationId}"
+        parameters.OrganizationName <- request.OrganizationName
+        parameters.RepositoryId <- $"{request.RepositoryId}"
+        parameters.RepositoryName <- request.RepositoryName
+        parameters.CorrelationId <- request.CorrelationId
+        parameters
+
+    let private error correlationId message = Error(GraceError.Create message correlationId)
+
+    let private emptyResult fileVersion =
+        { FileVersion = fileVersion; Manifest = None; Bytes = Array.empty; DownloadedBlockCount = 0; UsedManifestDownload = false }
+
+    let private buildDownloadUriParameters request contentBlockAddress =
+        let parameters = GetContentBlockDownloadUriParameters()
+        setStorageParameters request parameters |> ignore
+        parameters.ContentBlockAddress <- contentBlockAddress
+        parameters
+
+    let private describeValidationError validationError =
+        match validationError with
+        | ManifestValidation.ContentBlockPayloadInvalid (_, contentBlockError) -> $"ContentBlock payload is invalid: {contentBlockError}"
+        | ManifestValidation.MissingContentBlockPayload (index, address) -> $"Manifest block {index} is missing ContentBlock payload {address}."
+        | ManifestValidation.ContentBlockPayloadSizeMismatch (index, expected, actual) ->
+            $"Manifest block {index} size mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.FileContentHashMismatch (expected, actual) -> $"File content hash mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.ManifestSizeMismatch (expected, actual) -> $"Manifest size mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.ChunkingSuiteMismatch (expected, actual) -> $"Chunking suite mismatch. Expected {expected}, actual {actual}."
+        | ManifestValidation.ManifestAddressMismatch (expected, actual) -> $"Manifest address mismatch. Expected {expected}, actual {actual}."
+        | other -> $"{other}"
+
+    let private uniqueManifestBlocks (manifest: FileManifest) =
+        let addresses = ResizeArray<ContentBlockAddress>()
+        let seen = HashSet<ContentBlockAddress>()
+        let mutable index = 0
+
+        while index < manifest.Blocks.Count do
+            let block = manifest.Blocks[index]
+
+            if
+                not (isNull (box block))
+                && seen.Add(block.Address)
+            then
+                addresses.Add(block.Address)
+
+            index <- index + 1
+
+        addresses.ToArray()
+
+    let downloadFileWithClient (client: ManifestDownloadClient) (request: ManifestDownloadRequest) : Task<GraceResult<ManifestDownloadResult>> =
+        task {
+            if isNull (box request.FileVersion) then
+                return error request.CorrelationId "FileVersion is required for manifest download."
+            elif
+                isNull (box request.FileVersion.ContentReference)
+                || request.FileVersion.ContentReference.ReferenceType = FileContentReferenceType.WholeFileContent
+            then
+                return Ok(GraceReturnValue.Create (emptyResult request.FileVersion) request.CorrelationId)
+            else
+                match request.FileVersion.ContentReference.Manifest with
+                | None -> return error request.CorrelationId "FileVersion ContentReference did not include a FileManifest."
+                | Some manifest ->
+                    let blockPayloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
+                    let blockAddresses = uniqueManifestBlocks manifest
+                    let mutable errorResult = None
+                    let mutable index = 0
+
+                    while index < blockAddresses.Length
+                          && Option.isNone errorResult do
+                        let contentBlockAddress = blockAddresses[index]
+                        let parameters = buildDownloadUriParameters request contentBlockAddress
+
+                        match! client.GetContentBlockDownloadUri parameters with
+                        | Error error -> errorResult <- Some error
+                        | Ok uriResult ->
+                            match Uri.TryCreate(uriResult.ReturnValue, UriKind.Absolute) with
+                            | false, _ ->
+                                errorResult <-
+                                    Some(GraceError.Create $"Failed to get a valid ContentBlock download URI for {contentBlockAddress}." request.CorrelationId)
+                            | true, downloadUri ->
+                                match! client.DownloadContentBlock contentBlockAddress downloadUri with
+                                | Error error -> errorResult <- Some error
+                                | Ok payloadResult -> blockPayloads.Add(ManifestValidation.createBlockPayload contentBlockAddress payloadResult.ReturnValue)
+
+                        index <- index + 1
+
+                    match errorResult with
+                    | Some error -> return Error error
+                    | None ->
+                        match ManifestValidation.validate request.ExpectedChunkingSuiteId manifest blockPayloads with
+                        | Error validationError ->
+                            return error request.CorrelationId $"Manifest download reconstruction failed: {describeValidationError validationError}"
+                        | Ok reconstructedBytes ->
+                            return
+                                Ok(
+                                    GraceReturnValue.Create
+                                        {
+                                            FileVersion = request.FileVersion
+                                            Manifest = Some manifest
+                                            Bytes = reconstructedBytes
+                                            DownloadedBlockCount = blockPayloads.Count
+                                            UsedManifestDownload = true
+                                        }
+                                        request.CorrelationId
+                                )
+        }
+
+    let serverClient correlationId =
+        {
+            GetContentBlockDownloadUri = Storage.GetContentBlockDownloadUri
+            DownloadContentBlock = fun contentBlockAddress uri -> Storage.DownloadContentBlockFromObjectStorage contentBlockAddress uri correlationId
+        }
+
+    let downloadFile request = downloadFileWithClient (serverClient request.CorrelationId) request

--- a/src/Grace.SDK/ManifestDownload.SDK.fs
+++ b/src/Grace.SDK/ManifestDownload.SDK.fs
@@ -1,12 +1,13 @@
 namespace Grace.SDK
 
+open Blake3
 open Grace.Shared
 open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Types
 open System
-open System.Collections.Generic
+open System.IO
 open System.Threading.Tasks
 
 module ManifestDownload =
@@ -19,6 +20,7 @@ module ManifestDownload =
             RepositoryId: string
             RepositoryName: RepositoryName
             FileVersion: FileVersion
+            OutputStream: Stream option
             CorrelationId: CorrelationId
             ExpectedChunkingSuiteId: ChunkingSuiteId
         }
@@ -27,7 +29,7 @@ module ManifestDownload =
         {
             FileVersion: FileVersion
             Manifest: FileManifest option
-            Bytes: byte array
+            BytesWritten: int64
             DownloadedBlockCount: int
             UsedManifestDownload: bool
         }
@@ -51,7 +53,7 @@ module ManifestDownload =
     let private error correlationId message = Error(GraceError.Create message correlationId)
 
     let private emptyResult fileVersion =
-        { FileVersion = fileVersion; Manifest = None; Bytes = Array.empty; DownloadedBlockCount = 0; UsedManifestDownload = false }
+        { FileVersion = fileVersion; Manifest = None; BytesWritten = 0L; DownloadedBlockCount = 0; UsedManifestDownload = false }
 
     let private buildDownloadUriParameters request contentBlockAddress =
         let parameters = GetContentBlockDownloadUriParameters()
@@ -71,81 +73,182 @@ module ManifestDownload =
         | ManifestValidation.ManifestAddressMismatch (expected, actual) -> $"Manifest address mismatch. Expected {expected}, actual {actual}."
         | other -> $"{other}"
 
-    let private uniqueManifestBlocks (manifest: FileManifest) =
-        let addresses = ResizeArray<ContentBlockAddress>()
-        let seen = HashSet<ContentBlockAddress>()
+    let private validateManifestShape expectedChunkingSuiteId (manifest: FileManifest) =
+        if isNull (box manifest) then
+            Error ManifestValidation.NullManifest
+        elif String.IsNullOrWhiteSpace(expectedChunkingSuiteId) then
+            Error(ManifestValidation.InvalidChunkingSuiteId expectedChunkingSuiteId)
+        elif manifest.Size <= 0L then
+            Error ManifestValidation.InvalidManifestSize
+        elif isNull manifest.Blocks
+             || manifest.Blocks.Count = 0 then
+            Error ManifestValidation.EmptyManifest
+        elif String.IsNullOrWhiteSpace(manifest.ChunkingSuiteId) then
+            Error(ManifestValidation.InvalidChunkingSuiteId manifest.ChunkingSuiteId)
+        elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
+            Error(ManifestValidation.InvalidFileContentHash manifest.FileContentHash)
+        elif not (ContentAddress.isValidAddress manifest.ManifestAddress) then
+            Error(ManifestValidation.InvalidManifestAddress manifest.ManifestAddress)
+        elif manifest.ChunkingSuiteId
+             <> expectedChunkingSuiteId then
+            Error(ManifestValidation.ChunkingSuiteMismatch(expectedChunkingSuiteId, manifest.ChunkingSuiteId))
+        else
+            Ok()
+
+    let private validateManifestRanges (manifest: FileManifest) =
+        let mutable expectedOffset = 0L
+        let mutable validationError = None
         let mutable index = 0
 
-        while index < manifest.Blocks.Count do
+        while index < manifest.Blocks.Count
+              && Option.isNone validationError do
             let block = manifest.Blocks[index]
 
-            if
-                not (isNull (box block))
-                && seen.Add(block.Address)
-            then
-                addresses.Add(block.Address)
+            if isNull (box block) then
+                validationError <- Some(ManifestValidation.NullContentBlock index)
+            elif not (ContentAddress.isValidAddress block.Address) then
+                validationError <- Some(ManifestValidation.InvalidContentBlockAddress(index, block.Address))
+            elif block.Size <= 0L then
+                validationError <- Some(ManifestValidation.BlockRangeNotPositive index)
+            elif block.Offset <> expectedOffset then
+                validationError <- Some(ManifestValidation.BlockRangeOutOfOrder index)
+            else
+                expectedOffset <- expectedOffset + block.Size
 
             index <- index + 1
 
-        addresses.ToArray()
+        match validationError with
+        | Some validationError -> Error validationError
+        | None when expectedOffset <> manifest.Size -> Error(ManifestValidation.ManifestSizeMismatch(manifest.Size, expectedOffset))
+        | None -> Ok()
+
+    let private validateManifestAddress (manifest: FileManifest) =
+        let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+        if manifest.ManifestAddress <> expectedAddress then
+            Error(ManifestValidation.ManifestAddressMismatch(expectedAddress, manifest.ManifestAddress))
+        else
+            Ok()
+
+    let private validateManifest expectedChunkingSuiteId manifest =
+        validateManifestShape expectedChunkingSuiteId manifest
+        |> Result.bind (fun () -> validateManifestRanges manifest)
+        |> Result.bind (fun () -> validateManifestAddress manifest)
+
+    let private writeManifestToStream (client: ManifestDownloadClient) (request: ManifestDownloadRequest) (manifest: FileManifest) (outputStream: Stream) =
+        task {
+            use hasher = Hasher.New()
+            let mutable errorResult = None
+            let mutable index = 0
+            let mutable bytesWritten = 0L
+
+            while index < manifest.Blocks.Count
+                  && Option.isNone errorResult do
+                let block = manifest.Blocks[index]
+                let parameters = buildDownloadUriParameters request block.Address
+
+                match! client.GetContentBlockDownloadUri parameters with
+                | Error error -> errorResult <- Some error
+                | Ok uriResult ->
+                    match Uri.TryCreate(uriResult.ReturnValue, UriKind.Absolute) with
+                    | false, _ ->
+                        errorResult <- Some(GraceError.Create $"Failed to get a valid ContentBlock download URI for {block.Address}." request.CorrelationId)
+                    | true, downloadUri ->
+                        match! client.DownloadContentBlock block.Address downloadUri with
+                        | Error error -> errorResult <- Some error
+                        | Ok payloadResult ->
+                            match ContentBlockFormat.decode payloadResult.ReturnValue with
+                            | Error decodeError ->
+                                errorResult <-
+                                    Some(
+                                        GraceError.Create
+                                            $"Manifest download reconstruction failed: {describeValidationError (ManifestValidation.ContentBlockPayloadInvalid(block.Address, decodeError))}"
+                                            request.CorrelationId
+                                    )
+                            | Ok decodedBlock ->
+                                match ContentBlockFormat.validateAddress block.Address decodedBlock with
+                                | Error addressError ->
+                                    errorResult <-
+                                        Some(
+                                            GraceError.Create
+                                                $"Manifest download reconstruction failed: {describeValidationError (ManifestValidation.ContentBlockPayloadInvalid(block.Address, addressError))}"
+                                                request.CorrelationId
+                                        )
+                                | Ok () ->
+                                    let actualSize = int64 decodedBlock.Payload.Length
+
+                                    if actualSize <> block.Size then
+                                        errorResult <-
+                                            Some(
+                                                GraceError.Create
+                                                    $"Manifest download reconstruction failed: {describeValidationError (ManifestValidation.ContentBlockPayloadSizeMismatch(index, block.Size, actualSize))}"
+                                                    request.CorrelationId
+                                            )
+                                    else
+                                        try
+                                            do! outputStream.WriteAsync(decodedBlock.Payload, 0, decodedBlock.Payload.Length)
+                                            hasher.Update(decodedBlock.Payload)
+                                            bytesWritten <- bytesWritten + actualSize
+                                        with
+                                        | ex ->
+                                            errorResult <-
+                                                Some(
+                                                    GraceError.Create
+                                                        $"Failed writing manifest-backed file to output stream: {ExceptionResponse.Create ex}"
+                                                        request.CorrelationId
+                                                )
+
+                index <- index + 1
+
+            match errorResult with
+            | Some error -> return Error error
+            | None when bytesWritten <> manifest.Size ->
+                return
+                    error
+                        request.CorrelationId
+                        $"Manifest download reconstruction failed: {describeValidationError (ManifestValidation.ManifestSizeMismatch(manifest.Size, bytesWritten))}"
+            | None ->
+                let actualHash = FileContentHash(hasher.Finalize().ToString().ToLowerInvariant())
+
+                if manifest.FileContentHash <> actualHash then
+                    return
+                        error
+                            request.CorrelationId
+                            $"Manifest download reconstruction failed: {describeValidationError (ManifestValidation.FileContentHashMismatch(manifest.FileContentHash, actualHash))}"
+                else
+                    return
+                        Ok(
+                            GraceReturnValue.Create
+                                {
+                                    FileVersion = request.FileVersion
+                                    Manifest = Some manifest
+                                    BytesWritten = bytesWritten
+                                    DownloadedBlockCount = manifest.Blocks.Count
+                                    UsedManifestDownload = true
+                                }
+                                request.CorrelationId
+                        )
+        }
 
     let downloadFileWithClient (client: ManifestDownloadClient) (request: ManifestDownloadRequest) : Task<GraceResult<ManifestDownloadResult>> =
-        task {
-            if isNull (box request.FileVersion) then
-                return error request.CorrelationId "FileVersion is required for manifest download."
-            elif
-                isNull (box request.FileVersion.ContentReference)
-                || request.FileVersion.ContentReference.ReferenceType = FileContentReferenceType.WholeFileContent
-            then
-                return Ok(GraceReturnValue.Create (emptyResult request.FileVersion) request.CorrelationId)
-            else
-                match request.FileVersion.ContentReference.Manifest with
-                | None -> return error request.CorrelationId "FileVersion ContentReference did not include a FileManifest."
-                | Some manifest ->
-                    let blockPayloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
-                    let blockAddresses = uniqueManifestBlocks manifest
-                    let mutable errorResult = None
-                    let mutable index = 0
-
-                    while index < blockAddresses.Length
-                          && Option.isNone errorResult do
-                        let contentBlockAddress = blockAddresses[index]
-                        let parameters = buildDownloadUriParameters request contentBlockAddress
-
-                        match! client.GetContentBlockDownloadUri parameters with
-                        | Error error -> errorResult <- Some error
-                        | Ok uriResult ->
-                            match Uri.TryCreate(uriResult.ReturnValue, UriKind.Absolute) with
-                            | false, _ ->
-                                errorResult <-
-                                    Some(GraceError.Create $"Failed to get a valid ContentBlock download URI for {contentBlockAddress}." request.CorrelationId)
-                            | true, downloadUri ->
-                                match! client.DownloadContentBlock contentBlockAddress downloadUri with
-                                | Error error -> errorResult <- Some error
-                                | Ok payloadResult -> blockPayloads.Add(ManifestValidation.createBlockPayload contentBlockAddress payloadResult.ReturnValue)
-
-                        index <- index + 1
-
-                    match errorResult with
-                    | Some error -> return Error error
-                    | None ->
-                        match ManifestValidation.validate request.ExpectedChunkingSuiteId manifest blockPayloads with
-                        | Error validationError ->
-                            return error request.CorrelationId $"Manifest download reconstruction failed: {describeValidationError validationError}"
-                        | Ok reconstructedBytes ->
-                            return
-                                Ok(
-                                    GraceReturnValue.Create
-                                        {
-                                            FileVersion = request.FileVersion
-                                            Manifest = Some manifest
-                                            Bytes = reconstructedBytes
-                                            DownloadedBlockCount = blockPayloads.Count
-                                            UsedManifestDownload = true
-                                        }
-                                        request.CorrelationId
-                                )
-        }
+        if isNull (box request.FileVersion) then
+            Task.FromResult(error request.CorrelationId "FileVersion is required for manifest download.")
+        elif
+            isNull (box request.FileVersion.ContentReference)
+            || request.FileVersion.ContentReference.ReferenceType = FileContentReferenceType.WholeFileContent
+        then
+            Task.FromResult(Ok(GraceReturnValue.Create (emptyResult request.FileVersion) request.CorrelationId))
+        else
+            match request.FileVersion.ContentReference.Manifest with
+            | None -> Task.FromResult(error request.CorrelationId "FileVersion ContentReference did not include a FileManifest.")
+            | Some manifest ->
+                match request.OutputStream with
+                | None -> Task.FromResult(error request.CorrelationId "OutputStream is required for manifest download.")
+                | Some outputStream ->
+                    match validateManifest request.ExpectedChunkingSuiteId manifest with
+                    | Error validationError ->
+                        Task.FromResult(error request.CorrelationId $"Manifest download reconstruction failed: {describeValidationError validationError}")
+                    | Ok () -> writeManifestToStream client request manifest outputStream
 
     let serverClient correlationId =
         {

--- a/src/Grace.SDK/ManifestDownload.SDK.fs
+++ b/src/Grace.SDK/ManifestDownload.SDK.fs
@@ -12,11 +12,11 @@ open System.Threading.Tasks
 module ManifestDownload =
     type ManifestDownloadRequest =
         {
-            OwnerId: OwnerId
+            OwnerId: string
             OwnerName: OwnerName
-            OrganizationId: OrganizationId
+            OrganizationId: string
             OrganizationName: OrganizationName
-            RepositoryId: RepositoryId
+            RepositoryId: string
             RepositoryName: RepositoryName
             FileVersion: FileVersion
             CorrelationId: CorrelationId
@@ -39,11 +39,11 @@ module ManifestDownload =
         }
 
     let private setStorageParameters (request: ManifestDownloadRequest) (parameters: StorageParameters) =
-        parameters.OwnerId <- $"{request.OwnerId}"
+        parameters.OwnerId <- request.OwnerId
         parameters.OwnerName <- request.OwnerName
-        parameters.OrganizationId <- $"{request.OrganizationId}"
+        parameters.OrganizationId <- request.OrganizationId
         parameters.OrganizationName <- request.OrganizationName
-        parameters.RepositoryId <- $"{request.RepositoryId}"
+        parameters.RepositoryId <- request.RepositoryId
         parameters.RepositoryName <- request.RepositoryName
         parameters.CorrelationId <- request.CorrelationId
         parameters

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -336,6 +336,29 @@ module Storage =
                 return Error(GraceError.Create (exceptionResponse.ToString()) correlationId)
         }
 
+    let DownloadContentBlockFromObjectStorage (contentBlockAddress: ContentBlockAddress) (blobUriWithSasToken: Uri) correlationId =
+        task {
+            try
+                match Current().ObjectStorageProvider with
+                | ObjectStorageProvider.Unknown -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) correlationId)
+                | ObjectStorageProvider.AzureBlobStorage ->
+                    use transport = new HttpClientTransport(getHttpClient correlationId)
+
+                    let blobClientOptions = BlobClientOptions(Transport = transport)
+                    blobClientOptions.Retry.NetworkTimeout <- TimeSpan.FromMinutes(60.0)
+
+                    let blobClient = BlobClient(blobUriWithSasToken, blobClientOptions)
+                    let! response = blobClient.DownloadContentAsync()
+
+                    return Ok(GraceReturnValue.Create (response.Value.Content.ToArray()) correlationId)
+                | ObjectStorageProvider.AWSS3 -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) correlationId)
+                | ObjectStorageProvider.GoogleCloudStorage -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) correlationId)
+            with
+            | ex ->
+                let exceptionResponse = ExceptionResponse.Create ex
+                return Error(GraceError.Create $"Failed to download ContentBlock {contentBlockAddress}: {exceptionResponse.ToString()}" correlationId)
+        }
+
     /// Gets an upload URI with a SAS token for uploading a file to object storage.
     let GetUploadUri (parameters: GetUploadUriParameters) =
         task {


### PR DESCRIPTION
Closes #102.

## Summary

- Adds `Grace.SDK.ManifestDownload` for manifest-backed download reconstruction.
- Resolves distinct ContentBlock download URIs, downloads encoded block payloads, validates through `ManifestValidation`, and returns reconstructed unencoded bytes.
- Routes CLI object-cache downloads through manifest reconstruction only when `FileVersion.ContentReference = FileManifest`; `WholeFileContent` continues to use the existing download path.
- Adds focused SDK tests for successful reconstruction, WholeFileContent fallback, out-of-order manifest ranges, and corrupt ContentBlock payload rejection.

## Validation

- RED: `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter ManifestDownload --configuration Release` initially failed because `ManifestDownload` did not exist.
- `dotnet tool run fantomas --recurse .` from `./src` completed successfully; unrelated formatter churn outside the #102 write set was reverted.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter ManifestDownload --configuration Release` passed: 4 tests.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "ManifestUpload|ManifestDownload" --configuration Release` passed: 9 tests.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed: build clean; Authorization 21, CLI 210, Types 49.
- `pwsh ./scripts/validate.ps1 -Full` passed: build clean; Authorization 21, CLI 210, Types 49, Server 320.

## Test Coverage Changes

- Added `ManifestDownload.SDK.Tests.fs` covering manifest block resolution/reconstruction, compatibility fallback for WholeFileContent, range validation failure, and corrupt block rejection.

## Docs Impact

- No public docs updated. This slice enables the SDK/CLI download behavior behind existing content-reference data without adding a new user-facing command or option.

## Skipped Validation

- None.

## Residual Risk

- Manifest-backed CLI downloads now depend on existing ContentBlock download URI endpoints and Azure blob reads. Full validation passed, but a real large-file round trip should still be watched closely when CL5 enables manifest upload/download by default.

## Follow-ups

- #103 should enable manifest defaults once adjacent DAG slices are merged and coordinated.
- #101 remains responsible for dedupe discovery/claim optimization; this PR intentionally does not implement it.