### PR TITLE
[Webhooks/Approvals] Add approval request lifecycle

### DIFF
--- a/src/Grace.Actors/ActorProxy.Extensions.Actor.fs
+++ b/src/Grace.Actors/ActorProxy.Extensions.Actor.fs
@@ -8,6 +8,7 @@ open Grace.Actors.Timing
 open Grace.Actors.Types
 open Grace.Shared
 open Grace.Types.Types
+open Grace.Types.Webhooks
 open Grace.Shared.Utilities
 open Orleans
 open Orleans.Runtime
@@ -286,6 +287,25 @@ module ActorProxy =
             let orleansContext = Dictionary<string, obj>()
             orleansContext.Add(nameof RepositoryId, repositoryId)
             orleansContext.Add(Constants.ActorNameProperty, ActorName.Artifact)
+            memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
+            grain
+
+    module ApprovalRequest =
+        let scopeKey (scope: ApprovalScope) = $"{scope.OwnerId:N}|{scope.OrganizationId:N}|{scope.RepositoryId:N}|{scope.TargetBranchId:N}"
+
+        let CreateActorProxy (approvalRequestId: ApprovalRequestId) (repositoryId: RepositoryId) (correlationId: string) =
+            let grain = orleansClient.CreateActorProxyWithCorrelationId<IApprovalRequestActor>(approvalRequestId, correlationId)
+            let orleansContext = Dictionary<string, obj>()
+            orleansContext.Add(nameof RepositoryId, repositoryId)
+            orleansContext.Add(Constants.ActorNameProperty, ActorName.ApprovalRequest)
+            memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
+            grain
+
+        let CreateIndexActorProxy (scope: ApprovalScope) (correlationId: string) =
+            let grain = orleansClient.CreateActorProxyWithCorrelationId<IApprovalRequestIndexActor>(scopeKey scope, correlationId)
+            let orleansContext = Dictionary<string, obj>()
+            orleansContext.Add(nameof RepositoryId, scope.RepositoryId)
+            orleansContext.Add(Constants.ActorNameProperty, ActorName.ApprovalRequestIndex)
             memoryCache.CreateOrleansContextEntry(grain.GetGrainId(), orleansContext)
             grain
 

--- a/src/Grace.Actors/ApprovalRequest.Actor.fs
+++ b/src/Grace.Actors/ApprovalRequest.Actor.fs
@@ -220,10 +220,31 @@ module ApprovalRequest =
                     Some request
                 |> returnTask
 
+            member this.GetJson correlationId =
+                this.correlationId <- correlationId
+
+                if request.ApprovalRequestId = ApprovalRequestId.Empty then
+                    None
+                else
+                    Some(serialize request)
+                |> returnTask
+
             member this.GetEvents correlationId =
                 this.correlationId <- correlationId
 
                 (state.State :> IReadOnlyList<ApprovalRequestEvent>)
+                |> returnTask
+
+            member this.GetHistoryJson correlationId =
+                this.correlationId <- correlationId
+
+                state.State
+                |> Seq.filter (fun event -> isNull (box event) |> not)
+                |> Seq.filter (fun event -> isNull (box event.Event) |> not)
+                |> Seq.scan (fun current event -> ApprovalRequest.UpdateDto event current) Grace.Types.Webhooks.ApprovalRequest.Default
+                |> Seq.skip 1
+                |> Seq.toArray
+                |> serialize
                 |> returnTask
 
             member this.Create request metadata = this.ProcessCommand (ApprovalRequestCommand.Create request) metadata
@@ -272,16 +293,33 @@ module ApprovalRequest =
             member this.RecordDecision decision metadata = this.ProcessCommand (ApprovalRequestCommand.RecordDecision decision) metadata
 
             member this.RecordDecisionGenerated(decision, decidedBy, reason, clientDecisionId, metadata) =
-                let requestDecision =
-                    { ApprovalRequestDecision.Default with
-                        Decision = decision
-                        DecidedBy = UserId decidedBy
-                        DecidedAt = metadata.Timestamp
-                        Reason = reason
-                        ClientDecisionId = clientDecisionId
-                    }
+                match decision with
+                | value when String.Equals(value, nameof ApprovalDecision.Approve, StringComparison.OrdinalIgnoreCase) ->
+                    let requestDecision =
+                        { ApprovalRequestDecision.Default with
+                            Decision = ApprovalDecision.Approve
+                            DecidedBy = UserId decidedBy
+                            DecidedAt = metadata.Timestamp
+                            Reason = reason
+                            ClientDecisionId = clientDecisionId
+                        }
 
-                this.ProcessCommand (ApprovalRequestCommand.RecordDecision requestDecision) metadata
+                    this.ProcessCommand (ApprovalRequestCommand.RecordDecision requestDecision) metadata
+                | value when String.Equals(value, nameof ApprovalDecision.Reject, StringComparison.OrdinalIgnoreCase) ->
+                    let requestDecision =
+                        { ApprovalRequestDecision.Default with
+                            Decision = ApprovalDecision.Reject
+                            DecidedBy = UserId decidedBy
+                            DecidedAt = metadata.Timestamp
+                            Reason = reason
+                            ClientDecisionId = clientDecisionId
+                        }
+
+                    this.ProcessCommand (ApprovalRequestCommand.RecordDecision requestDecision) metadata
+                | _ ->
+                    GraceError.Create $"Approval decision '{decision}' is not valid." metadata.CorrelationId
+                    |> Error
+                    |> returnTask
 
             member this.Handle command metadata = this.ProcessCommand command metadata
 
@@ -292,17 +330,39 @@ module ApprovalRequest =
         inherit Grain()
 
         let mutable requestIds = HashSet<ApprovalRequestId>()
+        let mutable requests = Dictionary<ApprovalRequestId, ApprovalRequest>()
+        let mutable requestJsonById = Dictionary<ApprovalRequestId, string>()
         member val private correlationId: CorrelationId = String.Empty with get, set
 
         override _.OnActivateAsync(ct) =
             if isNull state.State then state.State <- List<ApprovalRequestIndexEvent>()
 
             requestIds <- HashSet<ApprovalRequestId>()
+            requests <- Dictionary<ApprovalRequestId, ApprovalRequest>()
+            requestJsonById <- Dictionary<ApprovalRequestId, string>()
 
             state.State
             |> Seq.iter (fun indexEvent ->
-                match indexEvent.Event with
-                | ApprovalRequestIndexEventType.RequestAdded approvalRequestId -> requestIds.Add approvalRequestId |> ignore)
+                if isNull (box indexEvent) |> not
+                   && isNull (box indexEvent.Event) |> not then
+                    match indexEvent.Event with
+                    | ApprovalRequestIndexEventType.RequestAdded approvalRequestId -> requestIds.Add approvalRequestId |> ignore
+                    | ApprovalRequestIndexEventType.RequestIndexed request ->
+                        if isNull (box request) |> not
+                           && request.ApprovalRequestId
+                              <> ApprovalRequestId.Empty then
+                            requestIds.Add request.ApprovalRequestId |> ignore
+                            requests[request.ApprovalRequestId] <- request
+                            requestJsonById[request.ApprovalRequestId] <- serialize request
+                    | ApprovalRequestIndexEventType.RequestIndexedJson requestJson ->
+                        if String.IsNullOrWhiteSpace requestJson |> not then
+                            let request = deserialize<ApprovalRequest> requestJson
+
+                            if request.ApprovalRequestId
+                               <> ApprovalRequestId.Empty then
+                                requestIds.Add request.ApprovalRequestId |> ignore
+                                requests[request.ApprovalRequestId] <- request
+                                requestJsonById[request.ApprovalRequestId] <- requestJson)
 
             Task.CompletedTask
 
@@ -326,6 +386,33 @@ module ApprovalRequest =
                     return Ok returnValue
             }
 
+        member private this.RegisterRequestCore (request: ApprovalRequest) (eventMetadata: EventMetadata) =
+            task {
+                this.correlationId <- eventMetadata.CorrelationId
+
+                if
+                    isNull (box request)
+                    || request.ApprovalRequestId = ApprovalRequestId.Empty
+                then
+                    return Error(GraceError.Create "ApprovalRequestId must be a non-empty Guid." eventMetadata.CorrelationId)
+                elif requests.ContainsKey request.ApprovalRequestId
+                     && requests[request.ApprovalRequestId] = request then
+                    let returnValue = GraceReturnValue.Create (requestIds |> Seq.toArray) eventMetadata.CorrelationId
+                    return Ok returnValue
+                else
+                    let requestJson = serialize request
+                    let event: ApprovalRequestIndexEvent = { Event = ApprovalRequestIndexEventType.RequestIndexedJson requestJson; Metadata = eventMetadata }
+                    if isNull state.State then state.State <- List<ApprovalRequestIndexEvent>()
+
+                    state.State.Add event
+                    do! state.WriteStateAsync()
+                    requestIds.Add request.ApprovalRequestId |> ignore
+                    requests[request.ApprovalRequestId] <- request
+                    requestJsonById[request.ApprovalRequestId] <- requestJson
+                    let returnValue = GraceReturnValue.Create (requestIds |> Seq.toArray) eventMetadata.CorrelationId
+                    return Ok returnValue
+            }
+
         interface IApprovalRequestIndexActor with
             member this.Handle command metadata =
                 task {
@@ -336,6 +423,65 @@ module ApprovalRequest =
                 }
 
             member this.AddRequest(approvalRequestId, eventMetadata) = this.AddRequestCore approvalRequestId eventMetadata
+
+            member this.RegisterRequest(request, eventMetadata) = this.RegisterRequestCore request eventMetadata
+
+            member this.RegisterGeneratedRequest
+                (
+                    approvalRequestId,
+                    approvalPolicyId,
+                    approvalPolicyVersion,
+                    subject,
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    targetBranchId,
+                    promotionSetId,
+                    stepsComputationAttempt,
+                    requiredResponder,
+                    createdBy,
+                    eventMetadata
+                ) =
+                let request =
+                    { Grace.Types.Webhooks.ApprovalRequest.Default with
+                        ApprovalRequestId = approvalRequestId
+                        ApprovalPolicyId = approvalPolicyId
+                        ApprovalPolicyVersion = approvalPolicyVersion
+                        Subject = subject
+                        Scope =
+                            { ApprovalScope.Default with
+                                OwnerId = ownerId
+                                OrganizationId = organizationId
+                                RepositoryId = repositoryId
+                                TargetBranchId = targetBranchId
+                                PromotionSetId = promotionSetId
+                                StepsComputationAttempt = stepsComputationAttempt
+                                ApprovalPolicyId = Some approvalPolicyId
+                                ApprovalPolicyVersion = Some approvalPolicyVersion
+                            }
+                        RequiredResponder = requiredResponder
+                        Status = ApprovalRequestStatus.Pending
+                        CreatedBy = UserId createdBy
+                        CreatedAt = eventMetadata.Timestamp
+                    }
+
+                this.RegisterRequestCore request eventMetadata
+
+            member this.GetRequest approvalRequestId correlationId =
+                this.correlationId <- correlationId
+
+                match requests.TryGetValue approvalRequestId with
+                | true, request -> Some request
+                | _ -> None
+                |> returnTask
+
+            member this.GetRequestJson approvalRequestId correlationId =
+                this.correlationId <- correlationId
+
+                match requestJsonById.TryGetValue approvalRequestId with
+                | true, requestJson -> Some requestJson
+                | _ -> None
+                |> returnTask
 
             member this.List correlationId =
                 this.correlationId <- correlationId

