### PR TITLE
[Webhooks/Approvals] Add webhook dispatch runtime

### DIFF
--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="Approval.Server.Tests.fs" />
     <Compile Include="Webhook.Server.Tests.fs" />
+    <Compile Include="WebhookDispatch.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -60,6 +60,32 @@ module private WebhookDispatchTestHelpers =
                         )
                 }
 
+    type CancelingTransport(cancellationTokenSource: CancellationTokenSource) =
+        let requests = List<OutboundWebhookRequest>()
+
+        member _.Requests = requests |> Seq.toArray
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, cancellationToken) =
+                task {
+                    requests.Add request
+                    cancellationTokenSource.Cancel()
+                    return raise (OperationCanceledException(cancellationToken))
+                }
+
+    type CancelAfterSuccessTransport(cancellationTokenSource: CancellationTokenSource) =
+        let requests = List<OutboundWebhookRequest>()
+
+        member _.Requests = requests |> Seq.toArray
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, _) =
+                task {
+                    requests.Add request
+                    cancellationTokenSource.Cancel()
+                    return OutboundWebhookResult.Succeeded 200
+                }
+
     let configuration: IConfiguration = ConfigurationBuilder().Build()
 
     let hostEnvironment = TestHostEnvironment() :> IHostEnvironment
@@ -558,6 +584,243 @@ type WebhookDispatchUnitTests() =
             let retriedDelivery = retriedDeliveries[0]
             Assert.That(retriedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
             Assert.That(retriedDelivery.AttemptCount, Is.EqualTo(2))
+        }
+
+    [<Test>]
+    member _.ScheduledRetryCancellationPropagatesWithoutMutatingDueDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            WebhookStore.upsertRule rule |> ignore
+
+            let! dispatchResult =
+                WebhookDispatchTestHelpers.dispatch
+                    (WebhookDispatchTestHelpers.RecordingTransport(
+                        [
+                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        ]
+                    ))
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
+
+            let scheduledDelivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
+
+            let dueDelivery =
+                { scheduledDelivery with
+                    NextAttemptAt =
+                        Some(
+                            getCurrentInstant()
+                                .Minus(Duration.FromSeconds(1.0))
+                        )
+                }
+
+            WebhookStore.upsertDelivery dueDelivery |> ignore
+
+            use cancellationTokenSource = new CancellationTokenSource()
+            let transport = WebhookDispatchTestHelpers.CancelingTransport(cancellationTokenSource)
+
+            let operation =
+                Func<Task> (fun () ->
+                    task {
+                        let! _ =
+                            WebhookDispatch.processScheduledRetriesAsync
+                                WebhookDispatchTestHelpers.logger
+                                WebhookDispatchTestHelpers.configuration
+                                WebhookDispatchTestHelpers.hostEnvironment
+                                transport
+                                (getCurrentInstant ())
+                                10
+                                cancellationTokenSource.Token
+
+                        return ()
+                    }
+                    :> Task)
+
+            Assert.ThrowsAsync<OperationCanceledException>(operation)
+            |> ignore
+
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let unchangedDelivery =
+                WebhookStore.tryGetDelivery dueDelivery.WebhookDeliveryId
+                |> Option.get
+
+            Assert.That(unchangedDelivery.Status, Is.EqualTo(dueDelivery.Status))
+            Assert.That(unchangedDelivery.AttemptCount, Is.EqualTo(dueDelivery.AttemptCount))
+            Assert.That(unchangedDelivery.LastAttemptAt, Is.EqualTo(dueDelivery.LastAttemptAt))
+            Assert.That(unchangedDelivery.LastStatusCode, Is.EqualTo(dueDelivery.LastStatusCode))
+            Assert.That(unchangedDelivery.LastError, Is.EqualTo(dueDelivery.LastError))
+            Assert.That(unchangedDelivery.NextAttemptAt, Is.EqualTo(dueDelivery.NextAttemptAt))
+        }
+
+    [<Test>]
+    member _.ScheduledRetryCancellationBetweenItemsDoesNotMutateNextDueDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let firstTargetBranchId = Guid.NewGuid()
+            let secondTargetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let firstRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some firstTargetBranchId)
+
+            let secondRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some secondTargetBranchId)
+
+            WebhookStore.upsertRule firstRule |> ignore
+            WebhookStore.upsertRule secondRule |> ignore
+
+            let! firstDispatchResult =
+                WebhookDispatchTestHelpers.dispatch
+                    (WebhookDispatchTestHelpers.RecordingTransport(
+                        [
+                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        ]
+                    ))
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId firstTargetBranchId promotionSetId (Guid.NewGuid()))
+
+            let! secondDispatchResult =
+                WebhookDispatchTestHelpers.dispatch
+                    (WebhookDispatchTestHelpers.RecordingTransport(
+                        [
+                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        ]
+                    ))
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId secondTargetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(firstDispatchResult.FailedCount, Is.EqualTo(1))
+            Assert.That(secondDispatchResult.FailedCount, Is.EqualTo(1))
+
+            let now = getCurrentInstant ()
+
+            let firstDueDelivery =
+                { (WebhookStore.listDeliveries firstRule.Scope firstRule.WebhookRuleId true)[0] with
+                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(2.0)))
+                }
+
+            let secondDueDelivery =
+                { (WebhookStore.listDeliveries secondRule.Scope secondRule.WebhookRuleId true)[0] with
+                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(1.0)))
+                }
+
+            WebhookStore.upsertDelivery firstDueDelivery
+            |> ignore
+
+            WebhookStore.upsertDelivery secondDueDelivery
+            |> ignore
+
+            use cancellationTokenSource = new CancellationTokenSource()
+            let transport = WebhookDispatchTestHelpers.CancelAfterSuccessTransport(cancellationTokenSource)
+
+            let operation =
+                Func<Task> (fun () ->
+                    task {
+                        let! _ =
+                            WebhookDispatch.processScheduledRetriesAsync
+                                WebhookDispatchTestHelpers.logger
+                                WebhookDispatchTestHelpers.configuration
+                                WebhookDispatchTestHelpers.hostEnvironment
+                                transport
+                                now
+                                10
+                                cancellationTokenSource.Token
+
+                        return ()
+                    }
+                    :> Task)
+
+            Assert.ThrowsAsync<OperationCanceledException>(operation)
+            |> ignore
+
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let firstRetriedDelivery =
+                WebhookStore.tryGetDelivery firstDueDelivery.WebhookDeliveryId
+                |> Option.get
+
+            Assert.That(firstRetriedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+            Assert.That(firstRetriedDelivery.AttemptCount, Is.EqualTo(2))
+
+            let unchangedSecondDelivery =
+                WebhookStore.tryGetDelivery secondDueDelivery.WebhookDeliveryId
+                |> Option.get
+
+            Assert.That(unchangedSecondDelivery.Status, Is.EqualTo(secondDueDelivery.Status))
+            Assert.That(unchangedSecondDelivery.AttemptCount, Is.EqualTo(secondDueDelivery.AttemptCount))
+            Assert.That(unchangedSecondDelivery.LastAttemptAt, Is.EqualTo(secondDueDelivery.LastAttemptAt))
+            Assert.That(unchangedSecondDelivery.LastStatusCode, Is.EqualTo(secondDueDelivery.LastStatusCode))
+            Assert.That(unchangedSecondDelivery.LastError, Is.EqualTo(secondDueDelivery.LastError))
+            Assert.That(unchangedSecondDelivery.NextAttemptAt, Is.EqualTo(secondDueDelivery.NextAttemptAt))
+        }
+
+    [<Test>]
+    member _.ScheduledRetryTransportExceptionIsRedactedAndDeadLetteredAtMaxAttempts() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            WebhookStore.upsertRule rule |> ignore
+
+            let! dispatchResult =
+                WebhookDispatchTestHelpers.dispatch
+                    (WebhookDispatchTestHelpers.RecordingTransport(
+                        [
+                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        ]
+                    ))
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
+
+            let scheduledDelivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
+
+            WebhookStore.upsertDelivery
+                { scheduledDelivery with
+                    NextAttemptAt =
+                        Some(
+                            getCurrentInstant()
+                                .Minus(Duration.FromSeconds(1.0))
+                        )
+                }
+            |> ignore
+
+            let! retryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    (WebhookDispatchTestHelpers.ThrowingTransport())
+                    (getCurrentInstant ())
+                    10
+                    CancellationToken.None
+
+            Assert.That(retryResult.FailedCount, Is.EqualTo(1))
+
+            let retriedDelivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
+            Assert.That(retriedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
+            Assert.That(retriedDelivery.AttemptCount, Is.EqualTo(2))
+            Assert.That(retriedDelivery.LastError.Value, Does.Not.Contain("super-secret-token"))
+            Assert.That(retriedDelivery.LastError.Value, Does.Not.Contain("signed-secret"))
+            Assert.That(retriedDelivery.LastError.Value, Does.Contain("token=REDACTED"))
+            Assert.That(retriedDelivery.LastError.Value, Does.Contain("signature=REDACTED"))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -114,16 +114,13 @@ module private WebhookDispatchTestHelpers =
 
         member _.WaitForFirstRequestAsync() = firstRequest.Task
 
-        member _.Release() =
-            release.TrySetResult(())
-            |> ignore
+        member _.Release() = release.TrySetResult(()) |> ignore
 
         interface IOutboundWebhookTransport with
             member _.SendAsync(request, _) =
                 task {
                     requests.Add request
-                    firstRequest.TrySetResult(())
-                    |> ignore
+                    firstRequest.TrySetResult(()) |> ignore
 
                     do! release.Task
                     return OutboundWebhookResult.Succeeded 200
@@ -352,10 +349,10 @@ type WebhookDispatchUnitTests() =
 
             let transport = WebhookDispatchTestHelpers.BlockingSuccessTransport()
             let graceEvent = WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId
+
             let dispatches =
                 [|
-                    for _ in 1..16 ->
-                        WebhookDispatchTestHelpers.dispatch transport graceEvent
+                    for _ in 1..16 -> WebhookDispatchTestHelpers.dispatch transport graceEvent
                 |]
 
             do! transport.WaitForFirstRequestAsync()
@@ -363,9 +360,24 @@ type WebhookDispatchUnitTests() =
 
             let! results = Task.WhenAll dispatches
 
-            Assert.That(results |> Array.sumBy _.DeliveryCount, Is.EqualTo(1))
-            Assert.That(results |> Array.sumBy _.DeliveredCount, Is.EqualTo(1))
-            Assert.That(results |> Array.sumBy _.SkippedDuplicateCount, Is.EqualTo(15))
+            Assert.That(
+                results
+                |> Array.sumBy (fun result -> result.DeliveryCount),
+                Is.EqualTo(1)
+            )
+
+            Assert.That(
+                results
+                |> Array.sumBy (fun result -> result.DeliveredCount),
+                Is.EqualTo(1)
+            )
+
+            Assert.That(
+                results
+                |> Array.sumBy (fun result -> result.SkippedDuplicateCount),
+                Is.EqualTo(15)
+            )
+
             Assert.That(transport.Requests, Has.Length.EqualTo(1))
 
             let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
@@ -443,21 +455,14 @@ type WebhookDispatchUnitTests() =
                     RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
                 }
 
-            let successRule =
-                WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            let successRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
 
             WebhookStore.upsertRule timeoutRule |> ignore
             WebhookStore.upsertRule successRule |> ignore
 
-            let timeoutStep _ _ =
-                task {
-                    return raise (TaskCanceledException("simulated request timeout"))
-                }
+            let timeoutStep _ _ = task { return raise (TaskCanceledException("simulated request timeout")) }
 
-            let successStep _ _ =
-                task {
-                    return OutboundWebhookResult.Succeeded 200
-                }
+            let successStep _ _ = task { return OutboundWebhookResult.Succeeded 200 }
 
             let transport = WebhookDispatchTestHelpers.ScriptedTransport([ timeoutStep; successStep ])
 
@@ -476,7 +481,12 @@ type WebhookDispatchUnitTests() =
                 |> Seq.toArray
 
             Assert.That(deliveries, Has.Length.EqualTo(2))
-            Assert.That(deliveries |> Seq.filter (fun delivery -> delivery.Status = WebhookDeliveryStatus.Succeeded), Has.Exactly(1).Items)
+
+            Assert.That(
+                deliveries
+                |> Seq.filter (fun delivery -> delivery.Status = WebhookDeliveryStatus.Succeeded),
+                Has.Exactly(1).Items
+            )
 
             let retryDelivery =
                 deliveries
@@ -485,6 +495,54 @@ type WebhookDispatchUnitTests() =
             Assert.That(retryDelivery.AttemptCount, Is.EqualTo(1))
             Assert.That(retryDelivery.LastError.Value, Does.Contain("simulated request timeout"))
             Assert.That(retryDelivery.NextAttemptAt, Is.Not.EqualTo(Option.None))
+        }
+
+    [<Test>]
+    member _.CommittedEventCancellationBetweenRulesDoesNotClaimOrSendNextRule() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let firstRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            let secondRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+
+            WebhookStore.upsertRule firstRule |> ignore
+            WebhookStore.upsertRule secondRule |> ignore
+
+            use cancellationTokenSource = new CancellationTokenSource()
+            let transport = WebhookDispatchTestHelpers.CancelAfterSuccessTransport(cancellationTokenSource)
+
+            let operation =
+                Func<Task> (fun () ->
+                    task {
+                        let! _ =
+                            WebhookDispatch.dispatchCommittedEventAsync
+                                WebhookDispatchTestHelpers.logger
+                                WebhookDispatchTestHelpers.configuration
+                                WebhookDispatchTestHelpers.hostEnvironment
+                                transport
+                                (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+                                cancellationTokenSource.Token
+
+                        return ()
+                    }
+                    :> Task)
+
+            Assert.ThrowsAsync<OperationCanceledException>(operation)
+            |> ignore
+
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let deliveries =
+                WebhookStore.listDeliveries firstRule.Scope WebhookRuleId.Empty true
+                |> Seq.toArray
+
+            Assert.That(deliveries, Has.Length.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+            Assert.That(deliveries[0].AttemptCount, Is.EqualTo(1))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -278,7 +278,7 @@ type WebhookDispatchUnitTests() =
             Assert.That(result.DeliveryCount, Is.EqualTo(0))
             Assert.That(transport.Requests, Is.Empty)
 
-            let referenceEvent =
+            let referenceEvent: ReferenceEvent =
                 {
                     Event =
                         ReferenceEventType.Created(

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -16,6 +16,7 @@ open Microsoft.Extensions.Logging.Abstractions
 open NodaTime
 open NUnit.Framework
 open System
+open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Threading
 open System.Threading.Tasks
@@ -60,6 +61,24 @@ module private WebhookDispatchTestHelpers =
                         )
                 }
 
+    type ScriptedTransport(steps: (OutboundWebhookRequest -> CancellationToken -> Task<OutboundWebhookResult>) list) =
+        let requests = List<OutboundWebhookRequest>()
+        let mutable remainingSteps = steps
+
+        member _.Requests = requests |> Seq.toArray
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, cancellationToken) =
+                task {
+                    requests.Add request
+
+                    match remainingSteps with
+                    | step :: tail ->
+                        remainingSteps <- tail
+                        return! step request cancellationToken
+                    | [] -> return OutboundWebhookResult.Succeeded 200
+                }
+
     type CancelingTransport(cancellationTokenSource: CancellationTokenSource) =
         let requests = List<OutboundWebhookRequest>()
 
@@ -83,6 +102,30 @@ module private WebhookDispatchTestHelpers =
                 task {
                     requests.Add request
                     cancellationTokenSource.Cancel()
+                    return OutboundWebhookResult.Succeeded 200
+                }
+
+    type BlockingSuccessTransport() =
+        let requests = ConcurrentBag<OutboundWebhookRequest>()
+        let firstRequest = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+        let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        member _.Requests = requests.ToArray()
+
+        member _.WaitForFirstRequestAsync() = firstRequest.Task
+
+        member _.Release() =
+            release.TrySetResult(())
+            |> ignore
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, _) =
+                task {
+                    requests.Add request
+                    firstRequest.TrySetResult(())
+                    |> ignore
+
+                    do! release.Task
                     return OutboundWebhookResult.Succeeded 200
                 }
 
