### PR TITLE
Audit ADR storage docs and OpenAPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ This repo is primarily **F#** and targets **.NET 10**.
 
 3. Build:
 
-   - `dotnet build ./src/Grace.sln`
+   - `dotnet build ./src/Grace.slnx`
 
 4. Test:
 
-   - `dotnet test ./src/Grace.sln` (optionally add `-c Release`)
+   - `dotnet test ./src/Grace.slnx` (optionally add `-c Release`)
    - Or run the repo validator: `pwsh ./scripts/validate.ps1 -Full`
 
 5. Format F#:
@@ -35,6 +35,9 @@ This repo is primarily **F#** and targets **.NET 10**.
   editing.
 - Use a focused branch for each issue. Maintainers and agents should use issue-owned worktrees for repo-local work.
 - Prefer vertical slices with focused validation and a commit after each completed slice.
+- Before treating coding work as complete, run the local review-only subagent loop described in
+  `docs/Development process.md`; use the dedicated Code Review capability when available, address every issue, and stop
+  only after the reviewer reports no issues.
 - Open normal ready-for-review pull requests unless a maintainer explicitly asks for a draft pull request.
 - Add or update tests when changing behavior.
 - Please add any useful AI prompts you used for diagnosis or implementation to the PR description.
@@ -54,13 +57,13 @@ and `dotnet restore`.
 
 From the repo root:
 
-- `dotnet build ./src/Grace.sln`
+- `dotnet build ./src/Grace.slnx`
 
 ## Tests
 
 From the repo root:
 
-- `dotnet test ./src/Grace.sln` (optionally `-c Release`)
+- `dotnet test ./src/Grace.slnx` (optionally `-c Release`)
 
 This repo also includes a validation script:
 
@@ -317,10 +320,11 @@ Prometheus:
 
 ## Pull request checklist
 
-- [ ] Builds: `dotnet build ./src/Grace.sln`
-- [ ] Tests: `dotnet test ./src/Grace.sln`
+- [ ] Builds: `dotnet build ./src/Grace.slnx`
+- [ ] Tests: `dotnet test ./src/Grace.slnx`
 - [ ] Formatting: run `dotnet tool run fantomas --recurse .` from `./src`
 - [ ] Focused validation for the touched behavior is listed in the PR
+- [ ] Local review-only subagent loop completed with no remaining issues
 - [ ] Skipped validation is listed with a reason
 - [ ] Documentation updated (if behavior changed)
 - [ ] Docs impact, residual risk, and rollback or recovery notes are recorded when relevant

--- a/README.md
+++ b/README.md
@@ -217,7 +217,11 @@ A version control system is \<waves hands\> just a series of modifications to fi
 
 ### 3) Files are stored in object storage
 
-Grace relies on cloud object storage systems to provide a safe and infinitely scalable storage layer. Grace currently uses Azure Blob Storage, with the intention of adding the ability to run it on AWS S3 and others. Currently, all files are stored as single blobs in Azure; soon Grace will shift to a content-addressible storage construct that will enable efficient handling of changes to large binary files.
+Grace relies on cloud object storage systems to provide a safe and infinitely scalable storage layer. Grace currently
+uses Azure Blob Storage, with the intention of adding the ability to run it on AWS S3 and others. Small and regular
+files use the repository-scoped whole-file path. Eligible large files use ADR-0001 manifest-backed content-addressed
+storage: clients split content into ContentBlocks, upload only missing payloads, and finalize a FileManifest that lets
+Grace reconstruct the file without tying content identity to a repository path.
 
 ### 4) `grace watch` for effortless, background update tracking
 
@@ -254,10 +258,10 @@ Grace is evolving quickly. Strap in....
 - Native GUI for Windows, MacOS, Linux Desktop, Android, iOS, and WASM.
 - Not Electron.
 
-### Full rewrite of object storage layer
+### Continue the object storage layer rewrite
 
-- Switch to content-addressable storage for more efficient object storage and network transfer
-- Automatic chunking of large binary files
+- Keep hardening manifest-backed content-addressable storage for efficient object storage and network transfer
+- Expand automatic chunking, dedupe discovery, rebuild, garbage collection, and compaction coverage for large files
 
 ### Multi-hash semantics
 

--- a/docs/adr/0001-content-addressed-storage-contentblocks.md
+++ b/docs/adr/0001-content-addressed-storage-contentblocks.md
@@ -481,6 +481,35 @@ Tests should include:
 - Repository contribution zero-crossing tests.
 - Compaction concurrency tests.
 
+## Implementation Status
+
+As of May 25, 2026, ADR-0001 has landed as a first implementation wave rather than only a future design. The current
+repository includes these implemented surfaces:
+
+- Domain contracts for `FileContentReference`, `WholeFileContent`, `FileManifest`, `ContentBlock`, manifest eligibility,
+  content addresses, storage keys, upload sessions, repository content counters, manifest contribution workflows,
+  dedupe index records, and `ContentBlockMetadata`.
+- Manifest validation and physical ContentBlock payload helpers that validate stable addresses, reconstruction order,
+  file hash, chunking suite, and payload integrity before manifest finalization.
+- Server storage endpoints for manifest upload sessions, bounded dedupe discovery, range claims, ContentBlock upload
+  registration and confirmation, manifest finalization, ContentBlock upload/download URIs, and whole-file compatibility
+  paths.
+- SDK and CLI upload/download paths that enable manifest-backed uploads by default for eligible large files while
+  keeping whole-file upload as the compatibility path for ineligible files or recoverable fallback cases.
+- Repository save-boundary validation that accepts finalized manifest references without re-uploading whole-file
+  content.
+- Repository contribution and ContentBlock metadata behavior for zero-crossing contribution fan-out, authoritative
+  range presence, stale-hint safety, and compaction candidate/churn guards.
+- OpenAPI source files for the ADR-0001 storage routes and CAS DTO shapes, plus route coverage validation for those
+  documented paths.
+
+Remaining follow-ups after this wave should stay narrow and tracked separately:
+
+- Broaden the static OpenAPI source to cover every non-ADR route that predates this audit.
+- Keep hardening Aspire-backed integration coverage for end-to-end manifest upload/download, rebuild, GC, and
+  compaction operations as those runtime flows mature.
+- Add operator-facing rebuild and compaction runbooks when the operational commands and schedules are finalized.
+
 ## Supporting Design Artifacts
 
 The detailed design report and diagram that led to this ADR are:

