### PR TITLE
[Webhooks/Approvals] Add CLI webhook and approval UX

### DIFF
--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -242,6 +242,9 @@ module PromotionSet =
                 |> Option.bind (fun approvalRequest ->
                     approvalRequest.Decision
                     |> Option.map (fun decision -> decision.DecidedAt))
+            ExpiresAt =
+                request
+                |> Option.bind (fun approvalRequest -> approvalRequest.ExpiresAt)
             Reason = reason
         }
 

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="WorkItem.CLI.Tests.fs" />
     <Compile Include="Review.CLI.Tests.fs" />
     <Compile Include="Queue.CLI.Tests.fs" />
+    <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -432,6 +432,8 @@ module RootHelpGroupingTests =
             reviewAndPromotion |> should contain "candidate"
             reviewAndPromotion |> should contain "queue"
             reviewAndPromotion |> should contain "agent"
+            reviewAndPromotion |> should contain "approval"
+            reviewAndPromotion |> should contain "webhook"
 
             reviewAndPromotion
             |> should contain "promotion-set")

--- a/src/Grace.CLI.Tests/WebhookApproval.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/WebhookApproval.CLI.Tests.fs
@@ -1,0 +1,436 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.Shared
+open Grace.Types.PromotionSet
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open NodaTime
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+
+[<NonParallelizable>]
+module WebhookApprovalCommandTests =
+    let private ownerId = Guid.NewGuid()
+    let private organizationId = Guid.NewGuid()
+    let private repositoryId = Guid.NewGuid()
+    let private branchId = Guid.NewGuid()
+
+    let private withIds (args: string array) =
+        Array.append
+            args
+            [|
+                "--owner-id"
+                ownerId.ToString()
+                "--organization-id"
+                organizationId.ToString()
+                "--repository-id"
+                repositoryId.ToString()
+            |]
+
+    let private assertParses (args: string array) =
+        let parseResult = GraceCommand.rootCommand.Parse(withIds args)
+        parseResult.Errors |> should be Empty
+
+    let private assertDoesNotParse (args: string array) =
+        let parseResult = GraceCommand.rootCommand.Parse(args)
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
+
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private captureOutput (action: unit -> unit) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+            action ()
+            writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    [<TestCase("create")>]
+    [<TestCase("list")>]
+    [<TestCase("show")>]
+    [<TestCase("update")>]
+    [<TestCase("enable")>]
+    [<TestCase("disable")>]
+    [<TestCase("delete")>]
+    [<TestCase("test")>]
+    [<TestCase("deliveries")>]
+    let ``webhook command parses required verbs`` verb =
+        let webhookId = Guid.NewGuid().ToString()
+
+        let args =
+            match verb with
+            | "create" ->
+                [|
+                    "webhook"
+                    "create"
+                    "--name"
+                    "apply"
+                    "--event"
+                    "promotion-set.applied"
+                    "--url"
+                    "https://example.test/webhook"
+                |]
+            | "list" -> [| "webhook"; "list" |]
+            | "show" ->
+                [|
+                    "webhook"
+                    "show"
+                    "--webhook"
+                    webhookId
+                |]
+            | "update" ->
+                [|
+                    "webhook"
+                    "update"
+                    "--webhook"
+                    webhookId
+                    "--event"
+                    "promotion-set.applied"
+                |]
+            | "test" ->
+                [|
+                    "webhook"
+                    "test"
+                    "--webhook"
+                    webhookId
+                |]
+            | "deliveries" ->
+                [|
+                    "webhook"
+                    "deliveries"
+                    "--webhook"
+                    webhookId
+                |]
+            | other ->
+                [|
+                    "webhook"
+                    other
+                    "--webhook"
+                    webhookId
+                |]
+
+        assertParses args
+
+    [<Test>]
+    let ``webhook delivery show parses`` () =
+        assertParses [| "webhook"
+                        "delivery"
+                        "show"
+                        "--delivery"
+                        Guid.NewGuid().ToString() |]
+
+    [<TestCase("create")>]
+    [<TestCase("list")>]
+    [<TestCase("show")>]
+    [<TestCase("update")>]
+    [<TestCase("enable")>]
+    [<TestCase("disable")>]
+    [<TestCase("delete")>]
+    [<TestCase("evaluate")>]
+    let ``approval policy command parses required verbs`` verb =
+        let policyId = Guid.NewGuid().ToString()
+
+        let args =
+            match verb with
+            | "create" ->
+                [|
+                    "approval"
+                    "policy"
+                    "create"
+                    "--name"
+                    "release"
+                    "--subject"
+                    Guid.NewGuid().ToString()
+                    "--required-responder"
+                    "maintainer"
+                |]
+            | "list" -> [| "approval"; "policy"; "list" |]
+            | "show" ->
+                [|
+                    "approval"
+                    "policy"
+                    "show"
+                    "--policy"
+                    policyId
+                |]
+            | "update" ->
+                [|
+                    "approval"
+                    "policy"
+                    "update"
+                    "--policy"
+                    policyId
+                    "--name"
+                    "release"
+                    "--subject"
+                    Guid.NewGuid().ToString()
+                    "--required-responder"
+                    "maintainer"
+                |]
+            | "evaluate" ->
+                [|
+                    "approval"
+                    "policy"
+                    "evaluate"
+                    "--subject"
+                    Guid.NewGuid().ToString()
+                |]
+            | other ->
+                [|
+                    "approval"
+                    "policy"
+                    other
+                    "--policy"
+                    policyId
+                |]
+
+        assertParses args
+
+    [<TestCase("list")>]
+    [<TestCase("show")>]
+    [<TestCase("approve")>]
+    [<TestCase("reject")>]
+    [<TestCase("wait")>]
+    [<TestCase("history")>]
+    let ``approval request command parses required verbs`` verb =
+        let requestId = Guid.NewGuid().ToString()
+
+        let args =
+            match verb with
+            | "list" -> [| "approval"; "request"; "list" |]
+            | "reject" ->
+                [|
+                    "approval"
+                    "request"
+                    "reject"
+                    "--request"
+                    requestId
+                    "--reason"
+                    "needs more review"
+                |]
+            | other ->
+                [|
+                    "approval"
+                    "request"
+                    other
+                    "--request"
+                    requestId
+                |]
+
+        assertParses args
+
+    [<Test>]
+    let ``promotion set approval commands parse`` () =
+        let promotionSetId = Guid.NewGuid().ToString()
+
+        assertParses [| "promotion-set"
+                        "show"
+                        "--promotion-set"
+                        promotionSetId |]
+
+        assertParses [| "promotion-set"
+                        "list"
+                        "--branch"
+                        branchId.ToString() |]
+
+        assertParses [| "promotion-set"
+                        "request-approval"
+                        "--promotion-set"
+                        promotionSetId |]
+
+    [<Test>]
+    let ``forbidden webhook and approval nouns do not parse`` () =
+        assertDoesNotParse [| "hook"; "list" |]
+
+        assertDoesNotParse [| "subscription"
+                              "list" |]
+
+        assertDoesNotParse [| "notification"
+                              "rule"
+                              "list" |]
+
+        assertDoesNotParse [| "approval"
+                              "request"
+                              "create" |]
+
+    [<Test>]
+    let ``webhook create requires event and url`` () =
+        assertDoesNotParse (
+            withIds [| "webhook"
+                       "create"
+                       "--url"
+                       "https://example.test/webhook" |]
+        )
+
+        assertDoesNotParse (
+            withIds [| "webhook"
+                       "create"
+                       "--event"
+                       "promotion-set.applied" |]
+        )
+
+    [<Test>]
+    let ``approval policy create requires name subject and required responder`` () =
+        assertDoesNotParse (
+            withIds [| "approval"
+                       "policy"
+                       "create"
+                       "--subject"
+                       "promotion"
+                       "--required-responder"
+                       "maintainer" |]
+        )
+
+        assertDoesNotParse (
+            withIds [| "approval"
+                       "policy"
+                       "create"
+                       "--name"
+                       "release"
+                       "--required-responder"
+                       "maintainer" |]
+        )
+
+        assertDoesNotParse (
+            withIds [| "approval"
+                       "policy"
+                       "create"
+                       "--name"
+                       "release"
+                       "--subject"
+                       "promotion" |]
+        )
+
+    [<Test>]
+    let ``pending approval output includes request policy status expiration and next command`` () =
+        let requestId = Guid.NewGuid()
+        let policyId = Guid.NewGuid()
+
+        let summary =
+            {
+                Class = nameof PromotionSetApprovalSummary
+                PromotionSetId = Guid.NewGuid()
+                TargetBranchId = branchId
+                StepsComputationAttempt = 3
+                State = PromotionSetApprovalState.Pending
+                ApprovalRequestId = Some requestId
+                ApprovalPolicyId = Some policyId
+                RequiredResponder = Some "maintainer"
+                LastDecisionAt = Some(Instant.FromUtc(2026, 6, 3, 10, 0))
+                Reason = Some "Approval is required before apply can continue."
+            }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "promotion-set"
+                           "apply"
+                           "--promotion-set"
+                           summary.PromotionSetId.ToString() |]
+            )
+
+        let output = captureOutput (fun () -> ApprovalCommand.renderPendingApproval parseResult summary)
+
+        output |> should contain (requestId.ToString())
+        output |> should contain (policyId.ToString())
+        output |> should contain "Pending"
+        output |> should contain "LastDecisionAt"
+
+        output
+        |> should contain "grace approval request approve --request"
+
+    [<Test>]
+    let ``promotion set list output includes compact approval summary`` () =
+        let promotionSet =
+            { PromotionSetDto.Default with
+                PromotionSetId = Guid.NewGuid()
+                TargetBranchId = branchId
+                Status = PromotionSetStatus.Blocked
+                StepsComputationAttempt = 2
+            }
+
+        let summary =
+            { PromotionSetApprovalSummary.NotRequired promotionSet.PromotionSetId branchId 2 with
+                State = PromotionSetApprovalState.Pending
+                ApprovalRequestId = Some(Guid.NewGuid())
+                ApprovalPolicyId = Some(Guid.NewGuid())
+            }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "promotion-set"
+                           "list"
+                           "--branch"
+                           branchId.ToString() |]
+            )
+
+        let output = captureOutput (fun () -> PromotionSetCommand.renderPromotionSetList parseResult [ promotionSet, Some summary ])
+
+        output
+        |> should
+            contain
+            (promotionSet
+                .PromotionSetId
+                .ToString()
+                .Substring(0, 12))
+
+        output |> should contain "Pending"
+
+        output
+        |> should
+            contain
+            (summary
+                .ApprovalRequestId
+                .Value
+                .ToString()
+                .Substring(0, 12))
+
+    [<Test>]
+    let ``webhook delivery output includes delivery identity retry status and redacted failure`` () =
+        let delivery =
+            { WebhookDelivery.Default with
+                WebhookDeliveryId = Guid.NewGuid()
+                WebhookRuleId = Guid.NewGuid()
+                EventName = "promotion-set.applied"
+                EventVersion = 1
+                AttemptCount = 2
+                Status = WebhookDeliveryStatus.RetryScheduled
+                NextAttemptAt = Some(Instant.FromUtc(2026, 6, 3, 10, 15))
+                LastError = Some "[redacted] HTTP 500"
+            }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "webhook"
+                           "delivery"
+                           "show"
+                           "--delivery"
+                           delivery.WebhookDeliveryId.ToString() |]
+            )
+
+        let output = captureOutput (fun () -> WebhookCommand.renderWebhookDelivery parseResult delivery)
+
+        output
+        |> should contain (delivery.WebhookDeliveryId.ToString())
+
+        output
+        |> should contain (delivery.WebhookRuleId.ToString())
+
+        output |> should contain "promotion-set.applied"
+        output |> should contain "2"
+        output |> should contain "RetryScheduled"
+        output |> should contain "[redacted] HTTP 500"

--- a/src/Grace.CLI.Tests/WebhookApproval.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/WebhookApproval.CLI.Tests.fs
@@ -4,6 +4,8 @@ open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Queue
 open Grace.Types.PromotionSet
 open Grace.Types.Types
 open Grace.Types.Webhooks
@@ -12,6 +14,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Threading.Tasks
 
 [<NonParallelizable>]
 module WebhookApprovalCommandTests =
@@ -101,6 +104,8 @@ module WebhookApprovalCommandTests =
                     webhookId
                     "--event"
                     "promotion-set.applied"
