### PR TITLE
Enable manifest uploads by default

### DIFF
--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.CLI.Tests
 
 open Azure
+open Grace.CLI
 open Grace.SDK
 open Grace.Shared
 open Grace.Shared.Parameters.Storage
@@ -38,6 +39,18 @@ type ManifestUploadSdkTests() =
     static member private BinaryPolicy thresholdBytes = { ManifestEligibilityPolicy.Default with ThresholdBytes = thresholdBytes; BinaryScanBytes = 16 }
 
     static member private ComputeSha256Hash(bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+
+    static member private UploadParameters correlationId fileVersions =
+        let parameters = GetUploadMetadataForFilesParameters()
+        parameters.OwnerId <- "22222222-2222-2222-2222-222222222222"
+        parameters.OwnerName <- "owner"
+        parameters.OrganizationId <- "33333333-3333-3333-3333-333333333333"
+        parameters.OrganizationName <- "org"
+        parameters.RepositoryId <- "11111111-1111-1111-1111-111111111111"
+        parameters.RepositoryName <- "repo"
+        parameters.CorrelationId <- correlationId
+        parameters.FileVersions <- fileVersions
+        parameters
 
     static member private Decision correlationId sessionId operationId =
         let session =
@@ -300,6 +313,61 @@ type ManifestUploadSdkTests() =
                     Assert.That(uploadResult.UploadSessionId, Is.Not.EqualTo(None))
             finally
                 if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.UploadFilesToObjectStorageFallsBackOnlyForNonManifestResults() =
+        task {
+            let correlationId = "corr-cli-manifest-fallback-routing"
+            let manifestFile = FileVersion.Create "large.bin" (Sha256Hash "manifest-sha") String.Empty true 2048L
+            let ineligibleFile = FileVersion.Create "small.fs" (Sha256Hash "ineligible-sha") String.Empty false 128L
+            let manifestAttempts = ResizeArray<string>()
+            let wholeFileFallbacks = ResizeArray<FileVersion array>()
+
+            let manifestUpload (fileVersion: FileVersion) : Task<GraceResult<ManifestUpload.ManifestUploadResult>> =
+                task {
+                    manifestAttempts.Add(fileVersion.RelativePath)
+
+                    let result: ManifestUpload.ManifestUploadResult =
+                        {
+                            FileVersion = fileVersion
+                            Manifest = None
+                            UploadSessionId = None
+                            UploadedBlockCount = if fileVersion.RelativePath = manifestFile.RelativePath then 1 else 0
+                            UsedManifestUpload = fileVersion.RelativePath = manifestFile.RelativePath
+                        }
+
+                    return Ok(GraceReturnValue.Create result correlationId)
+                }
+
+            let wholeFileUpload (parameters: GetUploadMetadataForFilesParameters) =
+                task {
+                    wholeFileFallbacks.Add(parameters.FileVersions)
+                    return Ok(GraceReturnValue.Create true correlationId)
+                }
+
+            let parameters = ManifestUploadSdkTests.UploadParameters correlationId [| manifestFile; ineligibleFile |]
+
+            let! result = Services.uploadFilesToObjectStorageWithClients manifestUpload wholeFileUpload parameters
+
+            match result with
+            | Error error -> Assert.Fail($"{error.Error}{Environment.NewLine}{serialize error.Properties}")
+            | Ok returnValue ->
+                Assert.That(returnValue.ReturnValue, Is.True)
+
+                Assert.That(
+                    manifestAttempts,
+                    Is.EquivalentTo(
+                        [|
+                            manifestFile.RelativePath
+                            ineligibleFile.RelativePath
+                        |]
+                    )
+                )
+
+                Assert.That(wholeFileFallbacks.Count, Is.EqualTo(1))
+                Assert.That(wholeFileFallbacks[0].Length, Is.EqualTo(1))
+                Assert.That(wholeFileFallbacks[0][0], Is.EqualTo(ineligibleFile))
         }
 
     [<Test>]

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -31,6 +31,10 @@ type ManifestUploadSdkTests() =
 
         bytes
 
+    static member private TextLikePseudoRandomBytes length =
+        ManifestUploadSdkTests.PseudoRandomBytes length
+        |> Array.map (fun value -> if value = 0uy then 1uy else value)
+
     static member private BinaryPolicy thresholdBytes = { ManifestEligibilityPolicy.Default with ThresholdBytes = thresholdBytes; BinaryScanBytes = 16 }
 
     static member private ComputeSha256Hash(bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
@@ -203,6 +207,97 @@ type ManifestUploadSdkTests() =
                     Assert.That(calls, Does.Not.Contain("claim"))
 
                     Assert.That(uploadedBlocks.Keys, Is.EquivalentTo(confirmedBlocks.Keys))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.SmallSourceFileUsesWholeFileContentWithoutStartingManifestSession() =
+        task {
+            let payload = Encoding.UTF8.GetBytes("module Tiny\n\nlet answer = 42\n")
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-small-source-{Guid.NewGuid():N}.fs")
+            let correlationId = "corr-sdk-manifest-small-source"
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion = FileVersion.Create "Tiny.fs" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty false (int64 payload.Length)
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun _ -> failwith "Small source files must not start manifest upload sessions."
+                        DiscoverContentBlocks = fun _ -> failwith "Small source files must not discover manifest blocks."
+                        IssueDedupeDiscovery = fun _ -> failwith "Small source files must not issue dedupe discovery."
+                        ClaimReuseRanges = fun _ -> failwith "Small source files must not claim manifest ranges."
+                        RegisterBlockUpload = fun _ -> failwith "Small source files must not register manifest blocks."
+                        UploadContentBlock = fun _ _ -> failwith "Small source files must not upload manifest blocks."
+                        ConfirmBlockUploaded = fun _ -> failwith "Small source files must not confirm manifest blocks."
+                        FinalizeManifest = fun _ -> failwith "Small source files must not finalize manifests."
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client (ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId)
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    let uploadResult = returnValue.ReturnValue
+                    Assert.That(uploadResult.UsedManifestUpload, Is.False)
+                    Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(0))
+                    Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
+                    Assert.That(uploadResult.Manifest, Is.EqualTo(None))
+                    Assert.That(uploadResult.UploadSessionId, Is.EqualTo(None))
+            finally
+                if File.Exists(tempPath) then File.Delete(tempPath)
+        }
+
+    [<Test>]
+    member _.LargeCompressedTextUsesManifestUploadByDefaultPolicy() =
+        task {
+            let payload =
+                ManifestUploadSdkTests.TextLikePseudoRandomBytes(
+                    int ManifestEligibilityPolicy.Default.ThresholdBytes
+                    + 65536
+                )
+
+            let tempPath = Path.Combine(Path.GetTempPath(), $"grace-manifest-large-text-{Guid.NewGuid():N}.txt")
+            let correlationId = "corr-sdk-manifest-large-text"
+            let uploadedBlocks = Dictionary<ContentBlockAddress, byte array>()
+
+            try
+                File.WriteAllBytes(tempPath, payload)
+
+                let fileVersion = FileVersion.Create "large.txt" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty false (int64 payload.Length)
+
+                let client: ManifestUpload.ManifestUploadClient =
+                    {
+                        StartSession = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        DiscoverContentBlocks = fun parameters -> ManifestUploadSdkTests.EmptyDiscovery correlationId parameters.KeyChunkAddresses.Length
+                        IssueDedupeDiscovery = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        ClaimReuseRanges = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        RegisterBlockUpload = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        UploadContentBlock =
+                            fun parameters payload ->
+                                uploadedBlocks[parameters.ContentBlockAddress] <- payload
+
+                                let placement =
+                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+
+                                Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
+                        ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                        FinalizeManifest = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
+                    }
+
+                let! result = ManifestUpload.uploadFileWithClient client (ManifestUploadSdkTests.CreateRequest tempPath fileVersion correlationId)
+
+                match result with
+                | Error error -> Assert.Fail(error.Error)
+                | Ok returnValue ->
+                    let uploadResult = returnValue.ReturnValue
+                    Assert.That(uploadResult.UsedManifestUpload, Is.True)
+                    Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
+                    Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
+                    Assert.That(uploadResult.Manifest, Is.Not.EqualTo(None))
+                    Assert.That(uploadResult.UploadSessionId, Is.Not.EqualTo(None))
             finally
                 if File.Exists(tempPath) then File.Delete(tempPath)
         }
@@ -807,15 +902,15 @@ type ManifestUploadSdkTests() =
         }
 
     [<Test>]
