### PR TITLE
Document final test boundaries

### DIFF
--- a/skills/grace/references/tests.md
+++ b/skills/grace/references/tests.md
@@ -8,8 +8,9 @@ Load this reference when adding, updating, repairing, or selecting tests.
 | -------- | --------------- |
 | `Grace.Types` contracts | `src/Grace.Types.Tests` |
 | Authorization, endpoint manifest, PAT, claims, path permissions | `src/Grace.Authorization.Tests` |
-| HTTP API and server-surface actor behavior | `src/Grace.Server.Tests` |
-| CLI parsing, command routing, local config/history | `src/Grace.CLI.Tests` |
+| No-Aspire server helpers, contracts, and deterministic unit coverage | `src/Grace.Server.Unit.Tests` |
+| HTTP API, Aspire resources, storage routes, and server-surface actor behavior | `src/Grace.Server.Tests` |
+| CLI pure parsing, command routing, local config/history | `src/Grace.CLI.Tests` |
 | SDK client contract | SDK consumer tests or server contract tests |
 
 ## Server Integration Tests
@@ -17,21 +18,37 @@ Load this reference when adding, updating, repairing, or selecting tests.
 Key guidance from `src/Grace.Server.Tests/AGENTS.md`:
 
 - Tests boot the local Aspire stack with Cosmos, Azurite, Service Bus emulator, Redis, and Grace.Server.
+- Keep HTTP-hosted, emulator/resource, storage route, upload-session, and cross-service behavior here.
 - The first HTTP call in the run must be `POST /owner/create`, done by the setup fixture.
 - Use the shared host module in `AspireTestHost.fs`.
 - Reuse shared state such as `HttpClient`, owner ID, and Service Bus settings.
 - Validate Service Bus messages through the dedicated test subscription so tests do not race the server processor.
 - Do not reintroduce Dapr sidecars, Dapr ports, or Dapr cleanup logic.
 - Log useful diagnostics on failure and redact secrets.
+- This project remains integration-controlled; do not add assembly-level parallel defaults without a new audit.
+
+## Server Unit Tests
+
+Key guidance from `src/Grace.Server.Unit.Tests/AGENTS.md`:
+
+- Use this project for pure, no-Aspire server-adjacent helper, contract, determinism, and unit-shaped coverage.
+- Keep it free of HTTP hosting, emulators, Service Bus, blob storage, Redis, `Grace.Server.Tests.Services`, and
+  `Grace.Aspire.AppHost`.
+- Move ambiguous behavior back to `Grace.Server.Tests` unless it is clearly no-Aspire and unit-shaped.
+- Assembly-level NUnit defaults are deferred while process-static approval-store mutation remains in the project.
 
 ## CLI Tests
 
 Key guidance from `src/Grace.CLI.Tests/AGENTS.md`:
 
 - Match test files to command files when practical.
+- Keep pure parse-only tests in `*.CLI.Parsing.Tests.fs` files so they can be parallelized.
+- Keep invocation, config, environment, console, filesystem, current-directory, local-state, and SDK identity tests in
+  serialized non-parsing files.
 - Keep tests isolated; back up and restore files touched under `~/.grace`.
 - Prefer deterministic timestamps for history-related tests.
 - Use FsUnit for assertions and FsCheck when properties add value.
+- Assembly-level NUnit defaults are deferred while global/current-process mutations remain in the assembly.
 
 ## Type Tests
 
@@ -60,15 +77,26 @@ Add canned regressions for:
 
 ## Validation Commands
 
-Use focused tests first. Then run the selected profile.
+Use focused tests first. Then run the selected profile. Build the matching project in Release before any
+project-specific `dotnet test --no-build` command.
 
 ```powershell
+dotnet build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj
 dotnet test --no-build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
 dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+dotnet build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
 dotnet test --no-build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
+dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+dotnet test --no-build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj
 dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj
 pwsh ./scripts/validate.ps1 -Fast
 pwsh ./scripts/validate.ps1 -Full
 ```
+
+`validate.ps1` uses one solution-level `dotnet test "src/Grace.slnx"` invocation with Fast or Full selection filters,
+not custom per-project process fan-out. Fast selects Authorization, CLI, Types, and Server.Unit tests. Full adds Server
+integration tests.
 
 Run `dotnet tool run fantomas --recurse .` from `./src` after F# changes when formatting is needed.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -74,12 +74,31 @@ update the issue before editing the new paths.
 
 ## Test Project Organization
 