+                    "--url"
+                    "https://example.test/webhook"
                 |]
             | "test" ->
                 [|
@@ -285,6 +290,17 @@ module WebhookApprovalCommandTests =
         )
 
     [<Test>]
+    let ``webhook update requires url to match server update contract`` () =
+        assertDoesNotParse (
+            withIds [| "webhook"
+                       "update"
+                       "--webhook"
+                       Guid.NewGuid().ToString()
+                       "--event"
+                       "promotion-set.applied" |]
+        )
+
+    [<Test>]
     let ``approval policy create requires name subject and required responder`` () =
         assertDoesNotParse (
             withIds [| "approval"
@@ -320,6 +336,7 @@ module WebhookApprovalCommandTests =
     let ``pending approval output includes request policy status expiration and next command`` () =
         let requestId = Guid.NewGuid()
         let policyId = Guid.NewGuid()
+        let expiresAt = Instant.FromUtc(2026, 6, 3, 11, 0)
 
         let summary =
             {
@@ -332,6 +349,7 @@ module WebhookApprovalCommandTests =
                 ApprovalPolicyId = Some policyId
                 RequiredResponder = Some "maintainer"
                 LastDecisionAt = Some(Instant.FromUtc(2026, 6, 3, 10, 0))
+                ExpiresAt = Some expiresAt
                 Reason = Some "Approval is required before apply can continue."
             }
 
@@ -349,9 +367,170 @@ module WebhookApprovalCommandTests =
         output |> should contain (policyId.ToString())
         output |> should contain "Pending"
         output |> should contain "LastDecisionAt"
+        output |> should contain "ExpiresAt"
+        output |> should contain (expiresAt.ToString())
 
         output
         |> should contain "grace approval request approve --request"
+
+    [<Test>]
+    let ``json output redacts webhook destination and signing secret version`` () =
+        let secretUrl = "https://example.test/webhook?sig=secret-token"
+        let secretVersion = "kv-secret-version"
+
+        let rule =
+            { WebhookRule.Default with
+                WebhookRuleId = Guid.NewGuid()
+                Name = "apply"
+                EventName = "promotion-set.applied"
+                Url = { Url = secretUrl; Safety = OutboundUrlSafety.PublicHttps }
+                SigningSecretVersion = secretVersion
+            }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "webhook"
+                           "show"
+                           "--webhook"
+                           rule.WebhookRuleId.ToString()
+                           "--output"
+                           "Json" |]
+            )
+
+        let output =
+            captureOutput (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create rule "corr"))
+                |> ignore)
+
+        output |> should not' (contain secretUrl)
+        output |> should not' (contain "secret-token")
+        output |> should not' (contain secretVersion)
+        output |> should contain "Safety"
+
+        let listOutput =
+            captureOutput (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create [| rule |] "corr"))
+                |> ignore)
+
+        listOutput |> should not' (contain secretUrl)
+        listOutput |> should not' (contain secretVersion)
+
+    [<Test>]
+    let ``json output redacts approval policy notification url`` () =
+        let secretUrl = "https://example.test/approval?callback=secret-token"
+
+        let policy =
+            { ApprovalPolicy.Default with
+                ApprovalPolicyId = Guid.NewGuid()
+                Name = "release"
+                Subject = "promotion"
+                RequiredResponder = "maintainer"
+                NotificationUrl = Some { Url = secretUrl; Safety = OutboundUrlSafety.PublicHttps }
+            }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "approval"
+                           "policy"
+                           "show"
+                           "--policy"
+                           policy.ApprovalPolicyId.ToString()
+                           "--output"
+                           "Json" |]
+            )
+
+        let output =
+            captureOutput (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create policy "corr"))
+                |> ignore)
+
+        output |> should not' (contain secretUrl)
+        output |> should not' (contain "secret-token")
+        output |> should contain "NotificationUrl"
+
+        let listOutput =
+            captureOutput (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create [| policy |] "corr"))
+                |> ignore)
+
+        listOutput |> should not' (contain secretUrl)
+
+    [<Test>]
+    let ``approval request wait returns error when timeout expires while pending`` () =
+        let requestId = Guid.NewGuid()
+
+        let pending = { ApprovalRequest.Default with ApprovalRequestId = requestId; Status = ApprovalRequestStatus.Pending }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "approval"
+                           "request"
+                           "wait"
+                           "--request"
+                           requestId.ToString()
+                           "--wait-timeout-seconds"
+                           "1"
+                           "--poll-seconds"
+                           "1"
+                           "--output"
+                           "Silent" |]
+            )
+
+        let showRequest (_: Grace.Shared.Parameters.Approval.ShowApprovalRequestParameters) = Task.FromResult(Ok(GraceReturnValue.Create pending "corr"))
+
+        match ApprovalCommand.waitRequestWith showRequest parseResult
+              |> fun task -> task.GetAwaiter().GetResult()
+            with
+        | Error error ->
+            error.Error |> should contain "timed out"
+            error.Error |> should contain "Pending"
+        | Ok _ -> Assert.Fail("Expected approval request wait to fail when the timeout expires while the request is pending.")
+
+    [<Test>]
+    let ``promotion set list fails when a child promotion set fetch fails`` () =
+        let firstPromotionSetId = Guid.NewGuid()
+        let secondPromotionSetId = Guid.NewGuid()
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "promotion-set"
+                           "list"
+                           "--branch"
+                           branchId.ToString()
+                           "--output"
+                           "Silent" |]
+            )
+
+        let queue =
+            { PromotionQueue.Default with
+                TargetBranchId = branchId
+                PromotionSetIds =
+                    [
+                        firstPromotionSetId
+                        secondPromotionSetId
+                    ]
+            }
+
+        let getQueueStatus (_: Grace.Shared.Parameters.Queue.QueueStatusParameters) = Task.FromResult(Ok(GraceReturnValue.Create queue "corr"))
+
+        let getPromotionSet (parameters: Grace.Shared.Parameters.PromotionSet.GetPromotionSetParameters) =
+            if parameters.PromotionSetId = firstPromotionSetId.ToString() then
+                Task.FromResult(
+                    Ok(GraceReturnValue.Create { PromotionSetDto.Default with PromotionSetId = firstPromotionSetId; TargetBranchId = branchId } "corr")
+                )
+            else
+                Task.FromResult(Error(GraceError.Create "stale promotion set id" "corr"))
+
+        match PromotionSetCommand.listPromotionSetsWith getQueueStatus getPromotionSet parseResult
+              |> fun task -> task.GetAwaiter().GetResult()
+            with
+        | Error error ->
+            error.Error
+            |> should contain "promotion set fetch"
+
+            serialize error.Properties
+            |> should contain "stale promotion set id"
+        | Ok _ -> Assert.Fail("Expected promotion-set list to fail when any child promotion set fetch fails.")
 
     [<Test>]
     let ``promotion set list output includes compact approval summary`` () =

