### PR TITLE
[Webhooks/Approvals] Gate promotion apply on approval state

### DIFF
--- a/src/Grace.Actors/ApprovalPolicySnapshotResolver.Actor.fs
+++ b/src/Grace.Actors/ApprovalPolicySnapshotResolver.Actor.fs
@@ -1,0 +1,10 @@
+namespace Grace.Actors
+
+open Grace.Types.PromotionSet
+open Grace.Types.Types
+open System.Threading.Tasks
+
+type IApprovalPolicySnapshotResolver =
+    abstract member GetCurrentApprovalPoliciesForPromotionApply:
+        ownerId: OwnerId * organizationId: OrganizationId * repositoryId: RepositoryId * targetBranchId: BranchId * correlationId: CorrelationId ->
+            Task<PromotionSetApprovalPolicySnapshot list>

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -21,6 +21,7 @@
         <Compile Include="Constants.Actor.fs" />
         <Compile Include="Types.Actor.fs" />
         <Compile Include="Interfaces.Actor.fs" />
+        <Compile Include="ApprovalPolicySnapshotResolver.Actor.fs" />
         <Compile Include="Context.Actor.fs" />
         <Compile Include="PersonalAccessToken.Actor.fs" />
         <Compile Include="Timing.Actor.fs" />

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -135,22 +135,60 @@ module PromotionSet =
         |> String.concat "|"
         |> createDeterministicGuid
 
