### PR TITLE
[Webhooks/Approvals] Add approval API surface

### DIFF
--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -104,6 +104,40 @@ type AuthorizationSemanticsTests() =
         Assert.That(repoAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
 
     [<Test>]
+    member _.ApprovalOperationsUseConservativeRoleGrants() =
+        let repoAdmin =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+
+        let repoReader =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("RepoReader", StringComparison.OrdinalIgnoreCase))
+
+        let repoContributor =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("RepoContributor", StringComparison.OrdinalIgnoreCase))
+
+        let responder =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase))
+
+        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
+        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+        Assert.That(repoAdmin.AllowedOperations.Contains WebhookManage, Is.True)
+        Assert.That(repoAdmin.AllowedOperations.Contains WebhookDeliveryRead, Is.True)
+
+        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+        Assert.That(repoContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+
+        Assert.That(responder.AppliesTo.Contains("repository"), Is.True)
+        Assert.That(responder.AppliesTo.Contains("branch"), Is.True)
+        Assert.That(responder.AllowedOperations.Count, Is.EqualTo(2))
+        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+
+    [<Test>]
     member _.IrrelevantAssignmentsDoNotAffectDecision() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)

--- a/src/Grace.SDK/Approval.SDK.fs
+++ b/src/Grace.SDK/Approval.SDK.fs
@@ -1,0 +1,62 @@
+namespace Grace.SDK
+
+open Grace.SDK.Common
+open Grace.Shared.Parameters.Approval
+open Grace.Types.Webhooks
+open System.Collections.Generic
+
+/// The ApprovalPolicy module provides approval policy lifecycle helpers.
+type ApprovalPolicy() =
+    /// Creates an approval policy.
+    static member public Create(parameters: CreateApprovalPolicyParameters) =
+        postServer<CreateApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/create")
+
+    /// Lists approval policies for a repository or branch scope.
+    static member public List(parameters: ListApprovalPoliciesParameters) =
+        postServer<ListApprovalPoliciesParameters, IReadOnlyList<ApprovalPolicy>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/list")
+
+    /// Shows a single approval policy.
+    static member public Show(parameters: ShowApprovalPolicyParameters) =
+        postServer<ShowApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/show")
+
+    /// Updates an approval policy and increments its version.
+    static member public Update(parameters: UpdateApprovalPolicyParameters) =
+        postServer<UpdateApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/update")
+
+    /// Enables an approval policy.
+    static member public Enable(parameters: EnableApprovalPolicyParameters) =
+        postServer<EnableApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/enable")
+
+    /// Disables an approval policy.
+    static member public Disable(parameters: DisableApprovalPolicyParameters) =
+        postServer<DisableApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/disable")
+
+    /// Deletes an approval policy.
+    static member public Delete(parameters: DeleteApprovalPolicyParameters) =
+        postServer<DeleteApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/delete")
+
+    /// Evaluates enabled approval policies for a subject.
+    static member public Evaluate(parameters: EvaluateApprovalPolicyParameters) =
+        postServer<EvaluateApprovalPolicyParameters, IReadOnlyList<ApprovalPolicy>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/evaluate")
+
+/// The ApprovalRequest module provides read and response helpers for workflow-generated approval requests.
+type ApprovalRequest() =
+    /// Lists approval requests for a repository or branch scope.
+    static member public List(parameters: ListApprovalRequestsParameters) =
+        postServer<ListApprovalRequestsParameters, IReadOnlyList<ApprovalRequest>> (parameters |> ensureCorrelationIdIsSet, "approval/request/list")
+
+    /// Shows a workflow-generated approval request.
+    static member public Show(parameters: ShowApprovalRequestParameters) =
+        postServer<ShowApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/show")
+
+    /// Approves a workflow-generated approval request.
+    static member public Approve(parameters: ApproveApprovalRequestParameters) =
+        postServer<ApproveApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/approve")
+
+    /// Rejects a workflow-generated approval request.
+    static member public Reject(parameters: RejectApprovalRequestParameters) =
+        postServer<RejectApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/reject")
+
+    /// Gets approval request history.
+    static member public History(parameters: ApprovalRequestHistoryParameters) =
+        postServer<ApprovalRequestHistoryParameters, IReadOnlyList<ApprovalRequest>> (parameters |> ensureCorrelationIdIsSet, "approval/request/history")

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -35,6 +35,7 @@
                 <Compile Include="WorkItem.SDK.fs" />
                 <Compile Include="Policy.SDK.fs" />
                 <Compile Include="PromotionSet.SDK.fs" />
+                <Compile Include="Approval.SDK.fs" />
                 <Compile Include="Review.SDK.fs" />
                 <Compile Include="Queue.SDK.fs" />
                 <Compile Include="ValidationSet.SDK.fs" />

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -79,6 +79,30 @@ module private ApprovalTestHelpers =
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
 
+    let updatePolicyParameters (repositoryId: string) (branchId: string) (policyId: string) =
+        let parameters = createPolicyParameters repositoryId branchId
+        parameters.ApprovalPolicyId <- policyId
+        parameters.Name <- $"updated-{Guid.NewGuid():N}"
+        parameters
+
+    let listPolicyParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Approval.ListApprovalPoliciesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let listRequestParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Approval.ListApprovalRequestsParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
     let requestParameters<'T when 'T :> Parameters.Approval.ApprovalRequestParameters and 'T: (new: unit -> 'T)>
         (repositoryId: string)
         (branchId: string)
@@ -117,6 +141,14 @@ module private ApprovalTestHelpers =
         |> ignore
 
         requestId.ToString()
