### PR TITLE
Add manifest route policy assertions

### DIFF
--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Authorization.Tests
 
 open Grace.Server.Security.EndpointAuthorizationManifest
+open Grace.Types.Authorization
 open NUnit.Framework
 open System
 open System.IO
@@ -9,14 +10,9 @@ open System.Text.RegularExpressions
 [<Parallelizable(ParallelScope.All)>]
 type EndpointAuthorizationManifestTests() =
 
-    let startupPath =
-        Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Startup.Server.fs"))
+    let startupPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Startup.Server.fs"))
 
-    let tokenRegex =
-        Regex(
-            "(?<method>\\bGET\\b|\\bPOST\\b|\\bPUT\\b)\\s*\\[|(?<kind>subRoute|routef|route)\\s+\"(?<path>[^\"]+)\"",
-            RegexOptions.Multiline
-        )
+    let tokenRegex = Regex("(?<method>\\bGET\\b|\\bPOST\\b|\\bPUT\\b)\\s*\\[|(?<kind>subRoute|routef|route)\\s+\"(?<path>[^\"]+)\"", RegexOptions.Multiline)
 
     let parseStartupRoutes () =
         let text = File.ReadAllText(startupPath)
@@ -34,31 +30,54 @@ type EndpointAuthorizationManifestTests() =
 
                 if kind = "subRoute" then
                     currentPrefix <- path
+                else if String.IsNullOrWhiteSpace currentMethod then
+                    invalidOp $"Missing HTTP method before route '{path}'."
                 else
-                    if String.IsNullOrWhiteSpace currentMethod then
-                        invalidOp $"Missing HTTP method before route '{path}'."
-                    else
-                        let fullPath =
-                            if String.IsNullOrWhiteSpace currentPrefix then
-                                path
-                            else
-                                $"{currentPrefix}{path}"
+                    let fullPath =
+                        if String.IsNullOrWhiteSpace currentPrefix then
+                            path
+                        else
+                            $"{currentPrefix}{path}"
 
-                        routes.Add(currentMethod, fullPath)
+                    routes.Add(currentMethod, fullPath)
 
         routes
         |> Seq.toList
-        |> List.append [ ("GET", "/metrics"); ("GET", "/notifications") ]
+        |> List.append [ ("GET", "/metrics")
+                         ("GET", "/notifications") ]
+
+    let assertRouteSecurity method_ path (expectedSecurity: EndpointSecurity) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
+
+        match matchingDefinitions with
+        | [ definition ] ->
+            Assert.That(
+                definition.Security,
+                Is.EqualTo(expectedSecurity),
+                $"Expected {method_} {path} to use {expectedSecurity}, but manifest uses {definition.Security}."
+            )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
+
+    let assertRoutesUseSecurity expectedSecurity routes =
+        for method_, path in routes do
+            assertRouteSecurity method_ path expectedSecurity
 
     [<Test>]
     member _.ManifestCoversAllRoutes() =
         let startupRoutes = parseStartupRoutes () |> Set.ofList
+
         let manifestRoutes =
             definitions
             |> List.map (fun definition -> definition.Method, definition.Path)
             |> Set.ofList
 
         let missing = startupRoutes - manifestRoutes
+
         if missing.Count > 0 then
             let missingText =
                 missing
@@ -69,6 +88,7 @@ type EndpointAuthorizationManifestTests() =
             Assert.Fail($"EndpointAuthorizationManifest is missing routes:{Environment.NewLine}{missingText}")
 
         let extra = manifestRoutes - startupRoutes
+
         if extra.Count > 0 then
             let extraText =
                 extra
@@ -83,11 +103,7 @@ type EndpointAuthorizationManifestTests() =
         let duplicates =
             definitions
             |> List.groupBy (fun definition -> definition.Method, definition.Path)
-            |> List.choose (fun (key, entries) ->
-                if entries.Length > 1 then
-                    Some key
-                else
-                    None)
+            |> List.choose (fun (key, entries) -> if entries.Length > 1 then Some key else None)
 
         if duplicates.Length > 0 then
             let message =
@@ -96,3 +112,125 @@ type EndpointAuthorizationManifestTests() =
                 |> String.concat Environment.NewLine
 
             Assert.Fail($"EndpointAuthorizationManifest contains duplicate entries:{Environment.NewLine}{message}")