--- a/src/Grace.Actors/ApprovalRequest.Actor.fs
+++ b/src/Grace.Actors/ApprovalRequest.Actor.fs
@@ -1,0 +1,342 @@
+namespace Grace.Actors
+
+open Grace.Actors.Constants
+open Grace.Actors.Context
+open Grace.Actors.Interfaces
+open Grace.Actors.Services
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types.Events
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Microsoft.Extensions.Logging
+open Orleans
+open Orleans.Runtime
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module ApprovalRequest =
+
+    let private commandName command =
+        match command with
+        | ApprovalRequestCommand.Create _ -> "Create"
+        | ApprovalRequestCommand.RecordDecision _ -> "RecordDecision"
+        | ApprovalRequestCommand.Expire -> "Expire"
+        | ApprovalRequestCommand.Cancel -> "Cancel"
+        | ApprovalRequestCommand.Supersede _ -> "Supersede"
+
+    let private applyEvents (events: ApprovalRequestEvent list) (request: ApprovalRequest) =
+        events
+        |> List.fold (fun current event -> ApprovalRequest.UpdateDto event current) request
+
+    let private graceError correlationId message = GraceError.Create message correlationId
+
+    let private createdRequestMatches (existing: ApprovalRequest) (candidate: ApprovalRequest) =
+        existing.ApprovalPolicyId = candidate.ApprovalPolicyId
+        && existing.ApprovalPolicyVersion = candidate.ApprovalPolicyVersion
+        && existing.Subject = candidate.Subject
+        && existing.Scope = candidate.Scope
+        && existing.RequiredResponder = candidate.RequiredResponder
+
+    let private decisionMatches (existing: ApprovalRequestDecision) (candidate: ApprovalRequestDecision) =
+        existing.Decision = candidate.Decision
+        && existing.DecidedBy = candidate.DecidedBy
+        && existing.Reason = candidate.Reason
+        && existing.ClientDecisionId = candidate.ClientDecisionId
+
+    let private ok (request: ApprovalRequest) (events: ApprovalRequestEvent list) wasReplay message =
+        Ok { Request = applyEvents events request; Events = events; WasIdempotentReplay = wasReplay; Message = message }
+
+    let decideCommand (request: ApprovalRequest) (command: ApprovalRequestCommand) (metadata: EventMetadata) =
+        let exists =
+            request.ApprovalRequestId
+            <> ApprovalRequestId.Empty
+
+        match command with
+        | ApprovalRequestCommand.Create candidate ->
+            if candidate.ApprovalRequestId = ApprovalRequestId.Empty then
+                Error(graceError metadata.CorrelationId "ApprovalRequestId must be a non-empty Guid.")
+            elif isNull (box candidate.Scope) then
+                Error(graceError metadata.CorrelationId "Approval request scope is required.")
+            elif candidate.ApprovalPolicyId = ApprovalPolicyId.Empty then
+                Error(graceError metadata.CorrelationId "ApprovalPolicyId must be a non-empty Guid.")
+            elif String.IsNullOrWhiteSpace candidate.Subject then
+                Error(graceError metadata.CorrelationId "Approval request subject is required.")
+            elif String.IsNullOrWhiteSpace candidate.RequiredResponder then
+                Error(graceError metadata.CorrelationId "Approval request responder selector is required.")
+            elif exists && createdRequestMatches request candidate then
+                ok request [] true "Approval request create command replayed."
+            elif exists then
+                Error(graceError metadata.CorrelationId "Approval request already exists with a different payload.")
+            else
+                let created = { candidate with Status = ApprovalRequestStatus.Pending; Decision = None; UpdatedAt = None; SupersededByApprovalRequestId = None }
+
+                let event: ApprovalRequestEvent = { Event = ApprovalRequestEventType.Created created; Metadata = metadata }
+                ok request [ event ] false "Approval request created."
+        | ApprovalRequestCommand.RecordDecision decision ->
+            if not exists then
+                Error(graceError metadata.CorrelationId "Approval request must be created before recording a decision.")
+            elif String.IsNullOrWhiteSpace decision.ClientDecisionId then
+                Error(graceError metadata.CorrelationId "ClientDecisionId is required.")
+            else
+                match request.Decision with
+                | Some existing when
+                    existing.ClientDecisionId = decision.ClientDecisionId
+                    && decisionMatches existing decision
+                    ->
+                    ok request [] true "Approval request decision replayed."
+                | Some existing when existing.ClientDecisionId = decision.ClientDecisionId ->
+                    Error(graceError metadata.CorrelationId "ClientDecisionId was already used with a different approval decision.")
+                | Some _ -> Error(graceError metadata.CorrelationId $"Approval request is already {request.Status}.")
+                | None when request.Status.IsTerminal -> Error(graceError metadata.CorrelationId $"Approval request is already {request.Status}.")
+                | None ->
+                    let event: ApprovalRequestEvent = { Event = ApprovalRequestEventType.DecisionRecorded decision; Metadata = metadata }
+                    ok request [ event ] false "Approval request decision recorded."
+        | ApprovalRequestCommand.Expire ->
+            if not exists then
+                Error(graceError metadata.CorrelationId "Approval request must be created before expiring.")
+            elif request.Status = ApprovalRequestStatus.Expired then
+                ok request [] true "Approval request expiration replayed."
+            elif request.Status.IsTerminal then
+                Error(graceError metadata.CorrelationId $"Approval request is already {request.Status}.")
+            else
+                let event: ApprovalRequestEvent = { Event = ApprovalRequestEventType.Expired; Metadata = metadata }
+                ok request [ event ] false "Approval request expired."
+        | ApprovalRequestCommand.Cancel ->
+            if not exists then
+                Error(graceError metadata.CorrelationId "Approval request must be created before cancelling.")
+            elif request.Status = ApprovalRequestStatus.Cancelled then
+                ok request [] true "Approval request cancellation replayed."
+            elif request.Status.IsTerminal then
+                Error(graceError metadata.CorrelationId $"Approval request is already {request.Status}.")
+            else
+                let event: ApprovalRequestEvent = { Event = ApprovalRequestEventType.Cancelled; Metadata = metadata }
+                ok request [ event ] false "Approval request cancelled."
+        | ApprovalRequestCommand.Supersede supersededByApprovalRequestId ->
+            if not exists then
+                Error(graceError metadata.CorrelationId "Approval request must be created before superseding.")
+            elif supersededByApprovalRequestId = ApprovalRequestId.Empty then
+                Error(graceError metadata.CorrelationId "SupersededByApprovalRequestId must be a non-empty Guid.")
+            elif request.Status = ApprovalRequestStatus.Superseded
+                 && request.SupersededByApprovalRequestId = Some supersededByApprovalRequestId then
+                ok request [] true "Approval request supersede command replayed."
+            elif request.Status.IsTerminal then
+                Error(graceError metadata.CorrelationId $"Approval request is already {request.Status}.")
+            else
+                let event: ApprovalRequestEvent = { Event = ApprovalRequestEventType.Superseded supersededByApprovalRequestId; Metadata = metadata }
+                ok request [ event ] false "Approval request superseded."
+
+    type ApprovalRequestActor([<PersistentState(StateName.ApprovalRequest, GraceActorStorage)>] state: IPersistentState<List<ApprovalRequestEvent>>) =
+        inherit Grain()
+
+        let log = loggerFactory.CreateLogger("ApprovalRequest.Actor")
+        let mutable request = Grace.Types.Webhooks.ApprovalRequest.Default
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override this.OnActivateAsync(ct) =
+            let activateStartTime = getCurrentInstant ()
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+
+            if isNull state.State then state.State <- List<ApprovalRequestEvent>()
+
+            request <-
+                state.State
+                |> Seq.fold (fun current event -> ApprovalRequest.UpdateDto event current) Grace.Types.Webhooks.ApprovalRequest.Default
+
+            Task.CompletedTask
+
+        member private this.ApplyEvents(events: ApprovalRequestEvent list) =
+            task {
+                if isNull state.State then state.State <- List<ApprovalRequestEvent>()
+
+                state.State.AddRange(events)
+                do! state.WriteStateAsync()
+                request <- applyEvents events request
+
+                let mutable index = 0
+
+                while index < events.Length do
+                    let approvalRequestEvent = events[index]
+                    do! publishGraceEvent (GraceEvent.ApprovalRequestEvent approvalRequestEvent) approvalRequestEvent.Metadata
+                    index <- index + 1
+            }
+
+        member private this.ProcessCommand (command: ApprovalRequestCommand) (metadata: EventMetadata) =
+            task {
+                this.correlationId <- metadata.CorrelationId
+                RequestContext.Set(CurrentCommandProperty, commandName command)
+
+                let currentRequest =
+                    if isNull (box request) then
+                        Grace.Types.Webhooks.ApprovalRequest.Default
+                    else
+                        request
+
+                match decideCommand currentRequest command metadata with
+                | Ok decision ->
+                    if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
+                    let returnValue =
+                        (GraceReturnValue.Create decision metadata.CorrelationId)
+                            .enhance(nameof ApprovalRequestId, decision.Request.ApprovalRequestId)
+                            .enhance(nameof RepositoryId, decision.Request.Scope.RepositoryId)
+                            .enhance (nameof ApprovalRequestStatus, decision.Request.Status)
+
+                    return Ok returnValue
+                | Error error ->
+                    log.LogWarning(
+                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected ApprovalRequest command {Command}. Error: {Error}",
+                        getCurrentInstantExtended (),
+                        getMachineName,
+                        metadata.CorrelationId,
+                        commandName command,
+                        error.Error
+                    )
+
+                    return Error error
+            }
+
+        interface IHasRepositoryId with
+            member this.GetRepositoryId correlationId =
+                this.correlationId <- correlationId
+                request.Scope.RepositoryId |> returnTask
+
+        interface IApprovalRequestActor with
+            member this.Exists correlationId =
+                this.correlationId <- correlationId
+
+                (request.ApprovalRequestId
+                 <> ApprovalRequestId.Empty)
+                |> returnTask
+
+            member this.Get correlationId =
+                this.correlationId <- correlationId
+
+                if request.ApprovalRequestId = ApprovalRequestId.Empty then
+                    None
+                else
+                    Some request
+                |> returnTask
+
+            member this.GetEvents correlationId =
+                this.correlationId <- correlationId
+
+                (state.State :> IReadOnlyList<ApprovalRequestEvent>)
+                |> returnTask
+
+            member this.Create request metadata = this.ProcessCommand (ApprovalRequestCommand.Create request) metadata
+
+            member this.CreateGenerated
+                (
+                    approvalRequestId,
+                    approvalPolicyId,
+                    approvalPolicyVersion,
+                    subject,
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    targetBranchId,
+                    promotionSetId,
+                    stepsComputationAttempt,
+                    requiredResponder,
+                    createdBy,
+                    metadata
+                ) =
+                let request =
+                    { Grace.Types.Webhooks.ApprovalRequest.Default with
+                        ApprovalRequestId = approvalRequestId
+                        ApprovalPolicyId = approvalPolicyId
+                        ApprovalPolicyVersion = approvalPolicyVersion
+                        Subject = subject
+                        Scope =
+                            { ApprovalScope.Default with
+                                OwnerId = ownerId
+                                OrganizationId = organizationId
+                                RepositoryId = repositoryId
+                                TargetBranchId = targetBranchId
+                                PromotionSetId = promotionSetId
+                                StepsComputationAttempt = stepsComputationAttempt
+                                ApprovalPolicyId = Some approvalPolicyId
+                                ApprovalPolicyVersion = Some approvalPolicyVersion
+                            }
+                        RequiredResponder = requiredResponder
+                        Status = ApprovalRequestStatus.Pending
+                        CreatedBy = UserId createdBy
+                        CreatedAt = metadata.Timestamp
+                    }
+
+                this.ProcessCommand (ApprovalRequestCommand.Create request) metadata
+
+            member this.RecordDecision decision metadata = this.ProcessCommand (ApprovalRequestCommand.RecordDecision decision) metadata
+
+            member this.RecordDecisionGenerated(decision, decidedBy, reason, clientDecisionId, metadata) =
+                let requestDecision =
+                    { ApprovalRequestDecision.Default with
+                        Decision = decision
+                        DecidedBy = UserId decidedBy
+                        DecidedAt = metadata.Timestamp
+                        Reason = reason
+                        ClientDecisionId = clientDecisionId
+                    }
+
+                this.ProcessCommand (ApprovalRequestCommand.RecordDecision requestDecision) metadata
+
+            member this.Handle command metadata = this.ProcessCommand command metadata
+
+    type ApprovalRequestIndexActor
+        (
+            [<PersistentState(StateName.ApprovalRequestIndex, GraceActorStorage)>] state: IPersistentState<List<ApprovalRequestIndexEvent>>
+        ) =
+        inherit Grain()
+
+        let mutable requestIds = HashSet<ApprovalRequestId>()
+        member val private correlationId: CorrelationId = String.Empty with get, set
+
+        override _.OnActivateAsync(ct) =
+            if isNull state.State then state.State <- List<ApprovalRequestIndexEvent>()
+
+            requestIds <- HashSet<ApprovalRequestId>()
+
+            state.State
+            |> Seq.iter (fun indexEvent ->
+                match indexEvent.Event with
+                | ApprovalRequestIndexEventType.RequestAdded approvalRequestId -> requestIds.Add approvalRequestId |> ignore)
+
+            Task.CompletedTask
+
+        member private this.AddRequestCore (approvalRequestId: ApprovalRequestId) (eventMetadata: EventMetadata) =
+            task {
+                this.correlationId <- eventMetadata.CorrelationId
+
+                if approvalRequestId = ApprovalRequestId.Empty then
+                    return Error(GraceError.Create "ApprovalRequestId must be a non-empty Guid." eventMetadata.CorrelationId)
+                elif requestIds.Contains approvalRequestId then
+                    let returnValue = GraceReturnValue.Create (requestIds |> Seq.toArray) eventMetadata.CorrelationId
+                    return Ok returnValue
+                else
+                    let event: ApprovalRequestIndexEvent = { Event = ApprovalRequestIndexEventType.RequestAdded approvalRequestId; Metadata = eventMetadata }
+                    if isNull state.State then state.State <- List<ApprovalRequestIndexEvent>()
+
+                    state.State.Add event
+                    do! state.WriteStateAsync()
+                    requestIds.Add approvalRequestId |> ignore
+                    let returnValue = GraceReturnValue.Create (requestIds |> Seq.toArray) eventMetadata.CorrelationId
+                    return Ok returnValue
+            }
+
+        interface IApprovalRequestIndexActor with
+            member this.Handle command metadata =
+                task {
+                    this.correlationId <- metadata.CorrelationId
+
+                    match command with
+                    | ApprovalRequestIndexCommand.AddRequest approvalRequestId -> return! this.AddRequestCore approvalRequestId metadata
+                }
+
+            member this.AddRequest(approvalRequestId, eventMetadata) = this.AddRequestCore approvalRequestId eventMetadata
+
+            member this.List correlationId =
+                this.correlationId <- correlationId
+                requestIds |> Seq.toArray |> returnTask

--- a/src/Grace.Actors/Constants.Actor.fs
+++ b/src/Grace.Actors/Constants.Actor.fs
@@ -86,6 +86,12 @@ module Constants =
         let Artifact = "ArtifactActor"
 
         [<Literal>]
+        let ApprovalRequest = "ApprovalRequestActor"
+
+        [<Literal>]
+        let ApprovalRequestIndex = "ApprovalRequestIndexActor"
+
+        [<Literal>]
         let ContentBlockMetadata = "ContentBlockMetadataActor"
 
         [<Literal>]