-    member _.ManifestUploadsAreDisabledUnlessEnvironmentOptInIsOne() =
+    member _.ManifestUploadsAreEnabledByDefaultAfterManifestDownloadReconstruction() =
         let previous = Environment.GetEnvironmentVariable(ManifestUpload.OptInEnvironmentVariable)
 
         try
             Environment.SetEnvironmentVariable(ManifestUpload.OptInEnvironmentVariable, null)
-            Assert.That(ManifestUpload.isOptedIn (), Is.False)
+            Assert.That(ManifestUpload.isOptedIn (), Is.True)
 
             Environment.SetEnvironmentVariable(ManifestUpload.OptInEnvironmentVariable, "0")
-            Assert.That(ManifestUpload.isOptedIn (), Is.False)
+            Assert.That(ManifestUpload.isOptedIn (), Is.True)
 
             Environment.SetEnvironmentVariable(ManifestUpload.OptInEnvironmentVariable, "1")
             Assert.That(ManifestUpload.isOptedIn (), Is.True)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -913,9 +913,7 @@ module Services =
     /// Uploads all new or changed files from a directory to object storage.
     let uploadFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
         task {
-            if not (ManifestUpload.isOptedIn ()) then
-                return! uploadWholeFilesToObjectStorage parameters
-            elif parameters.FileVersions.Count() = 0 then
+            if parameters.FileVersions.Count() = 0 then
                 return Ok(GraceReturnValue.Create true parameters.CorrelationId)
             else
                 let fallbackFileVersions = ConcurrentQueue<FileVersion>()

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -910,8 +910,11 @@ module Services =
 
         request
 
-    /// Uploads all new or changed files from a directory to object storage.
-    let uploadFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
+    let internal uploadFilesToObjectStorageWithClients
+        (manifestUpload: FileVersion -> Task<GraceResult<ManifestUpload.ManifestUploadResult>>)
+        (wholeFileUpload: GetUploadMetadataForFilesParameters -> Task<GraceResult<bool>>)
+        (parameters: GetUploadMetadataForFilesParameters)
+        =
         task {
             if parameters.FileVersions.Count() = 0 then
                 return Ok(GraceReturnValue.Create true parameters.CorrelationId)
@@ -923,8 +926,9 @@ module Services =
                 while fileVersionIndex < parameters.FileVersions.Length do
                     let fileVersion = parameters.FileVersions[fileVersionIndex]
 
-                    match! ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion) with
-                    | Ok _ -> fallbackFileVersions.Enqueue(fileVersion)
+                    match! manifestUpload fileVersion with
+                    | Ok result when not result.ReturnValue.UsedManifestUpload -> fallbackFileVersions.Enqueue(fileVersion)
+                    | Ok _ -> ()
                     | Error error -> errors.Enqueue(error)
 
                     fileVersionIndex <- fileVersionIndex + 1
@@ -942,8 +946,15 @@ module Services =
                     if fallback.Length = 0 then
                         return Ok(GraceReturnValue.Create true parameters.CorrelationId)
                     else
-                        return! uploadWholeFilesToObjectStorage (copyStorageParameters parameters fallback)
+                        return! wholeFileUpload (copyStorageParameters parameters fallback)
         }