+
+    let createPolicyAsync (client: HttpClient) repositoryId branchId =
+        task {
+            let! createResponse = client.PostAsync("/approval/policy/create", createJsonContent (createPolicyParameters repositoryId branchId))
+
+            Assert.That(createResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            return! deserializeContent<ApprovalPolicy> createResponse
+        }
 
 [<NonParallelizable>]
 type ApprovalApiIntegrationTests() =
@@ -169,6 +201,129 @@ type ApprovalApiIntegrationTests() =
             use client = ApprovalTestHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
             let! response = client.PostAsync("/approval/request/create", createJsonContent (obj ()))
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
+        }
+
+    [<Test>]
+    member _.PolicyListReturnsOnlyRequestedAuthorizedScope() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = $"{Guid.NewGuid()}"
+            let otherBranchId = $"{Guid.NewGuid()}"
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let! allowedPolicy = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId allowedBranchId
+            let! otherPolicy = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId otherBranchId
+
+            let! listResponse =
+                adminClient.PostAsync("/approval/policy/list", createJsonContent (ApprovalTestHelpers.listPolicyParameters repositoryId allowedBranchId))
+
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! policies = deserializeContent<ApprovalPolicy array> listResponse
+
+            Assert.That(
+                policies
+                |> Array.map (fun policy -> policy.ApprovalPolicyId),
+                Is.EquivalentTo([| allowedPolicy.ApprovalPolicyId |])
+            )
+
+            Assert.That(
+                policies
+                |> Array.exists (fun policy -> policy.ApprovalPolicyId = otherPolicy.ApprovalPolicyId),
+                Is.False
+            )
+        }
+
+    [<Test>]
+    member _.PolicyStoredScopeBlocksBodyScopeSpoofingForShowAndUpdate() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = $"{Guid.NewGuid()}"
+            let storedBranchId = $"{Guid.NewGuid()}"
+            let adminUser = $"{Guid.NewGuid()}"
+            let limitedUser = $"{Guid.NewGuid()}"
+
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let! storedPolicy = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId storedBranchId
+
+            let! grantLimited = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId limitedUser "BranchAdmin"
+
+            Assert.That(grantLimited.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use limitedClient = ApprovalTestHelpers.createAuthenticatedClient limitedUser
+
+            let spoofedShow = ApprovalTestHelpers.showPolicyParameters repositoryId allowedBranchId (storedPolicy.ApprovalPolicyId.ToString())
+
+            let! showResponse = limitedClient.PostAsync("/approval/policy/show", createJsonContent spoofedShow)
+            Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let spoofedUpdate = ApprovalTestHelpers.updatePolicyParameters repositoryId allowedBranchId (storedPolicy.ApprovalPolicyId.ToString())
+
+            let! updateResponse = limitedClient.PostAsync("/approval/policy/update", createJsonContent spoofedUpdate)
+            Assert.That(updateResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+        }
+
+    [<Test>]
+    member _.PolicyUpdateRejectsScopeChangeEvenForStoredScopeManager() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let storedBranchId = repositoryDefaultBranchIds[0]
+            let otherBranchId = $"{Guid.NewGuid()}"
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let! storedPolicy = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId storedBranchId
+
+            let movedUpdate = ApprovalTestHelpers.updatePolicyParameters repositoryId otherBranchId (storedPolicy.ApprovalPolicyId.ToString())
+
+            let! updateResponse = adminClient.PostAsync("/approval/policy/update", createJsonContent movedUpdate)
+            Assert.That(updateResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.RequestListReturnsOnlyRequestedAuthorizedScope() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = $"{Guid.NewGuid()}"
+            let otherBranchId = $"{Guid.NewGuid()}"
+            let userId = $"{Guid.NewGuid()}"
+            let allowedRequestId = ApprovalTestHelpers.seedRequest repositoryId allowedBranchId $"user:{userId}"
+            let otherRequestId = ApprovalTestHelpers.seedRequest repositoryId otherBranchId $"user:{Guid.NewGuid()}"
+
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+
+            let! listResponse =
+                client.PostAsync("/approval/request/list", createJsonContent (ApprovalTestHelpers.listRequestParameters repositoryId allowedBranchId))
+
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! requests = deserializeContent<ApprovalRequest array> listResponse
+
+            Assert.That(
+                requests
+                |> Array.map (fun request -> request.ApprovalRequestId.ToString()),
+                Is.EquivalentTo([| allowedRequestId |])
+            )
+
+            Assert.That(
+                requests
+                |> Array.exists (fun request -> request.ApprovalRequestId.ToString() = otherRequestId),
+                Is.False
+            )
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -1,0 +1,247 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+
+module private ApprovalTestHelpers =
+
+    let createAuthenticatedClient (userId: string) =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    let createClientWithGroup (userId: string) (groupId: string) =
+        let client = createAuthenticatedClient userId
+        client.DefaultRequestHeaders.Add("x-grace-groups", groupId)
+        client
+
+    let createUnauthenticatedClient () =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client
+
+    let grantRoleAsync
+        (client: HttpClient)
+        (scopeKind: string)
+        (ownerId: string)
+        (organizationId: string)
+        (repositoryId: string)
+        (branchId: string)
+        (principalId: string)
+        (roleId: string)
+        =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- scopeKind
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+        }
+
+    let createPolicyParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Approval.CreateApprovalPolicyParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.Name <- $"policy-{Guid.NewGuid():N}"
+        parameters.Subject <- "promotion"
+        parameters.RequiredResponder <- "role:ApprovalResponder"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let showPolicyParameters (repositoryId: string) (branchId: string) (policyId: string) =
+        let parameters = Parameters.Approval.ShowApprovalPolicyParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.ApprovalPolicyId <- policyId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let requestParameters<'T when 'T :> Parameters.Approval.ApprovalRequestParameters and 'T: (new: unit -> 'T)>
+        (repositoryId: string)
+        (branchId: string)
+        (requestId: string)
+        =
+        let parameters = new 'T()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.ApprovalRequestId <- requestId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let seedRequest (repositoryId: string) (branchId: string) (selector: string) =
+        let requestId = Guid.NewGuid()
+
+        ApprovalStore.seedGeneratedRequest
+            { ApprovalRequest.Default with
+                ApprovalRequestId = requestId
+                ApprovalPolicyId = Guid.NewGuid()
+                ApprovalPolicyVersion = 1
+                Subject = "promotion"
+                Scope =
+                    { ApprovalScope.Default with
+                        OwnerId = Guid.Parse ownerId
+                        OrganizationId = Guid.Parse organizationId
+                        RepositoryId = Guid.Parse repositoryId
+                        TargetBranchId = Guid.Parse branchId
+                    }
+                RequiredResponder = selector
+                Status = ApprovalRequestStatus.Pending
+                CreatedBy = UserId "workflow"
+                CreatedAt = getCurrentInstant ()
+            }
+        |> ignore
+
+        requestId.ToString()
+
+[<NonParallelizable>]
+type ApprovalApiIntegrationTests() =
+
+    [<SetUp>]
+    member _.SetUp() = ApprovalStore.clearForTests ()
+
+    [<Test>]
+    member _.PolicyLifecycleHappyPath() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+
+            let! createResponse =
+                adminClient.PostAsync("/approval/policy/create", createJsonContent (ApprovalTestHelpers.createPolicyParameters repositoryId branchId))
+
+            Assert.That(createResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! created = deserializeContent<ApprovalPolicy> createResponse
+            Assert.That(created.Status, Is.EqualTo(ApprovalPolicyStatus.Disabled))
+
+            let showParameters = ApprovalTestHelpers.showPolicyParameters repositoryId branchId (created.ApprovalPolicyId.ToString())
+            let! enableResponse = adminClient.PostAsync("/approval/policy/enable", createJsonContent showParameters)
+            Assert.That(enableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! showResponse = adminClient.PostAsync("/approval/policy/show", createJsonContent showParameters)
+            Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! evaluateResponse =
+                adminClient.PostAsync("/approval/policy/evaluate", createJsonContent (ApprovalTestHelpers.createPolicyParameters repositoryId branchId))
+
+            Assert.That(evaluateResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! disableResponse = adminClient.PostAsync("/approval/policy/disable", createJsonContent showParameters)
+            Assert.That(disableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! deleteResponse = adminClient.PostAsync("/approval/policy/delete", createJsonContent showParameters)
+            Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+        }
+
+    [<Test>]
+    member _.NoPublicApprovalRequestCreateRouteExists() =
+        task {
+            use client = ApprovalTestHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
+            let! response = client.PostAsync("/approval/request/create", createJsonContent (obj ()))
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
+        }
+
+    [<Test>]
+    member _.ResponseRejectsMissingRespondPermissionEvenWhenSelectorMatches() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepoReader"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+        }
+
+    [<Test>]
+    member _.ResponseRejectsResponderRoleCallerWhenSelectorDoesNotMatch() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.RejectApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/reject", createJsonContent parameters)
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.BodySuppliedScopeEscalationDoesNotBypassStoredScope() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = repositoryDefaultBranchIds[0]
+            let storedBranchId = $"{Guid.NewGuid()}"
+            let userId = $"{Guid.NewGuid()}"
+            let requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId allowedBranchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+        }
+
+    [<Test>]
+    member _.DuplicateResponseIsRejectedAfterTerminalDecision() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.RejectApprovalRequestParameters> repositoryId branchId requestId
+            let! first = client.PostAsync("/approval/request/reject", createJsonContent parameters)
+            Assert.That(first.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! duplicate = client.PostAsync("/approval/request/reject", createJsonContent parameters)
+            Assert.That(duplicate.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="Approval.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -30,40 +30,84 @@ module ApprovalStore =
     let private requests = ConcurrentDictionary<ApprovalRequestId, ApprovalRequestDto>()
     let private history = ConcurrentDictionary<ApprovalRequestId, ResizeArray<ApprovalRequestDto>>()
 
-    let private requestSeedDirectory = Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds")
+    let private requestSeedEnabled () =
+        let isDevelopment value = String.Equals(value, "Development", StringComparison.OrdinalIgnoreCase)
 
-    let private requestSeedPath approvalRequestId = Path.Combine(requestSeedDirectory, $"{approvalRequestId:N}.json")
+        Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
+        || isDevelopment (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"))
+        || isDevelopment (Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"))
+
+    let private requestSeedDirectory () =
+        let runId = Environment.GetEnvironmentVariable("GRACE_TEST_RUN_ID")
+
+        let seedNamespace = if String.IsNullOrWhiteSpace runId then $"{Environment.ProcessId}" else runId
+
+        Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds", seedNamespace)
+
+    let private requestSeedPath approvalRequestId = Path.Combine(requestSeedDirectory (), $"{approvalRequestId:N}.json")
 
     let private persistSeededRequest (request: ApprovalRequestDto) =
-        Directory.CreateDirectory(requestSeedDirectory)
-        |> ignore
+        if requestSeedEnabled () then
+            Directory.CreateDirectory(requestSeedDirectory ())
+            |> ignore
 
-        File.WriteAllText(requestSeedPath request.ApprovalRequestId, JsonSerializer.Serialize(request, Constants.JsonSerializerOptions))
+            File.WriteAllText(requestSeedPath request.ApprovalRequestId, JsonSerializer.Serialize(request, Constants.JsonSerializerOptions))
 
     let private tryReadSeededRequest approvalRequestId =
-        let path = requestSeedPath approvalRequestId
-
-        if File.Exists path then
-            try
-                let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
-
-                if isNull (box request) then
-                    None
-                else
-                    requests[approvalRequestId] <- request
-                    Some request
-            with
-            | _ -> None
-        else
+        if requestSeedEnabled () |> not then
             None
+        else
+            let path = requestSeedPath approvalRequestId
+
+            if File.Exists path then
+                try
+                    let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
+
+                    if isNull (box request) then
+                        None
+                    else
+                        requests[approvalRequestId] <- request
+                        Some request
+                with
+                | _ -> None
+            else
+                None
+
+    let private hydrateSeededRequests () =
+        if requestSeedEnabled () then
+            let directory = requestSeedDirectory ()
+
+            if Directory.Exists directory then
+                Directory.EnumerateFiles(directory, "*.json")
+                |> Seq.iter (fun path ->
+                    try
+                        let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
+
+                        if isNull (box request) |> not then
+                            requests[request.ApprovalRequestId] <- request
+                    with
+                    | _ -> ())
+
+    let private scopeMatches (expected: ApprovalScope) (actual: ApprovalScope) =
+        actual.OwnerId = expected.OwnerId
+        && actual.OrganizationId = expected.OrganizationId
+        && actual.RepositoryId = expected.RepositoryId
+        && actual.TargetBranchId = expected.TargetBranchId
+
+    let private tryDeleteDirectory path =
+        if Directory.Exists path then
+            try
+                Directory.Delete(path, true)
+            with
+            | _ -> ()
 
     let clearForTests () =
         policies.Clear()
         requests.Clear()
         history.Clear()
 
-        if Directory.Exists requestSeedDirectory then
-            Directory.Delete(requestSeedDirectory, true)
+        let root = Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds")
+        tryDeleteDirectory root
 
     let upsertPolicy (policy: ApprovalPolicyDto) =
         policies[policy.ApprovalPolicyId] <- policy
@@ -74,11 +118,12 @@ module ApprovalStore =
         | true, policy -> Some policy
         | _ -> None
 
-    let listPolicies includeDeleted =
+    let listPolicies scope includeDeleted =
         policies.Values
         |> Seq.filter (fun policy ->
-            includeDeleted
-            || policy.Status <> ApprovalPolicyStatus.Deleted)
+            scopeMatches scope policy.Scope
+            && (includeDeleted
+                || policy.Status <> ApprovalPolicyStatus.Deleted))
         |> Seq.toArray
         :> IReadOnlyList<ApprovalPolicyDto>
 
@@ -101,9 +146,13 @@ module ApprovalStore =
         entries.Add request
         request
 
-    let listRequests includeTerminal =
+    let listRequests scope includeTerminal =
+        hydrateSeededRequests ()
+
         requests.Values
-        |> Seq.filter (fun request -> includeTerminal || not request.Status.IsTerminal)
+        |> Seq.filter (fun request ->
+            scopeMatches scope request.Scope
+            && (includeTerminal || not request.Status.IsTerminal))
         |> Seq.toArray
         :> IReadOnlyList<ApprovalRequestDto>
 
@@ -168,6 +217,12 @@ module ApprovalCommon =
         else
             Resource.Repository(scope.OwnerId, scope.OrganizationId, scope.RepositoryId)
 
+    let scopeEquals left right =
+        left.OwnerId = right.OwnerId
+        && left.OrganizationId = right.OrganizationId
+        && left.RepositoryId = right.RepositoryId
+        && left.TargetBranchId = right.TargetBranchId
+
     let currentUserId (context: HttpContext) =
         PrincipalMapper.tryGetUserId context.User
         |> Option.defaultValue "unknown"
@@ -228,6 +283,29 @@ module ApprovalPolicy =
                         }
         }
 
+    let private policyIdFromContext<'T when 'T :> ApprovalPolicyParameters> (context: HttpContext) =
+        task {
+            context.Request.EnableBuffering()
+            let! parameters = context.BindJsonAsync<'T>()
+
+            context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+            |> ignore
+
+            return
+                tryParseGuid parameters.ApprovalPolicyId
+                |> Option.bind ApprovalStore.tryGetPolicy
+        }
+
+    let resolveStoredPolicyForManage<'T when 'T :> ApprovalPolicyParameters> (context: HttpContext) =
+        task {
+            let! policy = policyIdFromContext<'T> context
+
+            return
+                match policy with
+                | Some approvalPolicy -> Ok(Operation.ApprovalPolicyManage, resourceFromApprovalScope approvalPolicy.Scope)
+                | None -> Error(error context "Approval policy was not found.")
+        }
+
     let Create: HttpHandler =
         fun _ context ->
             task {
@@ -249,10 +327,11 @@ module ApprovalPolicy =
         fun _ context ->
             task {
                 let! parameters = Services.parse<ListApprovalPoliciesParameters> context
+                let scope = scopeFromPolicyParameters parameters
 
                 return!
                     context
-                    |> Services.result200Ok (ApprovalStore.listPolicies parameters.IncludeDeleted)
+                    |> Services.result200Ok (ApprovalStore.listPolicies scope parameters.IncludeDeleted)
             }
 
     let Show: HttpHandler =
@@ -277,18 +356,25 @@ module ApprovalPolicy =
                     with
                 | None -> return! Services.result404NotFound context
                 | Some existing ->
-                    match! buildPolicy context existing.ApprovalPolicyId (existing.Version + 1) existing.Status parameters with
-                    | Error message ->
+                    let requestedScope = scopeFromPolicyParameters parameters
+
+                    if scopeEquals requestedScope existing.Scope |> not then
                         return!
                             context
-                            |> Services.result400BadRequest (error context message)
-                    | Ok policy ->
-                        return!
-                            context
-                            |> Services.result200Ok (
-                                ApprovalStore.upsertPolicy
-                                    { policy with CreatedBy = existing.CreatedBy; CreatedAt = existing.CreatedAt; UpdatedAt = Some(getCurrentInstant ()) }
-                            )
+                            |> Services.result400BadRequest (error context "Approval policy scope cannot be changed.")
+                    else
+                        match! buildPolicy context existing.ApprovalPolicyId (existing.Version + 1) existing.Status parameters with
+                        | Error message ->
+                            return!
+                                context
+                                |> Services.result400BadRequest (error context message)
+                        | Ok policy ->
+                            return!
+                                context
+                                |> Services.result200Ok (
+                                    ApprovalStore.upsertPolicy
+                                        { policy with CreatedBy = existing.CreatedBy; CreatedAt = existing.CreatedAt; UpdatedAt = Some(getCurrentInstant ()) }
+                                )
             }
 
     let private setStatus status : HttpHandler =
@@ -319,13 +405,9 @@ module ApprovalPolicy =
                 let scope = scopeFromPolicyParameters parameters
 
                 let matches =
-                    ApprovalStore.listPolicies false
+                    ApprovalStore.listPolicies scope false
                     |> Seq.filter (fun policy ->
                         policy.Status = ApprovalPolicyStatus.Enabled
-                        && policy.Scope.OwnerId = scope.OwnerId
-                        && policy.Scope.OrganizationId = scope.OrganizationId
-                        && policy.Scope.RepositoryId = scope.RepositoryId
-                        && policy.Scope.TargetBranchId = scope.TargetBranchId
                         && (String.IsNullOrWhiteSpace parameters.Subject
                             || policy.Subject = parameters.Subject))
                     |> Seq.toArray

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -1,0 +1,335 @@
+namespace Grace.Server
+
+open Giraffe
+open Grace.Server.Security
+open Grace.Shared
+open Grace.Shared.Parameters.Approval
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Authorization
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.DependencyInjection
+open NodaTime
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.IO
+open System.Text.Json
+open System.Threading.Tasks
+
+module ApprovalStore =
+
+    type ApprovalPolicyDto = Grace.Types.Webhooks.ApprovalPolicy
+    type ApprovalRequestDto = Grace.Types.Webhooks.ApprovalRequest
+
+    let private policies = ConcurrentDictionary<ApprovalPolicyId, ApprovalPolicyDto>()
+    let private requests = ConcurrentDictionary<ApprovalRequestId, ApprovalRequestDto>()
+    let private history = ConcurrentDictionary<ApprovalRequestId, ResizeArray<ApprovalRequestDto>>()
+
+    let private requestSeedDirectory = Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds")
+
+    let private requestSeedPath approvalRequestId = Path.Combine(requestSeedDirectory, $"{approvalRequestId:N}.json")
+
+    let private persistSeededRequest (request: ApprovalRequestDto) =
+        Directory.CreateDirectory(requestSeedDirectory)
+        |> ignore
+
+        File.WriteAllText(requestSeedPath request.ApprovalRequestId, JsonSerializer.Serialize(request, Constants.JsonSerializerOptions))
+
+    let private tryReadSeededRequest approvalRequestId =
+        let path = requestSeedPath approvalRequestId
+
+        if File.Exists path then
+            try
+                let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
+
+                if isNull (box request) then
+                    None
+                else
+                    requests[approvalRequestId] <- request
+                    Some request
+            with
+            | _ -> None
+        else
+            None
+
+    let clearForTests () =
+        policies.Clear()
+        requests.Clear()
+        history.Clear()
+
+        if Directory.Exists requestSeedDirectory then
+            Directory.Delete(requestSeedDirectory, true)
+
+    let upsertPolicy (policy: ApprovalPolicyDto) =
+        policies[policy.ApprovalPolicyId] <- policy
+        policy
+
+    let tryGetPolicy approvalPolicyId =
+        match policies.TryGetValue approvalPolicyId with
+        | true, policy -> Some policy
+        | _ -> None
+
+    let listPolicies includeDeleted =
+        policies.Values
+        |> Seq.filter (fun policy ->
+            includeDeleted
+            || policy.Status <> ApprovalPolicyStatus.Deleted)
+        |> Seq.toArray
+        :> IReadOnlyList<ApprovalPolicyDto>
+
+    let seedGeneratedRequest (request: ApprovalRequestDto) =
+        requests[request.ApprovalRequestId] <- request
+        persistSeededRequest request
+        let entries = history.GetOrAdd(request.ApprovalRequestId, (fun _ -> ResizeArray()))
+        entries.Add request
+        request
+
+    let tryGetRequest approvalRequestId =
+        match requests.TryGetValue approvalRequestId with
+        | true, request -> Some request
+        | _ -> tryReadSeededRequest approvalRequestId
+
+    let updateRequest (request: ApprovalRequestDto) =
+        requests[request.ApprovalRequestId] <- request
+        persistSeededRequest request
+        let entries = history.GetOrAdd(request.ApprovalRequestId, (fun _ -> ResizeArray()))
+        entries.Add request
+        request
+
+    let listRequests includeTerminal =
+        requests.Values
+        |> Seq.filter (fun request -> includeTerminal || not request.Status.IsTerminal)
+        |> Seq.toArray
+        :> IReadOnlyList<ApprovalRequestDto>
+
+    let requestHistory approvalRequestId =
+        match history.TryGetValue approvalRequestId with
+        | true, entries -> entries.ToArray() :> IReadOnlyList<ApprovalRequestDto>
+        | _ -> Array.empty<ApprovalRequestDto> :> IReadOnlyList<ApprovalRequestDto>
+
+module ApprovalCommon =
+
+    let tryParseGuid value =
+        let mutable parsed = Guid.Empty
+
+        if String.IsNullOrWhiteSpace value |> not
+           && Guid.TryParse(value, &parsed)
+           && parsed <> Guid.Empty then
+            Some parsed
+        else
+            None
+
+    let scopeFromPolicyParameters (parameters: ApprovalPolicyParameters) =
+        let ownerId =
+            tryParseGuid parameters.OwnerId
+            |> Option.defaultValue OwnerId.Empty
+
+        let organizationId =
+            tryParseGuid parameters.OrganizationId
+            |> Option.defaultValue OrganizationId.Empty
+
+        let repositoryId =
+            tryParseGuid parameters.RepositoryId
+            |> Option.defaultValue RepositoryId.Empty
+
+        let targetBranchId =
+            tryParseGuid parameters.TargetBranchId
+            |> Option.defaultValue BranchId.Empty
+
+        { ApprovalScope.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+
+    let scopeFromRequestParameters (parameters: ApprovalRequestParameters) =
+        let ownerId =
+            tryParseGuid parameters.OwnerId
+            |> Option.defaultValue OwnerId.Empty
+
+        let organizationId =
+            tryParseGuid parameters.OrganizationId
+            |> Option.defaultValue OrganizationId.Empty
+
+        let repositoryId =
+            tryParseGuid parameters.RepositoryId
+            |> Option.defaultValue RepositoryId.Empty
+
+        let targetBranchId =
+            tryParseGuid parameters.TargetBranchId
+            |> Option.defaultValue BranchId.Empty
+
+        { ApprovalScope.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+
+    let resourceFromApprovalScope (scope: ApprovalScope) =
+        if scope.TargetBranchId <> BranchId.Empty then
+            Resource.Branch(scope.OwnerId, scope.OrganizationId, scope.RepositoryId, scope.TargetBranchId)
+        else
+            Resource.Repository(scope.OwnerId, scope.OrganizationId, scope.RepositoryId)
+
+    let currentUserId (context: HttpContext) =
+        PrincipalMapper.tryGetUserId context.User
+        |> Option.defaultValue "unknown"
+        |> UserId
+
+    let error context message = GraceError.Create message (Services.getCorrelationId context)
+
+module ApprovalPolicy =
+
+    open ApprovalCommon
+
+    let private validateNotificationUrl (context: HttpContext) (parameters: CreateApprovalPolicyParameters) =
+        if String.IsNullOrWhiteSpace parameters.NotificationUrl then
+            Ok None
+        else
+            let configuration = context.RequestServices.GetRequiredService<IConfiguration>()
+            let hostEnvironment = context.RequestServices.GetService<IHostEnvironment>()
+
+            let request: OutboundUrlSafety.ValidationRequest =
+                {
+                    Url = parameters.NotificationUrl
+                    RequestedSafety = parameters.NotificationUrlSafety
+                    AcknowledgeUnsafeLocalDevelopment = parameters.AcknowledgeUnsafeLocalDevelopment
+                }
+
+            match OutboundUrlSafety.validate hostEnvironment configuration request with
+            | Ok validated -> Ok(Some validated.ScopedUrl)
+            | Error failure -> Error $"NotificationUrl is not allowed: {failure}."
+
+    let private buildPolicy context approvalPolicyId version status (parameters: CreateApprovalPolicyParameters) =
+        task {
+            match validateNotificationUrl context parameters with
+            | Error message -> return Error message
+            | Ok notificationUrl ->
+                let scope = { scopeFromPolicyParameters parameters with ApprovalPolicyId = Some approvalPolicyId; ApprovalPolicyVersion = Some version }
+
+                let timeoutSeconds =
+                    if parameters.TimeoutSeconds.HasValue then
+                        Some parameters.TimeoutSeconds.Value
+                    else
+                        None
+
+                return
+                    Ok
+                        { Grace.Types.Webhooks.ApprovalPolicy.Default with
+                            ApprovalPolicyId = approvalPolicyId
+                            Version = version
+                            Name = parameters.Name
+                            Subject = parameters.Subject
+                            Scope = scope
+                            RequiredResponder = parameters.RequiredResponder
+                            NotificationUrl = notificationUrl
+                            TimeoutSeconds = timeoutSeconds
+                            OnTimeout = parameters.OnTimeout
+                            Status = status
+                            CreatedBy = currentUserId context
+                            CreatedAt = getCurrentInstant ()
+                        }
+        }
+
+    let Create: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<CreateApprovalPolicyParameters> context
+                let approvalPolicyId = Guid.NewGuid()
+
+                match! buildPolicy context approvalPolicyId 1 ApprovalPolicyStatus.Disabled parameters with
+                | Error message ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (error context message)
+                | Ok policy ->
+                    return!
+                        context
+                        |> Services.result200Ok (ApprovalStore.upsertPolicy policy)
+            }
+
+    let List: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ListApprovalPoliciesParameters> context
+
+                return!
+                    context
+                    |> Services.result200Ok (ApprovalStore.listPolicies parameters.IncludeDeleted)
+            }
+
+    let Show: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ShowApprovalPolicyParameters> context
+
+                match tryParseGuid parameters.ApprovalPolicyId
+                      |> Option.bind ApprovalStore.tryGetPolicy
+                    with
+                | Some policy -> return! context |> Services.result200Ok policy
+                | None -> return! Services.result404NotFound context
+            }
+
+    let Update: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<UpdateApprovalPolicyParameters> context
+
+                match tryParseGuid parameters.ApprovalPolicyId
+                      |> Option.bind ApprovalStore.tryGetPolicy
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some existing ->
+                    match! buildPolicy context existing.ApprovalPolicyId (existing.Version + 1) existing.Status parameters with
+                    | Error message ->
+                        return!
+                            context
+                            |> Services.result400BadRequest (error context message)
+                    | Ok policy ->
+                        return!
+                            context
+                            |> Services.result200Ok (
+                                ApprovalStore.upsertPolicy
+                                    { policy with CreatedBy = existing.CreatedBy; CreatedAt = existing.CreatedAt; UpdatedAt = Some(getCurrentInstant ()) }
+                            )
+            }
+
+    let private setStatus status : HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ApprovalPolicyParameters> context
+
+                match tryParseGuid parameters.ApprovalPolicyId
+                      |> Option.bind ApprovalStore.tryGetPolicy
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some policy ->
+                    return!
+                        context
+                        |> Services.result200Ok (ApprovalStore.upsertPolicy { policy with Status = status; UpdatedAt = Some(getCurrentInstant ()) })
+            }
+
+    let Enable: HttpHandler = setStatus ApprovalPolicyStatus.Enabled
+
+    let Disable: HttpHandler = setStatus ApprovalPolicyStatus.Disabled
+
+    let Delete: HttpHandler = setStatus ApprovalPolicyStatus.Deleted
+
+    let Evaluate: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<EvaluateApprovalPolicyParameters> context
+                let scope = scopeFromPolicyParameters parameters
+
+                let matches =
+                    ApprovalStore.listPolicies false
+                    |> Seq.filter (fun policy ->
+                        policy.Status = ApprovalPolicyStatus.Enabled
+                        && policy.Scope.OwnerId = scope.OwnerId
+                        && policy.Scope.OrganizationId = scope.OrganizationId
+                        && policy.Scope.RepositoryId = scope.RepositoryId
+                        && policy.Scope.TargetBranchId = scope.TargetBranchId
+                        && (String.IsNullOrWhiteSpace parameters.Subject
+                            || policy.Subject = parameters.Subject))
+                    |> Seq.toArray
+                    :> IReadOnlyList<Grace.Types.Webhooks.ApprovalPolicy>
+
+                return! context |> Services.result200Ok matches
+            }

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -136,10 +136,11 @@ module ApprovalRequest =
         fun _ context ->
             task {
                 let! parameters = Services.parse<ListApprovalRequestsParameters> context
+                let scope = scopeFromRequestParameters parameters
 
                 return!
                     context
-                    |> Services.result200Ok (ApprovalStore.listRequests parameters.IncludeTerminal)
+                    |> Services.result200Ok (ApprovalStore.listRequests scope parameters.IncludeTerminal)
             }
 
     let Show: HttpHandler =

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -1,0 +1,185 @@
+namespace Grace.Server
+
+open Giraffe
+open Grace.Server.Security
+open Grace.Shared.Authorization
+open Grace.Shared.Parameters.Approval
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Authorization
+open Grace.Types.Webhooks
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open System
+open System.Collections.Generic
+open System.IO
+open System.Threading.Tasks
+
+module ApprovalRequest =
+
+    open ApprovalCommon
+
+    let private requestIdFromContext<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
+        task {
+            context.Request.EnableBuffering()
+            let! parameters = context.BindJsonAsync<'T>()
+
+            context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+            |> ignore
+
+            return
+                tryParseGuid parameters.ApprovalRequestId
+                |> Option.bind ApprovalStore.tryGetRequest
+        }
+
+    let resolveStoredRequestForRead<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
+        task {
+            let! request = requestIdFromContext<'T> context
+
+            return
+                match request with
+                | Some approvalRequest -> Ok(Operation.ApprovalRequestRead, resourceFromApprovalScope approvalRequest.Scope)
+                | None -> Error(error context "Approval request was not found.")
+        }
+
+    let resolveStoredRequestForRespond<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
+        task {
+            let! request = requestIdFromContext<'T> context
+
+            return
+                match request with
+                | Some approvalRequest -> Ok(Operation.ApprovalRequestRespond, resourceFromApprovalScope approvalRequest.Scope)
+                | None -> Error(error context "Approval request was not found.")
+        }
+
+    let private selectorMatches (context: HttpContext) (request: ApprovalRequest) =
+        let selector =
+            if isNull request.RequiredResponder then
+                String.Empty
+            else
+                request.RequiredResponder.Trim()
+
+        let principals = PrincipalMapper.getPrincipals context.User
+        let claims = PrincipalMapper.getEffectiveClaims context.User
+
+        if selector.StartsWith("user:", StringComparison.OrdinalIgnoreCase) then
+            let expected = selector.Substring("user:".Length)
+
+            principals
+            |> List.exists (fun principal ->
+                principal.PrincipalType = PrincipalType.User
+                && principal.PrincipalId.Equals(expected, StringComparison.OrdinalIgnoreCase))
+        elif selector.StartsWith("group:", StringComparison.OrdinalIgnoreCase) then
+            let expected = selector.Substring("group:".Length)
+
+            principals
+            |> List.exists (fun principal ->
+                principal.PrincipalType = PrincipalType.Group
+                && principal.PrincipalId.Equals(expected, StringComparison.OrdinalIgnoreCase))
+        elif selector.Equals("role:ApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+            let decision =
+                evaluator
+                    .CheckAsync(principals, claims, Operation.ApprovalRequestRespond, resourceFromApprovalScope request.Scope)
+                    .GetAwaiter()
+                    .GetResult()
+
+            match decision with
+            | Allowed _ -> true
+            | Denied _ -> false
+        else
+            false
+
+    let private respond decision approvalRequestId reason clientDecisionId : HttpHandler =
+        fun _ context ->
+            task {
+                match tryParseGuid approvalRequestId
+                      |> Option.bind ApprovalStore.tryGetRequest
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some request when request.Status.IsTerminal ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (error context $"Approval request is already {request.Status}.")
+                | Some request when not (selectorMatches context request) ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (error context "Caller does not match the stored approval responder selector.")
+                | Some request ->
+                    let status =
+                        match decision with
+                        | ApprovalDecision.Approve -> ApprovalRequestStatus.Approved
+                        | ApprovalDecision.Reject -> ApprovalRequestStatus.Rejected
+
+                    let updated: Grace.Types.Webhooks.ApprovalRequest =
+                        { request with
+                            Status = status
+                            Decision =
+                                Some
+                                    { ApprovalRequestDecision.Default with
+                                        Decision = decision
+                                        DecidedBy = currentUserId context
+                                        DecidedAt = getCurrentInstant ()
+                                        Reason = if String.IsNullOrWhiteSpace reason then None else Some reason
+                                        ClientDecisionId = clientDecisionId
+                                    }
+                            UpdatedAt = Some(getCurrentInstant ())
+                        }
+
+                    return!
+                        context
+                        |> Services.result200Ok (ApprovalStore.updateRequest updated)
+            }
+
+    let List: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ListApprovalRequestsParameters> context
+
+                return!
+                    context
+                    |> Services.result200Ok (ApprovalStore.listRequests parameters.IncludeTerminal)
+            }
+
+    let Show: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ShowApprovalRequestParameters> context
+
+                match tryParseGuid parameters.ApprovalRequestId
+                      |> Option.bind ApprovalStore.tryGetRequest
+                    with
+                | Some request -> return! context |> Services.result200Ok request
+                | None -> return! Services.result404NotFound context
+            }
+
+    let Approve: HttpHandler =
+        fun next context ->
+            task {
+                let! parameters = Services.parse<ApproveApprovalRequestParameters> context
+                return! respond ApprovalDecision.Approve parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId next context
+            }
+
+    let Reject: HttpHandler =
+        fun next context ->
+            task {
+                let! parameters = Services.parse<RejectApprovalRequestParameters> context
+                return! respond ApprovalDecision.Reject parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId next context
+            }
+
+    let History: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ApprovalRequestHistoryParameters> context
+
+                match tryParseGuid parameters.ApprovalRequestId with
+                | Some requestId ->
+                    return!
+                        context
+                        |> Services.result200Ok (ApprovalStore.requestHistory requestId)
+                | None ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (error context "ApprovalRequestId is required.")
+            }

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -77,6 +77,8 @@
 		<Compile Include="Branch.Server.fs" />
                 
                 <Compile Include="PromotionSet.Server.fs" />
