### PR TITLE
Remove model-specific agent doc requirements

### DIFF
--- a/docs/AI Submissions.md
+++ b/docs/AI Submissions.md
@@ -34,19 +34,16 @@ Please treat the submission like professional engineering work product that you'
 
 ## Non-Negotiable Submission Rules
 
-1. Use the latest and most powerful generally available reasoning model from your chosen provider at submission time.
-   (i.e. Opus, not Sonnet; nothing with "mini" in the name) [^models]
-2. Use reasoning at least equivalent to Codex and Claude's `high` (or stronger) to plan and implement the work.
+1. Use tooling that is capable of doing careful repository research, making focused changes, and producing verifiable
+   evidence for reviewers.
+2. Disclose the available run metadata for the AI assistance you used, including harness, provider, model, and
+   reasoning or effort settings when the harness exposes them.
 3. Use the required Grace issue and pull request template prompts to have your agent automatically create the submission
    package.
    - Issue description prompt: [Grace issue summary.md](/prompts/Grace%20issue%20summary.md)
    - Pull request description prompt: [Grace pull request summary.md](/prompts/Grace%20pull%20request%20summary.md)
 4. Include the prompts used to produce the final result.
 5. Assume your output will be re-researched and reviewed by other LLMs and humans.
-
-[^models]: I realize that this creates a barrier for AI submission that includes only those who can afford to run frontier models.
-That's the minimum quality I need in the first half of 2026. I expect that by 2027 "Sonnet" and "Mini" level models will achieve a
-similar capability level, and I will adjust these requirements when they're ready.
 
 Write-ups should:
 
@@ -55,18 +52,11 @@ Write-ups should:
 - Be thorough.
 - Prefer evidence over vague claims.
 
-## Reasoning Level Mapping Guidance
+## Runtime Metadata Guidance
 
-Your provider may use different labels. Map your configuration to the closest equivalent that is at least Codex or Claude
-`high`.
-
-- OpenAI: `high` or `xhigh` reasoning.
-- Anthropic: `high` or `max` effort.
-- Google Gemini: thinking enabled with a high/maximum reasoning configuration.
-- Other providers: choose the highest non-experimental reasoning mode generally available for production use.
-
-If your provider exposes only vague labels, document exactly what you selected and why it is equivalent or stronger
-than `high`.
+Different harnesses expose different run metadata. Capture what is available from runtime status, settings, logs, or
+configuration without guessing. If a value is unknown, say exactly what was checked and why the value could not be
+confirmed.
 
 ## Quality Expectations
 
@@ -78,6 +68,5 @@ comprehensive submissions that validate that you've done the work correctly, and
 Submissions can be closed or requested for revision when:
 
 1. Model/reasoning metadata is missing or unclear.
-2. The run does not meet the latest-model or high-reasoning rule.
-3. Prompt history is omitted.
-4. The write-up is shallow, unverifiable, or inconsistent with the code.
+2. Prompt history is omitted.
+3. The write-up is shallow, unverifiable, or inconsistent with the code.

--- a/prompts/Grace issue summary.md
+++ b/prompts/Grace issue summary.md
@@ -7,24 +7,20 @@ Use this prompt to produce a complete GitHub issue body for the Grace repository
 You are preparing a high-rigor issue write-up that will be reviewed by humans and re-researched by other LLMs.
 Write clearly, concretely, and thoroughly.
 
-## Compliance Gate
+## Runtime Transparency Check
 
 Before writing, confirm and report:
 
 1. Harness used.
 2. Exact model used.
 3. Reasoning or effort level used.
-4. Whether this run used the latest generally available model from that provider.
-5. Whether reasoning is at least equivalent to OpenAI `high`.
-
-If items 4 or 5 are not true, stop and output only:
-`NON-COMPLIANT: latest-model and high-reasoning requirements not met.`
+4. Metadata source and evidence.
+5. Any unavailable metadata fields and what was checked.
 
 ## Runtime Metadata Script (Required)
 
 Before drafting the issue body, run the metadata collection script and use its output as the source of truth for:
-`harness`, `provider`, `model`, `reasoning_level`, `reasoning_level_equivalent`, `high_reasoning_asserted`,
-`latest_model_asserted`, `metadata_source`, and `metadata_evidence`.
+`harness`, `provider`, `model`, `reasoning_level`, `metadata_source`, and `metadata_evidence`.
 
 PowerShell:
 
@@ -43,25 +39,38 @@ For auditability, prefer a second run with `-Verbose` and capture important disc
 ## Copy/Paste Snippet
 
 Use one of these commands to print a ready-to-paste YAML block for the top of the issue body.