+
+    /// Uploads all new or changed files from a directory to object storage.
+    let uploadFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
+        uploadFilesToObjectStorageWithClients
+            (fun fileVersion -> ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion))
+            uploadWholeFilesToObjectStorage
+            parameters
 
     /// Creates an updated LocalDirectoryVersion instance, with a new DirectoryId, based on changes to an existing one.
     ///

--- a/src/Grace.SDK/AGENTS.md
+++ b/src/Grace.SDK/AGENTS.md
@@ -46,10 +46,8 @@ Consult `../AGENTS.md` for global policies before modifying the SDK.
   (January 6, 2026).
 - Added `Auth.getOidcClientConfig` for fetching server-provided OIDC client
   configuration (January 8, 2026).
-- Manifest-backed uploads are temporarily guarded by `GRACE_MANIFEST_UPLOADS=1`.
-  The CL2 SDK flow plans local ContentBlocks, uploads only new local blocks,
-  confirms them, finalizes the manifest without reposting block payload bytes,
-  and returns `FileVersion.ContentReference = FileManifest`. CLI callers keep
-  the whole-file compatibility upload path until
-  manifest download reconstruction lands; keep the default whole-file upload path
-  unchanged until CL5 removes this opt-in gate.
+- Manifest-backed uploads are enabled by default for files that satisfy
+  `ManifestEligibilityPolicy`. The SDK flow plans local ContentBlocks, uploads
+  only new local blocks, confirms them, finalizes the manifest without reposting
+  block payload bytes, and returns `FileVersion.ContentReference = FileManifest`.
+  Ineligible files still use the whole-file compatibility path.

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -55,7 +55,7 @@ module ManifestUpload =
             FinalizeManifest: FinalizeManifestUploadParameters -> Task<GraceResult<UploadSessionDecision>>
         }
 
-    let isOptedIn () = String.Equals(Environment.GetEnvironmentVariable(OptInEnvironmentVariable), "1", StringComparison.OrdinalIgnoreCase)
+    let isOptedIn () = true
 
     let private setStorageParameters (request: ManifestUploadRequest) (parameters: StorageParameters) =
         parameters.OwnerId <- $"{request.OwnerId}"