+                <Compile Include="ApprovalPolicy.Server.fs" />
+                <Compile Include="ApprovalRequest.Server.fs" />
                 <Compile Include="WorkItem.Server.fs" />
                 <Compile Include="Policy.Server.fs" />
                 <Compile Include="ReviewModels.Server.fs" />

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -34,6 +34,19 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/access/upsertPathPermission" (Authorized(RepoAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/list" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/show" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/update" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/enable" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/disable" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/delete" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/policy/evaluate" (Authorized(ApprovalPolicyManage, Repository))
+            endpoint "POST" "/approval/request/list" (Authorized(ApprovalRequestRead, Repository))
+            endpoint "POST" "/approval/request/show" (Authorized(ApprovalRequestRead, Repository))
+            endpoint "POST" "/approval/request/approve" (Authorized(ApprovalRequestRespond, Repository))
+            endpoint "POST" "/approval/request/reject" (Authorized(ApprovalRequestRespond, Repository))
+            endpoint "POST" "/approval/request/history" (Authorized(ApprovalRequestRead, Repository))
             endpoint "GET" "/auth/login" AllowAnonymous
             endpoint "GET" "/auth/login/%s" AllowAnonymous
             endpoint "GET" "/auth/logout" Authenticated

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -267,6 +267,48 @@ module Application =
 
         let requireBranchWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchWrite branchResourceFromContext
 
