### PR TITLE
Split storage SDK contract into unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ completed sub-issues are checked.
   `pwsh ./scripts/validate.ps1 -Fast`, do not also run separate full-solution `dotnet build` or broad `dotnet test`
   commands unless there is a specific diagnostic reason; prefer only the narrow focused tests that prove the changed
   behavior, then `validate -Fast`.
+- When a focused test command uses `--no-build`, run the matching Release build for that project after formatting and
+  before the `--no-build` test command.
 - Commit after each completed slice and keep pull requests focused and reviewable.
 - When acting as the main implementation orchestrator, delegate all coding and fixing tasks to worker subagents and use
   fresh review-only subagents for code review. The main orchestrator must not implement, repair, inspect or validate

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -396,7 +396,9 @@ projects. If a worker is going to run `validate -Fast`, it should not also run a
 
 1. Run Fantomas formatting or targeted Fantomas checks for touched F# files.
 2. Run the narrow focused test command that proves the changed behavior, if that focused test is outside the fast gate
-   or gives faster defect localization.
+   or gives faster defect localization. When the focused command uses `--no-build`, first run the matching
+   `dotnet build --configuration Release <project>` command so the test assembly exists and reflects the current
+   source.
 3. Run `pwsh ./scripts/validate.ps1 -Fast`.
 4. Run `git diff --check`.
 
@@ -424,7 +426,8 @@ order is:
 
 1. Apply the code change.
 2. Run Fantomas on the touched files, or run the repo-standard recursive Fantomas command when the edit is broad.
-3. Run focused tests and `validate -Fast` using the non-duplicative validation order above.
+3. Build the focused project before any focused `dotnet test --no-build` command, then run focused tests and
+   `validate -Fast` using the non-duplicative validation order above.
 4. Run `git diff --check`.
 
 Avoid running the full test suite before formatting, then discovering Fantomas rewrote files and forcing another

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -36,7 +36,7 @@ update the issue before editing the new paths.
   also run separate full-solution `dotnet build` or broad `dotnet test` commands unless there is a specific diagnostic
   reason; prefer only the narrow focused tests that prove the changed behavior, then `validate -Fast`.
 - If running commands manually instead of `validate -Fast`, use `dotnet build --configuration Release` and
-  `dotnet test --no-build`.
+  `dotnet test --no-build`; build the focused project before any project-specific `--no-build` test command.
 - Resolve all compilation errors before considering a task complete.
 - Run impacted tests for each task and fix failures introduced by your changes.
 - Create a new git commit after each completed task to keep review scope clear.

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -9,7 +9,6 @@ open NUnit.Framework
 open System
 open System.Net
 open System.Net.Http
-open System.Reflection
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
@@ -396,52 +395,6 @@ type StorageContentBlockDiscoveryRoutes() =
             Assert.That(body, Does.Contain("KeyChunkAddresses"))
             Assert.That(body, Does.Contain($"{maxDiscoveryKeyChunkAddresses}"))
         }