### PR DESCRIPTION
## Summary

Closes #103.

- Removes the manifest-upload opt-in from the CLI upload route so files are evaluated by `ManifestEligibilityPolicy` by default.
- Keeps ineligible files on the whole-file compatibility path through the existing SDK fallback result.
- Adds focused SDK/CLI tests for small source files, large compressed text, and the default-enabled manifest switch.
- Updates the SDK agent note so future agents inherit the new default behavior.

## Touched Paths

- `src/Grace.SDK/ManifestUpload.SDK.fs`
- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs`
- `src/Grace.SDK/AGENTS.md`

No write-set expansion beyond issue #103 owned paths.

## Validation

- RED: `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "ManifestUploadSdkTests.ManifestUploadsAreEnabledByDefaultAfterManifestDownloadReconstruction|ManifestUploadSdkTests.SmallSourceFileUsesWholeFileContentWithoutStartingManifestSession|ManifestUploadSdkTests.LargeCompressedTextUsesManifestUploadByDefaultPolicy"`
  - Failed as expected before implementation because manifest uploads were still disabled by default.
- GREEN focused: same focused filter passed after implementation, 3 tests.
- Manifest suite: `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "ManifestUploadSdkTests"`
  - Passed, 12 tests.
- Formatting: `dotnet tool run fantomas .\src\Grace.SDK\ManifestUpload.SDK.fs .\src\Grace.CLI\Command\Services.CLI.fs .\src\Grace.CLI.Tests\ManifestUpload.SDK.Tests.fs`
  - Completed; only the test file was rewritten by Fantomas.
- Markdown: `npx --yes markdownlint-cli2 "src/Grace.SDK/AGENTS.md"`
  - Passed, 0 errors.
- Whitespace: `git diff --check`
  - Passed.
- Fast gate: `pwsh ./scripts/validate.ps1 -Fast`
  - Passed; build succeeded; authorization 21 tests, CLI 220 tests, types 49 tests; elapsed 00:03:40.
- Full gate: `pwsh ./scripts/validate.ps1 -Full`
  - Passed; build succeeded; server 337 tests; elapsed 00:05:08.

## Required Internal Code Review

Final required internal review completed by McClintock (`019e5db5-239a-7ee1-bf53-65fde73ec4e6`) using `gpt-5.4-mini` with high reasoning against `ba154a5..3f6364f`.

Result:

> There are no actionable issues in this diff.
> I checked the manifest-default switch in `src/Grace.SDK/ManifestUpload.SDK.fs`, the CLI routing change in `src/Grace.CLI/Command/Services.CLI.fs`, and the new/updated tests. The focused `ManifestUploadSdkTests` slice passed locally (`12` tests).

## Docs Impact

Updated `src/Grace.SDK/AGENTS.md` to remove the temporary `GRACE_MANIFEST_UPLOADS=1` note and document policy-driven manifest uploads as the default for eligible files.

## Skipped Validation

None.

## Residual Risk

Low. The change intentionally removes the manifest-upload opt-in and routes all changed files through SDK eligibility planning before using the whole-file compatibility path for ineligible files.
## Review-Fix Update

After the initial PR opened, the local review loop identified a fallback-routing gap: manifest-successful files were still being queued for the whole-file compatibility upload. Fixed in `9f878cf` / branch head `93ded25` by routing whole-file fallback only when `ManifestUploadResult.UsedManifestUpload = false`.

Additional focused regression coverage:

- `UploadFilesToObjectStorageFallsBackOnlyForNonManifestResults` verifies the CLI upload route attempts manifest planning for a mixed file set while whole-file fallback receives only the non-manifest result.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "ManifestUploadSdkTests.UploadFilesToObjectStorageFallsBackOnlyForNonManifestResults|ManifestUploadSdkTests"` passed, 13 tests.
- `dotnet tool run fantomas .\src\Grace.CLI\Command\Services.CLI.fs .\src\Grace.CLI.Tests\ManifestUpload.SDK.Tests.fs` passed.
- `git diff --check` passed.

Final local review-only subagent result after the fix: Copernicus (`019e5dde-fbc6-7e81-8da7-8d3f96dbc775`), `gpt-5.4-mini` with high reasoning, reviewed `ba154a5..9f878cf` and reported no actionable issues. It specifically verified that `uploadFilesToObjectStorageWithClients` only queues whole-file fallback when `UsedManifestUpload` is `false`, and that the new CLI-level test covers the manifest-vs-fallback split directly.

Latest main agent docs were merged into the branch in `93ded25`; the local review-only subagent path is the required completion gate, not the automatic GitHub Codex PR bot.