-- `Grace.Server/*.Server.fs` should be primarily covered by `Grace.Server.Tests/*Server.Tests.fs`.
-- `Grace.CLI/Command/*.CLI.fs` should be primarily covered by `Grace.CLI.Tests/*.CLI.Tests.fs`.
+- `Grace.Server.Tests` is the Aspire-backed server integration project. Put HTTP flows, emulator/resource coverage,
+  Service Bus validation, storage route behavior, and server-surface actor behavior there.
+- `Grace.Server.Unit.Tests` is the no-Aspire server-adjacent project. Put pure helper, deterministic contract, and
+  unit-shaped server coverage there only when it does not need HTTP hosting, emulators, blob storage, Service Bus,
+  Redis, `Grace.Server.Tests.Services`, or `Grace.Aspire.AppHost`.
+- `Grace.CLI/Command/*.CLI.fs` should be primarily covered by `Grace.CLI.Tests/*.CLI.Tests.fs`. Pure parser coverage
+  belongs in dedicated `*.CLI.Parsing.Tests.fs` files that can be parallelized. Tests that touch command invocation,
+  local config/history, environment variables, console output, filesystem/current-directory state, or SDK identity
+  remain serialized in the non-parsing CLI test files.
 - `Grace.Types/*.Types.fs` should be covered by `Grace.Types.Tests/*.Types.Tests.fs`.
 - Keep auth-focused suites separate for now (`Grace.Authorization.Tests`, plus auth-specific files inside other test
   projects).
 - Prefer server-surface integration tests for actor behavior; avoid duplicating deep actor internals in server test files.
+
+## Test Parallelization And Validation
+
+- `pwsh ./scripts/validate.ps1 -Fast` and `-Full` run one solution-level `dotnet test "src/Grace.slnx"` command with
+  selection filters. Fast selects Authorization, CLI, Types, and Server.Unit tests. Full adds Server integration tests.
+- Do not reintroduce custom per-project process fan-out into validation unless a future issue owns that runner change.
+- Assembly-level NUnit parallel defaults are intentionally limited. `Grace.Authorization.Tests` and `Grace.Types.Tests`
+  have bounded defaults. `Grace.Server.Unit.Tests` is deferred while process-static approval-store mutation remains in
+  the project. `Grace.CLI.Tests` is deferred while global/current-process mutations remain. `Grace.Server.Tests` stays
+  integration-controlled because it shares Aspire-hosted resources and setup state.
+- If running a project-specific `dotnet test --no-build` command, run the matching Release build for that project first
+  so the test assembly exists and reflects current source.
 
 ## F# Coding Guidelines
 

--- a/src/Grace.CLI.Tests/AGENTS.md
+++ b/src/Grace.CLI.Tests/AGENTS.md
@@ -6,6 +6,7 @@ Read `../AGENTS.md` for global expectations before updating CLI tests.
 
 - Validate CLI command behavior and helpers without requiring server access.
 - Keep tests deterministic and focused on parsing, command routing, output shaping, and local history/config behavior.
+- Keep pure parse-only coverage separate from stateful command tests so NUnit can parallelize the safe subset.
 
 ## Test File Organization
 
@@ -15,7 +16,11 @@ Read `../AGENTS.md` for global expectations before updating CLI tests.
   - `Grace.CLI/Command/Queue.CLI.fs` -> `Grace.CLI.Tests/Queue.CLI.Tests.fs`
   - `Grace.CLI/Command/Review.CLI.fs` -> `Grace.CLI.Tests/Review.CLI.Tests.fs`
   - `Grace.CLI/Command/WorkItem.CLI.fs` -> `Grace.CLI.Tests/WorkItem.CLI.Tests.fs`
-  - Root command behavior belongs in `Grace.CLI.Tests/Program.CLI.Tests.fs`.
+- Root command behavior belongs in `Grace.CLI.Tests/Program.CLI.Tests.fs`.
+- Pure parser tests belong in dedicated `*.CLI.Parsing.Tests.fs` files and should not touch invocation, console,
+  environment, filesystem, current-directory, local config/history, or SDK identity state.
+- Stateful command invocation, config, environment, console, filesystem, local-state, and SDK identity tests remain in
+  the non-parsing files and stay serialized.
 - Keep auth-focused tests separate for now (`Auth.Tests.fs`, `AuthTokenBundle.Tests.fs`).
 
 ## Key Patterns
