### PR TITLE
Implement SDK dedupe discovery claims

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,26 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  fast:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    env:
-      GraceBuildKind: ci
-      GraceBuildNumber: ${{ github.run_number }}
-      GraceSourceRevisionId: ${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          global-json-file: global.json
-      - name: Install .NET Aspire workload
-        run: dotnet workload install aspire
-      - name: Validate (Fast)
-        run: pwsh ./scripts/validate.ps1 -Fast
-
   full:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       GraceBuildKind: ci
@@ -44,11 +25,38 @@ jobs:
       - name: Docker info
         run: docker info
       - name: Pre-pull Aspire images
+        shell: bash
         run: |
-          docker pull redis:latest
-          docker pull mcr.microsoft.com/azure-storage/azurite:latest
-          docker pull mcr.microsoft.com/mssql/server:2022-latest
-          docker pull mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
-          docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+          set -euo pipefail
+
+          images=(
+            "redis:latest"
+            "mcr.microsoft.com/azure-storage/azurite:latest"
+            "mcr.microsoft.com/mssql/server:2022-latest"
+            "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest"
+            "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest"
+          )
+
+          pids=()
+          for image in "${images[@]}"; do
+            echo "Starting pull for ${image}"
+            docker pull "${image}" &
+            pids+=("$!")
+          done
+
+          failed=0
+          for index in "${!pids[@]}"; do
+            image="${images[$index]}"
+            pid="${pids[$index]}"
+
+            if wait "${pid}"; then
+              echo "Completed pull for ${image}"
+            else
+              echo "Failed pull for ${image}" >&2
+              failed=1
+            fi
+          done
+
+          exit "${failed}"
       - name: Validate (Full)
         run: pwsh ./scripts/validate.ps1 -Full

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,18 @@ jobs:
           global-json-file: global.json
       - name: Install .NET Aspire workload
         run: dotnet workload install aspire
+      - name: Format
+        run: echo "Skipped (temporarily disabled pending full repo formatting)."
+      - name: Restore
+        run: dotnet restore "src/Grace.slnx"
+      - name: Build
+        run: |
+          dotnet build "src/Grace.slnx" \
+            --configuration Release \
+            --no-restore \
+            -p:GraceBuildKind="${GraceBuildKind}" \
+            -p:GraceBuildNumber="${GraceBuildNumber}" \
+            -p:GraceSourceRevisionId="${GraceSourceRevisionId}"
       - name: Docker info
         run: docker info
       - name: Pre-pull Aspire images
@@ -58,5 +70,5 @@ jobs:
           done
 
           exit "${failed}"
-      - name: Validate (Full)
-        run: pwsh ./scripts/validate.ps1 -Full
+      - name: Test
+        run: dotnet test "src/Grace.slnx" --configuration Release --no-build --no-restore

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -14,6 +14,7 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Security.Cryptography
+open System.Text
 open System.Threading.Tasks
 
 [<NonParallelizable>]
@@ -70,7 +71,10 @@ type ManifestUploadSdkTests() =
         }
         |> fun discovery -> Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
 
-    static member private ProtectedChunkAddress storagePoolId chunkAddress = $"{storagePoolId}|{chunkAddress}"
+    static member private ProtectedChunkAddress storagePoolId chunkAddress =
+        let preimage = $"grace.dedupe-index.v1.protected-window\n{storagePoolId}\n{chunkAddress}"
+        let hash = SHA256.HashData(Encoding.UTF8.GetBytes(preimage))
+        $"protected-sha256:{Convert.ToHexString(hash).ToLowerInvariant()}"
 
     static member private CreateRequest tempPath (fileVersion: FileVersion) correlationId : ManifestUpload.ManifestUploadRequest =
         {
@@ -212,6 +216,10 @@ type ManifestUploadSdkTests() =
                 let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
                 let claimedBlock = plan.Blocks[0]
                 let storagePoolId = StoragePoolId $"{request.RepositoryId}"
+                let protectedKeyChunkAddress = ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId claimedBlock.KeyChunkAddress
+
+                Assert.That(protectedKeyChunkAddress, Does.StartWith("protected-sha256:"))
+                Assert.That(protectedKeyChunkAddress, Is.Not.EqualTo($"{storagePoolId}|{claimedBlock.KeyChunkAddress}"))
 
                 let client: ManifestUpload.ManifestUploadClient =
                     {
@@ -229,10 +237,7 @@ type ManifestUploadSdkTests() =
                                         OrdinalCount = 8
                                         MetadataVersion = 7L
                                         MatchingKeyChunkCount = 1
-                                        ProtectedChunkAddresses =
-                                            [|
-                                                ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId claimedBlock.KeyChunkAddress
-                                            |]
+                                        ProtectedChunkAddresses = [| protectedKeyChunkAddress |]
                                     }
 
                                 let discovery =

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -46,6 +46,32 @@ type ManifestUploadSdkTests() =
 
         Task.FromResult(Ok(GraceReturnValue.Create decision correlationId))
 
+    static member private DiscoveryPolicy minimumReuseRunLength =
+        {
+            MaxKeyChunkAddresses = 256
+            MaxCandidateWindowsPerKeyChunk = 4
+            MaxWindowChunks = 256
+            MaxResponseProtectedChunks = 16384
+            ResponseTtlSeconds = 300
+            MinimumAcceptedReuseRunLength = minimumReuseRunLength
+            PositiveCandidatesEnabled = true
+            EmptyResponseMeansAbsent = false
+            IsAuthoritative = false
+        }
+
+    static member private EmptyDiscovery correlationId requested =
+        {
+            RequestedKeyChunkCount = requested
+            AcceptedKeyChunkCount = requested
+            Policy = ManifestUploadSdkTests.DiscoveryPolicy 8
+            CandidateContentBlocks = Array.empty
+            IsPartial = false
+            Message = "empty discovery is non-authoritative"
+        }
+        |> fun discovery -> Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
+
+    static member private ProtectedChunkAddress storagePoolId chunkAddress = $"{storagePoolId}|{chunkAddress}"
+
     static member private CreateRequest tempPath (fileVersion: FileVersion) correlationId : ManifestUpload.ManifestUploadRequest =
         {
             OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
@@ -98,6 +124,18 @@ type ManifestUploadSdkTests() =
                                 calls.Add("start")
                                 sessionIds.Add(parameters.UploadSessionId)
                                 ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks =
+                            fun parameters ->
+                                calls.Add("discover")
+                                ManifestUploadSdkTests.EmptyDiscovery correlationId parameters.KeyChunkAddresses.Length
+                        IssueDedupeDiscovery =
+                            fun parameters ->
+                                calls.Add("issue-discovery")
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun parameters ->
+                                calls.Add("claim")
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
                         RegisterBlockUpload =
                             fun parameters ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
@@ -143,13 +181,350 @@ type ManifestUploadSdkTests() =
                     Assert.That(calls[0], Is.EqualTo("start"))
                     Assert.That(calls[calls.Count - 1], Is.EqualTo("finalize"))
 
-                    Assert.That(
-                        calls
-                        |> Seq.exists (fun call -> call.StartsWith("discover", StringComparison.OrdinalIgnoreCase)),
-                        Is.False
-                    )
+                    Assert.That(calls, Does.Contain("discover"))
+                    Assert.That(calls, Does.Not.Contain("issue-discovery"))
+                    Assert.That(calls, Does.Not.Contain("claim"))
 
                     Assert.That(uploadedBlocks.Keys, Is.EquivalentTo(confirmedBlocks.Keys))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.ManifestUploadClaimsValidDiscoveryCandidateAndSkipsUploadingClaimedBlock() =
+        task {
+            let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 1uy
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-upload-reuse-{Guid.NewGuid():N}.bin")
+            let correlationId = "corr-sdk-manifest-upload-reuse"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let confirmedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let claimedHints = ResizeArray<ContentBlockReuseRangeHint>()
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion =
+                    FileVersion.Create "reuse-large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+
+                let request = ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId
+                let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
+                let claimedBlock = plan.Blocks[0]
+                let storagePoolId = StoragePoolId $"{request.RepositoryId}"
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks =
+                            fun parameters ->
+                                Assert.That(parameters.KeyChunkAddresses, Does.Contain(claimedBlock.KeyChunkAddress))
+
+                                let candidate =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ManifestAddress = ManifestAddress "manifest-reuse-candidate"
+                                        ContentBlockAddress = claimedBlock.Address
+                                        OrdinalStart = 0
+                                        OrdinalCount = 8
+                                        MetadataVersion = 7L
+                                        MatchingKeyChunkCount = 1
+                                        ProtectedChunkAddresses =
+                                            [|
+                                                ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId claimedBlock.KeyChunkAddress
+                                            |]
+                                    }
+
+                                let discovery =
+                                    {
+                                        RequestedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        AcceptedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        Policy = ManifestUploadSdkTests.DiscoveryPolicy 8
+                                        CandidateContentBlocks = [| candidate |]
+                                        IsPartial = false
+                                        Message = "candidate"
+                                    }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
+                        IssueDedupeDiscovery =
+                            fun parameters ->
+                                Assert.That(parameters.Hints, Has.Length.EqualTo(1))
+                                Assert.That(parameters.Hints[0].ContentBlockAddress, Is.EqualTo(claimedBlock.Address))
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun parameters ->
+                                Assert.That(parameters.Hints, Has.Length.EqualTo(1))
+                                claimedHints.AddRange(parameters.Hints)
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        RegisterBlockUpload =
+                            fun parameters ->
+                                Assert.That(parameters.ContentBlockAddress, Is.Not.EqualTo(claimedBlock.Address))
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                Assert.That(parameters.ContentBlockAddress, Is.Not.EqualTo(claimedBlock.Address))
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded =
+                            fun parameters ->
+                                Assert.That(parameters.ContentBlockAddress, Is.Not.EqualTo(claimedBlock.Address))
+                                confirmedBlocks[parameters.ContentBlockAddress] <- parameters.Payload
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client request
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    Assert.That(returnValue.ReturnValue.UsedManifestUpload, Is.True)
+                    Assert.That(claimedHints, Has.Count.EqualTo(1))
+                    Assert.That(uploadedBlocks.ContainsKey claimedBlock.Address, Is.False)
+                    Assert.That(confirmedBlocks.ContainsKey claimedBlock.Address, Is.False)
+                    Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length - 1))
+                    Assert.That(returnValue.ReturnValue.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.ManifestUploadTreatsDiscoveryFailureAsNonAuthoritativeAndUploadsBlocks() =
+        task {
+            let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 3uy
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-upload-discovery-failure-{Guid.NewGuid():N}.bin")
+            let correlationId = "corr-sdk-manifest-upload-discovery-failure"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let mutable issuedDiscovery = false
+            let mutable claimedReuse = false
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion =
+                    FileVersion.Create "discovery-failure-large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+
+                let request = ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId
+                let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks = fun _parameters -> Task.FromResult(Error(GraceError.Create "discovery unavailable" correlationId))
+                        IssueDedupeDiscovery =
+                            fun parameters ->
+                                issuedDiscovery <- true
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun parameters ->
+                                claimedReuse <- true
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        RegisterBlockUpload = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client request
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    Assert.That(returnValue.ReturnValue.UsedManifestUpload, Is.True)
+                    Assert.That(issuedDiscovery, Is.False)
+                    Assert.That(claimedReuse, Is.False)
+                    Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.ManifestUploadDuplicatesDiscoveryCandidatesBelowMinimumReuseRunLength() =
+        task {
+            let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 4uy
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-upload-short-reuse-{Guid.NewGuid():N}.bin")
+            let correlationId = "corr-sdk-manifest-upload-short-reuse"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let mutable issuedDiscovery = false
+            let mutable claimedReuse = false
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion =
+                    FileVersion.Create "short-reuse-large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+
+                let request = ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId
+                let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
+                let candidateBlock = plan.Blocks[0]
+                let storagePoolId = StoragePoolId $"{request.RepositoryId}"
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks =
+                            fun parameters ->
+                                let candidate =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ManifestAddress = ManifestAddress "manifest-short-candidate"
+                                        ContentBlockAddress = candidateBlock.Address
+                                        OrdinalStart = 0
+                                        OrdinalCount = 7
+                                        MetadataVersion = 7L
+                                        MatchingKeyChunkCount = 1
+                                        ProtectedChunkAddresses =
+                                            [|
+                                                ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId candidateBlock.KeyChunkAddress
+                                            |]
+                                    }
+
+                                let discovery =
+                                    {
+                                        RequestedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        AcceptedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        Policy = ManifestUploadSdkTests.DiscoveryPolicy 8
+                                        CandidateContentBlocks = [| candidate |]
+                                        IsPartial = false
+                                        Message = "short candidate"
+                                    }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
+                        IssueDedupeDiscovery =
+                            fun parameters ->
+                                issuedDiscovery <- true
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun parameters ->
+                                claimedReuse <- true
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        RegisterBlockUpload = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client request
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    Assert.That(returnValue.ReturnValue.UsedManifestUpload, Is.True)
+                    Assert.That(issuedDiscovery, Is.False)
+                    Assert.That(claimedReuse, Is.False)
+                    Assert.That(uploadedBlocks.ContainsKey candidateBlock.Address, Is.True)
+                    Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.ManifestUploadFallsBackToUploadingBlocksWhenReuseClaimIsStale() =
+        task {
+            let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 5uy
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-upload-stale-reuse-{Guid.NewGuid():N}.bin")
+            let correlationId = "corr-sdk-manifest-upload-stale-reuse"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let mutable issuedDiscovery = false
+            let mutable attemptedClaim = false
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion =
+                    FileVersion.Create "stale-reuse-large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+
+                let request = ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId
+                let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
+                let candidateBlock = plan.Blocks[0]
+                let storagePoolId = StoragePoolId $"{request.RepositoryId}"
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks =
+                            fun parameters ->
+                                let candidate =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ManifestAddress = ManifestAddress "manifest-stale-candidate"
+                                        ContentBlockAddress = candidateBlock.Address
+                                        OrdinalStart = 0
+                                        OrdinalCount = 8
+                                        MetadataVersion = 6L
+                                        MatchingKeyChunkCount = 1
+                                        ProtectedChunkAddresses =
+                                            [|
+                                                ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId candidateBlock.KeyChunkAddress
+                                            |]
+                                    }
+
+                                let discovery =
+                                    {
+                                        RequestedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        AcceptedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        Policy = ManifestUploadSdkTests.DiscoveryPolicy 8
+                                        CandidateContentBlocks = [| candidate |]
+                                        IsPartial = false
+                                        Message = "stale candidate"
+                                    }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
+                        IssueDedupeDiscovery =
+                            fun parameters ->
+                                issuedDiscovery <- true
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun _parameters ->
+                                attemptedClaim <- true
+                                Task.FromResult(Error(GraceError.Create "stale reuse range hint rejected" correlationId))
+                        RegisterBlockUpload = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client request
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    Assert.That(returnValue.ReturnValue.UsedManifestUpload, Is.True)
+                    Assert.That(issuedDiscovery, Is.True)
+                    Assert.That(attemptedClaim, Is.True)
+                    Assert.That(uploadedBlocks.ContainsKey candidateBlock.Address, Is.True)
+                    Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length))
             finally
                 if File.Exists(tempPath) then File.Delete(tempPath)
         }