@@ -296,6 +339,41 @@ type WebhookDispatchUnitTests() =
         }
 
     [<Test>]
+    member _.ConcurrentDuplicateCommittedEventOnlySendsOnceForDedupeKey() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId Option.None
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.BlockingSuccessTransport()
+            let graceEvent = WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId
+            let dispatches =
+                [|
+                    for _ in 1..16 ->
+                        WebhookDispatchTestHelpers.dispatch transport graceEvent
+                |]
+
+            do! transport.WaitForFirstRequestAsync()
+            transport.Release()
+
+            let! results = Task.WhenAll dispatches
+
+            Assert.That(results |> Array.sumBy _.DeliveryCount, Is.EqualTo(1))
+            Assert.That(results |> Array.sumBy _.DeliveredCount, Is.EqualTo(1))
+            Assert.That(results |> Array.sumBy _.SkippedDuplicateCount, Is.EqualTo(15))
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+        }
+
+    [<Test>]
     member _.TransientFailureSchedulesRetryWithoutBlockingCommittedEventDispatch() =
         task {
             let ownerId = Guid.NewGuid()
@@ -349,6 +427,64 @@ type WebhookDispatchUnitTests() =
             let updatedDeliveries = WebhookStore.listDeliveries transientRule.Scope transientRule.WebhookRuleId true
             Assert.That(updatedDeliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
             Assert.That(updatedDeliveries[0].AttemptCount, Is.EqualTo(2))
+        }
+
+    [<Test>]
+    member _.TimeoutLikeCancellationSchedulesRetryAndDoesNotAbortCommittedEventBatch() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let timeoutRule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            let successRule =
+                WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+
+            WebhookStore.upsertRule timeoutRule |> ignore
+            WebhookStore.upsertRule successRule |> ignore
+
+            let timeoutStep _ _ =
+                task {
+                    return raise (TaskCanceledException("simulated request timeout"))
+                }
+
+            let successStep _ _ =
+                task {
+                    return OutboundWebhookResult.Succeeded 200
+                }
+
+            let transport = WebhookDispatchTestHelpers.ScriptedTransport([ timeoutStep; successStep ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(2))
+            Assert.That(result.DeliveredCount, Is.EqualTo(1))
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(2))
+
+            let deliveries =
+                WebhookStore.listDeliveries timeoutRule.Scope WebhookRuleId.Empty true
+                |> Seq.toArray
+
+            Assert.That(deliveries, Has.Length.EqualTo(2))
+            Assert.That(deliveries |> Seq.filter (fun delivery -> delivery.Status = WebhookDeliveryStatus.Succeeded), Has.Exactly(1).Items)
+
+            let retryDelivery =
+                deliveries
+                |> Seq.find (fun delivery -> delivery.Status = WebhookDeliveryStatus.RetryScheduled)
+
+            Assert.That(retryDelivery.AttemptCount, Is.EqualTo(1))
+            Assert.That(retryDelivery.LastError.Value, Does.Contain("simulated request timeout"))
+            Assert.That(retryDelivery.NextAttemptAt, Is.Not.EqualTo(Option.None))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -50,7 +50,15 @@ module private WebhookDispatchTestHelpers =
 
     type ThrowingTransport() =
         interface IOutboundWebhookTransport with
-            member _.SendAsync(_, _) = task { return raise (InvalidOperationException("simulated outbound failure with secret")) }
+            member _.SendAsync(_, _) =
+                task {
+                    return
+                        raise (
+                            InvalidOperationException(
+                                "simulated outbound failure token=super-secret-token url=https://example.test/hook?signature=signed-secret"
+                            )
+                        )
+                }
 
     let configuration: IConfiguration = ConfigurationBuilder().Build()
 
@@ -262,7 +270,7 @@ type WebhookDispatchUnitTests() =
         }
 
     [<Test>]
-    member _.TransientFailuresRetryAndExhaustedAttemptsDeadLetter() =
+    member _.TransientFailureSchedulesRetryWithoutBlockingCommittedEventDispatch() =
         task {
             let ownerId = Guid.NewGuid()
             let organizationId = Guid.NewGuid()
@@ -280,8 +288,7 @@ type WebhookDispatchUnitTests() =
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
                     [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.TransientFailure(Option.Some 500, "server error")
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable token=response-secret")
                         OutboundWebhookResult.Succeeded 200
                     ]
                 )
@@ -291,17 +298,48 @@ type WebhookDispatchUnitTests() =
                     transport
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
 
-            Assert.That(result.DeliveredCount, Is.EqualTo(1))
-            Assert.That(transport.Requests, Has.Length.EqualTo(3))
+            Assert.That(result.DeliveredCount, Is.EqualTo(0))
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
             let deliveries = WebhookStore.listDeliveries transientRule.Scope transientRule.WebhookRuleId true
             let delivery = deliveries[0]