--- a/src/Grace.CLI/Command/Approval.CLI.fs
+++ b/src/Grace.CLI/Command/Approval.CLI.fs
@@ -1,0 +1,827 @@
+namespace Grace.CLI.Command
+
+open Grace.CLI.Common
+open Grace.CLI.Services
+open Grace.CLI.Text
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Spectre.Console
+open System
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Threading
+open System.Threading.Tasks
+
+module ApprovalCommand =
+    module private Options =
+        let policyId =
+            new Option<string>(
+                "--policy",
+                [|
+                    "--policy-id"
+                    "--approval-policy"
+                    "--approval-policy-id"
+                |],
+                Required = true,
+                Description = "The approval policy ID <Guid>.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let requestId =
+            new Option<string>(
+                "--request",
+                [|
+                    "--request-id"
+                    "--approval-request"
+                    "--approval-request-id"
+                |],
+                Required = true,
+                Description = "The approval request ID <Guid>.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let name = new Option<string>("--name", Required = true, Description = "The approval policy name.", Arity = ArgumentArity.ExactlyOne)
+        let nameOptional = new Option<string>("--name", Required = false, Description = "The approval policy name.", Arity = ArgumentArity.ExactlyOne)
+
+        let subject =
+            new Option<string>(
+                "--subject",
+                [| "--promotion-set" |],
+                Required = true,
+                Description = "The approval subject, such as a promotion set ID.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let requiredResponder =
+            new Option<string>(
+                "--required-responder",
+                [| "--responder"; "--approver" |],
+                Required = true,
+                Description = "Required approval responder selector.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let notificationUrl =
+            new Option<string>("--notification-url", Required = false, Description = "Optional approval notification URL.", Arity = ArgumentArity.ExactlyOne)
+
+        let allowUnsafeLocal =
+            new Option<bool>(
+                "--allow-unsafe-local-development",
+                [|
+                    "--acknowledge-unsafe-local-development"
+                |],
+                Required = false,
+                Description = "Allow unsafe local-development notification URLs.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let timeoutSeconds =
+            new Option<int>(
+                "--timeout-seconds",
+                Required = false,
+                Description = "Optional approval timeout in seconds.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 0)
+            )
+
+        let onTimeout =
+            new Option<ApprovalTimeoutAction>(
+                "--on-timeout",
+                Required = false,
+                Description = "Action when approval times out.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> ApprovalTimeoutAction.Reject)
+            )
+
+        let includeDeleted =
+            new Option<bool>(
+                "--include-deleted",
+                Required = false,
+                Description = "Include deleted approval policies.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let includeTerminal =
+            new Option<bool>(
+                "--include-terminal",
+                Required = false,
+                Description = "Include terminal approval requests.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> true)
+            )
+
+        let reason = new Option<string>("--reason", Required = false, Description = "Decision reason.", Arity = ArgumentArity.ExactlyOne)
+
+        let clientDecisionId =
+            new Option<string>(
+                "--client-decision-id",
+                Required = false,
+                Description = "Idempotency key for the approval decision.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let targetBranchId =
+            new Option<BranchId>(
+                OptionName.BranchId,
+                Required = false,
+                Description = "Optional target branch ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> BranchId.Empty)
+            )
+
+        let waitTimeoutSeconds =
+            new Option<int>(
+                "--wait-timeout-seconds",
+                Required = false,
+                Description = "Maximum time to wait for a terminal request status.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 300)
+            )
+
+        let pollSeconds =
+            new Option<int>(
+                "--poll-seconds",
+                Required = false,
+                Description = "Polling interval while waiting.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 5)
+            )
+
+        let ownerId =
+            new Option<OwnerId>(
+                OptionName.OwnerId,
+                Required = false,
+                Description = "The repository's owner ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> OwnerId.Empty)
+            )
+
+        let ownerName =
+            new Option<string>(
+                OptionName.OwnerName,
+                Required = false,
+                Description = "The repository's owner name. [default: current owner]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let organizationId =
+            new Option<OrganizationId>(
+                OptionName.OrganizationId,
+                Required = false,
+                Description = "The organization's ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> OrganizationId.Empty)
+            )
+
+        let organizationName =
+            new Option<string>(
+                OptionName.OrganizationName,
+                Required = false,
+                Description = "The organization's name. [default: current organization]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let repositoryId =
+            new Option<RepositoryId>(
+                OptionName.RepositoryId,
+                Required = false,
+                Description = "The repository's ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> RepositoryId.Empty)
+            )
+
+        let repositoryName =
+            new Option<string>(
+                OptionName.RepositoryName,
+                Required = false,
+                Description = "The repository's name. [default: current repository]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+    let private targetBranch (parseResult: ParseResult) =
+        let value = parseResult.GetValue(Options.targetBranchId)
+        if value = BranchId.Empty then String.Empty else value.ToString()
+
+    let private urlSafety allowUnsafe =
+        if allowUnsafe then
+            OutboundUrlSafety.LocalUnsafeDevOnly
+        else
+            OutboundUrlSafety.PublicHttps
+
+    let private nullableTimeout seconds = if seconds <= 0 then Nullable<int>() else Nullable<int>(seconds)
+
+    let private addPolicyScope (parameters: #Grace.Shared.Parameters.Approval.ApprovalPolicyParameters) (graceIds: GraceIds) (parseResult: ParseResult) =
+        parameters.OwnerId <- graceIds.OwnerIdString
+        parameters.OwnerName <- graceIds.OwnerName
+        parameters.OrganizationId <- graceIds.OrganizationIdString
+        parameters.OrganizationName <- graceIds.OrganizationName
+        parameters.RepositoryId <- graceIds.RepositoryIdString
+        parameters.RepositoryName <- graceIds.RepositoryName
+        parameters.TargetBranchId <- targetBranch parseResult
+        parameters.CorrelationId <- graceIds.CorrelationId
+        parameters
+
+    let private addRequestScope (parameters: #Grace.Shared.Parameters.Approval.ApprovalRequestParameters) (graceIds: GraceIds) (parseResult: ParseResult) =
+        parameters.OwnerId <- graceIds.OwnerIdString
+        parameters.OwnerName <- graceIds.OwnerName
+        parameters.OrganizationId <- graceIds.OrganizationIdString
+        parameters.OrganizationName <- graceIds.OrganizationName
+        parameters.RepositoryId <- graceIds.RepositoryIdString
+        parameters.RepositoryName <- graceIds.RepositoryName
+        parameters.TargetBranchId <- targetBranch parseResult
+        parameters.CorrelationId <- graceIds.CorrelationId
+        parameters
+
+    let internal approvalCommandText (requestId: ApprovalRequestId) = $"grace approval request approve --request {requestId}"
+
+    let internal renderApprovalSummary (parseResult: ParseResult) (summary: PromotionSetApprovalSummary) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("Field") |> ignore
+            table.AddColumn("Value") |> ignore
+
+            table.AddRow("ApprovalState", Markup.Escape(getDiscriminatedUnionCaseName summary.State))
+            |> ignore
+
+            table.AddRow(
+                "ApprovalRequestId",
+                summary.ApprovalRequestId
+                |> Option.map string
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            table.AddRow(
+                "RequiredPolicy",
+                summary.ApprovalPolicyId
+                |> Option.map string
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            table.AddRow(
+                "RequiredResponder",
+                summary.RequiredResponder
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            table.AddRow(
+                "LastDecisionAt",
+                summary.LastDecisionAt
+                |> Option.map string
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            table.AddRow(
+                "Reason",
+                summary.Reason
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            match summary.ApprovalRequestId with
+            | Some requestId when summary.State = PromotionSetApprovalState.Pending ->
+                table.AddRow("NextCommand", Markup.Escape(approvalCommandText requestId))
+                |> ignore
+            | _ -> ()
+
+            AnsiConsole.Write(table)
+
+    let internal renderPendingApproval (parseResult: ParseResult) (summary: PromotionSetApprovalSummary) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            AnsiConsole.MarkupLine("[yellow]Promotion set apply is waiting for approval.[/]")
+            renderApprovalSummary parseResult summary
+
+    let internal renderApprovalPolicy (parseResult: ParseResult) (policy: ApprovalPolicy) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("Field") |> ignore
+            table.AddColumn("Value") |> ignore
+
+            table.AddRow("ApprovalPolicyId", Markup.Escape(policy.ApprovalPolicyId.ToString()))
+            |> ignore
+
+            table.AddRow("Name", Markup.Escape(policy.Name))
+            |> ignore
+
+            table.AddRow("Subject", Markup.Escape(policy.Subject))
+            |> ignore
+
+            table.AddRow("RequiredResponder", Markup.Escape(policy.RequiredResponder))
+            |> ignore
+
+            table.AddRow("Status", Markup.Escape(getDiscriminatedUnionCaseName policy.Status))
+            |> ignore
+
+            table.AddRow(
+                "TimeoutSeconds",
+                policy.TimeoutSeconds
+                |> Option.map string
+                |> Option.defaultValue "-"
+            )
+            |> ignore
+
+            AnsiConsole.Write(table)
+
+    let internal renderApprovalPolicies (parseResult: ParseResult) (policies: ApprovalPolicy seq) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("ApprovalPolicyId") |> ignore
+            table.AddColumn("Name") |> ignore
+            table.AddColumn("Subject") |> ignore
+            table.AddColumn("Responder") |> ignore
+            table.AddColumn("Status") |> ignore
+
+            policies
+            |> Seq.iter (fun policy ->
+                table.AddRow(
+                    Markup.Escape(policy.ApprovalPolicyId.ToString()),
+                    Markup.Escape(policy.Name),
+                    Markup.Escape(policy.Subject),
+                    Markup.Escape(policy.RequiredResponder),
+                    Markup.Escape(getDiscriminatedUnionCaseName policy.Status)
+                )
+                |> ignore)
+
+            AnsiConsole.Write(table)
+
+    let internal renderApprovalRequest (parseResult: ParseResult) (request: ApprovalRequest) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("Field") |> ignore
+            table.AddColumn("Value") |> ignore
+
+            table.AddRow("ApprovalRequestId", Markup.Escape(request.ApprovalRequestId.ToString()))
+            |> ignore
+
+            table.AddRow("ApprovalPolicyId", Markup.Escape(request.ApprovalPolicyId.ToString()))
+            |> ignore
+
+            table.AddRow("Subject", Markup.Escape(request.Subject))
+            |> ignore
+
+            table.AddRow("RequiredResponder", Markup.Escape(request.RequiredResponder))
+            |> ignore
+
+            table.AddRow("Status", Markup.Escape(getDiscriminatedUnionCaseName request.Status))
+            |> ignore
+
+            table.AddRow(
+                "ExpiresAt",
+                request.ExpiresAt
+                |> Option.map string
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            AnsiConsole.Write(table)
+
+    let internal renderApprovalRequests (parseResult: ParseResult) (requests: ApprovalRequest seq) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("ApprovalRequestId") |> ignore
+            table.AddColumn("Policy") |> ignore
+            table.AddColumn("Subject") |> ignore
+            table.AddColumn("Status") |> ignore
+            table.AddColumn("ExpiresAt") |> ignore
+
+            requests
+            |> Seq.iter (fun request ->
+                table.AddRow(
+                    Markup.Escape(request.ApprovalRequestId.ToString()),
+                    Markup.Escape(request.ApprovalPolicyId.ToString()),
+                    Markup.Escape(request.Subject),
+                    Markup.Escape(getDiscriminatedUnionCaseName request.Status),
+                    request.ExpiresAt
+                    |> Option.map string
+                    |> Option.defaultValue "-"
+                    |> Markup.Escape
+                )
+                |> ignore)
+
+            AnsiConsole.Write(table)
+
+    let private execute action render =
+        task {
+            try
+                let! result = action ()
+
+                match result with
+                | Ok returnValue ->
+                    render returnValue.ReturnValue
+                    return Ok returnValue
+                | Error error -> return Error error
+            with
+            | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" String.Empty)
+        }
+
+    let private createPolicyParameters (parseResult: ParseResult) =
+        let allowUnsafe = parseResult.GetValue(Options.allowUnsafeLocal)
+
+        let parameters = Grace.Shared.Parameters.Approval.CreateApprovalPolicyParameters()
+        parameters.ApprovalPolicyId <- Guid.NewGuid().ToString()
+        parameters.Name <- parseResult.GetValue(Options.name)
+        parameters.Subject <- parseResult.GetValue(Options.subject)
+        parameters.RequiredResponder <- parseResult.GetValue(Options.requiredResponder)
+
+        parameters.NotificationUrl <-
+            parseResult.GetValue(Options.notificationUrl)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.NotificationUrlSafety <- urlSafety allowUnsafe
+        parameters.AcknowledgeUnsafeLocalDevelopment <- allowUnsafe
+        parameters.TimeoutSeconds <- nullableTimeout (parseResult.GetValue(Options.timeoutSeconds))
+        parameters.OnTimeout <- parseResult.GetValue(Options.onTimeout)
+        parameters
+
+    let private updatePolicyParameters (parseResult: ParseResult) =
+        let allowUnsafe = parseResult.GetValue(Options.allowUnsafeLocal)
+
+        let parameters = Grace.Shared.Parameters.Approval.UpdateApprovalPolicyParameters()
+        parameters.ApprovalPolicyId <- parseResult.GetValue(Options.policyId)
+        parameters.Name <- parseResult.GetValue(Options.name)
+        parameters.Subject <- parseResult.GetValue(Options.subject)
+        parameters.RequiredResponder <- parseResult.GetValue(Options.requiredResponder)
+
+        parameters.NotificationUrl <-
+            parseResult.GetValue(Options.notificationUrl)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.NotificationUrlSafety <- urlSafety allowUnsafe
+        parameters.AcknowledgeUnsafeLocalDevelopment <- allowUnsafe
+        parameters.TimeoutSeconds <- nullableTimeout (parseResult.GetValue(Options.timeoutSeconds))
+        parameters.OnTimeout <- parseResult.GetValue(Options.onTimeout)
+        parameters
+
+    let private createPolicyHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = createPolicyParameters parseResult
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalPolicy.Create parameters) (renderApprovalPolicy parseResult)
+
+    let private listPolicyHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Approval.ListApprovalPoliciesParameters(IncludeDeleted = parseResult.GetValue(Options.includeDeleted))
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalPolicy.List parameters) (renderApprovalPolicies parseResult)
+
+    let private showPolicyHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = Grace.Shared.Parameters.Approval.ShowApprovalPolicyParameters(ApprovalPolicyId = parseResult.GetValue(Options.policyId))
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalPolicy.Show parameters) (renderApprovalPolicy parseResult)
+
+    let private updatePolicyHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = updatePolicyParameters parseResult
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalPolicy.Update parameters) (renderApprovalPolicy parseResult)
+
+    let private simplePolicyHandler makeParameters sdkCall parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = makeParameters (parseResult.GetValue(Options.policyId))
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> sdkCall parameters) (renderApprovalPolicy parseResult)
+
+    let private evaluatePolicyHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Approval.EvaluateApprovalPolicyParameters(Subject = parseResult.GetValue(Options.subject))
+
+        addPolicyScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalPolicy.Evaluate parameters) (renderApprovalPolicies parseResult)
+
+    let private listRequestHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Approval.ListApprovalRequestsParameters(IncludeTerminal = parseResult.GetValue(Options.includeTerminal))
+
+        addRequestScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalRequest.List parameters) (renderApprovalRequests parseResult)
+
+    let private showRequestHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = Grace.Shared.Parameters.Approval.ShowApprovalRequestParameters(ApprovalRequestId = parseResult.GetValue(Options.requestId))
+
+        addRequestScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalRequest.Show parameters) (renderApprovalRequest parseResult)
+
+    let private approveRequestHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Approval.ApproveApprovalRequestParameters()
+        parameters.ApprovalRequestId <- parseResult.GetValue(Options.requestId)
+
+        parameters.Reason <-
+            parseResult.GetValue(Options.reason)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.ClientDecisionId <-
+            parseResult.GetValue(Options.clientDecisionId)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        addRequestScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalRequest.Approve parameters) (renderApprovalRequest parseResult)
+
+    let private rejectRequestHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Approval.RejectApprovalRequestParameters()
+        parameters.ApprovalRequestId <- parseResult.GetValue(Options.requestId)
+
+        parameters.Reason <-
+            parseResult.GetValue(Options.reason)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.ClientDecisionId <-
+            parseResult.GetValue(Options.clientDecisionId)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        addRequestScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalRequest.Reject parameters) (renderApprovalRequest parseResult)
+
+    let private historyRequestHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = Grace.Shared.Parameters.Approval.ApprovalRequestHistoryParameters(ApprovalRequestId = parseResult.GetValue(Options.requestId))
+
+        addRequestScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.ApprovalRequest.History parameters) (renderApprovalRequests parseResult)
+
+    let private waitRequestHandler parseResult =
+        task {
+            let graceIds = parseResult |> getNormalizedIdsAndNames
+            let requestId = parseResult.GetValue(Options.requestId)
+            let timeoutSeconds = max 1 (parseResult.GetValue(Options.waitTimeoutSeconds))
+            let pollSeconds = max 1 (parseResult.GetValue(Options.pollSeconds))
+            let deadline = DateTimeOffset.UtcNow.AddSeconds(float timeoutSeconds)
+            let mutable completed = false
+            let mutable lastResult: GraceResult<ApprovalRequest> option = None
+
+            while not completed do
+                let parameters = Grace.Shared.Parameters.Approval.ShowApprovalRequestParameters(ApprovalRequestId = requestId)
+
+                addRequestScope parameters graceIds parseResult
+                |> ignore
+
+                let! result = Grace.SDK.ApprovalRequest.Show parameters
+                lastResult <- Some result
+
+                match result with
+                | Ok returnValue when returnValue.ReturnValue.Status.IsTerminal ->
+                    renderApprovalRequest parseResult returnValue.ReturnValue
+                    completed <- true
+                | Error _ -> completed <- true
+                | _ when DateTimeOffset.UtcNow >= deadline -> completed <- true
+                | _ -> do! Task.Delay(TimeSpan.FromSeconds(float pollSeconds))
+
+            match lastResult with
+            | Some result -> return result
+            | None -> return Error(GraceError.Create "Approval request wait did not fetch a request." graceIds.CorrelationId)
+        }
+
+    type Action<'T>(handler: ParseResult -> Task<GraceResult<'T>>) =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, _: CancellationToken) : Task<int> =
+            task {
+                let! result = handler parseResult
+                return result |> renderOutput parseResult
+            }
+
+    let private action<'T> (handler: ParseResult -> Task<GraceResult<'T>>) = Action<'T>(handler)
+
+    let Build =
+        let addCommonOptions (command: Command) =
+            command
+            |> addOption Options.ownerName
+            |> addOption Options.ownerId
+            |> addOption Options.organizationName
+            |> addOption Options.organizationId
+            |> addOption Options.repositoryName
+            |> addOption Options.repositoryId
+            |> addOption Options.targetBranchId
+
+        let approvalCommand = new Command("approval", Description = "Manage approval policies and approval requests.")
+        let policyCommand = new Command("policy", Description = "Manage approval policies.")
+
+        let createPolicyCommand =
+            new Command("create", Description = "Create an approval policy.")
+            |> addOption Options.name
+            |> addOption Options.subject
+            |> addOption Options.requiredResponder
+            |> addOption Options.notificationUrl
+            |> addOption Options.allowUnsafeLocal
+            |> addOption Options.timeoutSeconds
+            |> addOption Options.onTimeout
+            |> addCommonOptions
+
+        createPolicyCommand.Action <- action createPolicyHandler
+        policyCommand.Subcommands.Add(createPolicyCommand)
+
+        let listPolicyCommand =
+            new Command("list", Description = "List approval policies.")
+            |> addOption Options.includeDeleted
+            |> addCommonOptions
+
+        listPolicyCommand.Action <- action listPolicyHandler
+        policyCommand.Subcommands.Add(listPolicyCommand)
+
+        let showPolicyCommand =
+            new Command("show", Description = "Show an approval policy.")
+            |> addOption Options.policyId
+            |> addCommonOptions
+
+        showPolicyCommand.Action <- action showPolicyHandler
+        policyCommand.Subcommands.Add(showPolicyCommand)
+
+        let updatePolicyCommand =
+            new Command("update", Description = "Update an approval policy.")
+            |> addOption Options.policyId
+            |> addOption Options.name
+            |> addOption Options.subject
+            |> addOption Options.requiredResponder
+            |> addOption Options.notificationUrl
+            |> addOption Options.allowUnsafeLocal
+            |> addOption Options.timeoutSeconds
+            |> addOption Options.onTimeout
+            |> addCommonOptions
+
+        updatePolicyCommand.Action <- action updatePolicyHandler
+        policyCommand.Subcommands.Add(updatePolicyCommand)
+
+        let enablePolicyCommand =
+            new Command("enable", Description = "Enable an approval policy.")
+            |> addOption Options.policyId
+            |> addCommonOptions
+
+        enablePolicyCommand.Action <-
+            action (
+                simplePolicyHandler
+                    (fun id -> Grace.Shared.Parameters.Approval.EnableApprovalPolicyParameters(ApprovalPolicyId = id))
+                    Grace.SDK.ApprovalPolicy.Enable
+            )
+
+        policyCommand.Subcommands.Add(enablePolicyCommand)
+
+        let disablePolicyCommand =
+            new Command("disable", Description = "Disable an approval policy.")
+            |> addOption Options.policyId
+            |> addCommonOptions
+
+        disablePolicyCommand.Action <-
+            action (
+                simplePolicyHandler
+                    (fun id -> Grace.Shared.Parameters.Approval.DisableApprovalPolicyParameters(ApprovalPolicyId = id))
+                    Grace.SDK.ApprovalPolicy.Disable
+            )
+
+        policyCommand.Subcommands.Add(disablePolicyCommand)
+
+        let deletePolicyCommand =
+            new Command("delete", Description = "Delete an approval policy.")
+            |> addOption Options.policyId
+            |> addCommonOptions
+
+        deletePolicyCommand.Action <-
+            action (
+                simplePolicyHandler
+                    (fun id -> Grace.Shared.Parameters.Approval.DeleteApprovalPolicyParameters(ApprovalPolicyId = id))
+                    Grace.SDK.ApprovalPolicy.Delete
+            )
+
+        policyCommand.Subcommands.Add(deletePolicyCommand)
+
+        let evaluatePolicyCommand =
+            new Command("evaluate", Description = "Evaluate approval policies for a subject.")
+            |> addOption Options.subject
+            |> addCommonOptions
+
+        evaluatePolicyCommand.Action <- action evaluatePolicyHandler
+        policyCommand.Subcommands.Add(evaluatePolicyCommand)
+
+        approvalCommand.Subcommands.Add(policyCommand)
+
+        let requestCommand = new Command("request", Description = "Inspect and respond to approval requests.")
+
+        let listRequestCommand =
+            new Command("list", Description = "List approval requests.")
+            |> addOption Options.includeTerminal
+            |> addCommonOptions
+
+        listRequestCommand.Action <- action listRequestHandler
+        requestCommand.Subcommands.Add(listRequestCommand)
+
+        let showRequestCommand =
+            new Command("show", Description = "Show an approval request.")
+            |> addOption Options.requestId
+            |> addCommonOptions
+
+        showRequestCommand.Action <- action showRequestHandler
+        requestCommand.Subcommands.Add(showRequestCommand)
+
+        let approveRequestCommand =
+            new Command("approve", Description = "Approve an approval request.")
+            |> addOption Options.requestId
+            |> addOption Options.reason
+            |> addOption Options.clientDecisionId
+            |> addCommonOptions
+
+        approveRequestCommand.Action <- action approveRequestHandler
+        requestCommand.Subcommands.Add(approveRequestCommand)
+
+        let rejectRequestCommand =
+            new Command("reject", Description = "Reject an approval request.")
+            |> addOption Options.requestId
+            |> addOption Options.reason
+            |> addOption Options.clientDecisionId
+            |> addCommonOptions
+
+        rejectRequestCommand.Action <- action rejectRequestHandler
+        requestCommand.Subcommands.Add(rejectRequestCommand)
+
+        let waitRequestCommand =
+            new Command("wait", Description = "Wait for an approval request to reach a terminal state.")
+            |> addOption Options.requestId
+            |> addOption Options.waitTimeoutSeconds
+            |> addOption Options.pollSeconds
+            |> addCommonOptions
+
+        waitRequestCommand.Action <- action waitRequestHandler
+        requestCommand.Subcommands.Add(waitRequestCommand)
+
+        let historyRequestCommand =
+            new Command("history", Description = "Show approval request history.")
+            |> addOption Options.requestId
+            |> addCommonOptions
+
+        historyRequestCommand.Action <- action historyRequestHandler
+        requestCommand.Subcommands.Add(historyRequestCommand)
+
+        approvalCommand.Subcommands.Add(requestCommand)
+        approvalCommand

--- a/src/Grace.CLI/Command/Approval.CLI.fs
+++ b/src/Grace.CLI/Command/Approval.CLI.fs
@@ -288,6 +288,15 @@ module ApprovalCommand =
             |> ignore
 
             table.AddRow(
+                "ExpiresAt",
+                summary.ExpiresAt
+                |> Option.map string
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            table.AddRow(
                 "Reason",
                 summary.Reason
                 |> Option.defaultValue "-"
@@ -613,7 +622,10 @@ module ApprovalCommand =
 
         execute (fun () -> Grace.SDK.ApprovalRequest.History parameters) (renderApprovalRequests parseResult)
 
-    let private waitRequestHandler parseResult =
+    let internal waitRequestWith
+        (showRequest: Grace.Shared.Parameters.Approval.ShowApprovalRequestParameters -> Task<GraceResult<ApprovalRequest>>)
+        parseResult
+        =
         task {
             let graceIds = parseResult |> getNormalizedIdsAndNames
             let requestId = parseResult.GetValue(Options.requestId)
@@ -629,7 +641,7 @@ module ApprovalCommand =
                 addRequestScope parameters graceIds parseResult
                 |> ignore
 
-                let! result = Grace.SDK.ApprovalRequest.Show parameters
+                let! result = showRequest parameters
                 lastResult <- Some result
 
                 match result with
@@ -641,9 +653,18 @@ module ApprovalCommand =
                 | _ -> do! Task.Delay(TimeSpan.FromSeconds(float pollSeconds))
 
             match lastResult with
+            | Some (Ok returnValue) when not returnValue.ReturnValue.Status.IsTerminal ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"Approval request wait timed out after {timeoutSeconds} seconds while request {requestId} remained {getDiscriminatedUnionCaseName returnValue.ReturnValue.Status}."
+                            graceIds.CorrelationId
+                    )
             | Some result -> return result
             | None -> return Error(GraceError.Create "Approval request wait did not fetch a request." graceIds.CorrelationId)
         }
+
+    let private waitRequestHandler parseResult = waitRequestWith Grace.SDK.ApprovalRequest.Show parseResult
 
     type Action<'T>(handler: ParseResult -> Task<GraceResult<'T>>) =
         inherit AsynchronousCommandLineAction()

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -8,9 +8,11 @@ open Grace.Shared.Validation.Errors
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Resources.Text
 open Grace.Types.Types
+open Grace.Types.Webhooks
 open Grace.Shared.Utilities
 open Spectre.Console
 open System
+open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Parsing
 open System.Globalization
@@ -402,6 +404,45 @@ module Common =
         AnsiConsole.Write(markup)
         AnsiConsole.WriteLine()
 
+    let private redactedValue = "[redacted]"
+
+    let private redactScopedOutboundUrl (url: ScopedOutboundUrl) = { url with Url = redactedValue }
+
+    let private redactWebhookRule (rule: WebhookRule) = { rule with Url = redactScopedOutboundUrl rule.Url; SigningSecretVersion = redactedValue }
+
+    let private redactApprovalPolicy (policy: ApprovalPolicy) =
+        { policy with
+            NotificationUrl =
+                policy.NotificationUrl
+                |> Option.map redactScopedOutboundUrl
+        }
+
+    let private redactJsonReturnValue<'T> (returnValue: 'T) =
+        match box returnValue with
+        | :? WebhookRule as rule -> box (redactWebhookRule rule)
+        | :? (WebhookRule array) as rules -> box (rules |> Array.map redactWebhookRule)
+        | :? (IEnumerable<WebhookRule>) as rules -> box (rules |> Seq.map redactWebhookRule |> Seq.toArray)
+        | :? ApprovalPolicy as policy -> box (redactApprovalPolicy policy)
+        | :? (ApprovalPolicy array) as policies -> box (policies |> Array.map redactApprovalPolicy)
+        | :? (IEnumerable<ApprovalPolicy>) as policies ->
+            box (
+                policies
+                |> Seq.map redactApprovalPolicy
+                |> Seq.toArray
+            )
+        | _ -> box returnValue
+
+    let private renderJsonReturnValue (graceReturnValue: GraceReturnValue<'T>) =
+        let output =
+            {|
+                ReturnValue = redactJsonReturnValue graceReturnValue.ReturnValue
+                EventTime = graceReturnValue.EventTime
+                CorrelationId = graceReturnValue.CorrelationId
+                Properties = graceReturnValue.Properties.Select(fun kvp -> {| Key = kvp.Key; Value = kvp.Value |})
+            |}
+
+        serialize output
+
     /// Prints output to the console, depending on the output format.
     let renderOutput (parseResult: ParseResult) (result: GraceResult<'T>) =
         let outputFormat =
@@ -413,7 +454,7 @@ module Common =
         match result with
         | Ok graceReturnValue ->
             match outputFormat with
-            | Json -> AnsiConsole.WriteLine(Markup.Escape($"{graceReturnValue}"))
+            | Json -> AnsiConsole.WriteLine(Markup.Escape(renderJsonReturnValue graceReturnValue))
             | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
             | Silent -> ()
             | Verbose ->

--- a/src/Grace.CLI/Command/PromotionSet.CLI.fs
+++ b/src/Grace.CLI/Command/PromotionSet.CLI.fs
@@ -9,6 +9,7 @@ open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.PromotionSet
 open Grace.Types.Types
+open Grace.Types.Webhooks
 open Spectre.Console
 open System
 open System.CommandLine
@@ -51,6 +52,15 @@ module PromotionSetCommand =
                 [| "--target-branch" |],
                 Required = true,
                 Description = "The target branch ID <Guid>.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let branch =
+            new Option<string>(
+                "--branch",
+                [| "-b"; "--target-branch" |],
+                Required = false,
+                Description = "Target branch ID or name.",
                 Arity = ArgumentArity.ExactlyOne
             )
 
@@ -252,6 +262,20 @@ module PromotionSetCommand =
             with
             | ex -> Error($"Unable to read promotion pointers file: {ex.Message}")
 
+    let internal tryApprovalSummaryFromProperties (properties: Collections.Generic.IDictionary<string, obj>) =
+        match properties.TryGetValue("ApprovalSummary") with
+        | true, value when not (isNull value) ->
+            try
+                match value with
+                | :? PromotionSetApprovalSummary as summary -> Option.Some summary
+                | :? JsonElement as jsonElement -> Option.Some(jsonElement.Deserialize<PromotionSetApprovalSummary>(Constants.JsonSerializerOptions))
+                | _ ->
+                    let jsonText = JsonSerializer.Serialize(value, Constants.JsonSerializerOptions)
+                    Option.Some(JsonSerializer.Deserialize<PromotionSetApprovalSummary>(jsonText, Constants.JsonSerializerOptions))
+            with
+            | _ -> Option.None
+        | _ -> Option.None
+
     let private getPromotionSet (graceIds: GraceIds) (promotionSetId: PromotionSetId) =
         let parameters =
             Parameters.PromotionSet.GetPromotionSetParameters(
@@ -308,6 +332,57 @@ module PromotionSetCommand =
 
             table.AddRow("StepCount", promotionSet.Steps.Length.ToString())
             |> ignore
+
+            AnsiConsole.Write(table)
+
+    let internal renderPromotionSetWithApprovalSummary
+        (parseResult: ParseResult)
+        (promotionSet: PromotionSetDto)
+        (approvalSummary: PromotionSetApprovalSummary option)
+        =
+        renderPromotionSet parseResult promotionSet
+
+        match approvalSummary with
+        | Option.Some summary when
+            summary.State
+            <> PromotionSetApprovalState.NotRequired
+            ->
+            ApprovalCommand.renderApprovalSummary parseResult summary
+        | _ -> ()
+
+    let internal renderPromotionSetList (parseResult: ParseResult) (items: (PromotionSetDto * PromotionSetApprovalSummary option) seq) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("PromotionSetId") |> ignore
+            table.AddColumn("TargetBranchId") |> ignore
+            table.AddColumn("Status") |> ignore
+            table.AddColumn("Approval") |> ignore
+            table.AddColumn("ApprovalRequestId") |> ignore
+
+            items
+            |> Seq.iter (fun (promotionSet, summary) ->
+                let approvalState =
+                    summary
+                    |> Option.map (fun value -> getDiscriminatedUnionCaseName value.State)
+                    |> Option.defaultValue "-"
+
+                let approvalRequestId =
+                    summary
+                    |> Option.bind (fun value -> value.ApprovalRequestId)
+                    |> Option.map string
+                    |> Option.defaultValue "-"
+
+                table.AddRow(
+                    Markup.Escape(promotionSet.PromotionSetId.ToString()),
+                    Markup.Escape(promotionSet.TargetBranchId.ToString()),
+                    Markup.Escape(getDiscriminatedUnionCaseName promotionSet.Status),
+                    Markup.Escape(approvalState),
+                    Markup.Escape(approvalRequestId)
+                )
+                |> ignore)
 
             AnsiConsole.Write(table)
 
@@ -526,9 +601,16 @@ module PromotionSetCommand =
                 | Ok promotionSetId ->
                     match! getPromotionSet graceIds promotionSetId with
                     | Ok returnValue ->
-                        renderPromotionSet parseResult returnValue.ReturnValue
+                        renderPromotionSetWithApprovalSummary parseResult returnValue.ReturnValue (tryApprovalSummaryFromProperties returnValue.Properties)
                         return Ok returnValue
-                    | Error error -> return Error error
+                    | Error error ->
+                        match tryApprovalSummaryFromProperties error.Properties with
+                        | Option.Some summary when summary.State = PromotionSetApprovalState.Pending ->
+                            ApprovalCommand.renderPendingApproval parseResult summary
+                        | Option.Some summary -> ApprovalCommand.renderApprovalSummary parseResult summary
+                        | Option.None -> ()
+
+                        return Error error
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }
@@ -539,6 +621,110 @@ module PromotionSetCommand =
         override _.InvokeAsync(parseResult: ParseResult, _: CancellationToken) : Task<int> =
             task {
                 let! result = getPromotionSetHandler parseResult
+                return result |> renderOutput parseResult
+            }
+
+    let private resolveTargetBranchId (parseResult: ParseResult) (graceIds: GraceIds) =
+        task {
+            let branchRaw =
+                parseResult.GetValue(Options.branch)
+                |> Option.ofObj
+                |> Option.defaultValue String.Empty
+
+            if String.IsNullOrWhiteSpace branchRaw then
+                return Ok graceIds.BranchId
+            else
+                let mutable parsed = Guid.Empty
+
+                if
+                    Guid.TryParse(branchRaw, &parsed)
+                    && parsed <> Guid.Empty
+                then
+                    return Ok parsed
+                else
+                    let parameters =
+                        Parameters.Branch.GetBranchParameters(
+                            BranchName = branchRaw,
+                            OwnerId = graceIds.OwnerIdString,
+                            OwnerName = graceIds.OwnerName,
+                            OrganizationId = graceIds.OrganizationIdString,
+                            OrganizationName = graceIds.OrganizationName,
+                            RepositoryId = graceIds.RepositoryIdString,
+                            RepositoryName = graceIds.RepositoryName,
+                            CorrelationId = graceIds.CorrelationId
+                        )
+
+                    match! Grace.SDK.Branch.Get(parameters) with
+                    | Ok branch -> return Ok branch.ReturnValue.BranchId
+                    | Error error -> return Error error
+        }
+
+    let private listPromotionSetsHandler (parseResult: ParseResult) =
+        task {
+            try
+                if parseResult |> verbose then printParseResult parseResult
+                let graceIds = parseResult |> getNormalizedIdsAndNames
+                let! targetBranchIdResult = resolveTargetBranchId parseResult graceIds
+
+                match targetBranchIdResult with
+                | Error error -> return Error error
+                | Ok targetBranchId when targetBranchId = Guid.Empty ->
+                    return Error(GraceError.Create (QueueError.getErrorMessage QueueError.InvalidTargetBranchId) (getCorrelationId parseResult))
+                | Ok targetBranchId ->
+                    let parameters =
+                        Parameters.Queue.QueueStatusParameters(
+                            TargetBranchId = targetBranchId.ToString(),
+                            OwnerId = graceIds.OwnerIdString,
+                            OwnerName = graceIds.OwnerName,
+                            OrganizationId = graceIds.OrganizationIdString,
+                            OrganizationName = graceIds.OrganizationName,
+                            RepositoryId = graceIds.RepositoryIdString,
+                            RepositoryName = graceIds.RepositoryName,
+                            CorrelationId = graceIds.CorrelationId
+                        )
+
+                    match! Grace.SDK.Queue.Status(parameters) with
+                    | Error error -> return Error error
+                    | Ok queue ->
+                        let! promotionSets =
+                            queue.ReturnValue.PromotionSetIds
+                            |> Seq.map (fun promotionSetId ->
+                                task {
+                                    let parameters =
+                                        Parameters.PromotionSet.GetPromotionSetParameters(
+                                            PromotionSetId = promotionSetId.ToString(),
+                                            OwnerId = graceIds.OwnerIdString,
+                                            OwnerName = graceIds.OwnerName,
+                                            OrganizationId = graceIds.OrganizationIdString,
+                                            OrganizationName = graceIds.OrganizationName,
+                                            RepositoryId = graceIds.RepositoryIdString,
+                                            RepositoryName = graceIds.RepositoryName,
+                                            CorrelationId = graceIds.CorrelationId
+                                        )
+
+                                    return! Grace.SDK.PromotionSet.Get(parameters)
+                                })
+                            |> Task.WhenAll
+
+                        let successful =
+                            promotionSets
+                            |> Array.choose (function
+                                | Ok value -> Option.Some(value.ReturnValue, tryApprovalSummaryFromProperties value.Properties)
+                                | Error _ -> Option.None)
+                            |> Array.toList
+
+                        renderPromotionSetList parseResult successful
+                        return Ok(GraceReturnValue.Create successful graceIds.CorrelationId)
+            with
+            | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
+        }
+
+    type ListPromotionSets() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, _: CancellationToken) : Task<int> =
+            task {
+                let! result = listPromotionSetsHandler parseResult
                 return result |> renderOutput parseResult
             }
 
@@ -724,7 +910,14 @@ module PromotionSetCommand =
                             AnsiConsole.MarkupLine($"[green]Requested apply for promotion set[/] {Markup.Escape(promotionSetId.ToString())}")
 
                         return Ok returnValue
-                    | Error error -> return Error error
+                    | Error error ->
+                        match tryApprovalSummaryFromProperties error.Properties with
+                        | Option.Some summary when summary.State = PromotionSetApprovalState.Pending ->
+                            ApprovalCommand.renderPendingApproval parseResult summary
+                        | Option.Some summary -> ApprovalCommand.renderApprovalSummary parseResult summary
+                        | Option.None -> ()
+
+                        return Error error
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }
@@ -897,6 +1090,22 @@ module PromotionSetCommand =
         getCommand.Action <- new GetPromotionSet()
         promotionSetCommand.Subcommands.Add(getCommand)
 
+        let showCommand =
+            new Command("show", Description = "Show promotion set details.")
+            |> addOption Options.promotionSetId
+            |> addCommonOptions
+
+        showCommand.Action <- new GetPromotionSet()
+        promotionSetCommand.Subcommands.Add(showCommand)
+
+        let listCommand =
+            new Command("list", Description = "List promotion sets for a target branch.")
+            |> addOption Options.branch
+            |> addCommonOptions
+
+        listCommand.Action <- new ListPromotionSets()
+        promotionSetCommand.Subcommands.Add(listCommand)
+
         let getEventsCommand =
             new Command("get-events", Description = "Get promotion set events.")
             |> addOption Options.promotionSetId
@@ -930,6 +1139,14 @@ module PromotionSetCommand =
 
         applyCommand.Action <- new ApplyPromotionSet()
         promotionSetCommand.Subcommands.Add(applyCommand)
+
+        let requestApprovalCommand =
+            new Command("request-approval", Description = "Request approval for a promotion set.")
+            |> addOption Options.promotionSetId
+            |> addCommonOptions
+
+        requestApprovalCommand.Action <- new ApplyPromotionSet()
+        promotionSetCommand.Subcommands.Add(requestApprovalCommand)
 
         let deleteCommand =
             new Command("delete", Description = "Logically delete a promotion set.")

--- a/src/Grace.CLI/Command/PromotionSet.CLI.fs
+++ b/src/Grace.CLI/Command/PromotionSet.CLI.fs
@@ -659,7 +659,11 @@ module PromotionSetCommand =
                     | Error error -> return Error error
         }
 
-    let private listPromotionSetsHandler (parseResult: ParseResult) =
+    let internal listPromotionSetsWith
+        (getQueueStatus: Parameters.Queue.QueueStatusParameters -> Task<GraceResult<Grace.Types.Queue.PromotionQueue>>)
+        (getPromotionSet: Parameters.PromotionSet.GetPromotionSetParameters -> Task<GraceResult<PromotionSetDto>>)
+        (parseResult: ParseResult)
+        =
         task {
             try
                 if parseResult |> verbose then printParseResult parseResult
@@ -683,10 +687,10 @@ module PromotionSetCommand =
                             CorrelationId = graceIds.CorrelationId
                         )
 
-                    match! Grace.SDK.Queue.Status(parameters) with
+                    match! getQueueStatus parameters with
                     | Error error -> return Error error
                     | Ok queue ->
-                        let! promotionSets =
+                        let! (promotionSets: GraceResult<PromotionSetDto> array) =
                             queue.ReturnValue.PromotionSetIds
                             |> Seq.map (fun promotionSetId ->
                                 task {
@@ -702,22 +706,44 @@ module PromotionSetCommand =
                                             CorrelationId = graceIds.CorrelationId
                                         )
 
-                                    return! Grace.SDK.PromotionSet.Get(parameters)
+                                    return! getPromotionSet parameters
                                 })
                             |> Task.WhenAll
 
-                        let successful =
+                        let failures =
                             promotionSets
                             |> Array.choose (function
-                                | Ok value -> Option.Some(value.ReturnValue, tryApprovalSummaryFromProperties value.Properties)
-                                | Error _ -> Option.None)
-                            |> Array.toList
+                                | Error error -> Option.Some error
+                                | Ok _ -> Option.None)
 