--- a/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
+++ b/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="PersonalAccessToken.Tests.fs" />
     <Compile Include="PermissionEvaluator.Tests.fs" />
     <Compile Include="EndpointAuthorizationManifest.Tests.fs" />
+    <Compile Include="OpenApiRouteCoverage.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
+++ b/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
@@ -1,0 +1,50 @@
+namespace Grace.Authorization.Tests
+
+open NUnit.Framework
+open System
+open System.IO
+open System.Text.RegularExpressions
+
+[<Parallelizable(ParallelScope.All)>]
+type OpenApiRouteCoverageTests() =
+
+    let openApiMainPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "OpenAPI", "Main.OpenAPI.yaml"))
+
+    let openApiPathRegex = Regex("^  (?<path>/[^:]+):\\s*$", RegexOptions.Compiled)
+
+    let openApiPaths () =
+        File.ReadAllLines(openApiMainPath)
+        |> Array.choose (fun line ->
+            let matchItem = openApiPathRegex.Match(line)
+
+            if matchItem.Success then Some matchItem.Groups["path"].Value else None)
+        |> Set.ofArray
+
+    [<Test>]
+    member _.OpenApiCoversAdrStorageRoutes() =
+        let expectedStorageRoutes =
+            [
+                "/storage/getUploadMetadataForFiles"
+                "/storage/getUploadUri"
+                "/storage/getDownloadUri"
+                "/storage/getContentBlockUploadUri"
+                "/storage/getContentBlockDownloadUri"
+                "/storage/discoverContentBlocks"
+                "/storage/startManifestUploadSession"
+                "/storage/issueDedupeDiscovery"
+                "/storage/claimReuseRanges"
+                "/storage/registerContentBlockUpload"
+                "/storage/confirmContentBlockUpload"
+                "/storage/finalizeManifestUpload"
+            ]
+            |> Set.ofList
+
+        let missing = expectedStorageRoutes - openApiPaths ()
+
+        if missing.Count > 0 then
+            let missingText =
+                missing
+                |> Seq.sort
+                |> String.concat Environment.NewLine
+
+            Assert.Fail($"OpenAPI is missing ADR-0001 storage routes:{Environment.NewLine}{missingText}")

--- a/src/Grace.CLI/AGENTS.md
+++ b/src/Grace.CLI/AGENTS.md
@@ -50,6 +50,9 @@ Read `../AGENTS.md` for global expectations before updating CLI code.
 - `grace connect` accepts a positional shortcut in the form
   `owner/organization/repository`; do not combine it with explicit owner,
   organization, or repository options.
+- Manifest-backed uploads are default-on for eligible large files. Keep whole-file
+  fallback limited to ineligible files or recoverable manifest-upload failures so
+  eligible files are not uploaded twice.
 
 ## Continuous Review Commands
 

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -186,6 +186,31 @@ paths:
   /repository/getBranchesByBranchId:
     $ref: './Repository.Paths.OpenAPI.yaml#/~1repository~1getBranchesByBranchId'
 
+  /storage/getUploadMetadataForFiles:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1getUploadMetadataForFiles'
+  /storage/getUploadUri:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1getUploadUri'
+  /storage/getDownloadUri:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1getDownloadUri'
+  /storage/getContentBlockUploadUri:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1getContentBlockUploadUri'
+  /storage/getContentBlockDownloadUri:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1getContentBlockDownloadUri'
+  /storage/discoverContentBlocks:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1discoverContentBlocks'
+  /storage/startManifestUploadSession:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1startManifestUploadSession'
+  /storage/issueDedupeDiscovery:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1issueDedupeDiscovery'
+  /storage/claimReuseRanges:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1claimReuseRanges'
+  /storage/registerContentBlockUpload:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1registerContentBlockUpload'
+  /storage/confirmContentBlockUpload:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1confirmContentBlockUpload'
+  /storage/finalizeManifestUpload:
+    $ref: './Storage.Paths.OpenAPI.yaml#/~1storage~1finalizeManifestUpload'
+
 components:
   schemas:
     BranchParameters:
@@ -338,6 +363,55 @@ components:
       $ref: 'Repository.Components.OpenAPI.yaml#/GetBranchesByBranchIdParameters'
     UndeleteRepositoryParameters:
       $ref: 'Repository.Components.OpenAPI.yaml#/UndeleteRepositoryParameters'