-            Assert.That(delivery.Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
-            Assert.That(delivery.AttemptCount, Is.EqualTo(3))
+            Assert.That(delivery.Status, Is.EqualTo(WebhookDeliveryStatus.RetryScheduled))
+            Assert.That(delivery.AttemptCount, Is.EqualTo(1))
+            Assert.That(delivery.NextAttemptAt, Is.Not.EqualTo(Option.None))
+            Assert.That(delivery.LastError.Value, Does.Not.Contain("response-secret"))
 
-            WebhookStore.clearForTests ()
+            let! retryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    transport
+                    (delivery.NextAttemptAt.Value.Plus(Duration.FromSeconds(1.0)))
+                    10
+                    CancellationToken.None
 
-            let exhaustedRule =
-                { transientRule with WebhookRuleId = Guid.NewGuid(); RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
+            Assert.That(retryResult.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(2))
+            let updatedDeliveries = WebhookStore.listDeliveries transientRule.Scope transientRule.WebhookRuleId true
+            Assert.That(updatedDeliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+            Assert.That(updatedDeliveries[0].AttemptCount, Is.EqualTo(2))
+        }
+
+    [<Test>]
+    member _.ScheduledRetryExhaustionDeadLettersWithoutBlockingSourceWorkflow() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let transientRule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            let exhaustedRule = { transientRule with WebhookRuleId = Guid.NewGuid() }
 
             WebhookStore.upsertRule exhaustedRule |> ignore
 
@@ -319,11 +357,28 @@ type WebhookDispatchUnitTests() =
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
 
             Assert.That(exhaustedResult.FailedCount, Is.EqualTo(1))
-            Assert.That(exhaustedTransport.Requests, Has.Length.EqualTo(2))
+            Assert.That(exhaustedTransport.Requests, Has.Length.EqualTo(1))
             let exhaustedDeliveries = WebhookStore.listDeliveries exhaustedRule.Scope exhaustedRule.WebhookRuleId true
             let exhaustedDelivery = exhaustedDeliveries[0]
-            Assert.That(exhaustedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
-            Assert.That(exhaustedDelivery.AttemptCount, Is.EqualTo(2))
+            Assert.That(exhaustedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.RetryScheduled))
+            Assert.That(exhaustedDelivery.AttemptCount, Is.EqualTo(1))
+
+            let! retryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    exhaustedTransport
+                    (exhaustedDelivery.NextAttemptAt.Value.Plus(Duration.FromSeconds(1.0)))
+                    10
+                    CancellationToken.None
+
+            Assert.That(retryResult.FailedCount, Is.EqualTo(1))
+            Assert.That(exhaustedTransport.Requests, Has.Length.EqualTo(2))
+            let retriedDeliveries = WebhookStore.listDeliveries exhaustedRule.Scope exhaustedRule.WebhookRuleId true
+            let retriedDelivery = retriedDeliveries[0]
+            Assert.That(retriedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
+            Assert.That(retriedDelivery.AttemptCount, Is.EqualTo(2))
         }
 
     [<Test>]
@@ -380,6 +435,50 @@ type WebhookDispatchUnitTests() =
 
             let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
             Assert.That(deliveries, Has.Count.EqualTo(1))
-            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
-            Assert.That(deliveries[0].AttemptCount, Is.EqualTo(rule.RetryPolicy.MaxAttempts))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.RetryScheduled))
+            Assert.That(deliveries[0].AttemptCount, Is.EqualTo(1))
+            Assert.That(deliveries[0].LastError.Value, Does.Not.Contain("super-secret-token"))
+            Assert.That(deliveries[0].LastError.Value, Does.Not.Contain("signed-secret"))
+            Assert.That(deliveries[0].LastError.Value, Does.Contain("token=REDACTED"))
+            Assert.That(deliveries[0].LastError.Value, Does.Contain("signature=REDACTED"))
+        }
+
+    [<Test>]
+    member _.FailedResponseErrorIsRedactedBeforePersistence() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.PermanentFailure(
+                            Option.Some 400,
+                            "bad response from https://example.test/hook?token=response-token&signature=response-signature secret=response-secret"
+                        )
+                    ]
+                )
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Failed))
+            Assert.That(deliveries[0].LastError.Value, Does.Not.Contain("response-token"))
+            Assert.That(deliveries[0].LastError.Value, Does.Not.Contain("response-signature"))
+            Assert.That(deliveries[0].LastError.Value, Does.Not.Contain("response-secret"))
+            Assert.That(deliveries[0].LastError.Value, Does.Contain("token=REDACTED"))
+            Assert.That(deliveries[0].LastError.Value, Does.Contain("signature=REDACTED"))
+            Assert.That(deliveries[0].LastError.Value, Does.Contain("secret=REDACTED"))
         }

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -1,0 +1,385 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Server.WebhookDispatch
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Events
+open Grace.Types.PromotionSet
+open Grace.Types.Reference
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.FileProviders
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging.Abstractions
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
+open System.Text.Json
+
+module private WebhookDispatchTestHelpers =
+
+    type TestHostEnvironment() =
+        interface IHostEnvironment with
+            member val ApplicationName = "Grace.Server.Tests" with get, set
+            member val EnvironmentName = Environments.Production with get, set
+            member val ContentRootPath = Environment.CurrentDirectory with get, set
+            member val ContentRootFileProvider = NullFileProvider() :> IFileProvider with get, set
+
+    type RecordingTransport(results: OutboundWebhookResult list) =
+        let requests = List<OutboundWebhookRequest>()
+        let mutable remainingResults = results
+
+        member _.Requests = requests |> Seq.toArray
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, _) =
+                task {
+                    requests.Add request
+
+                    match remainingResults with
+                    | result :: tail ->
+                        remainingResults <- tail
+                        return result
+                    | [] -> return OutboundWebhookResult.Succeeded 200
+                }
+
+    type ThrowingTransport() =
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(_, _) = task { return raise (InvalidOperationException("simulated outbound failure with secret")) }
+
+    let configuration: IConfiguration = ConfigurationBuilder().Build()
+
+    let hostEnvironment = TestHostEnvironment() :> IHostEnvironment
+
+    let logger = NullLogger.Instance
+
+    let metadata ownerId organizationId repositoryId targetBranchId promotionSetId correlationId =
+        let properties = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        properties[nameof OwnerId] <- $"{ownerId}"
+        properties[nameof OrganizationId] <- $"{organizationId}"
+        properties[nameof RepositoryId] <- $"{repositoryId}"
+        properties[nameof BranchId] <- $"{targetBranchId}"
+        properties[nameof PromotionSetId] <- $"{promotionSetId}"
+        properties["ActorId"] <- $"{promotionSetId}"
+
+        {
+            Timestamp = Instant.FromUtc(2026, 6, 2, 12, 0)
+            CorrelationId = correlationId
+            Principal = "tester"
+            ClientType = Option.None
+            Properties = properties
+        }
+
+    let appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId =
+        let promotionSetEvent: PromotionSetEvent =
+            {
+                Event = PromotionSetEventType.Applied terminalReferenceId
+                Metadata = metadata ownerId organizationId repositoryId targetBranchId promotionSetId "corr-webhook"
+            }
+
+        GraceEvent.PromotionSetEvent promotionSetEvent
+
+    let rule ruleId ownerId organizationId repositoryId targetBranchId =
+        { WebhookRule.Default with
+            WebhookRuleId = ruleId
+            EventName = ExternalWebhookEventRegistry.PromotionSetAppliedName
+            EventVersion = 1
+            Scope = { OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+            Url = { Url = "https://8.8.8.8/grace?token=secret"; Safety = OutboundUrlSafety.PublicHttps }
+            SigningSecretVersion = "test-secret-v1"
+            RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+            Status = WebhookRuleStatus.Enabled
+            CreatedBy = UserId "tester"
+            CreatedAt = Instant.FromUtc(2026, 6, 2, 11, 0)
+        }
+
+    let dispatch transport graceEvent =
+        WebhookDispatch.dispatchCommittedEventAsync logger configuration hostEnvironment transport graceEvent CancellationToken.None
+
+[<NonParallelizable>]
+type WebhookDispatchUnitTests() =
+
+    [<SetUp>]
+    member _.SetUp() = WebhookStore.clearForTests ()
+
+    [<Test>]
+    member _.CommittedPromotionSetAppliedCreatesSignedVersionedDeliveryForMatchingRule() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 202 ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(1))
+            Assert.That(result.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let request = transport.Requests[0]
+            Assert.That(request.Headers["x-grace-webhook-event-name"], Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName))
+            Assert.That(request.Headers["x-grace-webhook-event-version"], Is.EqualTo("1"))
+            Assert.That(request.Headers["x-grace-webhook-signature"], Does.StartWith("sha256="))
+            Assert.That(request.Headers["x-grace-webhook-signature"], Does.Not.Contain(rule.SigningSecretVersion))
+            Assert.That(request.RedactedUrl, Does.Contain("token=REDACTED"))
+            Assert.That(request.RedactedUrl, Does.Not.Contain("secret"))
+
+            use payload = JsonDocument.Parse(request.PayloadJson)
+
+            Assert.That(
+                payload
+                    .RootElement
+                    .GetProperty("eventName")
+                    .GetString(),
+                Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName)
+            )
+
+            Assert.That(
+                payload
+                    .RootElement
+                    .GetProperty("eventVersion")
+                    .GetInt32(),
+                Is.EqualTo(1)
+            )
+
+            Assert.That(
+                payload
+                    .RootElement
+                    .GetProperty("promotionSetId")
+                    .GetGuid(),
+                Is.EqualTo(promotionSetId)
+            )
+
+            Assert.That(
+                payload
+                    .RootElement
+                    .GetProperty("terminalPromotionReferenceId")
+                    .GetGuid(),
+                Is.EqualTo(terminalReferenceId)
+            )
+
+            Assert.That(request.PayloadJson, Does.Not.Contain("DataJson"))
+            Assert.That(request.PayloadJson, Does.Not.Contain("AutomationEventEnvelope"))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+            Assert.That(deliveries[0].AttemptCount, Is.EqualTo(1))
+            Assert.That(deliveries[0].LastStatusCode, Is.EqualTo(Option.Some 202))
+        }
+
+    [<Test>]
+    member _.NonMatchingRuleAndNonCanonicalReferenceSourceDoNotCreateDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let matchingBranchId = Guid.NewGuid()
+            let otherBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some otherBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId matchingBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(0))
+            Assert.That(transport.Requests, Is.Empty)
+
+            let referenceEvent =
+                {
+                    Event =
+                        ReferenceEventType.Created(
+                            Guid.NewGuid(),
+                            ownerId,
+                            organizationId,
+                            repositoryId,
+                            otherBranchId,
+                            Guid.NewGuid(),
+                            Sha256Hash String.Empty,
+                            ReferenceType.Promotion,
+                            "promotion",
+                            [
+                                ReferenceLinkType.PromotionSetTerminal promotionSetId
+                            ]
+                        )
+                    Metadata = WebhookDispatchTestHelpers.metadata ownerId organizationId repositoryId otherBranchId promotionSetId "corr-reference"
+                }
+
+            let! referenceResult = WebhookDispatchTestHelpers.dispatch transport (GraceEvent.ReferenceEvent referenceEvent)
+            Assert.That(referenceResult.DeliveryCount, Is.EqualTo(0))
+            Assert.That(transport.Requests, Is.Empty)
+        }
+
+    [<Test>]
+    member _.DuplicateCommittedEventSkipsExistingDedupeKey() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId Option.None
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.Succeeded 200
+                        OutboundWebhookResult.Succeeded 200
+                    ]
+                )
+
+            let graceEvent = WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId
+            let! first = WebhookDispatchTestHelpers.dispatch transport graceEvent
+            let! second = WebhookDispatchTestHelpers.dispatch transport graceEvent
+
+            Assert.That(first.DeliveryCount, Is.EqualTo(1))
+            Assert.That(second.SkippedDuplicateCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+        }
+
+    [<Test>]
+    member _.TransientFailuresRetryAndExhaustedAttemptsDeadLetter() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let transientRule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            WebhookStore.upsertRule transientRule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.TransientFailure(Option.Some 500, "server error")
+                        OutboundWebhookResult.Succeeded 200
+                    ]
+                )
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(3))
+            let deliveries = WebhookStore.listDeliveries transientRule.Scope transientRule.WebhookRuleId true
+            let delivery = deliveries[0]
+            Assert.That(delivery.Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+            Assert.That(delivery.AttemptCount, Is.EqualTo(3))
+
+            WebhookStore.clearForTests ()
+
+            let exhaustedRule =
+                { transientRule with WebhookRuleId = Guid.NewGuid(); RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
+
+            WebhookStore.upsertRule exhaustedRule |> ignore
+
+            let exhaustedTransport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                    ]
+                )
+
+            let! exhaustedResult =
+                WebhookDispatchTestHelpers.dispatch
+                    exhaustedTransport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(exhaustedResult.FailedCount, Is.EqualTo(1))
+            Assert.That(exhaustedTransport.Requests, Has.Length.EqualTo(2))
+            let exhaustedDeliveries = WebhookStore.listDeliveries exhaustedRule.Scope exhaustedRule.WebhookRuleId true
+            let exhaustedDelivery = exhaustedDeliveries[0]
+            Assert.That(exhaustedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
+            Assert.That(exhaustedDelivery.AttemptCount, Is.EqualTo(2))
+        }
+
+    [<Test>]
+    member _.DeliveryRejectsUnsafeUrlWithoutCallingTransportOrLeakingSecretUrl() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    Url = { Url = "https://127.0.0.1/hook?token=secret"; Safety = OutboundUrlSafety.PublicHttps }
+                }
+
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Is.Empty)
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            let delivery = deliveries[0]
+            Assert.That(delivery.Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
+            Assert.That(delivery.LastError.Value, Does.Contain("Outbound URL rejected"))
+            Assert.That(delivery.LastError.Value, Does.Not.Contain("secret"))
+        }
+
+    [<Test>]
+    member _.OutboundTransportExceptionDoesNotEscapeCommittedEventDispatch() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+
+            WebhookStore.upsertRule rule |> ignore
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    (WebhookDispatchTestHelpers.ThrowingTransport())
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.DeadLettered))
+            Assert.That(deliveries[0].AttemptCount, Is.EqualTo(rule.RetryPolicy.MaxAttempts))
+        }