@@ -175,6 +181,12 @@ module Constants =
 
         [<Literal>]
         let Artifact = "Artifact"
+
+        [<Literal>]
+        let ApprovalRequest = "ApprovalRequest"
+
+        [<Literal>]
+        let ApprovalRequestIndex = "ApprovalRequestIndex"
 
         [<Literal>]
         let ContentBlockMetadata = "ContentBlockMetadata"

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -50,6 +50,7 @@
         <Compile Include="ValidationSet.Actor.fs" />
         <Compile Include="ValidationResult.Actor.fs" />
         <Compile Include="Artifact.Actor.fs" />
+        <Compile Include="ApprovalRequest.Actor.fs" />
         <Compile Include="DedupeIndex.Actor.fs" />
         <Compile Include="ContentBlockMetadata.Actor.fs" />
         <Compile Include="UploadSession.Actor.fs" />

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -22,6 +22,7 @@ open Grace.Types.Queue
 open Grace.Types.Validation
 open Grace.Types.Artifact
 open Grace.Types.UploadSession
+open Grace.Types.Webhooks
 open Grace.Types.WorkItem
 open Grace.Types.Types
 open Grace.Shared.Utilities
@@ -472,6 +473,65 @@ module Interfaces =
 
         /// Validates incoming commands and converts them to events that are stored in the database.
         abstract member Handle: command: ArtifactCommand -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+    /// Defines the operations for the approval request actor.
+    [<Interface>]
+    type IApprovalRequestActor =
+        inherit IGrainWithGuidKey
+
+        /// Returns true if this approval request has been created.
+        abstract member Exists: correlationId: CorrelationId -> Task<bool>
+
+        /// Returns the current approval request state.
+        abstract member Get: correlationId: CorrelationId -> Task<ApprovalRequest option>
+
+        /// Returns the events handled by this approval request.
+        abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<ApprovalRequestEvent>>
+
+        /// Creates a workflow-generated approval request.
+        abstract member Create: request: ApprovalRequest -> eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestDecisionResult>>
+
+        /// Creates a workflow-generated approval request from primitive fields across the Orleans boundary.
+        abstract member CreateGenerated:
+            approvalRequestId: ApprovalRequestId *
+            approvalPolicyId: ApprovalPolicyId *
+            approvalPolicyVersion: ApprovalPolicyVersion *
+            subject: ApprovalSubject *
+            ownerId: OwnerId *
+            organizationId: OrganizationId *
+            repositoryId: RepositoryId *
+            targetBranchId: BranchId *
+            promotionSetId: PromotionSetId option *
+            stepsComputationAttempt: int option *
+            requiredResponder: ApprovalResponderSelector *
+            createdBy: string *
+            eventMetadata: EventMetadata ->
+                Task<GraceResult<ApprovalRequestDecisionResult>>
+
+        /// Records an approval request decision.
+        abstract member RecordDecision: decision: ApprovalRequestDecision -> eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestDecisionResult>>
+
+        /// Records an approval request decision from primitive fields across the Orleans boundary.
+        abstract member RecordDecisionGenerated:
+            decision: ApprovalDecision * decidedBy: string * reason: string option * clientDecisionId: ApprovalClientDecisionId * eventMetadata: EventMetadata ->
+                Task<GraceResult<ApprovalRequestDecisionResult>>
+
+        /// Validates incoming commands and converts them to persisted events.
+        abstract member Handle: command: ApprovalRequestCommand -> eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestDecisionResult>>
+
+    /// Defines the operations for the approval request scope index actor.
+    [<Interface>]
+    type IApprovalRequestIndexActor =
+        inherit IGrainWithStringKey
+
+        /// Adds an approval request id to this scope index.
+        abstract member Handle: command: ApprovalRequestIndexCommand -> eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestId array>>
+
+        /// Adds an approval request id to this scope index across the Orleans boundary.
+        abstract member AddRequest: approvalRequestId: ApprovalRequestId * eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestId array>>
+
+        /// Returns the request ids currently indexed for the scope.
+        abstract member List: correlationId: CorrelationId -> Task<ApprovalRequestId array>
 
     /// Defines the operations for the StoragePool-scoped ContentBlock metadata actor.
     [<Interface>]

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -485,8 +485,14 @@ module Interfaces =
         /// Returns the current approval request state.
         abstract member Get: correlationId: CorrelationId -> Task<ApprovalRequest option>
 
+        /// Returns the current approval request state as JSON.
+        abstract member GetJson: correlationId: CorrelationId -> Task<string option>
+
         /// Returns the events handled by this approval request.
         abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<ApprovalRequestEvent>>
+
+        /// Returns the request history reconstructed inside the actor as JSON.
+        abstract member GetHistoryJson: correlationId: CorrelationId -> Task<string>
 
         /// Creates a workflow-generated approval request.
         abstract member Create: request: ApprovalRequest -> eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestDecisionResult>>
@@ -513,7 +519,7 @@ module Interfaces =
 
         /// Records an approval request decision from primitive fields across the Orleans boundary.
         abstract member RecordDecisionGenerated:
-            decision: ApprovalDecision * decidedBy: string * reason: string option * clientDecisionId: ApprovalClientDecisionId * eventMetadata: EventMetadata ->
+            decision: string * decidedBy: string * reason: string option * clientDecisionId: ApprovalClientDecisionId * eventMetadata: EventMetadata ->
                 Task<GraceResult<ApprovalRequestDecisionResult>>
 
         /// Validates incoming commands and converts them to persisted events.
@@ -529,6 +535,32 @@ module Interfaces =
 
         /// Adds an approval request id to this scope index across the Orleans boundary.
         abstract member AddRequest: approvalRequestId: ApprovalRequestId * eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestId array>>
+
+        /// Adds or replays a durable approval request record in this index.
+        abstract member RegisterRequest: request: ApprovalRequest * eventMetadata: EventMetadata -> Task<GraceResult<ApprovalRequestId array>>
+
+        /// Adds or replays a durable generated approval request record from primitive fields across the Orleans boundary.
+        abstract member RegisterGeneratedRequest:
+            approvalRequestId: ApprovalRequestId *
+            approvalPolicyId: ApprovalPolicyId *
+            approvalPolicyVersion: ApprovalPolicyVersion *
+            subject: ApprovalSubject *
+            ownerId: OwnerId *
+            organizationId: OrganizationId *
+            repositoryId: RepositoryId *
+            targetBranchId: BranchId *
+            promotionSetId: PromotionSetId option *
+            stepsComputationAttempt: int option *
+            requiredResponder: ApprovalResponderSelector *
+            createdBy: string *
+            eventMetadata: EventMetadata ->
+                Task<GraceResult<ApprovalRequestId array>>
+
+        /// Returns an indexed approval request record when this index has one.
+        abstract member GetRequest: approvalRequestId: ApprovalRequestId -> correlationId: CorrelationId -> Task<ApprovalRequest option>
+
+        /// Returns an indexed approval request record as JSON when this index has one.
+        abstract member GetRequestJson: approvalRequestId: ApprovalRequestId -> correlationId: CorrelationId -> Task<string option>
 
         /// Returns the request ids currently indexed for the scope.
         abstract member List: correlationId: CorrelationId -> Task<ApprovalRequestId array>

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -117,25 +117,33 @@ module private ApprovalTestHelpers =
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
 
+    let seedGeneratedParameters (repositoryId: string) (branchId: string) (requestId: Guid option) (policyId: Guid) (selector: string) attempt =
+        let parameters = Parameters.Approval.SeedGeneratedApprovalRequestParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+
+        parameters.ApprovalRequestId <-
+            match requestId with
+            | Some value -> value.ToString()
+            | None -> String.Empty
+
+        parameters.ApprovalPolicyId <- policyId.ToString()
+        parameters.ApprovalPolicyVersion <- 1
+        parameters.Subject <- "promotion"
+        parameters.RequiredResponder <- selector
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        match attempt with
+        | Some value -> parameters.StepsComputationAttempt <- Nullable value
+        | None -> ()
+
+        parameters
+
     let seedRequestWithAttempt (repositoryId: string) (branchId: string) (selector: string) attempt =
         task {
-            let requestId = Guid.NewGuid()
-
-            let parameters = Parameters.Approval.SeedGeneratedApprovalRequestParameters()
-            parameters.OwnerId <- ownerId
-            parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryId
-            parameters.TargetBranchId <- branchId
-            parameters.ApprovalRequestId <- requestId.ToString()
-            parameters.ApprovalPolicyId <- Guid.NewGuid().ToString()
-            parameters.ApprovalPolicyVersion <- 1
-            parameters.Subject <- "promotion"
-            parameters.RequiredResponder <- selector
-            parameters.CorrelationId <- generateCorrelationId ()
-
-            match attempt with
-            | Some value -> parameters.StepsComputationAttempt <- Nullable value
-            | None -> ()
+            let parameters = seedGeneratedParameters repositoryId branchId (Some(Guid.NewGuid())) (Guid.NewGuid()) selector attempt
 
             let! response = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent parameters)
             let! responseText = response.Content.ReadAsStringAsync()
@@ -333,6 +341,57 @@ type ApprovalApiIntegrationTests() =
         }
 
     [<Test>]
+    member _.RepeatedGeneratedCreateWithoutStableRequestIdReturnsExistingRequestForSameAttempt() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = $"{Guid.NewGuid()}"
+            let policyId = Guid.NewGuid()
+            let userId = $"{Guid.NewGuid()}"
+            let parameters = ApprovalTestHelpers.seedGeneratedParameters repositoryId branchId None policyId "role:ApprovalResponder" (Some 5)
+
+            let! firstResponse = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent parameters)
+            let! firstText = firstResponse.Content.ReadAsStringAsync()
+            Assert.That(firstResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstText)
+            let first = deserialize<ApprovalRequest> firstText
+
+            parameters.CorrelationId <- generateCorrelationId ()
+            let! retryResponse = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent parameters)
+            let! retryText = retryResponse.Content.ReadAsStringAsync()
+            Assert.That(retryResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), retryText)
+            let retry = deserialize<ApprovalRequest> retryText
+
+            Assert.That(retry.ApprovalRequestId, Is.EqualTo(first.ApprovalRequestId))
+
+            let staleAttemptParameters = ApprovalTestHelpers.seedGeneratedParameters repositoryId branchId None policyId "role:ApprovalResponder" (Some 6)
+            let! staleAttemptResponse = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent staleAttemptParameters)
+            let! staleAttemptText = staleAttemptResponse.Content.ReadAsStringAsync()
+            Assert.That(staleAttemptResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), staleAttemptText)
+            let staleAttempt = deserialize<ApprovalRequest> staleAttemptText
+
+            Assert.That(staleAttempt.ApprovalRequestId, Is.Not.EqualTo(first.ApprovalRequestId))
+
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let listParameters = ApprovalTestHelpers.listRequestParameters repositoryId branchId
+            let! listResponse = client.PostAsync("/approval/request/list", createJsonContent listParameters)
+            let! listText = listResponse.Content.ReadAsStringAsync()
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), listText)
+            let requests = deserialize<ApprovalRequest array> listText
+
+            let attemptFiveRequests =
+                requests
+                |> Array.filter (fun request ->
+                    request.ApprovalPolicyId = policyId
+                    && request.Subject = "promotion"
+                    && request.Scope.StepsComputationAttempt = Some 5)
+
+            Assert.That(attemptFiveRequests, Has.Length.EqualTo(1))
+            Assert.That(attemptFiveRequests[0].ApprovalRequestId, Is.EqualTo(first.ApprovalRequestId))
+        }
+
+    [<Test>]
     member _.ResponseRejectsMissingRespondPermissionEvenWhenSelectorMatches() =
         task {
             let repositoryId = repositoryIds[0]
@@ -407,4 +466,36 @@ type ApprovalApiIntegrationTests() =
 
             let! duplicate = client.PostAsync("/approval/request/reject", createJsonContent parameters)
             Assert.That(duplicate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+        }
+
+    [<Test>]
+    member _.RequestHistoryReturnsActorBackedEventsFromStoredRepositoryPartition() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
+
+            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let rejectParameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.RejectApprovalRequestParameters> repositoryId branchId requestId
+            rejectParameters.ClientDecisionId <- $"{Guid.NewGuid():N}"
+
+            let! rejectResponse = client.PostAsync("/approval/request/reject", createJsonContent rejectParameters)
+            let! rejectText = rejectResponse.Content.ReadAsStringAsync()
+            Assert.That(rejectResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), rejectText)
+
+            let historyParameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApprovalRequestHistoryParameters> repositoryId branchId requestId
+            let! historyResponse = client.PostAsync("/approval/request/history", createJsonContent historyParameters)
+            let! historyText = historyResponse.Content.ReadAsStringAsync()
+            Assert.That(historyResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), historyText)
+            let history = deserialize<ApprovalRequest array> historyText
+
+            Assert.That(history, Has.Length.EqualTo(2))
+            Assert.That(history[ 0 ].ApprovalRequestId.ToString(), Is.EqualTo(requestId))
+            Assert.That(history[0].Status, Is.EqualTo(ApprovalRequestStatus.Pending))
+            Assert.That(history[1].Status, Is.EqualTo(ApprovalRequestStatus.Rejected))
+            Assert.That(history[1].Decision.IsSome, Is.True)
         }

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -117,30 +117,35 @@ module private ApprovalTestHelpers =
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
 
