### PR TITLE
[Webhooks/Approvals] Add domain contracts and ADR 0002

### DIFF
--- a/docs/adr/0002-durable-approval-requests.md
+++ b/docs/adr/0002-durable-approval-requests.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+date: 2026-06-02
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Use durable ApprovalRequest state for gated transitions
+
+Grace will model approvals as durable `ApprovalRequest` state transitions created by Grace workflows. Webhooks remain
+post-event notifications, and validation results remain evidence records. Neither synchronous webhook responses nor
+generic validation-result records are approval authority.
+
+## Context
+
+Grace is adding webhooks and approvals to support automation around sensitive workflows such as `promotion-set.apply`.
+The product invariant is:
+
+> Webhooks observe committed facts. Approval policies gate proposed transitions. Approval requests are runtime
+> decisions.
+
+The first protected workflow is promotion set apply. A matching approval policy can require a responder before the apply
+transition commits. That decision must be scoped to the repository, target branch, promotion set, steps computation
+attempt, approval policy id, and approval policy version so an approval for stale work cannot authorize newer work.
+
+Grace already has automation events and validation result records. Those are useful adjacent concepts, but they do not
+represent a server-created pending decision that survives retries, process restarts, responder authorization checks, and
+terminal state transitions.
+
+## Decision
+
+Grace will create or find a durable `ApprovalRequest` when a protected workflow reaches an approval gate and no valid
+approval already exists for the exact current scope. The request owns the runtime decision state:
+
+- `Pending`
+- `Approved`
+- `Rejected`
+- `Expired`
+- `Cancelled`
+- `Superseded`
+
+Approval responses are state transitions on the stored request. The responder must be authorized against the stored
+scope and must match the request's stored responder selector. Duplicate identical responses can be idempotent, while
+conflicting responses are rejected.
+
+Promotion sets do not gain a `PendingApproval` status. List and show surfaces can expose a derived promotion set
+approval summary sourced from approval request state.
+
+## Rejected Alternatives
+
+### Synchronous webhook responses
+
+Grace will not block a workflow while waiting for a webhook receiver to return approval. A webhook is a post-event
+outbound notification rule. Letting a receiver synchronously approve a proposed transition would mix notification
+delivery with workflow authority, make retries ambiguous, and make approval state depend on a transient HTTP exchange.
+
+### Generic validation result records
+
+Grace will not treat generic validation-result records as approval authority. Validation results can provide evidence,
+but they do not prove Grace created a pending request, selected the responder, captured the protected scope, or enforced
+terminal approval transitions.
+
+### PromotionSetStatus.PendingApproval
+
+Grace will not encode pending approval as a promotion set status. Pending approval is derived from approval request
+state for the current apply scope. Keeping that state separate prevents stale approvals and avoids confusing readiness
+of the promotion set with readiness of a particular apply attempt.
+
+## Consequences
+
+This decision gives Grace a durable and auditable approval boundary:
+
+- Approval decisions survive restarts and retries.
+- Approval scope can include a steps computation attempt and policy version.
+- Authorization uses the stored request scope instead of trusting response body data.
+- Webhook delivery can fail or retry without changing source workflow state.
+- Validation evidence can remain separate while future slices may link it to approval requests explicitly.
+
+The cost is a dedicated approval request lifecycle and persistence model. Future implementation slices must add server,
+authorization, actor, SDK, and CLI behavior around these contracts before the feature is complete.

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Automation.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />
+    <Compile Include="Webhooks.Types.Tests.fs" />
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Types.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />

--- a/src/Grace.Types.Tests/Webhooks.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Webhooks.Types.Tests.fs
@@ -191,6 +191,12 @@ type ExternalWebhookEventRegistryTests() =
         )
 
     [<Test>]
+    member _.RegistryHasUniqueCanonicalSources() =
+        match validateUniqueCanonicalSources All with
+        | Ok () -> Assert.Pass()
+        | Error errorText -> Assert.Fail(errorText)
+
+    [<Test>]
     member _.RegistryRejectsDuplicateCanonicalSources() =
         let duplicate = { promotionSetApplied with Name = "promotion-set.applied.copy" }
 