+
+    StorageParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/StorageParameters'
+    GetUploadMetadataForFilesParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadMetadataForFilesParameters'
+    GetUploadUriParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadUriParameters'
+    GetDownloadUriParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/GetDownloadUriParameters'
+    GetContentBlockUploadUriParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockUploadUriParameters'
+    GetContentBlockDownloadUriParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockDownloadUriParameters'
+    DiscoverContentBlocksParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksParameters'
+    StartManifestUploadSessionParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/StartManifestUploadSessionParameters'
+    IssueDedupeDiscoveryParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/IssueDedupeDiscoveryParameters'
+    ClaimReuseRangesParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ClaimReuseRangesParameters'
+    RegisterContentBlockUploadParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/RegisterContentBlockUploadParameters'
+    ConfirmContentBlockUploadParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ConfirmContentBlockUploadParameters'
+    FinalizeManifestUploadParameters:
+      $ref: 'Storage.Components.OpenAPI.yaml#/FinalizeManifestUploadParameters'
+    DiscoverContentBlocksResult:
+      $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksResult'
+    UploadSessionDecision:
+      $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecision'
+    FileManifest:
+      $ref: 'Storage.Components.OpenAPI.yaml#/FileManifest'
+    ContentBlock:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ContentBlock'
+    ContentBlockAddress:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ContentBlockAddress'
+    ManifestAddress:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ManifestAddress'
+    FileContentHash:
+      $ref: 'Storage.Components.OpenAPI.yaml#/FileContentHash'
+    ChunkAddress:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ChunkAddress'
+    StoragePoolId:
+      $ref: 'Storage.Components.OpenAPI.yaml#/StoragePoolId'
+    ChunkingSuiteId:
+      $ref: 'Storage.Components.OpenAPI.yaml#/ChunkingSuiteId'
+    UploadSessionOperationId:
+      $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionOperationId'
 
     Instant:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'

--- a/src/OpenAPI/Storage.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Components.OpenAPI.yaml
@@ -369,15 +369,13 @@ UploadSessionDecision:
   type: object
   properties:
     Session:
-      type: object
-      additionalProperties: true
+      $ref: '#/UploadSessionDto'
     OperationId:
       $ref: '#/UploadSessionOperationId'
     Events:
       type: array
       items:
-        type: object
-        additionalProperties: true
+        $ref: '#/UploadSessionEvent'
     WasIdempotentReplay:
       type: boolean
     Message:
@@ -388,6 +386,377 @@ UploadSessionDecision:
     - Events
     - WasIdempotentReplay
     - Message