@@ -178,6 +553,9 @@ type ManifestUploadSdkTests() =
                             fun parameters ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
                                 ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks = fun parameters -> ManifestUploadSdkTests.EmptyDiscovery correlationId parameters.KeyChunkAddresses.Length
+                        IssueDedupeDiscovery = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
                         RegisterBlockUpload =
                             fun parameters ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
@@ -239,6 +617,9 @@ type ManifestUploadSdkTests() =
                             fun parameters ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
                                 ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks = fun parameters -> ManifestUploadSdkTests.EmptyDiscovery correlationId parameters.KeyChunkAddresses.Length
+                        IssueDedupeDiscovery = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
                         RegisterBlockUpload =
                             fun parameters ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -47,6 +47,19 @@ type ManifestUploadSdkTests() =
 
         Task.FromResult(Ok(GraceReturnValue.Create decision correlationId))
 
+    static member private ClaimDecision correlationId sessionId operationId claimedRanges =
+        let session =
+            { UploadSessionDto.Default with
+                UploadSessionId = sessionId
+                RepositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                ClaimedReuseRanges = claimedRanges
+                LastOperationId = Some operationId
+            }
+
+        let decision = { Session = session; OperationId = operationId; Events = []; WasIdempotentReplay = false; Message = "accepted" }
+
+        Task.FromResult(Ok(GraceReturnValue.Create decision correlationId))
+
     static member private DiscoveryPolicy minimumReuseRunLength =
         {
             MaxKeyChunkAddresses = 256
@@ -260,7 +273,20 @@ type ManifestUploadSdkTests() =
                             fun parameters ->
                                 Assert.That(parameters.Hints, Has.Length.EqualTo(1))
                                 claimedHints.AddRange(parameters.Hints)
-                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+
+                                let claimedRange =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ContentBlockAddress = claimedBlock.Address
+                                        OrdinalStart = parameters.Hints[0].OrdinalStart
+                                        OrdinalCount = parameters.Hints[0].OrdinalCount
+                                        PhysicalOffset = 0L
+                                        PhysicalLength = claimedBlock.Size
+                                        MetadataVersion = parameters.Hints[0].MetadataVersion
+                                        ClaimedAt = getCurrentInstant ()
+                                    }
+
+                                ManifestUploadSdkTests.ClaimDecision correlationId parameters.UploadSessionId parameters.OperationId [| claimedRange |]
                         RegisterBlockUpload =
                             fun parameters ->
                                 Assert.That(parameters.ContentBlockAddress, Is.Not.EqualTo(claimedBlock.Address))
@@ -292,6 +318,109 @@ type ManifestUploadSdkTests() =
                     Assert.That(uploadedBlocks.ContainsKey claimedBlock.Address, Is.False)
                     Assert.That(confirmedBlocks.ContainsKey claimedBlock.Address, Is.False)
                     Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length - 1))