-                        renderPromotionSetList parseResult successful
-                        return Ok(GraceReturnValue.Create successful graceIds.CorrelationId)
+                        if failures.Length > 0 then
+                            let details =
+                                failures
+                                |> Seq.map (fun error -> error.Error)
+                                |> String.concat Environment.NewLine
+
+                            return
+                                Error(
+                                    (GraceError.Create
+                                        $"Unable to list promotion sets because {failures.Length} promotion set fetch(es) failed."
+                                        graceIds.CorrelationId)
+                                        .enhance ("Errors", details)
+                                )
+                        else
+                            let successful =
+                                promotionSets
+                                |> Array.choose (function
+                                    | Ok value -> Option.Some(value.ReturnValue, tryApprovalSummaryFromProperties value.Properties)
+                                    | Error _ -> Option.None)
+                                |> Array.toList
+
+                            renderPromotionSetList parseResult successful
+                            return Ok(GraceReturnValue.Create successful graceIds.CorrelationId)
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }
+
+    let private listPromotionSetsHandler parseResult = listPromotionSetsWith Grace.SDK.Queue.Status Grace.SDK.PromotionSet.Get parseResult
 
     type ListPromotionSets() =
         inherit AsynchronousCommandLineAction()

--- a/src/Grace.CLI/Command/Webhook.CLI.fs
+++ b/src/Grace.CLI/Command/Webhook.CLI.fs
@@ -1,0 +1,632 @@
+namespace Grace.CLI.Command
+
+open Grace.CLI.Common
+open Grace.CLI.Services
+open Grace.CLI.Text
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Types
+open Grace.Types.Webhooks
+open Spectre.Console
+open System
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Threading
+open System.Threading.Tasks
+
+module WebhookCommand =
+    module private Options =
+        let webhookId =
+            new Option<string>(
+                "--webhook",
+                [|
+                    "--webhook-id"
+                    "--rule"
+                    "--rule-id"
+                |],
+                Required = true,
+                Description = "The webhook rule ID <Guid>.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let deliveryId =
+            new Option<string>(
+                "--delivery",
+                [|
+                    "--delivery-id"
+                    "--webhook-delivery"
+                    "--webhook-delivery-id"
+                |],
+                Required = true,
+                Description = "The webhook delivery ID <Guid>.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let name = new Option<string>("--name", Required = false, Description = "The webhook display name.", Arity = ArgumentArity.ExactlyOne)
+
+        let eventName =
+            new Option<string>("--event", [| "--event-name" |], Required = true, Description = "The webhook event name.", Arity = ArgumentArity.ExactlyOne)
+
+        let eventVersion =
+            new Option<int>(
+                "--event-version",
+                Required = false,
+                Description = "The webhook event version.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 1)
+            )
+
+        let url = new Option<string>("--url", Required = true, Description = "The destination URL.", Arity = ArgumentArity.ExactlyOne)
+
+        let urlOptional = new Option<string>("--url", Required = false, Description = "The destination URL.", Arity = ArgumentArity.ExactlyOne)
+
+        let allowUnsafeLocal =
+            new Option<bool>(
+                "--allow-unsafe-local-development",
+                [|
+                    "--acknowledge-unsafe-local-development"
+                |],
+                Required = false,
+                Description = "Allow unsafe local-development webhook URLs.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let signingSecretVersion =
+            new Option<string>(
+                "--signing-secret-version",
+                Required = false,
+                Description = "Signing secret version used for this webhook.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let maxAttempts =
+            new Option<int>(
+                "--max-attempts",
+                Required = false,
+                Description = "Maximum delivery attempts.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> WebhookRetryPolicy.Default.MaxAttempts)
+            )
+
+        let initialDelaySeconds =
+            new Option<int>(
+                "--initial-delay-seconds",
+                Required = false,
+                Description = "Initial retry delay in seconds.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> WebhookRetryPolicy.Default.InitialDelaySeconds)
+            )
+
+        let maxDelaySeconds =
+            new Option<int>(
+                "--max-delay-seconds",
+                Required = false,
+                Description = "Maximum retry delay in seconds.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> WebhookRetryPolicy.Default.MaxDelaySeconds)
+            )
+
+        let targetBranchId =
+            new Option<BranchId>(
+                OptionName.BranchId,
+                Required = false,
+                Description = "Optional target branch ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> BranchId.Empty)
+            )
+
+        let includeDeleted =
+            new Option<bool>(
+                "--include-deleted",
+                Required = false,
+                Description = "Include deleted webhook rules.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let includeTerminal =
+            new Option<bool>(
+                "--include-terminal",
+                Required = false,
+                Description = "Include terminal deliveries.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> true)
+            )
+
+        let dedupeKey =
+            new Option<string>("--dedupe-key", Required = false, Description = "Optional test delivery dedupe key.", Arity = ArgumentArity.ExactlyOne)
+
+        let ownerId =
+            new Option<OwnerId>(
+                OptionName.OwnerId,
+                Required = false,
+                Description = "The repository's owner ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> OwnerId.Empty)
+            )
+
+        let ownerName =
+            new Option<string>(
+                OptionName.OwnerName,
+                Required = false,
+                Description = "The repository's owner name. [default: current owner]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let organizationId =
+            new Option<OrganizationId>(
+                OptionName.OrganizationId,
+                Required = false,
+                Description = "The organization's ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> OrganizationId.Empty)
+            )
+
+        let organizationName =
+            new Option<string>(
+                OptionName.OrganizationName,
+                Required = false,
+                Description = "The organization's name. [default: current organization]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let repositoryId =
+            new Option<RepositoryId>(
+                OptionName.RepositoryId,
+                Required = false,
+                Description = "The repository's ID <Guid>.",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> RepositoryId.Empty)
+            )
+
+        let repositoryName =
+            new Option<string>(
+                OptionName.RepositoryName,
+                Required = false,
+                Description = "The repository's name. [default: current repository]",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+    let private noValue (value: string) = if String.IsNullOrWhiteSpace value then String.Empty else value
+
+    let private targetBranch (parseResult: ParseResult) =
+        let value = parseResult.GetValue(Options.targetBranchId)
+        if value = BranchId.Empty then String.Empty else value.ToString()
+
+    let private urlSafety allowUnsafe =
+        if allowUnsafe then
+            OutboundUrlSafety.LocalUnsafeDevOnly
+        else
+            OutboundUrlSafety.PublicHttps
+
+    let private addScope (parameters: #Grace.Shared.Parameters.Webhook.WebhookRuleParameters) (graceIds: GraceIds) (parseResult: ParseResult) =
+        parameters.OwnerId <- graceIds.OwnerIdString
+        parameters.OwnerName <- graceIds.OwnerName
+        parameters.OrganizationId <- graceIds.OrganizationIdString
+        parameters.OrganizationName <- graceIds.OrganizationName
+        parameters.RepositoryId <- graceIds.RepositoryIdString
+        parameters.RepositoryName <- graceIds.RepositoryName
+        parameters.TargetBranchId <- targetBranch parseResult
+        parameters.CorrelationId <- graceIds.CorrelationId
+        parameters
+
+    let private addDeliveryScope (parameters: #Grace.Shared.Parameters.Webhook.WebhookDeliveryParameters) (graceIds: GraceIds) (parseResult: ParseResult) =
+        parameters.OwnerId <- graceIds.OwnerIdString
+        parameters.OwnerName <- graceIds.OwnerName
+        parameters.OrganizationId <- graceIds.OrganizationIdString
+        parameters.OrganizationName <- graceIds.OrganizationName
+        parameters.RepositoryId <- graceIds.RepositoryIdString
+        parameters.RepositoryName <- graceIds.RepositoryName
+        parameters.TargetBranchId <- targetBranch parseResult
+        parameters.CorrelationId <- graceIds.CorrelationId
+        parameters
+
+    let internal renderWebhookRule (parseResult: ParseResult) (rule: WebhookRule) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("Field") |> ignore
+            table.AddColumn("Value") |> ignore
+
+            table.AddRow("WebhookRuleId", Markup.Escape(rule.WebhookRuleId.ToString()))
+            |> ignore
+
+            table.AddRow("Name", Markup.Escape(rule.Name))
+            |> ignore
+
+            table.AddRow("Event", Markup.Escape($"{rule.EventName} v{rule.EventVersion}"))
+            |> ignore
+
+            table.AddRow("Status", Markup.Escape(getDiscriminatedUnionCaseName rule.Status))
+            |> ignore
+
+            table.AddRow("UrlSafety", Markup.Escape(getDiscriminatedUnionCaseName rule.Url.Safety))
+            |> ignore
+
+            table.AddRow("MaxAttempts", rule.RetryPolicy.MaxAttempts.ToString())
+            |> ignore
+
+            AnsiConsole.Write(table)
+
+    let internal renderWebhookRules (parseResult: ParseResult) (rules: WebhookRule seq) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("WebhookRuleId") |> ignore
+            table.AddColumn("Name") |> ignore
+            table.AddColumn("Event") |> ignore
+            table.AddColumn("Status") |> ignore
+
+            rules
+            |> Seq.iter (fun rule ->
+                table.AddRow(
+                    Markup.Escape(rule.WebhookRuleId.ToString()),
+                    Markup.Escape(rule.Name),
+                    Markup.Escape($"{rule.EventName} v{rule.EventVersion}"),
+                    Markup.Escape(getDiscriminatedUnionCaseName rule.Status)
+                )
+                |> ignore)
+
+            AnsiConsole.Write(table)
+
+    let internal renderWebhookDelivery (parseResult: ParseResult) (delivery: WebhookDelivery) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("Field") |> ignore
+            table.AddColumn("Value") |> ignore
+
+            table.AddRow("DeliveryId", Markup.Escape(delivery.WebhookDeliveryId.ToString()))
+            |> ignore
+
+            table.AddRow("WebhookRuleId", Markup.Escape(delivery.WebhookRuleId.ToString()))
+            |> ignore
+
+            table.AddRow("Event", Markup.Escape($"{delivery.EventName} v{delivery.EventVersion}"))
+            |> ignore
+
+            table.AddRow("AttemptCount", delivery.AttemptCount.ToString())
+            |> ignore
+
+            table.AddRow("Status", Markup.Escape(getDiscriminatedUnionCaseName delivery.Status))
+            |> ignore
+
+            table.AddRow(
+                "NextRetry",
+                delivery.NextAttemptAt
+                |> Option.map string
+                |> Option.defaultValue "-"
+            )
+            |> ignore
+
+            table.AddRow(
+                "LastStatusCode",
+                delivery.LastStatusCode
+                |> Option.map string
+                |> Option.defaultValue "-"
+            )
+            |> ignore
+
+            table.AddRow(
+                "FailureDetails",
+                delivery.LastError
+                |> Option.defaultValue "-"
+                |> Markup.Escape
+            )
+            |> ignore
+
+            AnsiConsole.Write(table)
+
+    let internal renderWebhookDeliveries (parseResult: ParseResult) (deliveries: WebhookDelivery seq) =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            let table = Table(Border = TableBorder.Rounded)
+            table.AddColumn("DeliveryId") |> ignore
+            table.AddColumn("WebhookRuleId") |> ignore
+            table.AddColumn("Event") |> ignore
+            table.AddColumn("Attempts") |> ignore
+            table.AddColumn("Status") |> ignore
+            table.AddColumn("NextRetry") |> ignore
+
+            deliveries
+            |> Seq.iter (fun delivery ->
+                table.AddRow(
+                    Markup.Escape(delivery.WebhookDeliveryId.ToString()),
+                    Markup.Escape(delivery.WebhookRuleId.ToString()),
+                    Markup.Escape($"{delivery.EventName} v{delivery.EventVersion}"),
+                    delivery.AttemptCount.ToString(),
+                    Markup.Escape(getDiscriminatedUnionCaseName delivery.Status),
+                    delivery.NextAttemptAt
+                    |> Option.map string
+                    |> Option.defaultValue "-"
+                )
+                |> ignore)
+
+            AnsiConsole.Write(table)
+
+    let private execute action render =
+        task {
+            try
+                let! result = action ()
+
+                match result with
+                | Ok returnValue ->
+                    render returnValue.ReturnValue
+                    return Ok returnValue
+                | Error error -> return Error error
+            with
+            | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" String.Empty)
+        }
+
+    let private createHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let allowUnsafe = parseResult.GetValue(Options.allowUnsafeLocal)
+
+        let parameters = Grace.Shared.Parameters.Webhook.CreateWebhookRuleParameters()
+        parameters.WebhookRuleId <- Guid.NewGuid().ToString()
+
+        parameters.Name <-
+            parseResult.GetValue(Options.name)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.EventName <- parseResult.GetValue(Options.eventName)
+        parameters.EventVersion <- parseResult.GetValue(Options.eventVersion)
+        parameters.Url <- parseResult.GetValue(Options.url)
+        parameters.UrlSafety <- urlSafety allowUnsafe
+        parameters.AcknowledgeUnsafeLocalDevelopment <- allowUnsafe
+
+        parameters.SigningSecretVersion <-
+            parseResult.GetValue(Options.signingSecretVersion)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.MaxAttempts <- parseResult.GetValue(Options.maxAttempts)
+        parameters.InitialDelaySeconds <- parseResult.GetValue(Options.initialDelaySeconds)
+        parameters.MaxDelaySeconds <- parseResult.GetValue(Options.maxDelaySeconds)
+
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> Grace.SDK.WebhookRule.Create parameters) (renderWebhookRule parseResult)
+
+    let private listHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Webhook.ListWebhookRulesParameters(IncludeDeleted = parseResult.GetValue(Options.includeDeleted))
+
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> Grace.SDK.WebhookRule.List parameters) (renderWebhookRules parseResult)
+
+    let private showHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = Grace.Shared.Parameters.Webhook.ShowWebhookRuleParameters(WebhookRuleId = parseResult.GetValue(Options.webhookId))
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> Grace.SDK.WebhookRule.Show parameters) (renderWebhookRule parseResult)
+
+    let private updateHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let allowUnsafe = parseResult.GetValue(Options.allowUnsafeLocal)
+
+        let parameters = Grace.Shared.Parameters.Webhook.UpdateWebhookRuleParameters()
+        parameters.WebhookRuleId <- parseResult.GetValue(Options.webhookId)
+
+        parameters.Name <-
+            parseResult.GetValue(Options.name)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.EventName <- parseResult.GetValue(Options.eventName)
+        parameters.EventVersion <- parseResult.GetValue(Options.eventVersion)
+
+        parameters.Url <-
+            parseResult.GetValue(Options.urlOptional)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.UrlSafety <- urlSafety allowUnsafe
+        parameters.AcknowledgeUnsafeLocalDevelopment <- allowUnsafe
+
+        parameters.SigningSecretVersion <-
+            parseResult.GetValue(Options.signingSecretVersion)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.MaxAttempts <- parseResult.GetValue(Options.maxAttempts)
+        parameters.InitialDelaySeconds <- parseResult.GetValue(Options.initialDelaySeconds)
+        parameters.MaxDelaySeconds <- parseResult.GetValue(Options.maxDelaySeconds)
+
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> Grace.SDK.WebhookRule.Update parameters) (renderWebhookRule parseResult)
+
+    let private simpleRuleHandler makeParameters sdkCall parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+        let parameters = makeParameters (parseResult.GetValue(Options.webhookId))
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> sdkCall parameters) (renderWebhookRule parseResult)
+
+    let private testHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Webhook.TestWebhookRuleParameters()
+        parameters.WebhookRuleId <- parseResult.GetValue(Options.webhookId)
+
+        parameters.DedupeKey <-
+            parseResult.GetValue(Options.dedupeKey)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        addScope parameters graceIds parseResult |> ignore
+        execute (fun () -> Grace.SDK.WebhookRule.Test parameters) (renderWebhookDelivery parseResult)
+
+    let private deliveriesHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Webhook.ListWebhookDeliveriesParameters()
+
+        parameters.WebhookRuleId <-
+            parseResult.GetValue(Options.webhookId)
+            |> Option.ofObj
+            |> Option.defaultValue String.Empty
+
+        parameters.IncludeTerminal <- parseResult.GetValue(Options.includeTerminal)
+
+        addDeliveryScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.WebhookDelivery.List parameters) (renderWebhookDeliveries parseResult)
+
+    let private deliveryShowHandler parseResult =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let parameters = Grace.Shared.Parameters.Webhook.ShowWebhookDeliveryParameters(WebhookDeliveryId = parseResult.GetValue(Options.deliveryId))
+
+        addDeliveryScope parameters graceIds parseResult
+        |> ignore
+
+        execute (fun () -> Grace.SDK.WebhookDelivery.Show parameters) (renderWebhookDelivery parseResult)
+
+    type Action<'T>(handler: ParseResult -> Task<GraceResult<'T>>) =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, _: CancellationToken) : Task<int> =
+            task {
+                let! result = handler parseResult
+                return result |> renderOutput parseResult
+            }
+
+    let private action<'T> (handler: ParseResult -> Task<GraceResult<'T>>) = Action<'T>(handler)
+
+    let Build =
+        let addCommonOptions (command: Command) =
+            command
+            |> addOption Options.ownerName
+            |> addOption Options.ownerId
+            |> addOption Options.organizationName
+            |> addOption Options.organizationId
+            |> addOption Options.repositoryName
+            |> addOption Options.repositoryId
+            |> addOption Options.targetBranchId
+
+        let webhookCommand = new Command("webhook", Description = "Manage webhook rules and deliveries.")
+
+        let createCommand =
+            new Command("create", Description = "Create a webhook rule.")
+            |> addOption Options.name
+            |> addOption Options.eventName
+            |> addOption Options.eventVersion
+            |> addOption Options.url
+            |> addOption Options.allowUnsafeLocal
+            |> addOption Options.signingSecretVersion
+            |> addOption Options.maxAttempts
+            |> addOption Options.initialDelaySeconds
+            |> addOption Options.maxDelaySeconds
+            |> addCommonOptions
+
+        createCommand.Action <- action createHandler
+        webhookCommand.Subcommands.Add(createCommand)
+
+        let listCommand =
+            new Command("list", Description = "List webhook rules.")
+            |> addOption Options.includeDeleted
+            |> addCommonOptions
+
+        listCommand.Action <- action listHandler
+        webhookCommand.Subcommands.Add(listCommand)
+
+        let showCommand =
+            new Command("show", Description = "Show a webhook rule.")
+            |> addOption Options.webhookId
+            |> addCommonOptions
+
+        showCommand.Action <- action showHandler
+        webhookCommand.Subcommands.Add(showCommand)
+
+        let updateCommand =
+            new Command("update", Description = "Update a webhook rule.")
+            |> addOption Options.webhookId
+            |> addOption Options.name
+            |> addOption Options.eventName
+            |> addOption Options.eventVersion
+            |> addOption Options.urlOptional
+            |> addOption Options.allowUnsafeLocal
+            |> addOption Options.signingSecretVersion
+            |> addOption Options.maxAttempts
+            |> addOption Options.initialDelaySeconds
+            |> addOption Options.maxDelaySeconds
+            |> addCommonOptions
+
+        updateCommand.Action <- action updateHandler
+        webhookCommand.Subcommands.Add(updateCommand)
+
+        let enableCommand =
+            new Command("enable", Description = "Enable a webhook rule.")
+            |> addOption Options.webhookId
+            |> addCommonOptions
+
+        enableCommand.Action <-
+            action (simpleRuleHandler (fun id -> Grace.Shared.Parameters.Webhook.EnableWebhookRuleParameters(WebhookRuleId = id)) Grace.SDK.WebhookRule.Enable)
+
+        webhookCommand.Subcommands.Add(enableCommand)
+
+        let disableCommand =
+            new Command("disable", Description = "Disable a webhook rule.")
+            |> addOption Options.webhookId
+            |> addCommonOptions
+
+        disableCommand.Action <-
+            action (
+                simpleRuleHandler (fun id -> Grace.Shared.Parameters.Webhook.DisableWebhookRuleParameters(WebhookRuleId = id)) Grace.SDK.WebhookRule.Disable
+            )
+
+        webhookCommand.Subcommands.Add(disableCommand)
+
+        let deleteCommand =
+            new Command("delete", Description = "Delete a webhook rule.")
+            |> addOption Options.webhookId
+            |> addCommonOptions
+
+        deleteCommand.Action <-
+            action (simpleRuleHandler (fun id -> Grace.Shared.Parameters.Webhook.DeleteWebhookRuleParameters(WebhookRuleId = id)) Grace.SDK.WebhookRule.Delete)
+
+        webhookCommand.Subcommands.Add(deleteCommand)
+
+        let testCommand =
+            new Command("test", Description = "Create a test webhook delivery.")
+            |> addOption Options.webhookId
+            |> addOption Options.dedupeKey
+            |> addCommonOptions
+
+        testCommand.Action <- action testHandler
+        webhookCommand.Subcommands.Add(testCommand)
+
+        let deliveriesCommand =
+            new Command("deliveries", Description = "List webhook deliveries.")
+            |> addOption Options.webhookId
+            |> addOption Options.includeTerminal
+            |> addCommonOptions
+
+        deliveriesCommand.Action <- action deliveriesHandler
+        webhookCommand.Subcommands.Add(deliveriesCommand)
+
+        let deliveryCommand = new Command("delivery", Description = "Inspect one webhook delivery.")
+
+        let deliveryShowCommand =
+            new Command("show", Description = "Show a webhook delivery.")
+            |> addOption Options.deliveryId
+            |> addCommonOptions
+
+        deliveryShowCommand.Action <- action deliveryShowHandler
+        deliveryCommand.Subcommands.Add(deliveryShowCommand)
+        webhookCommand.Subcommands.Add(deliveryCommand)
+
+        webhookCommand