--- a/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WebhookDispatch.Server.Tests.fs
@@ -326,6 +326,185 @@ type WebhookDispatchUnitTests() =
         }
 
     [<Test>]
+    member _.ScheduledRetryUsesOriginalRuleSnapshotAfterRuleUrlAndSigningUpdate() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let originalRule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    Url = { Url = "https://8.8.8.8/original?token=original-secret"; Safety = OutboundUrlSafety.PublicHttps }
+                    SigningSecretVersion = "original-secret-version"
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            WebhookStore.upsertRule originalRule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.Succeeded 200
+                    ]
+                )
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+            let delivery = (WebhookStore.listDeliveries originalRule.Scope originalRule.WebhookRuleId true)[0]
+
+            let updatedRule =
+                { originalRule with
+                    Url = { Url = "https://8.8.4.4/updated?token=updated-secret"; Safety = OutboundUrlSafety.PublicHttps }
+                    SigningSecretVersion = "updated-secret-version"
+                }
+
+            WebhookStore.upsertRule updatedRule |> ignore
+
+            let! retryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    transport
+                    (delivery.NextAttemptAt.Value.Plus(Duration.FromSeconds(1.0)))
+                    10
+                    CancellationToken.None
+
+            Assert.That(retryResult.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(2))
+            Assert.That(transport.Requests[1].Url.AbsoluteUri, Is.EqualTo("https://8.8.8.8/original?token=original-secret"))
+            Assert.That(transport.Requests[1].Headers["x-grace-webhook-signature-key-id"], Is.EqualTo("original-secret-version"))
+        }
+
+    [<Test>]
+    member _.ScheduledRetryUsesOriginalRuleSnapshotAfterLiveRuleIsDisabledOrDeleted() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let originalRule =
+                { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
+                    RetryPolicy = { MaxAttempts = 4; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
+                }
+
+            WebhookStore.upsertRule originalRule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.Succeeded 200
+                    ]
+                )
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(result.FailedCount, Is.EqualTo(1))
+            let firstDelivery = (WebhookStore.listDeliveries originalRule.Scope originalRule.WebhookRuleId true)[0]
+
+            WebhookStore.upsertRule { originalRule with Status = WebhookRuleStatus.Disabled }
+            |> ignore
+
+            let! disabledRetryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    transport
+                    (firstDelivery.NextAttemptAt.Value.Plus(Duration.FromSeconds(1.0)))
+                    10
+                    CancellationToken.None
+
+            Assert.That(disabledRetryResult.RescheduledCount, Is.EqualTo(1))
+            let secondDelivery = (WebhookStore.listDeliveries originalRule.Scope originalRule.WebhookRuleId true)[0]
+            Assert.That(secondDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.RetryScheduled))
+            Assert.That(secondDelivery.AttemptCount, Is.EqualTo(2))
+
+            WebhookStore.upsertRule { originalRule with Status = WebhookRuleStatus.Deleted }
+            |> ignore
+
+            let! deletedRetryResult =
+                WebhookDispatch.processScheduledRetriesAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    transport
+                    (secondDelivery.NextAttemptAt.Value.Plus(Duration.FromSeconds(1.0)))
+                    10
+                    CancellationToken.None
+
+            Assert.That(deletedRetryResult.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(3))
+            Assert.That(transport.Requests[1].Url.AbsoluteUri, Is.EqualTo(originalRule.Url.Url))
+            Assert.That(transport.Requests[2].Url.AbsoluteUri, Is.EqualTo(originalRule.Url.Url))
+        }
+
+    [<Test>]
+    member _.DrainScheduledRetriesOnceProcessesDueRetryBatch() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport =
+                WebhookDispatchTestHelpers.RecordingTransport(
+                    [
+                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                        OutboundWebhookResult.Succeeded 200
+                    ]
+                )
+
+            let! dispatchResult =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
+
+            Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
+            let delivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
+
+            WebhookStore.upsertDelivery
+                { delivery with
+                    NextAttemptAt =
+                        Some(
+                            getCurrentInstant()
+                                .Minus(Duration.FromSeconds(1.0))
+                        )
+                }
+            |> ignore
+
+            let! retryResult =
+                WebhookDispatch.drainScheduledRetriesOnceAsync
+                    WebhookDispatchTestHelpers.logger
+                    WebhookDispatchTestHelpers.configuration
+                    WebhookDispatchTestHelpers.hostEnvironment
+                    transport
+                    10
+                    CancellationToken.None
+
+            Assert.That(retryResult.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(2))
+        }
+
+    [<Test>]
     member _.ScheduledRetryExhaustionDeadLettersWithoutBlockingSourceWorkflow() =
         task {
             let ownerId = Guid.NewGuid()

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -80,6 +80,7 @@
                 <Compile Include="ApprovalPolicy.Server.fs" />
                 <Compile Include="ApprovalRequest.Server.fs" />
                 <Compile Include="Webhook.Server.fs" />
+                <Compile Include="WebhookDispatch.Server.fs" />
                 <Compile Include="WorkItem.Server.fs" />
                 <Compile Include="Policy.Server.fs" />
                 <Compile Include="ReviewModels.Server.fs" />

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -951,6 +951,19 @@ module Notification =
                 | Some envelope ->
                     do! emitAutomationEvent hubContext envelope
 
+                    let configuration = serviceProvider.GetRequiredService<IConfiguration>()
+                    let hostEnvironment = serviceProvider.GetService<IHostEnvironment>()
+                    use transport = new WebhookDispatch.HttpOutboundWebhookTransport(configuration, hostEnvironment)
+
+                    let! _ =
+                        WebhookDispatch.dispatchCommittedEventAsync
+                            log
+                            configuration
+                            hostEnvironment
+                            (transport :> WebhookDispatch.IOutboundWebhookTransport)
+                            graceEvent
+                            CancellationToken.None
+
                     if envelope.EventType = AutomationEventType.PromotionSetStepsUpdated then
                         let recomputeSucceededEnvelope =
                             { envelope with

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1861,6 +1861,8 @@ module Application =
                 .AddLogging()
                 .AddHostedService<ReminderService>()
                 .AddHostedService<Notification.Subscriber.GraceEventSubscriptionService>()
+                .AddSingleton<WebhookDispatch.IOutboundWebhookTransport, WebhookDispatch.HttpOutboundWebhookTransport>()
+                .AddHostedService<WebhookRetryHostedService>()
                 .AddHttpLogging()
                 .AddOrleans(fun siloBuilder ->
                     siloBuilder.Services.AddSerializer (fun serializerBuilder ->

--- a/src/Grace.Server/Webhook.Server.fs
+++ b/src/Grace.Server/Webhook.Server.fs
@@ -59,10 +59,34 @@ module WebhookStore =
         deliveries[delivery.WebhookDeliveryId] <- delivery
         delivery
 
+    let upsertDelivery (delivery: WebhookDeliveryDto) =
+        deliveries[delivery.WebhookDeliveryId] <- delivery
+        delivery
+
     let tryGetDelivery webhookDeliveryId =
         match deliveries.TryGetValue webhookDeliveryId with
         | true, delivery -> Some delivery
         | _ -> None
+
+    let tryGetDeliveryByRuleAndDedupe webhookRuleId dedupeKey =
+        deliveries.Values
+        |> Seq.tryFind (fun delivery ->
+            delivery.WebhookRuleId = webhookRuleId
+            && delivery.DedupeKey = dedupeKey)
+
+    let listEnabledRulesForEvent (scope: WebhookScope) eventName eventVersion =
+        rules.Values
+        |> Seq.filter (fun rule ->
+            rule.Status = WebhookRuleStatus.Enabled
+            && rule.EventName = eventName
+            && rule.EventVersion = eventVersion
+            && rule.Scope.OwnerId = scope.OwnerId
+            && rule.Scope.OrganizationId = scope.OrganizationId
+            && rule.Scope.RepositoryId = scope.RepositoryId
+            && (rule.Scope.TargetBranchId.IsNone
+                || rule.Scope.TargetBranchId = scope.TargetBranchId))
+        |> Seq.toArray
+        :> IReadOnlyList<WebhookRuleDto>
 
     let listDeliveries scope webhookRuleId includeTerminal =
         deliveries.Values

--- a/src/Grace.Server/Webhook.Server.fs
+++ b/src/Grace.Server/Webhook.Server.fs
@@ -26,6 +26,7 @@ module WebhookStore =
 
     let private rules = ConcurrentDictionary<WebhookRuleId, WebhookRuleDto>()
     let private deliveries = ConcurrentDictionary<WebhookDeliveryId, WebhookDeliveryDto>()
+    let private deliveryPayloads = ConcurrentDictionary<WebhookDeliveryId, string>()
 
     let private scopeMatches (expected: WebhookScope) (actual: WebhookScope) =
         actual.OwnerId = expected.OwnerId
@@ -36,6 +37,7 @@ module WebhookStore =
     let clearForTests () =
         rules.Clear()
         deliveries.Clear()
+        deliveryPayloads.Clear()
 
     let upsertRule (rule: WebhookRuleDto) =
         rules[rule.WebhookRuleId] <- rule
@@ -58,6 +60,15 @@ module WebhookStore =
     let addDelivery (delivery: WebhookDeliveryDto) =
         deliveries[delivery.WebhookDeliveryId] <- delivery
         delivery
+
+    let addDeliveryPayload webhookDeliveryId payloadJson =
+        deliveryPayloads[webhookDeliveryId] <- payloadJson
+        payloadJson
+
+    let tryGetDeliveryPayload webhookDeliveryId =
+        match deliveryPayloads.TryGetValue webhookDeliveryId with
+        | true, payloadJson -> Some payloadJson
+        | _ -> None
 
     let upsertDelivery (delivery: WebhookDeliveryDto) =
         deliveries[delivery.WebhookDeliveryId] <- delivery
@@ -100,6 +111,18 @@ module WebhookStore =
                     || delivery.Status = WebhookDeliveryStatus.Pending
                     || delivery.Status = WebhookDeliveryStatus.RetryScheduled)
             | None -> false)
+        |> Seq.toArray
+        :> IReadOnlyList<WebhookDeliveryDto>
+
+    let listScheduledRetries dueAt maxCount =
+        deliveries.Values
+        |> Seq.filter (fun delivery ->
+            delivery.Status = WebhookDeliveryStatus.RetryScheduled
+            && match delivery.NextAttemptAt with
+               | Some nextAttemptAt -> nextAttemptAt <= dueAt
+               | None -> false)
+        |> Seq.sortBy (fun delivery -> delivery.NextAttemptAt)
+        |> Seq.truncate maxCount
         |> Seq.toArray
         :> IReadOnlyList<WebhookDeliveryDto>
 

--- a/src/Grace.Server/Webhook.Server.fs
+++ b/src/Grace.Server/Webhook.Server.fs
@@ -26,8 +26,11 @@ module WebhookStore =
 
     let private rules = ConcurrentDictionary<WebhookRuleId, WebhookRuleDto>()
     let private deliveries = ConcurrentDictionary<WebhookDeliveryId, WebhookDeliveryDto>()
+    let private deliveryDedupeIndex = ConcurrentDictionary<string, WebhookDeliveryId>()
     let private deliveryPayloads = ConcurrentDictionary<WebhookDeliveryId, string>()
     let private deliveryRuleSnapshots = ConcurrentDictionary<WebhookDeliveryId, WebhookRuleDto>()
+
+    let private deliveryDedupeKey webhookRuleId dedupeKey = $"{webhookRuleId:N}:{dedupeKey}"
 
     let private scopeMatches (expected: WebhookScope) (actual: WebhookScope) =
         actual.OwnerId = expected.OwnerId
@@ -38,6 +41,7 @@ module WebhookStore =
     let clearForTests () =
         rules.Clear()
         deliveries.Clear()
+        deliveryDedupeIndex.Clear()
         deliveryPayloads.Clear()
         deliveryRuleSnapshots.Clear()
 
@@ -61,7 +65,15 @@ module WebhookStore =
 
     let addDelivery (delivery: WebhookDeliveryDto) =
         deliveries[delivery.WebhookDeliveryId] <- delivery
+        deliveryDedupeIndex[deliveryDedupeKey delivery.WebhookRuleId delivery.DedupeKey] <- delivery.WebhookDeliveryId
         delivery
+
+    let tryClaimDeliveryByRuleAndDedupe (delivery: WebhookDeliveryDto) =
+        if deliveryDedupeIndex.TryAdd(deliveryDedupeKey delivery.WebhookRuleId delivery.DedupeKey, delivery.WebhookDeliveryId) then
+            deliveries[delivery.WebhookDeliveryId] <- delivery
+            true
+        else
+            false
 
     let addDeliveryPayload webhookDeliveryId payloadJson =
         deliveryPayloads[webhookDeliveryId] <- payloadJson
@@ -91,10 +103,13 @@ module WebhookStore =
         | _ -> None
 
     let tryGetDeliveryByRuleAndDedupe webhookRuleId dedupeKey =
-        deliveries.Values
-        |> Seq.tryFind (fun delivery ->
-            delivery.WebhookRuleId = webhookRuleId
-            && delivery.DedupeKey = dedupeKey)
+        match deliveryDedupeIndex.TryGetValue(deliveryDedupeKey webhookRuleId dedupeKey) with
+        | true, webhookDeliveryId -> tryGetDelivery webhookDeliveryId
+        | _ ->
+            deliveries.Values
+            |> Seq.tryFind (fun delivery ->
+                delivery.WebhookRuleId = webhookRuleId
+                && delivery.DedupeKey = dedupeKey)
 
     let listEnabledRulesForEvent (scope: WebhookScope) eventName eventVersion =
         rules.Values

--- a/src/Grace.Server/Webhook.Server.fs
+++ b/src/Grace.Server/Webhook.Server.fs
@@ -27,6 +27,7 @@ module WebhookStore =
     let private rules = ConcurrentDictionary<WebhookRuleId, WebhookRuleDto>()
     let private deliveries = ConcurrentDictionary<WebhookDeliveryId, WebhookDeliveryDto>()
     let private deliveryPayloads = ConcurrentDictionary<WebhookDeliveryId, string>()
+    let private deliveryRuleSnapshots = ConcurrentDictionary<WebhookDeliveryId, WebhookRuleDto>()
 
     let private scopeMatches (expected: WebhookScope) (actual: WebhookScope) =
         actual.OwnerId = expected.OwnerId
@@ -38,6 +39,7 @@ module WebhookStore =
         rules.Clear()
         deliveries.Clear()
         deliveryPayloads.Clear()
+        deliveryRuleSnapshots.Clear()
 
     let upsertRule (rule: WebhookRuleDto) =
         rules[rule.WebhookRuleId] <- rule
@@ -68,6 +70,15 @@ module WebhookStore =
     let tryGetDeliveryPayload webhookDeliveryId =
         match deliveryPayloads.TryGetValue webhookDeliveryId with
         | true, payloadJson -> Some payloadJson
+        | _ -> None
+
+    let addDeliveryRuleSnapshot webhookDeliveryId (rule: WebhookRuleDto) =
+        deliveryRuleSnapshots[webhookDeliveryId] <- rule
+        rule
+
+    let tryGetDeliveryRuleSnapshot webhookDeliveryId =
+        match deliveryRuleSnapshots.TryGetValue webhookDeliveryId with
+        | true, rule -> Some rule
         | _ -> None
 
     let upsertDelivery (delivery: WebhookDeliveryDto) =

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -349,7 +349,15 @@ module WebhookDispatch =
                     try
                         return! transport.SendAsync(request, cancellationToken)
                     with
-                    | :? OperationCanceledException as ex -> return raise ex
+                    | :? OperationCanceledException as ex when cancellationToken.IsCancellationRequested -> return raise ex
+                    | :? OperationCanceledException as ex ->
+                        let message =
+                            if String.IsNullOrWhiteSpace ex.Message then
+                                "Outbound request timed out or was canceled before completion."
+                            else
+                                ex.Message
+
+                        return TransientFailure(Option.None, message)
                     | ex -> return TransientFailure(Option.None, ex.Message)
                 }
 
@@ -383,22 +391,20 @@ module WebhookDispatch =
         cancellationToken
         =
         task {
-            match WebhookStore.tryGetDeliveryByRuleAndDedupe rule.WebhookRuleId dedupeKey with
-            | Option.Some _ -> return Choice2Of2 true
-            | Option.None ->
-                let delivery =
-                    { WebhookDelivery.Default with
-                        WebhookDeliveryId = Guid.NewGuid()
-                        WebhookRuleId = rule.WebhookRuleId
-                        EventName = definition.Name
-                        EventVersion = definition.Version
-                        DedupeKey = dedupeKey
-                        Status = WebhookDeliveryStatus.Pending
-                        CreatedAt = getCurrentInstant ()
-                    }
+            let delivery =
+                { WebhookDelivery.Default with
+                    WebhookDeliveryId = Guid.NewGuid()
+                    WebhookRuleId = rule.WebhookRuleId
+                    EventName = definition.Name
+                    EventVersion = definition.Version
+                    DedupeKey = dedupeKey
+                    Status = WebhookDeliveryStatus.Pending
+                    CreatedAt = getCurrentInstant ()
+                }
 
-                WebhookStore.addDelivery delivery |> ignore
-
+            if WebhookStore.tryClaimDeliveryByRuleAndDedupe delivery |> not then
+                return Choice2Of2 true
+            else
                 WebhookStore.addDeliveryPayload delivery.WebhookDeliveryId payloadJson
                 |> ignore
 
@@ -528,6 +534,7 @@ module WebhookDispatch =
                             SkippedDuplicateCount = duplicateCount
                         }
             with
+            | :? OperationCanceledException as ex when cancellationToken.IsCancellationRequested -> return raise ex
             | ex ->
                 logger.LogError(ex, "Webhook dispatch failed after source event commit; source workflow will not be blocked.")
                 return DispatchResult.Empty

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -349,6 +349,7 @@ module WebhookDispatch =
                     try
                         return! transport.SendAsync(request, cancellationToken)
                     with
+                    | :? OperationCanceledException as ex -> return raise ex
                     | ex -> return TransientFailure(Option.None, ex.Message)
                 }
 
