### PR TITLE
Extract storage authorization resource builders

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="StorageAuthorizationResources.Unit.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
@@ -1,0 +1,120 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Shared
+open Grace.Shared.Parameters
+open Grace.Types.Authorization
+open Grace.Types.Types
+open NUnit.Framework
+open System
+
+[<Parallelizable(ParallelScope.All)>]
+type StorageAuthorizationResourcesTests() =
+    let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+    let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+    let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+
+    let fileVersion (relativePath: RelativePath) =
+        let value = FileVersion()
+        value.RelativePath <- relativePath
+        value
+
+    let assertPathResource (expectedPath: RelativePath) resource =
+        match resource with
+        | Resource.Path (actualOwnerId, actualOrganizationId, actualRepositoryId, actualPath) ->
+            Assert.That(actualOwnerId, Is.EqualTo(ownerId))
+            Assert.That(actualOrganizationId, Is.EqualTo(organizationId))
+            Assert.That(actualRepositoryId, Is.EqualTo(repositoryId))
+            Assert.That(actualPath, Is.EqualTo(expectedPath))
+        | other -> Assert.Fail($"Expected Resource.Path but received {other}.")
+
+    [<Test>]
+    member _.UploadMetadataFileVersionsMapToPathResources() =
+        let parameters = Storage.GetUploadMetadataForFilesParameters()
+
+        parameters.FileVersions <-
+            [|
+                fileVersion "src/app.fs"
+                fileVersion "docs/readme.md"
+            |]
+
+        let resources = StorageAuthorizationResources.uploadMetadataResources ownerId organizationId repositoryId parameters
+
+        Assert.That(resources.Length, Is.EqualTo(2))
+        assertPathResource "src/app.fs" resources[0]
+        assertPathResource "docs/readme.md" resources[1]
+
+    [<Test>]
+    member _.UploadUriFileVersionsMapToPathResources() =
+        let parameters = Storage.GetUploadUriParameters()
+
+        parameters.FileVersions <-
+            [|
+                fileVersion "src/upload.fs"
+                fileVersion "assets/icon.png"
+            |]
+
+        let resources = StorageAuthorizationResources.uploadUriResources ownerId organizationId repositoryId parameters
+
+        Assert.That(resources.Length, Is.EqualTo(2))
+        assertPathResource "src/upload.fs" resources[0]
+        assertPathResource "assets/icon.png" resources[1]
+
+    [<Test>]
+    member _.DownloadUriFileVersionMapsToSinglePathResource() =
+        let parameters = Storage.GetDownloadUriParameters()
+        parameters.FileVersion <- fileVersion "src/download.fs"
+
+        let resource = StorageAuthorizationResources.downloadUriResource ownerId organizationId repositoryId parameters
+
+        assertPathResource "src/download.fs" resource
+
+    [<Test>]
+    member _.ContentBlockUploadHonorsExplicitAuthorizedScope() =
+        let parameters = Storage.GetContentBlockUploadUriParameters()
+        parameters.ContentBlockAddress <- "sha256-explicit"
+        parameters.AuthorizedScope <- "manifest/file.bin"
+
+        let resource = StorageAuthorizationResources.contentBlockUploadResource ownerId organizationId repositoryId parameters
+
+        assertPathResource "manifest/file.bin" resource
+
+    [<Test>]
+    member _.ContentBlockUploadFallsBackToContentBlockObjectKeyWhenScopeIsBlank() =
+        let parameters = Storage.GetContentBlockUploadUriParameters()
+        parameters.ContentBlockAddress <- "sha256-blank-scope"
+        parameters.AuthorizedScope <- "   "
+
+        let resource = StorageAuthorizationResources.contentBlockUploadResource ownerId organizationId repositoryId parameters
+
+        assertPathResource (StorageKeys.contentBlockObjectKey "sha256-blank-scope") resource
+
+    [<Test>]
+    member _.ContentBlockDownloadUsesContentBlockObjectKey() =
+        let parameters = Storage.GetContentBlockDownloadUriParameters()
+        parameters.ContentBlockAddress <- "sha256-download"
+
+        let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
+
+        assertPathResource (StorageKeys.contentBlockObjectKey "sha256-download") resource
+
+    [<Test>]
+    member _.UploadSessionStorageUsesAuthorizedScope() =
+        let parameters = Storage.UploadSessionStorageParameters()
+        parameters.AuthorizedScope <- "sessions/session-file.bin"
+
+        let resource = StorageAuthorizationResources.uploadSessionResource ownerId organizationId repositoryId parameters
+
+        assertPathResource "sessions/session-file.bin" resource
+
+    [<Test>]
+    member _.EmptyUploadFileListReturnsEmptyResourceList() =
+        let metadataParameters = Storage.GetUploadMetadataForFilesParameters()
+        let uploadUriParameters = Storage.GetUploadUriParameters()
+
+        let metadataResources = StorageAuthorizationResources.uploadMetadataResources ownerId organizationId repositoryId metadataParameters
+
+        let uploadUriResources = StorageAuthorizationResources.uploadUriResources ownerId organizationId repositoryId uploadUriParameters
+
+        Assert.That(metadataResources, Is.Empty)
+        Assert.That(uploadUriResources, Is.Empty)

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -63,6 +63,7 @@
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />
 		<Compile Include="Security\EndpointAuthorizationManifest.Server.fs" />
