### PR TITLE
Extract ValidateIds metadata decision helpers

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs
@@ -1,0 +1,109 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Middleware
+open Microsoft.AspNetCore.Http
+open NUnit.Framework
+open System
+open System.Threading.Tasks
+
+type BodyWithAllEntityProperties() =
+    member val OwnerId = "" with get, set
+    member val OwnerName = "" with get, set
+    member val OrganizationId = "" with get, set
+    member val OrganizationName = "" with get, set
+    member val RepositoryId = "" with get, set
+    member val RepositoryName = "" with get, set
+    member val BranchId = "" with get, set
+    member val BranchName = "" with get, set
+
+type BodyWithMissingEntityProperties() =
+    member val OwnerId = "" with get, set
+    member val RepositoryName = "" with get, set
+
+[<Parallelizable(ParallelScope.All)>]
+type ValidateIdsDecisionsTests() =
+
+    let endpointWithMetadata (metadata: obj array) =
+        Endpoint(RequestDelegate(fun _ -> Task.CompletedTask), EndpointMetadataCollection(metadata), "test endpoint")
+
+    [<Test>]
+    member _.IgnoredPathsReturnNoBodyType() =
+        let endpoint = endpointWithMetadata [| typeof<BodyWithAllEntityProperties> |]
+
+        for path in
+            [
+                "/healthz"
+                "/notifications"
+                "/approval/request/_seedGenerated"
+            ] do
+            let result = ValidateIdsDecisions.tryGetBodyType path endpoint
+
+            Assert.That(result, Is.EqualTo(None), $"Expected {path} to be ignored.")
+
+    [<Test>]
+    member _.IgnoredPathMatchingIsCaseInsensitiveAndPrefixAware() =
+        let endpoint = endpointWithMetadata [| typeof<BodyWithAllEntityProperties> |]
+
+        for path in
+            [
+                "/HeAlThZ/details"
+                "/NOTIFICATIONS/stream"
+                "/Approval/Request/_SeedGenerated/test"
+            ] do
+            let result = ValidateIdsDecisions.tryGetBodyType path endpoint
+
+            Assert.That(result, Is.EqualTo(None), $"Expected {path} to be ignored.")
+
+    [<Test>]
+    member _.EndpointWithNoMetadataReturnsNoBodyType() =
+        let endpoint = endpointWithMetadata [||]
+        let result = ValidateIdsDecisions.tryGetBodyType "/owner/create" endpoint
+
+        Assert.That(result, Is.EqualTo(None))
+
+    [<Test>]
+    member _.EndpointWithNonTypeMetadataReturnsNoBodyType() =
+        let endpoint =
+            endpointWithMetadata [| "metadata"
+                                    42
+                                    DateTimeOffset.UnixEpoch |]
+
+        let result = ValidateIdsDecisions.tryGetBodyType "/owner/create" endpoint
+
+        Assert.That(result, Is.EqualTo(None))
+
+    [<Test>]
+    member _.EndpointWithBodyTypeMetadataReturnsThatType() =
+        let endpoint =
+            endpointWithMetadata [| "metadata"
+                                    typeof<BodyWithAllEntityProperties> |]
+
+        let result = ValidateIdsDecisions.tryGetBodyType "/owner/create" endpoint
+
+        Assert.That(result, Is.EqualTo(Some(typeof<BodyWithAllEntityProperties>)))
+
+    [<Test>]
+    member _.EntityPropertyDiscoveryFindsOwnerOrganizationRepositoryAndBranchProperties() =
+        let properties = ValidateIdsDecisions.discoverEntityProperties typeof<BodyWithAllEntityProperties>
+
+        Assert.That(properties.OwnerId.Value.Name, Is.EqualTo("OwnerId"))
+        Assert.That(properties.OwnerName.Value.Name, Is.EqualTo("OwnerName"))
+        Assert.That(properties.OrganizationId.Value.Name, Is.EqualTo("OrganizationId"))
+        Assert.That(properties.OrganizationName.Value.Name, Is.EqualTo("OrganizationName"))
+        Assert.That(properties.RepositoryId.Value.Name, Is.EqualTo("RepositoryId"))
+        Assert.That(properties.RepositoryName.Value.Name, Is.EqualTo("RepositoryName"))
+        Assert.That(properties.BranchId.Value.Name, Is.EqualTo("BranchId"))
+        Assert.That(properties.BranchName.Value.Name, Is.EqualTo("BranchName"))
+
+    [<Test>]
+    member _.EntityPropertyDiscoveryLeavesMissingNameOrIdPropertiesAbsent() =
+        let properties = ValidateIdsDecisions.discoverEntityProperties typeof<BodyWithMissingEntityProperties>
+
+        Assert.That(properties.OwnerId.IsSome, Is.True)
+        Assert.That(properties.OwnerName.IsNone, Is.True)
+        Assert.That(properties.OrganizationId.IsNone, Is.True)
+        Assert.That(properties.OrganizationName.IsNone, Is.True)
+        Assert.That(properties.RepositoryId.IsNone, Is.True)
+        Assert.That(properties.RepositoryName.IsSome, Is.True)
+        Assert.That(properties.BranchId.IsNone, Is.True)
+        Assert.That(properties.BranchName.IsNone, Is.True)

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -67,6 +67,7 @@
 		<Compile Include="Middleware\Fake.Middleware.fs" />
 		<Compile Include="Middleware\HttpSecurityHeaders.Middleware.fs" />
 		<Compile Include="Middleware\CorrelationId.Middleware.fs" />