+
+UploadSessionDto:
+  description: Server state snapshot for a manifest upload session.
+  type: object
+  properties:
+    Class:
+      type: string
+      enum:
+        - UploadSessionDto
+    UploadSessionId:
+      type: string
+      format: uuid
+    OwnerId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+    OrganizationId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+    RepositoryId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+    AuthorizedScope:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+    FileContentHash:
+      $ref: '#/FileContentHash'
+    ExpectedSize:
+      type: integer
+      format: int64
+    ChunkingSuiteId:
+      $ref: '#/ChunkingSuiteId'
+    SamplingPolicySnapshot:
+      type: string
+    LifecycleState:
+      $ref: '#/UploadSessionLifecycleState'
+    StartedAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+    CompletedAt:
+      nullable: true
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+    FinalizedManifestAddress:
+      nullable: true
+      $ref: '#/ManifestAddress'
+    BlockUploadIntents:
+      type: array
+      items:
+        $ref: '#/BlockUploadIntent'
+    ConfirmedBlockUploads:
+      type: array
+      items:
+        $ref: '#/ConfirmedBlockUpload'
+    DedupeDiscovery:
+      nullable: true
+      $ref: '#/DedupeDiscoverySnapshot'
+    ClaimedReuseRanges:
+      type: array
+      items:
+        $ref: '#/ClaimedReuseRange'
+    CleanupReminderScheduledAt:
+      nullable: true
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+    CleanupReminderOperationId:
+      nullable: true
+      $ref: '#/UploadSessionOperationId'
+    LastOperationId:
+      nullable: true
+      $ref: '#/UploadSessionOperationId'
+  required:
+    - Class
+    - UploadSessionId
+    - OwnerId
+    - OrganizationId
+    - RepositoryId
+    - AuthorizedScope
+    - FileContentHash
+    - ExpectedSize
+    - ChunkingSuiteId
+    - SamplingPolicySnapshot
+    - LifecycleState
+    - StartedAt
+    - CompletedAt
+    - FinalizedManifestAddress
+    - BlockUploadIntents
+    - ConfirmedBlockUploads
+    - DedupeDiscovery
+    - ClaimedReuseRanges
+    - CleanupReminderScheduledAt
+    - CleanupReminderOperationId
+    - LastOperationId
+
+UploadSessionLifecycleState:
+  description: Lifecycle state for a manifest upload session.
+  type: string
+  enum:
+    - NotStarted
+    - Started
+    - Discovering
+    - UploadingBlocks
+    - ClaimingRanges
+    - FinalizingManifest
+    - Finalized
+    - Abandoned
+    - Expired
+    - RetentionPending
+    - StateDeleted
+
+BlockUploadIntent:
+  description: Registered intent to upload a logical ContentBlock range.
+  type: object
+  properties:
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    LogicalOffset:
+      type: integer
+      format: int64
+    LogicalLength:
+      type: integer
+      format: int64
+    ExpectedPayloadLength:
+      type: integer
+      format: int64
+    RegisteredAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+  required:
+    - ContentBlockAddress
+    - LogicalOffset
+    - LogicalLength
+    - ExpectedPayloadLength
+    - RegisteredAt
+
+ConfirmedBlockUpload:
+  description: Confirmed object-storage placement for an uploaded ContentBlock.
+  type: object
+  properties:
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    PayloadLength:
+      type: integer
+      format: int64
+    StoragePlacement:
+      $ref: '#/ContentBlockStoragePlacement'
+    Ranges:
+      type: array
+      items:
+        $ref: '#/ContentBlockMetadataRange'
+    ConfirmedAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+  required:
+    - ContentBlockAddress
+    - PayloadLength
+    - StoragePlacement
+    - Ranges
+    - ConfirmedAt
+
+DedupeDiscoverySnapshot:
+  description: Server-issued dedupe discovery snapshot retained by an upload session.
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    ExpiresAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+    MinimumReuseRunLength:
+      type: integer
+    Hints:
+      type: array
+      items:
+        $ref: '#/ContentBlockReuseRangeHint'
+  required:
+    - OperationId
+    - ExpiresAt
+    - MinimumReuseRunLength
+    - Hints
+
+ClaimedReuseRange:
+  description: Reuse range accepted by the upload-session workflow.
+  type: object
+  properties:
+    StoragePoolId:
+      $ref: '#/StoragePoolId'
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    OrdinalStart:
+      type: integer
+    OrdinalCount:
+      type: integer
+    PhysicalOffset:
+      type: integer
+      format: int64
+    PhysicalLength:
+      type: integer
+      format: int64
+    MetadataVersion:
+      type: integer
+      format: int64
+    ClaimedAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+  required:
+    - StoragePoolId
+    - ContentBlockAddress
+    - OrdinalStart
+    - OrdinalCount
+    - PhysicalOffset
+    - PhysicalLength
+    - MetadataVersion
+    - ClaimedAt
+
+ContentBlockMetadataRange:
+  description: Physical range metadata for ContentBlock reconstruction, reuse, and compaction.
+  type: object
+  properties:
+    OrdinalStart:
+      type: integer
+    OrdinalCount:
+      type: integer
+    ActiveManifestCount:
+      type: integer
+    PhysicalOffset:
+      type: integer
+      format: int64
+    PhysicalLength:
+      type: integer
+      format: int64
+  required:
+    - OrdinalStart
+    - OrdinalCount
+    - ActiveManifestCount
+    - PhysicalOffset
+    - PhysicalLength
+
+UploadSessionEvent:
+  description: Event emitted by the upload-session actor, paired with event metadata.
+  type: object
+  properties:
+    Event:
+      $ref: '#/UploadSessionEventType'
+    Metadata:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/EventMetadata'
+  required:
+    - Event
+    - Metadata
+
+UploadSessionEventType:
+  description: Upload-session event union payload. Event objects contain the fields for one emitted union case.
+  oneOf:
+    - $ref: '#/UploadSessionStartedEvent'
+    - $ref: '#/UploadSessionOperationEvent'
+    - $ref: '#/UploadSessionFinalizedEvent'
+    - $ref: '#/UploadSessionCleanupReminderScheduledEvent'
+    - $ref: '#/UploadSessionBlockUploadIntentRegisteredEvent'
+    - $ref: '#/UploadSessionBlockUploadConfirmedEvent'
+    - $ref: '#/UploadSessionDedupeDiscoveryIssuedEvent'
+    - $ref: '#/UploadSessionReuseRangesClaimedEvent'
+
+UploadSessionStartedEvent:
+  type: object
+  properties:
+    Started:
+      $ref: '#/StartManifestUploadSessionParameters'
+  required:
+    - Started
+
+UploadSessionOperationEvent:
+  type: object
+  description: Event cases whose payload is only an operation id.
+  properties:
+    EventCase:
+      type: string
+      enum:
+        - Abandoned
+        - Expired
+        - PhysicalStateDeleted
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+  required:
+    - EventCase
+    - OperationId
+
+UploadSessionFinalizedEvent:
+  type: object
+  properties:
+    Finalized:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        ManifestAddress:
+          $ref: '#/ManifestAddress'
+      required:
+        - OperationId
+        - ManifestAddress
+  required:
+    - Finalized
+
+UploadSessionCleanupReminderScheduledEvent:
+  type: object
+  properties:
+    CleanupReminderScheduled:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        ReminderTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+      required:
+        - OperationId
+        - ReminderTime
+  required:
+    - CleanupReminderScheduled
+
+UploadSessionBlockUploadIntentRegisteredEvent:
+  type: object
+  properties:
+    BlockUploadIntentRegistered:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        Intent:
+          $ref: '#/BlockUploadIntent'
+      required:
+        - OperationId
+        - Intent
+  required:
+    - BlockUploadIntentRegistered
+
+UploadSessionBlockUploadConfirmedEvent:
+  type: object
+  properties:
+    BlockUploadConfirmed:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        ConfirmedBlock:
+          $ref: '#/ConfirmedBlockUpload'
+      required:
+        - OperationId
+        - ConfirmedBlock
+  required:
+    - BlockUploadConfirmed
+
+UploadSessionDedupeDiscoveryIssuedEvent:
+  type: object
+  properties:
+    DedupeDiscoveryIssued:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        Discovery:
+          $ref: '#/DedupeDiscoverySnapshot'
+      required:
+        - OperationId
+        - Discovery
+  required:
+    - DedupeDiscoveryIssued
+
+UploadSessionReuseRangesClaimedEvent:
+  type: object
+  properties:
+    ReuseRangesClaimed:
+      type: object
+      properties:
+        OperationId:
+          $ref: '#/UploadSessionOperationId'
+        ClaimedRanges:
+          type: array
+          items:
+            $ref: '#/ClaimedReuseRange'
+      required:
+        - OperationId
+        - ClaimedRanges
+  required:
+    - ReuseRangesClaimed
 
 ContentBlockReuseRangeHint:
   description: Server-issued hint used to claim a reusable ContentBlock range.