-    let seedRequest (repositoryId: string) (branchId: string) (selector: string) =
-        let requestId = Guid.NewGuid()
+    let seedRequestWithAttempt (repositoryId: string) (branchId: string) (selector: string) attempt =
+        task {
+            let requestId = Guid.NewGuid()
 
-        ApprovalStore.seedGeneratedRequest
-            { ApprovalRequest.Default with
-                ApprovalRequestId = requestId
-                ApprovalPolicyId = Guid.NewGuid()
-                ApprovalPolicyVersion = 1
-                Subject = "promotion"
-                Scope =
-                    { ApprovalScope.Default with
-                        OwnerId = Guid.Parse ownerId
-                        OrganizationId = Guid.Parse organizationId
-                        RepositoryId = Guid.Parse repositoryId
-                        TargetBranchId = Guid.Parse branchId
-                    }
-                RequiredResponder = selector
-                Status = ApprovalRequestStatus.Pending
-                CreatedBy = UserId "workflow"
-                CreatedAt = getCurrentInstant ()
-            }
-        |> ignore
+            let parameters = Parameters.Approval.SeedGeneratedApprovalRequestParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.TargetBranchId <- branchId
+            parameters.ApprovalRequestId <- requestId.ToString()
+            parameters.ApprovalPolicyId <- Guid.NewGuid().ToString()
+            parameters.ApprovalPolicyVersion <- 1
+            parameters.Subject <- "promotion"
+            parameters.RequiredResponder <- selector
+            parameters.CorrelationId <- generateCorrelationId ()
 
-        requestId.ToString()
+            match attempt with
+            | Some value -> parameters.StepsComputationAttempt <- Nullable value
+            | None -> ()
+
+            let! response = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            let! stored = deserializeContent<ApprovalRequest> response
+            Assert.That(stored.ApprovalRequestId, Is.Not.EqualTo(Guid.Empty))
+            return stored.ApprovalRequestId.ToString()
+        }
+
+    let seedRequest (repositoryId: string) (branchId: string) (selector: string) = seedRequestWithAttempt repositoryId branchId selector None
 
     let createPolicyAsync (client: HttpClient) repositoryId branchId =
         task {
@@ -297,8 +302,8 @@ type ApprovalApiIntegrationTests() =
             let allowedBranchId = $"{Guid.NewGuid()}"
             let otherBranchId = $"{Guid.NewGuid()}"
             let userId = $"{Guid.NewGuid()}"
-            let allowedRequestId = ApprovalTestHelpers.seedRequest repositoryId allowedBranchId $"user:{userId}"
-            let otherRequestId = ApprovalTestHelpers.seedRequest repositoryId otherBranchId $"user:{Guid.NewGuid()}"
+            let! allowedRequestId = ApprovalTestHelpers.seedRequest repositoryId allowedBranchId $"user:{userId}"
+            let! otherRequestId = ApprovalTestHelpers.seedRequest repositoryId otherBranchId $"user:{Guid.NewGuid()}"
 
             let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
 
@@ -309,9 +314,10 @@ type ApprovalApiIntegrationTests() =
             let! listResponse =
                 client.PostAsync("/approval/request/list", createJsonContent (ApprovalTestHelpers.listRequestParameters repositoryId allowedBranchId))
 
-            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! listResponseText = listResponse.Content.ReadAsStringAsync()
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), listResponseText)
 
-            let! requests = deserializeContent<ApprovalRequest array> listResponse
+            let requests = deserialize<ApprovalRequest array> listResponseText
 
             Assert.That(
                 requests
@@ -332,7 +338,7 @@ type ApprovalApiIntegrationTests() =
             let repositoryId = repositoryIds[0]
             let branchId = repositoryDefaultBranchIds[0]
             let userId = $"{Guid.NewGuid()}"
-            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
             let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepoReader"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -350,7 +356,7 @@ type ApprovalApiIntegrationTests() =
             let repositoryId = repositoryIds[0]
             let branchId = repositoryDefaultBranchIds[0]
             let userId = $"{Guid.NewGuid()}"
-            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
 
             let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -369,7 +375,7 @@ type ApprovalApiIntegrationTests() =
             let allowedBranchId = repositoryDefaultBranchIds[0]
             let storedBranchId = $"{Guid.NewGuid()}"
             let userId = $"{Guid.NewGuid()}"
-            let requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
 
             let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -377,17 +383,18 @@ type ApprovalApiIntegrationTests() =
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
             let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId allowedBranchId requestId
             let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
 
-            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden), responseText)
         }
 
     [<Test>]
-    member _.DuplicateResponseIsRejectedAfterTerminalDecision() =
+    member _.DuplicateResponseIsIdempotentAfterTerminalDecision() =
         task {
             let repositoryId = repositoryIds[0]
             let branchId = repositoryDefaultBranchIds[0]
             let userId = $"{Guid.NewGuid()}"
-            let requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
             let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -395,8 +402,9 @@ type ApprovalApiIntegrationTests() =
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
             let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.RejectApprovalRequestParameters> repositoryId branchId requestId
             let! first = client.PostAsync("/approval/request/reject", createJsonContent parameters)
-            Assert.That(first.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! firstText = first.Content.ReadAsStringAsync()
+            Assert.That(first.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstText)
 
             let! duplicate = client.PostAsync("/approval/request/reject", createJsonContent parameters)
-            Assert.That(duplicate.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+            Assert.That(duplicate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -392,6 +392,61 @@ type ApprovalApiIntegrationTests() =
         }
 
     [<Test>]
+    member _.ConcurrentGeneratedCreateWithoutStableRequestIdConvergesOnOneRequestForSameLogicalKey() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = $"{Guid.NewGuid()}"
+            let policyId = Guid.NewGuid()
+            let userId = $"{Guid.NewGuid()}"
+            let selector = "role:ApprovalResponder"
+            let attempt = Some 12
+
+            let createOne _ =
+                task {
+                    let parameters = ApprovalTestHelpers.seedGeneratedParameters repositoryId branchId None policyId selector attempt
+                    let! response = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent parameters)
+                    let! text = response.Content.ReadAsStringAsync()
+                    Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), text)
+                    return deserialize<ApprovalRequest> text
+                }
+
+            let! created = [| 1..8 |] |> Array.map createOne |> Task.WhenAll
+            let requestIds = created |> Array.map _.ApprovalRequestId |> Array.distinct
+
+            Assert.That(requestIds, Has.Length.EqualTo(1))
+            Assert.That(requestIds[0], Is.Not.EqualTo(Guid.Empty))
+
+            let nextAttemptParameters = ApprovalTestHelpers.seedGeneratedParameters repositoryId branchId None policyId selector (Some 13)
+            let! nextAttemptResponse = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent nextAttemptParameters)
+            let! nextAttemptText = nextAttemptResponse.Content.ReadAsStringAsync()
+            Assert.That(nextAttemptResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), nextAttemptText)
+            let nextAttempt = deserialize<ApprovalRequest> nextAttemptText
+
+            Assert.That(nextAttempt.ApprovalRequestId, Is.Not.EqualTo(requestIds[0]))
+
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let listParameters = ApprovalTestHelpers.listRequestParameters repositoryId branchId
+            let! listResponse = client.PostAsync("/approval/request/list", createJsonContent listParameters)
+            let! listText = listResponse.Content.ReadAsStringAsync()
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), listText)
+            let requests = deserialize<ApprovalRequest array> listText
+
+            let matchingRequests =
+                requests
+                |> Array.filter (fun request ->
+                    request.ApprovalPolicyId = policyId
+                    && request.Subject = "promotion"
+                    && request.RequiredResponder = selector
+                    && request.Scope.StepsComputationAttempt = attempt)
+
+            Assert.That(matchingRequests, Has.Length.EqualTo(1))
+            Assert.That(matchingRequests[0].ApprovalRequestId, Is.EqualTo(requestIds[0]))
+        }
+
+    [<Test>]
     member _.ResponseRejectsMissingRespondPermissionEvenWhenSelectorMatches() =
         task {
             let repositoryId = repositoryIds[0]

--- a/src/Grace.Server.Tests/ApprovalRequest.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ApprovalRequest.Actor.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Actors.ApprovalRequest
+open Grace.Server
 open Grace.Shared.Utilities
 open Grace.Types.Types
 open Grace.Types.Webhooks
@@ -153,3 +154,42 @@ type ApprovalRequestActorDecisionTests() =
         match decideCommand created.Request (ApprovalRequestCommand.Create currentAttempt) (metadata ()) with
         | Ok _ -> Assert.Fail "A request for a different attempt should not replay as the existing request."
         | Error error -> Assert.That(error.Error, Does.Contain("different payload"))
+
+[<TestFixture>]
+type GeneratedApprovalRequestIdTests() =
+
+    let requestFor attempt =
+        { ApprovalRequest.Default with
+            ApprovalRequestId = Guid.Empty
+            ApprovalPolicyId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            ApprovalPolicyVersion = 3
+            Subject = "promotion"
+            Scope =
+                { ApprovalScope.Default with
+                    OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    OrganizationId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+                    RepositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+                    TargetBranchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+                    PromotionSetId = Some(Guid.Parse("66666666-6666-6666-6666-666666666666"))
+                    StepsComputationAttempt = attempt
+                    ApprovalPolicyId = Some(Guid.Parse("11111111-1111-1111-1111-111111111111"))
+                    ApprovalPolicyVersion = Some 3
+                }
+            RequiredResponder = "role:ApprovalResponder"
+            CreatedBy = UserId "workflow"
+            CreatedAt = getCurrentInstant ()
+        }
+
+    [<Test>]
+    member _.GeneratedRequestIdIsStableForSameLogicalKeyAndDistinctAcrossAttempts() =
+        let first = requestFor (Some 7)
+        let replay = { first with CreatedAt = getCurrentInstant (); CreatedBy = UserId "retrying-workflow" }
+        let nextAttempt = { first with Scope = { first.Scope with StepsComputationAttempt = Some 8 } }
+
+        let firstId = ApprovalStore.buildGeneratedApprovalRequestId first
+        let replayId = ApprovalStore.buildGeneratedApprovalRequestId replay
+        let nextAttemptId = ApprovalStore.buildGeneratedApprovalRequestId nextAttempt
+
+        Assert.That(firstId, Is.Not.EqualTo(Guid.Empty))
+        Assert.That(replayId, Is.EqualTo(firstId))
+        Assert.That(nextAttemptId, Is.Not.EqualTo(firstId))

--- a/src/Grace.Server.Tests/ApprovalRequest.Actor.Tests.fs
+++ b/src/Grace.Server.Tests/ApprovalRequest.Actor.Tests.fs
@@ -1,0 +1,155 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors.ApprovalRequest
+open Grace.Shared.Utilities
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open NUnit.Framework
+open System
+
+[<TestFixture>]
+type ApprovalRequestActorDecisionTests() =
+
+    let metadata () = EventMetadata.New (generateCorrelationId ()) "test"
+
+    let requestFor attempt =
+        { ApprovalRequest.Default with
+            ApprovalRequestId = Guid.NewGuid()
+            ApprovalPolicyId = Guid.NewGuid()
+            ApprovalPolicyVersion = 1
+            Subject = "promotion"
+            Scope =
+                { ApprovalScope.Default with
+                    OwnerId = Guid.NewGuid()
+                    OrganizationId = Guid.NewGuid()
+                    RepositoryId = Guid.NewGuid()
+                    TargetBranchId = Guid.NewGuid()
+                    StepsComputationAttempt = attempt
+                    ApprovalPolicyId = Some(Guid.NewGuid())
+                    ApprovalPolicyVersion = Some 1
+                }
+            RequiredResponder = "role:ApprovalResponder"
+            CreatedBy = UserId "workflow"
+            CreatedAt = getCurrentInstant ()
+        }
+
+    let decision clientDecisionId approvalDecision =
+        { ApprovalRequestDecision.Default with
+            Decision = approvalDecision
+            DecidedBy = UserId "approver"
+            DecidedAt = getCurrentInstant ()
+            Reason = Some "looks good"
+            ClientDecisionId = clientDecisionId
+        }
+
+    [<Test>]
+    member _.CreateForSamePolicySubjectScopeAndAttemptIsIdempotent() =
+        let request = requestFor (Some 7)
+        let first = decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create request) (metadata ())
+
+        match first with
+        | Error error -> Assert.Fail error.Error
+        | Ok created ->
+            let replay = decideCommand created.Request (ApprovalRequestCommand.Create request) (metadata ())
+
+            match replay with
+            | Error error -> Assert.Fail error.Error
+            | Ok replayed ->
+                Assert.That(replayed.WasIdempotentReplay, Is.True)
+                Assert.That(replayed.Events, Is.Empty)
+                Assert.That(replayed.Request.ApprovalRequestId, Is.EqualTo(request.ApprovalRequestId))
+
+    [<Test>]
+    member _.DuplicateIdenticalDecisionIsIdempotentButConflictingDuplicateFails() =
+        let request = requestFor (Some 1)
+
+        let created =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create request) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let approve = decision "client-decision-1" ApprovalDecision.Approve
+
+        let approved =
+            decideCommand created.Request (ApprovalRequestCommand.RecordDecision approve) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let replay =
+            decideCommand approved.Request (ApprovalRequestCommand.RecordDecision approve) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        Assert.That(replay.WasIdempotentReplay, Is.True)
+        Assert.That(replay.Events, Is.Empty)
+
+        let conflicting = { approve with Reason = Some "different payload" }
+
+        match decideCommand approved.Request (ApprovalRequestCommand.RecordDecision conflicting) (metadata ()) with
+        | Ok _ -> Assert.Fail "Conflicting duplicate decision should fail."
+        | Error error -> Assert.That(error.Error, Does.Contain("different approval decision"))
+
+    [<Test>]
+    member _.TerminalRequestsCannotBeChanged() =
+        let request = requestFor None
+
+        let created =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create request) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let expired =
+            decideCommand created.Request ApprovalRequestCommand.Expire (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        match decideCommand expired.Request (ApprovalRequestCommand.RecordDecision(decision "late" ApprovalDecision.Approve)) (metadata ()) with
+        | Ok _ -> Assert.Fail "Terminal request should reject later decisions."
+        | Error error -> Assert.That(error.Error, Does.Contain("already Expired"))
+
+    [<Test>]
+    member _.ExpiredCancelledAndSupersededStatesAreRepresentedAndAuditable() =
+        let expireRequest = requestFor None
+        let cancelRequest = requestFor None
+        let supersedeRequest = requestFor None
+        let replacementRequestId = Guid.NewGuid()
+
+        let createdExpired =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create expireRequest) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let expired =
+            decideCommand createdExpired.Request ApprovalRequestCommand.Expire (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let createdCancelled =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create cancelRequest) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let cancelled =
+            decideCommand createdCancelled.Request ApprovalRequestCommand.Cancel (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let createdSuperseded =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create supersedeRequest) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        let superseded =
+            decideCommand createdSuperseded.Request (ApprovalRequestCommand.Supersede replacementRequestId) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        Assert.That(expired.Request.Status, Is.EqualTo(ApprovalRequestStatus.Expired))
+        Assert.That(cancelled.Request.Status, Is.EqualTo(ApprovalRequestStatus.Cancelled))
+        Assert.That(superseded.Request.Status, Is.EqualTo(ApprovalRequestStatus.Superseded))
+        Assert.That(superseded.Request.SupersededByApprovalRequestId, Is.EqualTo(Some replacementRequestId))
+        Assert.That(expired.Events |> List.length, Is.EqualTo(1))
+        Assert.That(cancelled.Events |> List.length, Is.EqualTo(1))
+        Assert.That(superseded.Events |> List.length, Is.EqualTo(1))
+
+    [<Test>]
+    member _.StaleAttemptDoesNotMatchCurrentAttemptCreateKey() =
+        let oldAttempt = requestFor (Some 1)
+        let currentAttempt = { oldAttempt with ApprovalRequestId = Guid.NewGuid(); Scope = { oldAttempt.Scope with StepsComputationAttempt = Some 2 } }
+
+        let created =
+            decideCommand ApprovalRequest.Default (ApprovalRequestCommand.Create oldAttempt) (metadata ())
+            |> Result.defaultWith (fun error -> failwith error.Error)
+
+        match decideCommand created.Request (ApprovalRequestCommand.Create currentAttempt) (metadata ()) with
+        | Ok _ -> Assert.Fail "A request for a different attempt should not replay as the existing request."
+        | Error error -> Assert.That(error.Error, Does.Contain("different payload"))

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="Approval.Server.Tests.fs" />
+    <Compile Include="ApprovalRequest.Actor.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server
 
 open Giraffe