+		<Compile Include="Middleware\ValidateIds.Decisions.fs" />
 		<Compile Include="Middleware\ValidateIds.Middleware.fs" />
 		<Compile Include="Middleware\LogRequestHeaders.Middleware.fs" />
 		<Compile Include="Middleware\LogAuthorizationFailure.Middleware.fs" />

--- a/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
@@ -1,0 +1,76 @@
+namespace Grace.Server.Middleware
+
+open Grace.Types.Types
+open Microsoft.AspNetCore.Http
+open System
+open System.Reflection
+
+/// Holds the PropertyInfo for each Entity Id and Name property.
+type EntityProperties =
+    {
+        OwnerId: PropertyInfo option
+        OwnerName: PropertyInfo option
+        OrganizationId: PropertyInfo option
+        OrganizationName: PropertyInfo option
+        RepositoryId: PropertyInfo option
+        RepositoryName: PropertyInfo option
+        BranchId: PropertyInfo option
+        BranchName: PropertyInfo option
+    }
+
+    static member Default =
+        {
+            OwnerId = None
+            OwnerName = None
+            OrganizationId = None
+            OrganizationName = None
+            RepositoryId = None
+            RepositoryName = None
+            BranchId = None
+            BranchName = None
+        }
+
+module ValidateIdsDecisions =
+
+    /// Paths that we want to ignore, because they won't have Ids and Names in the body.
+    let ignoredPaths =
+        [
+            "/healthz"
+            "/notifications"
+            "/approval/request/_seedGenerated"
+        ]
+
+    let isIgnoredPath (path: string) =
+        ignoredPaths
+        |> Seq.exists (fun ignoredPath -> path.StartsWith(ignoredPath, StringComparison.InvariantCultureIgnoreCase))
+
+    /// Gets the parameter type for the endpoint from the endpoint metadata created in Startup.Server.fs.
+    let tryGetBodyType (path: string) (endpoint: Endpoint) =
+        if isIgnoredPath path
+           || isNull endpoint
+           || endpoint.Metadata.Count = 0 then
+            None
+        else
+            endpoint.Metadata
+            |> Seq.tryPick (function
+                | :? Type as requestBodyType -> Some requestBodyType
+                | _ -> None)
+
+    let discoverEntityProperties (requestBodyType: Type) =
+        let properties = requestBodyType.GetProperties(BindingFlags.Public ||| BindingFlags.Instance)
+
+        /// Checks if a property with the given name exists on the request body type.
+        let findProperty name =
+            properties
+            |> Seq.tryFind (fun property -> property.Name = name)
+
+        {
+            OwnerId = findProperty (nameof OwnerId)
+            OwnerName = findProperty (nameof OwnerName)
+            OrganizationId = findProperty (nameof OrganizationId)
+            OrganizationName = findProperty (nameof OrganizationName)
+            RepositoryId = findProperty (nameof RepositoryId)
+            RepositoryName = findProperty (nameof RepositoryName)
+            BranchId = findProperty (nameof BranchId)
+            BranchName = findProperty (nameof BranchName)
+        }

--- a/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
@@ -19,36 +19,10 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.Linq
 open System.Net
-open System.Reflection
 open System.Threading.Tasks
 open System.Text
 open System.Text.Json
 open Grace.Actors.Constants.ActorName
-
-/// Holds the PropertyInfo for each Entity Id and Name property.
-type EntityProperties =
-    {
-        OwnerId: PropertyInfo option
-        OwnerName: PropertyInfo option
-        OrganizationId: PropertyInfo option
-        OrganizationName: PropertyInfo option
-        RepositoryId: PropertyInfo option
-        RepositoryName: PropertyInfo option
-        BranchId: PropertyInfo option
-        BranchName: PropertyInfo option
-    }
-
-    static member Default =
-        {
-            OwnerId = None
-            OwnerName = None
-            OrganizationId = None
-            OrganizationName = None
-            RepositoryId = None
-            RepositoryName = None
-            BranchId = None
-            BranchName = None
-        }
 
 /// Examines the body of the incoming request to validate the Ids and Names in the request, and ensure that we know the right Ids. Having the Ids already figured out saves work for the rest of the pipeline.
 ///