+        let approvalPolicyResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Approval.ApprovalPolicyParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let scope = ApprovalCommon.scopeFromPolicyParameters parameters
+                return ApprovalCommon.resourceFromApprovalScope scope
+            }
+
+        let approvalRequestListResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Approval.ApprovalRequestParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let scope = ApprovalCommon.scopeFromRequestParameters parameters
+                return ApprovalCommon.resourceFromApprovalScope scope
+            }
+
+        let requireApprovalPolicyManage: HttpHandler =
+            AuthorizationMiddleware.requiresPermission Operation.ApprovalPolicyManage approvalPolicyResourceFromContext
+
+        let requireApprovalRequestRead: HttpHandler =
+            AuthorizationMiddleware.requiresPermission Operation.ApprovalRequestRead approvalRequestListResourceFromContext
+
+        let requireApprovalRequestShow: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalRequest.resolveStoredRequestForRead<Approval.ShowApprovalRequestParameters>
+
+        let requireApprovalRequestHistory: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalRequest.resolveStoredRequestForRead<Approval.ApprovalRequestHistoryParameters>
+
+        let requireApprovalRequestApprove: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalRequest.resolveStoredRequestForRespond<Approval.ApproveApprovalRequestParameters>
+
+        let requireApprovalRequestReject: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalRequest.resolveStoredRequestForRespond<Approval.RejectApprovalRequestParameters>
+
         let requirePathWrite: HttpHandler = AuthorizationMiddleware.requiresPermissions Operation.PathWrite uploadPathResourcesFromContext
 
         let requirePathWriteForUploadUri: HttpHandler = AuthorizationMiddleware.requiresPermissions Operation.PathWrite uploadUriResourcesFromContext
