### PR TITLE
[Webhooks/Approvals] Add webhook rule API surface

### DIFF
--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -36,6 +36,7 @@
                 <Compile Include="Policy.SDK.fs" />
                 <Compile Include="PromotionSet.SDK.fs" />
                 <Compile Include="Approval.SDK.fs" />
+                <Compile Include="Webhook.SDK.fs" />
                 <Compile Include="Review.SDK.fs" />
                 <Compile Include="Queue.SDK.fs" />
                 <Compile Include="ValidationSet.SDK.fs" />

--- a/src/Grace.SDK/Webhook.SDK.fs
+++ b/src/Grace.SDK/Webhook.SDK.fs
@@ -1,0 +1,50 @@
+namespace Grace.SDK
+
+open Grace.SDK.Common
+open Grace.Shared.Parameters.Webhook
+open Grace.Types.Webhooks
+open System.Collections.Generic
+
+/// The WebhookRule module provides webhook rule lifecycle helpers.
+type WebhookRule() =
+    /// Creates a webhook rule with its destination URL.
+    static member public Create(parameters: CreateWebhookRuleParameters) =
+        postServer<CreateWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/create")
+
+    /// Lists webhook rules for a repository or branch scope.
+    static member public List(parameters: ListWebhookRulesParameters) =
+        postServer<ListWebhookRulesParameters, IReadOnlyList<WebhookRule>> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/list")
+
+    /// Shows a single webhook rule.
+    static member public Show(parameters: ShowWebhookRuleParameters) =
+        postServer<ShowWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/show")
+
+    /// Updates a webhook rule.
+    static member public Update(parameters: UpdateWebhookRuleParameters) =
+        postServer<UpdateWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/update")
+
+    /// Enables a webhook rule.
+    static member public Enable(parameters: EnableWebhookRuleParameters) =
+        postServer<EnableWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/enable")
+
+    /// Disables a webhook rule.
+    static member public Disable(parameters: DisableWebhookRuleParameters) =
+        postServer<DisableWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/disable")
+
+    /// Deletes a webhook rule.
+    static member public Delete(parameters: DeleteWebhookRuleParameters) =
+        postServer<DeleteWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/delete")
+
+    /// Records a pending test delivery for the webhook rule without dispatching it.
+    static member public Test(parameters: TestWebhookRuleParameters) =
+        postServer<TestWebhookRuleParameters, WebhookDelivery> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/test")
+
+/// The WebhookDelivery module provides read helpers for webhook delivery observability.
+type WebhookDelivery() =
+    /// Lists webhook deliveries for a repository or branch scope.
+    static member public List(parameters: ListWebhookDeliveriesParameters) =
+        postServer<ListWebhookDeliveriesParameters, IReadOnlyList<WebhookDelivery>> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/list")
+
+    /// Shows a single webhook delivery.
+    static member public Show(parameters: ShowWebhookDeliveryParameters) =
+        postServer<ShowWebhookDeliveryParameters, WebhookDelivery> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/show")

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="Approval.Server.Tests.fs" />
+    <Compile Include="Webhook.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -1,0 +1,311 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Webhooks
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+
+module private WebhookTestHelpers =
+
+    let createAuthenticatedClient (userId: string) =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    let grantRoleAsync
+        (client: HttpClient)
+        (scopeKind: string)
+        (ownerId: string)
+        (organizationId: string)
+        (repositoryId: string)
+        (branchId: string)
+        (principalId: string)
+        (roleId: string)
+        =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- scopeKind
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+        }
+
+    let ruleParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Webhook.CreateWebhookRuleParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.Name <- $"webhook-{Guid.NewGuid():N}"
+        parameters.EventName <- ExternalWebhookEventRegistry.PromotionSetAppliedName
+        parameters.EventVersion <- 1
+        parameters.Url <- "https://example.com/grace-webhook"
+        parameters.SigningSecretVersion <- "test-secret-v1"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let ruleIdParameters<'T when 'T :> Parameters.Webhook.WebhookRuleParameters and 'T: (new: unit -> 'T)>
+        (repositoryId: string)
+        (branchId: string)
+        (ruleId: string)
+        =
+        let parameters = new 'T()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.WebhookRuleId <- ruleId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let updateRuleParameters repositoryId branchId ruleId =
+        let parameters = ruleParameters repositoryId branchId
+        parameters.WebhookRuleId <- ruleId
+        parameters.Name <- $"updated-{Guid.NewGuid():N}"
+        parameters
+
+    let listRuleParameters repositoryId branchId =
+        let parameters = Parameters.Webhook.ListWebhookRulesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let listDeliveryParameters repositoryId branchId ruleId =
+        let parameters = Parameters.Webhook.ListWebhookDeliveriesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.WebhookRuleId <- ruleId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let showDeliveryParameters repositoryId branchId deliveryId =
+        let parameters = Parameters.Webhook.ShowWebhookDeliveryParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.WebhookDeliveryId <- deliveryId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let createRuleAsync (client: HttpClient) repositoryId branchId =
+        task {
+            let! createResponse = client.PostAsync("/webhook/rule/create", createJsonContent (ruleParameters repositoryId branchId))
+
+            Assert.That(createResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            return! deserializeContent<WebhookRule> createResponse
+        }
+
+[<NonParallelizable>]
+type WebhookApiIntegrationTests() =
+
+    [<SetUp>]
+    member _.SetUp() = WebhookStore.clearForTests ()
+
+    [<Test>]
+    member _.RuleLifecycleAndDeliveryQueryHappyPath() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
+            let! created = WebhookTestHelpers.createRuleAsync adminClient repositoryId branchId
+
+            Assert.That(created.Status, Is.EqualTo(WebhookRuleStatus.Disabled))
+            Assert.That(created.Url.Url, Is.EqualTo("https://example.com/grace-webhook"))
+            Assert.That(created.Url.Safety, Is.EqualTo(OutboundUrlSafety.PublicHttps))
+
+            let showParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.ShowWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            let enableParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.EnableWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            let! enableResponse = adminClient.PostAsync("/webhook/rule/enable", createJsonContent enableParameters)
+            Assert.That(enableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let testParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.TestWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            testParameters.DedupeKey <- "test-dedupe-key"
+            let! testResponse = adminClient.PostAsync("/webhook/rule/test", createJsonContent testParameters)
+            Assert.That(testResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! testDelivery = deserializeContent<WebhookDelivery> testResponse
+            Assert.That(testDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.Pending))
+            Assert.That(testDelivery.WebhookRuleId, Is.EqualTo(created.WebhookRuleId))
+            Assert.That(testDelivery.DedupeKey, Is.EqualTo("test-dedupe-key"))
+
+            let! listResponse =
+                adminClient.PostAsync(
+                    "/webhook/delivery/list",
+                    createJsonContent (WebhookTestHelpers.listDeliveryParameters repositoryId branchId (created.WebhookRuleId.ToString()))
+                )
+
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! deliveries = deserializeContent<WebhookDelivery array> listResponse
+
+            Assert.That(
+                deliveries
+                |> Array.map (fun delivery -> delivery.WebhookDeliveryId),
+                Is.EquivalentTo([| testDelivery.WebhookDeliveryId |])
+            )
+
+            let! showDeliveryResponse =
+                adminClient.PostAsync(
+                    "/webhook/delivery/show",
+                    createJsonContent (WebhookTestHelpers.showDeliveryParameters repositoryId branchId (testDelivery.WebhookDeliveryId.ToString()))
+                )
+
+            Assert.That(showDeliveryResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let disableParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.DisableWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            let deleteParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.DeleteWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            let! showResponse = adminClient.PostAsync("/webhook/rule/show", createJsonContent showParameters)
+            Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! disableResponse = adminClient.PostAsync("/webhook/rule/disable", createJsonContent disableParameters)
+            Assert.That(disableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! deleteResponse = adminClient.PostAsync("/webhook/rule/delete", createJsonContent deleteParameters)
+            Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+        }
+
+    [<Test>]
+    member _.CreateRejectsUnsafePublicUrl() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
+            let parameters = WebhookTestHelpers.ruleParameters repositoryId branchId
+            parameters.Url <- "http://localhost:5000/webhook"
+
+            let! response = adminClient.PostAsync("/webhook/rule/create", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.RuleListReturnsOnlyRequestedAuthorizedScope() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = $"{Guid.NewGuid()}"
+            let otherBranchId = $"{Guid.NewGuid()}"
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
+            let! allowedRule = WebhookTestHelpers.createRuleAsync adminClient repositoryId allowedBranchId
+            let! otherRule = WebhookTestHelpers.createRuleAsync adminClient repositoryId otherBranchId
+
+            let! listResponse =
+                adminClient.PostAsync("/webhook/rule/list", createJsonContent (WebhookTestHelpers.listRuleParameters repositoryId allowedBranchId))
+
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! rules = deserializeContent<WebhookRule array> listResponse
+
+            Assert.That(
+                rules
+                |> Array.map (fun rule -> rule.WebhookRuleId),
+                Is.EquivalentTo([| allowedRule.WebhookRuleId |])
+            )
+
+            Assert.That(
+                rules
+                |> Array.exists (fun rule -> rule.WebhookRuleId = otherRule.WebhookRuleId),
+                Is.False
+            )
+        }
+
+    [<Test>]
+    member _.StoredScopeBlocksBodyScopeSpoofingForRuleAndDeliveryShow() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let allowedBranchId = $"{Guid.NewGuid()}"
+            let storedBranchId = $"{Guid.NewGuid()}"
+            let adminUser = $"{Guid.NewGuid()}"
+            let limitedUser = $"{Guid.NewGuid()}"
+
+            let! grantAdmin = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
+            let! storedRule = WebhookTestHelpers.createRuleAsync adminClient repositoryId storedBranchId
+
+            let testParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.TestWebhookRuleParameters>
+                    repositoryId
+                    storedBranchId
+                    (storedRule.WebhookRuleId.ToString())
+
+            let! testResponse = adminClient.PostAsync("/webhook/rule/test", createJsonContent testParameters)
+            Assert.That(testResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! storedDelivery = deserializeContent<WebhookDelivery> testResponse
+
+            let! grantLimited = WebhookTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId limitedUser "BranchAdmin"
+
+            Assert.That(grantLimited.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use limitedClient = WebhookTestHelpers.createAuthenticatedClient limitedUser
+
+            let spoofedShow =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.ShowWebhookRuleParameters>
+                    repositoryId
+                    allowedBranchId
+                    (storedRule.WebhookRuleId.ToString())
+
+            let! showResponse = limitedClient.PostAsync("/webhook/rule/show", createJsonContent spoofedShow)
+            Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let spoofedUpdate = WebhookTestHelpers.updateRuleParameters repositoryId allowedBranchId (storedRule.WebhookRuleId.ToString())
+
+            let! updateResponse = limitedClient.PostAsync("/webhook/rule/update", createJsonContent spoofedUpdate)
+            Assert.That(updateResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let spoofedDeliveryShow = WebhookTestHelpers.showDeliveryParameters repositoryId allowedBranchId (storedDelivery.WebhookDeliveryId.ToString())
+
+            let! deliveryShowResponse = limitedClient.PostAsync("/webhook/delivery/show", createJsonContent spoofedDeliveryShow)
+            Assert.That(deliveryShowResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+        }
+
+    [<Test>]
+    member _.ApprovalNotificationDeliveryIsNotWebhookDeliverySurface() =
+        task {
+            use client = WebhookTestHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
+            let! response = client.PostAsync("/approval/notification-delivery/list", createJsonContent (obj ()))
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
+        }

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -79,6 +79,7 @@
                 <Compile Include="PromotionSet.Server.fs" />
                 <Compile Include="ApprovalPolicy.Server.fs" />
                 <Compile Include="ApprovalRequest.Server.fs" />
+                <Compile Include="Webhook.Server.fs" />
                 <Compile Include="WorkItem.Server.fs" />
                 <Compile Include="Policy.Server.fs" />
                 <Compile Include="ReviewModels.Server.fs" />

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -47,6 +47,16 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/approval/request/approve" (Authorized(ApprovalRequestRespond, Repository))
             endpoint "POST" "/approval/request/reject" (Authorized(ApprovalRequestRespond, Repository))
             endpoint "POST" "/approval/request/history" (Authorized(ApprovalRequestRead, Repository))
+            endpoint "POST" "/webhook/rule/create" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/list" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/show" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/update" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/enable" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/disable" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/delete" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/rule/test" (Authorized(WebhookManage, Repository))
+            endpoint "POST" "/webhook/delivery/list" (Authorized(WebhookDeliveryRead, Repository))
+            endpoint "POST" "/webhook/delivery/show" (Authorized(WebhookDeliveryRead, Repository))
             endpoint "GET" "/auth/login" AllowAnonymous
             endpoint "GET" "/auth/login/%s" AllowAnonymous
             endpoint "GET" "/auth/logout" Authenticated

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -291,6 +291,30 @@ module Application =
                 return ApprovalCommon.resourceFromApprovalScope scope
             }
 
+        let webhookRuleResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Webhook.WebhookRuleParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let scope = WebhookCommon.scopeFromRuleParameters parameters
+                return WebhookCommon.resourceFromWebhookScope scope
+            }
+
+        let webhookDeliveryListResourceFromContext (context: HttpContext) =
+            task {
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<Webhook.WebhookDeliveryParameters>()
+
+                context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+                |> ignore
+
+                let scope = WebhookCommon.scopeFromDeliveryParameters parameters
+                return WebhookCommon.resourceFromWebhookScope scope
+            }
+
         let requireApprovalPolicyManage: HttpHandler =
             AuthorizationMiddleware.requiresPermission Operation.ApprovalPolicyManage approvalPolicyResourceFromContext
 
@@ -323,6 +347,32 @@ module Application =
 
         let requireApprovalRequestReject: HttpHandler =
             AuthorizationMiddleware.requiresPermissionResolved ApprovalRequest.resolveStoredRequestForRespond<Approval.RejectApprovalRequestParameters>
+
+        let requireWebhookRuleManage: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.WebhookManage webhookRuleResourceFromContext
+
+        let requireWebhookRuleShow: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.ShowWebhookRuleParameters>
+
+        let requireWebhookRuleUpdate: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.UpdateWebhookRuleParameters>
+
+        let requireWebhookRuleEnable: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.EnableWebhookRuleParameters>
+
+        let requireWebhookRuleDisable: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.DisableWebhookRuleParameters>
+
+        let requireWebhookRuleDelete: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.DeleteWebhookRuleParameters>
+
+        let requireWebhookRuleTest: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookRule.resolveStoredRuleForManage<Webhook.TestWebhookRuleParameters>
+
+        let requireWebhookDeliveryRead: HttpHandler =
+            AuthorizationMiddleware.requiresPermission Operation.WebhookDeliveryRead webhookDeliveryListResourceFromContext
+
+        let requireWebhookDeliveryShow: HttpHandler =
+            AuthorizationMiddleware.requiresPermissionResolved WebhookDelivery.resolveStoredDeliveryForRead<Webhook.ShowWebhookDeliveryParameters>
 
         let requirePathWrite: HttpHandler = AuthorizationMiddleware.requiresPermissions Operation.PathWrite uploadPathResourcesFromContext
 
@@ -904,6 +954,42 @@ module Application =
 
                                route "/history" (composeHandlers requireApprovalRequestHistory ApprovalRequest.History)
                                |> addMetadata typeof<Approval.ApprovalRequestHistoryParameters> ]
+                    ]
+                subRoute
+                    "/webhook/rule"
+                    [
+                        POST [ route "/create" (composeHandlers requireWebhookRuleManage WebhookRule.Create)
+                               |> addMetadata typeof<Webhook.CreateWebhookRuleParameters>
+
+                               route "/list" (composeHandlers requireWebhookRuleManage WebhookRule.List)
+                               |> addMetadata typeof<Webhook.ListWebhookRulesParameters>
+
+                               route "/show" (composeHandlers requireWebhookRuleShow WebhookRule.Show)
+                               |> addMetadata typeof<Webhook.ShowWebhookRuleParameters>
+
+                               route "/update" (composeHandlers requireWebhookRuleUpdate WebhookRule.Update)
+                               |> addMetadata typeof<Webhook.UpdateWebhookRuleParameters>
+
+                               route "/enable" (composeHandlers requireWebhookRuleEnable WebhookRule.Enable)
+                               |> addMetadata typeof<Webhook.EnableWebhookRuleParameters>
+
+                               route "/disable" (composeHandlers requireWebhookRuleDisable WebhookRule.Disable)
+                               |> addMetadata typeof<Webhook.DisableWebhookRuleParameters>
+
+                               route "/delete" (composeHandlers requireWebhookRuleDelete WebhookRule.Delete)
+                               |> addMetadata typeof<Webhook.DeleteWebhookRuleParameters>
+
+                               route "/test" (composeHandlers requireWebhookRuleTest WebhookRule.Test)
+                               |> addMetadata typeof<Webhook.TestWebhookRuleParameters> ]
+                    ]
+                subRoute
+                    "/webhook/delivery"
+                    [
+                        POST [ route "/list" (composeHandlers requireWebhookDeliveryRead WebhookDelivery.List)
+                               |> addMetadata typeof<Webhook.ListWebhookDeliveriesParameters>
+
+                               route "/show" (composeHandlers requireWebhookDeliveryShow WebhookDelivery.Show)
+                               |> addMetadata typeof<Webhook.ShowWebhookDeliveryParameters> ]
                     ]
                 subRoute
                     "/branch"

--- a/src/Grace.Server/Webhook.Server.fs
+++ b/src/Grace.Server/Webhook.Server.fs
@@ -1,0 +1,401 @@
+namespace Grace.Server
+
+open Giraffe
+open Grace.Server.Security
+open Grace.Shared
+open Grace.Shared.Parameters.Webhook
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Authorization
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
+open NodaTime
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.IO
+
+module WebhookStore =
+
+    type WebhookRuleDto = Grace.Types.Webhooks.WebhookRule
+    type WebhookDeliveryDto = Grace.Types.Webhooks.WebhookDelivery
+
+    let private rules = ConcurrentDictionary<WebhookRuleId, WebhookRuleDto>()
+    let private deliveries = ConcurrentDictionary<WebhookDeliveryId, WebhookDeliveryDto>()
+
+    let private scopeMatches (expected: WebhookScope) (actual: WebhookScope) =
+        actual.OwnerId = expected.OwnerId
+        && actual.OrganizationId = expected.OrganizationId
+        && actual.RepositoryId = expected.RepositoryId
+        && actual.TargetBranchId = expected.TargetBranchId
+
+    let clearForTests () =
+        rules.Clear()
+        deliveries.Clear()
+
+    let upsertRule (rule: WebhookRuleDto) =
+        rules[rule.WebhookRuleId] <- rule
+        rule
+
+    let tryGetRule webhookRuleId =
+        match rules.TryGetValue webhookRuleId with
+        | true, rule -> Some rule
+        | _ -> None
+
+    let listRules scope includeDeleted =
+        rules.Values
+        |> Seq.filter (fun rule ->
+            scopeMatches scope rule.Scope
+            && (includeDeleted
+                || rule.Status <> WebhookRuleStatus.Deleted))
+        |> Seq.toArray
+        :> IReadOnlyList<WebhookRuleDto>
+
+    let addDelivery (delivery: WebhookDeliveryDto) =
+        deliveries[delivery.WebhookDeliveryId] <- delivery
+        delivery
+
+    let tryGetDelivery webhookDeliveryId =
+        match deliveries.TryGetValue webhookDeliveryId with
+        | true, delivery -> Some delivery
+        | _ -> None
+
+    let listDeliveries scope webhookRuleId includeTerminal =
+        deliveries.Values
+        |> Seq.filter (fun delivery ->
+            match tryGetRule delivery.WebhookRuleId with
+            | Some rule ->
+                scopeMatches scope rule.Scope
+                && (webhookRuleId = WebhookRuleId.Empty
+                    || delivery.WebhookRuleId = webhookRuleId)
+                && (includeTerminal
+                    || delivery.Status = WebhookDeliveryStatus.Pending
+                    || delivery.Status = WebhookDeliveryStatus.RetryScheduled)
+            | None -> false)
+        |> Seq.toArray
+        :> IReadOnlyList<WebhookDeliveryDto>
+
+module WebhookCommon =
+
+    let tryParseGuid value =
+        let mutable parsed = Guid.Empty
+
+        if String.IsNullOrWhiteSpace value |> not
+           && Guid.TryParse(value, &parsed)
+           && parsed <> Guid.Empty then
+            Some parsed
+        else
+            None
+
+    let scopeFromRuleParameters (parameters: WebhookRuleParameters) =
+        let ownerId =
+            tryParseGuid parameters.OwnerId
+            |> Option.defaultValue OwnerId.Empty
+
+        let organizationId =
+            tryParseGuid parameters.OrganizationId
+            |> Option.defaultValue OrganizationId.Empty
+
+        let repositoryId =
+            tryParseGuid parameters.RepositoryId
+            |> Option.defaultValue RepositoryId.Empty
+
+        let targetBranchId = tryParseGuid parameters.TargetBranchId
+
+        { WebhookScope.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+
+    let scopeFromDeliveryParameters (parameters: WebhookDeliveryParameters) =
+        let ownerId =
+            tryParseGuid parameters.OwnerId
+            |> Option.defaultValue OwnerId.Empty
+
+        let organizationId =
+            tryParseGuid parameters.OrganizationId
+            |> Option.defaultValue OrganizationId.Empty
+
+        let repositoryId =
+            tryParseGuid parameters.RepositoryId
+            |> Option.defaultValue RepositoryId.Empty
+
+        let targetBranchId = tryParseGuid parameters.TargetBranchId
+
+        { WebhookScope.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+
+    let resourceFromWebhookScope (scope: WebhookScope) =
+        match scope.TargetBranchId with
+        | Some branchId -> Resource.Branch(scope.OwnerId, scope.OrganizationId, scope.RepositoryId, branchId)
+        | None -> Resource.Repository(scope.OwnerId, scope.OrganizationId, scope.RepositoryId)
+
+    let scopeEquals (left: WebhookScope) (right: WebhookScope) =
+        left.OwnerId = right.OwnerId
+        && left.OrganizationId = right.OrganizationId
+        && left.RepositoryId = right.RepositoryId
+        && left.TargetBranchId = right.TargetBranchId
+
+    let currentUserId (context: HttpContext) =
+        PrincipalMapper.tryGetUserId context.User
+        |> Option.defaultValue "unknown"
+        |> UserId
+
+    let error context message = GraceError.Create message (Services.getCorrelationId context)
+
+module WebhookRule =
+
+    open WebhookCommon
+
+    let private validateUrl (context: HttpContext) (parameters: CreateWebhookRuleParameters) =
+        let configuration = context.RequestServices.GetRequiredService<IConfiguration>()
+        let hostEnvironment = context.RequestServices.GetService<IHostEnvironment>()
+
+        let request: OutboundUrlSafety.ValidationRequest =
+            { Url = parameters.Url; RequestedSafety = parameters.UrlSafety; AcknowledgeUnsafeLocalDevelopment = parameters.AcknowledgeUnsafeLocalDevelopment }
+
+        match OutboundUrlSafety.validate hostEnvironment configuration request with
+        | Ok validated -> Ok validated.ScopedUrl
+        | Error failure -> Error $"Url is not allowed: {failure}."
+
+    let private validateEvent (parameters: CreateWebhookRuleParameters) =
+        match ExternalWebhookEventRegistry.parse parameters.EventName with
+        | Error message -> Error message
+        | Ok definition when definition.Version <> parameters.EventVersion ->
+            Error $"Webhook event '{parameters.EventName}' version {parameters.EventVersion} is not registered."
+        | Ok _ -> Ok()
+
+    let private retryPolicyFromParameters (parameters: CreateWebhookRuleParameters) =
+        if parameters.MaxAttempts < 1 then
+            Error "MaxAttempts must be at least 1."
+        elif parameters.InitialDelaySeconds < 0 then
+            Error "InitialDelaySeconds cannot be negative."
+        elif parameters.MaxDelaySeconds < parameters.InitialDelaySeconds then
+            Error "MaxDelaySeconds must be greater than or equal to InitialDelaySeconds."
+        else
+            Ok { MaxAttempts = parameters.MaxAttempts; InitialDelaySeconds = parameters.InitialDelaySeconds; MaxDelaySeconds = parameters.MaxDelaySeconds }
+
+    let private buildRule context webhookRuleId status createdBy createdAt (parameters: CreateWebhookRuleParameters) =
+        task {
+            match validateEvent parameters, retryPolicyFromParameters parameters, validateUrl context parameters with
+            | Error message, _, _
+            | _, Error message, _
+            | _, _, Error message -> return Error message
+            | Ok (), Ok retryPolicy, Ok url ->
+                return
+                    Ok
+                        { Grace.Types.Webhooks.WebhookRule.Default with
+                            WebhookRuleId = webhookRuleId
+                            Name = parameters.Name
+                            EventName = parameters.EventName.Trim()
+                            EventVersion = parameters.EventVersion
+                            Scope = scopeFromRuleParameters parameters
+                            Url = url
+                            SigningSecretVersion = parameters.SigningSecretVersion
+                            RetryPolicy = retryPolicy
+                            Status = status
+                            CreatedBy = createdBy
+                            CreatedAt = createdAt
+                        }
+        }
+
+    let private ruleFromContext<'T when 'T :> WebhookRuleParameters> (context: HttpContext) =
+        task {
+            context.Request.EnableBuffering()
+            let! parameters = context.BindJsonAsync<'T>()
+
+            context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+            |> ignore
+
+            return
+                tryParseGuid parameters.WebhookRuleId
+                |> Option.bind WebhookStore.tryGetRule
+        }
+
+    let resolveStoredRuleForManage<'T when 'T :> WebhookRuleParameters> (context: HttpContext) =
+        task {
+            let! rule = ruleFromContext<'T> context
+
+            return
+                match rule with
+                | Some webhookRule -> Ok(Operation.WebhookManage, resourceFromWebhookScope webhookRule.Scope)
+                | None -> Error(error context "Webhook rule was not found.")
+        }
+
+    let Create: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<CreateWebhookRuleParameters> context
+                let webhookRuleId = Guid.NewGuid()
+                let createdAt = getCurrentInstant ()
+                let createdBy = currentUserId context
+
+                match! buildRule context webhookRuleId WebhookRuleStatus.Disabled createdBy createdAt parameters with
+                | Error message ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (error context message)
+                | Ok rule ->
+                    return!
+                        context
+                        |> Services.result200Ok (WebhookStore.upsertRule rule)
+            }
+
+    let List: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ListWebhookRulesParameters> context
+                let scope = scopeFromRuleParameters parameters
+
+                return!
+                    context
+                    |> Services.result200Ok (WebhookStore.listRules scope parameters.IncludeDeleted)
+            }
+
+    let Show: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ShowWebhookRuleParameters> context
+
+                match tryParseGuid parameters.WebhookRuleId
+                      |> Option.bind WebhookStore.tryGetRule
+                    with
+                | Some rule -> return! context |> Services.result200Ok rule
+                | None -> return! Services.result404NotFound context
+            }
+
+    let Update: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<UpdateWebhookRuleParameters> context
+
+                match tryParseGuid parameters.WebhookRuleId
+                      |> Option.bind WebhookStore.tryGetRule
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some existing ->
+                    let requestedScope = scopeFromRuleParameters parameters
+
+                    if scopeEquals requestedScope existing.Scope |> not then
+                        return!
+                            context
+                            |> Services.result400BadRequest (error context "Webhook rule scope cannot be changed.")
+                    else
+                        match! buildRule context existing.WebhookRuleId existing.Status existing.CreatedBy existing.CreatedAt parameters with
+                        | Error message ->
+                            return!
+                                context
+                                |> Services.result400BadRequest (error context message)
+                        | Ok rule ->
+                            return!
+                                context
+                                |> Services.result200Ok (WebhookStore.upsertRule { rule with UpdatedAt = Some(getCurrentInstant ()) })
+            }
+
+    let private setStatus status : HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<WebhookRuleParameters> context
+
+                match tryParseGuid parameters.WebhookRuleId
+                      |> Option.bind WebhookStore.tryGetRule
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some rule ->
+                    return!
+                        context
+                        |> Services.result200Ok (WebhookStore.upsertRule { rule with Status = status; UpdatedAt = Some(getCurrentInstant ()) })
+            }
+
+    let Enable: HttpHandler = setStatus WebhookRuleStatus.Enabled
+
+    let Disable: HttpHandler = setStatus WebhookRuleStatus.Disabled
+
+    let Delete: HttpHandler = setStatus WebhookRuleStatus.Deleted
+
+    let Test: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<TestWebhookRuleParameters> context
+
+                match tryParseGuid parameters.WebhookRuleId
+                      |> Option.bind WebhookStore.tryGetRule
+                    with
+                | None -> return! Services.result404NotFound context
+                | Some rule ->
+                    let delivery =
+                        { Grace.Types.Webhooks.WebhookDelivery.Default with
+                            WebhookDeliveryId = Guid.NewGuid()
+                            WebhookRuleId = rule.WebhookRuleId
+                            EventName = rule.EventName
+                            EventVersion = rule.EventVersion
+                            DedupeKey =
+                                if String.IsNullOrWhiteSpace parameters.DedupeKey then
+                                    $"test:{Guid.NewGuid():N}"
+                                else
+                                    parameters.DedupeKey.Trim()
+                            Status = WebhookDeliveryStatus.Pending
+                            CreatedAt = getCurrentInstant ()
+                        }
+
+                    return!
+                        context
+                        |> Services.result200Ok (WebhookStore.addDelivery delivery)
+            }
+
+module WebhookDelivery =
+
+    open WebhookCommon
+
+    let private deliveryFromContext<'T when 'T :> WebhookDeliveryParameters> (context: HttpContext) =
+        task {
+            context.Request.EnableBuffering()
+            let! parameters = context.BindJsonAsync<'T>()
+
+            context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
+            |> ignore
+
+            return
+                tryParseGuid parameters.WebhookDeliveryId
+                |> Option.bind WebhookStore.tryGetDelivery
+        }
+
+    let resolveStoredDeliveryForRead<'T when 'T :> WebhookDeliveryParameters> (context: HttpContext) =
+        task {
+            let! delivery = deliveryFromContext<'T> context
+
+            return
+                match delivery with
+                | Some webhookDelivery ->
+                    match WebhookStore.tryGetRule webhookDelivery.WebhookRuleId with
+                    | Some webhookRule -> Ok(Operation.WebhookDeliveryRead, resourceFromWebhookScope webhookRule.Scope)
+                    | None -> Error(error context "Webhook delivery rule was not found.")
+                | None -> Error(error context "Webhook delivery was not found.")
+        }
+
+    let List: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ListWebhookDeliveriesParameters> context
+                let scope = scopeFromDeliveryParameters parameters
+
+                let webhookRuleId =
+                    tryParseGuid parameters.WebhookRuleId
+                    |> Option.defaultValue WebhookRuleId.Empty
+
+                return!
+                    context
+                    |> Services.result200Ok (WebhookStore.listDeliveries scope webhookRuleId parameters.IncludeTerminal)
+            }
+
+    let Show: HttpHandler =
+        fun _ context ->
+            task {
+                let! parameters = Services.parse<ShowWebhookDeliveryParameters> context
+
+                match tryParseGuid parameters.WebhookDeliveryId
+                      |> Option.bind WebhookStore.tryGetDelivery
+                    with
+                | Some delivery -> return! context |> Services.result200Ok delivery
+                | None -> return! Services.result404NotFound context
+            }

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -59,6 +59,7 @@
         <Compile Include="Parameters\Policy.Parameters.fs" />
         <Compile Include="Parameters\PromotionSet.Parameters.fs" />
         <Compile Include="Parameters\Approval.Parameters.fs" />