@@ -451,6 +452,8 @@ module WebhookDispatch =
             let mutable index = 0
 
             while index < dueDeliveries.Count do
+                cancellationToken.ThrowIfCancellationRequested()
+
                 let delivery = dueDeliveries[index]
 
                 match WebhookStore.tryGetDeliveryRuleSnapshot delivery.WebhookDeliveryId, WebhookStore.tryGetDeliveryPayload delivery.WebhookDeliveryId with

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -401,6 +401,9 @@ module WebhookDispatch =
                 WebhookStore.addDeliveryPayload delivery.WebhookDeliveryId payloadJson
                 |> ignore
 
+                WebhookStore.addDeliveryRuleSnapshot delivery.WebhookDeliveryId rule
+                |> ignore
+
                 match validateDeliveryUrl hostEnvironment configuration rule with
                 | Error failure ->
                     recordValidationFailure logger rule delivery failure
@@ -450,7 +453,7 @@ module WebhookDispatch =
             while index < dueDeliveries.Count do
                 let delivery = dueDeliveries[index]
 
-                match WebhookStore.tryGetRule delivery.WebhookRuleId, WebhookStore.tryGetDeliveryPayload delivery.WebhookDeliveryId with
+                match WebhookStore.tryGetDeliveryRuleSnapshot delivery.WebhookDeliveryId, WebhookStore.tryGetDeliveryPayload delivery.WebhookDeliveryId with
                 | Some rule, Some payloadJson ->
                     match validateDeliveryUrl hostEnvironment configuration rule with
                     | Error failure ->
@@ -472,7 +475,7 @@ module WebhookDispatch =
                         { delivery with
                             Status = WebhookDeliveryStatus.DeadLettered
                             LastAttemptAt = Some(getCurrentInstant ())
-                            LastError = Some(trimError "Retry delivery could not be processed because its rule or payload is no longer available.")
+                            LastError = Some(trimError "Retry delivery could not be processed because its rule snapshot or payload is no longer available.")
                             NextAttemptAt = Option.None
                         }
                     |> ignore
@@ -526,3 +529,63 @@ module WebhookDispatch =
                 logger.LogError(ex, "Webhook dispatch failed after source event commit; source workflow will not be blocked.")
                 return DispatchResult.Empty
         }