@@ -23,8 +28,13 @@ Read `../AGENTS.md` for global expectations before updating CLI tests.
 1. Keep tests isolated: back up and restore any files touched under `~/.grace`.
 2. Use FsUnit for assertions and FsCheck for property-based coverage when appropriate.
 3. Prefer deterministic timestamps for history-related tests.
+4. Do not add assembly-level NUnit parallel defaults here until the remaining global/current-process mutations are
+   isolated or proven safe.
 
 ## Validation
 
-- Run `dotnet build --configuration Release` if needed.
-- Run `dotnet test --no-build --configuration Release` after changes.
+- Run the matching Release build before any project-specific `dotnet test --no-build` command.
+- Run `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` only after that build
+  context exists.
+- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate. The script uses one solution-level `dotnet test`
+  invocation with filters rather than custom per-project process fan-out.

--- a/src/Grace.Server.Tests/AGENTS.md
+++ b/src/Grace.Server.Tests/AGENTS.md
@@ -7,6 +7,8 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 - End-to-end integration tests that boot the local Aspire stack (Cosmos + Azurite + Service Bus emulator + Redis + Grace.Server).
 - Verify real HTTP flows against `Grace.Server` with an initialized Service Bus test subscription.
 - Validate actor behavior through server endpoints/contracts wherever possible.
+- Keep this project for HTTP-hosted, emulator-backed, resource, storage route, upload-session, and cross-service
+  behavior. Move pure no-Aspire helper, contract, or deterministic coverage to `Grace.Server.Unit.Tests`.
 
 ## Test File Organization
 
@@ -17,13 +19,18 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
   - `Grace.Server/Queue.Server.fs` -> `Grace.Server.Tests/Queue.Server.Tests.fs`
   - `Grace.Server/WorkItem.Server.fs` -> `Grace.Server.Tests/WorkItem.Server.Tests.fs`
 - Keep auth-focused tests separate for now.
+- Do not add pure SDK-contract or helper-only fixtures here when they can run without Aspire. Prefer
+  `Grace.Server.Unit.Tests` for those tests.
 
 ## Key Patterns
 
 - Tests use Aspire hosting via `Aspire.Hosting.Testing` and the shared host module in `AspireTestHost.fs`.
 - The first HTTP call in the test run must be `POST /owner/create` (done in the `[<SetUpFixture>]`).
-- Service Bus validation must read from the test subscription (`${serverSubscription}-tests`) to avoid racing the server processor.
+- Service Bus validation must read from the test subscription (`${serverSubscription}-tests`) to avoid racing the
+  server processor.
 - Shared state (HttpClient, OwnerId, Service Bus settings) is set during `OneTimeSetUp` and reused by test modules.
+- This project remains integration-controlled. Do not add assembly-level parallel defaults unless a future issue proves
+  the shared Aspire resources and setup state are safe under that change.
 
 ## Notes
 
@@ -33,6 +40,9 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 
 ## Validation
 
-- Run `dotnet build --configuration Release`.
-- Run `dotnet test --no-build --configuration Release`.
+- Run the matching Release build before any project-specific `dotnet test --no-build` command.
+- Run `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj` only after that
+  build context exists.
+- Run `pwsh ./scripts/validate.ps1 -Full` for the integration gate. The script uses one solution-level `dotnet test`
+  invocation with filters rather than custom per-project process fan-out.
 - Run `dotnet tool run fantomas --recurse .` from `./src` after F# changes.

--- a/src/Grace.Server.Unit.Tests/AGENTS.md
+++ b/src/Grace.Server.Unit.Tests/AGENTS.md
@@ -8,12 +8,15 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 - Keep coverage here free of HTTP-hosted server calls, emulator resources, Service Bus, blob storage, Redis, and
   `Grace.Server.Tests.Services`.
 - Move ambiguous server behavior back to `Grace.Server.Tests` unless it is clearly no-Aspire and unit-shaped.