+                    Assert.That(returnValue.ReturnValue.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.ManifestUploadUploadsBlockWhenReuseClaimCoversOnlyPartialWindow() =
+        task {
+            let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000
+            payload[0] <- 6uy
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-upload-partial-reuse-{Guid.NewGuid():N}.bin")
+            let correlationId = "corr-sdk-manifest-upload-partial-reuse"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let confirmedBlocks = Dictionary<ContentBlockAddress, byte array>()
+            let mutable attemptedClaim = false
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion =
+                    FileVersion.Create "partial-reuse-large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+
+                let request = ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId
+                let plan = LocalPlanner.analyzeFile request.PlannerOptions tempPath
+                let partiallyClaimedBlock = plan.Blocks[0]
+                let storagePoolId = StoragePoolId $"{request.RepositoryId}"
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks =
+                            fun parameters ->
+                                let candidate =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ManifestAddress = ManifestAddress "manifest-partial-candidate"
+                                        ContentBlockAddress = partiallyClaimedBlock.Address
+                                        OrdinalStart = 0
+                                        OrdinalCount = 8
+                                        MetadataVersion = 7L
+                                        MatchingKeyChunkCount = 1
+                                        ProtectedChunkAddresses =
+                                            [|
+                                                ManifestUploadSdkTests.ProtectedChunkAddress storagePoolId partiallyClaimedBlock.KeyChunkAddress
+                                            |]
+                                    }
+
+                                let discovery =
+                                    {
+                                        RequestedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        AcceptedKeyChunkCount = parameters.KeyChunkAddresses.Length
+                                        Policy = ManifestUploadSdkTests.DiscoveryPolicy 8
+                                        CandidateContentBlocks = [| candidate |]
+                                        IsPartial = false
+                                        Message = "partial candidate"
+                                    }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create discovery correlationId))
+                        IssueDedupeDiscovery = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges =
+                            fun parameters ->
+                                attemptedClaim <- true
+
+                                let partialRange =
+                                    {
+                                        StoragePoolId = storagePoolId
+                                        ContentBlockAddress = partiallyClaimedBlock.Address
+                                        OrdinalStart = parameters.Hints[0].OrdinalStart
+                                        OrdinalCount = parameters.Hints[0].OrdinalCount
+                                        PhysicalOffset = 0L
+                                        PhysicalLength = partiallyClaimedBlock.Size - 1L
+                                        MetadataVersion = parameters.Hints[0].MetadataVersion
+                                        ClaimedAt = getCurrentInstant ()
+                                    }
+
+                                ManifestUploadSdkTests.ClaimDecision correlationId parameters.UploadSessionId parameters.OperationId [| partialRange |]
+                        RegisterBlockUpload = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded =
+                            fun parameters ->
+                                confirmedBlocks[parameters.ContentBlockAddress] <- parameters.Payload
+                                ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client request
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    Assert.That(returnValue.ReturnValue.UsedManifestUpload, Is.True)
+                    Assert.That(attemptedClaim, Is.True)
+                    Assert.That(uploadedBlocks.ContainsKey partiallyClaimedBlock.Address, Is.True)
+                    Assert.That(confirmedBlocks.ContainsKey partiallyClaimedBlock.Address, Is.True)
+                    Assert.That(uploadedBlocks.Count, Is.EqualTo(plan.ContentBlockUploads.Length))
                     Assert.That(returnValue.ReturnValue.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
             finally
                 if File.Exists(tempPath) then File.Delete(tempPath)

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -11,6 +11,8 @@ open NodaTime
 open System
 open System.Collections.Generic
 open System.IO
+open System.Security.Cryptography
+open System.Text
 open System.Threading.Tasks
 
 module ManifestUpload =
@@ -173,7 +175,10 @@ module ManifestUpload =
         manifestVersion.ContentReference <- FileContentReference.FileManifest manifest
         manifestVersion
 
-    let private protectedChunkAddress storagePoolId chunkAddress = $"{storagePoolId}|{chunkAddress}"
+    let private protectedChunkAddress storagePoolId chunkAddress =
+        let preimage = $"grace.dedupe-index.v1.protected-window\n{storagePoolId}\n{chunkAddress}"
+        let hash = SHA256.HashData(Encoding.UTF8.GetBytes(preimage))
+        $"protected-sha256:{Convert.ToHexString(hash).ToLowerInvariant()}"
 
     let private candidateMatchesBlock (block: LocalPlanner.ContentBlockPlan) (candidate: ContentBlockDiscoveryCandidate) =
         candidate.ContentBlockAddress = block.Address

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -214,6 +214,28 @@ module ManifestUpload =
 
             hints.ToArray()
 
+    let private addFullyClaimedBlockAddresses
+        (plan: LocalPlanner.LocalFilePlan)
+        (claimedBlockAddresses: HashSet<ContentBlockAddress>)
+        (session: UploadSessionDto)
+        =
+        if
+            not (isNull (box session))
+            && not (isNull session.ClaimedReuseRanges)
+        then
+            let mutable claimedRangeIndex = 0
+
+            while claimedRangeIndex < session.ClaimedReuseRanges.Length do
+                let claimedRange = session.ClaimedReuseRanges[claimedRangeIndex]
+
+                plan.Blocks
+                |> Array.tryFind (fun block ->
+                    block.Address = claimedRange.ContentBlockAddress
+                    && block.Size = claimedRange.PhysicalLength)
+                |> Option.iter (fun block -> claimedBlockAddresses.Add block.Address |> ignore)
+
+                claimedRangeIndex <- claimedRangeIndex + 1
+
     let uploadFileWithClient (client: ManifestUploadClient) (request: ManifestUploadRequest) : Task<GraceResult<ManifestUploadResult>> =
         task {
             if isNull (box request.FileVersion) then
@@ -275,11 +297,7 @@ module ManifestUpload =
                                         let claimParameters = buildClaimReuseRangesParameters request uploadSessionId 0 issueParameters.OperationId reuseHints
 
                                         match! client.ClaimReuseRanges claimParameters with
-                                        | Ok _ ->
-                                            reuseHints
-                                            |> Array.iter (fun hint ->
-                                                claimedBlockAddresses.Add hint.ContentBlockAddress
-                                                |> ignore)
+                                        | Ok claimResult -> addFullyClaimedBlockAddresses plan claimedBlockAddresses claimResult.ReturnValue.Session
                                         | Error _ -> ()
                                     | Error _ -> ()
                             | _ -> ()

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -7,6 +7,7 @@ open Grace.Shared.Validation.Errors
 open Grace.Types.ContentBlockMetadata
 open Grace.Types.Types
 open Grace.Types.UploadSession
+open NodaTime
 open System
 open System.Collections.Generic
 open System.IO
@@ -43,6 +44,9 @@ module ManifestUpload =
     type ManifestUploadClient =
         {
             StartSession: StartManifestUploadSessionParameters -> Task<GraceResult<UploadSessionDecision>>
+            DiscoverContentBlocks: DiscoverContentBlocksParameters -> Task<GraceResult<DiscoverContentBlocksResult>>
+            IssueDedupeDiscovery: IssueDedupeDiscoveryParameters -> Task<GraceResult<UploadSessionDecision>>
+            ClaimReuseRanges: ClaimReuseRangesParameters -> Task<GraceResult<UploadSessionDecision>>
             RegisterBlockUpload: RegisterContentBlockUploadParameters -> Task<GraceResult<UploadSessionDecision>>
             UploadContentBlock: GetContentBlockUploadUriParameters -> byte array -> Task<GraceResult<ContentBlockStoragePlacement>>
             ConfirmBlockUploaded: ConfirmContentBlockUploadParameters -> Task<GraceResult<UploadSessionDecision>>
@@ -93,6 +97,37 @@ module ManifestUpload =
         parameters.OperationId <- $"manifest-upload-{uploadSessionId:N}-start"
         parameters
 
+    let private buildDiscoveryParameters request (plan: LocalPlanner.LocalFilePlan) =
+        let parameters = DiscoverContentBlocksParameters()
+        setStorageParameters request parameters |> ignore
+
+        parameters.KeyChunkAddresses <-
+            plan.KeyChunks
+            |> Array.map (fun keyChunk -> keyChunk.Address)
+
+        parameters
+
+    let private buildIssueDiscoveryParameters request uploadSessionId operationIndex expiresAt minimumReuseRunLength hints =
+        let parameters = IssueDedupeDiscoveryParameters()
+        setStorageParameters request parameters |> ignore
+        parameters.UploadSessionId <- uploadSessionId
+        parameters.AuthorizedScope <- request.AuthorizedScope
+        parameters.OperationId <- $"manifest-upload-{uploadSessionId:N}-discovery-{operationIndex}"
+        parameters.ExpiresAt <- expiresAt
+        parameters.MinimumReuseRunLength <- minimumReuseRunLength
+        parameters.Hints <- hints
+        parameters
+
+    let private buildClaimReuseRangesParameters request uploadSessionId operationIndex discoveryOperationId hints =
+        let parameters = ClaimReuseRangesParameters()
+        setStorageParameters request parameters |> ignore
+        parameters.UploadSessionId <- uploadSessionId
+        parameters.AuthorizedScope <- request.AuthorizedScope
+        parameters.OperationId <- $"manifest-upload-{uploadSessionId:N}-claim-{operationIndex}"
+        parameters.DiscoveryOperationId <- discoveryOperationId
+        parameters.Hints <- hints
+        parameters
+
     let private buildRegisterParameters request uploadSessionId operationIndex (block: ContentBlockFormat.EncodedContentBlock) logicalOffset logicalLength =
         let parameters = RegisterContentBlockUploadParameters()
         setStorageParameters request parameters |> ignore
@@ -138,6 +173,42 @@ module ManifestUpload =
         manifestVersion.ContentReference <- FileContentReference.FileManifest manifest
         manifestVersion
 
+    let private protectedChunkAddress storagePoolId chunkAddress = $"{storagePoolId}|{chunkAddress}"
+
+    let private candidateMatchesBlock (block: LocalPlanner.ContentBlockPlan) (candidate: ContentBlockDiscoveryCandidate) =
+        candidate.ContentBlockAddress = block.Address
+        && block.ChunkAddresses
+           |> Array.exists (fun chunkAddress ->
+               candidate.ProtectedChunkAddresses
+               |> Array.exists (fun protectedAddress -> protectedAddress = protectedChunkAddress candidate.StoragePoolId chunkAddress))
+
+    let private reusableHints (plan: LocalPlanner.LocalFilePlan) (discovery: DiscoverContentBlocksResult) =
+        if isNull discovery.CandidateContentBlocks
+           || isNull (box discovery.Policy)
+           || discovery.Policy.PositiveCandidatesEnabled |> not then
+            Array.empty
+        else
+            let minimumRunLength = discovery.Policy.MinimumAcceptedReuseRunLength
+            let hints = ResizeArray<ContentBlockReuseRangeHint>()
+            let claimedBlockAddresses = HashSet<ContentBlockAddress>()
+            let mutable candidateIndex = 0
+
+            while candidateIndex < discovery.CandidateContentBlocks.Length do
+                let candidate = discovery.CandidateContentBlocks[candidateIndex]
+
+                if candidate.OrdinalCount >= minimumRunLength then
+                    let matchingBlock =
+                        plan.Blocks
+                        |> Array.tryFind (fun block -> candidateMatchesBlock block candidate)
+
+                    match matchingBlock with
+                    | Some block when claimedBlockAddresses.Add block.Address -> hints.Add(DedupeIndex.toReuseRangeHint candidate)
+                    | _ -> ()
+
+                candidateIndex <- candidateIndex + 1
+
+            hints.ToArray()
+
     let uploadFileWithClient (client: ManifestUploadClient) (request: ManifestUploadRequest) : Task<GraceResult<ManifestUploadResult>> =
         task {
             if isNull (box request.FileVersion) then
@@ -174,51 +245,92 @@ module ManifestUpload =
                         match! client.StartSession(buildStartParameters request uploadSessionId plan) with
                         | Error error -> return Error error
                         | Ok _ ->
+                            let claimedBlockAddresses = HashSet<ContentBlockAddress>()
+
+                            match! client.DiscoverContentBlocks(buildDiscoveryParameters request plan) with
+                            | Ok discoveryResult when
+                                not (isNull discoveryResult.ReturnValue.CandidateContentBlocks)
+                                && discoveryResult.ReturnValue.CandidateContentBlocks.Length > 0
+                                ->
+                                let reuseHints = reusableHints plan discoveryResult.ReturnValue
+
+                                if reuseHints.Length > 0 then
+                                    let issueParameters =
+                                        buildIssueDiscoveryParameters
+                                            request
+                                            uploadSessionId
+                                            0
+                                            (getCurrentInstant()
+                                                .Plus(Duration.FromSeconds(int64 discoveryResult.ReturnValue.Policy.ResponseTtlSeconds)))
+                                            discoveryResult.ReturnValue.Policy.MinimumAcceptedReuseRunLength
+                                            reuseHints
+
+                                    match! client.IssueDedupeDiscovery issueParameters with
+                                    | Ok _ ->
+                                        let claimParameters = buildClaimReuseRangesParameters request uploadSessionId 0 issueParameters.OperationId reuseHints
+
+                                        match! client.ClaimReuseRanges claimParameters with
+                                        | Ok _ ->
+                                            reuseHints
+                                            |> Array.iter (fun hint ->
+                                                claimedBlockAddresses.Add hint.ContentBlockAddress
+                                                |> ignore)
+                                        | Error _ -> ()
+                                    | Error _ -> ()
+                            | _ -> ()
+
                             let errors = ResizeArray<GraceError>()
                             let mutable registerIndex = 0
 
                             while registerIndex < plan.Blocks.Length do
                                 let logicalBlockPlan = plan.Blocks[registerIndex]
 
-                                match encodedBlocksByAddress.TryGetValue logicalBlockPlan.Address with
-                                | false, _ ->
-                                    errors.Add(
-                                        GraceError.Create
-                                            $"Missing encoded ContentBlock payload for manifest block {logicalBlockPlan.Address}."
-                                            request.CorrelationId
-                                    )
-                                | true, encodedBlock ->
-                                    match!
-                                        client.RegisterBlockUpload
-                                            (
-                                                buildRegisterParameters
-                                                    request
-                                                    uploadSessionId
-                                                    registerIndex
-                                                    encodedBlock
-                                                    logicalBlockPlan.Offset
-                                                    logicalBlockPlan.Size
-                                            )
-                                        with
-                                    | Error error -> errors.Add error
-                                    | Ok _ -> ()
+                                if claimedBlockAddresses.Contains logicalBlockPlan.Address then
+                                    ()
+                                else
+                                    match encodedBlocksByAddress.TryGetValue logicalBlockPlan.Address with
+                                    | false, _ ->
+                                        errors.Add(
+                                            GraceError.Create
+                                                $"Missing encoded ContentBlock payload for manifest block {logicalBlockPlan.Address}."
+                                                request.CorrelationId
+                                        )
+                                    | true, encodedBlock ->
+                                        match!
+                                            client.RegisterBlockUpload
+                                                (
+                                                    buildRegisterParameters
+                                                        request
+                                                        uploadSessionId
+                                                        registerIndex
+                                                        encodedBlock
+                                                        logicalBlockPlan.Offset
+                                                        logicalBlockPlan.Size
+                                                )
+                                            with
+                                        | Error error -> errors.Add error
+                                        | Ok _ -> ()
 
                                 registerIndex <- registerIndex + 1
 
                             let mutable index = 0
+                            let mutable uploadedBlockCount = 0
 
                             while index < encodedBlocks.Count do
                                 let encodedBlock = encodedBlocks[index]
 
-                                match! client.UploadContentBlock (buildUploadUriParameters request encodedBlock.Address) encodedBlock.Payload with
-                                | Error error -> errors.Add error
-                                | Ok placementResult ->
-                                    match!
-                                        client.ConfirmBlockUploaded
-                                            (buildConfirmParameters request uploadSessionId index encodedBlock placementResult.ReturnValue)
-                                        with
+                                if claimedBlockAddresses.Contains encodedBlock.Address then
+                                    ()
+                                else
+                                    match! client.UploadContentBlock (buildUploadUriParameters request encodedBlock.Address) encodedBlock.Payload with
                                     | Error error -> errors.Add error
-                                    | Ok _ -> ()
+                                    | Ok placementResult ->
+                                        match!
+                                            client.ConfirmBlockUploaded
+                                                (buildConfirmParameters request uploadSessionId index encodedBlock placementResult.ReturnValue)
+                                            with
+                                        | Error error -> errors.Add error
+                                        | Ok _ -> uploadedBlockCount <- uploadedBlockCount + 1
 
                                 index <- index + 1
 
@@ -235,7 +347,7 @@ module ManifestUpload =
                                                     FileVersion = manifestFileVersion request.FileVersion manifest
                                                     Manifest = Some manifest
                                                     UploadSessionId = Some uploadSessionId
-                                                    UploadedBlockCount = encodedBlocks.Count
+                                                    UploadedBlockCount = uploadedBlockCount
                                                     UsedManifestUpload = true
                                                 }
                                                 request.CorrelationId
@@ -258,6 +370,9 @@ module ManifestUpload =
     let serverClient =
         {
             StartSession = Storage.StartManifestUploadSession
+            DiscoverContentBlocks = Storage.DiscoverContentBlocks
+            IssueDedupeDiscovery = Storage.IssueDedupeDiscovery
+            ClaimReuseRanges = Storage.ClaimReuseRanges
             RegisterBlockUpload = Storage.RegisterContentBlockUpload
             UploadContentBlock =
                 fun parameters payload ->

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -467,6 +467,12 @@ module Storage =
             "storage/startManifestUploadSession"
         )
 
+    let IssueDedupeDiscovery (parameters: IssueDedupeDiscoveryParameters) =
+        Common.postServer<IssueDedupeDiscoveryParameters, UploadSessionDecision> (parameters |> Common.ensureCorrelationIdIsSet, "storage/issueDedupeDiscovery")
+
+    let ClaimReuseRanges (parameters: ClaimReuseRangesParameters) =
+        Common.postServer<ClaimReuseRangesParameters, UploadSessionDecision> (parameters |> Common.ensureCorrelationIdIsSet, "storage/claimReuseRanges")
+
     let RegisterContentBlockUpload (parameters: RegisterContentBlockUploadParameters) =
         Common.postServer<RegisterContentBlockUploadParameters, UploadSessionDecision> (
             parameters |> Common.ensureCorrelationIdIsSet,

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -753,6 +753,30 @@ type StorageManifestUploadSessionRoutes() =
         }
 
     [<Test>]
+    member _.IssueDedupeDiscoveryRejectsMissingSessionBeforeDedupeIndexLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- Guid.NewGuid()
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- [| reuseHint 0 |]
+
+            let! body = postUploadSessionBadRequest "/storage/issueDedupeDiscovery" issue
+            Assert.That(body, Does.Contain("UploadSession must be started"))
+            Assert.That(body, Does.Not.Contain("server discovery candidates"))
+        }
+
+    [<Test>]
     member _.IssueDedupeDiscoveryRejectsHintsNotBackedByServerDiscovery() =
         task {
             let repositoryId = repositoryIds[0]

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -794,6 +794,149 @@ type StorageManifestUploadSessionRoutes() =
         }
 
     [<Test>]
+    member _.IssueDedupeDiscoveryNormalizesNullHintArrayToEmptySnapshot() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 6uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- sessionId
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- null
+
+            let! result = postUploadSessionDecision "/storage/issueDedupeDiscovery" issue
+            Assert.That(result.ReturnValue.Session.DedupeDiscovery, Is.Not.EqualTo(None))
+            Assert.That(result.ReturnValue.Session.DedupeDiscovery.Value.Hints, Is.Empty)
+        }
+
+    [<Test>]
+    member _.ClaimReuseRangesTreatsNullHintArrayAsEmptyBeforeMetadataLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 7uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- sessionId
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery-active"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- Array.empty
+
+            let! _ = postUploadSessionDecision "/storage/issueDedupeDiscovery" issue
+
+            let claim = Parameters.Storage.ClaimReuseRangesParameters()
+            setStorageParameters claim repositoryId correlationId
+            claim.UploadSessionId <- sessionId
+            claim.AuthorizedScope <- "/"
+            claim.OperationId <- "claim"
+            claim.DiscoveryOperationId <- "discovery-active"
+            claim.Hints <- null
+
+            let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
+            Assert.That(body, Does.Contain("At least one reuse range claim is required"))
+            Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
+        }
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsWrongStoragePoolBeforeMetadataLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 9uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- sessionId
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery-active"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- Array.empty
+
+            let! _ = postUploadSessionDecision "/storage/issueDedupeDiscovery" issue
+
+            let claim = Parameters.Storage.ClaimReuseRangesParameters()
+            setStorageParameters claim repositoryId correlationId
+            claim.UploadSessionId <- sessionId
+            claim.AuthorizedScope <- "/"
+            claim.OperationId <- "claim"
+            claim.DiscoveryOperationId <- "discovery-active"
+            claim.Hints <- [| reuseHint 2 |]
+
+            let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
+            Assert.That(body, Does.Contain("upload session repository storage pool"))
+            Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
+        }
+
+    [<Test>]
     member _.ClaimReuseRangesRejectsOversizedHintArraysBeforeMetadataLookup() =
         task {
             let repositoryId = repositoryIds[0]

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -711,7 +711,7 @@ type StorageManifestUploadSessionRoutes() =
                     .Plus(NodaTime.Duration.FromMinutes 5L)
 
             issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
-            issue.Hints <- [| reuseHint 0 |]
+            issue.Hints <- Array.empty
 
             let! _ = postUploadSessionDecision "/storage/issueDedupeDiscovery" issue
 
@@ -726,6 +726,71 @@ type StorageManifestUploadSessionRoutes() =
             let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
             Assert.That(body, Does.Contain("DiscoveryOperationId does not match"))
             Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
+        }
+
+    [<Test>]
+    member _.IssueDedupeDiscoveryRejectsOversizedHintArraysBeforeDispatch() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- Guid.NewGuid()
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- Array.init (Parameters.Storage.MaxReuseRangeClaims + 1) reuseHint
+
+            let! body = postUploadSessionBadRequest "/storage/issueDedupeDiscovery" issue
+            Assert.That(body, Does.Contain("IssueDedupeDiscovery Hints"))
+            Assert.That(body, Does.Contain($"{Parameters.Storage.MaxReuseRangeClaims}"))
+        }
+
+    [<Test>]
+    member _.IssueDedupeDiscoveryRejectsHintsNotBackedByServerDiscovery() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 5uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- sessionId
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- [| reuseHint 0 |]
+
+            let! body = postUploadSessionBadRequest "/storage/issueDedupeDiscovery" issue
+            Assert.That(body, Does.Contain("server discovery candidates"))
+            Assert.That(body, Does.Not.Contain("Dedupe discovery issued"))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -485,6 +485,15 @@ type StorageManifestUploadSessionRoutes() =
         parameters.RepositoryId <- repositoryId
         parameters.CorrelationId <- correlationId
 