+
+    let drainScheduledRetriesOnceAsync
+        (logger: ILogger)
+        (configuration: IConfiguration)
+        (hostEnvironment: IHostEnvironment)
+        (transport: IOutboundWebhookTransport)
+        maxDeliveries
+        (cancellationToken: CancellationToken)
+        =
+        processScheduledRetriesAsync logger configuration hostEnvironment transport (getCurrentInstant ()) maxDeliveries cancellationToken
+
+type WebhookRetryHostedService
+    (
+        logger: ILogger<WebhookRetryHostedService>,
+        configuration: IConfiguration,
+        hostEnvironment: IHostEnvironment,
+        transport: WebhookDispatch.IOutboundWebhookTransport
+    ) =
+    inherit BackgroundService()
+
+    let pollIntervalSeconds = max 1 (configuration.GetValue<int>("grace:webhooks:retryProcessor:pollIntervalSeconds", 30))
+    let initialDelaySeconds = max 0 (configuration.GetValue<int>("grace:webhooks:retryProcessor:initialDelaySeconds", 5))
+    let maxDeliveriesPerTick = max 1 (configuration.GetValue<int>("grace:webhooks:retryProcessor:maxDeliveriesPerTick", 25))
+    let pollInterval = TimeSpan.FromSeconds(float pollIntervalSeconds)
+    let initialDelay = TimeSpan.FromSeconds(float initialDelaySeconds)
+
+    member internal _.DrainOnceAsync(cancellationToken: CancellationToken) =
+        WebhookDispatch.drainScheduledRetriesOnceAsync logger configuration hostEnvironment transport maxDeliveriesPerTick cancellationToken
+
+    override this.ExecuteAsync(stoppingToken: CancellationToken) =
+        task {
+            try
+                if initialDelay > TimeSpan.Zero then do! Task.Delay(initialDelay, stoppingToken)
+
+                use periodicTimer = new PeriodicTimer(pollInterval)
+                let mutable ticked = true
+
+                while ticked
+                      && not stoppingToken.IsCancellationRequested do
+                    try
+                        let! result = this.DrainOnceAsync(stoppingToken)
+
+                        if result.ProcessedCount > 0 then
+                            logger.LogInformation(
+                                "Processed {ProcessedCount} scheduled webhook retries: {DeliveredCount} delivered, {FailedCount} failed, {RescheduledCount} rescheduled.",
+                                result.ProcessedCount,
+                                result.DeliveredCount,
+                                result.FailedCount,
+                                result.RescheduledCount
+                            )
+                    with
+                    | :? OperationCanceledException when stoppingToken.IsCancellationRequested -> ()
+                    | ex -> logger.LogError(ex, "Scheduled webhook retry processing failed; the processor will continue on the next tick.")
+
+                    let! tick = periodicTimer.WaitForNextTickAsync(stoppingToken)
+                    ticked <- tick
+            with
+            | :? OperationCanceledException when stoppingToken.IsCancellationRequested -> ()
+        }
+        :> Task

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -1,0 +1,414 @@
+namespace Grace.Server
+
+open Grace.Server.Security
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Events
+open Grace.Types.PromotionSet
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
+open NodaTime
+open System
+open System.Collections.Generic
+open System.Globalization
+open System.Net
+open System.Net.Http
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+module WebhookDispatch =
+
+    type OutboundWebhookRequest =
+        {
+            DeliveryId: WebhookDeliveryId
+            Url: Uri
+            UrlSafety: OutboundUrlSafety
+            RedactedUrl: string
+            Headers: IReadOnlyDictionary<string, string>
+            PayloadJson: string
+        }
+
+    type OutboundWebhookResult =
+        | Succeeded of statusCode: int
+        | TransientFailure of statusCode: int option * error: string
+        | PermanentFailure of statusCode: int option * error: string
+
+    type IOutboundWebhookTransport =
+        abstract member SendAsync: OutboundWebhookRequest * CancellationToken -> Task<OutboundWebhookResult>
+
+    type HttpOutboundWebhookTransport(configuration: IConfiguration, hostEnvironment: IHostEnvironment) =
+        let handler = new HttpClientHandler()
+
+        do handler.AllowAutoRedirect <- false
+
+        let client = new HttpClient(handler, disposeHandler = true)
+
+        let classifyStatusCode (statusCode: HttpStatusCode) =
+            let numericStatusCode = int statusCode
+
+            if numericStatusCode >= 200
+               && numericStatusCode <= 299 then
+                Succeeded numericStatusCode
+            elif numericStatusCode = 408
+                 || numericStatusCode = 409
+                 || numericStatusCode = 425
+                 || numericStatusCode = 429
+                 || numericStatusCode >= 500 then
+                TransientFailure(Some numericStatusCode, $"HTTP {numericStatusCode}")
+            else
+                PermanentFailure(Some numericStatusCode, $"HTTP {numericStatusCode}")
+
+        interface IDisposable with
+            member _.Dispose() = client.Dispose()
+
+        interface IOutboundWebhookTransport with
+            member _.SendAsync(request, cancellationToken) =
+                task {
+                    use message = new HttpRequestMessage(HttpMethod.Post, request.Url)
+                    use content = new StringContent(request.PayloadJson, Encoding.UTF8, "application/json")
+                    message.Content <- content
+
+                    for header in request.Headers do
+                        message.Headers.TryAddWithoutValidation(header.Key, header.Value)
+                        |> ignore
+
+                    let! response = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+
+                    match int response.StatusCode with
+                    | statusCode when
+                        statusCode >= 300
+                        && statusCode <= 399
+                        && response.Headers.Location <> null
+                        ->
+                        let original: OutboundUrlSafety.ValidatedOutboundUrl =
+                            {
+                                Uri = request.Url
+                                ScopedUrl = { Url = request.Url.AbsoluteUri; Safety = request.UrlSafety }
+                                RedirectPolicy = OutboundUrlSafety.RedirectPolicy.RevalidateEveryRedirect
+                                ResolvedAddresses = Array.empty
+                            }
+
+                        match OutboundUrlSafety.validateRedirect hostEnvironment configuration original response.Headers.Location with
+                        | Error failure -> return PermanentFailure(Some statusCode, $"Redirect rejected: {failure}")
+                        | Ok _ -> return TransientFailure(Some statusCode, "Redirected delivery will be retried.")
+                    | _ -> return classifyStatusCode response.StatusCode
+                }
+
+    type DispatchResult =
+        {
+            DeliveryCount: int
+            DeliveredCount: int
+            FailedCount: int
+            SkippedDuplicateCount: int
+        }
+
+        static member Empty = { DeliveryCount = 0; DeliveredCount = 0; FailedCount = 0; SkippedDuplicateCount = 0 }
+
+    let private tryGetGuidFromMetadata propertyName (metadata: EventMetadata) =
+        match metadata.Properties.TryGetValue(propertyName) with
+        | true, rawValue ->
+            match Guid.TryParse rawValue with
+            | true, parsed when parsed <> Guid.Empty -> Option.Some parsed
+            | _ -> Option.None
+        | _ -> Option.None
+
+    let private tryGetPromotionSetId (metadata: EventMetadata) =
+        match tryGetGuidFromMetadata (nameof PromotionSetId) metadata with
+        | Option.Some promotionSetId -> Option.Some promotionSetId
+        | Option.None -> tryGetGuidFromMetadata "ActorId" metadata
+
+    let private tryGetTargetBranchId (metadata: EventMetadata) =
+        match tryGetGuidFromMetadata (nameof BranchId) metadata with
+        | Option.Some branchId -> Option.Some branchId
+        | Option.None -> tryGetGuidFromMetadata "TargetBranchId" metadata
+
+    let private scopeFromMetadata metadata =
+        {
+            OwnerId =
+                tryGetGuidFromMetadata (nameof OwnerId) metadata
+                |> Option.defaultValue OwnerId.Empty
+            OrganizationId =
+                tryGetGuidFromMetadata (nameof OrganizationId) metadata
+                |> Option.defaultValue OrganizationId.Empty
+            RepositoryId =
+                tryGetGuidFromMetadata (nameof RepositoryId) metadata
+                |> Option.defaultValue RepositoryId.Empty
+            TargetBranchId = tryGetTargetBranchId metadata
+        }
+
+    let private tryCreatePromotionSetAppliedDispatchEvent (promotionSetEvent: PromotionSetEvent) =
+        match promotionSetEvent.Event with
+        | PromotionSetEventType.Applied terminalPromotionReferenceId ->
+            let definition = ExternalWebhookEventRegistry.promotionSetApplied
+            let scope = scopeFromMetadata promotionSetEvent.Metadata
+
+            let promotionSetId =
+                tryGetPromotionSetId promotionSetEvent.Metadata
+                |> Option.defaultValue PromotionSetId.Empty
+
+            let dedupeKey =
+                String.Join(
+                    ":",
+                    [|
+                        definition.Name
+                        $"{definition.Version}"
+                        $"{scope.OwnerId}"
+                        $"{scope.OrganizationId}"
+                        $"{scope.RepositoryId}"
+                        $"{scope.TargetBranchId
+                           |> Option.defaultValue BranchId.Empty}"
+                        $"{promotionSetId}"
+                        $"{terminalPromotionReferenceId}"
+                    |]
+                )
+
+            let payload =
+                {|
+                    eventName = definition.Name
+                    eventVersion = definition.Version
+                    eventTime = promotionSetEvent.Metadata.Timestamp
+                    correlationId = promotionSetEvent.Metadata.CorrelationId
+                    ownerId = scope.OwnerId
+                    organizationId = scope.OrganizationId
+                    repositoryId = scope.RepositoryId
+                    targetBranchId = scope.TargetBranchId
+                    promotionSetId = promotionSetId
+                    terminalPromotionReferenceId = terminalPromotionReferenceId
+                |}
+
+            Option.Some(definition, scope, dedupeKey, serialize payload)
+        | _ -> Option.None
+
+    let private tryCreateDispatchEvent graceEvent =
+        match graceEvent with
+        | GraceEvent.PromotionSetEvent promotionSetEvent -> tryCreatePromotionSetAppliedDispatchEvent promotionSetEvent
+        | _ -> Option.None
+
+    let private hmacSha256Hex (key: string) (material: byte array) =
+        use hmac = new HMACSHA256(Encoding.UTF8.GetBytes key)
+
+        hmac.ComputeHash material
+        |> Array.map (fun value -> value.ToString("x2", CultureInfo.InvariantCulture))
+        |> String.concat String.Empty
+
+    let private headersForDelivery (delivery: WebhookDelivery) (rule: WebhookRule) (payloadJson: string) (timestamp: string) =
+        let payload = Encoding.UTF8.GetBytes payloadJson
+        let signingInput = OutboundUrlSafety.Signing.createSigningInput $"{delivery.WebhookDeliveryId}" timestamp rule.SigningSecretVersion payload
+        let signature = hmacSha256Hex rule.SigningSecretVersion signingInput.SignedMaterial
+
+        Dictionary<string, string>(
+            dict [ "x-grace-webhook-delivery-id", $"{delivery.WebhookDeliveryId}"
+                   "x-grace-webhook-event-name", rule.EventName
+                   "x-grace-webhook-event-version", $"{rule.EventVersion}"
+                   "x-grace-webhook-timestamp", signingInput.Timestamp
+                   "x-grace-webhook-signature-key-id", signingInput.KeyId
+                   "x-grace-webhook-payload-sha256", signingInput.PayloadSha256Hex
+                   "x-grace-webhook-signature", $"sha256={signature}" ]
+        )
+        :> IReadOnlyDictionary<string, string>
+
+    let private retryDelaySeconds attemptCount (policy: WebhookRetryPolicy) =
+        if policy.InitialDelaySeconds <= 0 then
+            0
+        else
+            let multiplier = Math.Pow(2.0, float (max 0 (attemptCount - 1)))
+            min policy.MaxDelaySeconds (int (float policy.InitialDelaySeconds * multiplier))
+
+    let private trimError (value: string) =
+        if String.IsNullOrWhiteSpace value then String.Empty
+        elif value.Length <= 256 then value
+        else value.Substring(0, 256)
+
+    let private validateDeliveryUrl hostEnvironment configuration (rule: WebhookRule) =
+        OutboundUrlSafety.validate
+            hostEnvironment
+            configuration
+            {
+                Url = rule.Url.Url
+                RequestedSafety = rule.Url.Safety
+                AcknowledgeUnsafeLocalDevelopment = rule.Url.Safety = OutboundUrlSafety.LocalUnsafeDevOnly
+            }
+
+    let private terminalDeliveryStatus attempts (policy: WebhookRetryPolicy) result =
+        match result with
+        | Succeeded statusCode -> WebhookDeliveryStatus.Succeeded, Option.Some statusCode, Option.None, Option.None
+        | PermanentFailure (statusCode, error) -> WebhookDeliveryStatus.Failed, statusCode, Option.Some(trimError error), Option.None
+        | TransientFailure (statusCode, error) when attempts >= policy.MaxAttempts ->
+            WebhookDeliveryStatus.DeadLettered, statusCode, Option.Some(trimError error), Option.None
+        | TransientFailure (statusCode, error) ->
+            let nextAttemptAt =
+                getCurrentInstant()
+                    .Plus(Duration.FromSeconds(float (retryDelaySeconds attempts policy)))
+
+            WebhookDeliveryStatus.RetryScheduled, statusCode, Option.Some(trimError error), Option.Some nextAttemptAt
+
+    let private recordValidationFailure (logger: ILogger) (rule: WebhookRule) (delivery: WebhookDelivery) failure =
+        let redactedUrl = OutboundUrlSafety.Redaction.redactUri rule.Url.Url
+
+        logger.LogWarning(
+            "Rejected webhook delivery {WebhookDeliveryId} for {EventName} to {RedactedUrl}: {Failure}.",
+            delivery.WebhookDeliveryId,
+            rule.EventName,
+            redactedUrl,
+            failure
+        )
+
+        WebhookStore.upsertDelivery
+            { delivery with
+                Status = WebhookDeliveryStatus.DeadLettered
+                LastAttemptAt = Option.Some(getCurrentInstant ())
+                LastError = Option.Some $"Outbound URL rejected: {failure}"
+            }
+        |> ignore
+
+    let private deliverRule
+        (logger: ILogger)
+        (configuration: IConfiguration)
+        (hostEnvironment: IHostEnvironment)
+        (transport: IOutboundWebhookTransport)
+        (definition: ExternalWebhookEventDefinition)
+        dedupeKey
+        (payloadJson: string)
+        (rule: WebhookRule)
+        cancellationToken
+        =
+        task {
+            match WebhookStore.tryGetDeliveryByRuleAndDedupe rule.WebhookRuleId dedupeKey with
+            | Option.Some _ -> return Choice2Of2 true
+            | Option.None ->
+                let delivery =
+                    { WebhookDelivery.Default with
+                        WebhookDeliveryId = Guid.NewGuid()
+                        WebhookRuleId = rule.WebhookRuleId
+                        EventName = definition.Name
+                        EventVersion = definition.Version
+                        DedupeKey = dedupeKey
+                        Status = WebhookDeliveryStatus.Pending
+                        CreatedAt = getCurrentInstant ()
+                    }
+
+                WebhookStore.addDelivery delivery |> ignore
+
+                match validateDeliveryUrl hostEnvironment configuration rule with
+                | Error failure ->
+                    recordValidationFailure logger rule delivery failure
+                    return Choice1Of2 false
+                | Ok validatedUrl ->
+                    let mutable currentDelivery = delivery
+                    let mutable shouldContinue = true
+
+                    while shouldContinue
+                          && currentDelivery.AttemptCount < rule.RetryPolicy.MaxAttempts do
+                        let attempt = currentDelivery.AttemptCount + 1
+                        let attemptAt = getCurrentInstant ()
+
+                        let timestamp =
+                            attemptAt
+                                .ToDateTimeUtc()
+                                .ToString("O", CultureInfo.InvariantCulture)
+
+                        let request =
+                            {
+                                DeliveryId = currentDelivery.WebhookDeliveryId
+                                Url = validatedUrl.Uri
+                                UrlSafety = rule.Url.Safety
+                                RedactedUrl = OutboundUrlSafety.Redaction.redactUri rule.Url.Url
+                                Headers = headersForDelivery currentDelivery rule payloadJson timestamp
+                                PayloadJson = payloadJson
+                            }
+
+                        logger.LogInformation(
+                            "Dispatching webhook delivery {WebhookDeliveryId} for {EventName} to {RedactedUrl}, attempt {AttemptCount}.",
+                            currentDelivery.WebhookDeliveryId,
+                            rule.EventName,
+                            request.RedactedUrl,
+                            attempt
+                        )
+
+                        let! result =
+                            task {
+                                try
+                                    return! transport.SendAsync(request, cancellationToken)
+                                with
+                                | ex -> return TransientFailure(Option.None, trimError ex.Message)
+                            }
+
+                        let status, statusCode, error, nextAttemptAt = terminalDeliveryStatus attempt rule.RetryPolicy result
+
+                        currentDelivery <-
+                            { currentDelivery with
+                                AttemptCount = attempt
+                                LastAttemptAt = Some attemptAt
+                                LastStatusCode = statusCode
+                                LastError = error
+                                NextAttemptAt = nextAttemptAt
+                                Status = status
+                            }
+
+                        WebhookStore.upsertDelivery currentDelivery
+                        |> ignore
+
+                        match result with
+                        | TransientFailure _ when attempt < rule.RetryPolicy.MaxAttempts -> ()
+                        | _ -> shouldContinue <- false
+
+                    match currentDelivery.Status with
+                    | WebhookDeliveryStatus.Succeeded -> return Choice1Of2 true
+                    | _ ->
+                        logger.LogWarning(
+                            "Webhook delivery {WebhookDeliveryId} for {EventName} finished with {WebhookDeliveryStatus}.",
+                            currentDelivery.WebhookDeliveryId,
+                            currentDelivery.EventName,
+                            currentDelivery.Status
+                        )
+
+                        return Choice1Of2 false
+        }
+
+    let dispatchCommittedEventAsync
+        (logger: ILogger)
+        (configuration: IConfiguration)
+        (hostEnvironment: IHostEnvironment)
+        (transport: IOutboundWebhookTransport)
+        (graceEvent: GraceEvent)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            try
+                match tryCreateDispatchEvent graceEvent with
+                | Option.None -> return DispatchResult.Empty
+                | Option.Some (definition, scope, dedupeKey, payloadJson) ->
+                    let rules = WebhookStore.listEnabledRulesForEvent scope definition.Name definition.Version
+                    let mutable deliveredCount = 0
+                    let mutable failedCount = 0
+                    let mutable duplicateCount = 0
+                    let mutable index = 0
+
+                    while index < rules.Count do
+                        let! result = deliverRule logger configuration hostEnvironment transport definition dedupeKey payloadJson rules[index] cancellationToken
+
+                        match result with
+                        | Choice1Of2 true -> deliveredCount <- deliveredCount + 1
+                        | Choice1Of2 false -> failedCount <- failedCount + 1
+                        | Choice2Of2 true -> duplicateCount <- duplicateCount + 1
+                        | Choice2Of2 false -> ()
+
+                        index <- index + 1
+
+                    return
+                        {
+                            DeliveryCount = rules.Count - duplicateCount
+                            DeliveredCount = deliveredCount
+                            FailedCount = failedCount
+                            SkippedDuplicateCount = duplicateCount
+                        }
+            with
+            | ex ->
+                logger.LogError(ex, "Webhook dispatch failed after source event commit; source workflow will not be blocked.")
+                return DispatchResult.Empty
+        }

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -402,7 +402,8 @@ module WebhookDispatch =
                     CreatedAt = getCurrentInstant ()
                 }
 