-    let internal scopeMatchesPolicy (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+    let internal policyMatchesApplyScope (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
         policy.OwnerId = promotionSetDto.OwnerId
         && policy.OrganizationId = promotionSetDto.OrganizationId
         && policy.RepositoryId = promotionSetDto.RepositoryId
         && policy.TargetBranchId = promotionSetDto.TargetBranchId
         && String.Equals(policy.Subject, approvalSubject, StringComparison.OrdinalIgnoreCase)
-        && policy.ApprovalPolicyId <> Guid.Empty
+
+    let internal policyIsValidForApply (policy: PromotionSetApprovalPolicySnapshot) =
+        policy.ApprovalPolicyId <> Guid.Empty
         && policy.Version > 0
         && String.IsNullOrWhiteSpace policy.RequiredResponder
            |> not
+
+    let internal scopeMatchesPolicy (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        policyMatchesApplyScope promotionSetDto policy
+        && policyIsValidForApply policy
+
+    let internal invalidMatchingApprovalPolicy (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+        approvalPolicies
+        |> List.filter (policyMatchesApplyScope promotionSetDto)
+        |> List.filter (policyIsValidForApply >> not)
+        |> List.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
+        |> List.tryHead
 
     let internal selectApprovalPolicy (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
         approvalPolicies
         |> List.filter (scopeMatchesPolicy promotionSetDto)
         |> List.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
         |> List.tryHead
+
+    let internal selectApprovalPolicyOrInvalid (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+        match invalidMatchingApprovalPolicy promotionSetDto approvalPolicies with
+        | Option.Some invalidPolicy -> Error invalidPolicy
+        | Option.None -> Ok(selectApprovalPolicy promotionSetDto approvalPolicies)
+
+    let internal currentApprovalPoliciesForGate
+        (resolver: IApprovalPolicySnapshotResolver option)
+        (promotionSetDto: PromotionSetDto)
+        (fallbackApprovalPolicies: PromotionSetApprovalPolicySnapshot list)
+        correlationId
+        =
+        task {
+            match resolver with
+            | Option.Some policyResolver ->
+                return!
+                    policyResolver.GetCurrentApprovalPoliciesForPromotionApply(
+                        promotionSetDto.OwnerId,
+                        promotionSetDto.OrganizationId,
+                        promotionSetDto.RepositoryId,
+                        promotionSetDto.TargetBranchId,
+                        correlationId
+                    )
+            | Option.None -> return fallbackApprovalPolicies
+        }
 
     let internal approvalScope (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
         { ApprovalScope.Default with
@@ -309,6 +347,14 @@ module PromotionSet =
                 match services.GetService(typeof<IConflictResolutionModelProvider>) with
                 | null -> NullConflictResolutionModelProvider() :> IConflictResolutionModelProvider
                 | provider -> provider :?> IConflictResolutionModelProvider
+
+        member private this.GetApprovalPolicySnapshotResolver() =
+            match hostServiceProvider with
+            | null -> Option.None
+            | services ->
+                match services.GetService(typeof<IApprovalPolicySnapshotResolver>) with
+                | null -> Option.None
+                | resolver -> Option.Some(resolver :?> IApprovalPolicySnapshotResolver)
 
         member private this.UploadArtifactPayload(blobPath: string, payloadJson: string, metadata: EventMetadata) =
             task {
@@ -1828,8 +1874,27 @@ module PromotionSet =
 
         member private this.EnsureApprovalAllowsApply(approvalPolicies: PromotionSetApprovalPolicySnapshot list, metadata: EventMetadata) =
             task {
-                match selectApprovalPolicy promotionSetDto approvalPolicies with
-                | Option.None ->
+                let! currentApprovalPolicies =
+                    currentApprovalPoliciesForGate (this.GetApprovalPolicySnapshotResolver()) promotionSetDto approvalPolicies metadata.CorrelationId
+
+                match selectApprovalPolicyOrInvalid promotionSetDto currentApprovalPolicies with
+                | Error invalidPolicy ->
+                    let summary =
+                        approvalSummary
+                            promotionSetDto
+                            invalidPolicy
+                            Option.None
+                            PromotionSetApprovalState.Stale
+                            (Option.Some "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid.")
+
+                    return
+                        Error(
+                            (GraceError.Create
+                                "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid."
+                                metadata.CorrelationId)
+                                .enhance ("ApprovalSummary", summary)
+                        )
+                | Ok Option.None ->
                     return
                         Ok(
                             PromotionSetApprovalSummary.NotRequired
@@ -1837,7 +1902,7 @@ module PromotionSet =
                                 promotionSetDto.TargetBranchId
                                 promotionSetDto.StepsComputationAttempt
                         )
-                | Option.Some policy ->
+                | Ok (Option.Some policy) ->
                     let scope = approvalScope promotionSetDto policy
 
                     let requestTemplate =

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -21,7 +21,9 @@ open Grace.Types.Reference
 open Grace.Types.Reminder
 open Grace.Types.Types
 open Grace.Types.Validation
+open Grace.Types.Webhooks
 open Microsoft.Extensions.Logging
+open NodaTime
 open Orleans
 open Orleans.Runtime
 open System
@@ -30,6 +32,7 @@ open System.Diagnostics
 open System.Globalization
 open System.IO
 open System.IO.Compression
+open System.Security.Cryptography
 open System.Text
 open System.Threading.Tasks
 
@@ -69,9 +72,9 @@ module PromotionSet =
             | PromotionSetCommand.CreatePromotionSet _ -> Ok promotionSetCommand
             | _ when currentPromotionSetDto.PromotionSetId = PromotionSetId.Empty ->
                 Error(GraceError.Create "PromotionSet does not exist." eventMetadata.CorrelationId)
-            | PromotionSetCommand.Apply when currentPromotionSetDto.Status = PromotionSetStatus.Succeeded ->
+            | PromotionSetCommand.Apply _ when currentPromotionSetDto.Status = PromotionSetStatus.Succeeded ->
                 Error(GraceError.Create "PromotionSet has already been applied successfully." eventMetadata.CorrelationId)
-            | PromotionSetCommand.Apply when currentPromotionSetDto.Status = PromotionSetStatus.Running ->
+            | PromotionSetCommand.Apply _ when currentPromotionSetDto.Status = PromotionSetStatus.Running ->
                 Error(GraceError.Create "PromotionSet is already running." eventMetadata.CorrelationId)
             | PromotionSetCommand.RecomputeStepsIfStale _ when currentPromotionSetDto.StepsComputationStatus = StepsComputationStatus.Computing ->
                 Error(GraceError.Create "PromotionSet steps are already computing." eventMetadata.CorrelationId)
@@ -83,6 +86,111 @@ module PromotionSet =
             | PromotionSetCommand.UpdateInputPromotions _ when currentPromotionSetDto.Status = PromotionSetStatus.Succeeded ->
                 Error(GraceError.Create "PromotionSet has already succeeded and cannot be edited." eventMetadata.CorrelationId)
             | _ -> Ok promotionSetCommand
+
+    let private approvalSubject = "promotion"
+
+    let private canonicalSegment (value: string) =
+        let segment = if isNull value then String.Empty else value
+        $"{segment.Length}:{segment}"
+
+    let private canonicalGuid (value: Guid) = value.ToString("D").ToLowerInvariant()
+
+    let private canonicalOptionalGuid (value: Guid option) =
+        match value with
+        | Some guid -> canonicalGuid guid
+        | Option.None -> String.Empty
+
+    let private canonicalOptionalInt (value: int option) =
+        match value with
+        | Some attempt -> attempt.ToString(CultureInfo.InvariantCulture)
+        | Option.None -> String.Empty
+
+    let private createDeterministicGuid (seed: string) =
+        let seedBytes = Encoding.UTF8.GetBytes(seed)
+
+        use hasher = SHA256.Create()
+        let hash = hasher.ComputeHash(seedBytes)
+        let guidBytes = hash[0..15]
+        guidBytes[6] <- (guidBytes[6] &&& 0x0Fuy) ||| 0x50uy
+        guidBytes[8] <- (guidBytes[8] &&& 0x3Fuy) ||| 0x80uy
+        Guid(guidBytes)
+
+    let internal buildGeneratedApprovalRequestId (request: ApprovalRequest) =
+        let scope = if isNull (box request.Scope) then ApprovalScope.Default else request.Scope
+
+        [|
+            "grace.approval-request.generated.v1"
+            canonicalGuid request.ApprovalPolicyId
+            request.ApprovalPolicyVersion.ToString(CultureInfo.InvariantCulture)
+            request.Subject
+            canonicalGuid scope.OwnerId
+            canonicalGuid scope.OrganizationId
+            canonicalGuid scope.RepositoryId
+            canonicalGuid scope.TargetBranchId
+            canonicalOptionalGuid scope.PromotionSetId
+            canonicalOptionalInt scope.StepsComputationAttempt
+            request.RequiredResponder
+        |]
+        |> Array.map canonicalSegment
+        |> String.concat "|"
+        |> createDeterministicGuid
+
+    let internal scopeMatchesPolicy (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        policy.OwnerId = promotionSetDto.OwnerId
+        && policy.OrganizationId = promotionSetDto.OrganizationId
+        && policy.RepositoryId = promotionSetDto.RepositoryId
+        && policy.TargetBranchId = promotionSetDto.TargetBranchId
+        && String.Equals(policy.Subject, approvalSubject, StringComparison.OrdinalIgnoreCase)
+        && policy.ApprovalPolicyId <> Guid.Empty
+        && policy.Version > 0
+        && String.IsNullOrWhiteSpace policy.RequiredResponder
+           |> not
+
+    let internal selectApprovalPolicy (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+        approvalPolicies
+        |> List.filter (scopeMatchesPolicy promotionSetDto)
+        |> List.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
+        |> List.tryHead
+
+    let internal approvalScope (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        { ApprovalScope.Default with
+            OwnerId = promotionSetDto.OwnerId
+            OrganizationId = promotionSetDto.OrganizationId
+            RepositoryId = promotionSetDto.RepositoryId
+            TargetBranchId = promotionSetDto.TargetBranchId
+            PromotionSetId = Option.Some promotionSetDto.PromotionSetId
+            StepsComputationAttempt = Option.Some promotionSetDto.StepsComputationAttempt
+            ApprovalPolicyId = Option.Some policy.ApprovalPolicyId
+            ApprovalPolicyVersion = Option.Some policy.Version
+        }
+
+    let internal requestMatchesCurrentAttempt (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) (request: ApprovalRequest) =
+        request.ApprovalPolicyId = policy.ApprovalPolicyId
+        && request.ApprovalPolicyVersion = policy.Version
+        && request.Subject = approvalSubject
+        && request.RequiredResponder = policy.RequiredResponder
+        && request.Scope = approvalScope promotionSetDto policy
+
+    let internal expirationIsValid (now: NodaTime.Instant) (request: ApprovalRequest) =
+        match request.ExpiresAt with
+        | Some expiresAt when expiresAt <= now -> false
+        | _ -> true
+
+    let private approvalSummary (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) (request: ApprovalRequest option) state reason =
+        { (PromotionSetApprovalSummary.NotRequired promotionSetDto.PromotionSetId promotionSetDto.TargetBranchId promotionSetDto.StepsComputationAttempt) with
+            State = state
+            ApprovalRequestId =
+                request
+                |> Option.map (fun approvalRequest -> approvalRequest.ApprovalRequestId)
+            ApprovalPolicyId = Option.Some policy.ApprovalPolicyId
+            RequiredResponder = Option.Some policy.RequiredResponder
+            LastDecisionAt =
+                request
+                |> Option.bind (fun approvalRequest ->
+                    approvalRequest.Decision
+                    |> Option.map (fun decision -> decision.DecidedAt))
+            Reason = reason
+        }
 
     type PromotionSetActor([<PersistentState(StateName.PromotionSet, Constants.GraceActorStorage)>] state: IPersistentState<List<PromotionSetEvent>>) =
         inherit Grain()
@@ -1673,7 +1781,161 @@ module PromotionSet =
                             )
             }
 
-        member private this.ApplyPromotionSet(metadata: EventMetadata) =
+        member private this.GetApprovalRequestFromDurableHistory(approvalRequestId: ApprovalRequestId, scope: ApprovalScope, correlationId: CorrelationId) =
+            task {
+                let actor = ApprovalRequest.CreateActorProxy approvalRequestId scope.RepositoryId correlationId
+                let! requestJson = actor.GetJson correlationId
+
+                match requestJson with
+                | Option.Some json when String.IsNullOrWhiteSpace json |> not -> return Option.Some(deserialize<ApprovalRequest> json)
+                | _ ->
+                    let! events = actor.GetEvents correlationId
+
+                    let request =
+                        events
+                        |> Seq.filter (fun event -> isNull (box event) |> not)
+                        |> Seq.filter (fun event -> isNull (box event.Event) |> not)
+                        |> Seq.fold
+                            (fun current event -> Grace.Types.Webhooks.ApprovalRequest.UpdateDto event current)
+                            Grace.Types.Webhooks.ApprovalRequest.Default
+
+                    if request.ApprovalRequestId = ApprovalRequestId.Empty then
+                        return Option.None
+                    else
+                        return Option.Some request
+            }
+
+        member private this.CreatePendingApprovalRequest(request: ApprovalRequest, metadata: EventMetadata) =
+            task {
+                let scope = request.Scope
+                let approvalRequestId = request.ApprovalRequestId
+                let actor = ApprovalRequest.CreateActorProxy approvalRequestId scope.RepositoryId this.correlationId
+
+                let! createResult = actor.Create request metadata
+
+                match createResult with
+                | Error graceError -> return Error graceError
+                | Ok result ->
+                    let request = result.ReturnValue.Request
+                    let indexActor = ApprovalRequest.CreateIndexActorProxy scope this.correlationId
+
+                    let! indexResult = indexActor.RegisterRequest(request, metadata)
+
+                    match indexResult with
+                    | Error graceError -> return Error graceError
+                    | Ok _ -> return Ok request
+            }
+
+        member private this.EnsureApprovalAllowsApply(approvalPolicies: PromotionSetApprovalPolicySnapshot list, metadata: EventMetadata) =
+            task {
+                match selectApprovalPolicy promotionSetDto approvalPolicies with
+                | Option.None ->
+                    return
+                        Ok(
+                            PromotionSetApprovalSummary.NotRequired
+                                promotionSetDto.PromotionSetId
+                                promotionSetDto.TargetBranchId
+                                promotionSetDto.StepsComputationAttempt
+                        )
+                | Option.Some policy ->
+                    let scope = approvalScope promotionSetDto policy
+
+                    let requestTemplate =
+                        { Grace.Types.Webhooks.ApprovalRequest.Default with
+                            ApprovalPolicyId = policy.ApprovalPolicyId
+                            ApprovalPolicyVersion = policy.Version
+                            Subject = approvalSubject
+                            Scope = scope
+                            RequiredResponder = policy.RequiredResponder
+                            Status = ApprovalRequestStatus.Pending
+                            CreatedBy = UserId metadata.Principal
+                            CreatedAt = metadata.Timestamp
+                            ExpiresAt =
+                                policy.TimeoutSeconds
+                                |> Option.map (fun seconds -> metadata.Timestamp.Plus(Duration.FromSeconds(float seconds)))
+                        }
+
+                    let approvalRequestId = buildGeneratedApprovalRequestId requestTemplate
+                    let! currentRequest = this.GetApprovalRequestFromDurableHistory(approvalRequestId, scope, metadata.CorrelationId)
+                    let now = getCurrentInstant ()
+
+                    match currentRequest with
+                    | Option.Some request when
+                        not
+                        <| requestMatchesCurrentAttempt promotionSetDto policy request
+                        ->
+                        let summary =
+                            approvalSummary
+                                promotionSetDto
+                                policy
+                                (Option.Some request)
+                                PromotionSetApprovalState.Stale
+                                (Option.Some "Approval request is not valid for the current apply attempt.")
+
+                        return
+                            Error(
+                                (GraceError.Create "Approval request is not valid for the current apply attempt." metadata.CorrelationId)
+                                    .enhance ("ApprovalSummary", summary)
+                            )
+                    | Option.Some request when
+                        request.Status = ApprovalRequestStatus.Approved
+                        && expirationIsValid now request
+                        ->
+                        return Ok(approvalSummary promotionSetDto policy (Option.Some request) PromotionSetApprovalState.Approved Option.None)
+                    | Option.Some request when
+                        request.Status = ApprovalRequestStatus.Pending
+                        && expirationIsValid now request
+                        ->
+                        let summary =
+                            approvalSummary
+                                promotionSetDto
+                                policy
+                                (Option.Some request)
+                                PromotionSetApprovalState.Pending
+                                (Option.Some "Approval is required before apply can continue.")
+
+                        return
+                            Error(
+                                (GraceError.Create "Approval is required before apply can continue." metadata.CorrelationId)
+                                    .enhance ("ApprovalSummary", summary)
+                            )
+                    | Option.Some request ->
+                        let state, message =
+                            match request.Status with
+                            | ApprovalRequestStatus.Rejected -> PromotionSetApprovalState.Rejected, "Approval request was rejected."
+                            | ApprovalRequestStatus.Expired -> PromotionSetApprovalState.Expired, "Approval request is expired."
+                            | ApprovalRequestStatus.Cancelled -> PromotionSetApprovalState.Stale, "Approval request was cancelled."
+                            | ApprovalRequestStatus.Superseded -> PromotionSetApprovalState.Stale, "Approval request was superseded."
+                            | ApprovalRequestStatus.Approved -> PromotionSetApprovalState.Stale, "Approval request is expired."
+                            | ApprovalRequestStatus.Pending -> PromotionSetApprovalState.Stale, "Approval request is expired."
+
+                        let summary = approvalSummary promotionSetDto policy (Option.Some request) state (Option.Some message)
+
+                        return
+                            Error(
+                                (GraceError.Create message metadata.CorrelationId)
+                                    .enhance ("ApprovalSummary", summary)
+                            )
+                    | Option.None ->
+                        match! this.CreatePendingApprovalRequest({ requestTemplate with ApprovalRequestId = approvalRequestId }, metadata) with
+                        | Error graceError -> return Error graceError
+                        | Ok request ->
+                            let summary =
+                                approvalSummary
+                                    promotionSetDto
+                                    policy
+                                    (Option.Some request)
+                                    PromotionSetApprovalState.Pending
+                                    (Option.Some "Approval is required before apply can continue.")
+
+                            return
+                                Error(
+                                    (GraceError.Create "Approval is required before apply can continue." metadata.CorrelationId)
+                                        .enhance ("ApprovalSummary", summary)
+                                )
+            }
+
+        member private this.ApplyPromotionSet(approvalPolicies: PromotionSetApprovalPolicySnapshot list, metadata: EventMetadata) =
             task {
                 if promotionSetDto.Status = PromotionSetStatus.Succeeded then
                     return this.BuildError("PromotionSet has already been applied successfully.", metadata.CorrelationId)
@@ -1710,6 +1972,11 @@ module PromotionSet =
 
                     if preconditionError.IsNone then
                         match! this.EnsureRequiredValidationsPass metadata with
+                        | Ok _ -> ()
+                        | Error graceError -> preconditionError <- Option.Some graceError
+
+                    if preconditionError.IsNone then
+                        match! this.EnsureApprovalAllowsApply(approvalPolicies, metadata) with
                         | Ok _ -> ()
                         | Error graceError -> preconditionError <- Option.Some graceError
 
@@ -1828,7 +2095,7 @@ module PromotionSet =
                         | PromotionSetCommand.RecomputeStepsIfStale reason -> return! this.RecomputeSteps(eventMetadata, reason, Option.None)
                         | PromotionSetCommand.ResolveConflicts (stepId, resolutions) ->
                             return! this.RecomputeSteps(eventMetadata, Option.Some "Manual conflict resolutions submitted.", Option.Some(stepId, resolutions))
-                        | PromotionSetCommand.Apply -> return! this.ApplyPromotionSet eventMetadata
+                        | PromotionSetCommand.Apply approvalPolicies -> return! this.ApplyPromotionSet(approvalPolicies, eventMetadata)
                         | PromotionSetCommand.DeleteLogical (force, deleteReason) ->
                             return! this.ApplyEvent { Event = PromotionSetEventType.LogicalDeleted(force, deleteReason); Metadata = eventMetadata }
                     }

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -159,16 +159,27 @@ module PromotionSet =
         |> List.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
         |> List.tryHead
 
-    let internal selectApprovalPolicy (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+    let internal validMatchingApprovalPolicies (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
         approvalPolicies
         |> List.filter (scopeMatchesPolicy promotionSetDto)
         |> List.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
+
+    let internal selectApprovalPolicy (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+        validMatchingApprovalPolicies promotionSetDto approvalPolicies
         |> List.tryHead
 
-    let internal selectApprovalPolicyOrInvalid (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
+    type ApprovalPolicySelectionFailure =
+        | InvalidMatchingApprovalPolicy of PromotionSetApprovalPolicySnapshot
+        | MultipleMatchingApprovalPolicies of PromotionSetApprovalPolicySnapshot list
+
+    let selectApprovalPolicyOrInvalid (promotionSetDto: PromotionSetDto) (approvalPolicies: PromotionSetApprovalPolicySnapshot list) =
         match invalidMatchingApprovalPolicy promotionSetDto approvalPolicies with
-        | Option.Some invalidPolicy -> Error invalidPolicy
-        | Option.None -> Ok(selectApprovalPolicy promotionSetDto approvalPolicies)
+        | Option.Some invalidPolicy -> Error(InvalidMatchingApprovalPolicy invalidPolicy)
+        | Option.None ->
+            match validMatchingApprovalPolicies promotionSetDto approvalPolicies with
+            | [] -> Ok Option.None
+            | [ policy ] -> Ok(Option.Some policy)
+            | matchingPolicies -> Error(MultipleMatchingApprovalPolicies matchingPolicies)
 
     let internal currentApprovalPoliciesForGate
         (resolver: IApprovalPolicySnapshotResolver option)
@@ -179,7 +190,7 @@ module PromotionSet =
         task {
             match resolver with
             | Option.Some policyResolver ->
-                return!
+                let! policies =
                     policyResolver.GetCurrentApprovalPoliciesForPromotionApply(
                         promotionSetDto.OwnerId,
                         promotionSetDto.OrganizationId,
@@ -187,7 +198,11 @@ module PromotionSet =
                         promotionSetDto.TargetBranchId,
                         correlationId
                     )
-            | Option.None -> return fallbackApprovalPolicies
+
+                return Ok policies
+            | Option.None when fallbackApprovalPolicies.IsEmpty ->
+                return Error(GraceError.Create "Approval policy resolver is unavailable for promotion apply." correlationId)
+            | Option.None -> return Ok fallbackApprovalPolicies
         }
 
     let internal approvalScope (promotionSetDto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
@@ -1874,117 +1889,104 @@ module PromotionSet =
 
         member private this.EnsureApprovalAllowsApply(approvalPolicies: PromotionSetApprovalPolicySnapshot list, metadata: EventMetadata) =
             task {
-                let! currentApprovalPolicies =
+                let! currentApprovalPoliciesResult =
                     currentApprovalPoliciesForGate (this.GetApprovalPolicySnapshotResolver()) promotionSetDto approvalPolicies metadata.CorrelationId
 
-                match selectApprovalPolicyOrInvalid promotionSetDto currentApprovalPolicies with
-                | Error invalidPolicy ->
-                    let summary =
-                        approvalSummary
-                            promotionSetDto
-                            invalidPolicy
-                            Option.None
-                            PromotionSetApprovalState.Stale
-                            (Option.Some "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid.")
-
-                    return
-                        Error(
-                            (GraceError.Create
-                                "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid."
-                                metadata.CorrelationId)
-                                .enhance ("ApprovalSummary", summary)
-                        )
-                | Ok Option.None ->
-                    return
-                        Ok(
-                            PromotionSetApprovalSummary.NotRequired
-                                promotionSetDto.PromotionSetId
-                                promotionSetDto.TargetBranchId
-                                promotionSetDto.StepsComputationAttempt
-                        )
-                | Ok (Option.Some policy) ->
-                    let scope = approvalScope promotionSetDto policy
-
-                    let requestTemplate =
-                        { Grace.Types.Webhooks.ApprovalRequest.Default with
-                            ApprovalPolicyId = policy.ApprovalPolicyId
-                            ApprovalPolicyVersion = policy.Version
-                            Subject = approvalSubject
-                            Scope = scope
-                            RequiredResponder = policy.RequiredResponder
-                            Status = ApprovalRequestStatus.Pending
-                            CreatedBy = UserId metadata.Principal
-                            CreatedAt = metadata.Timestamp
-                            ExpiresAt =
-                                policy.TimeoutSeconds
-                                |> Option.map (fun seconds -> metadata.Timestamp.Plus(Duration.FromSeconds(float seconds)))
-                        }
-
-                    let approvalRequestId = buildGeneratedApprovalRequestId requestTemplate
-                    let! currentRequest = this.GetApprovalRequestFromDurableHistory(approvalRequestId, scope, metadata.CorrelationId)
-                    let now = getCurrentInstant ()
-
-                    match currentRequest with
-                    | Option.Some request when
-                        not
-                        <| requestMatchesCurrentAttempt promotionSetDto policy request
-                        ->
+                match currentApprovalPoliciesResult with
+                | Error graceError -> return Error graceError
+                | Ok currentApprovalPolicies ->
+                    match selectApprovalPolicyOrInvalid promotionSetDto currentApprovalPolicies with
+                    | Error (InvalidMatchingApprovalPolicy invalidPolicy) ->
                         let summary =
                             approvalSummary
                                 promotionSetDto
-                                policy
-                                (Option.Some request)
+                                invalidPolicy
+                                Option.None
                                 PromotionSetApprovalState.Stale
-                                (Option.Some "Approval request is not valid for the current apply attempt.")
+                                (Option.Some "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid.")
 
                         return
                             Error(
-                                (GraceError.Create "Approval request is not valid for the current apply attempt." metadata.CorrelationId)
+                                (GraceError.Create
+                                    "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid."
+                                    metadata.CorrelationId)
                                     .enhance ("ApprovalSummary", summary)
                             )
-                    | Option.Some request when
-                        request.Status = ApprovalRequestStatus.Approved
-                        && expirationIsValid now request
-                        ->
-                        return Ok(approvalSummary promotionSetDto policy (Option.Some request) PromotionSetApprovalState.Approved Option.None)
-                    | Option.Some request when
-                        request.Status = ApprovalRequestStatus.Pending
-                        && expirationIsValid now request
-                        ->
+                    | Error (MultipleMatchingApprovalPolicies matchingPolicies) ->
                         let summary =
-                            approvalSummary
-                                promotionSetDto
-                                policy
-                                (Option.Some request)
-                                PromotionSetApprovalState.Pending
-                                (Option.Some "Approval is required before apply can continue.")
+                            { (PromotionSetApprovalSummary.NotRequired
+                                  promotionSetDto.PromotionSetId
+                                  promotionSetDto.TargetBranchId
+                                  promotionSetDto.StepsComputationAttempt) with
+                                State = PromotionSetApprovalState.Stale
+                                Reason = Option.Some "Multiple enabled approval policies match promotion apply scope; apply requires exactly one."
+                            }
 
                         return
                             Error(
-                                (GraceError.Create "Approval is required before apply can continue." metadata.CorrelationId)
+                                ((GraceError.Create
+                                    "Multiple enabled approval policies match promotion apply scope; apply requires exactly one."
+                                    metadata.CorrelationId)
+                                    .enhance ("ApprovalPolicyCount", matchingPolicies.Length))
                                     .enhance ("ApprovalSummary", summary)
                             )
-                    | Option.Some request ->
-                        let state, message =
-                            match request.Status with
-                            | ApprovalRequestStatus.Rejected -> PromotionSetApprovalState.Rejected, "Approval request was rejected."
-                            | ApprovalRequestStatus.Expired -> PromotionSetApprovalState.Expired, "Approval request is expired."
-                            | ApprovalRequestStatus.Cancelled -> PromotionSetApprovalState.Stale, "Approval request was cancelled."
-                            | ApprovalRequestStatus.Superseded -> PromotionSetApprovalState.Stale, "Approval request was superseded."
-                            | ApprovalRequestStatus.Approved -> PromotionSetApprovalState.Stale, "Approval request is expired."
-                            | ApprovalRequestStatus.Pending -> PromotionSetApprovalState.Stale, "Approval request is expired."
-
-                        let summary = approvalSummary promotionSetDto policy (Option.Some request) state (Option.Some message)
-
+                    | Ok Option.None ->
                         return
-                            Error(
-                                (GraceError.Create message metadata.CorrelationId)
-                                    .enhance ("ApprovalSummary", summary)
+                            Ok(
+                                PromotionSetApprovalSummary.NotRequired
+                                    promotionSetDto.PromotionSetId
+                                    promotionSetDto.TargetBranchId
+                                    promotionSetDto.StepsComputationAttempt
                             )
-                    | Option.None ->
-                        match! this.CreatePendingApprovalRequest({ requestTemplate with ApprovalRequestId = approvalRequestId }, metadata) with
-                        | Error graceError -> return Error graceError
-                        | Ok request ->
+                    | Ok (Option.Some policy) ->
+                        let scope = approvalScope promotionSetDto policy
+
+                        let requestTemplate =
+                            { Grace.Types.Webhooks.ApprovalRequest.Default with
+                                ApprovalPolicyId = policy.ApprovalPolicyId
+                                ApprovalPolicyVersion = policy.Version
+                                Subject = approvalSubject
+                                Scope = scope
+                                RequiredResponder = policy.RequiredResponder
+                                Status = ApprovalRequestStatus.Pending
+                                CreatedBy = UserId metadata.Principal
+                                CreatedAt = metadata.Timestamp
+                                ExpiresAt =
+                                    policy.TimeoutSeconds
+                                    |> Option.map (fun seconds -> metadata.Timestamp.Plus(Duration.FromSeconds(float seconds)))
+                            }
+
+                        let approvalRequestId = buildGeneratedApprovalRequestId requestTemplate
+                        let! currentRequest = this.GetApprovalRequestFromDurableHistory(approvalRequestId, scope, metadata.CorrelationId)
+                        let now = getCurrentInstant ()
+
+                        match currentRequest with
+                        | Option.Some request when
+                            not
+                            <| requestMatchesCurrentAttempt promotionSetDto policy request
+                            ->
+                            let summary =
+                                approvalSummary
+                                    promotionSetDto
+                                    policy
+                                    (Option.Some request)
+                                    PromotionSetApprovalState.Stale
+                                    (Option.Some "Approval request is not valid for the current apply attempt.")
+
+                            return
+                                Error(
+                                    (GraceError.Create "Approval request is not valid for the current apply attempt." metadata.CorrelationId)
+                                        .enhance ("ApprovalSummary", summary)
+                                )
+                        | Option.Some request when
+                            request.Status = ApprovalRequestStatus.Approved
+                            && expirationIsValid now request
+                            ->
+                            return Ok(approvalSummary promotionSetDto policy (Option.Some request) PromotionSetApprovalState.Approved Option.None)
+                        | Option.Some request when
+                            request.Status = ApprovalRequestStatus.Pending
+                            && expirationIsValid now request
+                            ->
                             let summary =
                                 approvalSummary
                                     promotionSetDto
@@ -1998,6 +2000,40 @@ module PromotionSet =
                                     (GraceError.Create "Approval is required before apply can continue." metadata.CorrelationId)
                                         .enhance ("ApprovalSummary", summary)
                                 )
+                        | Option.Some request ->
+                            let state, message =
+                                match request.Status with
+                                | ApprovalRequestStatus.Rejected -> PromotionSetApprovalState.Rejected, "Approval request was rejected."
+                                | ApprovalRequestStatus.Expired -> PromotionSetApprovalState.Expired, "Approval request is expired."
+                                | ApprovalRequestStatus.Cancelled -> PromotionSetApprovalState.Stale, "Approval request was cancelled."
+                                | ApprovalRequestStatus.Superseded -> PromotionSetApprovalState.Stale, "Approval request was superseded."
+                                | ApprovalRequestStatus.Approved -> PromotionSetApprovalState.Stale, "Approval request is expired."
+                                | ApprovalRequestStatus.Pending -> PromotionSetApprovalState.Stale, "Approval request is expired."
+
+                            let summary = approvalSummary promotionSetDto policy (Option.Some request) state (Option.Some message)
+
+                            return
+                                Error(
+                                    (GraceError.Create message metadata.CorrelationId)
+                                        .enhance ("ApprovalSummary", summary)
+                                )
+                        | Option.None ->
+                            match! this.CreatePendingApprovalRequest({ requestTemplate with ApprovalRequestId = approvalRequestId }, metadata) with
+                            | Error graceError -> return Error graceError
+                            | Ok request ->
+                                let summary =
+                                    approvalSummary
+                                        promotionSetDto
+                                        policy
+                                        (Option.Some request)
+                                        PromotionSetApprovalState.Pending
+                                        (Option.Some "Approval is required before apply can continue.")
+
+                                return
+                                    Error(
+                                        (GraceError.Create "Approval is required before apply can continue." metadata.CorrelationId)
+                                            .enhance ("ApprovalSummary", summary)
+                                    )
             }
 
         member private this.ApplyPromotionSet(approvalPolicies: PromotionSetApprovalPolicySnapshot list, metadata: EventMetadata) =

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -209,6 +209,50 @@ type ApprovalApiIntegrationTests() =
         }
 
     [<Test>]
+    member _.PolicyCreateRejectsBlankRequiredResponder() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let parameters = ApprovalTestHelpers.createPolicyParameters repositoryId branchId
+            parameters.RequiredResponder <- "   "
+
+            let! createResponse = adminClient.PostAsync("/approval/policy/create", createJsonContent parameters)
+            let! responseText = createResponse.Content.ReadAsStringAsync()
+
+            Assert.That(createResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseText)
+            Assert.That(responseText, Does.Contain("RequiredResponder is required."))
+        }
+
+    [<Test>]
+    member _.PolicyUpdateRejectsBlankRequiredResponder() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let! storedPolicy = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId branchId
+
+            let updateParameters = ApprovalTestHelpers.updatePolicyParameters repositoryId branchId (storedPolicy.ApprovalPolicyId.ToString())
+            updateParameters.RequiredResponder <- ""
+
+            let! updateResponse = adminClient.PostAsync("/approval/policy/update", createJsonContent updateParameters)
+            let! responseText = updateResponse.Content.ReadAsStringAsync()
+
+            Assert.That(updateResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseText)
+            Assert.That(responseText, Does.Contain("RequiredResponder is required."))
+        }
+
+    [<Test>]
     member _.NoPublicApprovalRequestCreateRouteExists() =
         task {
             use client = ApprovalTestHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
@@ -411,7 +455,11 @@ type ApprovalApiIntegrationTests() =
                 }
 
             let! created = [| 1..8 |] |> Array.map createOne |> Task.WhenAll
-            let requestIds = created |> Array.map _.ApprovalRequestId |> Array.distinct
+
+            let requestIds =
+                created
+                |> Array.map (fun request -> request.ApprovalRequestId)
+                |> Array.distinct
 
             Assert.That(requestIds, Has.Length.EqualTo(1))
             Assert.That(requestIds[0], Is.Not.EqualTo(Guid.Empty))

--- a/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
@@ -50,6 +50,25 @@ type PromotionSetCommandValidationTests() =
             RequiredResponder = "role:ApprovalResponder"
         }
 
+    let storedApprovalPolicyFor (dto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        { ApprovalPolicy.Default with
+            ApprovalPolicyId = policy.ApprovalPolicyId
+            Version = policy.Version
+            Subject = policy.Subject
+            Scope =
+                { ApprovalScope.Default with
+                    OwnerId = dto.OwnerId
+                    OrganizationId = dto.OrganizationId
+                    RepositoryId = dto.RepositoryId
+                    TargetBranchId = dto.TargetBranchId
+                    ApprovalPolicyId = Some policy.ApprovalPolicyId
+                    ApprovalPolicyVersion = Some policy.Version
+                }
+            RequiredResponder = policy.RequiredResponder
+            TimeoutSeconds = policy.TimeoutSeconds
+            Status = ApprovalPolicyStatus.Enabled
+        }
+
     let approvalRequestFor (dto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
         { ApprovalRequest.Default with
             ApprovalRequestId = Guid.NewGuid()
@@ -146,8 +165,22 @@ type PromotionSetCommandValidationTests() =
         let validPolicy = approvalPolicyFor dto (Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")) 1
 
         match PromotionSet.selectApprovalPolicyOrInvalid dto [ validPolicy; invalidPolicy ] with
-        | Error selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(invalidPolicy.ApprovalPolicyId))
+        | Error (PromotionSet.InvalidMatchingApprovalPolicy selected) -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(invalidPolicy.ApprovalPolicyId))
         | Ok _ -> Assert.Fail("Expected invalid matching approval policy to block apply gate selection.")
+        | Error _ -> Assert.Fail("Expected the invalid matching approval policy to be reported.")
+
+    [<Test>]
+    member _.MultipleMatchingApprovalPoliciesAreRejectedInsteadOfCollapsed() =
+        let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+        let firstPolicy = approvalPolicyFor dto (Guid.Parse("11111111-1111-1111-1111-111111111111")) 1
+        let secondPolicy = approvalPolicyFor dto (Guid.Parse("22222222-2222-2222-2222-222222222222")) 1
+
+        match PromotionSet.selectApprovalPolicyOrInvalid dto [ secondPolicy; firstPolicy ] with
+        | Error (PromotionSet.MultipleMatchingApprovalPolicies matchingPolicies) ->
+            Assert.That(matchingPolicies.Length, Is.EqualTo(2))
+            Assert.That(matchingPolicies[0].ApprovalPolicyId, Is.EqualTo(firstPolicy.ApprovalPolicyId))
+        | Ok _ -> Assert.Fail("Expected multiple matching approval policies to block apply gate selection.")
+        | Error _ -> Assert.Fail("Expected multiple matching approval policies to be reported.")
 
     [<Test>]
     member _.CurrentPolicyResolverOverridesStaleCallerSnapshotAtApplyGate() =
@@ -157,11 +190,80 @@ type PromotionSetCommandValidationTests() =
             let currentPolicy = approvalPolicyFor dto (Guid.Parse("22222222-2222-2222-2222-222222222222")) 2
             let resolver = FixedApprovalPolicySnapshotResolver([ currentPolicy ]) :> IApprovalPolicySnapshotResolver
 
-            let! policies = PromotionSet.currentApprovalPoliciesForGate (Some resolver) dto [ stalePolicy ] "corr-current-policy"
+            let! policiesResult = PromotionSet.currentApprovalPoliciesForGate (Some resolver) dto [ stalePolicy ] "corr-current-policy"
 
-            match PromotionSet.selectApprovalPolicy dto policies with
-            | Option.Some selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(currentPolicy.ApprovalPolicyId))
-            | Option.None -> Assert.Fail("Expected current resolver policy to be selected.")
+            match policiesResult with
+            | Ok policies ->
+                match PromotionSet.selectApprovalPolicy dto policies with
+                | Option.Some selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(currentPolicy.ApprovalPolicyId))
+                | Option.None -> Assert.Fail("Expected current resolver policy to be selected.")
+            | Error graceError -> Assert.Fail($"Expected resolver policies, but got {graceError.Error}.")
+        }
+
+    [<Test>]
+    member _.MissingCurrentPolicyResolverFailsClosedWhenNoFallbackSnapshotsExist() =
+        task {
+            let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+
+            let! policiesResult = PromotionSet.currentApprovalPoliciesForGate Option.None dto [] "corr-missing-policy-resolver"
+
+            match policiesResult with
+            | Error graceError -> Assert.That(graceError.Error, Is.EqualTo("Approval policy resolver is unavailable for promotion apply."))
+            | Ok _ -> Assert.Fail("Expected missing resolver without fallback snapshots to fail closed.")
+        }
+
+    [<Test>]
+    member _.NonHostedFallbackSnapshotsRemainUsableWhenExplicitlySupplied() =
+        task {
+            let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+            let fallbackPolicy = approvalPolicyFor dto (Guid.Parse("11111111-1111-1111-1111-111111111111")) 1
+
+            let! policiesResult = PromotionSet.currentApprovalPoliciesForGate Option.None dto [ fallbackPolicy ] "corr-fallback-policy"
+
+            match policiesResult with
+            | Ok [ selected ] -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(fallbackPolicy.ApprovalPolicyId))
+            | Ok policies -> Assert.Fail($"Expected one fallback policy, got {policies.Length}.")
+            | Error graceError -> Assert.Fail($"Expected fallback snapshots, but got {graceError.Error}.")
+        }
+
+    [<Test>]
+    member _.DerivedApprovalSummaryReportsInvalidMatchingPolicyAsStale() =
+        task {
+            let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+            let invalidPolicy = { approvalPolicyFor dto (Guid.NewGuid()) 1 with RequiredResponder = " " }
+
+            Grace.Server.ApprovalStore.upsertPolicy (storedApprovalPolicyFor dto invalidPolicy)
+            |> ignore
+
+            let! summary = Grace.Server.PromotionSet.deriveApprovalSummary dto "corr-invalid-summary"
+
+            Assert.That(summary.State, Is.EqualTo(PromotionSetApprovalState.Stale))
+            Assert.That(summary.ApprovalPolicyId, Is.EqualTo(Some invalidPolicy.ApprovalPolicyId))
+
+            Assert.That(
+                summary.Reason,
+                Is.EqualTo(Some "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid.")
+            )
+        }
+
+    [<Test>]
+    member _.DerivedApprovalSummaryReportsMultipleMatchingPoliciesAsStale() =
+        task {
+            let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+            let firstPolicy = approvalPolicyFor dto (Guid.NewGuid()) 1
+            let secondPolicy = approvalPolicyFor dto (Guid.NewGuid()) 1
+
+            Grace.Server.ApprovalStore.upsertPolicy (storedApprovalPolicyFor dto firstPolicy)
+            |> ignore
+
+            Grace.Server.ApprovalStore.upsertPolicy (storedApprovalPolicyFor dto secondPolicy)
+            |> ignore
+
+            let! summary = Grace.Server.PromotionSet.deriveApprovalSummary dto "corr-multiple-summary"
+
+            Assert.That(summary.State, Is.EqualTo(PromotionSetApprovalState.Stale))
+            Assert.That(summary.ApprovalPolicyId.IsNone, Is.True)
+            Assert.That(summary.Reason, Is.EqualTo(Some "Multiple enabled approval policies match promotion apply scope; apply requires exactly one."))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
@@ -80,6 +80,18 @@ type PromotionSetCommandValidationTests() =
             Status = ApprovalRequestStatus.Pending
         }
 
+    let assertPastExpiresAtSummaryIsStaleFor status =
+        let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+        let policy = approvalPolicyFor dto (Guid.NewGuid()) 1
+
+        let request = { approvalRequestFor dto policy with Status = status; ExpiresAt = Some(Instant.FromUtc(2026, 1, 1, 0, 0)) }
+
+        let summary = Grace.Server.PromotionSet.approvalSummaryFromRequest dto policy (Some request)
+
+        Assert.That(summary.State, Is.EqualTo(PromotionSetApprovalState.Stale))
+        Assert.That(summary.ApprovalPolicyId, Is.EqualTo(Some policy.ApprovalPolicyId))
+        Assert.That(summary.Reason, Is.EqualTo(Some "Approval request is expired."))
+
     [<Test>]
     member _.ApplyRejectedWhenPromotionSetAlreadySucceeded() =
         let dto = existingPromotionSet PromotionSetStatus.Succeeded StepsComputationStatus.Computed
@@ -265,6 +277,25 @@ type PromotionSetCommandValidationTests() =
             Assert.That(summary.ApprovalPolicyId.IsNone, Is.True)
             Assert.That(summary.Reason, Is.EqualTo(Some "Multiple enabled approval policies match promotion apply scope; apply requires exactly one."))
         }
+
+    [<Test>]
+    member _.DerivedApprovalSummaryKeepsExplicitExpiredStatusWhenRequestExpiresAtIsPast() =
+        let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+        let policy = approvalPolicyFor dto (Guid.NewGuid()) 1
+
+        let request = { approvalRequestFor dto policy with Status = ApprovalRequestStatus.Expired; ExpiresAt = Some(Instant.FromUtc(2026, 1, 1, 0, 0)) }
+
+        let summary = Grace.Server.PromotionSet.approvalSummaryFromRequest dto policy (Some request)
+
+        Assert.That(summary.State, Is.EqualTo(PromotionSetApprovalState.Expired))
+        Assert.That(summary.ApprovalPolicyId, Is.EqualTo(Some policy.ApprovalPolicyId))
+        Assert.That(summary.Reason, Is.EqualTo(Some "Approval request is expired."))
+
+    [<Test>]
+    member _.DerivedApprovalSummaryReportsPastExpiresAtPendingRequestAsStale() = assertPastExpiresAtSummaryIsStaleFor ApprovalRequestStatus.Pending
+
+    [<Test>]
+    member _.DerivedApprovalSummaryReportsPastExpiresAtApprovedRequestAsStale() = assertPastExpiresAtSummaryIsStaleFor ApprovalRequestStatus.Approved
 
     [<Test>]
     member _.ApprovalRequestMustMatchExactCurrentAttemptIdentity() =

--- a/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
@@ -9,6 +9,11 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Threading.Tasks
+
+type private FixedApprovalPolicySnapshotResolver(policies: PromotionSetApprovalPolicySnapshot list) =
+    interface IApprovalPolicySnapshotResolver with
+        member _.GetCurrentApprovalPoliciesForPromotionApply(_, _, _, _, _) = Task.FromResult policies
 
 [<Parallelizable(ParallelScope.All)>]
 type PromotionSetCommandValidationTests() =
@@ -133,6 +138,31 @@ type PromotionSetCommandValidationTests() =
             with
         | Option.Some selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(earlierPolicy.ApprovalPolicyId))
         | Option.None -> Assert.Fail("Expected a matching approval policy.")
+
+    [<Test>]
+    member _.InvalidMatchingApprovalPolicyIsReportedInsteadOfDropped() =
+        let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+        let invalidPolicy = { approvalPolicyFor dto (Guid.Parse("11111111-1111-1111-1111-111111111111")) 1 with RequiredResponder = " " }
+        let validPolicy = approvalPolicyFor dto (Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")) 1
+
+        match PromotionSet.selectApprovalPolicyOrInvalid dto [ validPolicy; invalidPolicy ] with
+        | Error selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(invalidPolicy.ApprovalPolicyId))
+        | Ok _ -> Assert.Fail("Expected invalid matching approval policy to block apply gate selection.")
+
+    [<Test>]
+    member _.CurrentPolicyResolverOverridesStaleCallerSnapshotAtApplyGate() =
+        task {
+            let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+            let stalePolicy = approvalPolicyFor dto (Guid.Parse("11111111-1111-1111-1111-111111111111")) 1
+            let currentPolicy = approvalPolicyFor dto (Guid.Parse("22222222-2222-2222-2222-222222222222")) 2
+            let resolver = FixedApprovalPolicySnapshotResolver([ currentPolicy ]) :> IApprovalPolicySnapshotResolver
+
+            let! policies = PromotionSet.currentApprovalPoliciesForGate (Some resolver) dto [ stalePolicy ] "corr-current-policy"
+
+            match PromotionSet.selectApprovalPolicy dto policies with
+            | Option.Some selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(currentPolicy.ApprovalPolicyId))
+            | Option.None -> Assert.Fail("Expected current resolver policy to be selected.")
+        }
 
     [<Test>]
     member _.ApprovalRequestMustMatchExactCurrentAttemptIdentity() =

--- a/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.CommandValidation.Tests.fs
@@ -4,6 +4,7 @@ open Grace.Actors
 open Grace.Types.Events
 open Grace.Types.PromotionSet
 open Grace.Types.Types
+open Grace.Types.Webhooks
 open NodaTime
 open NUnit.Framework
 open System
@@ -32,12 +33,35 @@ type PromotionSetCommandValidationTests() =
             StepsComputationStatus = computationStatus
         }
 
+    let approvalPolicyFor (dto: PromotionSetDto) policyId version =
+        { PromotionSetApprovalPolicySnapshot.Default with
+            ApprovalPolicyId = policyId
+            Version = version
+            Subject = "promotion"
+            OwnerId = dto.OwnerId
+            OrganizationId = dto.OrganizationId
+            RepositoryId = dto.RepositoryId
+            TargetBranchId = dto.TargetBranchId
+            RequiredResponder = "role:ApprovalResponder"
+        }
+
+    let approvalRequestFor (dto: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        { ApprovalRequest.Default with
+            ApprovalRequestId = Guid.NewGuid()
+            ApprovalPolicyId = policy.ApprovalPolicyId
+            ApprovalPolicyVersion = policy.Version
+            Subject = "promotion"
+            Scope = PromotionSet.approvalScope dto policy
+            RequiredResponder = policy.RequiredResponder
+            Status = ApprovalRequestStatus.Pending
+        }
+
     [<Test>]
     member _.ApplyRejectedWhenPromotionSetAlreadySucceeded() =
         let dto = existingPromotionSet PromotionSetStatus.Succeeded StepsComputationStatus.Computed
         let metadata = createMetadata "corr-apply-succeeded"
 
-        match PromotionSet.validateCommandForState [] dto PromotionSetCommand.Apply metadata with
+        match PromotionSet.validateCommandForState [] dto (PromotionSetCommand.Apply []) metadata with
         | Ok _ -> Assert.Fail("Expected apply validation to fail for succeeded PromotionSet.")
         | Error graceError -> Assert.That(graceError.Error, Is.EqualTo("PromotionSet has already been applied successfully."))
 
@@ -46,7 +70,7 @@ type PromotionSetCommandValidationTests() =
         let dto = existingPromotionSet PromotionSetStatus.Running StepsComputationStatus.Computing
         let metadata = createMetadata "corr-apply-running"
 
-        match PromotionSet.validateCommandForState [] dto PromotionSetCommand.Apply metadata with
+        match PromotionSet.validateCommandForState [] dto (PromotionSetCommand.Apply []) metadata with
         | Ok _ -> Assert.Fail("Expected apply validation to fail for running PromotionSet.")
         | Error graceError -> Assert.That(graceError.Error, Is.EqualTo("PromotionSet is already running."))
 
@@ -83,9 +107,69 @@ type PromotionSetCommandValidationTests() =
                 { Event = PromotionSetEventType.ApplyStarted; Metadata = createMetadata duplicateCorrelationId }
             ]
 
-        match PromotionSet.validateCommandForState existingEvents dto PromotionSetCommand.Apply (createMetadata duplicateCorrelationId) with
+        match PromotionSet.validateCommandForState existingEvents dto (PromotionSetCommand.Apply []) (createMetadata duplicateCorrelationId) with
         | Ok _ -> Assert.Fail("Expected duplicate correlation ID validation to fail.")
         | Error graceError -> Assert.That(graceError.Error, Is.EqualTo("Duplicate correlation ID for PromotionSet command."))
+
+    [<Test>]
+    member _.ApprovalPolicySelectionUsesDeterministicMatchingOrder() =
+        let dto = existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed
+        let laterPolicy = approvalPolicyFor dto (Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")) 1
+        let earlierPolicy = approvalPolicyFor dto (Guid.Parse("11111111-1111-1111-1111-111111111111")) 3
+
+        let nonPromotionPolicy = { approvalPolicyFor dto (Guid.Parse("00000000-0000-0000-0000-000000000001")) 1 with Subject = "webhook" }
+
+        let wrongScopePolicy = { approvalPolicyFor dto (Guid.Parse("00000000-0000-0000-0000-000000000002")) 1 with RepositoryId = Guid.NewGuid() }
+
+        match
+            PromotionSet.selectApprovalPolicy
+                dto
+                [
+                    laterPolicy
+                    wrongScopePolicy
+                    nonPromotionPolicy
+                    earlierPolicy
+                ]
+            with
+        | Option.Some selected -> Assert.That(selected.ApprovalPolicyId, Is.EqualTo(earlierPolicy.ApprovalPolicyId))
+        | Option.None -> Assert.Fail("Expected a matching approval policy.")
+
+    [<Test>]
+    member _.ApprovalRequestMustMatchExactCurrentAttemptIdentity() =
+        let dto = { existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed with StepsComputationAttempt = 4 }
+
+        let policy = approvalPolicyFor dto (Guid.NewGuid()) 2
+        let currentRequest = approvalRequestFor dto policy
+
+        let priorAttemptRequest = { currentRequest with Scope = { currentRequest.Scope with StepsComputationAttempt = Option.Some 3 } }
+
+        let priorPolicyVersionRequest =
+            { currentRequest with
+                ApprovalPolicyVersion = policy.Version - 1
+                Scope = { currentRequest.Scope with ApprovalPolicyVersion = Option.Some(policy.Version - 1) }
+            }
+
+        Assert.That(PromotionSet.requestMatchesCurrentAttempt dto policy currentRequest, Is.True)
+        Assert.That(PromotionSet.requestMatchesCurrentAttempt dto policy priorAttemptRequest, Is.False)
+        Assert.That(PromotionSet.requestMatchesCurrentAttempt dto policy priorPolicyVersionRequest, Is.False)
+
+    [<Test>]
+    member _.GeneratedApprovalRequestIdIncludesCurrentAttemptIdentity() =
+        let dto = { existingPromotionSet PromotionSetStatus.Ready StepsComputationStatus.Computed with StepsComputationAttempt = 4 }
+
+        let policy = approvalPolicyFor dto (Guid.NewGuid()) 1
+        let currentRequest = approvalRequestFor dto policy
+
+        let replayRequest = { currentRequest with ApprovalRequestId = Guid.NewGuid() }
+
+        let nextAttemptRequest = { currentRequest with Scope = { currentRequest.Scope with StepsComputationAttempt = Option.Some 5 } }
+
+        Assert.That(PromotionSet.buildGeneratedApprovalRequestId replayRequest, Is.EqualTo(PromotionSet.buildGeneratedApprovalRequestId currentRequest))
+
+        Assert.That(
+            PromotionSet.buildGeneratedApprovalRequestId nextAttemptRequest,
+            Is.Not.EqualTo(PromotionSet.buildGeneratedApprovalRequestId currentRequest)
+        )
 
     [<Test>]
     member _.UpdateInputPromotionsRejectedAfterSuccess() =

--- a/src/Grace.Server/ApprovalPolicy.Server.fs
+++ b/src/Grace.Server/ApprovalPolicy.Server.fs
@@ -94,11 +94,7 @@ module ApprovalStore =
         eventMetadata
 
     let private canonicalSegment (value: string) =
-        let segment =
-            if isNull value then
-                String.Empty
-            else
-                value
+        let segment = if isNull value then String.Empty else value
 
         $"{segment.Length}:{segment}"
 
@@ -125,23 +121,21 @@ module ApprovalStore =
         Guid(guidBytes)
 
     let buildGeneratedApprovalRequestId (request: ApprovalRequestDto) =
-        let scope =
-            if isNull (box request.Scope) then
-                ApprovalScope.Default
-            else
-                request.Scope
+        let scope = if isNull (box request.Scope) then ApprovalScope.Default else request.Scope
 
-        [| "grace.approval-request.generated.v1"
-           canonicalGuid request.ApprovalPolicyId
-           request.ApprovalPolicyVersion.ToString(CultureInfo.InvariantCulture)
-           request.Subject
-           canonicalGuid scope.OwnerId
-           canonicalGuid scope.OrganizationId
-           canonicalGuid scope.RepositoryId
-           canonicalGuid scope.TargetBranchId
-           canonicalOptionalGuid scope.PromotionSetId
-           canonicalOptionalInt scope.StepsComputationAttempt
-           request.RequiredResponder |]
+        [|
+            "grace.approval-request.generated.v1"
+            canonicalGuid request.ApprovalPolicyId
+            request.ApprovalPolicyVersion.ToString(CultureInfo.InvariantCulture)
+            request.Subject
+            canonicalGuid scope.OwnerId
+            canonicalGuid scope.OrganizationId
+            canonicalGuid scope.RepositoryId
+            canonicalGuid scope.TargetBranchId
+            canonicalOptionalGuid scope.PromotionSetId
+            canonicalOptionalInt scope.StepsComputationAttempt
+            request.RequiredResponder
+        |]
         |> Array.map canonicalSegment
         |> String.concat "|"
         |> createDeterministicGuid
@@ -430,33 +424,36 @@ module ApprovalPolicy =
 
     let private buildPolicy context approvalPolicyId version status (parameters: CreateApprovalPolicyParameters) =
         task {
-            match validateNotificationUrl context parameters with
-            | Error message -> return Error message
-            | Ok notificationUrl ->
-                let scope = { scopeFromPolicyParameters parameters with ApprovalPolicyId = Some approvalPolicyId; ApprovalPolicyVersion = Some version }
+            if String.IsNullOrWhiteSpace parameters.RequiredResponder then
+                return Error "RequiredResponder is required."
+            else
+                match validateNotificationUrl context parameters with
+                | Error message -> return Error message
+                | Ok notificationUrl ->
+                    let scope = { scopeFromPolicyParameters parameters with ApprovalPolicyId = Some approvalPolicyId; ApprovalPolicyVersion = Some version }
 
-                let timeoutSeconds =
-                    if parameters.TimeoutSeconds.HasValue then
-                        Some parameters.TimeoutSeconds.Value
-                    else
-                        None
+                    let timeoutSeconds =
+                        if parameters.TimeoutSeconds.HasValue then
+                            Some parameters.TimeoutSeconds.Value
+                        else
+                            None
 
-                return
-                    Ok
-                        { Grace.Types.Webhooks.ApprovalPolicy.Default with
-                            ApprovalPolicyId = approvalPolicyId
-                            Version = version
-                            Name = parameters.Name
-                            Subject = parameters.Subject
-                            Scope = scope
-                            RequiredResponder = parameters.RequiredResponder
-                            NotificationUrl = notificationUrl
-                            TimeoutSeconds = timeoutSeconds
-                            OnTimeout = parameters.OnTimeout
-                            Status = status
-                            CreatedBy = currentUserId context
-                            CreatedAt = getCurrentInstant ()
-                        }
+                    return
+                        Ok
+                            { Grace.Types.Webhooks.ApprovalPolicy.Default with
+                                ApprovalPolicyId = approvalPolicyId
+                                Version = version
+                                Name = parameters.Name
+                                Subject = parameters.Subject
+                                Scope = scope
+                                RequiredResponder = parameters.RequiredResponder.Trim()
+                                NotificationUrl = notificationUrl
+                                TimeoutSeconds = timeoutSeconds
+                                OnTimeout = parameters.OnTimeout
+                                Status = status
+                                CreatedBy = currentUserId context
+                                CreatedAt = getCurrentInstant ()
+                            }
         }
 
     let private policyIdFromContext<'T when 'T :> ApprovalPolicyParameters> (context: HttpContext) =

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -76,9 +76,9 @@
 		<Compile Include="Repository.Server.fs" />
 		<Compile Include="Branch.Server.fs" />
                 
-                <Compile Include="PromotionSet.Server.fs" />
                 <Compile Include="ApprovalPolicy.Server.fs" />
                 <Compile Include="ApprovalRequest.Server.fs" />
+                <Compile Include="PromotionSet.Server.fs" />
                 <Compile Include="Webhook.Server.fs" />
                 <Compile Include="WebhookDispatch.Server.fs" />
                 <Compile Include="WorkItem.Server.fs" />

--- a/src/Grace.Server/PromotionSet.Server.fs
+++ b/src/Grace.Server/PromotionSet.Server.fs
@@ -11,6 +11,7 @@ open Grace.Shared.Validation.Errors
 open Grace.Shared.Validation.Utilities
 open Grace.Types.PromotionSet
 open Grace.Types.Types
+open Grace.Types.Webhooks
 open Grace.Shared.Utilities
 open Microsoft.AspNetCore.Http
 open System
@@ -50,6 +51,126 @@ module PromotionSet =
                     Some "PromotionPointer.DirectoryVersionId must be a non-empty Guid."
                 else
                     Option.None)
+
+    let private approvalSubject = "promotion"
+
+    let private approvalScopeFromPromotionSet (promotionSet: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        { ApprovalScope.Default with
+            OwnerId = promotionSet.OwnerId
+            OrganizationId = promotionSet.OrganizationId
+            RepositoryId = promotionSet.RepositoryId
+            TargetBranchId = promotionSet.TargetBranchId
+            PromotionSetId = Some promotionSet.PromotionSetId
+            StepsComputationAttempt = Some promotionSet.StepsComputationAttempt
+            ApprovalPolicyId = Some policy.ApprovalPolicyId
+            ApprovalPolicyVersion = Some policy.Version
+        }
+
+    let private policySnapshot (policy: ApprovalPolicy) : PromotionSetApprovalPolicySnapshot =
+        { PromotionSetApprovalPolicySnapshot.Default with
+            ApprovalPolicyId = policy.ApprovalPolicyId
+            Version = policy.Version
+            Subject = policy.Subject
+            OwnerId = policy.Scope.OwnerId
+            OrganizationId = policy.Scope.OrganizationId
+            RepositoryId = policy.Scope.RepositoryId
+            TargetBranchId = policy.Scope.TargetBranchId
+            RequiredResponder = policy.RequiredResponder
+            TimeoutSeconds = policy.TimeoutSeconds
+        }
+
+    let private matchingApprovalPolicies ownerId organizationId repositoryId targetBranchId : PromotionSetApprovalPolicySnapshot list =
+        let scope =
+            { ApprovalScope.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; TargetBranchId = targetBranchId }
+
+        ApprovalStore.listPolicies scope false
+        |> Seq.filter (fun (policy: ApprovalPolicy) -> policy.Status = ApprovalPolicyStatus.Enabled)
+        |> Seq.filter (fun (policy: ApprovalPolicy) -> String.Equals(policy.Subject, approvalSubject, StringComparison.OrdinalIgnoreCase))
+        |> Seq.map policySnapshot
+        |> Seq.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
+        |> Seq.toList
+
+    let private approvalSummaryFromRequest
+        (promotionSet: PromotionSetDto)
+        (policy: PromotionSetApprovalPolicySnapshot)
+        (request: ApprovalRequest option)
+        : PromotionSetApprovalSummary
+        =
+        let baseSummary = PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt
+
+        let policySummary state reason =
+            { baseSummary with
+                State = state
+                ApprovalPolicyId = Some policy.ApprovalPolicyId
+                ApprovalRequestId =
+                    request
+                    |> Option.map (fun approvalRequest -> approvalRequest.ApprovalRequestId)
+                RequiredResponder = Some policy.RequiredResponder
+                LastDecisionAt =
+                    request
+                    |> Option.bind (fun approvalRequest ->
+                        approvalRequest.Decision
+                        |> Option.map (fun decision -> decision.DecidedAt))
+                Reason = reason
+            }
+
+        let now = getCurrentInstant ()
+
+        match request with
+        | Option.None -> policySummary PromotionSetApprovalState.Pending (Option.Some "Approval is required before apply can continue.")
+        | Option.Some approvalRequest when
+            approvalRequest.ExpiresAt
+            |> Option.exists (fun expiresAt -> expiresAt <= now)
+            ->
+            policySummary PromotionSetApprovalState.Stale (Some "Approval request is expired.")
+        | Option.Some approvalRequest ->
+            match approvalRequest.Status with
+            | ApprovalRequestStatus.Pending -> policySummary PromotionSetApprovalState.Pending (Some "Approval is required before apply can continue.")
+            | ApprovalRequestStatus.Approved -> policySummary PromotionSetApprovalState.Approved Option.None
+            | ApprovalRequestStatus.Rejected -> policySummary PromotionSetApprovalState.Rejected (Some "Approval request was rejected.")
+            | ApprovalRequestStatus.Expired -> policySummary PromotionSetApprovalState.Expired (Some "Approval request is expired.")
+            | ApprovalRequestStatus.Cancelled -> policySummary PromotionSetApprovalState.Stale (Some "Approval request was cancelled.")
+            | ApprovalRequestStatus.Superseded -> policySummary PromotionSetApprovalState.Stale (Some "Approval request was superseded.")
+
+    let private deriveApprovalSummary (promotionSet: PromotionSetDto) correlationId =
+        task {
+            let matchingPolicies =
+                matchingApprovalPolicies promotionSet.OwnerId promotionSet.OrganizationId promotionSet.RepositoryId promotionSet.TargetBranchId
+
+            match matchingPolicies with
+            | [] -> return PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt
+            | policy :: _ ->
+                let scope = approvalScopeFromPromotionSet promotionSet policy
+
+                let requestTemplate =
+                    { ApprovalRequest.Default with
+                        ApprovalPolicyId = policy.ApprovalPolicyId
+                        ApprovalPolicyVersion = policy.Version
+                        Subject = approvalSubject
+                        Scope = scope
+                        RequiredResponder = policy.RequiredResponder
+                    }
+
+                let approvalRequestId = ApprovalStore.buildGeneratedApprovalRequestId requestTemplate
+                let! request = ApprovalStore.tryGetRequestAsync approvalRequestId scope correlationId
+
+                match request with
+                | Option.Some approvalRequest when
+                    approvalRequest.ApprovalPolicyId = policy.ApprovalPolicyId
+                    && approvalRequest.ApprovalPolicyVersion = policy.Version
+                    && approvalRequest.Subject = approvalSubject
+                    && approvalRequest.RequiredResponder = policy.RequiredResponder
+                    && approvalRequest.Scope = scope
+                    ->
+                    return approvalSummaryFromRequest promotionSet policy (Option.Some approvalRequest)
+                | Option.Some approvalRequest ->
+                    return
+                        { approvalSummaryFromRequest promotionSet policy (Option.Some approvalRequest) with
+                            State = PromotionSetApprovalState.Stale
+                            Reason = Option.Some "Approval request is not valid for the current apply attempt."
+                        }
+                | Option.None -> return approvalSummaryFromRequest promotionSet policy Option.None
+        }
 
     let private processCommand<'T when 'T :> PromotionSetParameters>
         (context: HttpContext)
@@ -105,6 +226,7 @@ module PromotionSet =
             let correlationId = getCorrelationId context
             let actorProxy = PromotionSet.CreateActorProxy promotionSetId graceIds.RepositoryId correlationId
             let! promotionSet = actorProxy.Get correlationId
+            let! approvalSummary = deriveApprovalSummary promotionSet correlationId
 
             let graceReturnValue =
                 (GraceReturnValue.Create promotionSet correlationId)
@@ -113,6 +235,7 @@ module PromotionSet =
                     .enhance(nameof OrganizationId, graceIds.OrganizationId)
                     .enhance(nameof RepositoryId, graceIds.RepositoryId)
                     .enhance(nameof PromotionSetId, promotionSetId)
+                    .enhance("ApprovalSummary", approvalSummary)
                     .enhance ("Path", context.Request.Path.Value)
 
             return! context |> result200Ok graceReturnValue
@@ -304,7 +427,17 @@ module PromotionSet =
                     |]
 
                 let promotionSetId = Guid.Parse(parameters.PromotionSetId)
-                let command = PromotionSetCommand.Apply
+                let correlationId = getCorrelationId context
+                let actorProxy = PromotionSet.CreateActorProxy promotionSetId graceIds.RepositoryId correlationId
+                let! promotionSet = actorProxy.Get correlationId
+
+                let approvalPolicies =
+                    if promotionSet.PromotionSetId = PromotionSetId.Empty then
+                        []
+                    else
+                        matchingApprovalPolicies graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId promotionSet.TargetBranchId
+
+                let command = PromotionSetCommand.Apply approvalPolicies
                 return! processCommand context parameters validations promotionSetId command
             }
 
@@ -342,7 +475,13 @@ module PromotionSet =
                 else
                     let mutable stepId = Guid.Empty
 
-                    if not (Guid.TryParse(parameters.StepId, &stepId) && stepId <> Guid.Empty) then
+                    if
+                        not
+                            (
+                                Guid.TryParse(parameters.StepId, &stepId)
+                                && stepId <> Guid.Empty
+                            )
+                    then
                         return!
                             context
                             |> result400BadRequest (

--- a/src/Grace.Server/PromotionSet.Server.fs
+++ b/src/Grace.Server/PromotionSet.Server.fs
@@ -138,14 +138,31 @@ module PromotionSet =
             | ApprovalRequestStatus.Cancelled -> policySummary PromotionSetApprovalState.Stale (Some "Approval request was cancelled.")
             | ApprovalRequestStatus.Superseded -> policySummary PromotionSetApprovalState.Stale (Some "Approval request was superseded.")
 
-    let private deriveApprovalSummary (promotionSet: PromotionSetDto) correlationId =
+    let private multiplePoliciesApprovalSummary (promotionSet: PromotionSetDto) =
+        { (PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt) with
+            State = PromotionSetApprovalState.Stale
+            Reason = Some "Multiple enabled approval policies match promotion apply scope; apply requires exactly one."
+        }
+
+    let private invalidPolicyApprovalSummary (promotionSet: PromotionSetDto) (policy: PromotionSetApprovalPolicySnapshot) =
+        { (PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt) with
+            State = PromotionSetApprovalState.Stale
+            ApprovalPolicyId = Some policy.ApprovalPolicyId
+            RequiredResponder = Some policy.RequiredResponder
+            Reason = Some "Approval policy is invalid for apply because RequiredResponder is blank or policy identity is invalid."
+        }
+
+    let internal deriveApprovalSummary (promotionSet: PromotionSetDto) correlationId =
         task {
             let matchingPolicies =
                 matchingApprovalPolicies promotionSet.OwnerId promotionSet.OrganizationId promotionSet.RepositoryId promotionSet.TargetBranchId
 
-            match matchingPolicies with
-            | [] -> return PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt
-            | policy :: _ ->
+            match Grace.Actors.PromotionSet.selectApprovalPolicyOrInvalid promotionSet matchingPolicies with
+            | Error (Grace.Actors.PromotionSet.InvalidMatchingApprovalPolicy policy) -> return invalidPolicyApprovalSummary promotionSet policy
+            | Error (Grace.Actors.PromotionSet.MultipleMatchingApprovalPolicies _) -> return multiplePoliciesApprovalSummary promotionSet
+            | Ok Option.None ->
+                return PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId promotionSet.TargetBranchId promotionSet.StepsComputationAttempt
+            | Ok (Option.Some policy) ->
                 let scope = approvalScopeFromPromotionSet promotionSet policy
 
                 let requestTemplate =

--- a/src/Grace.Server/PromotionSet.Server.fs
+++ b/src/Grace.Server/PromotionSet.Server.fs
@@ -90,6 +90,12 @@ module PromotionSet =
         |> Seq.sortBy (fun policy -> policy.ApprovalPolicyId, policy.Version)
         |> Seq.toList
 
+    type ApprovalPolicySnapshotResolver() =
+        interface Grace.Actors.IApprovalPolicySnapshotResolver with
+            member _.GetCurrentApprovalPoliciesForPromotionApply(ownerId, organizationId, repositoryId, targetBranchId, _correlationId) =
+                matchingApprovalPolicies ownerId organizationId repositoryId targetBranchId
+                |> Task.FromResult
+
     let private approvalSummaryFromRequest
         (promotionSet: PromotionSetDto)
         (policy: PromotionSetApprovalPolicySnapshot)
@@ -428,16 +434,7 @@ module PromotionSet =
 
                 let promotionSetId = Guid.Parse(parameters.PromotionSetId)
                 let correlationId = getCorrelationId context
-                let actorProxy = PromotionSet.CreateActorProxy promotionSetId graceIds.RepositoryId correlationId
-                let! promotionSet = actorProxy.Get correlationId
-
-                let approvalPolicies =
-                    if promotionSet.PromotionSetId = PromotionSetId.Empty then
-                        []
-                    else
-                        matchingApprovalPolicies graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId promotionSet.TargetBranchId
-
-                let command = PromotionSetCommand.Apply approvalPolicies
+                let command = PromotionSetCommand.Apply []
                 return! processCommand context parameters validations promotionSetId command
             }
 

--- a/src/Grace.Server/PromotionSet.Server.fs
+++ b/src/Grace.Server/PromotionSet.Server.fs
@@ -96,7 +96,7 @@ module PromotionSet =
                 matchingApprovalPolicies ownerId organizationId repositoryId targetBranchId
                 |> Task.FromResult
 
-    let private approvalSummaryFromRequest
+    let internal approvalSummaryFromRequest
         (promotionSet: PromotionSetDto)
         (policy: PromotionSetApprovalPolicySnapshot)
         (request: ApprovalRequest option)
@@ -124,13 +124,14 @@ module PromotionSet =
 
         match request with
         | Option.None -> policySummary PromotionSetApprovalState.Pending (Option.Some "Approval is required before apply can continue.")
-        | Option.Some approvalRequest when
-            approvalRequest.ExpiresAt
-            |> Option.exists (fun expiresAt -> expiresAt <= now)
-            ->
-            policySummary PromotionSetApprovalState.Stale (Some "Approval request is expired.")
         | Option.Some approvalRequest ->
             match approvalRequest.Status with
+            | ApprovalRequestStatus.Pending
+            | ApprovalRequestStatus.Approved when
+                approvalRequest.ExpiresAt
+                |> Option.exists (fun expiresAt -> expiresAt <= now)
+                ->
+                policySummary PromotionSetApprovalState.Stale (Some "Approval request is expired.")
             | ApprovalRequestStatus.Pending -> policySummary PromotionSetApprovalState.Pending (Some "Approval is required before apply can continue.")
             | ApprovalRequestStatus.Approved -> policySummary PromotionSetApprovalState.Approved Option.None
             | ApprovalRequestStatus.Rejected -> policySummary PromotionSetApprovalState.Rejected (Some "Approval request was rejected.")

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1860,6 +1860,7 @@ module Application =
                     Json.Serializer(Constants.JsonSerializerOptions)
                 )
                 .AddSingleton<IPartitionKeyProvider, GracePartitionKeyProvider>()
+                .AddSingleton<IApprovalPolicySnapshotResolver, PromotionSet.ApprovalPolicySnapshotResolver>()
                 .AddRouting()
                 .AddLogging()
                 .AddHostedService<ReminderService>()

--- a/src/Grace.Types/PromotionSet.Types.fs
+++ b/src/Grace.Types/PromotionSet.Types.fs
@@ -74,6 +74,33 @@ module PromotionSet =
     [<GenerateSerializer>]
     type PromotionPointer = { BranchId: BranchId; ReferenceId: ReferenceId; DirectoryVersionId: DirectoryVersionId }
 
+    [<CLIMutable; GenerateSerializer>]
+    type PromotionSetApprovalPolicySnapshot =
+        {
+            ApprovalPolicyId: Guid
+            Version: int
+            Subject: string
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            TargetBranchId: BranchId
+            RequiredResponder: string
+            TimeoutSeconds: int option
+        }
+
+        static member Default =
+            {
+                ApprovalPolicyId = Guid.Empty
+                Version = 1
+                Subject = String.Empty
+                OwnerId = OwnerId.Empty
+                OrganizationId = OrganizationId.Empty
+                RepositoryId = RepositoryId.Empty
+                TargetBranchId = BranchId.Empty
+                RequiredResponder = String.Empty
+                TimeoutSeconds = Option.None
+            }
+
     [<GenerateSerializer>]
     type PromotionSetStep =
         {
@@ -146,7 +173,7 @@ module PromotionSet =
         | UpdateInputPromotions of promotionPointers: PromotionPointer list
         | RecomputeStepsIfStale of reason: string option
         | ResolveConflicts of stepId: PromotionSetStepId * resolutions: ConflictResolutionDecision list
-        | Apply
+        | Apply of approvalPolicies: PromotionSetApprovalPolicySnapshot list
         | DeleteLogical of force: bool * deleteReason: DeleteReason
 
         static member GetKnownTypes() = GetKnownTypes<PromotionSetCommand>()


### PR DESCRIPTION
## Summary

- Gates promotion-set apply on matching approval policy/request state before `ApplyStarted`.
- Resolves enabled matching approval policies on the server and passes approval-policy snapshots into `PromotionSetCommand.Apply`.
- Creates or reuses deterministic generated approval requests for the exact current apply attempt when approval is required.
- Allows apply only when the durable approval request matches the exact current attempt and is approved/not expired.
- Blocks pending, rejected, expired, cancelled, superseded, mismatched, or stale approval requests without adding `PromotionSetStatus.PendingApproval`.
- Exposes a derived `ApprovalSummary` on promotion-set get/show responses via `GraceReturnValue.Properties`.

Closes #148.

## Validation

Worker validation:

- `dotnet build src\Grace.slnx --configuration Release`: passed.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~PromotionSetCommandValidationTests"`: passed, 9/9.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~ApprovalApiIntegrationTests"`: passed, 13/13.
- `dotnet tool run fantomas Grace.Actors\PromotionSet.Actor.fs Grace.Server\PromotionSet.Server.fs Grace.Types\PromotionSet.Types.fs Grace.Server.Tests\PromotionSet.CommandValidation.Tests.fs` from `src`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Format step skipped by the script as currently disabled.
  - Build passed.
  - `Grace.Authorization.Tests`: 23/23 passed.
  - `Grace.CLI.Tests`: 222 passed, 1 skipped.
  - `Grace.Types.Tests`: 62/62 passed.

## Review Status

Implementation and review fixes are complete through `ba4628a3c6775cb2670ce0b8ecb6b1b4a6f44f5d`:

- Original implementation: `e2f1710256175a97a99deaec7c6b92ab17567c8e Gate promotion apply on approvals`.
- First latest-main rebase: `e20f3695d20b6c842b4fef2108d5ab2e3e2f87e3`.
- Review pass 1 fixes: `de56eda0a9c61b9142086710a6412fc55a330a69`.
- Post-fix rebase: `ad7197beed9c9a8eae35744c1e880c9588c080b7`.
- Review pass 2 fixes: `b9b74058ae7338b47edd1d0bafcd8d5bd97f43ed`.
- Review pass 3 fix: `ba4628a3c6775cb2670ce0b8ecb6b1b4a6f44f5d`.

Review pass 1 found two issues, both fixed:

- High: blank approval-policy responder could bypass the apply gate.
- Medium: actor applied a server-captured policy snapshot that could become stale before `ApplyStarted`.

Review pass 2 found two issues, both fixed:

- High: missing resolver could fail open by falling back to an empty caller-provided policy list.
- Medium: public approval summary derivation was not aligned with the actor gate's invalid/multiple-policy selection semantics.

Review pass 3 found one issue, now fixed:

- P2: public approval summary reported explicitly expired durable requests as `Stale`, while the apply gate maps `ApprovalRequestStatus.Expired` to `Expired`.

Review pass 4 found no issues. The full clean review output is posted on the PR and includes `Reviewed And OK` coverage for the pass 1, pass 2, and pass 3 fixes.

Detailed review output: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608107572
First rebase evidence: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608143440
Pass 1 fix evidence: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608222228
Post-fix rebase evidence: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608265896
Pass 2 review output: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608311687
Pass 2 fix evidence: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608424281
Pass 3 review output: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608457523
Pass 3 fix evidence: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608540680
Pass 4 clean review output: https://github.com/ScottArbeit/Grace/pull/159#issuecomment-4608587874

CI full check passed on `ba4628a3c6775cb2670ce0b8ecb6b1b4a6f44f5d`.
## Residual Risks From Worker

- Focused tests cover approval-gate identity invariants and the existing approval API integration suite, but there is not yet a full end-to-end promotion-set apply integration test that drives a real computed promotion set through apply. The worker noted that path requires broader promotion/reference setup than the existing focused promotion-set test surface.
- Promotion-set list coverage is limited because this branch does not appear to expose a promotion-set list endpoint; the derived summary is wired into the get/show-style server response.
- SDK changes were not needed because the summary is carried through `GraceReturnValue.Properties`; CLI rendering remains untouched for #151.