--- a/src/OpenAPI/Storage.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Components.OpenAPI.yaml
@@ -1,0 +1,379 @@
+StorageParameters:
+  description: Parameters common to storage endpoints.
+  allOf:
+    - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
+  type: object
+  properties:
+    OwnerId:
+      type: string
+    OwnerName:
+      type: string
+    OrganizationId:
+      type: string
+    OrganizationName:
+      type: string
+    RepositoryId:
+      type: string
+    RepositoryName:
+      type: string
+
+GetUploadMetadataForFilesParameters:
+  description: Parameters for /storage/getUploadMetadataForFiles.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    FileVersions:
+      type: array
+      items:
+        $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileVersion'
+
+GetUploadUriParameters:
+  description: Parameters for /storage/getUploadUri.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    FileVersions:
+      type: array
+      items:
+        $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileVersion'
+
+GetDownloadUriParameters:
+  description: Parameters for /storage/getDownloadUri.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    FileVersion:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileVersion'
+
+GetContentBlockUploadUriParameters:
+  description: Parameters for /storage/getContentBlockUploadUri.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    AuthorizedScope:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+
+GetContentBlockDownloadUriParameters:
+  description: Parameters for /storage/getContentBlockDownloadUri.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+
+DiscoverContentBlocksParameters:
+  description: >-
+    Parameters for /storage/discoverContentBlocks. Discovery is bounded and non-authoritative; empty results do not
+    prove that chunks or future ContentBlocks are absent.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    KeyChunkAddresses:
+      type: array
+      maxItems: 256
+      items:
+        $ref: '#/ChunkAddress'
+
+UploadSessionStorageParameters:
+  description: Parameters common to manifest upload-session endpoints.
+  allOf:
+    - $ref: '#/StorageParameters'
+  type: object
+  properties:
+    UploadSessionId:
+      type: string
+      format: uuid
+    AuthorizedScope:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+
+StartManifestUploadSessionParameters:
+  description: Parameters for /storage/startManifestUploadSession.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    FileContentHash:
+      $ref: '#/FileContentHash'
+    ExpectedSize:
+      type: integer
+      format: int64
+    ChunkingSuiteId:
+      $ref: '#/ChunkingSuiteId'
+    SamplingPolicySnapshot:
+      type: string
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+
+IssueDedupeDiscoveryParameters:
+  description: Parameters for /storage/issueDedupeDiscovery.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    ExpiresAt:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+    MinimumReuseRunLength:
+      type: integer
+      minimum: 8
+    Hints:
+      type: array
+      maxItems: 1024
+      items:
+        $ref: '#/ContentBlockReuseRangeHint'
+
+ClaimReuseRangesParameters:
+  description: Parameters for /storage/claimReuseRanges.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    DiscoveryOperationId:
+      $ref: '#/UploadSessionOperationId'
+    Hints:
+      type: array
+      maxItems: 1024
+      items:
+        $ref: '#/ContentBlockReuseRangeHint'
+
+RegisterContentBlockUploadParameters:
+  description: Parameters for /storage/registerContentBlockUpload.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    LogicalOffset:
+      type: integer
+      format: int64
+    LogicalLength:
+      type: integer
+      format: int64
+    ExpectedPayloadLength:
+      type: integer
+      format: int64
+
+ConfirmContentBlockUploadParameters:
+  description: Parameters for /storage/confirmContentBlockUpload.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    Payload:
+      type: string
+      format: byte
+    StoragePlacement:
+      $ref: '#/ContentBlockStoragePlacement'
+
+FinalizeManifestUploadParameters:
+  description: Parameters for /storage/finalizeManifestUpload.
+  allOf:
+    - $ref: '#/UploadSessionStorageParameters'
+  type: object
+  properties:
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    Manifest:
+      $ref: '#/FileManifest'
+    BlockPayloads:
+      type: array
+      items:
+        $ref: '#/FinalizeManifestBlockPayload'
+
+ContentBlockDiscoveryPolicy:
+  description: Bounded, non-authoritative discovery policy returned by /storage/discoverContentBlocks.
+  type: object
+  properties:
+    MaxKeyChunkAddresses:
+      type: integer
+      example: 256
+    MaxCandidateWindowsPerKeyChunk:
+      type: integer
+      example: 4
+    MaxWindowChunks:
+      type: integer
+      example: 256
+    MaxResponseProtectedChunks:
+      type: integer
+      example: 16384
+    ResponseTtlSeconds:
+      type: integer
+      example: 300
+    MinimumAcceptedReuseRunLength:
+      type: integer
+      example: 8
+    PositiveCandidatesEnabled:
+      type: boolean
+    EmptyResponseMeansAbsent:
+      type: boolean
+      example: false
+    IsAuthoritative:
+      type: boolean
+      example: false
+
+ContentBlockDiscoveryCandidate:
+  description: A bounded, response-protected candidate window for possible ContentBlock reuse.
+  type: object
+  properties:
+    StoragePoolId:
+      $ref: '#/StoragePoolId'
+    ManifestAddress:
+      $ref: '#/ManifestAddress'
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    OrdinalStart:
+      type: integer
+    OrdinalCount:
+      type: integer
+    MetadataVersion:
+      type: integer
+      format: int64
+    MatchingKeyChunkCount:
+      type: integer
+    ProtectedChunkAddresses:
+      type: array
+      items:
+        type: string
+
+DiscoverContentBlocksResult:
+  description: Non-authoritative ContentBlock discovery result.
+  type: object
+  properties:
+    RequestedKeyChunkCount:
+      type: integer
+    AcceptedKeyChunkCount:
+      type: integer
+    Policy:
+      $ref: '#/ContentBlockDiscoveryPolicy'
+    CandidateContentBlocks:
+      type: array
+      items:
+        $ref: '#/ContentBlockDiscoveryCandidate'
+    IsPartial:
+      type: boolean
+    Message:
+      type: string
+
+UploadSessionDecision:
+  description: UploadSession command decision returned by manifest upload-session endpoints.
+  type: object
+  additionalProperties: true
+
+ContentBlockReuseRangeHint:
+  description: Server-issued hint used to claim a reusable ContentBlock range.
+  type: object
+  properties:
+    StoragePoolId:
+      $ref: '#/StoragePoolId'
+    ManifestAddress:
+      $ref: '#/ManifestAddress'
+    ContentBlockAddress:
+      $ref: '#/ContentBlockAddress'
+    OrdinalStart:
+      type: integer
+    OrdinalCount:
+      type: integer
+    MetadataVersion:
+      type: integer
+      format: int64
+    ProtectedChunkAddresses:
+      type: array
+      items:
+        type: string
+
+ContentBlockStoragePlacement:
+  description: Object-storage placement metadata for a confirmed ContentBlock payload.
+  type: object
+  additionalProperties: true
+
+FinalizeManifestBlockPayload:
+  description: Optional inline payload used by manifest finalization compatibility paths.
+  type: object
+  properties:
+    Address:
+      $ref: '#/ContentBlockAddress'
+    Payload:
+      type: string
+      format: byte
+
+FileManifest:
+  description: Server-accepted reconstruction contract for one manifest-backed file.
+  type: object
+  properties:
+    ManifestAddress:
+      $ref: '#/ManifestAddress'
+    ChunkingSuiteId:
+      $ref: '#/ChunkingSuiteId'
+    FileContentHash:
+      $ref: '#/FileContentHash'
+    Size:
+      type: integer
+      format: int64
+    Blocks:
+      type: array
+      items:
+        $ref: '#/ContentBlock'
+
+ContentBlock:
+  description: Logical byte range inside a manifest-backed file.
+  type: object
+  properties:
+    Address:
+      $ref: '#/ContentBlockAddress'
+    Offset:
+      type: integer
+      format: int64
+    Size:
+      type: integer
+      format: int64
+
+ChunkAddress:
+  description: Lowercase 64-character BLAKE3 chunk address.
+  type: string
+  pattern: '^[a-f0-9]{64}$'
+
+ContentBlockAddress:
+  description: Lowercase 64-character BLAKE3-derived ContentBlock address.
+  type: string
+  pattern: '^[a-f0-9]{64}$'
+
+ManifestAddress:
+  description: Lowercase 64-character BLAKE3-derived FileManifest address.
+  type: string
+  pattern: '^[a-f0-9]{64}$'
+
+FileContentHash:
+  description: Lowercase 64-character BLAKE3 hash of the complete unencoded file bytes.
+  type: string
+  pattern: '^[a-f0-9]{64}$'
+
+StoragePoolId:
+  description: StoragePool-wide CAS scope identifier.
+  type: string
+
+ChunkingSuiteId:
+  description: Versioned chunking suite identifier.
+  type: string
+  example: rabin-v1
+
+UploadSessionOperationId:
+  description: Caller-supplied idempotency key for one upload-session operation.
+  type: string