+- This project is in the Fast validation gate and should stay independent of `Grace.Aspire.AppHost`.
 
 ## Test File Organization
 
 - Preserve existing test names and assertion intent when moving coverage from `Grace.Server.Tests`.
 - Keep files named for the behavior under test, even when the namespace still reflects historical test ownership.
 - Do not add `AspireTestHost.fs` or references to `Grace.Aspire.AppHost`.
+- Avoid adding assembly-level NUnit parallel defaults here for now. The current audit deferred the project because at
+  least one fixture mutates process-static approval-store state.
 
 ## Validation
 
@@ -22,4 +25,6 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
   `--no-build` tests.
 - Run `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
   only after that build context exists.
-- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate.
+- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate. The script runs solution-level `dotnet test` with
+  selection filters; because several moved files keep historical `Grace.Server.Tests` namespaces, the Server.Unit
+  filter currently derives fixture/type selectors from project compile items and source declarations.


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #171

Parent epic: #166

## Summary

Updates nearby test guidance after the full test-parallelization rollout:

- Documents the `Grace.Server.Unit.Tests` versus `Grace.Server.Tests` boundary.
- Documents CLI parse-only fixtures versus serialized stateful CLI tests.
- Documents final Fast/Full validation behavior using one solution-level `dotnet test "src/Grace.slnx"` invocation with selection filters.
- Records assembly-default audit decisions and deferrals.
- Captures residual risks and follow-up candidates for future test-speed work.

## Touched paths

- `src/AGENTS.md`
- `src/Grace.Server.Tests/AGENTS.md`
- `src/Grace.Server.Unit.Tests/AGENTS.md`
- `src/Grace.CLI.Tests/AGENTS.md`
- `skills/grace/references/tests.md`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `docs-only`
- Public behavior or docs-only validation target: test-boundary and validation-workflow guidance for future Grace agents/contributors.
- RED evidence or docs-only waiver: docs-only final audit slice; no RED test required.
- Focused validation: MarkdownLint and diff checks.

## Test coverage changes

Choose one:

- [ ] Tests added or updated; list the test files and covered behavior below.
- [x] No tests added; explain why new tests were not required for this change.

Details:

- Documentation-only change. Test behavior was implemented and validated in PRs #172, #173, #174, #178, and #179.

## Review Status

- Implementation handoff received from GPT-5.5 Medium worker Russell.
- Fresh local review-only sibling subagent Hegel (GPT-5.5 high): no issues; recorded at https://github.com/ScottArbeit/Grace/pull/180#issuecomment-4611500605
- Open findings: none.
- Detailed review comments: https://github.com/ScottArbeit/Grace/pull/180#issuecomment-4611500605

## Reviewer pass

- [ ] Owned paths and forbidden paths reviewed against the issue.
- [ ] Sensitive surfaces reviewed and marked below.
- [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [ ] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [x] Docs or workflow
- [ ] None of the above

## Docs impact

Choose one:

- [x] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [ ] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [ ] Focused tests: command
- [x] Formatting/linting: `npx --yes markdownlint-cli2 "src/AGENTS.md" "src/Grace.Server.Tests/AGENTS.md" "src/Grace.Server.Unit.Tests/AGENTS.md" "src/Grace.CLI.Tests/AGENTS.md" "skills/grace/references/tests.md"`; `git diff --check`; `git diff --cached --check` before commit
- [x] Manual validation: final audit against merged rollout PR evidence

## Validation not run

- Fast/Full validation skipped because this slice changed only Markdown guidance. Merged PR #174 and PR #179 carry Full validation evidence for implementation/runner behavior; PR #179 carries the final solution-filter Fast/Full behavior proof.
- Fantomas/build/test skipped because no F# or behavior files changed.

## Residual risks

- `Grace.Server.Unit.Tests` assembly-level defaults remain deferred until process-static approval-store mutation is isolated or proven safe.
- `Grace.CLI.Tests` assembly-level defaults remain deferred until global/current-process mutation hazards are isolated or proven safe.
- Additional CLI parser-adjacent extractions remain future work.
- `validate.ps1` Server.Unit filtering derives fixture/type selectors because many moved files retain historical `Grace.Server.Tests` namespaces; future module-level tests may need parser support or namespace cleanup.

## Rollback or recovery notes

- Revert this PR to restore the previous guidance text. The implementation changes remain in earlier merged PRs.

## Docs follow-up required

- None for this rollout beyond the residual risks listed above.