-            if WebhookStore.tryClaimDeliveryByRuleAndDedupe delivery |> not then
+            if WebhookStore.tryClaimDeliveryByRuleAndDedupe delivery
+               |> not then
                 return Choice2Of2 true
             else
                 WebhookStore.addDeliveryPayload delivery.WebhookDeliveryId payloadJson
@@ -516,6 +517,8 @@ module WebhookDispatch =
                     let mutable index = 0
 
                     while index < rules.Count do
+                        cancellationToken.ThrowIfCancellationRequested()
+
                         let! result = deliverRule logger configuration hostEnvironment transport definition dedupeKey payloadJson rules[index] cancellationToken
 
                         match result with

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -18,6 +18,7 @@ open System.Net
 open System.Net.Http
 open System.Security.Cryptography
 open System.Text
+open System.Text.RegularExpressions
 open System.Threading
 open System.Threading.Tasks
 
@@ -77,7 +78,7 @@ module WebhookDispatch =
                         message.Headers.TryAddWithoutValidation(header.Key, header.Value)
                         |> ignore
 
-                    let! response = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    use! response = client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
 
                     match int response.StatusCode with
                     | statusCode when
@@ -219,10 +220,51 @@ module WebhookDispatch =
             let multiplier = Math.Pow(2.0, float (max 0 (attemptCount - 1)))
             min policy.MaxDelaySeconds (int (float policy.InitialDelaySeconds * multiplier))
 
+    let private sensitiveErrorKeys =
+        [|
+            "access_token"
+            "api_key"
+            "apikey"
+            "client_secret"
+            "code"
+            "credential"
+            "key"
+            "password"
+            "secret"
+            "sig"
+            "signature"
+            "signed"
+            "token"
+        |]
+
+    let private redactSensitiveQueryValues (value: string) =
+        Regex.Replace(
+            value,
+            @"(?i)([?&;](?:access_token|api_key|apikey|client_secret|code|credential|key|password|secret|sig|signature|signed|token)=)([^&#;\s]+)",
+            "${1}REDACTED"
+        )
+
+    let private redactSensitiveAssignments (value: string) =
+        sensitiveErrorKeys
+        |> Array.fold
+            (fun current key ->
+                let pattern = sprintf @"(?i)\b(%s)(\s*[:=]\s*)(""[^""]*""|'[^']*'|[^&#\s,;]+)" (Regex.Escape key)
+
+                Regex.Replace(current, pattern, "${1}${2}REDACTED"))
+            value
+
+    let private sanitizePersistedError (value: string) =
+        if String.IsNullOrWhiteSpace value then
+            String.Empty
+        else
+            value
+            |> redactSensitiveQueryValues
+            |> redactSensitiveAssignments
+
     let private trimError (value: string) =
