### PR TITLE
Fill WorkItem validation unit-test gaps

### DIFF
--- a/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
@@ -31,6 +31,12 @@ type WorkItemServerUnitTests() =
         |> Async.AwaitTask
         |> Async.RunSynchronously
 
+    let getValidationError validations =
+        validations
+        |> getFirstError
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
+
     let applyCasePattern (pattern: bool array) (value: string) =
         let toggles = if isNull pattern then [||] else pattern
 
@@ -90,13 +96,19 @@ type WorkItemServerUnitTests() =
 
         let validations = WorkItem.validateLinkReferenceParameters parameters
 
-        let error =
-            validations
-            |> getFirstError
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
+        let error = validations |> getValidationError
 
         Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidReferenceId))
+
+    [<Test>]
+    member _.LinkReferenceValidationAcceptsValidParameters() =
+        let parameters = LinkReferenceParameters(WorkItemId = Guid.NewGuid().ToString(), ReferenceId = Guid.NewGuid().ToString())
+
+        let validations = WorkItem.validateLinkReferenceParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
 
     [<Test>]
     member _.WorkItemIdentifierValidationAcceptsPositiveNumber() =
@@ -125,6 +137,25 @@ type WorkItemServerUnitTests() =
         Assert.That(result, Is.EqualTo(Ok(): Result<unit, WorkItemError>))
 
     [<Test>]
+    member _.WorkItemIdentifierValidationAcceptsUppercaseGuid() =
+        let workItemId = Guid.NewGuid().ToString().ToUpperInvariant()
+
+        let result =
+            WorkItem.validateWorkItemIdentifier workItemId
+            |> runValidation
+
+        Assert.That(result, Is.EqualTo(Ok(): Result<unit, WorkItemError>))
+
+    [<Test>]
+    member _.WorkItemIdentifierValidationAcceptsVeryLargePositiveNumber() =
+        let result =
+            Int64.MaxValue.ToString()
+            |> WorkItem.validateWorkItemIdentifier
+            |> runValidation
+
+        Assert.That(result, Is.EqualTo(Ok(): Result<unit, WorkItemError>))
+
+    [<Test>]
     member _.WorkItemIdentifierValidationRejectsInvalidIdentifier() =
         let result =
             WorkItem.validateWorkItemIdentifier "not-a-guid-or-number"
@@ -138,13 +169,19 @@ type WorkItemServerUnitTests() =
 
         let validations = WorkItem.validateLinkPromotionSetParameters parameters
 
-        let error =
-            validations
-            |> getFirstError
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
+        let error = validations |> getValidationError
 
         Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidPromotionSetId))
+
+    [<Test>]
+    member _.LinkPromotionSetValidationAcceptsValidParameters() =
+        let parameters = LinkPromotionSetParameters(WorkItemId = Guid.NewGuid().ToString(), PromotionSetId = Guid.NewGuid().ToString())
+
+        let validations = WorkItem.validateLinkPromotionSetParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
 
     [<Test>]
     member _.LinkArtifactValidationRejectsInvalidArtifactId() =
@@ -152,13 +189,19 @@ type WorkItemServerUnitTests() =
 
         let validations = WorkItem.validateLinkArtifactParameters parameters
 
-        let error =
-            validations
-            |> getFirstError
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
+        let error = validations |> getValidationError
 
         Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactId))
+
+    [<Test>]
+    member _.LinkArtifactValidationAcceptsValidParameters() =
+        let parameters = LinkArtifactParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactId = Guid.NewGuid().ToString())
+
+        let validations = WorkItem.validateLinkArtifactParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
 
     [<Test>]
     member _.AddSummaryValidationAcceptsGuidIdentifier() =
@@ -311,13 +354,99 @@ type WorkItemServerUnitTests() =
 
         let validations = WorkItem.validateRemoveArtifactTypeLinksParameters parameters
 
-        let error =
-            validations
-            |> getFirstError
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
+        let error = validations |> getValidationError
 
         Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactType))