+    let reuseHint index =
+        {
+            StoragePoolId = StoragePoolId $"storage-pool-{Guid.NewGuid():N}"
+            ContentBlockAddress = ContentBlockAddress $"content-block-{index}-{Guid.NewGuid():N}"
+            OrdinalStart = 0
+            OrdinalCount = Parameters.Storage.MinimumAcceptedReuseRunLength
+            MetadataVersion = 1L
+        }
+
     let postUploadSessionDecision (route: string) parameters =
         task {
             let! response = Client.PostAsync(route, createJsonContent parameters)
@@ -630,6 +639,62 @@ type StorageManifestUploadSessionRoutes() =
 
             let! body = postUploadSessionBadRequest "/storage/registerContentBlockUpload" register
             Assert.That(body, Does.Contain("AuthorizedScope must match"))
+        }
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsAuthorizedScopeMismatchBeforeMetadataLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 3uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/allowed/file.bin"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let claim = Parameters.Storage.ClaimReuseRangesParameters()
+            setStorageParameters claim repositoryId correlationId
+            claim.UploadSessionId <- sessionId
+            claim.AuthorizedScope <- "/other/file.bin"
+            claim.OperationId <- "claim"
+            claim.DiscoveryOperationId <- "discovery"
+            claim.Hints <- [| reuseHint 0 |]
+
+            let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
+            Assert.That(body, Does.Contain("AuthorizedScope must match"))
+            Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
+        }
+
+    [<Test>]
+    member _.ClaimReuseRangesRejectsOversizedHintArraysBeforeMetadataLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+
+            let claim = Parameters.Storage.ClaimReuseRangesParameters()
+            setStorageParameters claim repositoryId correlationId
+            claim.UploadSessionId <- Guid.NewGuid()
+            claim.AuthorizedScope <- "/"
+            claim.OperationId <- "claim"
+            claim.DiscoveryOperationId <- "discovery"
+            claim.Hints <- Array.init (Parameters.Storage.MaxReuseRangeClaims + 1) reuseHint
+
+            let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
+            Assert.That(body, Does.Contain("ClaimReuseRanges Hints"))
+            Assert.That(body, Does.Contain($"{Parameters.Storage.MaxReuseRangeClaims}"))
+            Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -678,6 +678,57 @@ type StorageManifestUploadSessionRoutes() =
         }
 
     [<Test>]
