### PR TITLE
Gate NUnit assembly parallel defaults

### DIFF
--- a/src/Grace.Authorization.Tests/AssemblyInfo.fs
+++ b/src/Grace.Authorization.Tests/AssemblyInfo.fs
@@ -1,0 +1,7 @@
+namespace Grace.Authorization.Tests
+
+open NUnit.Framework
+
+[<assembly: Parallelizable(ParallelScope.Fixtures)>]
+[<assembly: LevelOfParallelism(4)>]
+do ()

--- a/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
+++ b/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="AuthorizationSemantics.Tests.fs" />
     <Compile Include="ClaimMapping.Tests.fs" />
     <Compile Include="PathPermissions.Tests.fs" />

--- a/src/Grace.Types.Tests/AssemblyInfo.fs
+++ b/src/Grace.Types.Tests/AssemblyInfo.fs
@@ -1,0 +1,7 @@
+namespace Grace.Types.Tests
+
+open NUnit.Framework
+
+[<assembly: Parallelizable(ParallelScope.Fixtures)>]
+[<assembly: LevelOfParallelism(4)>]
+do ()

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="EventMetadata.Types.Tests.fs" />
     <Compile Include="Automation.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/PromotionSet.ConflictModel.Types.Tests.fs
+++ b/src/Grace.Types.Tests/PromotionSet.ConflictModel.Types.Tests.fs
@@ -8,6 +8,7 @@ open System.Collections.Generic
 open System.Threading.Tasks
 
 [<TestFixture>]
+[<NonParallelizable>]
 type PromotionSetConflictModelTypesTests() =
 
     let sampleRequest: ConflictResolutionModelRequest =


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #170

Parent epic: #166

## Summary

Audits candidate NUnit test projects for assembly-level parallel defaults and applies them only where evidence supports safe execution.

- Applies bounded assembly defaults to `Grace.Authorization.Tests`.
- Applies bounded assembly defaults to `Grace.Types.Tests` after marking the environment-variable mutation fixture `NonParallelizable`.
- Explicitly defers `Grace.Server.Unit.Tests` because `PromotionSet.CommandValidation.Tests.fs` mutates a process-static approval store.
- Explicitly defers `Grace.CLI.Tests` because stateful/global process mutations remain in the assembly.
- Leaves `Grace.Server.Tests` untouched.

## Touched paths

- `src/Grace.Authorization.Tests/AssemblyInfo.fs`
- `src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`
- `src/Grace.Types.Tests/AssemblyInfo.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`
- `src/Grace.Types.Tests/PromotionSet.ConflictModel.Types.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public behavior or docs-only validation target: NUnit assembly-level parallelization defaults are applied only after global-state audit proves safety.
- RED evidence or docs-only waiver: Audit found unresolved global state in `Grace.Server.Unit.Tests` and `Grace.CLI.Tests`; defaults are intentionally deferred there.
- Focused validation: Authorization and Types project build/test runs, each repeated twice.

## Test coverage changes

Choose one:

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- Added assembly metadata files for safe NUnit defaults in Authorization and Types tests.
- Marked `PromotionSetConflictModelTypesTests` as `NonParallelizable` because it mutates/restores an environment variable.

## Review Status

- Implementation handoff received from GPT-5.5 Medium worker Locke.
- Fresh local review-only sibling subagent Nash (GPT-5.5 high): no issues; recorded at https://github.com/ScottArbeit/Grace/pull/178#issuecomment-4611243748
- Open findings: none.
- Detailed review comments: https://github.com/ScottArbeit/Grace/pull/178#issuecomment-4611243748

## Reviewer pass

- [ ] Owned paths and forbidden paths reviewed against the issue.
- [ ] Sensitive surfaces reviewed and marked below.
- [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [ ] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [x] Docs impact: Deferred to #171 final audit/docs slice, which will summarize applied/deferred defaults after validation-runner work in #177 lands.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet test --configuration Release --no-build .\src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj` twice; `dotnet test --configuration Release --no-build .\src\Grace.Types.Tests\Grace.Types.Tests.fsproj` twice, after matching Release builds
- [x] Formatting/linting: `dotnet tool run fantomas --check` on touched F# files; `git diff --check`
- [x] Manual validation: audit evidence posted at https://github.com/ScottArbeit/Grace/issues/170#issuecomment-4611171333

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full`: not required for this assembly-default audit because `Grace.Server.Tests` was untouched and explicitly deferred/forbidden. Full validation is expected in downstream validation-runner/final-audit work when appropriate.
- MarkdownLint: no repository Markdown files changed.

## Residual risks

- `Grace.Server.Unit.Tests` defaults are deferred until `ApprovalStore` process-static mutation is isolated or proven safe.
- `Grace.CLI.Tests` defaults are deferred while global/current-process mutations remain in the same assembly.

## Rollback or recovery notes

- Revert this PR to remove the new assembly-level defaults and the `NonParallelizable` marker.

## Docs follow-up required

- #171 should summarize the audit decisions and the deferred follow-up candidates.