### PR TITLE
Run validate tests through solution filter

### DIFF
--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -175,40 +175,63 @@ function Join-TestFilter([string[]]$Terms) {
     $Terms -join "|"
 }
 
+function Get-FSharpProjectTypeFilterTerms([string]$ProjectPath) {
+    if (-not (Test-Path $ProjectPath)) {
+        throw "Test project '$ProjectPath' was not found."
+    }
+
+    $projectDirectory = Split-Path -Path $ProjectPath -Parent
+    [xml]$project = Get-Content -Path $ProjectPath -Raw
+    $terms = @()
+
+    foreach ($compileItem in $project.SelectNodes("//Compile")) {
+        $include = $compileItem.Include
+        if ([string]::IsNullOrWhiteSpace($include)) {
+            continue
+        }
+
+        $sourcePath = Join-Path $projectDirectory $include
+        if (-not (Test-Path $sourcePath)) {
+            throw "Compile item '$include' from '$ProjectPath' was not found."
+        }
+
+        $namespace = $null
+        foreach ($line in Get-Content -Path $sourcePath) {
+            if ($line -match '^\s*namespace\s+([A-Za-z0-9_.]+)') {
+                $namespace = $Matches[1]
+                continue
+            }
+
+            if ($line -match '^\s*type\s+(?!private\b)([A-Za-z_][A-Za-z0-9_]*)') {
+                if ([string]::IsNullOrWhiteSpace($namespace)) {
+                    continue
+                }
+
+                $terms += "FullyQualifiedName~$namespace.$($Matches[1])"
+            }
+        }
+    }
+
+    [string[]]($terms | Select-Object -Unique)
+}
+
+function Get-ServerUnitTestFilterTerms {
+    $terms = Get-FSharpProjectTypeFilterTerms "src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj"
+    if ($terms.Length -eq 0) {
+        throw "No server unit test filter terms were discovered."
+    }
+
+    [string[]]$terms
+}
+
 function Get-FastTestFilterTerms {
     $terms = @(
         "FullyQualifiedName~Grace.Authorization.Tests",
         "FullyQualifiedName~Grace.CLI.Tests",
-        "FullyQualifiedName~Grace.Types.Tests",
-        "FullyQualifiedName~Grace.Server.Tests.ApprovalRequestActorDecisionTests",
-        "FullyQualifiedName~Grace.Server.Tests.GeneratedApprovalRequestIdTests",
-        "FullyQualifiedName~Grace.Server.Tests.ClaimMappingTests",
-        "FullyQualifiedName~Grace.Server.Tests.AuthorizationUnit",
-        "FullyQualifiedName~Grace.Server.Tests.ContentBlockMetadataActorTests",
-        "FullyQualifiedName~Grace.Server.Tests.DedupeIndexServerTests",
-        "FullyQualifiedName~Grace.Server.Tests.AutomationEventingTests",
-        "FullyQualifiedName~Grace.Server.Tests.EvidenceDeterminism",
-        "FullyQualifiedName~Grace.Server.Tests.ManifestContributionWorkflowActorTests",
-        "FullyQualifiedName~Grace.Server.Tests.NotificationServerTests",
-        "FullyQualifiedName~Grace.Server.Tests.OrleansPartitionKeyProviderTests",
-        "FullyQualifiedName~Grace.Server.Tests.OutboundUrlSafetyUnit",
-        "FullyQualifiedName~Grace.Server.Tests.PolicyDeterminism",
-        "FullyQualifiedName~Grace.Server.Tests.PolicyValidationDerivedTests",
-        "FullyQualifiedName~Grace.Server.Tests.PromotionSetCommandValidationTests",
-        "FullyQualifiedName~Grace.Server.Tests.QueuePromotionSetTests",
-        "FullyQualifiedName~Grace.Server.Tests.RepositoryContentCounterActorTests",
-        "FullyQualifiedName~Grace.Server.Tests.ReviewProjectionTests",
-        "FullyQualifiedName~Grace.Server.Tests.ReviewNotesDeterminism",
-        "FullyQualifiedName~Grace.Server.Tests.SaveBoundaryActorTests",
-        "FullyQualifiedName~Grace.Server.Tests.ServicesEffectivePromotionTests",
-        "FullyQualifiedName~Grace.Server.Tests.StorageContentBlockSdkContract",
-        "FullyQualifiedName~Grace.Server.Tests.UploadSessionActorTests",
-        "FullyQualifiedName~Grace.Server.Tests.ValidationArtifactContractTests",
-        "FullyQualifiedName~Grace.Server.Tests.Validations",
-        "FullyQualifiedName~Grace.Server.Tests.WorkItemServerUnitTests"
+        "FullyQualifiedName~Grace.Types.Tests"
     )
 
-    [string[]]$terms
+    [string[]]($terms + (Get-ServerUnitTestFilterTerms))
 }
 
 function Get-TestFilter([bool]$IncludeFullTests) {

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -167,72 +167,69 @@ function Invoke-External([string]$Label, [scriptblock]$Command) {
     }
 }
 