+open Grace.Actors.Interfaces
 open Grace.Actors.Extensions
 open Grace.Server.Security
 open Grace.Shared
@@ -26,7 +27,6 @@ module ApprovalStore =
     type ApprovalRequestDto = Grace.Types.Webhooks.ApprovalRequest
 
     let private policies = ConcurrentDictionary<ApprovalPolicyId, ApprovalPolicyDto>()
-    let private requestSnapshots = ConcurrentDictionary<ApprovalRequestId, ApprovalRequestDto>()
 
     let private scopeMatches (expected: ApprovalScope) (actual: ApprovalScope) =
         isNull (box actual) |> not
@@ -35,9 +35,38 @@ module ApprovalStore =
         && actual.RepositoryId = expected.RepositoryId
         && actual.TargetBranchId = expected.TargetBranchId
 
-    let clearForTests () =
-        policies.Clear()
-        requestSnapshots.Clear()
+    let private generatedRequestMatches (candidate: ApprovalRequestDto) (existing: ApprovalRequestDto) =
+        existing.ApprovalPolicyId = candidate.ApprovalPolicyId
+        && existing.ApprovalPolicyVersion = candidate.ApprovalPolicyVersion
+        && existing.Subject = candidate.Subject
+        && existing.Scope = candidate.Scope
+        && existing.RequiredResponder = candidate.RequiredResponder
+
+    let private requestIsComplete (request: ApprovalRequestDto) =
+        request.ApprovalRequestId
+        <> ApprovalRequestId.Empty
+        && (isNull (box request.Scope) |> not)
+        && (isNull (box request.Status) |> not)
+        && (String.IsNullOrWhiteSpace request.RequiredResponder
+            |> not)
+
+    let private usableEvents (events: IReadOnlyList<ApprovalRequestEvent>) =
+        events
+        |> Seq.filter (fun event -> isNull (box event) |> not)
+        |> Seq.filter (fun event -> isNull (box event.Event) |> not)
+
+    let private requestFromEvents (events: IReadOnlyList<ApprovalRequestEvent>) =
+        let request =
+            events
+            |> usableEvents
+            |> Seq.fold (fun current event -> ApprovalRequest.UpdateDto event current) ApprovalRequest.Default
+
+        if request.ApprovalRequestId = ApprovalRequestId.Empty then
+            None
+        else
+            Some request
+
+    let clearForTests () = policies.Clear()
 
     let upsertPolicy (policy: ApprovalPolicyDto) =
         policies[policy.ApprovalPolicyId] <- policy
@@ -61,6 +90,92 @@ module ApprovalStore =
         let eventMetadata = EventMetadata.New correlationId principal
         eventMetadata
 
+    let private normalizeRequest approvalRequestId fallbackScope (approvalRequest: ApprovalRequestDto) =
+        { approvalRequest with
+            ApprovalRequestId =
+                if approvalRequest.ApprovalRequestId = ApprovalRequestId.Empty then
+                    approvalRequestId
+                else
+                    approvalRequest.ApprovalRequestId
+            Scope =
+                if isNull (box approvalRequest.Scope) then
+                    fallbackScope
+                else
+                    approvalRequest.Scope
+            Status =
+                if isNull (box approvalRequest.Status) then
+                    ApprovalRequestStatus.Pending
+                else
+                    approvalRequest.Status
+        }
+
+    let private requestFromJson (requestJson: string option) =
+        requestJson
+        |> Option.bind (fun json ->
+            if String.IsNullOrWhiteSpace json then
+                None
+            else
+                Some(deserialize<ApprovalRequestDto> json))
+
+    let private tryGetRequestFromActorAsync approvalRequestId fallbackScope correlationId =
+        task {
+            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId fallbackScope.RepositoryId correlationId
+            let! requestJson = actor.GetJson correlationId
+
+            match requestFromJson requestJson with
+            | Some approvalRequest when requestIsComplete approvalRequest -> return Some(normalizeRequest approvalRequestId fallbackScope approvalRequest)
+            | Some _ ->
+                let! events = actor.GetEvents correlationId
+
+                return
+                    requestFromEvents events
+                    |> Option.map (normalizeRequest approvalRequestId fallbackScope)
+            | None -> return None
+        }
+
+    let tryGetRequestAsync approvalRequestId fallbackScope correlationId = tryGetRequestFromActorAsync approvalRequestId fallbackScope correlationId
+
+    let private registerGeneratedIndexRequestAsync (indexActor: IApprovalRequestIndexActor) (request: ApprovalRequestDto) correlationId =
+        indexActor.RegisterGeneratedRequest(
+            request.ApprovalRequestId,
+            request.ApprovalPolicyId,
+            request.ApprovalPolicyVersion,
+            request.Subject,
+            request.Scope.OwnerId,
+            request.Scope.OrganizationId,
+            request.Scope.RepositoryId,
+            request.Scope.TargetBranchId,
+            request.Scope.PromotionSetId,
+            request.Scope.StepsComputationAttempt,
+            request.RequiredResponder,
+            $"{request.CreatedBy}",
+            metadata correlationId "system"
+        )
+
+    let private tryFindGeneratedRequestAsync (candidate: ApprovalRequestDto) correlationId =
+        task {
+            let indexActor = ActorProxy.ApprovalRequest.CreateIndexActorProxy candidate.Scope correlationId
+            let! requestIds = indexActor.List correlationId
+            let mutable index = 0
+            let mutable matchedRequest = None
+
+            while index < requestIds.Length && matchedRequest.IsNone do
+                let! indexedRequestJson = indexActor.GetRequestJson requestIds[index] correlationId
+
+                let! request =
+                    match requestFromJson indexedRequestJson with
+                    | Some request -> Task.FromResult(Some request)
+                    | None -> tryGetRequestAsync requestIds[index] candidate.Scope correlationId
+
+                match request with
+                | Some existing when generatedRequestMatches candidate existing -> matchedRequest <- Some existing
+                | _ -> ()
+
+                index <- index + 1
+
+            return matchedRequest
+        }
+
     let seedGeneratedRequestAsync (request: ApprovalRequestDto) correlationId =
         task {
             let approvalRequestId =
@@ -71,83 +186,44 @@ module ApprovalStore =
 
             let requestToCreate = { request with ApprovalRequestId = approvalRequestId }
 
-            requestSnapshots[approvalRequestId] <- requestToCreate
+            match! tryFindGeneratedRequestAsync requestToCreate correlationId with
+            | Some existingRequest -> return Ok existingRequest
+            | None ->
+                let actor = ActorProxy.ApprovalRequest.CreateActorProxy requestToCreate.ApprovalRequestId requestToCreate.Scope.RepositoryId correlationId
 
-            let actor = ActorProxy.ApprovalRequest.CreateActorProxy requestToCreate.ApprovalRequestId requestToCreate.Scope.RepositoryId correlationId
-
-            match!
-                actor.CreateGenerated
-                    (
-                        requestToCreate.ApprovalRequestId,
-                        requestToCreate.ApprovalPolicyId,
-                        requestToCreate.ApprovalPolicyVersion,
-                        requestToCreate.Subject,
-                        requestToCreate.Scope.OwnerId,
-                        requestToCreate.Scope.OrganizationId,
-                        requestToCreate.Scope.RepositoryId,
-                        requestToCreate.Scope.TargetBranchId,
-                        requestToCreate.Scope.PromotionSetId,
-                        requestToCreate.Scope.StepsComputationAttempt,
-                        requestToCreate.RequiredResponder,
-                        $"{requestToCreate.CreatedBy}",
-                        metadata correlationId $"{requestToCreate.CreatedBy}"
-                    )
-                with
-            | Error error -> return Error error
-            | Ok result ->
-                let indexActor = ActorProxy.ApprovalRequest.CreateIndexActorProxy requestToCreate.Scope correlationId
-
-                let storedRequest =
-                    if result.ReturnValue.Request.ApprovalRequestId = ApprovalRequestId.Empty then
-                        requestToCreate
-                    else
-                        result.ReturnValue.Request
-
-                let! indexResult = indexActor.AddRequest(approvalRequestId, metadata correlationId "system")
-
-                match indexResult with
+                match!
+                    actor.CreateGenerated
+                        (
+                            requestToCreate.ApprovalRequestId,
+                            requestToCreate.ApprovalPolicyId,
+                            requestToCreate.ApprovalPolicyVersion,
+                            requestToCreate.Subject,
+                            requestToCreate.Scope.OwnerId,
+                            requestToCreate.Scope.OrganizationId,
+                            requestToCreate.Scope.RepositoryId,
+                            requestToCreate.Scope.TargetBranchId,
+                            requestToCreate.Scope.PromotionSetId,
+                            requestToCreate.Scope.StepsComputationAttempt,
+                            requestToCreate.RequiredResponder,
+                            $"{requestToCreate.CreatedBy}",
+                            metadata correlationId $"{requestToCreate.CreatedBy}"
+                        )
+                    with
                 | Error error -> return Error error
-                | Ok _ ->
-                    requestSnapshots[approvalRequestId] <- storedRequest
-                    return Ok storedRequest
-        }
+                | Ok result ->
+                    let indexActor = ActorProxy.ApprovalRequest.CreateIndexActorProxy requestToCreate.Scope correlationId
 
-    let tryGetRequestAsync approvalRequestId fallbackScope correlationId =
-        task {
-            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId fallbackScope.RepositoryId correlationId
-            let! request = actor.Get correlationId
-
-            return
-                match request, requestSnapshots.TryGetValue approvalRequestId with
-                | Some approvalRequest, (true, snapshot) when
-                    approvalRequest.ApprovalRequestId = ApprovalRequestId.Empty
-                    || isNull (box approvalRequest.Scope)
-                    || isNull (box approvalRequest.Status)
-                    || String.IsNullOrWhiteSpace approvalRequest.RequiredResponder
-                    ->
-                    Some snapshot
-                | Some approvalRequest, _ ->
-                    let scope =
-                        if isNull (box approvalRequest.Scope) then
-                            fallbackScope
+                    let storedRequest =
+                        if requestIsComplete result.ReturnValue.Request then
+                            result.ReturnValue.Request
                         else
-                            approvalRequest.Scope
+                            requestToCreate
 
-                    let status =
-                        if isNull (box approvalRequest.Status) then
-                            ApprovalRequestStatus.Pending
-                        else
-                            approvalRequest.Status
+                    let! indexResult = registerGeneratedIndexRequestAsync indexActor storedRequest correlationId
 
-                    let storedApprovalRequestId =
-                        if approvalRequest.ApprovalRequestId = ApprovalRequestId.Empty then
-                            approvalRequestId
-                        else
-                            approvalRequest.ApprovalRequestId
-
-                    Some { approvalRequest with ApprovalRequestId = storedApprovalRequestId; Scope = scope; Status = status }
-                | None, (true, snapshot) -> Some snapshot
-                | None, _ -> None
+                    match indexResult with
+                    | Error error -> return Error error
+                    | Ok _ -> return Ok storedRequest
         }
 
     let handleRequestCommandAsync approvalRequestId repositoryId command correlationId principal =