+    member _.ClaimReuseRangesRejectsDiscoveryOperationMismatchBeforeMetadataLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let payload = pseudoRandomBytes 220000
+            payload[0] <- 4uy
+            let block = encodeBlock payload
+            let manifest = manifestFor payload block
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- "/"
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- "sdk-dedupe-discovery-claim-test"
+            start.OperationId <- "start"
+
+            let! _ = postUploadSessionDecision "/storage/startManifestUploadSession" start
+
+            let issue = Parameters.Storage.IssueDedupeDiscoveryParameters()
+            setStorageParameters issue repositoryId correlationId
+            issue.UploadSessionId <- sessionId
+            issue.AuthorizedScope <- "/"
+            issue.OperationId <- "discovery-active"
+
+            issue.ExpiresAt <-
+                getCurrentInstant()
+                    .Plus(NodaTime.Duration.FromMinutes 5L)
+
+            issue.MinimumReuseRunLength <- Parameters.Storage.MinimumAcceptedReuseRunLength
+            issue.Hints <- [| reuseHint 0 |]
+
+            let! _ = postUploadSessionDecision "/storage/issueDedupeDiscovery" issue
+
+            let claim = Parameters.Storage.ClaimReuseRangesParameters()
+            setStorageParameters claim repositoryId correlationId
+            claim.UploadSessionId <- sessionId
+            claim.AuthorizedScope <- "/"
+            claim.OperationId <- "claim"
+            claim.DiscoveryOperationId <- "discovery-stale"
+            claim.Hints <- [| reuseHint 1 |]
+
+            let! body = postUploadSessionBadRequest "/storage/claimReuseRanges" claim
+            Assert.That(body, Does.Contain("DiscoveryOperationId does not match"))
+            Assert.That(body, Does.Not.Contain("Authoritative ContentBlockMetadata is absent"))
+        }
+
+    [<Test>]
     member _.ClaimReuseRangesRejectsOversizedHintArraysBeforeMetadataLookup() =
         task {
             let repositoryId = repositoryIds[0]

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -175,6 +175,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/review/report/get" Authenticated
             endpoint "POST" "/review/resolve" Authenticated
             endpoint "POST" "/storage/getDownloadUri" (Authorized(PathRead, Path))
+            endpoint "POST" "/storage/claimReuseRanges" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/confirmContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepoRead, Repository))
             endpoint "POST" "/storage/finalizeManifestUpload" (Authorized(PathWrite, Path))