+		<Compile Include="Security\StorageAuthorizationResources.Server.fs" />
         <Compile Include="OrleansFilters.Server.fs" />
 		<Compile Include="Middleware\Fake.Middleware.fs" />
 		<Compile Include="Middleware\HttpSecurityHeaders.Middleware.fs" />

--- a/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
+++ b/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
@@ -1,0 +1,38 @@
+namespace Grace.Server.Security
+
+open Grace.Shared
+open Grace.Shared.Parameters
+open Grace.Types.Authorization
+open Grace.Types.Types
+open System
+
+module internal StorageAuthorizationResources =
+    let private pathResource ownerId organizationId repositoryId relativePath = Resource.Path(ownerId, organizationId, repositoryId, relativePath)
+
+    let uploadMetadataResources ownerId organizationId repositoryId (parameters: Storage.GetUploadMetadataForFilesParameters) =
+        parameters.FileVersions
+        |> Seq.map (fun fileVersion -> pathResource ownerId organizationId repositoryId fileVersion.RelativePath)
+        |> Seq.toList
+
+    let uploadUriResources ownerId organizationId repositoryId (parameters: Storage.GetUploadUriParameters) =
+        parameters.FileVersions
+        |> Seq.map (fun fileVersion -> pathResource ownerId organizationId repositoryId fileVersion.RelativePath)
+        |> Seq.toList
+
+    let downloadUriResource ownerId organizationId repositoryId (parameters: Storage.GetDownloadUriParameters) =
+        pathResource ownerId organizationId repositoryId parameters.FileVersion.RelativePath
+
+    let contentBlockUploadResource ownerId organizationId repositoryId (parameters: Storage.GetContentBlockUploadUriParameters) =
+        let path =
+            if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
+                StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
+            else
+                parameters.AuthorizedScope
+
+        pathResource ownerId organizationId repositoryId path
+
+    let contentBlockDownloadResource ownerId organizationId repositoryId (parameters: Storage.GetContentBlockDownloadUriParameters) =
+        pathResource ownerId organizationId repositoryId (StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress)
+
+    let uploadSessionResource ownerId organizationId repositoryId (parameters: Storage.UploadSessionStorageParameters) =
+        pathResource ownerId organizationId repositoryId parameters.AuthorizedScope

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -153,12 +153,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                let resources =
-                    parameters.FileVersions
-                    |> Seq.map (fun fileVersion -> Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, fileVersion.RelativePath))
-                    |> Seq.toList
-
-                return resources
+                return StorageAuthorizationResources.uploadMetadataResources graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let uploadUriResourcesFromContext (context: HttpContext) =
@@ -171,12 +166,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                let resources =
-                    parameters.FileVersions
-                    |> Seq.map (fun fileVersion -> Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, fileVersion.RelativePath))
-                    |> Seq.toList
-
-                return resources
+                return StorageAuthorizationResources.uploadUriResources graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let downloadPathResourceFromContext (context: HttpContext) =
@@ -189,7 +179,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.FileVersion.RelativePath)
+                return StorageAuthorizationResources.downloadUriResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let contentBlockUploadPathResourceFromContext (context: HttpContext) =
@@ -202,13 +192,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                let path =
-                    if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
-                        StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
-                    else
-                        parameters.AuthorizedScope
-
-                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, path)
+                return StorageAuthorizationResources.contentBlockUploadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let contentBlockDownloadPathResourceFromContext (context: HttpContext) =
@@ -221,13 +205,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                return
-                    Resource.Path(
-                        graceIds.OwnerId,
-                        graceIds.OrganizationId,
-                        graceIds.RepositoryId,
-                        StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
-                    )
+                return StorageAuthorizationResources.contentBlockDownloadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let uploadSessionPathResourceFromContext (context: HttpContext) =
@@ -240,7 +218,7 @@ module Application =
 
                 let graceIds = Services.getGraceIds context
 
-                return Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, parameters.AuthorizedScope)
+                return StorageAuthorizationResources.uploadSessionResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
             }
 
         let composeHandlers (first: HttpHandler) (second: HttpHandler) : HttpHandler = fun next context -> first (second next) context


### PR DESCRIPTION
## Summary

- Extracts pure storage authorization `Resource.Path` construction from Startup route closures into an internal helper.
- Keeps `HttpContext`, request buffering, JSON binding, and request rewind in Startup while the helper receives scoped IDs and bound parameter objects.
- Adds no-Aspire Server.Unit tests for upload metadata, upload/download URI, content-block upload/download, upload-session scope, fallback scope, and empty file lists.

## Linked Issue

Closes #188.

## Validation

- `dotnet tool run fantomas -- Grace.Server/Security/StorageAuthorizationResources.Server.fs Grace.Server/Startup.Server.fs Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~StorageAuthorizationResources`: passed, `8` passed, `0` failed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because the change is pure-helper extraction and does not touch storage runtime, storage actors, blob clients, SDK methods, SAS generation, Aspire, or emulators.

## Review Status

- Implementation worker completed commit `4f935f3` and pushed `agent/188-storage-auth-resources`.
- Fresh local review-only sibling subagent found one actionable issue: https://github.com/ScottArbeit/Grace/pull/202#issuecomment-4617455280
- Branch-refresh fix committed and pushed in `b82c06b`: https://github.com/ScottArbeit/Grace/pull/202#issuecomment-4617491402
- Final fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/202#issuecomment-4617540410
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify resource construction preserves route authorization behavior, especially content-block fallback scope and multi-file path lists.