@@ -158,25 +234,16 @@ module ApprovalStore =
             | ApprovalRequestCommand.RecordDecision decision ->
                 let! result =
                     actor.RecordDecisionGenerated(
-                        decision.Decision,
+                        $"{decision.Decision}",
                         $"{decision.DecidedBy}",
                         decision.Reason,
                         decision.ClientDecisionId,
                         metadata correlationId principal
                     )
 
-                match result with
-                | Ok success -> requestSnapshots[approvalRequestId] <- success.ReturnValue.Request
-                | Error _ -> ()
-
                 return result
             | _ ->
                 let! result = actor.Handle command (metadata correlationId principal)
-
-                match result with
-                | Ok success -> requestSnapshots[approvalRequestId] <- success.ReturnValue.Request
-                | Error _ -> ()
-
                 return result
         }
 
@@ -204,17 +271,14 @@ module ApprovalStore =
             return requests.ToArray() :> IReadOnlyList<ApprovalRequestDto>
         }
 
-    let requestHistoryAsync approvalRequestId correlationId =
+    let requestHistoryAsync approvalRequestId fallbackScope correlationId =
         task {
-            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId RepositoryId.Empty correlationId
-            let! events = actor.GetEvents correlationId
-
-            return
-                events
-                |> Seq.scan (fun current event -> ApprovalRequest.UpdateDto event current) ApprovalRequest.Default
-                |> Seq.skip 1
-                |> Seq.toArray
-                :> IReadOnlyList<ApprovalRequestDto>
+            match! tryGetRequestAsync approvalRequestId fallbackScope correlationId with
+            | None -> return Array.empty<ApprovalRequestDto> :> IReadOnlyList<ApprovalRequestDto>
+            | Some request ->
+                let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId request.Scope.RepositoryId correlationId
+                let! historyJson = actor.GetHistoryJson correlationId
+                return deserialize<ApprovalRequestDto array> historyJson :> IReadOnlyList<ApprovalRequestDto>
         }
 
 module ApprovalCommon =

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -19,6 +19,9 @@ open NodaTime
 open System
 open System.Collections.Concurrent
 open System.Collections.Generic
+open System.Globalization
+open System.Security.Cryptography
+open System.Text
 open System.Threading.Tasks
 
 module ApprovalStore =
@@ -89,6 +92,59 @@ module ApprovalStore =
     let private metadata correlationId principal =
         let eventMetadata = EventMetadata.New correlationId principal
         eventMetadata