-        if String.IsNullOrWhiteSpace value then String.Empty
-        elif value.Length <= 256 then value
-        else value.Substring(0, 256)
+        let sanitized = sanitizePersistedError value
+
+        if sanitized.Length <= 256 then sanitized else sanitized.Substring(0, 256)
 
     let private validateDeliveryUrl hostEnvironment configuration (rule: WebhookRule) =
         OutboundUrlSafety.validate
@@ -262,9 +304,71 @@ module WebhookDispatch =
             { delivery with
                 Status = WebhookDeliveryStatus.DeadLettered
                 LastAttemptAt = Option.Some(getCurrentInstant ())
-                LastError = Option.Some $"Outbound URL rejected: {failure}"
+                LastError = Option.Some(trimError $"Outbound URL rejected: {failure}")
             }
         |> ignore
+
+    let private sendDeliveryAttempt
+        (logger: ILogger)
+        (transport: IOutboundWebhookTransport)
+        (rule: WebhookRule)
+        (validatedUrl: OutboundUrlSafety.ValidatedOutboundUrl)
+        (payloadJson: string)
+        (delivery: WebhookDelivery)
+        cancellationToken
+        =
+        task {
+            let attempt = delivery.AttemptCount + 1
+            let attemptAt = getCurrentInstant ()
+
+            let timestamp =
+                attemptAt
+                    .ToDateTimeUtc()
+                    .ToString("O", CultureInfo.InvariantCulture)
+
+            let request =
+                {
+                    DeliveryId = delivery.WebhookDeliveryId
+                    Url = validatedUrl.Uri
+                    UrlSafety = rule.Url.Safety
+                    RedactedUrl = OutboundUrlSafety.Redaction.redactUri rule.Url.Url
+                    Headers = headersForDelivery delivery rule payloadJson timestamp
+                    PayloadJson = payloadJson
+                }
+
+            logger.LogInformation(
+                "Dispatching webhook delivery {WebhookDeliveryId} for {EventName} to {RedactedUrl}, attempt {AttemptCount}.",
+                delivery.WebhookDeliveryId,
+                rule.EventName,
+                request.RedactedUrl,
+                attempt
+            )
+
+            let! result =
+                task {
+                    try
+                        return! transport.SendAsync(request, cancellationToken)
+                    with
+                    | ex -> return TransientFailure(Option.None, ex.Message)
+                }
+
+            let status, statusCode, error, nextAttemptAt = terminalDeliveryStatus attempt rule.RetryPolicy result
+
+            let updatedDelivery =
+                { delivery with
+                    AttemptCount = attempt
+                    LastAttemptAt = Some attemptAt
+                    LastStatusCode = statusCode
+                    LastError = error
+                    NextAttemptAt = nextAttemptAt
+                    Status = status
+                }
+
+            WebhookStore.upsertDelivery updatedDelivery
+            |> ignore
+
+            return updatedDelivery
+        }
 
     let private deliverRule
         (logger: ILogger)
@@ -294,68 +398,15 @@ module WebhookDispatch =
 
                 WebhookStore.addDelivery delivery |> ignore
 
+                WebhookStore.addDeliveryPayload delivery.WebhookDeliveryId payloadJson
+                |> ignore
+
                 match validateDeliveryUrl hostEnvironment configuration rule with
                 | Error failure ->
                     recordValidationFailure logger rule delivery failure
                     return Choice1Of2 false
                 | Ok validatedUrl ->
-                    let mutable currentDelivery = delivery
-                    let mutable shouldContinue = true
-
-                    while shouldContinue
-                          && currentDelivery.AttemptCount < rule.RetryPolicy.MaxAttempts do
-                        let attempt = currentDelivery.AttemptCount + 1
-                        let attemptAt = getCurrentInstant ()
-
-                        let timestamp =
-                            attemptAt
-                                .ToDateTimeUtc()
-                                .ToString("O", CultureInfo.InvariantCulture)
-
-                        let request =
-                            {
-                                DeliveryId = currentDelivery.WebhookDeliveryId
-                                Url = validatedUrl.Uri
-                                UrlSafety = rule.Url.Safety
-                                RedactedUrl = OutboundUrlSafety.Redaction.redactUri rule.Url.Url
-                                Headers = headersForDelivery currentDelivery rule payloadJson timestamp
-                                PayloadJson = payloadJson
-                            }
-
-                        logger.LogInformation(
-                            "Dispatching webhook delivery {WebhookDeliveryId} for {EventName} to {RedactedUrl}, attempt {AttemptCount}.",
-                            currentDelivery.WebhookDeliveryId,
-                            rule.EventName,
-                            request.RedactedUrl,
-                            attempt
-                        )
-
-                        let! result =
-                            task {
-                                try
-                                    return! transport.SendAsync(request, cancellationToken)
-                                with
-                                | ex -> return TransientFailure(Option.None, trimError ex.Message)
-                            }
-
-                        let status, statusCode, error, nextAttemptAt = terminalDeliveryStatus attempt rule.RetryPolicy result
-
-                        currentDelivery <-
-                            { currentDelivery with
-                                AttemptCount = attempt
-                                LastAttemptAt = Some attemptAt
-                                LastStatusCode = statusCode
-                                LastError = error
-                                NextAttemptAt = nextAttemptAt
-                                Status = status
-                            }
-
-                        WebhookStore.upsertDelivery currentDelivery
-                        |> ignore
-
-                        match result with
-                        | TransientFailure _ when attempt < rule.RetryPolicy.MaxAttempts -> ()
-                        | _ -> shouldContinue <- false
+                    let! currentDelivery = sendDeliveryAttempt logger transport rule validatedUrl payloadJson delivery cancellationToken
 
                     match currentDelivery.Status with
                     | WebhookDeliveryStatus.Succeeded -> return Choice1Of2 true
@@ -368,6 +419,69 @@ module WebhookDispatch =
                         )
 
                         return Choice1Of2 false
+        }
+
+    type ScheduledRetryResult =
+        {
+            ProcessedCount: int
+            DeliveredCount: int
+            FailedCount: int
+            RescheduledCount: int
+            SkippedCount: int
+        }
+
+        static member Empty = { ProcessedCount = 0; DeliveredCount = 0; FailedCount = 0; RescheduledCount = 0; SkippedCount = 0 }
+
+    let processScheduledRetriesAsync
+        (logger: ILogger)
+        (configuration: IConfiguration)
+        (hostEnvironment: IHostEnvironment)
+        (transport: IOutboundWebhookTransport)
+        dueAt
+        maxDeliveries
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let batchSize = max 0 maxDeliveries
+            let dueDeliveries = WebhookStore.listScheduledRetries dueAt batchSize
+            let mutable result = ScheduledRetryResult.Empty
+            let mutable index = 0
+
+            while index < dueDeliveries.Count do
+                let delivery = dueDeliveries[index]
+
+                match WebhookStore.tryGetRule delivery.WebhookRuleId, WebhookStore.tryGetDeliveryPayload delivery.WebhookDeliveryId with
+                | Some rule, Some payloadJson ->
+                    match validateDeliveryUrl hostEnvironment configuration rule with
+                    | Error failure ->
+                        recordValidationFailure logger rule delivery failure
+
+                        result <- { result with ProcessedCount = result.ProcessedCount + 1; FailedCount = result.FailedCount + 1 }
+                    | Ok validatedUrl ->
+                        let! updatedDelivery = sendDeliveryAttempt logger transport rule validatedUrl payloadJson delivery cancellationToken
+
+                        result <-
+                            match updatedDelivery.Status with
+                            | WebhookDeliveryStatus.Succeeded ->
+                                { result with ProcessedCount = result.ProcessedCount + 1; DeliveredCount = result.DeliveredCount + 1 }
+                            | WebhookDeliveryStatus.RetryScheduled ->
+                                { result with ProcessedCount = result.ProcessedCount + 1; RescheduledCount = result.RescheduledCount + 1 }
+                            | _ -> { result with ProcessedCount = result.ProcessedCount + 1; FailedCount = result.FailedCount + 1 }
+                | _ ->
+                    WebhookStore.upsertDelivery
+                        { delivery with
+                            Status = WebhookDeliveryStatus.DeadLettered
+                            LastAttemptAt = Some(getCurrentInstant ())
+                            LastError = Some(trimError "Retry delivery could not be processed because its rule or payload is no longer available.")
+                            NextAttemptAt = Option.None
+                        }
+                    |> ignore
+
+                    result <- { result with ProcessedCount = result.ProcessedCount + 1; FailedCount = result.FailedCount + 1 }
+
+                index <- index + 1
+
+            return result
         }
 
     let dispatchCommittedEventAsync


### PR DESCRIPTION
## Summary

- Adds committed-event webhook dispatch from stored webhook rules with versioned payloads.
- Uses the outbound URL safety policy and secret redaction paths for webhook delivery attempts.
- Persists delivery state, retry scheduling, immutable retry snapshots, and dead-letter outcomes.
- Wires scheduled retry processing through the hosted service path.
- Handles cooperative cancellation without mutating retry deliveries, treats timeout-like transport cancellation as transient failure, and prevents duplicate concurrent sends for the same rule/dedupe key.

Closes #150.

## Validation

Latest fix worker validation:

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WebhookDispatch"`: passed, 17/17.
- `dotnet tool run fantomas --check Grace.Server\WebhookDispatch.Server.fs Grace.Server.Tests\WebhookDispatch.Server.Tests.fs`: passed.
- `dotnet build src\Grace.slnx --configuration Release`: passed, 0 warnings, 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Integration worker validation after merging current `origin/main`:

- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WebhookDispatchUnitTests"`: passed, 17/17.
- `dotnet build src\Grace.slnx --configuration Release`: passed, 0 warnings, 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `dotnet tool run fantomas --check src\Grace.Server.Tests\WebhookDispatch.Server.Tests.fs`: passed.
- `git diff --check`: passed.

## Review Ledger

Issue ledger comments:

- Review pass 1/2 persisted: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607106611
- Review pass 3 persisted: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607117524
- Review pass 4: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607511344
- Pass 4 fix evidence: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607575570
- Review pass 5: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607603821
- Pass 5 fix evidence: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607663125
- Review pass 6: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607697278
- Integration evidence: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607743695
- Final integration review: https://github.com/ScottArbeit/Grace/issues/150#issuecomment-4607766086

Latest review-only sibling findings: none.

Reviewed And OK highlights:

- Timeout-like `TaskCanceledException` falls back to retryable transient failure unless the caller token is actually canceled.
- Atomic dedupe-claim prevents duplicate concurrent outbound sends for the same rule/dedupe key.
- Cancellation is guarded between scheduled retry items and between committed-event rules.
- Retry snapshots, hosted retry wiring, redaction, response disposal, server-side-only dispatch, and URL-safety handling are intact.
- Integration with current `main` did not alter committed-event dispatch, dedupe, or retry behavior.

## Notes

- `validate.ps1 -Fast` currently skips the repo format step by design and does not include `Grace.Server.Tests`; the webhook dispatch server unit suite was run separately and passed.
- Full Aspire/integration validation was not run for this slice.