-
-[<Parallelizable(ParallelScope.All)>]
-type StorageContentBlockSdkContract() =
-
-    let getStorageParameterType typeName =
-        typeof<Parameters.Storage.StorageParameters>.Assembly.GetType ($"Grace.Shared.Parameters.Storage+{typeName}", throwOnError = false)
-
-    let assertContentBlockParameterShape typeName =
-        let parameterType = getStorageParameterType typeName
-        Assert.That(parameterType, Is.Not.Null, $"{typeName} should be defined in Grace.Shared.Parameters.Storage.")
-        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
-        Assert.That(parameterType.GetProperty("RelativePath"), Is.Null)
-        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Not.Null)
-
-    let assertSdkMethod methodName parameterTypeName =
-        let parameterType = getStorageParameterType parameterTypeName
-        Assert.That(parameterType, Is.Not.Null)
-
-        let storageType = typeof<Grace.SDK.AgentSession>.Assembly.GetType ("Grace.SDK.Storage", throwOnError = false)
-        Assert.That(storageType, Is.Not.Null, "Grace.SDK.Storage should be available as an SDK module.")
-
-        let methodInfo: MethodInfo = storageType.GetMethod(methodName, BindingFlags.Public ||| BindingFlags.Static)
-
-        Assert.That(methodInfo, Is.Not.Null, $"Grace.SDK.Storage.{methodName} should be a public SDK method.")
-        let parameters: ParameterInfo array = methodInfo.GetParameters()
-        Assert.That(parameters, Has.Length.EqualTo(1))
-        Assert.That(parameters[0].ParameterType, Is.EqualTo(parameterType))
-
-    [<Test>]
-    member _.ContentBlockSasParametersExposeAddressWithoutCallerSuppliedPath() =
-        assertContentBlockParameterShape "GetContentBlockUploadUriParameters"
-        assertContentBlockParameterShape "GetContentBlockDownloadUriParameters"
-
-    [<Test>]
-    member _.ContentBlockSasSdkMethodsMatchSharedParameterContracts() =
-        assertSdkMethod "GetContentBlockUploadUri" "GetContentBlockUploadUriParameters"
-        assertSdkMethod "GetContentBlockDownloadUri" "GetContentBlockDownloadUriParameters"
-
-    [<Test>]
-    member _.ContentBlockDiscoverySdkMethodMatchesSharedParameterContract() =
-        let parameterType = getStorageParameterType "DiscoverContentBlocksParameters"
-        Assert.That(parameterType, Is.Not.Null)
-        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
-        Assert.That(parameterType.GetProperty("KeyChunkAddresses"), Is.Not.Null)
-        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Null)
-        assertSdkMethod "DiscoverContentBlocks" "DiscoverContentBlocksParameters"
 
 [<NonParallelizable>]
 type StorageManifestUploadSessionRoutes() =

--- a/src/Grace.Server.Unit.Tests/AGENTS.md
+++ b/src/Grace.Server.Unit.Tests/AGENTS.md
@@ -18,6 +18,8 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 ## Validation
 
 - Run targeted Fantomas formatting or checks before build and test validation after F# changes.
+- Build `src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj` in Release before running project-specific
+  `--no-build` tests.
 - Run `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
-  after a build context exists.
+  only after that build context exists.
 - Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate.

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
@@ -1,0 +1,51 @@
+namespace Grace.Server.Tests
+
+open Grace.Shared
+open NUnit.Framework
+open System.Reflection
+
+[<Parallelizable(ParallelScope.All)>]
+type StorageContentBlockSdkContract() =
+
+    let getStorageParameterType typeName =
+        typeof<Parameters.Storage.StorageParameters>.Assembly.GetType ($"Grace.Shared.Parameters.Storage+{typeName}", throwOnError = false)
+
+    let assertContentBlockParameterShape typeName =
+        let parameterType = getStorageParameterType typeName
+        Assert.That(parameterType, Is.Not.Null, $"{typeName} should be defined in Grace.Shared.Parameters.Storage.")
+        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
+        Assert.That(parameterType.GetProperty("RelativePath"), Is.Null)
+        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Not.Null)
+
+    let assertSdkMethod methodName parameterTypeName =
+        let parameterType = getStorageParameterType parameterTypeName
+        Assert.That(parameterType, Is.Not.Null)
+
+        let storageType = typeof<Grace.SDK.AgentSession>.Assembly.GetType ("Grace.SDK.Storage", throwOnError = false)
+        Assert.That(storageType, Is.Not.Null, "Grace.SDK.Storage should be available as an SDK module.")
+
+        let methodInfo: MethodInfo = storageType.GetMethod(methodName, BindingFlags.Public ||| BindingFlags.Static)
+
+        Assert.That(methodInfo, Is.Not.Null, $"Grace.SDK.Storage.{methodName} should be a public SDK method.")
+        let parameters: ParameterInfo array = methodInfo.GetParameters()
+        Assert.That(parameters, Has.Length.EqualTo(1))
+        Assert.That(parameters[0].ParameterType, Is.EqualTo(parameterType))
+
+    [<Test>]
+    member _.ContentBlockSasParametersExposeAddressWithoutCallerSuppliedPath() =
+        assertContentBlockParameterShape "GetContentBlockUploadUriParameters"
+        assertContentBlockParameterShape "GetContentBlockDownloadUriParameters"
+
+    [<Test>]
+    member _.ContentBlockSasSdkMethodsMatchSharedParameterContracts() =
+        assertSdkMethod "GetContentBlockUploadUri" "GetContentBlockUploadUriParameters"
+        assertSdkMethod "GetContentBlockDownloadUri" "GetContentBlockDownloadUriParameters"
+
+    [<Test>]
+    member _.ContentBlockDiscoverySdkMethodMatchesSharedParameterContract() =
+        let parameterType = getStorageParameterType "DiscoverContentBlocksParameters"
+        Assert.That(parameterType, Is.Not.Null)
+        Assert.That(parameterType.IsSubclassOf(typeof<Parameters.Storage.StorageParameters>), Is.True)
+        Assert.That(parameterType.GetProperty("KeyChunkAddresses"), Is.Not.Null)
+        Assert.That(parameterType.GetProperty("ContentBlockAddress"), Is.Null)
+        assertSdkMethod "DiscoverContentBlocks" "DiscoverContentBlocksParameters"


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #168

Parent epic: #166

## Summary

Splits the pure `StorageContentBlockSdkContract` fixture out of `Grace.Server.Tests/Storage.Server.Tests.fs` into the new `Grace.Server.Unit.Tests` project. HTTP, Aspire, storage route, and upload-session fixtures remain in `Grace.Server.Tests`.

Also clarifies validation-order docs so project-specific `dotnet test --no-build` commands are run after the matching Release build exists.

## Touched paths

- `src/Grace.Server.Tests/Storage.Server.Tests.fs`
- `src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs`
- `src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
- `src/Grace.Server.Unit.Tests/AGENTS.md`
- `AGENTS.md`
- `src/AGENTS.md`
- `docs/Development process.md`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