--- a/src/Grace.CLI/Command/Webhook.CLI.fs
+++ b/src/Grace.CLI/Command/Webhook.CLI.fs
@@ -428,11 +428,7 @@ module WebhookCommand =
         parameters.EventName <- parseResult.GetValue(Options.eventName)
         parameters.EventVersion <- parseResult.GetValue(Options.eventVersion)
 
-        parameters.Url <-
-            parseResult.GetValue(Options.urlOptional)
-            |> Option.ofObj
-            |> Option.defaultValue String.Empty
-
+        parameters.Url <- parseResult.GetValue(Options.url)
         parameters.UrlSafety <- urlSafety allowUnsafe
         parameters.AcknowledgeUnsafeLocalDevelopment <- allowUnsafe
 
@@ -557,7 +553,7 @@ module WebhookCommand =
             |> addOption Options.name
             |> addOption Options.eventName
             |> addOption Options.eventVersion
-            |> addOption Options.urlOptional
+            |> addOption Options.url
             |> addOption Options.allowUnsafeLocal
             |> addOption Options.signingSecretVersion
             |> addOption Options.maxAttempts

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -45,6 +45,8 @@
                 <Compile Include="Command\Review.CLI.fs" />
                 <Compile Include="Command\Candidate.CLI.fs" />
                 <Compile Include="Command\Queue.CLI.fs" />