@@ -182,6 +183,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/getContentBlockUploadUri" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getUploadMetadataForFiles" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getUploadUri" (Authorized(PathWrite, Path))
+            endpoint "POST" "/storage/issueDedupeDiscovery" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
             endpoint "POST" "/work/create" (Authorized(RepoWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1280,6 +1280,12 @@ module Application =
                                route "/startManifestUploadSession" (composeHandlers requirePathWriteForUploadSession Storage.StartManifestUploadSession)
                                |> addMetadata typeof<Storage.StartManifestUploadSessionParameters>
 
+                               route "/issueDedupeDiscovery" (composeHandlers requirePathWriteForUploadSession Storage.IssueDedupeDiscovery)
+                               |> addMetadata typeof<Storage.IssueDedupeDiscoveryParameters>
+
+                               route "/claimReuseRanges" (composeHandlers requirePathWriteForUploadSession Storage.ClaimReuseRanges)
+                               |> addMetadata typeof<Storage.ClaimReuseRangesParameters>
+
                                route "/registerContentBlockUpload" (composeHandlers requirePathWriteForUploadSession Storage.RegisterContentBlockUpload)
                                |> addMetadata typeof<Storage.RegisterContentBlockUploadParameters>
 

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -122,8 +122,9 @@ module Storage =
             let! sessionForScope = loadSessionForScope requestContext.UploadSessionActor correlationId
 
             if requireExistingSession
-               && sessionForScope.UploadSessionId = UploadSessionId.Empty then
-                return Error(GraceError.Create "UploadSession must be started before ClaimReuseRanges." correlationId)
+               && (sessionForScope.UploadSessionId = UploadSessionId.Empty
+                   || sessionForScope.LifecycleState = UploadSessionLifecycleState.NotStarted) then
+                return Error(GraceError.Create "UploadSession must be started before this operation." correlationId)
             elif sessionForScope.UploadSessionId
                  <> UploadSessionId.Empty
                  && sessionForScope.AuthorizedScope
@@ -576,27 +577,40 @@ module Storage =
                                     correlationId
                             )
                     else
-                        let graceIds = getGraceIds context
-                        let organizationId, repositoryId = resolveStorageIds graceIds parameters
-                        let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
-                        let! repositoryDto = repositoryActor.Get correlationId
-                        let storagePoolId = DedupeIndex.storagePoolIdForRepository repositoryDto
-                        let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
-                        let! records = dedupeIndexActor.Snapshot correlationId
+                        let! requestContext = createUploadSessionRequestContext context parameters correlationId
+                        let! scopeValidation = validateUploadSessionScope requestContext parameters correlationId true
 
-                        match validateIssuedDedupeDiscoveryHints correlationId storagePoolId hints records with
+                        match scopeValidation with
                         | Error error -> return! context |> result400BadRequest error
-                        | Ok boundHints ->
-                            let command =
-                                UploadSessionCommand.IssueDedupeDiscovery
-                                    {
-                                        OperationId = parameters.OperationId
-                                        ExpiresAt = parameters.ExpiresAt
-                                        MinimumReuseRunLength = parameters.MinimumReuseRunLength
-                                        Hints = boundHints
-                                    }
+                        | Ok requestContext ->
+                            let repositoryActor =
+                                Repository.CreateActorProxy
+                                    requestContext.SessionForScope.OrganizationId
+                                    requestContext.SessionForScope.RepositoryId
+                                    correlationId
 
-                            return! handleUploadSessionCommand context parameters command correlationId
+                            let! repositoryDto = repositoryActor.Get correlationId
+                            let storagePoolId = DedupeIndex.storagePoolIdForRepository repositoryDto
+                            let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+                            let! records = dedupeIndexActor.Snapshot correlationId
+
+                            match validateIssuedDedupeDiscoveryHints correlationId storagePoolId hints records with
+                            | Error error -> return! context |> result400BadRequest error
+                            | Ok boundHints ->
+                                let command =
+                                    UploadSessionCommand.IssueDedupeDiscovery
+                                        {
+                                            OperationId = parameters.OperationId
+                                            ExpiresAt = parameters.ExpiresAt
+                                            MinimumReuseRunLength = parameters.MinimumReuseRunLength
+                                            Hints = boundHints
+                                        }
+
+                                let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+
+                                match result with
+                                | Ok returnValue -> return! context |> result200Ok returnValue
+                                | Error error -> return! context |> result400BadRequest error
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -153,6 +153,48 @@ module Storage =
             Error(GraceError.Create "Dedupe discovery has expired; reuse ranges cannot be claimed." correlationId)
         | Some _ -> Ok()
 
+    let private hintMatchesDedupeIndexRecord (hint: ContentBlockReuseRangeHint) (record: DedupeIndex.DedupeIndexRecord) =
+        record.StoragePoolId = hint.StoragePoolId
+        && record.ContentBlockAddress = hint.ContentBlockAddress
+        && record.OrdinalStart = hint.OrdinalStart
+        && record.OrdinalCount = hint.OrdinalCount
+        && record.MetadataVersion = hint.MetadataVersion
+
+    let private reuseRangeHintFromDedupeIndexRecord (record: DedupeIndex.DedupeIndexRecord) : ContentBlockReuseRangeHint =
+        {
+            StoragePoolId = record.StoragePoolId
+            ContentBlockAddress = record.ContentBlockAddress
+            OrdinalStart = record.OrdinalStart
+            OrdinalCount = record.OrdinalCount
+            MetadataVersion = record.MetadataVersion
+        }
+
+    let private validateIssuedDedupeDiscoveryHints
+        correlationId
+        storagePoolId
+        (hints: ContentBlockReuseRangeHint array)
+        (records: DedupeIndex.DedupeIndexRecord array)
+        =
+        let boundHints = ResizeArray<ContentBlockReuseRangeHint>()
+        let mutable error = None
+        let mutable index = 0
+
+        while error.IsNone && index < hints.Length do
+            let hint = hints[index]
+
+            if hint.StoragePoolId <> storagePoolId then
+                error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates for this repository." correlationId)
+            else
+                match records |> Array.tryFind (hintMatchesDedupeIndexRecord hint) with
+                | Some record -> boundHints.Add(reuseRangeHintFromDedupeIndexRecord record)
+                | None -> error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates." correlationId)
+
+            index <- index + 1
+
+        match error with
+        | Some error -> Error error
+        | None -> Ok(boundHints.ToArray())
+
     let private handleUploadSessionCommand
         (context: HttpContext)
         (parameters: UploadSessionStorageParameters)
@@ -482,16 +524,38 @@ module Storage =
                 try
                     let! parameters = context.BindJsonAsync<IssueDedupeDiscoveryParameters>()
 
-                    let command =
-                        UploadSessionCommand.IssueDedupeDiscovery
-                            {
-                                OperationId = parameters.OperationId
-                                ExpiresAt = parameters.ExpiresAt
-                                MinimumReuseRunLength = parameters.MinimumReuseRunLength
-                                Hints = parameters.Hints
-                            }
+                    let hints = if isNull parameters.Hints then Array.empty else parameters.Hints
 
-                    return! handleUploadSessionCommand context parameters command correlationId
+                    if hints.Length > StorageParameterContracts.MaxReuseRangeClaims then
+                        return!
+                            context
+                            |> result400BadRequest (
+                                GraceError.Create
+                                    $"IssueDedupeDiscovery Hints must contain no more than {StorageParameterContracts.MaxReuseRangeClaims} items."
+                                    correlationId
+                            )
+                    else
+                        let graceIds = getGraceIds context
+                        let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                        let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
+                        let! repositoryDto = repositoryActor.Get correlationId
+                        let storagePoolId = DedupeIndex.storagePoolIdForRepository repositoryDto
+                        let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+                        let! records = dedupeIndexActor.Snapshot correlationId
+
+                        match validateIssuedDedupeDiscoveryHints correlationId storagePoolId hints records with
+                        | Error error -> return! context |> result400BadRequest error
+                        | Ok boundHints ->
+                            let command =
+                                UploadSessionCommand.IssueDedupeDiscovery
+                                    {
+                                        OperationId = parameters.OperationId
+                                        ExpiresAt = parameters.ExpiresAt
+                                        MinimumReuseRunLength = parameters.MinimumReuseRunLength
+                                        Hints = boundHints
+                                    }
+
+                            return! handleUploadSessionCommand context parameters command correlationId
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -91,6 +91,53 @@ module Storage =
         metadata.Properties[ "Path" ] <- $"{context.Request.Path}"
         metadata
 
+    type private UploadSessionRequestContext = { UploadSessionActor: IUploadSessionActor; Metadata: EventMetadata; SessionForScope: UploadSessionDto }
+
+    let private createUploadSessionRequestContext (context: HttpContext) (parameters: UploadSessionStorageParameters) correlationId =
+        task {
+            let graceIds = getGraceIds context
+            let _, repositoryId = resolveStorageIds graceIds parameters
+
+            let uploadSessionActor = Grace.Actors.Extensions.ActorProxy.UploadSession.CreateActorProxy parameters.UploadSessionId repositoryId correlationId
+
+            return { UploadSessionActor = uploadSessionActor; Metadata = createEventMetadata context correlationId; SessionForScope = UploadSessionDto.Default }
+        }
+
+    let private loadSessionForScope (uploadSessionActor: IUploadSessionActor) correlationId =
+        task {
+            let! session = uploadSessionActor.Get correlationId
+
+            if session.UploadSessionId = UploadSessionId.Empty then
+                let! events = uploadSessionActor.GetEvents correlationId
+
+                return
+                    events
+                    |> Seq.fold (fun dto event -> UploadSessionDto.UpdateDto event dto) UploadSessionDto.Default
+            else
+                return session
+        }
+
+    let private validateUploadSessionScope requestContext (parameters: UploadSessionStorageParameters) correlationId requireExistingSession =
+        task {
+            let! sessionForScope = loadSessionForScope requestContext.UploadSessionActor correlationId
+
+            if requireExistingSession
+               && sessionForScope.UploadSessionId = UploadSessionId.Empty then
+                return Error(GraceError.Create "UploadSession must be started before ClaimReuseRanges." correlationId)
+            elif sessionForScope.UploadSessionId
+                 <> UploadSessionId.Empty
+                 && sessionForScope.AuthorizedScope
+                    <> parameters.AuthorizedScope then
+                return
+                    Error(
+                        GraceError.Create
+                            $"UploadSession AuthorizedScope must match the scope recorded when the session was started. Expected '{sessionForScope.AuthorizedScope}', actual '{parameters.AuthorizedScope}'."
+                            correlationId
+                    )
+            else
+                return Ok { requestContext with SessionForScope = sessionForScope }
+        }
+
     let private handleUploadSessionCommand
         (context: HttpContext)
         (parameters: UploadSessionStorageParameters)
@@ -98,48 +145,19 @@ module Storage =
         (correlationId: CorrelationId)
         =
         task {
-            let graceIds = getGraceIds context
-            let _, repositoryId = resolveStorageIds graceIds parameters
-            let uploadSessionActor = Grace.Actors.Extensions.ActorProxy.UploadSession.CreateActorProxy parameters.UploadSessionId repositoryId correlationId
-            let metadata = createEventMetadata context correlationId
-
             let! scopeValidation =
                 task {
+                    let! requestContext = createUploadSessionRequestContext context parameters correlationId
+
                     match command with
-                    | UploadSessionCommand.Start _ -> return Ok()
-                    | _ ->
-                        let! session = uploadSessionActor.Get correlationId
-
-                        let! sessionForScope =
-                            task {
-                                if session.UploadSessionId = UploadSessionId.Empty then
-                                    let! events = uploadSessionActor.GetEvents correlationId
-
-                                    return
-                                        events
-                                        |> Seq.fold (fun dto event -> UploadSessionDto.UpdateDto event dto) UploadSessionDto.Default
-                                else
-                                    return session
-                            }
-
-                        if sessionForScope.UploadSessionId = UploadSessionId.Empty then
-                            return Ok()
-                        elif sessionForScope.AuthorizedScope
-                             <> parameters.AuthorizedScope then
-                            return
-                                Error(
-                                    GraceError.Create
-                                        $"UploadSession AuthorizedScope must match the scope recorded when the session was started. Expected '{sessionForScope.AuthorizedScope}', actual '{parameters.AuthorizedScope}'."
-                                        correlationId
-                                )
-                        else
-                            return Ok()
+                    | UploadSessionCommand.Start _ -> return Ok requestContext
+                    | _ -> return! validateUploadSessionScope requestContext parameters correlationId false
                 }
 
             match scopeValidation with
             | Error error -> return! context |> result400BadRequest error
-            | Ok _ ->
-                let! result = uploadSessionActor.Handle command metadata
+            | Ok requestContext ->
+                let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
 
                 match result with
                 | Ok returnValue -> return! context |> result200Ok returnValue
@@ -477,41 +495,69 @@ module Storage =
                 try
                     let! parameters = context.BindJsonAsync<ClaimReuseRangesParameters>()
                     let hints = if isNull parameters.Hints then Array.empty else parameters.Hints
-                    let ranges = ResizeArray<ClaimReuseRange>()
-                    let mutable error = None
-                    let mutable index = 0
 
-                    while error.IsNone && index < hints.Length do
-                        let hint = hints[index]
-
-                        let metadataActor =
-                            grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
-                                Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
-                                correlationId
+                    if hints.Length = 0 then
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create "At least one reuse range claim is required." correlationId)
+                    elif hints.Length > StorageParameterContracts.MaxReuseRangeClaims then
+                        return!
+                            context
+                            |> result400BadRequest (
+                                GraceError.Create
+                                    $"ClaimReuseRanges Hints must contain no more than {StorageParameterContracts.MaxReuseRangeClaims} items."
+                                    correlationId
                             )
+                    else
+                        let! requestContext = createUploadSessionRequestContext context parameters correlationId
+                        let! scopeValidation = validateUploadSessionScope requestContext parameters correlationId true
 
-                        let! metadata = metadataActor.Get correlationId
+                        match scopeValidation with
+                        | Error error -> return! context |> result400BadRequest error
+                        | Ok requestContext ->
+                            let ranges = ResizeArray<ClaimReuseRange>()
+                            let mutable error = None
+                            let mutable index = 0
 
-                        match metadata with
-                        | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
-                        | None ->
-                            error <-
-                                Some(
-                                    GraceError.Create
-                                        $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
+                            while error.IsNone && index < hints.Length do
+                                let hint = hints[index]
+
+                                let metadataActor =
+                                    grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
+                                        Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
                                         correlationId
-                                )
+                                    )
 