--- a/src/Grace.Types.Tests/Webhooks.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Webhooks.Types.Tests.fs
@@ -1,0 +1,219 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.ExternalWebhookEventRegistry
+open Grace.Types.PromotionSet
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open NodaTime
+open NUnit.Framework
+open System
+
+module WebhookContractTestHelpers =
+
+    let assertRoundTrips<'T when 'T: equality> (value: 'T) =
+        let json = Utilities.serialize value
+        let deserialized = Utilities.deserialize<'T> json
+
+        Assert.That(deserialized, Is.EqualTo(value))
+
+[<Parallelizable(ParallelScope.All)>]
+type WebhookContractSerializationTests() =
+
+    let instant = Instant.FromUtc(2026, 6, 2, 12, 0)
+
+    let scope =
+        {
+            OwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            OrganizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            RepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            TargetBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            PromotionSetId = Some(Guid.Parse("55555555-5555-5555-5555-555555555555"))
+            StepsComputationAttempt = Some 7
+            ApprovalPolicyId = Some(Guid.Parse("66666666-6666-6666-6666-666666666666"))
+            ApprovalPolicyVersion = Some 3
+        }
+
+    [<Test>]
+    member _.WebhookRuleRoundTripsSerialization() =
+        let rule =
+            { WebhookRule.Default with
+                WebhookRuleId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                Name = "notify-release-system"
+                EventName = PromotionSetAppliedName
+                EventVersion = 1
+                Scope =
+                    {
+                        OwnerId = scope.OwnerId
+                        OrganizationId = scope.OrganizationId
+                        RepositoryId = scope.RepositoryId
+                        TargetBranchId = Some scope.TargetBranchId
+                    }
+                Url = { Url = "https://release.example.com/grace"; Safety = OutboundUrlSafety.PublicHttps }
+                SigningSecretVersion = "secret-v1"
+                Status = WebhookRuleStatus.Enabled
+                CreatedBy = "release-admin"
+                CreatedAt = instant
+            }
+
+        WebhookContractTestHelpers.assertRoundTrips rule
+
+    [<Test>]
+    member _.WebhookDeliveryRoundTripsSerialization() =
+        let delivery =
+            { WebhookDelivery.Default with
+                WebhookDeliveryId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+                WebhookRuleId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                EventName = PromotionSetAppliedName
+                DedupeKey = "promotion-set.applied:v1:33333333:44444444:55555555:99999999"
+                Status = WebhookDeliveryStatus.RetryScheduled
+                AttemptCount = 2
+                LastAttemptAt = Some instant
+                NextAttemptAt = Some(instant + Duration.FromMinutes(5.0))
+                LastStatusCode = Some 503
+                LastError = Some "Service unavailable."
+                CreatedAt = instant
+            }
+
+        WebhookContractTestHelpers.assertRoundTrips delivery
+
+    [<Test>]
+    member _.ApprovalPolicyRoundTripsSerialization() =
+        let policy =
+            { ApprovalPolicy.Default with
+                ApprovalPolicyId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+                Version = 3
+                Name = "require-approval-responder-for-main"
+                Subject = "promotion-set.apply"
+                Scope = scope
+                RequiredResponder = "role:ApprovalResponder"
+                NotificationUrl = Some { Url = "https://release.example.com/approval-requested"; Safety = OutboundUrlSafety.PublicHttps }
+                TimeoutSeconds = Some 14400
+                OnTimeout = ApprovalTimeoutAction.Reject
+                Status = ApprovalPolicyStatus.Enabled
+                CreatedBy = "release-admin"
+                CreatedAt = instant
+            }
+
+        WebhookContractTestHelpers.assertRoundTrips policy
+
+    [<Test>]
+    member _.ApprovalRequestRoundTripsSerialization() =
+        let request =
+            { ApprovalRequest.Default with
+                ApprovalRequestId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+                ApprovalPolicyId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+                ApprovalPolicyVersion = 3
+                Subject = "promotion-set.apply"
+                Scope = scope
+                RequiredResponder = "role:ApprovalResponder"
+                Status = ApprovalRequestStatus.Approved
+                Decision =
+                    Some
+                        {
+                            Decision = ApprovalDecision.Approve
+                            DecidedBy = "approver-1"
+                            DecidedAt = instant
+                            Reason = Some "Reviewed release candidate and validation evidence."
+                            ClientDecisionId = "decision-123"
+                        }
+                CreatedBy = "developer-1"
+                CreatedAt = instant - Duration.FromMinutes(30.0)
+                UpdatedAt = Some instant
+            }
+
+        WebhookContractTestHelpers.assertRoundTrips request
+
+    [<Test>]
+    member _.ApprovalNotificationDeliveryRoundTripsSerializationWithoutBecomingWebhookDelivery() =
+        let delivery =
+            { ApprovalNotificationDelivery.Default with
+                ApprovalNotificationDeliveryId = Guid.Parse("88888888-8888-8888-8888-888888888888")
+                ApprovalRequestId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+                ApprovalPolicyId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+                Url = { Url = "http://localhost:8080/approval"; Safety = OutboundUrlSafety.LocalUnsafeDevOnly }
+                Status = ApprovalNotificationDeliveryStatus.Pending
+                CreatedAt = instant
+            }
+
+        let json = Utilities.serialize delivery
+        let deserialized = Utilities.deserialize<ApprovalNotificationDelivery> json
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(deserialized, Is.EqualTo(delivery))
+                Assert.That(deserialized.Class, Is.EqualTo(nameof ApprovalNotificationDelivery))
+                Assert.That(deserialized.Class, Is.Not.EqualTo(nameof WebhookDelivery)))
+        )
+
+    [<Test>]
+    member _.PromotionSetApprovalSummaryRoundTripsSerialization() =
+        let summary =
+            { PromotionSetApprovalSummary.NotRequired scope.PromotionSetId.Value scope.TargetBranchId 7 with
+                State = PromotionSetApprovalState.Pending
+                ApprovalRequestId = Some(Guid.Parse("77777777-7777-7777-7777-777777777777"))
+                ApprovalPolicyId = Some(Guid.Parse("66666666-6666-6666-6666-666666666666"))
+                RequiredResponder = Some "role:ApprovalResponder"
+                Reason = Some "Approval required before apply."
+            }
+
+        WebhookContractTestHelpers.assertRoundTrips summary
+
+[<Parallelizable(ParallelScope.All)>]
+type ExternalWebhookEventRegistryTests() =
+
+    [<Test>]
+    member _.PromotionSetAppliedParsesAsCanonicalExternalEvent() =
+        let parsed = parse "promotion-set.applied"
+
+        match parsed with
+        | Ok definition ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(definition.Name, Is.EqualTo(PromotionSetAppliedName))
+                    Assert.That(definition.Version, Is.EqualTo(1))
+
+                    Assert.That(definition.CanonicalSource, Is.EqualTo(ExternalWebhookEventSource.PromotionSetApplied))
+
+                    Assert.That(definition.DedupeKeyShape.Version, Is.EqualTo(1))
+                    Assert.That(definition.DedupeKeyShape.EventFields, Does.Contain("terminalPromotionReferenceId")))
+            )
+        | Error errorText -> Assert.Fail(errorText)
+
+    [<Test>]
+    member _.EventNameParsingIsStableAndCaseSensitive() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That((tryParse "promotion-set.applied").IsSome, Is.True)
+                Assert.That((tryParse " Promotion-Set.Applied ").IsNone, Is.True)
+                Assert.That((tryParse "PromotionSetApplied").IsNone, Is.True)
+                Assert.That((tryParse "").IsNone, Is.True))
+        )
+
+    [<Test>]
+    member _.RegistryRejectsDuplicateCanonicalSources() =
+        let duplicate = { promotionSetApplied with Name = "promotion-set.applied.copy" }
+
+        let result =
+            validateUniqueCanonicalSources [ promotionSetApplied
+                                             duplicate ]
+
+        match result with
+        | Ok () -> Assert.Fail("Duplicate canonical sources should be rejected.")
+        | Error errorText -> Assert.That(errorText, Does.Contain("duplicate canonical sources"))
+
+    [<Test>]
+    member _.PromotionSetAppliedDoesNotUseTerminalPromotionReferenceAsIndependentSource() =
+        let sources =
+            All
+            |> List.filter (fun definition -> definition.Name = PromotionSetAppliedName)
+            |> List.map (fun definition -> definition.CanonicalSource)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(sources.Length, Is.EqualTo(1))
+
+                Assert.That(sources[0], Is.EqualTo(ExternalWebhookEventSource.PromotionSetApplied))
+
+                Assert.That(sources, Does.Not.Contain(ExternalWebhookEventSource.TerminalPromotionReferenceCreated)))
+        )

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -30,6 +30,7 @@
         <Compile Include="Branch.Types.fs" />
         
         <Compile Include="PromotionSet.Types.fs" />