+                <Compile Include="Command\Webhook.CLI.fs" />
+                <Compile Include="Command\Approval.CLI.fs" />
                 <Compile Include="Command\PromotionSet.CLI.fs" />
                 <Compile Include="Command\Agent.CLI.fs" />
                 <Compile Include="Command\Access.CLI.fs" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -247,6 +247,8 @@ module GraceCommand =
                         "candidate"
                         "queue"
                         "promotion-set"
+                        "approval"
+                        "webhook"
                         "agent"
                     ]
             }
@@ -582,6 +584,8 @@ module GraceCommand =
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
         rootCommand.Subcommands.Add(QueueCommand.Build)
+        rootCommand.Subcommands.Add(WebhookCommand.Build)
+        rootCommand.Subcommands.Add(ApprovalCommand.Build)
         rootCommand.Subcommands.Add(PromotionSetCommand.Build)
         rootCommand.Subcommands.Add(AgentCommand.Build)
         rootCommand.Subcommands.Add(Admin.Build)

--- a/src/Grace.SDK/Approval.SDK.fs
+++ b/src/Grace.SDK/Approval.SDK.fs
@@ -5,58 +5,61 @@ open Grace.Shared.Parameters.Approval
 open Grace.Types.Webhooks
 open System.Collections.Generic
 