--- a/src/OpenAPI/Storage.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Components.OpenAPI.yaml
@@ -272,10 +272,122 @@ DiscoverContentBlocksResult:
     Message:
       type: string
 
+GraceReturnValueBase:
+  description: Common metadata returned with successful Grace responses.
+  type: object
+  properties:
+    EventTime:
+      type: string
+      format: date-time
+    CorrelationId:
+      type: string
+    Properties:
+      type: object
+      additionalProperties: true
+  required:
+    - EventTime
+    - CorrelationId
+    - Properties
+
+UploadMetadataArrayReturnValue:
+  description: Successful upload metadata response for whole-file compatibility uploads.
+  allOf:
+    - $ref: '#/GraceReturnValueBase'
+    - type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/UploadMetadata'
+      required:
+        - ReturnValue
+
+UploadSessionDecisionReturnValue:
+  description: Successful upload-session command response.
+  allOf:
+    - $ref: '#/GraceReturnValueBase'
+    - type: object
+      properties:
+        ReturnValue:
+          $ref: '#/UploadSessionDecision'
+      required:
+        - ReturnValue
+
+DiscoverContentBlocksReturnValue:
+  description: Successful ContentBlock discovery response.
+  allOf:
+    - $ref: '#/GraceReturnValueBase'
+    - type: object
+      properties:
+        ReturnValue:
+          $ref: '#/DiscoverContentBlocksResult'
+      required:
+        - ReturnValue
+
+UploadMetadata:
+  description: Upload metadata returned by whole-file compatibility upload planning.
+  type: object
+  properties:
+    RelativePath:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+    BlobUriWithSasToken:
+      type: string
+      format: uri
+    Sha256Hash:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+    ContentReference:
+      $ref: '#/FileContentReference'
+  required:
+    - RelativePath
+    - BlobUriWithSasToken
+    - Sha256Hash
+    - ContentReference
+
+FileContentReference:
+  description: Identifies whether a FileVersion refers to whole-file bytes or a FileManifest.
+  type: object
+  properties:
+    Class:
+      type: string
+      enum:
+        - FileContentReference
+    ReferenceType:
+      type: string
+      enum:
+        - WholeFileContent
+        - FileManifest
+    Manifest:
+      nullable: true
+      $ref: '#/FileManifest'
+  required:
+    - Class
+    - ReferenceType
+    - Manifest
+
 UploadSessionDecision:
   description: UploadSession command decision returned by manifest upload-session endpoints.
   type: object