@@ -803,6 +845,51 @@ module Application =
                               htmlString $"<h1>Grace server seems healthy!</h1><br/><p>The current server time is: {getCurrentInstantExtended ()}.</p>"))
                       |> addMetadata (AllowAnonymousAttribute()) ]
                 PUT []
+                subRoute
+                    "/approval/policy"
+                    [
+                        POST [ route "/create" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Create)
+                               |> addMetadata typeof<Approval.CreateApprovalPolicyParameters>
+
+                               route "/list" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.List)
+                               |> addMetadata typeof<Approval.ListApprovalPoliciesParameters>
+
+                               route "/show" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Show)
+                               |> addMetadata typeof<Approval.ShowApprovalPolicyParameters>
+
+                               route "/update" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Update)
+                               |> addMetadata typeof<Approval.UpdateApprovalPolicyParameters>
+
+                               route "/enable" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Enable)
+                               |> addMetadata typeof<Approval.EnableApprovalPolicyParameters>
+
+                               route "/disable" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Disable)
+                               |> addMetadata typeof<Approval.DisableApprovalPolicyParameters>
+
+                               route "/delete" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Delete)
+                               |> addMetadata typeof<Approval.DeleteApprovalPolicyParameters>
+
+                               route "/evaluate" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Evaluate)
+                               |> addMetadata typeof<Approval.EvaluateApprovalPolicyParameters> ]
+                    ]
+                subRoute
+                    "/approval/request"
+                    [
+                        POST [ route "/list" (composeHandlers requireApprovalRequestRead ApprovalRequest.List)
+                               |> addMetadata typeof<Approval.ListApprovalRequestsParameters>
+
+                               route "/show" (composeHandlers requireApprovalRequestShow ApprovalRequest.Show)
+                               |> addMetadata typeof<Approval.ShowApprovalRequestParameters>
+
+                               route "/approve" (composeHandlers requireApprovalRequestApprove ApprovalRequest.Approve)
+                               |> addMetadata typeof<Approval.ApproveApprovalRequestParameters>
+
+                               route "/reject" (composeHandlers requireApprovalRequestReject ApprovalRequest.Reject)
+                               |> addMetadata typeof<Approval.RejectApprovalRequestParameters>
+
+                               route "/history" (composeHandlers requireApprovalRequestHistory ApprovalRequest.History)
+                               |> addMetadata typeof<Approval.ApprovalRequestHistoryParameters> ]
+                    ]
                 subRoute
                     "/branch"
                     [

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -294,6 +294,21 @@ module Application =
         let requireApprovalPolicyManage: HttpHandler =
             AuthorizationMiddleware.requiresPermission Operation.ApprovalPolicyManage approvalPolicyResourceFromContext
 
+        let requireApprovalPolicyShow: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalPolicy.resolveStoredPolicyForManage<Approval.ShowApprovalPolicyParameters>
+
+        let requireApprovalPolicyUpdate: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalPolicy.resolveStoredPolicyForManage<Approval.UpdateApprovalPolicyParameters>
+
+        let requireApprovalPolicyEnable: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalPolicy.resolveStoredPolicyForManage<Approval.EnableApprovalPolicyParameters>
+
+        let requireApprovalPolicyDisable: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalPolicy.resolveStoredPolicyForManage<Approval.DisableApprovalPolicyParameters>
+
+        let requireApprovalPolicyDelete: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved ApprovalPolicy.resolveStoredPolicyForManage<Approval.DeleteApprovalPolicyParameters>
+
         let requireApprovalRequestRead: HttpHandler =
             AuthorizationMiddleware.requiresPermission Operation.ApprovalRequestRead approvalRequestListResourceFromContext
 
@@ -854,19 +869,19 @@ module Application =
                                route "/list" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.List)
                                |> addMetadata typeof<Approval.ListApprovalPoliciesParameters>
 