+type ApprovalPolicyDto = Grace.Types.Webhooks.ApprovalPolicy
+type ApprovalRequestDto = Grace.Types.Webhooks.ApprovalRequest
+
 /// The ApprovalPolicy module provides approval policy lifecycle helpers.
 type ApprovalPolicy() =
     /// Creates an approval policy.
     static member public Create(parameters: CreateApprovalPolicyParameters) =
-        postServer<CreateApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/create")
+        postServer<CreateApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/create")
 
     /// Lists approval policies for a repository or branch scope.
     static member public List(parameters: ListApprovalPoliciesParameters) =
-        postServer<ListApprovalPoliciesParameters, IReadOnlyList<ApprovalPolicy>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/list")
+        postServer<ListApprovalPoliciesParameters, IReadOnlyList<ApprovalPolicyDto>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/list")
 
     /// Shows a single approval policy.
     static member public Show(parameters: ShowApprovalPolicyParameters) =
-        postServer<ShowApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/show")
+        postServer<ShowApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/show")
 
     /// Updates an approval policy and increments its version.
     static member public Update(parameters: UpdateApprovalPolicyParameters) =
-        postServer<UpdateApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/update")
+        postServer<UpdateApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/update")
 
     /// Enables an approval policy.
     static member public Enable(parameters: EnableApprovalPolicyParameters) =