+        <Compile Include="Parameters\Webhook.Parameters.fs" />
         <Compile Include="Parameters\Review.Parameters.fs" />
         <Compile Include="Parameters\Queue.Parameters.fs" />
         <Compile Include="Parameters\Validation.Parameters.fs" />

--- a/src/Grace.Shared/Parameters/Webhook.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Webhook.Parameters.fs
@@ -1,0 +1,85 @@
+namespace Grace.Shared.Parameters
+
+open Grace.Shared.Parameters.Common
+open Grace.Types.Webhooks
+open System
+
+module Webhook =
+
+    /// Base parameters for webhook rule endpoints.
+    type WebhookRuleParameters() =
+        inherit CommonParameters()
+        member val public OwnerId = String.Empty with get, set
+        member val public OwnerName = String.Empty with get, set
+        member val public OrganizationId = String.Empty with get, set
+        member val public OrganizationName = String.Empty with get, set
+        member val public RepositoryId = String.Empty with get, set
+        member val public RepositoryName = String.Empty with get, set
+        member val public TargetBranchId = String.Empty with get, set
+        member val public WebhookRuleId = String.Empty with get, set
+
+    /// Parameters for /webhook/rule/create.
+    type CreateWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+        member val public Name = String.Empty with get, set
+        member val public EventName = String.Empty with get, set
+        member val public EventVersion = 1 with get, set
+        member val public Url = String.Empty with get, set
+        member val public UrlSafety = OutboundUrlSafety.PublicHttps with get, set
+        member val public AcknowledgeUnsafeLocalDevelopment = false with get, set
+        member val public SigningSecretVersion = String.Empty with get, set
+        member val public MaxAttempts = WebhookRetryPolicy.Default.MaxAttempts with get, set
+        member val public InitialDelaySeconds = WebhookRetryPolicy.Default.InitialDelaySeconds with get, set
+        member val public MaxDelaySeconds = WebhookRetryPolicy.Default.MaxDelaySeconds with get, set
+
+    /// Parameters for /webhook/rule/list.
+    type ListWebhookRulesParameters() =
+        inherit WebhookRuleParameters()
+        member val public IncludeDeleted = false with get, set
+
+    /// Parameters for /webhook/rule/show.
+    type ShowWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+
+    /// Parameters for /webhook/rule/update.
+    type UpdateWebhookRuleParameters() =
+        inherit CreateWebhookRuleParameters()
+
+    /// Parameters for /webhook/rule/enable.
+    type EnableWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+
+    /// Parameters for /webhook/rule/disable.
+    type DisableWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+
+    /// Parameters for /webhook/rule/delete.
+    type DeleteWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+
+    /// Parameters for /webhook/rule/test.
+    type TestWebhookRuleParameters() =
+        inherit WebhookRuleParameters()
+        member val public DedupeKey = String.Empty with get, set
+
+    /// Base parameters for webhook delivery endpoints.
+    type WebhookDeliveryParameters() =
+        inherit CommonParameters()
+        member val public OwnerId = String.Empty with get, set
+        member val public OwnerName = String.Empty with get, set
+        member val public OrganizationId = String.Empty with get, set
+        member val public OrganizationName = String.Empty with get, set
+        member val public RepositoryId = String.Empty with get, set
+        member val public RepositoryName = String.Empty with get, set
+        member val public TargetBranchId = String.Empty with get, set
+        member val public WebhookRuleId = String.Empty with get, set
+        member val public WebhookDeliveryId = String.Empty with get, set
+
+    /// Parameters for /webhook/delivery/list.
+    type ListWebhookDeliveriesParameters() =
+        inherit WebhookDeliveryParameters()
+        member val public IncludeTerminal = true with get, set
+
+    /// Parameters for /webhook/delivery/show.
+    type ShowWebhookDeliveryParameters() =
+        inherit WebhookDeliveryParameters()