-                               route "/show" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Show)
+                               route "/show" (composeHandlers requireApprovalPolicyShow ApprovalPolicy.Show)
                                |> addMetadata typeof<Approval.ShowApprovalPolicyParameters>
 
-                               route "/update" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Update)
+                               route "/update" (composeHandlers requireApprovalPolicyUpdate ApprovalPolicy.Update)
                                |> addMetadata typeof<Approval.UpdateApprovalPolicyParameters>
 
-                               route "/enable" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Enable)
+                               route "/enable" (composeHandlers requireApprovalPolicyEnable ApprovalPolicy.Enable)
                                |> addMetadata typeof<Approval.EnableApprovalPolicyParameters>
 
-                               route "/disable" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Disable)
+                               route "/disable" (composeHandlers requireApprovalPolicyDisable ApprovalPolicy.Disable)
                                |> addMetadata typeof<Approval.DisableApprovalPolicyParameters>
 
-                               route "/delete" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Delete)
+                               route "/delete" (composeHandlers requireApprovalPolicyDelete ApprovalPolicy.Delete)
                                |> addMetadata typeof<Approval.DeleteApprovalPolicyParameters>
 
                                route "/evaluate" (composeHandlers requireApprovalPolicyManage ApprovalPolicy.Evaluate)

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -28,7 +28,12 @@ module Authorization =
                   BranchRead
                   BranchWrite
                   PathRead