-function Invoke-TestProjectsParallel([object[]]$Projects, [string]$Configuration) {
-    if ($null -eq $Projects -or $Projects.Count -eq 0) {
-        return
+function Join-TestFilter([string[]]$Terms) {
+    if ($null -eq $Terms -or $Terms.Length -eq 0) {
+        throw "At least one test filter term is required."
     }
 
-    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("grace-validation-tests-{0}" -f [guid]::NewGuid().ToString("N"))
-    $null = New-Item -ItemType Directory -Path $tempRoot -Force
-    $processes = @()
+    $Terms -join "|"
+}
 
-    try {
-        foreach ($project in $Projects) {
-            $stdoutPath = Join-Path $tempRoot ("{0}.stdout.log" -f $project.Label)
-            $stderrPath = Join-Path $tempRoot ("{0}.stderr.log" -f $project.Label)
+function Get-FastTestFilterTerms {
+    $terms = @(
+        "FullyQualifiedName~Grace.Authorization.Tests",
+        "FullyQualifiedName~Grace.CLI.Tests",
+        "FullyQualifiedName~Grace.Types.Tests",
+        "FullyQualifiedName~Grace.Server.Tests.ApprovalRequestActorDecisionTests",
+        "FullyQualifiedName~Grace.Server.Tests.GeneratedApprovalRequestIdTests",
+        "FullyQualifiedName~Grace.Server.Tests.ClaimMappingTests",
+        "FullyQualifiedName~Grace.Server.Tests.AuthorizationUnit",
+        "FullyQualifiedName~Grace.Server.Tests.ContentBlockMetadataActorTests",
+        "FullyQualifiedName~Grace.Server.Tests.DedupeIndexServerTests",
+        "FullyQualifiedName~Grace.Server.Tests.AutomationEventingTests",
+        "FullyQualifiedName~Grace.Server.Tests.EvidenceDeterminism",
+        "FullyQualifiedName~Grace.Server.Tests.ManifestContributionWorkflowActorTests",
+        "FullyQualifiedName~Grace.Server.Tests.NotificationServerTests",
+        "FullyQualifiedName~Grace.Server.Tests.OrleansPartitionKeyProviderTests",
+        "FullyQualifiedName~Grace.Server.Tests.OutboundUrlSafetyUnit",
+        "FullyQualifiedName~Grace.Server.Tests.PolicyDeterminism",
+        "FullyQualifiedName~Grace.Server.Tests.PolicyValidationDerivedTests",
+        "FullyQualifiedName~Grace.Server.Tests.PromotionSetCommandValidationTests",
+        "FullyQualifiedName~Grace.Server.Tests.QueuePromotionSetTests",
+        "FullyQualifiedName~Grace.Server.Tests.RepositoryContentCounterActorTests",
+        "FullyQualifiedName~Grace.Server.Tests.ReviewProjectionTests",
+        "FullyQualifiedName~Grace.Server.Tests.ReviewNotesDeterminism",
+        "FullyQualifiedName~Grace.Server.Tests.SaveBoundaryActorTests",
+        "FullyQualifiedName~Grace.Server.Tests.ServicesEffectivePromotionTests",
+        "FullyQualifiedName~Grace.Server.Tests.StorageContentBlockSdkContract",
+        "FullyQualifiedName~Grace.Server.Tests.UploadSessionActorTests",
+        "FullyQualifiedName~Grace.Server.Tests.ValidationArtifactContractTests",
+        "FullyQualifiedName~Grace.Server.Tests.Validations",
+        "FullyQualifiedName~Grace.Server.Tests.WorkItemServerUnitTests"
+    )
 
-            Write-Host ("Starting {0}..." -f $project.Label)
-            $processArguments = @{
-                FilePath = "dotnet"
-                ArgumentList = @("test", $project.Path, "-c", $Configuration, "--no-build")
-                NoNewWindow = $true
-                PassThru = $true
-                RedirectStandardOutput = $stdoutPath
-                RedirectStandardError = $stderrPath
-            }
-            $process = Start-Process @processArguments
+    [string[]]$terms
+}
 
-            $processes += [pscustomobject]@{
-                Label = $project.Label
-                Process = $process
-                StartedAt = Get-Date
-                StdOut = $stdoutPath
-                StdErr = $stderrPath
-            }
-        }
+function Get-TestFilter([bool]$IncludeFullTests) {
+    $terms = Get-FastTestFilterTerms
 
-        $failures = @()
-        foreach ($entry in $processes) {
-            $entry.Process.WaitForExit()
-            $elapsed = $entry.Process.ExitTime - $entry.StartedAt
+    if ($IncludeFullTests) {
+        $terms += "FullyQualifiedName~Grace.Server.Tests"
+    }
 
-            Write-Host ""
-            Write-Host ("-- {0} ({1:c}) --" -f $entry.Label, $elapsed)
+    Join-TestFilter $terms
+}
 
-            if (Test-Path $entry.StdOut) {
-                $stdout = Get-Content $entry.StdOut -Raw
-                if (-not [string]::IsNullOrWhiteSpace($stdout)) {
-                    Write-Host $stdout.TrimEnd()
-                }
-            }
+function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
+    $testFilter = Get-TestFilter $IncludeFullTests
 
-            if (Test-Path $entry.StdErr) {
-                $stderr = Get-Content $entry.StdErr -Raw
-                if (-not [string]::IsNullOrWhiteSpace($stderr)) {
-                    Write-Host $stderr.TrimEnd()
-                }
-            }
+    Write-Host "Test target: src/Grace.slnx"
+    Write-Host ("Test filter: {0}" -f $testFilter)
+    Write-Host ("Running: dotnet test `"src/Grace.slnx`" -c {0} --no-build --filter `"{1}`"" -f $Configuration, $testFilter)
 
-            if ($entry.Process.ExitCode -ne 0) {
-                $failures += ("{0} failed with exit code {1}" -f $entry.Label, $entry.Process.ExitCode)
-            }
-        }
-
-        if ($failures.Count -gt 0) {
-            throw ("Test project failures: {0}." -f ($failures -join "; "))
-        }
-    } finally {
-        Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Invoke-External "Grace solution tests" {
+        dotnet test "src/Grace.slnx" -c $Configuration --no-build --filter $testFilter
     }
 }
 
@@ -293,33 +290,7 @@ try {
 
     if (-not $SkipTests) {
         Write-Section "Test"
-        $testProjects = @(
-            [pscustomobject]@{
-                Label = "Grace.Authorization.Tests"
-                Path = "src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj"
-            },
-            [pscustomobject]@{
-                Label = "Grace.CLI.Tests"
-                Path = "src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj"
-            },
-            [pscustomobject]@{
-                Label = "Grace.Types.Tests"
-                Path = "src/Grace.Types.Tests/Grace.Types.Tests.fsproj"
-            },
-            [pscustomobject]@{
-                Label = "Grace.Server.Unit.Tests"
-                Path = "src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj"
-            }
-        )
-
-        if ($Full) {
-            $testProjects += [pscustomobject]@{
-                Label = "Grace.Server.Tests"
-                Path = "src/Grace.Server.Tests/Grace.Server.Tests.fsproj"
-            }
-        }
-
-        Invoke-TestProjectsParallel $testProjects $Configuration
+        Invoke-SolutionTests $Configuration $Full
     } else {
         Write-Section "Test"
         Write-Host "Skipped (-SkipTests)."


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #177

Parent epic: #166

## Summary

Changes `scripts/validate.ps1` to run tests through one solution-level `dotnet test "src/Grace.slnx"` invocation with a Fast or Full filter, instead of starting selected test projects as parallel `dotnet test` processes.

The script now lets .NET/NUnit own test parallelization. Fast/Full membership is preserved by filter selection:

- Fast selects Authorization, CLI, Types, and Server.Unit tests.
- Full selects the Fast set plus Server integration tests.

## Touched paths

- `scripts/validate.ps1`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `deployment-runtime`
- Public behavior or docs-only validation target: `validate.ps1 -Fast` and `-Full` use one solution-level `dotnet test` command with selection filters.
- RED evidence or docs-only waiver: previous script used custom `Start-Process` fan-out per selected test project.
- Focused validation: `pwsh ./scripts/validate.ps1 -Fast` and `pwsh ./scripts/validate.ps1 -Full`.

## Test coverage changes

Choose one:

- [ ] Tests added or updated; list the test files and covered behavior below.
- [x] No tests added; explain why new tests were not required for this change.

Details:

- Validation-script behavior change only; existing test suites validate membership.

## Review Status

- Implementation handoff received from GPT-5.5 Medium worker Feynman.
- Coordinator found an initial Fast membership regression before PR creation; worker fixed it before this PR was opened.
- Fresh local review-only sibling subagent Averroes (GPT-5.5 high): no issues; recorded at https://github.com/ScottArbeit/Grace/pull/179#issuecomment-4611419064
- Open findings: none.
- Detailed review comments: https://github.com/ScottArbeit/Grace/pull/179#issuecomment-4611419064

## Reviewer pass

- [ ] Owned paths and forbidden paths reviewed against the issue.
- [ ] Sensitive surfaces reviewed and marked below.
- [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [ ] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [x] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [ ] Required; updated relevant docs.
- [x] Docs impact: Deferred to #171 final audit/docs slice, which will summarize final validation behavior.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [x] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: Fast/Full script runs with solution-level `dotnet test` filters
- [x] Formatting/linting: `git diff --check`
- [x] Manual validation: generated Fast-filter membership probe showed 265/265 Server.Unit tests selected and 0 Server integration tests selected.

## Validation not run

- MarkdownLint: no Markdown files changed.
- Fantomas: no F# files changed.

## Residual risks

- VSTest filter language did not expose a reliable project/assembly selector for this solution-level NUnit/VSTest run. The safe fallback derives server-unit fixture/type selectors from `Grace.Server.Unit.Tests.fsproj` compile items and source declarations.
- Future module-level NUnit tests in `Grace.Server.Unit.Tests` may require parser support if they do not appear under top-level fixture types.

## Rollback or recovery notes

- Revert this PR to restore per-project test-process fan-out in `validate.ps1`.

## Docs follow-up required

- #171 should document the final validation behavior and residual filter-generation risk.