@@ -65,31 +39,18 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
     /// Holds the property info for each request body type.
     let propertyLookup = ConcurrentDictionary<Type, EntityProperties>()
 
-    /// Paths that we want to ignore, because they won't have Ids and Names in the body.
-    let ignorePaths =
-        [
-            "/healthz"
-            "/notifications"
-            "/approval/request/_seedGenerated"
-        ]
-
     /// Gets the parameter type for the endpoint from the endpoint metadata created in Startup.Server.fs.
     let getBodyType (context: HttpContext) =
         let path = context.Request.Path.ToString()
 
-        if not
-           <| (ignorePaths
-               |> Seq.exists (fun ignorePath -> path.StartsWith(ignorePath, StringComparison.InvariantCultureIgnoreCase))) then
+        if not <| ValidateIdsDecisions.isIgnoredPath path then
             let endpoint = context.GetEndpoint()
 
             if isNull (endpoint) then
                 log.LogDebug("{CurrentInstant}: Path: {path}; Endpoint: null.", getCurrentInstantExtended (), path)
                 None
             elif endpoint.Metadata.Count > 0 then
-                let requestBodyType =
-                    endpoint.Metadata
-                    |> Seq.tryFind (fun metadataItem -> metadataItem.GetType().FullName = "System.RuntimeType") // The types that we add in Startup.Server.fs show up here as "System.RuntimeType".
-                    |> Option.map (fun metadataItem -> metadataItem :?> Type) // Convert the metadata item to a Type.
+                let requestBodyType = ValidateIdsDecisions.tryGetBodyType path endpoint
 
                 if requestBodyType |> Option.isSome then
                     log.LogDebug(
@@ -160,27 +121,7 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
                             not
                             <| propertyLookup.TryGetValue(requestBodyType, &entityProperties)
                         then
-
-                            // Get all of the properties on the request body type.
-                            let properties = requestBodyType.GetProperties(BindingFlags.Public ||| BindingFlags.Instance)
-
-                            /// Checks if a property with the given name exists on the request body type.
-                            let findProperty name =
-                                properties
-                                |> Seq.tryFind (fun property -> property.Name = name)
-
-                            // Check if these entity properties exist on the request body type.
-                            entityProperties <-
-                                {
-                                    OwnerId = findProperty (nameof OwnerId)
-                                    OwnerName = findProperty (nameof OwnerName)
-                                    OrganizationId = findProperty (nameof OrganizationId)
-                                    OrganizationName = findProperty (nameof OrganizationName)
-                                    RepositoryId = findProperty (nameof RepositoryId)
-                                    RepositoryName = findProperty (nameof RepositoryName)
-                                    BranchId = findProperty (nameof BranchId)
-                                    BranchName = findProperty (nameof BranchName)
-                                }
+                            entityProperties <- ValidateIdsDecisions.discoverEntityProperties requestBodyType
 
                             // Cache the property list for this request body type.
                             propertyLookup.TryAdd(requestBodyType, entityProperties)
@@ -476,9 +417,7 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
 
                     context.Request.Headers[ "X-MiddlewareTraceOut" ] <- $"{middlewareTraceOutHeader}{nameof ValidateIdsMiddleware} --> "
 
-                    if not
-                       <| (ignorePaths
-                           |> Seq.exists (fun ignorePath -> path.StartsWith(ignorePath, StringComparison.InvariantCultureIgnoreCase))) then
+                    if not <| ValidateIdsDecisions.isIgnoredPath path then
                         log.LogDebug(
                             "{CurrentInstant}: Path: {path}; Elapsed: {elapsed}ms; Status code: {statusCode}; graceIds: {graceIds}",
                             getCurrentInstantExtended (),


### PR DESCRIPTION
## Summary

- Extracts pure ValidateIds metadata/property decisions into a testable helper.
- Replaces inline ignored-path, endpoint body-type metadata, and entity-property discovery logic with helper calls.
- Adds focused Server.Unit tests for ignored paths, endpoint metadata type detection, and owner/org/repo/branch property discovery.

## Linked Issue

Closes #190.

## Validation

- `dotnet tool run fantomas src/Grace.Server/Middleware/ValidateIds.Decisions.fs src/Grace.Server/Middleware/ValidateIds.Middleware.fs src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~ValidateIds`: passed, `7` passed, `0` failed, `0` skipped.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is a no-Aspire metadata/helper extraction and Full was not expected.

## Review Status

- Implementation worker completed commit `30e42f6` and pushed `agent/190-validateids-metadata-decisions`.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/199#issuecomment-4617420104
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should check behavior preservation for ignored paths, endpoint metadata type matching, missing property handling, and F# compile order.