-                        index <- index + 1
+                                let! metadata = metadataActor.Get correlationId
 
-                    match error with
-                    | Some error -> return! context |> result400BadRequest error
-                    | None ->
-                        let command =
-                            UploadSessionCommand.ClaimReuseRanges
-                                { OperationId = parameters.OperationId; DiscoveryOperationId = parameters.DiscoveryOperationId; Ranges = ranges.ToArray() }
+                                match metadata with
+                                | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
+                                | None ->
+                                    error <-
+                                        Some(
+                                            GraceError.Create
+                                                $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
+                                                correlationId
+                                        )
 
-                        return! handleUploadSessionCommand context parameters command correlationId
+                                index <- index + 1
+
+                            match error with
+                            | Some error -> return! context |> result400BadRequest error
+                            | None ->
+                                let command =
+                                    UploadSessionCommand.ClaimReuseRanges
+                                        {
+                                            OperationId = parameters.OperationId
+                                            DiscoveryOperationId = parameters.DiscoveryOperationId
+                                            Ranges = ranges.ToArray()
+                                        }
+
+                                let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+
+                                match result with
+                                | Ok returnValue -> return! context |> result200Ok returnValue
+                                | Error error -> return! context |> result400BadRequest error
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -138,6 +138,21 @@ module Storage =
                 return Ok { requestContext with SessionForScope = sessionForScope }
         }
 
+    let private validateActiveDedupeDiscoveryForClaim requestContext (parameters: ClaimReuseRangesParameters) correlationId =
+        match requestContext.SessionForScope.DedupeDiscovery with
+        | None -> Error(GraceError.Create "Dedupe discovery must be issued before reuse ranges can be claimed." correlationId)
+        | Some discovery when
+            discovery.OperationId
+            <> parameters.DiscoveryOperationId
+            ->
+            Error(GraceError.Create "ClaimReuseRanges DiscoveryOperationId does not match the active discovery." correlationId)
+        | Some discovery when
+            requestContext.Metadata.Timestamp
+            >= discovery.ExpiresAt
+            ->
+            Error(GraceError.Create "Dedupe discovery has expired; reuse ranges cannot be claimed." correlationId)
+        | Some _ -> Ok()
+
     let private handleUploadSessionCommand
         (context: HttpContext)
         (parameters: UploadSessionStorageParameters)
@@ -515,49 +530,52 @@ module Storage =
                         match scopeValidation with
                         | Error error -> return! context |> result400BadRequest error
                         | Ok requestContext ->
-                            let ranges = ResizeArray<ClaimReuseRange>()
-                            let mutable error = None
-                            let mutable index = 0
+                            match validateActiveDedupeDiscoveryForClaim requestContext parameters correlationId with
+                            | Error error -> return! context |> result400BadRequest error
+                            | Ok _ ->
+                                let ranges = ResizeArray<ClaimReuseRange>()
+                                let mutable error = None
+                                let mutable index = 0
 
-                            while error.IsNone && index < hints.Length do
-                                let hint = hints[index]
+                                while error.IsNone && index < hints.Length do
+                                    let hint = hints[index]
 
-                                let metadataActor =
-                                    grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
-                                        Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
-                                        correlationId
-                                    )
-
-                                let! metadata = metadataActor.Get correlationId
-
-                                match metadata with
-                                | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
-                                | None ->
-                                    error <-
-                                        Some(
-                                            GraceError.Create
-                                                $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
-                                                correlationId
+                                    let metadataActor =
+                                        grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
+                                            Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
+                                            correlationId
                                         )
 
-                                index <- index + 1
+                                    let! metadata = metadataActor.Get correlationId
 
-                            match error with
-                            | Some error -> return! context |> result400BadRequest error
-                            | None ->
-                                let command =
-                                    UploadSessionCommand.ClaimReuseRanges
-                                        {
-                                            OperationId = parameters.OperationId
-                                            DiscoveryOperationId = parameters.DiscoveryOperationId
-                                            Ranges = ranges.ToArray()
-                                        }
+                                    match metadata with
+                                    | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
+                                    | None ->
+                                        error <-
+                                            Some(
+                                                GraceError.Create
+                                                    $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
+                                                    correlationId
+                                            )
 
-                                let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+                                    index <- index + 1
 
-                                match result with
-                                | Ok returnValue -> return! context |> result200Ok returnValue
-                                | Error error -> return! context |> result400BadRequest error
+                                match error with
+                                | Some error -> return! context |> result400BadRequest error
+                                | None ->
+                                    let command =
+                                        UploadSessionCommand.ClaimReuseRanges
+                                            {
+                                                OperationId = parameters.OperationId
+                                                DiscoveryOperationId = parameters.DiscoveryOperationId
+                                                Ranges = ranges.ToArray()
+                                            }
+
+                                    let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+
+                                    match result with
+                                    | Ok returnValue -> return! context |> result200Ok returnValue
+                                    | Error error -> return! context |> result400BadRequest error
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -8,6 +8,7 @@ open Giraffe
 open Grace.Actors
 open Grace.Actors.Constants
 open Grace.Actors.Extensions.ActorProxy
+open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Server.ApplicationContext
 open Grace.Server.Services
@@ -434,6 +435,87 @@ module Storage =
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex
                     logToConsole $"Exception in StartManifestUploadSession: {exceptionResponse}"
+
+                    return!
+                        context
+                        |> result500ServerError (GraceError.Create $"{exceptionResponse}" correlationId)
+            }
+
+    let IssueDedupeDiscovery: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+
+                try
+                    let! parameters = context.BindJsonAsync<IssueDedupeDiscoveryParameters>()
+
+                    let command =
+                        UploadSessionCommand.IssueDedupeDiscovery
+                            {
+                                OperationId = parameters.OperationId
+                                ExpiresAt = parameters.ExpiresAt
+                                MinimumReuseRunLength = parameters.MinimumReuseRunLength
+                                Hints = parameters.Hints
+                            }
+
+                    return! handleUploadSessionCommand context parameters command correlationId
+                with
+                | ex ->
+                    let exceptionResponse = ExceptionResponse.Create ex
+                    logToConsole $"Exception in IssueDedupeDiscovery: {exceptionResponse}"
+
+                    return!
+                        context
+                        |> result500ServerError (GraceError.Create $"{exceptionResponse}" correlationId)
+            }
+
+    let ClaimReuseRanges: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+
+                try
+                    let! parameters = context.BindJsonAsync<ClaimReuseRangesParameters>()
+                    let hints = if isNull parameters.Hints then Array.empty else parameters.Hints
+                    let ranges = ResizeArray<ClaimReuseRange>()
+                    let mutable error = None
+                    let mutable index = 0
+
+                    while error.IsNone && index < hints.Length do
+                        let hint = hints[index]
+
+                        let metadataActor =
+                            grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
+                                Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
+                                correlationId
+                            )
+
+                        let! metadata = metadataActor.Get correlationId
+
+                        match metadata with
+                        | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
+                        | None ->
+                            error <-
+                                Some(
+                                    GraceError.Create
+                                        $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
+                                        correlationId
+                                )
+
+                        index <- index + 1
+
+                    match error with
+                    | Some error -> return! context |> result400BadRequest error
+                    | None ->
+                        let command =
+                            UploadSessionCommand.ClaimReuseRanges
+                                { OperationId = parameters.OperationId; DiscoveryOperationId = parameters.DiscoveryOperationId; Ranges = ranges.ToArray() }
+
+                        return! handleUploadSessionCommand context parameters command correlationId
+                with
+                | ex ->
+                    let exceptionResponse = ExceptionResponse.Create ex
+                    logToConsole $"Exception in ClaimReuseRanges: {exceptionResponse}"
 
                     return!
                         context

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -185,7 +185,10 @@ module Storage =
             if hint.StoragePoolId <> storagePoolId then
                 error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates for this repository." correlationId)
             else
-                match records |> Array.tryFind (hintMatchesDedupeIndexRecord hint) with
+                match
+                    records
+                    |> Array.tryFind (hintMatchesDedupeIndexRecord hint)
+                    with
                 | Some record -> boundHints.Add(reuseRangeHintFromDedupeIndexRecord record)
                 | None -> error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates." correlationId)
 

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -151,7 +151,7 @@ module Storage =
             >= discovery.ExpiresAt
             ->
             Error(GraceError.Create "Dedupe discovery has expired; reuse ranges cannot be claimed." correlationId)
-        | Some _ -> Ok()
+        | Some discovery -> Ok discovery
 
     let private hintMatchesDedupeIndexRecord (hint: ContentBlockReuseRangeHint) (record: DedupeIndex.DedupeIndexRecord) =
         record.StoragePoolId = hint.StoragePoolId
@@ -182,7 +182,9 @@ module Storage =
         while error.IsNone && index < hints.Length do
             let hint = hints[index]
 
-            if hint.StoragePoolId <> storagePoolId then
+            if isNull (box hint) then
+                error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must not contain null entries." correlationId)
+            elif hint.StoragePoolId <> storagePoolId then
                 error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates for this repository." correlationId)
             else
                 match
@@ -191,6 +193,42 @@ module Storage =
                     with
                 | Some record -> boundHints.Add(reuseRangeHintFromDedupeIndexRecord record)
                 | None -> error <- Some(GraceError.Create "IssueDedupeDiscovery Hints must come from server discovery candidates." correlationId)