+
+    [<Test>]
+    member _.ApprovalPolicyRoutesRequireRepositoryPolicyManage() =
+        [
+            "POST", "/approval/policy/create"
+            "POST", "/approval/policy/list"
+            "POST", "/approval/policy/show"
+            "POST", "/approval/policy/update"
+            "POST", "/approval/policy/enable"
+            "POST", "/approval/policy/disable"
+            "POST", "/approval/policy/delete"
+            "POST", "/approval/policy/evaluate"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.ApprovalPolicyManage, ResourceKind.Repository))
+
+    [<Test>]
+    member _.ApprovalRequestRoutesUseExpectedRepositoryPolicies() =
+        [
+            "POST", "/approval/request/list"
+            "POST", "/approval/request/show"
+            "POST", "/approval/request/history"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.ApprovalRequestRead, ResourceKind.Repository))
+
+        [
+            "POST", "/approval/request/approve"
+            "POST", "/approval/request/reject"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.ApprovalRequestRespond, ResourceKind.Repository))
+
+        assertRouteSecurity "POST" "/approval/request/_seedGenerated" Authenticated
+
+    [<Test>]
+    member _.WebhookRoutesUseExpectedRepositoryPolicies() =
+        [
+            "POST", "/webhook/rule/create"
+            "POST", "/webhook/rule/list"
+            "POST", "/webhook/rule/show"
+            "POST", "/webhook/rule/update"
+            "POST", "/webhook/rule/enable"
+            "POST", "/webhook/rule/disable"
+            "POST", "/webhook/rule/delete"
+            "POST", "/webhook/rule/test"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.WebhookManage, ResourceKind.Repository))
+
+        [
+            "POST", "/webhook/delivery/list"
+            "POST", "/webhook/delivery/show"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.WebhookDeliveryRead, ResourceKind.Repository))
+
+    [<Test>]
+    member _.AuthRoutesUseExpectedAnonymousAndAuthenticatedPolicies() =
+        [
+            "GET", "/auth/login"
+            "GET", "/auth/login/%s"
+            "GET", "/auth/oidc/config"
+        ]
+        |> assertRoutesUseSecurity AllowAnonymous
+
+        [
+            "GET", "/auth/logout"
+            "GET", "/auth/me"
+            "POST", "/auth/token/create"
+            "POST", "/auth/token/list"
+            "POST", "/auth/token/revoke"
+        ]
+        |> assertRoutesUseSecurity Authenticated
+
+    [<Test>]
+    member _.MetricsAndManualRoutesUseExpectedPolicies() =
+        assertRouteSecurity "GET" "/metrics" (Authorized(Operation.SystemAdmin, ResourceKind.System))
+        assertRouteSecurity "GET" "/notifications" Authenticated
+
+    [<Test>]
+    member _.StorageRoutesUseExpectedPathAndRepositoryPolicies() =
+        [
+            "POST", "/storage/getDownloadUri"
+            "POST", "/storage/getContentBlockDownloadUri"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.PathRead, ResourceKind.Path))
+
+        [
+            "POST", "/storage/discoverContentBlocks"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))
+
+        [
+            "POST", "/storage/claimReuseRanges"
+            "POST", "/storage/confirmContentBlockUpload"
+            "POST", "/storage/finalizeManifestUpload"
+            "POST", "/storage/getContentBlockUploadUri"
+            "POST", "/storage/getUploadMetadataForFiles"
+            "POST", "/storage/getUploadUri"
+            "POST", "/storage/issueDedupeDiscovery"
+            "POST", "/storage/registerContentBlockUpload"
+            "POST", "/storage/startManifestUploadSession"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.PathWrite, ResourceKind.Path))
+
+    [<Test>]
+    member _.SelectedWorkItemRoutesUseExpectedPolicies() =
+        assertRouteSecurity "POST" "/work/create" (Authorized(Operation.RepoWrite, ResourceKind.Repository))
+
+        [
+            "POST", "/work/add-summary"
+            "POST", "/work/get"
+            "POST", "/work/link/artifact"
+            "POST", "/work/link/promotion-set"
+            "POST", "/work/link/reference"
+            "POST", "/work/links/list"
+            "POST", "/work/attachments/list"
+            "POST", "/work/attachments/show"
+            "POST", "/work/attachments/download"
+            "POST", "/work/links/remove/artifact"
+            "POST", "/work/links/remove/artifact-type"
+            "POST", "/work/links/remove/promotion-set"
+            "POST", "/work/links/remove/reference"
+            "POST", "/work/update"
+        ]
+        |> assertRoutesUseSecurity Authenticated


### PR DESCRIPTION
## Summary

- Adds route-specific `EndpointSecurity` assertions for sensitive manifest route families.
- Covers approval policy/request routes, webhook rule/delivery routes, auth routes, manual metrics/notifications routes, storage route families, and selected WorkItem routes.
- Keeps the slice test-only; no production authorization manifest or server startup files changed.

## Linked Issue

Closes #183.

## Validation

- `dotnet tool run fantomas --check src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj --filter FullyQualifiedName~EndpointAuthorizationManifestTests`: passed, `9/9` tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because the branch changes only authorization tests and no hosted server behavior.

## Review Status

- Implementation worker completed commit `5235ee8` and pushed `agent/183-route-policy-assertions`.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/200#issuecomment-4617421910
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify that the asserted route policies match the intended product/security contract and do not simply pin an incorrect current manifest state.