-                  PathWrite ]
+                  PathWrite
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
 
         let private ownerAdminOperations =
             set [ OwnerAdmin
@@ -42,7 +47,12 @@ module Authorization =
                   BranchRead
                   BranchWrite
                   PathRead
-                  PathWrite ]
+                  PathWrite
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
 
         let private ownerReaderOperations =
             set [ OwnerRead
@@ -61,7 +71,12 @@ module Authorization =
                   PathRead
                   BranchAdmin
                   BranchWrite
-                  BranchRead ]
+                  BranchRead
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
 
         let private orgReaderOperations =
             set [ OrgRead
@@ -77,7 +92,12 @@ module Authorization =
                   PathRead
                   BranchAdmin
                   BranchWrite
-                  BranchRead ]
+                  BranchRead
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
 
         let private repoContributorOperations =
             set [ RepoWrite
@@ -87,19 +107,24 @@ module Authorization =
                   BranchWrite
                   BranchRead ]
 
-        let private repoReaderOperations = set [ RepoRead; PathRead; BranchRead ]
+        let private repoReaderOperations =
+            set [ RepoRead
+                  PathRead
+                  BranchRead
+                  ApprovalRequestRead ]
 
         let private branchAdminOperations =
             set [ BranchAdmin
                   BranchWrite
                   BranchRead ]
 
-        let private branchWriterOperations =
-            set [ BranchWrite
-                  BranchRead ]
+        let private branchWriterOperations = set [ BranchWrite; BranchRead ]
 
-        let private branchReaderOperations =
-            set [ BranchRead ]
+        let private branchReaderOperations = set [ BranchRead ]
+
+        let private approvalResponderOperations =
+            set [ ApprovalRequestRead
+                  ApprovalRequestRespond ]
 
         let private roles: RoleDefinition list =
             [
@@ -114,6 +139,13 @@ module Authorization =
                 { RoleId = "BranchAdmin"; AllowedOperations = branchAdminOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchWriter"; AllowedOperations = branchWriterOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchReader"; AllowedOperations = branchReaderOperations; AppliesTo = Set.ofList [ scopeBranch ] }
+                {
+                    RoleId = "ApprovalResponder"
+                    AllowedOperations = approvalResponderOperations
+                    AppliesTo =
+                        Set.ofList [ scopeRepository
+                                     scopeBranch ]
+                }
             ]
 
         let getAll () = roles

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -58,6 +58,7 @@
         <Compile Include="Parameters\WorkItem.Parameters.fs" />
         <Compile Include="Parameters\Policy.Parameters.fs" />
         <Compile Include="Parameters\PromotionSet.Parameters.fs" />
+        <Compile Include="Parameters\Approval.Parameters.fs" />
         <Compile Include="Parameters\Review.Parameters.fs" />
         <Compile Include="Parameters\Queue.Parameters.fs" />
         <Compile Include="Parameters\Validation.Parameters.fs" />

