### PR TITLE
Document assigned-worktree patch guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ completed sub-issues are checked.
 - Declare owned paths, forbidden or sensitive paths, risk surfaces, validation, docs impact, and definition of done
   before editing.
 - After the issue exists, claim it and create an issue-owned branch/worktree from latest `origin/main` before editing.
+- When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
+  absolute path under the assigned worktree. After the first patch, verify git status in both locations.
 - Prefer vertical slices with focused tests and `pwsh ./scripts/validate.ps1 -Fast` as the normal validation gate.
 - Use `pwsh ./scripts/validate.ps1 -Full` when Aspire, emulators, storage, Service Bus, Cosmos DB, Redis,
   deployment/runtime behavior, or cross-service integration is affected.

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -162,6 +162,10 @@ Always inspect the current state before editing:
 git status --short --branch
 ```
 
+When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
+absolute path under the assigned worktree. After the first patch, verify `git status --short --branch` in both the
+assigned worktree and the workspace root.
+
 If unrelated changes already exist, leave them alone. If they affect the task, work with them instead of reverting them.
 If the task must expand beyond the issue's owned paths, comment on the issue before editing the new paths.
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -30,6 +30,8 @@ update the issue before editing the new paths.
   shapes, expected tests, and high-risk adversarial examples. The issue should be contextual enough for an
   implementation agent to succeed from the issue body alone without hidden project context.
 - Create or switch to an issue-owned branch/worktree from latest `origin/main` before editing implementation files.
+- When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
+  absolute path under the assigned worktree. After the first patch, verify git status in both locations.
 - Prefer vertical slices that prove one public behavior at a time through the closest stable boundary.
 - Validate changes with `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration coverage).
 - Order validation to avoid duplicate builds. Run formatters before validation. If `validate -Fast` will run, do not


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #175

## Summary

Adds assigned-worktree `apply_patch` guidance to Grace agent/process docs so workers use absolute patch filenames when their assigned worktree differs from the thread workspace root, and verify both worktrees after the first patch.

The user's personal `C:\Users\scott\.codex\AGENTS.md` was also updated outside this repo; that file is not part of this PR because `C:\Users\scott\.codex` is not a git repository.

## Touched paths

- `AGENTS.md`
- `src/AGENTS.md`
- `docs/Development process.md`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `docs-only`
- Public behavior or docs-only validation target: Assigned-worktree patch guidance in Grace workflow docs.
- RED evidence or docs-only waiver: docs-only change; no RED test required.
- Focused validation: MarkdownLint and `git diff --check`.

## Test coverage changes

Choose one:

- [ ] Tests added or updated; list the test files and covered behavior below.
- [x] No tests added; explain why new tests were not required for this change.

Details:

- Documentation/process-only change.

## Review Status

- Docs worker Kant completed the requested edits.
- Fresh local review-only sibling subagent Goodall (GPT-5.5 high): no issues; recorded at https://github.com/ScottArbeit/Grace/pull/176#issuecomment-4611088704
- Open findings: none.
- Detailed review comments: https://github.com/ScottArbeit/Grace/pull/176#issuecomment-4611088704

## Reviewer pass

- [ ] Owned paths and forbidden paths reviewed against the issue.
- [ ] Sensitive surfaces reviewed and marked below.
- [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [ ] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [ ] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [ ] Focused tests: command
- [x] Formatting/linting: `npx --yes markdownlint-cli2 "AGENTS.md" "src/AGENTS.md" "docs/Development process.md"`; `git diff --check`
- [x] Manual validation: verified `C:\Source\Grace-gh-168` remained clean; verified `C:\Users\scott\.codex` is not a git repo after personal docs update.

## Validation not run

- Fast/Full validation not run because this is docs-only workflow guidance.

## Residual risks

- None known.

## Rollback or recovery notes

- Revert this PR to remove the assigned-worktree patch guidance from Grace docs.

## Docs follow-up required

- None for this narrow rule. Broader test-boundary docs remain in #171.