### PR DESCRIPTION
## Summary

- Adds webhook rule management routes for create/list/show/update/enable/disable/delete/test.
- Adds webhook delivery list/show query routes for observable delivery state.
- Adds shared webhook parameters, SDK wrappers, authorization manifest entries, URL safety integration, and focused server tests.

## Scope Notes

- Parent epic: #142.
- Closes #149.
- This slice does not implement the background dispatch/delivery worker; that remains #150.
- Webhook creation carries the URL inline; no reusable destination object or destination noun is introduced.
- Approval notification delivery remains distinct from webhook delivery.

## Validation

- `dotnet tool run fantomas Grace.Shared\Parameters\Webhook.Parameters.fs Grace.Server\Webhook.Server.fs Grace.SDK\Webhook.SDK.fs Grace.Server.Tests\Webhook.Server.Tests.fs Grace.Server\Startup.Server.fs Grace.Server\Security\EndpointAuthorizationManifest.Server.fs` from `src`: passed; files unchanged after formatting.
- `dotnet build src\Grace.slnx --configuration Release`: passed, 0 warnings, 0 errors.
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~EndpointAuthorizationManifestTests|FullyQualifiedName~AuthorizationSemanticsTests"`: passed, 9 tests.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~WebhookApiIntegrationTests"`: first run hit a transient Service Bus emulator setup timeout before assertions; retry passed, 5 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.

## Review Evidence

Fresh local review-only sibling subagent reviewed `origin/main..HEAD` and found no actionable issues.

Reviewed and OK:
- Stored-rule scope is used for existing rule operations; body-supplied scope is not trusted for show/update/status/delete/test.
- Stored delivery scope is used for delivery show authorization.
- URL validation uses the shared outbound URL safety policy.
- `webhook/rule/test` only records a pending delivery and does not add a dispatch path.
- `ApprovalNotificationDelivery` remains distinct and is not exposed as webhook delivery.

Residual coverage note:
- Spoofed-scope regression coverage explicitly exercises rule show/update and delivery show. Enable/disable/delete/test share the same stored-rule auth helper and were reviewed, but are not each separately spoof-tested.