+
+            index <- index + 1
+
+        match error with
+        | Some error -> Error error
+        | None -> Ok(boundHints.ToArray())
+
+    let private hintMatchesIssuedHint (hint: ContentBlockReuseRangeHint) (issued: ContentBlockReuseRangeHint) =
+        not (isNull (box issued))
+        && issued.StoragePoolId = hint.StoragePoolId
+        && issued.ContentBlockAddress = hint.ContentBlockAddress
+        && issued.OrdinalStart = hint.OrdinalStart
+        && issued.OrdinalCount = hint.OrdinalCount
+        && issued.MetadataVersion = hint.MetadataVersion
+
+    let private validateClaimReuseHints correlationId storagePoolId (discovery: DedupeDiscoverySnapshot) (hints: ContentBlockReuseRangeHint array) =
+        let boundHints = ResizeArray<ContentBlockReuseRangeHint>()
+        let issuedHints = if isNull discovery.Hints then Array.empty else discovery.Hints
+
+        let mutable error = None
+        let mutable index = 0
+
+        while error.IsNone && index < hints.Length do
+            let hint = hints[index]
+
+            if isNull (box hint) then
+                error <- Some(GraceError.Create "ClaimReuseRanges Hints must not contain null entries." correlationId)
+            elif hint.StoragePoolId <> storagePoolId then
+                error <- Some(GraceError.Create "ClaimReuseRanges Hints must belong to the upload session repository storage pool." correlationId)
+            else
+                match
+                    issuedHints
+                    |> Array.tryFind (hintMatchesIssuedHint hint)
+                    with
+                | Some issuedHint -> boundHints.Add(issuedHint)
+                | None -> error <- Some(GraceError.Create "ClaimReuseRanges Hints must have been issued by the active dedupe discovery." correlationId)
 
             index <- index + 1
 
@@ -562,11 +600,17 @@ module Storage =
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex
+                    let exceptionText = $"{exceptionResponse}"
                     logToConsole $"Exception in IssueDedupeDiscovery: {exceptionResponse}"
 
-                    return!
-                        context
-                        |> result500ServerError (GraceError.Create $"{exceptionResponse}" correlationId)
+                    if exceptionText.Contains("expected JSON object, found Null", StringComparison.OrdinalIgnoreCase) then
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create "IssueDedupeDiscovery Hints must not contain null entries." correlationId)
+                    else
+                        return!
+                            context
+                            |> result500ServerError (GraceError.Create exceptionText correlationId)
             }
 
     let ClaimReuseRanges: HttpHandler =
@@ -599,58 +643,76 @@ module Storage =
                         | Ok requestContext ->
                             match validateActiveDedupeDiscoveryForClaim requestContext parameters correlationId with
                             | Error error -> return! context |> result400BadRequest error
-                            | Ok _ ->
-                                let ranges = ResizeArray<ClaimReuseRange>()
-                                let mutable error = None
-                                let mutable index = 0
+                            | Ok discovery ->
+                                let repositoryActor =
+                                    Repository.CreateActorProxy
+                                        requestContext.SessionForScope.OrganizationId
+                                        requestContext.SessionForScope.RepositoryId
+                                        correlationId
 
-                                while error.IsNone && index < hints.Length do
-                                    let hint = hints[index]
+                                let! repositoryDto = repositoryActor.Get correlationId
+                                let storagePoolId = DedupeIndex.storagePoolIdForRepository repositoryDto
 
-                                    let metadataActor =
-                                        grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
-                                            Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
-                                            correlationId
-                                        )
+                                match validateClaimReuseHints correlationId storagePoolId discovery hints with
+                                | Error error -> return! context |> result400BadRequest error
+                                | Ok hints ->
+                                    let ranges = ResizeArray<ClaimReuseRange>()
+                                    let mutable error = None
+                                    let mutable index = 0
 
-                                    let! metadata = metadataActor.Get correlationId
+                                    while error.IsNone && index < hints.Length do
+                                        let hint = hints[index]
 
-                                    match metadata with
-                                    | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
-                                    | None ->
-                                        error <-
-                                            Some(
-                                                GraceError.Create
-                                                    $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
-                                                    correlationId
+                                        let metadataActor =
+                                            grainFactory.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(
+                                                Grace.Actors.ContentBlockMetadataActorKey.Create hint.StoragePoolId hint.ContentBlockAddress,
+                                                correlationId
                                             )
 
-                                    index <- index + 1
+                                        let! metadata = metadataActor.Get correlationId
 
-                                match error with
-                                | Some error -> return! context |> result400BadRequest error
-                                | None ->
-                                    let command =
-                                        UploadSessionCommand.ClaimReuseRanges
-                                            {
-                                                OperationId = parameters.OperationId
-                                                DiscoveryOperationId = parameters.DiscoveryOperationId
-                                                Ranges = ranges.ToArray()
-                                            }
+                                        match metadata with
+                                        | Some metadata -> ranges.Add({ Hint = hint; Metadata = metadata })
+                                        | None ->
+                                            error <-
+                                                Some(
+                                                    GraceError.Create
+                                                        $"Authoritative ContentBlockMetadata is absent for {hint.ContentBlockAddress}; reuse range cannot be claimed."
+                                                        correlationId
+                                                )
 
-                                    let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+                                        index <- index + 1
 
-                                    match result with
-                                    | Ok returnValue -> return! context |> result200Ok returnValue
-                                    | Error error -> return! context |> result400BadRequest error
+                                    match error with
+                                    | Some error -> return! context |> result400BadRequest error
+                                    | None ->
+                                        let command =
+                                            UploadSessionCommand.ClaimReuseRanges
+                                                {
+                                                    OperationId = parameters.OperationId
+                                                    DiscoveryOperationId = parameters.DiscoveryOperationId
+                                                    Ranges = ranges.ToArray()
+                                                }
+
+                                        let! result = requestContext.UploadSessionActor.Handle command requestContext.Metadata
+
+                                        match result with
+                                        | Ok returnValue -> return! context |> result200Ok returnValue
+                                        | Error error -> return! context |> result400BadRequest error
                 with
                 | ex ->
                     let exceptionResponse = ExceptionResponse.Create ex
+                    let exceptionText = $"{exceptionResponse}"
                     logToConsole $"Exception in ClaimReuseRanges: {exceptionResponse}"
 
-                    return!
-                        context
-                        |> result500ServerError (GraceError.Create $"{exceptionResponse}" correlationId)
+                    if exceptionText.Contains("expected JSON object, found Null", StringComparison.OrdinalIgnoreCase) then
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create "ClaimReuseRanges Hints must not contain null entries." correlationId)
+                    else
+                        return!
+                            context
+                            |> result500ServerError (GraceError.Create exceptionText correlationId)
             }
 
     let RegisterContentBlockUpload: HttpHandler =

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -33,6 +33,10 @@ module Storage =
     [<Literal>]
     let MinimumAcceptedReuseRunLength = 8
 
+    /// Maximum reuse range hints accepted by one claim request.
+    [<Literal>]
+    let MaxReuseRangeClaims = 1024
+
     /// Parameters used by multiple endpoints in the /diff path.
     type StorageParameters() =
         inherit CommonParameters()

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -4,6 +4,7 @@ open Grace.Shared.Parameters.Common
 open Grace.Types.ContentBlockMetadata
 open Grace.Types.Types
 open Grace.Types.UploadSession
+open NodaTime
 open System
 
 module Storage =
@@ -84,6 +85,19 @@ module Storage =
         member val public ChunkingSuiteId: ChunkingSuiteId = String.Empty with get, set
         member val public SamplingPolicySnapshot: string = String.Empty with get, set
         member val public OperationId: UploadSessionOperationId = String.Empty with get, set
+
+    type IssueDedupeDiscoveryParameters() =
+        inherit UploadSessionStorageParameters()
+        member val public OperationId: UploadSessionOperationId = String.Empty with get, set
+        member val public ExpiresAt: Instant = Instant.MinValue with get, set
+        member val public MinimumReuseRunLength: int = 0 with get, set
+        member val public Hints = Array.empty<ContentBlockReuseRangeHint> with get, set
+
+    type ClaimReuseRangesParameters() =
+        inherit UploadSessionStorageParameters()
+        member val public OperationId: UploadSessionOperationId = String.Empty with get, set
+        member val public DiscoveryOperationId: UploadSessionOperationId = String.Empty with get, set
+        member val public Hints = Array.empty<ContentBlockReuseRangeHint> with get, set
 
     type RegisterContentBlockUploadParameters() =
         inherit UploadSessionStorageParameters()


### PR DESCRIPTION
Closes #101

## Summary

- Adds SDK discovery scanning before manifest block upload, matching protected candidate windows against local planned blocks.
- Adds issue/claim storage client calls and minimal server routes so SDK reuse claims go through the real upload-session boundary.
- Falls back to normal ContentBlock upload when discovery is empty, unavailable, below threshold, or claim issuance/claiming fails as stale/non-authoritative.
- Keeps manifest download reconstruction out of scope for #102.

## Owned Path Expansion

Issue #101 was updated before continuing with the shared/server edits. Added paths:

- `src/Grace.Shared/Parameters/Storage.Parameters.fs`
- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.Server/Startup.Server.fs`
- `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs`

Reason: `/storage/discoverContentBlocks` already existed, but upload-session discovery issuance and reuse-range claiming were actor-only. The SDK needs minimal shared/server contracts for real discovery/claim behavior instead of test-only fakes.

## Validation

- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter ManifestUploadSdkTests` - passed, 9 tests
- `dotnet build src\Grace.Server\Grace.Server.fsproj --configuration Release` - passed, 0 warnings/errors
- `dotnet tool run fantomas --recurse .` from `./src` - passed; unrelated formatter-only churn was reverted so the PR stays in the #101 lease
- `pwsh ./scripts/validate.ps1 -Fast` - passed; build clean, Authorization 21, CLI 210, Types 49
- `pwsh ./scripts/validate.ps1 -Full` - passed; build clean, Authorization 21, CLI 210, Types 49, Server 320

## Docs Impact

- No user-facing docs changed. SDK behavior remains behind the existing manifest upload opt-in; PR records the expanded API route/contract surface.

## Skipped Validation

- None.

## Residual Risk

- The new claim endpoint hydrates authoritative `ContentBlockMetadata` by hint before forwarding to the upload-session actor. Full validation passed, but live positive reuse still depends on dedupe-index freshness and metadata actor availability.
- Discovery remains non-authoritative by design. Empty/no-response/stale claim paths intentionally upload blocks rather than treating absence as proof.

## Follow-ups

- #102 owns manifest download reconstruction and should not rely on this PR to reconstruct reused payloads client-side.
- #103 can enable manifest behavior by default after #101/#102 are merged and reviewed.