+
+    [<Test>]
+    member _.ShowAttachmentValidationRejectsMissingAttachmentType() =
+        let parameters = ShowWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), AttachmentType = String.Empty)
+
+        let validations = WorkItem.validateShowWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactType))
+
+    [<Test>]
+    member _.ListAttachmentValidationAcceptsValidParameters() =
+        let parameters = ListWorkItemAttachmentsParameters(WorkItemId = Guid.NewGuid().ToString())
+
+        let validations = WorkItem.validateListWorkItemAttachmentsParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
+
+    [<Test>]
+    member _.ShowAttachmentValidationAcceptsValidParameters() =
+        let parameters = ShowWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), AttachmentType = "summary")
+
+        let validations = WorkItem.validateShowWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
+
+    [<Test>]
+    member _.DownloadAttachmentValidationAcceptsValidParameters() =
+        let parameters = DownloadWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactId = Guid.NewGuid().ToString())
+
+        let validations = WorkItem.validateDownloadWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(None: WorkItemError option))
+
+    [<Test>]
+    member _.DownloadAttachmentValidationRejectsMissingArtifactId() =
+        let parameters = DownloadWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactId = String.Empty)
+
+        let validations = WorkItem.validateDownloadWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactId))
+
+    [<Test>]
+    member _.DownloadAttachmentValidationRejectsEmptyGuidArtifactId() =
+        let parameters = DownloadWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactId = Guid.Empty.ToString())
+
+        let validations = WorkItem.validateDownloadWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactId))
+
+    [<Test>]
+    member _.DownloadAttachmentValidationRejectsInvalidArtifactId() =
+        let parameters = DownloadWorkItemAttachmentParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactId = "not-a-guid")
+
+        let validations = WorkItem.validateDownloadWorkItemAttachmentParameters parameters
+
+        let error = validations |> getValidationError
+
+        Assert.That(error, Is.EqualTo(Some WorkItemError.InvalidArtifactId))
+
+    [<Test>]
+    member _.RemoveArtifactTypeValidationAcceptsKnownAliases() =
+        let aliases =
+            [
+                "summary"
+                "agentsummary"
+                "prompt"
+                "notes"
+                "reviewnotes"
+            ]
+
+        for alias in aliases do
+            let parameters = RemoveArtifactTypeLinksParameters(WorkItemId = Guid.NewGuid().ToString(), ArtifactType = alias)
+
+            let validations = WorkItem.validateRemoveArtifactTypeLinksParameters parameters
+
+            let error = validations |> getValidationError
+
+            Assert.That(error, Is.EqualTo(None: WorkItemError option), $"Expected artifact type alias '{alias}' to pass validation.")
 
     [<Test>]
     member _.ParseRemovableArtifactTypeHandlesAliases() =

--- a/src/Grace.Server/WorkItem.Server.fs
+++ b/src/Grace.Server/WorkItem.Server.fs
@@ -389,6 +389,7 @@ module WorkItem =
     let internal validateDownloadWorkItemAttachmentParameters (parameters: DownloadWorkItemAttachmentParameters) =
         [|
             validateWorkItemIdentifier parameters.WorkItemId
+            String.isNotEmpty parameters.ArtifactId WorkItemError.InvalidArtifactId
             Guid.isValidAndNotEmptyGuid parameters.ArtifactId WorkItemError.InvalidArtifactId
         |]
 


### PR DESCRIPTION
## Summary

- Adds WorkItem validation unit coverage for link parameters, uppercase GUID work item IDs, large positive work item numbers, attachment parameters, missing attachment type, download artifact IDs, and removable artifact aliases.
- Fixes the RED case where an empty download attachment `ArtifactId` was accepted by adding an explicit non-empty check before GUID validation.
- Keeps coverage in Server.Unit with no actor, storage, hosted HTTP, or SDK calls.

## Linked Issue

Closes #185.

## Validation

Initial implementation evidence, captured before the #209 workflow correction:

- `dotnet tool run fantomas src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs src/Grace.Server/WorkItem.Server.fs`: passed.
- `dotnet tool run fantomas --check src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs src/Grace.Server/WorkItem.Server.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~WorkItemServerUnitTests`: passed, `44/44`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Current freshness validation, using the corrected one-build/test-gate rule:

- Targeted Fantomas/checks for touched F# files: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed as the sole final build/test gate.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is WorkItem validation helper coverage plus a small server boundary validation fix, with no Aspire, hosted HTTP, storage runtime, actors, emulators, Service Bus, Cosmos DB, or Redis changes.

## Review Status

- Implementation worker completed commit `befe66b` and pushed `agent/185-workitem-validation-tests`.
- Initial implementation validation included focused project build/test evidence before the workflow correction in #209; retained as historical evidence only, not as the current prompt pattern.
- Freshness gates completed through `8e782f`: branch was `4 0` ahead/behind current `origin/main`, had no deleted files in the PR diff, and diff paths were limited to #185 WorkItem files.
- Corrected freshness validation used targeted Fantomas/checks first, then `pwsh ./scripts/validate.ps1 -Fast` as the sole build/test gate, then `git diff --check`.
- Fresh review-only sibling subagent completed with no findings; details are in the PR comment "Fresh review-only pass for #185 / PR #203".
- GitHub Validate check completed successfully.
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should confirm the scope expansion to `WorkItem.Server.fs` is justified by the RED case and that empty artifact IDs are rejected without changing unrelated optional-ID semantics.