-  additionalProperties: true
+  properties:
+    Session:
+      type: object
+      additionalProperties: true
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+    Events:
+      type: array
+      items:
+        type: object
+        additionalProperties: true
+    WasIdempotentReplay:
+      type: boolean
+    Message:
+      type: string
+  required:
+    - Session
+    - OperationId
+    - Events
+    - WasIdempotentReplay
+    - Message
 
 ContentBlockReuseRangeHint:
   description: Server-issued hint used to claim a reusable ContentBlock range.
@@ -302,7 +414,14 @@ ContentBlockReuseRangeHint:
 ContentBlockStoragePlacement:
   description: Object-storage placement metadata for a confirmed ContentBlock payload.
   type: object
-  additionalProperties: true
+  properties:
+    ObjectKey:
+      type: string
+    ETag:
+      type: string
+      nullable: true
+  required:
+    - ObjectKey
 
 FinalizeManifestBlockPayload:
   description: Optional inline payload used by manifest finalization compatibility paths.
@@ -318,6 +437,10 @@ FileManifest:
   description: Server-accepted reconstruction contract for one manifest-backed file.
   type: object
   properties:
+    Class:
+      type: string
+      enum:
+        - FileManifest
     ManifestAddress:
       $ref: '#/ManifestAddress'
     ChunkingSuiteId:
@@ -331,11 +454,22 @@ FileManifest:
       type: array
       items:
         $ref: '#/ContentBlock'
+  required:
+    - Class
+    - ManifestAddress
+    - ChunkingSuiteId
+    - FileContentHash
+    - Size
+    - Blocks
 
 ContentBlock:
   description: Logical byte range inside a manifest-backed file.
   type: object
   properties:
+    Class:
+      type: string
+      enum:
+        - ContentBlock
     Address:
       $ref: '#/ContentBlockAddress'
     Offset:
@@ -344,6 +478,11 @@ ContentBlock:
     Size:
       type: integer
       format: int64
+  required:
+    - Class
+    - Address
+    - Offset
+    - Size
 
 ChunkAddress:
   description: Lowercase 64-character BLAKE3 chunk address.

--- a/src/OpenAPI/Storage.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Components.OpenAPI.yaml
@@ -39,6 +39,17 @@ GetUploadUriParameters:
       items:
         $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileVersion'
 
+UploadUriMap:
+  description: Upload URI response keyed by file relative path for whole-file compatibility uploads.
+  type: object
+  additionalProperties:
+    $ref: '#/UriString'
+
+UriString:
+  description: Absolute URI string.
+  type: string
+  format: uri
+
 GetDownloadUriParameters:
   description: Parameters for /storage/getDownloadUri.
   allOf:
@@ -111,6 +122,44 @@ StartManifestUploadSessionParameters:
       type: string
     OperationId:
       $ref: '#/UploadSessionOperationId'
+
+StartUploadSession:
+  description: Event payload recorded when a manifest upload session starts.
+  type: object
+  properties:
+    UploadSessionId:
+      type: string
+      format: uuid
+    OwnerId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+    OrganizationId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+    RepositoryId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+    AuthorizedScope:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+    FileContentHash:
+      $ref: '#/FileContentHash'
+    ExpectedSize:
+      type: integer
+      format: int64
+    ChunkingSuiteId:
+      $ref: '#/ChunkingSuiteId'
+    SamplingPolicySnapshot:
+      type: string
+    OperationId:
+      $ref: '#/UploadSessionOperationId'
+  required:
+    - UploadSessionId
+    - OwnerId
+    - OrganizationId
+    - RepositoryId
+    - AuthorizedScope
+    - FileContentHash
+    - ExpectedSize
+    - ChunkingSuiteId
+    - SamplingPolicySnapshot
+    - OperationId
 
 IssueDedupeDiscoveryParameters:
   description: Parameters for /storage/issueDedupeDiscovery.
@@ -640,7 +689,7 @@ UploadSessionStartedEvent:
   type: object
   properties:
     Started:
-      $ref: '#/StartManifestUploadSessionParameters'
+      $ref: '#/StartUploadSession'
   required:
     - Started
 

--- a/src/OpenAPI/Storage.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Paths.OpenAPI.yaml
@@ -1,7 +1,7 @@
 /storage/getUploadMetadataForFiles:
   post:
     summary: Gets upload metadata for files.
-    description: Gets upload URLs and content-reference metadata for whole-file and manifest-backed uploads.
+    description: Gets upload URLs and content-reference metadata for whole-file compatibility uploads.
     operationId: GetUploadMetadataForFiles
     requestBody:
       required: true
@@ -11,7 +11,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadMetadataForFilesParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadMetadataArrayReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -110,7 +114,7 @@
         content:
           application/json:
             schema:
-              $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksResult'
+              $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -129,7 +133,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/StartManifestUploadSessionParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -148,7 +156,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/IssueDedupeDiscoveryParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -167,7 +179,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/ClaimReuseRangesParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -186,7 +202,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/RegisterContentBlockUploadParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -205,7 +225,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/ConfirmContentBlockUploadParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -224,7 +248,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/FinalizeManifestUploadParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionDecisionReturnValue'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':

--- a/src/OpenAPI/Storage.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Paths.OpenAPI.yaml
@@ -34,7 +34,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadUriParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UploadUriMap'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -53,7 +57,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/GetDownloadUriParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          text/plain:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -72,7 +80,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockUploadUriParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          text/plain:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -91,7 +103,11 @@
             $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockDownloadUriParameters'
     responses:
       '200':
-        $ref: './Responses.OpenAPI.yaml#/200'
+        description: OK
+        content:
+          text/plain:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':

