### PR TITLE
Add ExternalAuthConfig unit tests

### DIFF
--- a/src/Grace.Server.Unit.Tests/ExternalAuthConfig.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ExternalAuthConfig.Unit.Tests.fs
@@ -1,0 +1,112 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Auth
+open Microsoft.Extensions.Configuration
+open NUnit.Framework
+open System.Collections.Generic
+
+[<Parallelizable(ParallelScope.All)>]
+type ExternalAuthConfigUnitTests() =
+
+    let configuration (values: (string * string) list) =
+        let pairs =
+            values
+            |> List.map (fun (key, value) -> KeyValuePair<string, string>(getConfigKey key, value))
+
+        ConfigurationBuilder()
+            .AddInMemoryCollection(pairs)
+            .Build()
+        :> IConfiguration
+
+    let assertOidcConfig (expectedAuthority: string) (expectedAudience: string) (result: ExternalAuthConfig.OidcAuthConfig option) =
+        match result with
+        | Some config ->
+            Assert.That(config.Authority, Is.EqualTo(expectedAuthority))
+            Assert.That(config.Audience, Is.EqualTo(expectedAudience))
+        | None -> Assert.Fail("Expected OIDC config to be returned.")
+
+    let assertClientConfig (expectedAuthority: string) (expectedAudience: string) (expectedCliClientId: string) (result: OidcClientConfig option) =
+        match result with
+        | Some config ->
+            Assert.That(config.Authority, Is.EqualTo(expectedAuthority))
+            Assert.That(config.Audience, Is.EqualTo(expectedAudience))
+            Assert.That(config.CliClientId, Is.EqualTo(expectedCliClientId))
+        | None -> Assert.Fail("Expected OIDC client config to be returned.")
+
+    let oidcConfiguration authority audience =
+        configuration [ Constants.EnvironmentVariables.GraceAuthOidcAuthority, authority
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, audience ]
+
+    let oidcClientConfiguration authority audience cliClientId =
+        configuration [ Constants.EnvironmentVariables.GraceAuthOidcAuthority, authority
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, audience
+                        Constants.EnvironmentVariables.GraceAuthOidcCliClientId, cliClientId ]
+
+    [<Test>]
+    member _.NullConfigurationReturnsNone() =
+        let nullConfiguration: IConfiguration = null
+
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig nullConfiguration, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.tryGetOidcClientConfig nullConfiguration, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.isOidcConfigured nullConfiguration, Is.False)
+
+    [<Test>]
+    member _.MissingAuthorityOrAudienceReturnsNone() =
+        let missingAuthority = configuration [ Constants.EnvironmentVariables.GraceAuthOidcAudience, "api://grace" ]
+
+        let missingAudience = configuration [ Constants.EnvironmentVariables.GraceAuthOidcAuthority, "https://login.example.test/tenant" ]
+
+        let blankAuthority = oidcConfiguration "   " "api://grace"
+        let blankAudience = oidcConfiguration "https://login.example.test/tenant" "   "
+
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig missingAuthority, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig missingAudience, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig blankAuthority, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig blankAudience, Is.EqualTo(None))
+
+        Assert.That(ExternalAuthConfig.isOidcConfigured missingAuthority, Is.False)
+        Assert.That(ExternalAuthConfig.isOidcConfigured missingAudience, Is.False)
+        Assert.That(ExternalAuthConfig.isOidcConfigured blankAuthority, Is.False)
+        Assert.That(ExternalAuthConfig.isOidcConfigured blankAudience, Is.False)
+
+    [<Test>]
+    member _.ValuesAreTrimmedAndAuthorityGetsOneTrailingSlash() =
+        oidcConfiguration "  https://login.example.test/tenant  " "  api://grace  "
+        |> ExternalAuthConfig.tryGetOidcConfig
+        |> assertOidcConfig "https://login.example.test/tenant/" "api://grace"
+
+        oidcConfiguration "  https://login.example.test/tenant/  " "  api://grace  "
+        |> ExternalAuthConfig.tryGetOidcConfig
+        |> assertOidcConfig "https://login.example.test/tenant/" "api://grace"
+
+    [<Test>]
+    member _.ClientConfigRequiresCliClientId() =
+        let missingClientId = oidcConfiguration "https://login.example.test/tenant" "api://grace"
+        let blankClientId = oidcClientConfiguration "https://login.example.test/tenant" "api://grace" "   "
+
+        Assert.That(ExternalAuthConfig.tryGetOidcClientConfig missingClientId, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.tryGetOidcClientConfig blankClientId, Is.EqualTo(None))
+
+    [<Test>]
+    member _.ClientConfigTrimsValuesAndNormalizesAuthority() =
+        oidcClientConfiguration "  https://login.example.test/tenant  " "  api://grace  " "  grace-cli  "
+        |> ExternalAuthConfig.tryGetOidcClientConfig
+        |> assertClientConfig "https://login.example.test/tenant/" "api://grace" "grace-cli"
+
+    [<Test>]
+    member _.IsOidcConfiguredReflectsTryGetOidcConfig() =
+        let configured = oidcConfiguration "https://login.example.test/tenant" "api://grace"
+        let notConfigured = oidcConfiguration "https://login.example.test/tenant" "   "
+
+        Assert.That(
+            ExternalAuthConfig.tryGetOidcConfig configured
+            |> Option.isSome,
+            Is.True
+        )
+
+        Assert.That(ExternalAuthConfig.isOidcConfigured configured, Is.True)
+        Assert.That(ExternalAuthConfig.tryGetOidcConfig notConfigured, Is.EqualTo(None))
+        Assert.That(ExternalAuthConfig.isOidcConfigured notConfigured, Is.False)

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="TestCommon.fs" />
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
+    <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds focused no-Aspire unit coverage for `ExternalAuthConfig` OIDC configuration parsing.
- Covers null/missing/blank values, trimming, single trailing slash normalization, CLI client ID requirements, and `isOidcConfigured` parity.
- Adds the new test file to `Grace.Server.Unit.Tests`.

## Linked Issue

Closes #186.

## Validation

- `dotnet tool run fantomas src/Grace.Server.Unit.Tests/ExternalAuthConfig.Unit.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~ExternalAuthConfig`: passed, `6/6` tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is no-Aspire unit coverage and does not touch hosted auth middleware, Aspire, emulators, storage, Service Bus, Redis, or runtime integration behavior.

## Review Status

- Implementation worker completed commit `f044717` and pushed `agent/186-external-auth-config-tests`.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/198#issuecomment-4617417980
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Low to moderate. This is test-only coverage, but the review should confirm the tests reflect the current parser contract and do not rely on process-wide environment state.