-        postServer<EnableApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/enable")
+        postServer<EnableApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/enable")
 
     /// Disables an approval policy.
     static member public Disable(parameters: DisableApprovalPolicyParameters) =
-        postServer<DisableApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/disable")
+        postServer<DisableApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/disable")
 
     /// Deletes an approval policy.
     static member public Delete(parameters: DeleteApprovalPolicyParameters) =
-        postServer<DeleteApprovalPolicyParameters, ApprovalPolicy> (parameters |> ensureCorrelationIdIsSet, "approval/policy/delete")
+        postServer<DeleteApprovalPolicyParameters, ApprovalPolicyDto> (parameters |> ensureCorrelationIdIsSet, "approval/policy/delete")
 
     /// Evaluates enabled approval policies for a subject.
     static member public Evaluate(parameters: EvaluateApprovalPolicyParameters) =
-        postServer<EvaluateApprovalPolicyParameters, IReadOnlyList<ApprovalPolicy>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/evaluate")
+        postServer<EvaluateApprovalPolicyParameters, IReadOnlyList<ApprovalPolicyDto>> (parameters |> ensureCorrelationIdIsSet, "approval/policy/evaluate")
 
 /// The ApprovalRequest module provides read and response helpers for workflow-generated approval requests.
 type ApprovalRequest() =
     /// Lists approval requests for a repository or branch scope.
     static member public List(parameters: ListApprovalRequestsParameters) =
-        postServer<ListApprovalRequestsParameters, IReadOnlyList<ApprovalRequest>> (parameters |> ensureCorrelationIdIsSet, "approval/request/list")
+        postServer<ListApprovalRequestsParameters, IReadOnlyList<ApprovalRequestDto>> (parameters |> ensureCorrelationIdIsSet, "approval/request/list")
 
     /// Shows a workflow-generated approval request.
     static member public Show(parameters: ShowApprovalRequestParameters) =
-        postServer<ShowApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/show")
+        postServer<ShowApprovalRequestParameters, ApprovalRequestDto> (parameters |> ensureCorrelationIdIsSet, "approval/request/show")
 
     /// Approves a workflow-generated approval request.
     static member public Approve(parameters: ApproveApprovalRequestParameters) =
-        postServer<ApproveApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/approve")
+        postServer<ApproveApprovalRequestParameters, ApprovalRequestDto> (parameters |> ensureCorrelationIdIsSet, "approval/request/approve")
 
     /// Rejects a workflow-generated approval request.
     static member public Reject(parameters: RejectApprovalRequestParameters) =
-        postServer<RejectApprovalRequestParameters, ApprovalRequest> (parameters |> ensureCorrelationIdIsSet, "approval/request/reject")
+        postServer<RejectApprovalRequestParameters, ApprovalRequestDto> (parameters |> ensureCorrelationIdIsSet, "approval/request/reject")
 
     /// Gets approval request history.
     static member public History(parameters: ApprovalRequestHistoryParameters) =
-        postServer<ApprovalRequestHistoryParameters, IReadOnlyList<ApprovalRequest>> (parameters |> ensureCorrelationIdIsSet, "approval/request/history")
+        postServer<ApprovalRequestHistoryParameters, IReadOnlyList<ApprovalRequestDto>> (parameters |> ensureCorrelationIdIsSet, "approval/request/history")

--- a/src/Grace.SDK/Webhook.SDK.fs
+++ b/src/Grace.SDK/Webhook.SDK.fs
@@ -5,46 +5,49 @@ open Grace.Shared.Parameters.Webhook
 open Grace.Types.Webhooks
 open System.Collections.Generic
 
+type WebhookRuleDto = Grace.Types.Webhooks.WebhookRule
+type WebhookDeliveryDto = Grace.Types.Webhooks.WebhookDelivery
+
 /// The WebhookRule module provides webhook rule lifecycle helpers.
 type WebhookRule() =
     /// Creates a webhook rule with its destination URL.
     static member public Create(parameters: CreateWebhookRuleParameters) =
-        postServer<CreateWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/create")
+        postServer<CreateWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/create")
 
     /// Lists webhook rules for a repository or branch scope.
     static member public List(parameters: ListWebhookRulesParameters) =
-        postServer<ListWebhookRulesParameters, IReadOnlyList<WebhookRule>> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/list")
+        postServer<ListWebhookRulesParameters, IReadOnlyList<WebhookRuleDto>> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/list")
 
     /// Shows a single webhook rule.
     static member public Show(parameters: ShowWebhookRuleParameters) =
-        postServer<ShowWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/show")
+        postServer<ShowWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/show")
 
     /// Updates a webhook rule.
     static member public Update(parameters: UpdateWebhookRuleParameters) =
-        postServer<UpdateWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/update")
+        postServer<UpdateWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/update")
 
     /// Enables a webhook rule.
     static member public Enable(parameters: EnableWebhookRuleParameters) =
-        postServer<EnableWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/enable")
+        postServer<EnableWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/enable")
 
     /// Disables a webhook rule.
     static member public Disable(parameters: DisableWebhookRuleParameters) =
-        postServer<DisableWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/disable")
+        postServer<DisableWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/disable")
 
     /// Deletes a webhook rule.
     static member public Delete(parameters: DeleteWebhookRuleParameters) =
-        postServer<DeleteWebhookRuleParameters, WebhookRule> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/delete")
+        postServer<DeleteWebhookRuleParameters, WebhookRuleDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/delete")
 
     /// Records a pending test delivery for the webhook rule without dispatching it.
     static member public Test(parameters: TestWebhookRuleParameters) =
-        postServer<TestWebhookRuleParameters, WebhookDelivery> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/test")
+        postServer<TestWebhookRuleParameters, WebhookDeliveryDto> (parameters |> ensureCorrelationIdIsSet, "webhook/rule/test")
 
 /// The WebhookDelivery module provides read helpers for webhook delivery observability.
 type WebhookDelivery() =
     /// Lists webhook deliveries for a repository or branch scope.
     static member public List(parameters: ListWebhookDeliveriesParameters) =
-        postServer<ListWebhookDeliveriesParameters, IReadOnlyList<WebhookDelivery>> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/list")
+        postServer<ListWebhookDeliveriesParameters, IReadOnlyList<WebhookDeliveryDto>> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/list")
 
     /// Shows a single webhook delivery.
     static member public Show(parameters: ShowWebhookDeliveryParameters) =
-        postServer<ShowWebhookDeliveryParameters, WebhookDelivery> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/show")
+        postServer<ShowWebhookDeliveryParameters, WebhookDeliveryDto> (parameters |> ensureCorrelationIdIsSet, "webhook/delivery/show")

--- a/src/Grace.Server/PromotionSet.Server.fs
+++ b/src/Grace.Server/PromotionSet.Server.fs
@@ -117,6 +117,9 @@ module PromotionSet =
                     |> Option.bind (fun approvalRequest ->
                         approvalRequest.Decision
                         |> Option.map (fun decision -> decision.DecidedAt))
+                ExpiresAt =
+                    request
+                    |> Option.bind (fun approvalRequest -> approvalRequest.ExpiresAt)
                 Reason = reason
             }
 

--- a/src/Grace.Types/Webhooks.Types.fs
+++ b/src/Grace.Types/Webhooks.Types.fs
@@ -449,6 +449,7 @@ module Webhooks =
             ApprovalPolicyId: ApprovalPolicyId option
             RequiredResponder: ApprovalResponderSelector option
             LastDecisionAt: Instant option
+            ExpiresAt: Instant option
             Reason: string option
         }
 
@@ -463,6 +464,7 @@ module Webhooks =
                 ApprovalPolicyId = None
                 RequiredResponder = None
                 LastDecisionAt = None
+                ExpiresAt = None
                 Reason = None
             }
 


### PR DESCRIPTION
## Summary

- Adds `grace webhook` command surface: create/list/show/update/enable/disable/delete/test/deliveries.
- Adds `grace webhook delivery show`.
- Adds `grace approval policy` command surface: create/list/show/update/enable/disable/delete/evaluate.
- Adds `grace approval request` command surface: list/show/approve/reject/wait/history.
- Adds `grace promotion-set request-approval`.
- Adds promotion-set approval summary output for show/list and pending-approval guidance for apply results.
- Updates root help grouping for the approved webhook and approval nouns.
- Fixes CLI-facing SDK return-type gaps caused by wrapper class names shadowing DTO names.
- Adds parser/output/help tests, including forbidden noun coverage.

Closes #151.

## Validation

Worker validation:

- `dotnet tool run fantomas src/Grace.CLI/Command/Webhook.CLI.fs src/Grace.CLI/Command/Approval.CLI.fs src/Grace.CLI/Command/PromotionSet.CLI.fs src/Grace.CLI/Program.CLI.fs src/Grace.CLI.Tests/WebhookApproval.CLI.Tests.fs src/Grace.CLI.Tests/Program.CLI.Tests.fs`: passed; run before build/tests.
- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WebhookApprovalCommandTests|FullyQualifiedName~RootHelpGroupingTests|FullyQualifiedName~PromotionSetCommandTests"`: passed, 48/48.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build: 0 warnings, 0 errors.
  - `Grace.Authorization.Tests`: 23 passed.
  - `Grace.CLI.Tests`: 254 passed.
  - `Grace.Types.Tests`: 62 passed.
  - Format phase skipped by script as currently configured; targeted Fantomas was run separately first.
- `git diff --check`: passed.

## Review Status

First implementation commit and push are complete, and PR #160 completed the review/fix loop:

- `4a0173a Add CLI webhook and approval commands`
- `b8773d4 Fix webhook approval CLI review findings`

Review pass 1 found five issues: three P1s around JSON redaction, `approval request wait` timeout signaling, and `webhook update --url` behavior; and two P2s around partial `promotion-set list` failures and missing approval expiration guidance. The full review output, including `Reviewed And OK` coverage, is recorded in https://github.com/ScottArbeit/Grace/pull/160#issuecomment-4608755393.

Fix pass 1 addressed those findings in `b8773d4`; fix evidence and validation are recorded in https://github.com/ScottArbeit/Grace/pull/160#issuecomment-4608836704.

Review pass 2 found no actionable issues and recorded final `Reviewed And OK` coverage in https://github.com/ScottArbeit/Grace/pull/160#issuecomment-4608863494.

CI is green on the latest pushed commit. This PR is ready to merge.
## Residual Risks From Worker

- `promotion-set list` is implemented client-side through queue status plus per-promotion-set fetches because there is no current `promotion-set/list` server endpoint and this issue forbids broad server/API behavior changes.
- Approval policy create/update follows the current shared parameter contract (`--subject`, `--required-responder`, notification/timeout options). The stale issue-body `--requires-approval` option was not added because it is not present in the current API contract.
- Pending approval output depends on the server/actor returning `ApprovalSummary` in result/error properties, which is how the current apply gate exposes approval state.