+        <Compile Include="Webhooks.Types.fs" />
         <Compile Include="WorkItem.Types.fs" />
         <Compile Include="Policy.Types.fs" />
         <Compile Include="RequiredAction.Types.fs" />

--- a/src/Grace.Types/Webhooks.Types.fs
+++ b/src/Grace.Types/Webhooks.Types.fs
@@ -1,0 +1,487 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open NodaTime
+open Orleans
+open System
+open System.Runtime.Serialization
+
+module Webhooks =
+
+    type WebhookRuleId = Guid
+    type WebhookDeliveryId = Guid
+    type ApprovalPolicyId = Guid
+    type ApprovalRequestId = Guid
+    type ApprovalNotificationDeliveryId = Guid
+    type ExternalWebhookEventName = string
+    type ExternalWebhookEventVersion = int
+    type ExternalWebhookDedupeKey = string
+    type WebhookSigningSecretVersion = string
+    type ApprovalPolicyVersion = int
+    type ApprovalSubject = string
+    type ApprovalResponderSelector = string
+    type ApprovalClientDecisionId = string
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type OutboundUrlSafety =
+        | PublicHttps
+        | LocalUnsafeDevOnly
+
+        static member GetKnownTypes() = GetKnownTypes<OutboundUrlSafety>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type WebhookRuleStatus =
+        | Enabled
+        | Disabled
+        | Deleted
+
+        static member GetKnownTypes() = GetKnownTypes<WebhookRuleStatus>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type WebhookDeliveryStatus =
+        | Pending
+        | Succeeded
+        | RetryScheduled
+        | Failed
+        | DeadLettered
+
+        static member GetKnownTypes() = GetKnownTypes<WebhookDeliveryStatus>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalPolicyStatus =
+        | Enabled
+        | Disabled
+        | Deleted
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalPolicyStatus>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalRequestStatus =
+        | Pending
+        | Approved
+        | Rejected
+        | Expired
+        | Cancelled
+        | Superseded
+
+        member this.IsTerminal =
+            match this with
+            | Pending -> false
+            | Approved
+            | Rejected
+            | Expired
+            | Cancelled
+            | Superseded -> true
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalRequestStatus>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalDecision =
+        | Approve
+        | Reject
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalDecision>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalTimeoutAction =
+        | Reject
+        | Expire
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalTimeoutAction>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalNotificationDeliveryStatus =
+        | Pending
+        | Succeeded
+        | RetryScheduled
+        | Failed
+        | DeadLettered
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalNotificationDeliveryStatus>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type PromotionSetApprovalState =
+        | NotRequired
+        | Pending
+        | Approved
+        | Rejected
+        | Expired
+        | Stale
+
+        static member GetKnownTypes() = GetKnownTypes<PromotionSetApprovalState>()
+
+    [<CLIMutable; GenerateSerializer>]
+    type ExternalWebhookEventSource =
+        {
+            SourceFamily: string
+            SourceCase: string
+        }
+
+        static member PromotionSetApplied =
+            { SourceFamily = nameof PromotionSet.PromotionSetEventType; SourceCase = nameof PromotionSet.PromotionSetEventType.Applied }
+
+        static member TerminalPromotionReferenceCreated = { SourceFamily = "TerminalPromotionReference"; SourceCase = "Created" }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ScopedOutboundUrl =
+        {
+            Url: string
+            Safety: OutboundUrlSafety
+        }
+
+        static member Default = { Url = String.Empty; Safety = OutboundUrlSafety.PublicHttps }
+
+    [<CLIMutable; GenerateSerializer>]
+    type WebhookScope =
+        {
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            TargetBranchId: BranchId option
+        }
+
+        static member Default = { OwnerId = OwnerId.Empty; OrganizationId = OrganizationId.Empty; RepositoryId = RepositoryId.Empty; TargetBranchId = None }
+
+    [<CLIMutable; GenerateSerializer>]
+    type WebhookRetryPolicy =
+        {
+            MaxAttempts: int
+            InitialDelaySeconds: int
+            MaxDelaySeconds: int
+        }
+
+        static member Default = { MaxAttempts = 8; InitialDelaySeconds = 30; MaxDelaySeconds = 3600 }
+
+    [<CLIMutable; GenerateSerializer>]
+    type WebhookRule =
+        {
+            Class: string
+            WebhookRuleId: WebhookRuleId
+            Name: string
+            EventName: ExternalWebhookEventName
+            EventVersion: ExternalWebhookEventVersion
+            Scope: WebhookScope
+            Url: ScopedOutboundUrl
+            SigningSecretVersion: WebhookSigningSecretVersion
+            RetryPolicy: WebhookRetryPolicy
+            Status: WebhookRuleStatus
+            CreatedBy: UserId
+            CreatedAt: Instant
+            UpdatedAt: Instant option
+        }
+
+        static member Default =
+            {
+                Class = nameof WebhookRule
+                WebhookRuleId = WebhookRuleId.Empty
+                Name = String.Empty
+                EventName = String.Empty
+                EventVersion = 1
+                Scope = WebhookScope.Default
+                Url = ScopedOutboundUrl.Default
+                SigningSecretVersion = String.Empty
+                RetryPolicy = WebhookRetryPolicy.Default
+                Status = WebhookRuleStatus.Disabled
+                CreatedBy = UserId String.Empty
+                CreatedAt = Constants.DefaultTimestamp
+                UpdatedAt = None
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type WebhookDelivery =
+        {
+            Class: string
+            WebhookDeliveryId: WebhookDeliveryId
+            WebhookRuleId: WebhookRuleId
+            EventName: ExternalWebhookEventName
+            EventVersion: ExternalWebhookEventVersion
+            DedupeKey: ExternalWebhookDedupeKey
+            Status: WebhookDeliveryStatus
+            AttemptCount: int
+            LastAttemptAt: Instant option
+            NextAttemptAt: Instant option
+            LastStatusCode: int option
+            LastError: string option
+            CreatedAt: Instant
+        }
+
+        static member Default =
+            {
+                Class = nameof WebhookDelivery
+                WebhookDeliveryId = WebhookDeliveryId.Empty
+                WebhookRuleId = WebhookRuleId.Empty
+                EventName = String.Empty
+                EventVersion = 1
+                DedupeKey = String.Empty
+                Status = WebhookDeliveryStatus.Pending
+                AttemptCount = 0
+                LastAttemptAt = None
+                NextAttemptAt = None
+                LastStatusCode = None
+                LastError = None
+                CreatedAt = Constants.DefaultTimestamp
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalScope =
+        {
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            TargetBranchId: BranchId
+            PromotionSetId: PromotionSetId option
+            StepsComputationAttempt: int option
+            ApprovalPolicyId: ApprovalPolicyId option
+            ApprovalPolicyVersion: ApprovalPolicyVersion option
+        }
+
+        static member Default =
+            {
+                OwnerId = OwnerId.Empty
+                OrganizationId = OrganizationId.Empty
+                RepositoryId = RepositoryId.Empty
+                TargetBranchId = BranchId.Empty
+                PromotionSetId = None
+                StepsComputationAttempt = None
+                ApprovalPolicyId = None
+                ApprovalPolicyVersion = None
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalPolicy =
+        {
+            Class: string
+            ApprovalPolicyId: ApprovalPolicyId
+            Version: ApprovalPolicyVersion
+            Name: string
+            Subject: ApprovalSubject
+            Scope: ApprovalScope
+            RequiredResponder: ApprovalResponderSelector
+            NotificationUrl: ScopedOutboundUrl option
+            TimeoutSeconds: int option
+            OnTimeout: ApprovalTimeoutAction
+            Status: ApprovalPolicyStatus
+            CreatedBy: UserId
+            CreatedAt: Instant
+            UpdatedAt: Instant option
+        }
+
+        static member Default =
+            {
+                Class = nameof ApprovalPolicy
+                ApprovalPolicyId = ApprovalPolicyId.Empty
+                Version = 1
+                Name = String.Empty
+                Subject = String.Empty
+                Scope = ApprovalScope.Default
+                RequiredResponder = String.Empty
+                NotificationUrl = None
+                TimeoutSeconds = None
+                OnTimeout = ApprovalTimeoutAction.Reject
+                Status = ApprovalPolicyStatus.Disabled
+                CreatedBy = UserId String.Empty
+                CreatedAt = Constants.DefaultTimestamp
+                UpdatedAt = None
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalRequestDecision =
+        {
+            Decision: ApprovalDecision
+            DecidedBy: UserId
+            DecidedAt: Instant
+            Reason: string option
+            ClientDecisionId: ApprovalClientDecisionId
+        }
+
+        static member Default =
+            {
+                Decision = ApprovalDecision.Approve
+                DecidedBy = UserId String.Empty
+                DecidedAt = Constants.DefaultTimestamp
+                Reason = None
+                ClientDecisionId = String.Empty
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalRequest =
+        {
+            Class: string
+            ApprovalRequestId: ApprovalRequestId
+            ApprovalPolicyId: ApprovalPolicyId
+            ApprovalPolicyVersion: ApprovalPolicyVersion
+            Subject: ApprovalSubject
+            Scope: ApprovalScope
+            RequiredResponder: ApprovalResponderSelector
+            Status: ApprovalRequestStatus
+            Decision: ApprovalRequestDecision option
+            CreatedBy: UserId
+            CreatedAt: Instant
+            ExpiresAt: Instant option
+            UpdatedAt: Instant option
+            SupersededByApprovalRequestId: ApprovalRequestId option
+        }
+
+        static member Default =
+            {
+                Class = nameof ApprovalRequest
+                ApprovalRequestId = ApprovalRequestId.Empty
+                ApprovalPolicyId = ApprovalPolicyId.Empty
+                ApprovalPolicyVersion = 1
+                Subject = String.Empty
+                Scope = ApprovalScope.Default
+                RequiredResponder = String.Empty
+                Status = ApprovalRequestStatus.Pending
+                Decision = None
+                CreatedBy = UserId String.Empty
+                CreatedAt = Constants.DefaultTimestamp
+                ExpiresAt = None
+                UpdatedAt = None
+                SupersededByApprovalRequestId = None
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalNotificationDelivery =
+        {
+            Class: string
+            ApprovalNotificationDeliveryId: ApprovalNotificationDeliveryId
+            ApprovalRequestId: ApprovalRequestId
+            ApprovalPolicyId: ApprovalPolicyId
+            Url: ScopedOutboundUrl
+            Status: ApprovalNotificationDeliveryStatus
+            AttemptCount: int
+            LastAttemptAt: Instant option
+            NextAttemptAt: Instant option
+            LastStatusCode: int option
+            LastError: string option
+            CreatedAt: Instant
+        }
+
+        static member Default =
+            {
+                Class = nameof ApprovalNotificationDelivery
+                ApprovalNotificationDeliveryId = ApprovalNotificationDeliveryId.Empty
+                ApprovalRequestId = ApprovalRequestId.Empty
+                ApprovalPolicyId = ApprovalPolicyId.Empty
+                Url = ScopedOutboundUrl.Default
+                Status = ApprovalNotificationDeliveryStatus.Pending
+                AttemptCount = 0
+                LastAttemptAt = None
+                NextAttemptAt = None
+                LastStatusCode = None
+                LastError = None
+                CreatedAt = Constants.DefaultTimestamp
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type PromotionSetApprovalSummary =
+        {
+            Class: string
+            PromotionSetId: PromotionSetId
+            TargetBranchId: BranchId
+            StepsComputationAttempt: int
+            State: PromotionSetApprovalState
+            ApprovalRequestId: ApprovalRequestId option
+            ApprovalPolicyId: ApprovalPolicyId option
+            RequiredResponder: ApprovalResponderSelector option
+            LastDecisionAt: Instant option
+            Reason: string option
+        }
+
+        static member NotRequired promotionSetId targetBranchId stepsComputationAttempt =
+            {
+                Class = nameof PromotionSetApprovalSummary
+                PromotionSetId = promotionSetId
+                TargetBranchId = targetBranchId
+                StepsComputationAttempt = stepsComputationAttempt
+                State = PromotionSetApprovalState.NotRequired
+                ApprovalRequestId = None
+                ApprovalPolicyId = None
+                RequiredResponder = None
+                LastDecisionAt = None
+                Reason = None
+            }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ExternalWebhookDedupeKeyShape = { Version: ExternalWebhookEventVersion; ScopeFields: string list; EventFields: string list }
+
+    [<CLIMutable; GenerateSerializer>]
+    type ExternalWebhookEventDefinition =
+        {
+            Name: ExternalWebhookEventName
+            Version: ExternalWebhookEventVersion
+            CanonicalSource: ExternalWebhookEventSource
+            DedupeKeyShape: ExternalWebhookDedupeKeyShape
+        }
+
+module ExternalWebhookEventRegistry =
+
+    open Webhooks
+
+    [<Literal>]
+    let PromotionSetAppliedName = "promotion-set.applied"
+
+    let promotionSetApplied =
+        {
+            Name = PromotionSetAppliedName
+            Version = 1
+            CanonicalSource = ExternalWebhookEventSource.PromotionSetApplied
+            DedupeKeyShape =
+                {
+                    Version = 1
+                    ScopeFields =
+                        [
+                            "ownerId"
+                            "organizationId"
+                            "repositoryId"
+                            "targetBranchId"
+                            "promotionSetId"
+                        ]
+                    EventFields = [ "terminalPromotionReferenceId" ]
+                }
+        }
+
+    let All = [ promotionSetApplied ]
+
+    let tryParse (eventName: string) =
+        if String.IsNullOrWhiteSpace eventName then
+            None
+        else
+            All
+            |> List.tryFind (fun definition -> String.Equals(definition.Name, eventName.Trim(), StringComparison.Ordinal))
+
+    let parse eventName =
+        match tryParse eventName with
+        | Some definition -> Ok definition
+        | None -> Error $"Unknown external webhook event '{eventName}'."
+
+    let validateUniqueCanonicalSources definitions =
+        let duplicates =
+            definitions
+            |> Seq.groupBy (fun definition -> definition.CanonicalSource)
+            |> Seq.choose (fun (source, entries) ->
+                let entries = entries |> Seq.toList
+
+                if entries.Length > 1 then
+                    Some(
+                        source,
+                        entries
+                        |> List.map (fun definition -> definition.Name)
+                    )
+                else
+                    None)
+            |> Seq.toList
+
+        if duplicates.IsEmpty then
+            Ok()
+        else
+            let duplicateText =
+                duplicates
+                |> List.map (fun (source, names) ->
+                    let joinedNames = String.Join(", ", names)
+                    $"{source}: {joinedNames}")
+                |> String.concat "; "
+
+            Error $"External webhook event registry contains duplicate canonical sources: {duplicateText}."

--- a/src/Grace.Types/Webhooks.Types.fs
+++ b/src/Grace.Types/Webhooks.Types.fs
@@ -443,20 +443,6 @@ module ExternalWebhookEventRegistry =
                 }
         }
 
-    let All = [ promotionSetApplied ]
-
-    let tryParse (eventName: string) =
-        if String.IsNullOrWhiteSpace eventName then
-            None
-        else
-            All
-            |> List.tryFind (fun definition -> String.Equals(definition.Name, eventName.Trim(), StringComparison.Ordinal))
-
-    let parse eventName =
-        match tryParse eventName with
-        | Some definition -> Ok definition
-        | None -> Error $"Unknown external webhook event '{eventName}'."
-
     let validateUniqueCanonicalSources definitions =
         let duplicates =
             definitions
@@ -485,3 +471,22 @@ module ExternalWebhookEventRegistry =
                 |> String.concat "; "
 
             Error $"External webhook event registry contains duplicate canonical sources: {duplicateText}."
+
+    let private registryDefinitions = [ promotionSetApplied ]
+
+    let All =
+        match validateUniqueCanonicalSources registryDefinitions with
+        | Ok () -> registryDefinitions
+        | Error errorText -> failwith errorText
+
+    let tryParse (eventName: string) =
+        if String.IsNullOrWhiteSpace eventName then
+            None
+        else
+            All
+            |> List.tryFind (fun definition -> String.Equals(definition.Name, eventName.Trim(), StringComparison.Ordinal))
+
+    let parse eventName =
+        match tryParse eventName with
+        | Some definition -> Ok definition
+        | None -> Error $"Unknown external webhook event '{eventName}'."


### PR DESCRIPTION
## Summary

- Adds the shared webhook and approval domain contracts for the epic noun model.
- Adds the external webhook event registry with `promotion-set.applied` mapped to `PromotionSetEventType.Applied`.
- Adds ADR 0002 for durable approval requests instead of synchronous webhook responses or validation-result records.

## Linked Issue

Closes #144.
Part of #142.

## Touched Paths

- `src/Grace.Types/**`
- `src/Grace.Types.Tests/**`
- `docs/adr/0002-durable-approval-requests.md`

## Product Noun Evidence

- `webhook` is modeled as a post-event notification rule with an inline URL and delivery state.
- `approval policy` is modeled as a pre-transition gate configuration.
- `approval request` is modeled as durable runtime decision state generated by Grace.
- No user-facing `hook`, `subscription`, `notification rule`, reusable destination, or generic approval request creation surface was added.

## Validation

- `dotnet tool run fantomas --recurse .` from `src`: passed; unrelated formatter spillover was restored before commit.
- `dotnet build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed, 0 warnings, 0 errors.
- `dotnet test --no-build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed, 62 passed.
- `npx --yes markdownlint-cli2 "docs/adr/0002-durable-approval-requests.md"`: passed, 0 errors.
- `git diff --check origin/main..HEAD`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build 0 warnings/errors; Authorization 22/22; CLI 222/223 with 1 existing skipped; Types 62/62.

## Review Path

- Implementation worker: Planck, GPT-5.5 low.
- Review-only sibling: Laplace, GPT-5.4-mini xhigh, reported one actionable duplicate-source guard issue.
- Review-fix worker: Avicenna, GPT-5.5 low, fixed the issue in `3a64b2e`.
- Final review-only sibling: Franklin, GPT-5.4-mini xhigh, reported no actionable issues.
- Dedicated Code Review capability was not directly exposed in the local subagent launcher, so the review-only siblings were fresh subagents explicitly instructed to review only and not edit files.

## Final Reviewed And OK

- `ExternalWebhookEventRegistry.All` now validates its own registry definitions before exposure.
- The registry exposes `promotion-set.applied` with canonical source `PromotionSetEventType.Applied`.
- ADR 0002 separates durable approval requests from synchronous webhook responses and generic validation-result records.

## Docs Impact

Added ADR 0002. No README, server, actor, CLI, SDK, or workflow docs changed in this contract slice.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not touch Aspire integration behavior,
  emulators, storage, Service Bus, Cosmos DB, Redis, deployment/runtime behavior, or cross-service integration.

## Residual Risk

Downstream API, actor, webhook delivery, CLI, and docs slices still need to consume these contracts and prove runtime behavior.