+
+    let private canonicalSegment (value: string) =
+        let segment =
+            if isNull value then
+                String.Empty
+            else
+                value
+
+        $"{segment.Length}:{segment}"
+
+    let private canonicalGuid (value: Guid) = value.ToString("D").ToLowerInvariant()
+
+    let private canonicalOptionalGuid (value: Guid option) =
+        match value with
+        | Some guid -> canonicalGuid guid
+        | None -> String.Empty
+
+    let private canonicalOptionalInt (value: int option) =
+        match value with
+        | Some attempt -> attempt.ToString(CultureInfo.InvariantCulture)
+        | None -> String.Empty
+
+    let private createDeterministicGuid (seed: string) =
+        let seedBytes = Encoding.UTF8.GetBytes(seed)
+
+        use hasher = SHA256.Create()
+        let hash = hasher.ComputeHash(seedBytes)
+        let guidBytes = hash[0..15]
+        guidBytes[6] <- (guidBytes[6] &&& 0x0Fuy) ||| 0x50uy
+        guidBytes[8] <- (guidBytes[8] &&& 0x3Fuy) ||| 0x80uy
+        Guid(guidBytes)
+
+    let buildGeneratedApprovalRequestId (request: ApprovalRequestDto) =
+        let scope =
+            if isNull (box request.Scope) then
+                ApprovalScope.Default
+            else
+                request.Scope
+
+        [| "grace.approval-request.generated.v1"
+           canonicalGuid request.ApprovalPolicyId
+           request.ApprovalPolicyVersion.ToString(CultureInfo.InvariantCulture)
+           request.Subject
+           canonicalGuid scope.OwnerId
+           canonicalGuid scope.OrganizationId
+           canonicalGuid scope.RepositoryId
+           canonicalGuid scope.TargetBranchId
+           canonicalOptionalGuid scope.PromotionSetId
+           canonicalOptionalInt scope.StepsComputationAttempt
+           request.RequiredResponder |]
+        |> Array.map canonicalSegment
+        |> String.concat "|"
+        |> createDeterministicGuid
 
     let private normalizeRequest approvalRequestId fallbackScope (approvalRequest: ApprovalRequestDto) =
         { approvalRequest with
@@ -180,7 +236,7 @@ module ApprovalStore =
         task {
             let approvalRequestId =
                 if request.ApprovalRequestId = Guid.Empty then
-                    Guid.NewGuid()
+                    buildGeneratedApprovalRequestId request
                 else
                     request.ApprovalRequestId
 

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server
 
 open Giraffe
+open Grace.Actors.Extensions
 open Grace.Server.Security
 open Grace.Shared
 open Grace.Shared.Parameters.Approval
@@ -17,8 +18,6 @@ open NodaTime
 open System
 open System.Collections.Concurrent
 open System.Collections.Generic
-open System.IO
-open System.Text.Json
 open System.Threading.Tasks
 
 module ApprovalStore =
@@ -27,87 +26,18 @@ module ApprovalStore =
     type ApprovalRequestDto = Grace.Types.Webhooks.ApprovalRequest
 
     let private policies = ConcurrentDictionary<ApprovalPolicyId, ApprovalPolicyDto>()
-    let private requests = ConcurrentDictionary<ApprovalRequestId, ApprovalRequestDto>()
-    let private history = ConcurrentDictionary<ApprovalRequestId, ResizeArray<ApprovalRequestDto>>()
-
-    let private requestSeedEnabled () =
-        let isDevelopment value = String.Equals(value, "Development", StringComparison.OrdinalIgnoreCase)
-
-        Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
-        || isDevelopment (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"))
-        || isDevelopment (Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"))
-
-    let private requestSeedDirectory () =
-        let runId = Environment.GetEnvironmentVariable("GRACE_TEST_RUN_ID")
-
-        let seedNamespace = if String.IsNullOrWhiteSpace runId then $"{Environment.ProcessId}" else runId
-
-        Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds", seedNamespace)
-
-    let private requestSeedPath approvalRequestId = Path.Combine(requestSeedDirectory (), $"{approvalRequestId:N}.json")
-
-    let private persistSeededRequest (request: ApprovalRequestDto) =
-        if requestSeedEnabled () then
-            Directory.CreateDirectory(requestSeedDirectory ())
-            |> ignore
-
-            File.WriteAllText(requestSeedPath request.ApprovalRequestId, JsonSerializer.Serialize(request, Constants.JsonSerializerOptions))
-
-    let private tryReadSeededRequest approvalRequestId =
-        if requestSeedEnabled () |> not then
-            None
-        else
-            let path = requestSeedPath approvalRequestId
-
-            if File.Exists path then
-                try
-                    let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
-
-                    if isNull (box request) then
-                        None
-                    else
-                        requests[approvalRequestId] <- request
-                        Some request
-                with
-                | _ -> None
-            else
-                None
-
-    let private hydrateSeededRequests () =
-        if requestSeedEnabled () then
-            let directory = requestSeedDirectory ()
-
-            if Directory.Exists directory then
-                Directory.EnumerateFiles(directory, "*.json")
-                |> Seq.iter (fun path ->
-                    try
-                        let request = JsonSerializer.Deserialize<ApprovalRequestDto>(File.ReadAllText path, Constants.JsonSerializerOptions)
-
-                        if isNull (box request) |> not then
-                            requests[request.ApprovalRequestId] <- request
-                    with
-                    | _ -> ())
+    let private requestSnapshots = ConcurrentDictionary<ApprovalRequestId, ApprovalRequestDto>()
 
     let private scopeMatches (expected: ApprovalScope) (actual: ApprovalScope) =
-        actual.OwnerId = expected.OwnerId
+        isNull (box actual) |> not
+        && actual.OwnerId = expected.OwnerId
         && actual.OrganizationId = expected.OrganizationId
         && actual.RepositoryId = expected.RepositoryId
         && actual.TargetBranchId = expected.TargetBranchId
 
-    let private tryDeleteDirectory path =
-        if Directory.Exists path then
-            try
-                Directory.Delete(path, true)
-            with
-            | _ -> ()
-
     let clearForTests () =
         policies.Clear()
-        requests.Clear()
-        history.Clear()
-
-        let root = Path.Combine(Path.GetTempPath(), "Grace.ApprovalRequestSeeds")
-        tryDeleteDirectory root
+        requestSnapshots.Clear()
 
     let upsertPolicy (policy: ApprovalPolicyDto) =
         policies[policy.ApprovalPolicyId] <- policy
@@ -127,39 +57,165 @@ module ApprovalStore =
         |> Seq.toArray
         :> IReadOnlyList<ApprovalPolicyDto>
 
-    let seedGeneratedRequest (request: ApprovalRequestDto) =
-        requests[request.ApprovalRequestId] <- request
-        persistSeededRequest request
-        let entries = history.GetOrAdd(request.ApprovalRequestId, (fun _ -> ResizeArray()))
-        entries.Add request
-        request
+    let private metadata correlationId principal =
+        let eventMetadata = EventMetadata.New correlationId principal
+        eventMetadata
 
-    let tryGetRequest approvalRequestId =
-        match requests.TryGetValue approvalRequestId with
-        | true, request -> Some request
-        | _ -> tryReadSeededRequest approvalRequestId
+    let seedGeneratedRequestAsync (request: ApprovalRequestDto) correlationId =
+        task {
+            let approvalRequestId =
+                if request.ApprovalRequestId = Guid.Empty then
+                    Guid.NewGuid()
+                else
+                    request.ApprovalRequestId
 
-    let updateRequest (request: ApprovalRequestDto) =
-        requests[request.ApprovalRequestId] <- request
-        persistSeededRequest request
-        let entries = history.GetOrAdd(request.ApprovalRequestId, (fun _ -> ResizeArray()))
-        entries.Add request
-        request
+            let requestToCreate = { request with ApprovalRequestId = approvalRequestId }
 
-    let listRequests scope includeTerminal =
-        hydrateSeededRequests ()
+            requestSnapshots[approvalRequestId] <- requestToCreate
 
-        requests.Values
-        |> Seq.filter (fun request ->
-            scopeMatches scope request.Scope
-            && (includeTerminal || not request.Status.IsTerminal))
-        |> Seq.toArray
-        :> IReadOnlyList<ApprovalRequestDto>
+            let actor = ActorProxy.ApprovalRequest.CreateActorProxy requestToCreate.ApprovalRequestId requestToCreate.Scope.RepositoryId correlationId
 
-    let requestHistory approvalRequestId =
-        match history.TryGetValue approvalRequestId with
-        | true, entries -> entries.ToArray() :> IReadOnlyList<ApprovalRequestDto>
-        | _ -> Array.empty<ApprovalRequestDto> :> IReadOnlyList<ApprovalRequestDto>
+            match!
+                actor.CreateGenerated
+                    (
+                        requestToCreate.ApprovalRequestId,
+                        requestToCreate.ApprovalPolicyId,
+                        requestToCreate.ApprovalPolicyVersion,
+                        requestToCreate.Subject,
+                        requestToCreate.Scope.OwnerId,
+                        requestToCreate.Scope.OrganizationId,
+                        requestToCreate.Scope.RepositoryId,
+                        requestToCreate.Scope.TargetBranchId,
+                        requestToCreate.Scope.PromotionSetId,
+                        requestToCreate.Scope.StepsComputationAttempt,
+                        requestToCreate.RequiredResponder,
+                        $"{requestToCreate.CreatedBy}",
+                        metadata correlationId $"{requestToCreate.CreatedBy}"
+                    )
+                with
+            | Error error -> return Error error
+            | Ok result ->
+                let indexActor = ActorProxy.ApprovalRequest.CreateIndexActorProxy requestToCreate.Scope correlationId
+
+                let storedRequest =
+                    if result.ReturnValue.Request.ApprovalRequestId = ApprovalRequestId.Empty then
+                        requestToCreate
+                    else
+                        result.ReturnValue.Request
+
+                let! indexResult = indexActor.AddRequest(approvalRequestId, metadata correlationId "system")
+
+                match indexResult with
+                | Error error -> return Error error
+                | Ok _ ->
+                    requestSnapshots[approvalRequestId] <- storedRequest
+                    return Ok storedRequest
+        }
+
+    let tryGetRequestAsync approvalRequestId fallbackScope correlationId =
+        task {
+            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId fallbackScope.RepositoryId correlationId
+            let! request = actor.Get correlationId
+
+            return
+                match request, requestSnapshots.TryGetValue approvalRequestId with
+                | Some approvalRequest, (true, snapshot) when
+                    approvalRequest.ApprovalRequestId = ApprovalRequestId.Empty
+                    || isNull (box approvalRequest.Scope)
+                    || isNull (box approvalRequest.Status)
+                    || String.IsNullOrWhiteSpace approvalRequest.RequiredResponder
+                    ->
+                    Some snapshot
+                | Some approvalRequest, _ ->
+                    let scope =
+                        if isNull (box approvalRequest.Scope) then
+                            fallbackScope
+                        else
+                            approvalRequest.Scope
+
+                    let status =
+                        if isNull (box approvalRequest.Status) then
+                            ApprovalRequestStatus.Pending
+                        else
+                            approvalRequest.Status
+
+                    let storedApprovalRequestId =
+                        if approvalRequest.ApprovalRequestId = ApprovalRequestId.Empty then
+                            approvalRequestId
+                        else
+                            approvalRequest.ApprovalRequestId
+
+                    Some { approvalRequest with ApprovalRequestId = storedApprovalRequestId; Scope = scope; Status = status }
+                | None, (true, snapshot) -> Some snapshot
+                | None, _ -> None
+        }
+
+    let handleRequestCommandAsync approvalRequestId repositoryId command correlationId principal =
+        task {
+            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId repositoryId correlationId
+
+            match command with
+            | ApprovalRequestCommand.RecordDecision decision ->
+                let! result =
+                    actor.RecordDecisionGenerated(
+                        decision.Decision,
+                        $"{decision.DecidedBy}",
+                        decision.Reason,
+                        decision.ClientDecisionId,
+                        metadata correlationId principal
+                    )
+
+                match result with
+                | Ok success -> requestSnapshots[approvalRequestId] <- success.ReturnValue.Request
+                | Error _ -> ()
+
+                return result
+            | _ ->
+                let! result = actor.Handle command (metadata correlationId principal)
+
+                match result with
+                | Ok success -> requestSnapshots[approvalRequestId] <- success.ReturnValue.Request
+                | Error _ -> ()
+
+                return result
+        }
+
+    let listRequestsAsync scope includeTerminal correlationId =
+        task {
+            let indexActor = ActorProxy.ApprovalRequest.CreateIndexActorProxy scope correlationId
+            let! requestIds = indexActor.List correlationId
+            let requests = ResizeArray<ApprovalRequestDto>()
+            let mutable index = 0
+
+            while index < requestIds.Length do
+                let! request = tryGetRequestAsync requestIds[index] scope correlationId
+
+                match request with
+                | Some approvalRequest when
+                    scopeMatches scope approvalRequest.Scope
+                    && (includeTerminal
+                        || not approvalRequest.Status.IsTerminal)
+                    ->
+                    requests.Add approvalRequest
+                | _ -> ()
+
+                index <- index + 1
+
+            return requests.ToArray() :> IReadOnlyList<ApprovalRequestDto>
+        }
+
+    let requestHistoryAsync approvalRequestId correlationId =
+        task {
+            let actor = ActorProxy.ApprovalRequest.CreateActorProxy approvalRequestId RepositoryId.Empty correlationId
+            let! events = actor.GetEvents correlationId
+
+            return
+                events
+                |> Seq.scan (fun current event -> ApprovalRequest.UpdateDto event current) ApprovalRequest.Default
+                |> Seq.skip 1
+                |> Seq.toArray
+                :> IReadOnlyList<ApprovalRequestDto>
+        }
 
 module ApprovalCommon =
 

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -257,7 +257,8 @@ module ApprovalRequest =
 
                 match tryParseGuid parameters.ApprovalRequestId with
                 | Some requestId ->
-                    let! history = ApprovalStore.requestHistoryAsync requestId (Services.getCorrelationId context)
+                    let scope = scopeFromRequestParameters parameters
+                    let! history = ApprovalStore.requestHistoryAsync requestId scope (Services.getCorrelationId context)
                     return! context |> Services.result200Ok history
                 | None ->
                     return!

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -188,7 +188,7 @@ module ApprovalRequest =
                             { Grace.Types.Webhooks.ApprovalRequest.Default with
                                 ApprovalRequestId =
                                     tryParseGuid parameters.ApprovalRequestId
-                                    |> Option.defaultValue (Guid.NewGuid())
+                                    |> Option.defaultValue ApprovalRequestId.Empty
                                 ApprovalPolicyId =
                                     tryParseGuid parameters.ApprovalPolicyId
                                     |> Option.defaultValue ApprovalPolicyId.Empty

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -19,6 +19,13 @@ module ApprovalRequest =
 
     open ApprovalCommon
 
+    let private requestSeedEnabled () =
+        let isDevelopment value = String.Equals(value, "Development", StringComparison.OrdinalIgnoreCase)
+
+        Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
+        || isDevelopment (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"))
+        || isDevelopment (Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"))
+
     let private requestIdFromContext<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
         task {
             context.Request.EnableBuffering()
@@ -29,12 +36,19 @@ module ApprovalRequest =
 
             return
                 tryParseGuid parameters.ApprovalRequestId
-                |> Option.bind ApprovalStore.tryGetRequest
+                |> Option.map (fun approvalRequestId ->
+                    let scope = scopeFromRequestParameters parameters
+                    ApprovalStore.tryGetRequestAsync approvalRequestId scope (Services.getCorrelationId context))
         }
 
     let resolveStoredRequestForRead<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
         task {
-            let! request = requestIdFromContext<'T> context
+            let! requestTask = requestIdFromContext<'T> context
+
+            let! request =
+                match requestTask with
+                | Some getRequest -> getRequest
+                | None -> Task.FromResult None
 
             return
                 match request with
@@ -44,7 +58,12 @@ module ApprovalRequest =
 
     let resolveStoredRequestForRespond<'T when 'T :> ApprovalRequestParameters> (context: HttpContext) =
         task {
-            let! request = requestIdFromContext<'T> context
+            let! requestTask = requestIdFromContext<'T> context
+
+            let! request =
+                match requestTask with
+                | Some getRequest -> getRequest
+                | None -> Task.FromResult None
 
             return
                 match request with
@@ -91,45 +110,51 @@ module ApprovalRequest =
         else
             false
 
-    let private respond decision approvalRequestId reason clientDecisionId : HttpHandler =
+    let private respond decision approvalRequestId reason clientDecisionId fallbackScope : HttpHandler =
         fun _ context ->
             task {
-                match tryParseGuid approvalRequestId
-                      |> Option.bind ApprovalStore.tryGetRequest
-                    with
+                let correlationId = Services.getCorrelationId context
+
+                match tryParseGuid approvalRequestId with
                 | None -> return! Services.result404NotFound context
-                | Some request when request.Status.IsTerminal ->
-                    return!
-                        context
-                        |> Services.result400BadRequest (error context $"Approval request is already {request.Status}.")
-                | Some request when not (selectorMatches context request) ->
-                    return!
-                        context
-                        |> Services.result400BadRequest (error context "Caller does not match the stored approval responder selector.")
-                | Some request ->
-                    let status =
-                        match decision with
-                        | ApprovalDecision.Approve -> ApprovalRequestStatus.Approved
-                        | ApprovalDecision.Reject -> ApprovalRequestStatus.Rejected
+                | Some requestId ->
+                    match! ApprovalStore.tryGetRequestAsync requestId fallbackScope correlationId with
+                    | None -> return! Services.result404NotFound context
+                    | Some request when not (selectorMatches context request) ->
+                        return!
+                            context
+                            |> Services.result400BadRequest (error context "Caller does not match the stored approval responder selector.")
+                    | Some request ->
+                        let responder = currentUserId context
 
-                    let updated: Grace.Types.Webhooks.ApprovalRequest =
-                        { request with
-                            Status = status
-                            Decision =
-                                Some
-                                    { ApprovalRequestDecision.Default with
-                                        Decision = decision
-                                        DecidedBy = currentUserId context
-                                        DecidedAt = getCurrentInstant ()
-                                        Reason = if String.IsNullOrWhiteSpace reason then None else Some reason
-                                        ClientDecisionId = clientDecisionId
-                                    }
-                            UpdatedAt = Some(getCurrentInstant ())
-                        }
+                        let normalizedClientDecisionId =
+                            if String.IsNullOrWhiteSpace clientDecisionId then
+                                $"{requestId:N}:{decision}:{responder}"
+                            else
+                                clientDecisionId
 
-                    return!
-                        context
-                        |> Services.result200Ok (ApprovalStore.updateRequest updated)
+                        let requestDecision =
+                            { ApprovalRequestDecision.Default with
+                                Decision = decision
+                                DecidedBy = responder
+                                DecidedAt = getCurrentInstant ()
+                                Reason = if String.IsNullOrWhiteSpace reason then None else Some reason
+                                ClientDecisionId = normalizedClientDecisionId
+                            }
+
+                        match!
+                            ApprovalStore.handleRequestCommandAsync
+                                requestId
+                                request.Scope.RepositoryId
+                                (ApprovalRequestCommand.RecordDecision requestDecision)
+                                correlationId
+                                $"{responder}"
+                            with
+                        | Ok result ->
+                            return!
+                                context
+                                |> Services.result200Ok result.ReturnValue.Request
+                        | Error failure -> return! context |> Services.result400BadRequest failure
             }
 
     let List: HttpHandler =
@@ -138,9 +163,60 @@ module ApprovalRequest =
                 let! parameters = Services.parse<ListApprovalRequestsParameters> context
                 let scope = scopeFromRequestParameters parameters
 
-                return!
-                    context
-                    |> Services.result200Ok (ApprovalStore.listRequests scope parameters.IncludeTerminal)
+                let! requests = ApprovalStore.listRequestsAsync scope parameters.IncludeTerminal (Services.getCorrelationId context)
+                return! context |> Services.result200Ok requests
+            }
+
+    let SeedGenerated: HttpHandler =
+        fun _ context ->
+            task {
+                try
+                    if requestSeedEnabled () |> not then
+                        return! Services.result404NotFound context
+                    else
+                        let! parameters = Services.parse<SeedGeneratedApprovalRequestParameters> context
+
+                        let promotionSetId = tryParseGuid parameters.PromotionSetId
+
+                        let attempt =
+                            if parameters.StepsComputationAttempt.HasValue then
+                                Some parameters.StepsComputationAttempt.Value
+                            else
+                                None
+
+                        let request =
+                            { Grace.Types.Webhooks.ApprovalRequest.Default with
+                                ApprovalRequestId =
+                                    tryParseGuid parameters.ApprovalRequestId
+                                    |> Option.defaultValue (Guid.NewGuid())
+                                ApprovalPolicyId =
+                                    tryParseGuid parameters.ApprovalPolicyId
+                                    |> Option.defaultValue ApprovalPolicyId.Empty
+                                ApprovalPolicyVersion = parameters.ApprovalPolicyVersion
+                                Subject = parameters.Subject
+                                Scope =
+                                    { scopeFromRequestParameters parameters with
+                                        PromotionSetId = promotionSetId
+                                        StepsComputationAttempt = attempt
+                                        ApprovalPolicyId = tryParseGuid parameters.ApprovalPolicyId
+                                        ApprovalPolicyVersion = Some parameters.ApprovalPolicyVersion
+                                    }
+                                RequiredResponder = parameters.RequiredResponder
+                                Status = ApprovalRequestStatus.Pending
+                                CreatedBy = Grace.Types.Types.UserId parameters.CreatedBy
+                                CreatedAt = getCurrentInstant ()
+                            }
+
+                        match! ApprovalStore.seedGeneratedRequestAsync request (Services.getCorrelationId context) with
+                        | Ok stored -> return! context |> Services.result200Ok stored
+                        | Error failure -> return! context |> Services.result400BadRequest failure
+                with
+                | ex ->
+                    return!
+                        context
+                        |> Services.result400BadRequest (
+                            Grace.Types.Types.GraceError.CreateWithException ex "Approval request seed failed." (Services.getCorrelationId context)
+                        )
             }
 
     let Show: HttpHandler =
@@ -148,10 +224,13 @@ module ApprovalRequest =
             task {
                 let! parameters = Services.parse<ShowApprovalRequestParameters> context
 
-                match tryParseGuid parameters.ApprovalRequestId
-                      |> Option.bind ApprovalStore.tryGetRequest
-                    with
-                | Some request -> return! context |> Services.result200Ok request
+                match tryParseGuid parameters.ApprovalRequestId with
+                | Some requestId ->
+                    let scope = scopeFromRequestParameters parameters
+
+                    match! ApprovalStore.tryGetRequestAsync requestId scope (Services.getCorrelationId context) with
+                    | Some request -> return! context |> Services.result200Ok request
+                    | None -> return! Services.result404NotFound context
                 | None -> return! Services.result404NotFound context
             }
 
@@ -159,14 +238,16 @@ module ApprovalRequest =
         fun next context ->
             task {
                 let! parameters = Services.parse<ApproveApprovalRequestParameters> context
-                return! respond ApprovalDecision.Approve parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId next context
+                let fallbackScope = scopeFromRequestParameters parameters
+                return! respond ApprovalDecision.Approve parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId fallbackScope next context
             }
 
     let Reject: HttpHandler =
         fun next context ->
             task {
                 let! parameters = Services.parse<RejectApprovalRequestParameters> context
-                return! respond ApprovalDecision.Reject parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId next context
+                let fallbackScope = scopeFromRequestParameters parameters
+                return! respond ApprovalDecision.Reject parameters.ApprovalRequestId parameters.Reason parameters.ClientDecisionId fallbackScope next context
             }
 
     let History: HttpHandler =
@@ -176,9 +257,8 @@ module ApprovalRequest =
 
                 match tryParseGuid parameters.ApprovalRequestId with
                 | Some requestId ->
-                    return!
-                        context
-                        |> Services.result200Ok (ApprovalStore.requestHistory requestId)
+                    let! history = ApprovalStore.requestHistoryAsync requestId (Services.getCorrelationId context)
+                    return! context |> Services.result200Ok history
                 | None ->
                     return!
                         context

--- a/src/Grace.Server/Eventing.Server.fs
+++ b/src/Grace.Server/Eventing.Server.fs
@@ -24,8 +24,7 @@ module EventingPublisher =
             | _ -> Option.None
         | _ -> Option.None
 
-    let private tryGetRepositoryId (metadata: EventMetadata) =
-        tryGetGuidFromMetadata (nameof RepositoryId) metadata
+    let private tryGetRepositoryId (metadata: EventMetadata) = tryGetGuidFromMetadata (nameof RepositoryId) metadata
 
     let private tryGetOwnerId (metadata: EventMetadata) = tryGetGuidFromMetadata (nameof OwnerId) metadata
 
@@ -67,11 +66,7 @@ module EventingPublisher =
         | PromotionSetEventType.ApplyFailed _ -> AutomationEventType.PromotionSetApplyFailed
         | PromotionSetEventType.LogicalDeleted _ -> AutomationEventType.PromotionSetUpdated
 
-    let tryCreateAgentSessionEnvelope
-        (eventType: AutomationEventType)
-        (metadata: EventMetadata)
-        (operationResult: AgentSessionOperationResult)
-        =
+    let tryCreateAgentSessionEnvelope (eventType: AutomationEventType) (metadata: EventMetadata) (operationResult: AgentSessionOperationResult) =
         let actorId =
             if String.IsNullOrWhiteSpace operationResult.Session.AgentId then
                 tryGetActorId metadata "AgentSession"
@@ -220,6 +215,7 @@ module EventingPublisher =
                 (serialize workItemEvent)
             |> Some
         | PolicyEvent _
+        | ApprovalRequestEvent _
         | OwnerEvent _
         | BranchEvent _
         | DirectoryVersionEvent _

--- a/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
@@ -66,7 +66,12 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
     let propertyLookup = ConcurrentDictionary<Type, EntityProperties>()
 
     /// Paths that we want to ignore, because they won't have Ids and Names in the body.
-    let ignorePaths = [ "/healthz"; "/notifications" ]
+    let ignorePaths =
+        [
+            "/healthz"
+            "/notifications"
+            "/approval/request/_seedGenerated"
+        ]
 
     /// Gets the parameter type for the endpoint from the endpoint metadata created in Startup.Server.fs.
     let getBodyType (context: HttpContext) =

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -946,6 +946,15 @@ module Notification =
                         getMachineName,
                         correlationId
                     )
+                | ApprovalRequestEvent approvalRequestEvent ->
+                    let correlationId = approvalRequestEvent.Metadata.CorrelationId
+
+                    log.LogInformation(
+                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Received ApprovalRequestEvent notification.",
+                        getCurrentInstantExtended (),
+                        getMachineName,
+                        correlationId
+                    )
 
                 match EventingPublisher.tryCreateEnvelope graceEvent with
                 | Some envelope ->

--- a/src/Grace.Server/OrleansFilters.Server.fs
+++ b/src/Grace.Server/OrleansFilters.Server.fs
@@ -64,6 +64,8 @@ module Orleans =
                             | StateName.ValidationSet -> repositoryId ()
                             | StateName.ValidationResult -> repositoryId ()
                             | StateName.Artifact -> repositoryId ()
+                            | StateName.ApprovalRequest -> repositoryId ()
+                            | StateName.ApprovalRequestIndex -> repositoryId ()
                             | StateName.Reference -> repositoryId ()
                             | StateName.Reminder -> StateName.Reminder
                             | StateName.Repository -> organizationId ()

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -47,6 +47,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/approval/request/approve" (Authorized(ApprovalRequestRespond, Repository))
             endpoint "POST" "/approval/request/reject" (Authorized(ApprovalRequestRespond, Repository))
             endpoint "POST" "/approval/request/history" (Authorized(ApprovalRequestRead, Repository))
+            endpoint "POST" "/approval/request/_seedGenerated" Authenticated
             endpoint "GET" "/auth/login" AllowAnonymous
             endpoint "GET" "/auth/login/%s" AllowAnonymous
             endpoint "GET" "/auth/logout" Authenticated

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -893,6 +893,9 @@ module Application =
                         POST [ route "/list" (composeHandlers requireApprovalRequestRead ApprovalRequest.List)
                                |> addMetadata typeof<Approval.ListApprovalRequestsParameters>
 
+                               route "/_seedGenerated" ApprovalRequest.SeedGenerated
+                               |> addMetadata typeof<Approval.SeedGeneratedApprovalRequestParameters>
+
                                route "/show" (composeHandlers requireApprovalRequestShow ApprovalRequest.Show)
                                |> addMetadata typeof<Approval.ShowApprovalRequestParameters>
 

--- a/src/Grace.Shared/Parameters/Approval.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Approval.Parameters.fs
@@ -96,3 +96,14 @@ module Approval =
     /// Parameters for /approval/request/history.
     type ApprovalRequestHistoryParameters() =
         inherit ApprovalRequestParameters()
+
+    /// Internal workflow/test seam for generated approval requests. Not exposed through SDK create APIs.
+    type SeedGeneratedApprovalRequestParameters() =
+        inherit ApprovalRequestParameters()
+        member val public ApprovalPolicyId = String.Empty with get, set
+        member val public ApprovalPolicyVersion = 1 with get, set
+        member val public Subject = String.Empty with get, set
+        member val public RequiredResponder = String.Empty with get, set
+        member val public PromotionSetId = String.Empty with get, set
+        member val public StepsComputationAttempt = Nullable<int>() with get, set
+        member val public CreatedBy = "workflow" with get, set

--- a/src/Grace.Types/Events.Types.fs
+++ b/src/Grace.Types/Events.Types.fs
@@ -13,6 +13,7 @@ open Grace.Types.Queue
 open Grace.Types.PromotionSet
 open Grace.Types.Validation
 open Grace.Types.Artifact
+open Grace.Types.Webhooks
 
 module Events =
 
@@ -33,6 +34,7 @@ module Events =
         | ValidationSetEvent of Validation.ValidationSetEvent
         | ValidationResultEvent of Validation.ValidationResultEvent
         | ArtifactEvent of Artifact.ArtifactEvent
+        | ApprovalRequestEvent of Webhooks.ApprovalRequestEvent
 
         static member GetKnownTypes() = GetKnownTypes<GraceEvent>()
 
@@ -52,3 +54,4 @@ module Events =
             | ValidationSetEvent e -> serialize e
             | ValidationResultEvent e -> serialize e
             | ArtifactEvent e -> serialize e
+            | ApprovalRequestEvent e -> serialize e

--- a/src/Grace.Types/Webhooks.Types.fs
+++ b/src/Grace.Types/Webhooks.Types.fs
@@ -396,6 +396,8 @@ module Webhooks =
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ApprovalRequestIndexEventType =
         | RequestAdded of approvalRequestId: ApprovalRequestId
+        | RequestIndexed of request: ApprovalRequest
+        | RequestIndexedJson of requestJson: string
 
         static member GetKnownTypes() = GetKnownTypes<ApprovalRequestIndexEventType>()
 

--- a/src/Grace.Types/Webhooks.Types.fs
+++ b/src/Grace.Types/Webhooks.Types.fs
@@ -23,6 +23,7 @@ module Webhooks =
     type ApprovalSubject = string
     type ApprovalResponderSelector = string
     type ApprovalClientDecisionId = string
+    type ApprovalRequestAttempt = int option
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type OutboundUrlSafety =
@@ -341,6 +342,65 @@ module Webhooks =
                 UpdatedAt = None
                 SupersededByApprovalRequestId = None
             }
+
+        static member UpdateDto (approvalRequestEvent: ApprovalRequestEvent) (current: ApprovalRequest) =
+            match approvalRequestEvent.Event with
+            | ApprovalRequestEventType.Created request -> request
+            | ApprovalRequestEventType.DecisionRecorded decision ->
+                let status =
+                    match decision.Decision with
+                    | ApprovalDecision.Approve -> ApprovalRequestStatus.Approved
+                    | ApprovalDecision.Reject -> ApprovalRequestStatus.Rejected
+
+                { current with Status = status; Decision = Some decision; UpdatedAt = Some approvalRequestEvent.Metadata.Timestamp }
+            | ApprovalRequestEventType.Expired ->
+                { current with Status = ApprovalRequestStatus.Expired; UpdatedAt = Some approvalRequestEvent.Metadata.Timestamp }
+            | ApprovalRequestEventType.Cancelled ->
+                { current with Status = ApprovalRequestStatus.Cancelled; UpdatedAt = Some approvalRequestEvent.Metadata.Timestamp }
+            | ApprovalRequestEventType.Superseded supersededByApprovalRequestId ->
+                { current with
+                    Status = ApprovalRequestStatus.Superseded
+                    UpdatedAt = Some approvalRequestEvent.Metadata.Timestamp
+                    SupersededByApprovalRequestId = Some supersededByApprovalRequestId
+                }
+
+    and [<KnownType("GetKnownTypes"); GenerateSerializer>] ApprovalRequestCommand =
+        | Create of request: ApprovalRequest
+        | RecordDecision of decision: ApprovalRequestDecision
+        | Expire
+        | Cancel
+        | Supersede of supersededByApprovalRequestId: ApprovalRequestId
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalRequestCommand>()
+
+    and [<KnownType("GetKnownTypes"); GenerateSerializer>] ApprovalRequestEventType =
+        | Created of request: ApprovalRequest
+        | DecisionRecorded of decision: ApprovalRequestDecision
+        | Expired
+        | Cancelled
+        | Superseded of supersededByApprovalRequestId: ApprovalRequestId
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalRequestEventType>()
+
+    and [<CLIMutable; GenerateSerializer>] ApprovalRequestEvent = { Event: ApprovalRequestEventType; Metadata: EventMetadata }
+
+    [<GenerateSerializer>]
+    type ApprovalRequestDecisionResult = { Request: ApprovalRequest; Events: ApprovalRequestEvent list; WasIdempotentReplay: bool; Message: string }
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalRequestIndexCommand =
+        | AddRequest of approvalRequestId: ApprovalRequestId
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalRequestIndexCommand>()
+
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type ApprovalRequestIndexEventType =
+        | RequestAdded of approvalRequestId: ApprovalRequestId
+
+        static member GetKnownTypes() = GetKnownTypes<ApprovalRequestIndexEventType>()
+
+    [<CLIMutable; GenerateSerializer>]
+    type ApprovalRequestIndexEvent = { Event: ApprovalRequestIndexEventType; Metadata: EventMetadata }
 
     [<CLIMutable; GenerateSerializer>]
     type ApprovalNotificationDelivery =


### PR DESCRIPTION
## Summary

- Adds the durable approval request lifecycle actor and API behavior for generated approval requests.
- Makes generated `_seedGenerated` creates idempotent by deriving deterministic request ids from the logical approval key when callers do not supply a stable id.
- Stores/replays request history from the correct repository partition and removes non-durable snapshot fallback for durable approval facts.
- Integrates with current webhook authorization manifest/test project entries from `main`.

Closes #147.

## Validation

Worker validation after latest fix:

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~GeneratedApprovalRequestIdTests|FullyQualifiedName~ConcurrentGeneratedCreateWithoutStableRequestIdConvergesOnOneRequestForSameLogicalKey|FullyQualifiedName~RepeatedGeneratedCreateWithoutStableRequestIdReturnsExistingRequestForSameAttempt"`: passed, 3/3.
- `dotnet build src\Grace.slnx --configuration Release`: passed, 0 warnings, 0 errors.
- `dotnet tool run fantomas --check .` from `src`: passed, no changes required.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Integration worker validation after merging current `origin/main`:

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~Approval"`: passed, 20/20.
- `dotnet build src\Grace.slnx --configuration Release`: passed, 0 warnings, 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `dotnet tool run fantomas --check .\Grace.Server\Security\EndpointAuthorizationManifest.Server.fs`: passed.
- `git diff --check`: passed.

## Review Ledger

Issue ledger comments:

- Review pass 1: https://github.com/ScottArbeit/Grace/issues/147#issuecomment-4607014621
- Review pass 2: https://github.com/ScottArbeit/Grace/issues/147#issuecomment-4607083056
- Review pass 3: https://github.com/ScottArbeit/Grace/issues/147#issuecomment-4607460483
- Final integration review: https://github.com/ScottArbeit/Grace/issues/147#issuecomment-4607533797

Latest review-only sibling findings: none.

Reviewed And OK highlights:

- Deterministic generated approval request ids route concurrent seeds through one request actor.
- `_seedGenerated` preserves `Guid.Empty` at the HTTP edge so deterministic store logic is used.
- Actor lifecycle, duplicate decision, history partition, and replay coverage are in place.
- Approval request events remain separate from webhook delivery.
- Final merge kept both approval and webhook test/auth manifest entries.

## Notes

- A repo-wide recursive Fantomas check is not currently a clean gate because unrelated existing files fail it. The conflict-touched F# file passed targeted Fantomas after integration.