Notes:

- The original issue owned the storage split paths. The docs/process write-set expansion is recorded in #168 before PR creation.
- Worker reported an early relative `apply_patch` mistake against the root checkout, then verified and cleaned `C:\Source\Grace`; committed/pushed changes are only in `C:\Source\Grace-gh-168`.

## Validation profile and public-boundary evidence

- Validation profile: `server-api`
- Public behavior or docs-only validation target: Pure storage SDK contract coverage runs under `Grace.Server.Unit.Tests`; HTTP/resource storage coverage remains under `Grace.Server.Tests`.
- RED evidence or docs-only waiver: Before this split, `StorageContentBlockSdkContract` compiled in the integration project.
- Focused validation: unit and integration test project builds/tests.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Moved `StorageContentBlockSdkContract` to `src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs`.
- Integration storage tests remain in `src/Grace.Server.Tests/Storage.Server.Tests.fs`.

## Review Status

- Implementation handoff received from GPT-5.5 Medium worker Gibbs.
- Fresh local review-only sibling subagent Arendt (GPT-5.5 high): found one worktree-hygiene issue; review recorded at https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611065827
- Hygiene issue resolved by preserving root docs changes under #175 / PR #176; fix note recorded at https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611066082
- Fresh local review-only sibling subagent McClintock (GPT-5.5 high): no issues after hygiene resolution; recorded at https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611096203
- Open findings: none.
- Detailed review/fix comments: https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611065827, https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611066082, and https://github.com/ScottArbeit/Grace/pull/174#issuecomment-4611096203
## Reviewer pass

- [ ] Owned paths and forbidden paths reviewed against the issue.
- [ ] Sensitive surfaces reviewed and marked below.
- [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [ ] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [x] Server or API contract
- [ ] Orleans actor behavior
- [x] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

Details:

- Clarified project-specific `dotnet test --no-build` validation order in agent/process docs.
- Broader final test-boundary guidance remains owned by #171 after all implementation/audit slices converge.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [x] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj` after matching Release build; `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj` after matching Release build
- [x] Formatting/linting: Fantomas check/format for touched F# files, MarkdownLint for changed Markdown files, `git diff --check`, and staged `git diff --cached --check`
- [x] Manual validation: negative scan over `src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs` for forbidden integration dependencies

## Validation not run

- None. Full validation passed in this environment.

## Residual risks

- No known residual risk in the code split. The moved fixture is pure reflection over `Grace.Shared.Parameters.Storage` and `Grace.SDK.Storage`; negative scan found no Aspire, HTTP, Service Bus, blob storage, Redis, emulator, or shared integration-state dependencies in the moved unit file.

## Rollback or recovery notes

- Revert this PR to move the storage SDK contract fixture back to the integration test project and remove the validation-order doc clarification.

## Docs follow-up required

- #171 should reconcile final repo-wide test placement guidance once #170 audit decisions are known.