--- a/src/OpenAPI/Storage.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Paths.OpenAPI.yaml
@@ -1,0 +1,231 @@
+/storage/getUploadMetadataForFiles:
+  post:
+    summary: Gets upload metadata for files.
+    description: Gets upload URLs and content-reference metadata for whole-file and manifest-backed uploads.
+    operationId: GetUploadMetadataForFiles
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadMetadataForFilesParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/getUploadUri:
+  post:
+    summary: Gets upload URIs for whole-file content.
+    description: Compatibility endpoint for uploading repository-scoped WholeFileContent.
+    operationId: GetUploadUri
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/GetUploadUriParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/getDownloadUri:
+  post:
+    summary: Gets a download URI for whole-file content.
+    description: Compatibility endpoint for downloading repository-scoped WholeFileContent.
+    operationId: GetDownloadUri
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/GetDownloadUriParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/getContentBlockUploadUri:
+  post:
+    summary: Gets an upload URI for a ContentBlock payload.
+    description: Gets an object-storage upload URI without probing whether the ContentBlock already exists.
+    operationId: GetContentBlockUploadUri
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockUploadUriParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/getContentBlockDownloadUri:
+  post:
+    summary: Gets a download URI for a ContentBlock payload.
+    description: Gets an object-storage download URI for an authorized manifest-backed reconstruction path.
+    operationId: GetContentBlockDownloadUri
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/GetContentBlockDownloadUriParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/discoverContentBlocks:
+  post:
+    summary: Discovers reusable ContentBlock candidates.
+    description: Returns bounded, non-authoritative candidate windows for key chunks; empty results do not prove absence.
+    operationId: DiscoverContentBlocks
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksParameters'
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'Storage.Components.OpenAPI.yaml#/DiscoverContentBlocksResult'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/startManifestUploadSession:
+  post:
+    summary: Starts a manifest upload session.
+    description: Starts the server-authoritative workflow for one manifest-backed file.
+    operationId: StartManifestUploadSession
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/StartManifestUploadSessionParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/issueDedupeDiscovery:
+  post:
+    summary: Issues upload-session dedupe discovery hints.
+    description: Records server-issued discovery hints for a started upload session before reuse claims.
+    operationId: IssueDedupeDiscovery
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/IssueDedupeDiscoveryParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/claimReuseRanges:
+  post:
+    summary: Claims reusable ContentBlock ranges.
+    description: Claims server-issued candidate ranges after authoritative ContentBlockMetadata validation.
+    operationId: ClaimReuseRanges
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/ClaimReuseRangesParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/registerContentBlockUpload:
+  post:
+    summary: Registers a ContentBlock upload intent.
+    description: Records the expected logical range and payload size before uploading a new ContentBlock.
+    operationId: RegisterContentBlockUpload
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/RegisterContentBlockUploadParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/confirmContentBlockUpload:
+  post:
+    summary: Confirms a ContentBlock upload.
+    description: Confirms object-storage placement for a ContentBlock that was uploaded for this manifest session.
+    operationId: ConfirmContentBlockUpload
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/ConfirmContentBlockUploadParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'
+
+/storage/finalizeManifestUpload:
+  post:
+    summary: Finalizes a manifest upload.
+    description: Finalizes the manifest after validating reconstruction, range claims, block presence, file hash, and size.
+    operationId: FinalizeManifestUpload
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: 'Storage.Components.OpenAPI.yaml#/FinalizeManifestUploadParameters'
+    responses:
+      '200':
+        $ref: './Responses.OpenAPI.yaml#/200'
+      '400':
+        $ref: './Responses.OpenAPI.yaml#/400'
+      '500':
+        $ref: './Responses.OpenAPI.yaml#/500'


### PR DESCRIPTION
## Summary

Completes the ADR-0001 final docs/OpenAPI audit slice for #107:

- updates README/CONTRIBUTING/ADR guidance for manifest-backed CAS, compaction, and current validation commands
- adds OpenAPI coverage for ADR storage and upload-session routes
- adds focused authorization/OpenAPI tests for the ADR storage route surface
- keeps nearby agent guidance aligned with the completed workflow

Closes #107.

## Validation

- `git diff --check origin/main...HEAD`: passed
- `npx --yes markdownlint-cli2 "README.md" "CONTRIBUTING.md" "AGENTS.md" "src/AGENTS.md" "docs/Development process.md" "docs/adr/0001-content-addressed-storage-contentblocks.md"`: passed, 0 errors
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release --filter "ManifestCoversAllRoutes|OpenApiCoversAdrStorageRoutes"`: passed, 2 tests

Skipped local full-repo markdownlint because the broader docs set currently has pre-existing markdownlint debt outside this issue's touched files. Skipped local `validate -Fast` / `validate -Full`; this docs/API audit slice is covered locally by focused markdownlint and route-coverage tests, and the PR validation workflow is the authoritative repo gate.

## Review Gate

Fresh local review-only sibling subagents were used for the completion gate. The final pass used `gpt-5.4-mini` with high reasoning and reported no actionable issues.

### Reviewed And OK

- Rechecked the prior OpenAPI contract fixes for `UploadSessionDecision`, `UploadSessionStartedEvent`, `FileManifest`, and `ContentBlock`; they line up with the live F# types.
- Checked the URI endpoint OpenAPI response shapes against server behavior; `getUploadUri` is documented as a JSON map and the remaining URI endpoints are documented as plain URI strings.
- Verified the ADR route coverage test guards the intended storage paths and the updated build/test command points at the existing `src/Grace.slnx` file.

## Docs Impact

This is the docs/API audit slice, so docs and OpenAPI updates are the primary deliverable. No runtime code paths are changed.

## Residual Risk

OpenAPI is still hand-maintained YAML, so future route or DTO changes can drift without keeping the focused route-coverage tests current.