--- a/src/Grace.Shared/Parameters/Approval.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Approval.Parameters.fs
@@ -1,0 +1,98 @@
+namespace Grace.Shared.Parameters
+
+open Grace.Shared.Parameters.Common
+open Grace.Types.Webhooks
+open System
+
+module Approval =
+
+    /// Base parameters for approval policy endpoints.
+    type ApprovalPolicyParameters() =
+        inherit CommonParameters()
+        member val public OwnerId = String.Empty with get, set
+        member val public OwnerName = String.Empty with get, set
+        member val public OrganizationId = String.Empty with get, set
+        member val public OrganizationName = String.Empty with get, set
+        member val public RepositoryId = String.Empty with get, set
+        member val public RepositoryName = String.Empty with get, set
+        member val public TargetBranchId = String.Empty with get, set
+        member val public ApprovalPolicyId = String.Empty with get, set
+
+    /// Parameters for /approval/policy/create.
+    type CreateApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+        member val public Name = String.Empty with get, set
+        member val public Subject = String.Empty with get, set
+        member val public RequiredResponder = String.Empty with get, set
+        member val public NotificationUrl = String.Empty with get, set
+        member val public NotificationUrlSafety = OutboundUrlSafety.PublicHttps with get, set
+        member val public AcknowledgeUnsafeLocalDevelopment = false with get, set
+        member val public TimeoutSeconds: Nullable<int> = Nullable() with get, set
+        member val public OnTimeout = ApprovalTimeoutAction.Reject with get, set
+
+    /// Parameters for /approval/policy/list.
+    type ListApprovalPoliciesParameters() =
+        inherit ApprovalPolicyParameters()
+        member val public IncludeDeleted = false with get, set
+
+    /// Parameters for /approval/policy/show.
+    type ShowApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+
+    /// Parameters for /approval/policy/update.
+    type UpdateApprovalPolicyParameters() =
+        inherit CreateApprovalPolicyParameters()
+
+    /// Parameters for /approval/policy/enable.
+    type EnableApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+
+    /// Parameters for /approval/policy/disable.
+    type DisableApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+
+    /// Parameters for /approval/policy/delete.
+    type DeleteApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+
+    /// Parameters for /approval/policy/evaluate.
+    type EvaluateApprovalPolicyParameters() =
+        inherit ApprovalPolicyParameters()
+        member val public Subject = String.Empty with get, set
+
+    /// Base parameters for approval request endpoints.
+    type ApprovalRequestParameters() =
+        inherit CommonParameters()
+        member val public OwnerId = String.Empty with get, set
+        member val public OwnerName = String.Empty with get, set
+        member val public OrganizationId = String.Empty with get, set
+        member val public OrganizationName = String.Empty with get, set
+        member val public RepositoryId = String.Empty with get, set
+        member val public RepositoryName = String.Empty with get, set
+        member val public TargetBranchId = String.Empty with get, set
+        member val public ApprovalRequestId = String.Empty with get, set
+
+    /// Parameters for /approval/request/list.
+    type ListApprovalRequestsParameters() =
+        inherit ApprovalRequestParameters()
+        member val public IncludeTerminal = true with get, set
+
+    /// Parameters for /approval/request/show.
+    type ShowApprovalRequestParameters() =
+        inherit ApprovalRequestParameters()
+
+    /// Parameters for /approval/request/approve.
+    type ApproveApprovalRequestParameters() =
+        inherit ApprovalRequestParameters()
+        member val public Reason = String.Empty with get, set
+        member val public ClientDecisionId = String.Empty with get, set
+
+    /// Parameters for /approval/request/reject.
+    type RejectApprovalRequestParameters() =
+        inherit ApprovalRequestParameters()
+        member val public Reason = String.Empty with get, set
+        member val public ClientDecisionId = String.Empty with get, set
+
+    /// Parameters for /approval/request/history.
+    type ApprovalRequestHistoryParameters() =
+        inherit ApprovalRequestParameters()

--- a/src/Grace.Types/Authorization.Types.fs
+++ b/src/Grace.Types/Authorization.Types.fs
@@ -69,6 +69,11 @@ module Authorization =
         | BranchWrite
         | PathRead
         | PathWrite
+        | ApprovalPolicyManage
+        | ApprovalRequestRead
+        | ApprovalRequestRespond
+        | WebhookManage
+        | WebhookDeliveryRead
 
         static member GetKnownTypes() = GetKnownTypes<Operation>()
 


### PR DESCRIPTION
Closes #146.

## Summary

- Adds the approval policy and workflow-generated approval request HTTP/SDK surface.
- Adds approval/webhook authorization operations and an `ApprovalResponder` role.
- Wires approval routes into Startup and the endpoint authorization manifest with scoped authorization.
- Keeps `approval/request/create` absent from public routes and SDK.

## Behavior

Approval policy APIs now expose create, list, show, update, enable, disable, delete, and evaluate. Approval policy notification URLs are validated through the outbound URL safety policy before being stored as `ScopedOutboundUrl`.

Approval request APIs now expose list, show, approve, reject, and history for workflow-generated requests. Approve/reject loads the stored request before authorization and requires both `ApprovalRequestRespond` on the stored scope and a stored responder selector match.

This slice intentionally uses a temporary server-side `ApprovalStore` adapter. It does not implement durable lifecycle/state-machine persistence; #147 replaces that backing store while preserving these public routes and SDK contracts.

## Authorization Evidence

- `RepoAdmin` includes approval/webhook management, read, respond, and delivery-read operations.
- `RepoReader` receives `ApprovalRequestRead` only.
- `RepoContributor` does not receive `ApprovalRequestRespond`.
- `ApprovalResponder` applies at repository and branch scope and grants `ApprovalRequestRead` plus `ApprovalRequestRespond`.
- Stored-scope policy operations use `requiresPermissionResolved` for show/update/enable/disable/delete.
- Request show/approve/reject/history use stored request scope; body-supplied scope cannot escalate privileges.
- Policy/request list endpoints filter to the authorized requested scope.

## Validation

- `dotnet tool run fantomas ...` on touched F# files: passed.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter FullyQualifiedName~Approval`: passed, 10 tests.
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release --filter "FullyQualifiedName~EndpointAuthorizationManifestTests|FullyQualifiedName~AuthorizationSemanticsTests"`: passed, 9 tests.
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release`: passed, 23 tests.
- `dotnet build src\Grace.slnx --configuration Release`: passed with 0 warnings and 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. The script's format stage reported its existing temporary skip; build and configured test projects passed.
- Fresh review-only subagent also ran `dotnet test C:\Source\GraceWorktrees\gh-146-approval-api-surface\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter ApprovalApiIntegrationTests`: passed, 10 tests.
- `git diff --check origin/main..HEAD`: passed.

## Review Path

Implementation work was delegated to a GPT-5.5 Low worker. A fresh GPT-5.4-mini xhigh review-only sibling found approval policy/request list and stored-scope authorization issues plus a temporary seed seam risk. A second GPT-5.5 Low worker fixed those issues in `f3707cb`. A final fresh GPT-5.4-mini xhigh review-only sibling reported no issues.

Final Reviewed And OK notes:

- Stored-scope authorization is resolved from persisted policy/request state before permission checks.
- Policy/request list and policy evaluate results are filtered to the authorized requested scope.
- No public `/approval/request/create` route or SDK method exists.
- The temporary request seed seam is gated to test/dev mode and namespaced, avoiding a production local-file spoof path.

## Docs Impact

No broad user documentation was updated in this slice. The API and authorization behavior are recorded here; final user docs and audit remain in #152.

## Skipped Validation

`pwsh ./scripts/validate.ps1 -Full` was not run. This slice did not add Aspire infrastructure, Service Bus delivery, Redis/Cosmos persistence behavior, or background workers; the temporary API surface was covered by focused server/auth tests and the Fast gate.