-After pasting, add `prompt_count: <integer>` on its own line inside the same YAML block.
+After pasting, replace `prompt_count: <integer>` with the actual prompt count.
 
 PowerShell:
 
-```powershell
-$meta = pwsh ./scripts/collect-runtime-metadata.ps1 -WorkspacePath . -OutputFormat Yaml
-$metaText = $meta -join [Environment]::NewLine
-(
-  '```yaml' + [Environment]::NewLine + $metaText + [Environment]::NewLine +
-  'prompt_count: <integer>' + [Environment]::NewLine + '```'
-)
+````powershell
+$meta = pwsh ./scripts/collect-runtime-metadata.ps1 -WorkspacePath . -OutputFormat Json | ConvertFrom-Json
+@"
+```yaml
+harness: $($meta.harness)
+provider: $($meta.provider)
+model: $($meta.model)
+reasoning_level: $($meta.reasoning_level)
+prompt_count: <integer>
+metadata_source: $($meta.metadata_source)
+metadata_evidence:
+  harness: $($meta.metadata_evidence.harness)
+  provider: $($meta.metadata_evidence.provider)
+  model: $($meta.metadata_evidence.model)
+  reasoning_level: $($meta.metadata_evidence.reasoning_level)
+generated_at_utc: $($meta.generated_at_utc)
 ```
+"@
+````
 
 bash / zsh:
 
 ```bash
-meta="$(pwsh ./scripts/collect-runtime-metadata.ps1 -WorkspacePath . -OutputFormat Yaml)"
-printf '```yaml\n%s\nprompt_count: <integer>\n```\n' "$meta"
+pwsh ./scripts/collect-runtime-metadata.ps1 -WorkspacePath . -OutputFormat Json
 ```
+
+For bash / zsh, convert the JSON output into the required YAML fields with your preferred local JSON tooling, or copy
+the values manually into the metadata block.
 
 ## Runtime Metadata Discovery (Required)
 
@@ -88,40 +97,11 @@ Always include a short evidence line for each discovered field. Evidence must be
 
 Do not claim a value without evidence.
 
-## Reasoning-Level Normalization (Required)
+## Reasoning And Model Metadata Handling
 
-Set `reasoning_level` to the provider-native setting (verbatim when available). Then compute
-`reasoning_level_equivalent` as one of: `low`, `medium`, `high`, `xhigh`.
-
-Normalization rules (use the first rule that applies):
-
-1. If provider explicitly reports one of `low|medium|high|xhigh`, use it directly.
-2. If provider reports text containing:
-    - `minimal`, `light`, `fast` => `low`
-    - `balanced`, `standard`, `normal`, `default` => `medium`
-    - `deep`, `intensive`, `high` => `high`
-    - `max`, `very-high`, `ultra`, `extended` => `xhigh`
-3. If reasoning/thinking is boolean only:
-    - disabled/off => `low`
-    - enabled/on with no strength/budget detail => `medium` (conservative default)
-4. If a numeric reasoning budget is available (tokens/steps):
-    - `<= 2000` => `low`
-    - `2001-8000` => `medium`
-    - `8001-24000` => `high`
-    - `> 24000` => `xhigh`
-5. If none apply => `unknown` and mark compliance as false.
-
-## Latest-Model Assertion Rule (Required)
-
-Set `latest_model_asserted: true` only when you have explicit evidence from this same run that the selected model is the
-latest generally available model for that provider.
-
-Acceptable evidence:
-
-- harness-provided statement that the active model is latest/current, or
-- a provider source checked in-run with date and link
-
-If that evidence is missing, set `latest_model_asserted: false`. Do not guess.
+Set `reasoning_level` to the provider-native setting verbatim when available. Do not normalize it into a required
+cross-provider tier, and do not infer whether the selected model is the newest or strongest option. If the value is not
+exposed by the harness, set it to `unknown` and describe the evidence checked.
 
 ## Input You Should Receive
 
@@ -168,9 +148,6 @@ harness: <tool/harness name>
 provider: <model provider>
 model: <exact model identifier>
 reasoning_level: <provider-specific setting>
-reasoning_level_equivalent: <OpenAI low|medium|high|xhigh equivalent>
-latest_model_asserted: true|false
-high_reasoning_asserted: true|false
 prompt_count: <integer>
 metadata_source: <status|runtime-settings|config-file|env|mixed|unknown>
 metadata_evidence:
@@ -187,9 +164,6 @@ generated_at_utc: <ISO-8601 UTC timestamp>
 - Provider:
 - Model:
 - Reasoning Level:
-- Reasoning Level Equivalent:
-- Latest-Model Compliance:
-- High-Reasoning Compliance:
 - Metadata Source:
 - Metadata Evidence:
 - Timestamp (UTC):

--- a/prompts/Grace pull request summary.md
+++ b/prompts/Grace pull request summary.md
@@ -7,18 +7,15 @@ Use this prompt to produce a complete GitHub pull request body for the Grace rep
 You are preparing a high-rigor PR summary that will be reviewed by humans and re-researched by other LLMs.
 Write clearly, concretely, and thoroughly.
 
-## Compliance Gate
+## Runtime Transparency Check
 
 Before writing, confirm and report:
 
 1. Harness used.
 2. Exact model used.
 3. Reasoning or effort level used.
-4. Whether this run used the latest generally available model from that provider.
-5. Whether reasoning / effort is at least equivalent to Codex and Claude's `high`.
-
-If items 4 or 5 are not true, stop and output only:
-`NON-COMPLIANT: latest-model and high-reasoning requirements not met.`
+4. Metadata source and evidence.
+5. Any unavailable metadata fields and what was checked.
 
 ## Input You Should Receive
 
@@ -59,10 +56,13 @@ harness: <tool/harness name>
 provider: <model provider>
 model: <exact model identifier>
 reasoning_level: <provider-specific setting>
-reasoning_level_equivalent: <OpenAI low|medium|high|xhigh equivalent>
-latest_model_asserted: true|false
-high_reasoning_asserted: true|false
 prompt_count: <integer>
+metadata_source: <status|runtime-settings|config-file|env|mixed|unknown>
+metadata_evidence:
+  harness: <short evidence>
+  provider: <short evidence>
+  model: <short evidence>
+  reasoning_level: <short evidence>
 generated_at_utc: <ISO-8601 UTC timestamp>
 ```
 
@@ -72,9 +72,8 @@ generated_at_utc: <ISO-8601 UTC timestamp>
 - Provider:
 - Model:
 - Reasoning Level:
-- Reasoning Level Equivalent:
-- Latest-Model Compliance:
-- High-Reasoning Compliance:
+- Metadata Source:
+- Metadata Evidence:
 - Timestamp (UTC):
 
 ### 2) PR Introduction

--- a/skills/grace/references/workflow.md
+++ b/skills/grace/references/workflow.md
@@ -41,9 +41,9 @@ For non-trivial tracked work:
 
 When acting as the main implementation orchestrator, follow the repo policy:
 
-- Delegate coding and fixing tasks to GPT-5.5 Medium worker subagents when the available tools and user authorization
-  allow delegation.
-- Use GPT-5.4-mini xhigh fresh local review-only sibling subagents for code review when available.
+- Delegate coding and fixing tasks to worker subagents when the available tools and user authorization allow
+  delegation.
+- Use fresh local review-only sibling subagents for code review when available.
 - Do not replace the worker by locally implementing or validating code fixes from the orchestrator role.
 - Persist each review report, including "Reviewed And OK" notes, to the issue or PR before starting another review.
 - Include prior OK notes in follow-up review prompts so reviewers do not repeat work without cause.


### PR DESCRIPTION
## Summary

- Removes repo-owned instructions that require specific providers, model families, latest-model status, or reasoning tiers.
- Keeps Grace's worker/review-only subagent workflow and evidence requirements provider-neutral.
- Preserves product-facing runtime metadata disclosure where Grace records or reports model/provider information.

## Linked Issue

Closes #182.

## Validation

- `npx --yes markdownlint-cli2 "AGENTS.md" "src/AGENTS.md" "docs/Development process.md" "CONTRIBUTING.md" "docs/AI Submissions.md" "prompts/Grace issue summary.md" "prompts/Grace pull request summary.md" "skills/grace/SKILL.md" "skills/grace/references/workflow.md"`: passed, `Summary: 0 error(s)`.
- `git diff --check -- AGENTS.md src/AGENTS.md "docs/Development process.md" CONTRIBUTING.md "docs/AI Submissions.md" prompts skills/grace .github`: passed, no output.
- `pwsh ./scripts/validate.ps1 -Fast`: skipped because this is a docs-only change and no build/test inputs changed.

## Review Status

- Implementation worker completed commit `9761052` and pushed `agent/182-provider-neutral-docs`.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/196#issuecomment-4617283669
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

Docs-only cleanup for repo-owned agent, contributor, prompt, and workflow guidance.

## Residual Risk

Low. The main risk is accidentally weakening the required subagent/review workflow while removing model-specific wording; this was checked by the local review-only sibling subagent.