### PR TITLE
Extract ValidateIds entity decision helpers

### DIFF
--- a/src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs
@@ -1,6 +1,8 @@
 namespace Grace.Server.Tests
 
 open Grace.Server.Middleware
+open Grace.Shared.Validation.Errors
+open Grace.Types.Types
 open Microsoft.AspNetCore.Http
 open NUnit.Framework
 open System
@@ -107,3 +109,182 @@ type ValidateIdsDecisionsTests() =
         Assert.That(properties.RepositoryName.IsSome, Is.True)
         Assert.That(properties.BranchId.IsNone, Is.True)
         Assert.That(properties.BranchName.IsNone, Is.True)
+
+    [<TestCase("/owner/create", ValidateIdsDecisions.EntityKind.Owner)>]
+    [<TestCase("/organization/create", ValidateIdsDecisions.EntityKind.Organization)>]
+    [<TestCase("/repository/create", ValidateIdsDecisions.EntityKind.Repository)>]
+    [<TestCase("/branch/create", ValidateIdsDecisions.EntityKind.Branch)>]
+    member _.CreatePathsChooseCreateValidationMode(path: string, entityKind: ValidateIdsDecisions.EntityKind) =
+        let result = ValidateIdsDecisions.validationModeForPath entityKind path
+
+        Assert.That(result, Is.EqualTo(ValidateIdsDecisions.EntityValidationMode.Create))
+
+    [<TestCase("/Owner/Create", ValidateIdsDecisions.EntityKind.Owner)>]
+    [<TestCase("/organization/list", ValidateIdsDecisions.EntityKind.Organization)>]
+    [<TestCase("/repository/create/details", ValidateIdsDecisions.EntityKind.Repository)>]
+    [<TestCase("/branch/delete", ValidateIdsDecisions.EntityKind.Branch)>]
+    member _.NonCreatePathsChooseExistingValidationMode(path: string, entityKind: ValidateIdsDecisions.EntityKind) =
+        let result = ValidateIdsDecisions.validationModeForPath entityKind path
+
+        if path.Equals("/Owner/Create", StringComparison.InvariantCultureIgnoreCase) then
+            Assert.That(result, Is.EqualTo(ValidateIdsDecisions.EntityValidationMode.Create))
+        else
+            Assert.That(result, Is.EqualTo(ValidateIdsDecisions.EntityValidationMode.Existing))
+
+    [<Test>]
+    member _.EntityValidationStopsWhenEarlierScopeAlreadyFailed() =
+        let currentError = Some(GraceError.Create "Earlier failure" "correlation-id")
+        let properties = ValidateIdsDecisions.discoverEntityProperties typeof<BodyWithAllEntityProperties>
+
+        let result = ValidateIdsDecisions.shouldValidateEntity currentError properties.OrganizationId properties.OrganizationName
+
+        Assert.That(result, Is.False)
+
+    [<Test>]
+    member _.EntityValidationRequiresIdAndNamePropertiesToExist() =
+        let properties = ValidateIdsDecisions.discoverEntityProperties typeof<BodyWithMissingEntityProperties>
+
+        let ownerResult = ValidateIdsDecisions.shouldValidateEntity None properties.OwnerId properties.OwnerName
+        let repositoryResult = ValidateIdsDecisions.shouldValidateEntity None properties.RepositoryId properties.RepositoryName
+
+        Assert.That(ownerResult, Is.False)
+        Assert.That(repositoryResult, Is.False)
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, "OwnerIdIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, "OrganizationIdIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, "RepositoryIdIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, "BranchIdIsRequired")>]
+    member _.CreateValidationRequiresIds(entityKind: ValidateIdsDecisions.EntityKind, expectedErrorName: string) =
+        task {
+            let! error = ValidateIdsDecisions.getEntityValidationErrorMessage entityKind ValidateIdsDecisions.EntityValidationMode.Create "" "valid-name"
+
+            let expected =
+                match expectedErrorName with
+                | "OwnerIdIsRequired" -> OwnerError.getErrorMessage OwnerError.OwnerIdIsRequired
+                | "OrganizationIdIsRequired" -> OrganizationError.getErrorMessage OrganizationError.OrganizationIdIsRequired
+                | "RepositoryIdIsRequired" -> RepositoryError.getErrorMessage RepositoryError.RepositoryIdIsRequired
+                | "BranchIdIsRequired" -> BranchError.getErrorMessage BranchError.BranchIdIsRequired
+                | _ -> failwith "Unexpected test case."
+
+            Assert.That(error, Is.EqualTo(Some expected))
+        }
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, "OwnerNameIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, "OrganizationNameIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, "RepositoryNameIsRequired")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, "BranchNameIsRequired")>]
+    member _.CreateValidationRequiresNames(entityKind: ValidateIdsDecisions.EntityKind, expectedErrorName: string) =
+        task {
+            let! error =
+                ValidateIdsDecisions.getEntityValidationErrorMessage entityKind ValidateIdsDecisions.EntityValidationMode.Create (Guid.NewGuid().ToString()) ""
+
+            let expected =
+                match expectedErrorName with
+                | "OwnerNameIsRequired" -> OwnerError.getErrorMessage OwnerError.OwnerNameIsRequired
+                | "OrganizationNameIsRequired" -> OrganizationError.getErrorMessage OrganizationError.OrganizationNameIsRequired
+                | "RepositoryNameIsRequired" -> RepositoryError.getErrorMessage RepositoryError.RepositoryNameIsRequired
+                | "BranchNameIsRequired" -> BranchError.getErrorMessage BranchError.BranchNameIsRequired
+                | _ -> failwith "Unexpected test case."
+
+            Assert.That(error, Is.EqualTo(Some expected))
+        }
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch)>]
+    member _.ExistingValidationAllowsOnlyId(entityKind: ValidateIdsDecisions.EntityKind) =
+        task {
+            let! error =
+                ValidateIdsDecisions.getEntityValidationErrorMessage
+                    entityKind
+                    ValidateIdsDecisions.EntityValidationMode.Existing
+                    (Guid.NewGuid().ToString())
+                    ""
+
+            Assert.That(error, Is.EqualTo(None))
+        }
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch)>]
+    member _.ExistingValidationAllowsOnlyName(entityKind: ValidateIdsDecisions.EntityKind) =
+        task {
+            let! error = ValidateIdsDecisions.getEntityValidationErrorMessage entityKind ValidateIdsDecisions.EntityValidationMode.Existing "" "valid-name"
+
+            Assert.That(error, Is.EqualTo(None))
+        }
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, "InvalidOwnerId")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, "InvalidOrganizationId")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, "InvalidRepositoryId")>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, "InvalidBranchId")>]
+    member _.InvalidIdsFailBeforeResolution(entityKind: ValidateIdsDecisions.EntityKind, expectedErrorName: string) =
+        task {
+            let! error =
+                ValidateIdsDecisions.getEntityValidationErrorMessage entityKind ValidateIdsDecisions.EntityValidationMode.Existing "not-a-guid" "valid-name"
+
+            let expected =
+                match expectedErrorName with
+                | "InvalidOwnerId" -> OwnerError.getErrorMessage OwnerError.InvalidOwnerId
+                | "InvalidOrganizationId" -> OrganizationError.getErrorMessage OrganizationError.InvalidOrganizationId
+                | "InvalidRepositoryId" -> RepositoryError.getErrorMessage RepositoryError.InvalidRepositoryId
+                | "InvalidBranchId" -> BranchError.getErrorMessage BranchError.InvalidBranchId
+                | _ -> failwith "Unexpected test case."
+
+            Assert.That(error, Is.EqualTo(Some expected))
+        }
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, false)>]
+    member _.NotFoundErrorSelectionPreservesIdVersusNameOnlyErrors(entityKind: ValidateIdsDecisions.EntityKind, hasId: bool) =
+        let id = if hasId then Guid.NewGuid().ToString() else ""
+        let result = ValidateIdsDecisions.notFoundErrorMessage entityKind id
+
+        let expected =
+            match entityKind, hasId with
+            | ValidateIdsDecisions.EntityKind.Owner, true -> OwnerError.getErrorMessage OwnerError.OwnerIdDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Owner, false -> OwnerError.getErrorMessage OwnerError.OwnerDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Organization, true -> OrganizationError.getErrorMessage OrganizationError.OrganizationIdDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Organization, false -> OrganizationError.getErrorMessage OrganizationError.OrganizationDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Repository, true -> RepositoryError.getErrorMessage RepositoryError.RepositoryIdDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Repository, false -> RepositoryError.getErrorMessage RepositoryError.RepositoryDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Branch, true -> BranchError.getErrorMessage BranchError.BranchIdDoesNotExist
+            | ValidateIdsDecisions.EntityKind.Branch, false -> BranchError.getErrorMessage BranchError.BranchDoesNotExist
+            | _ -> failwith "Unexpected test case."
+
+        Assert.That(result, Is.EqualTo(expected))
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch)>]
+    member _.ResolvedIdsPopulateExpectedGraceIdsFields(entityKind: ValidateIdsDecisions.EntityKind) =
+        let id = Guid.NewGuid().ToString()
+        let result = ValidateIdsDecisions.withEntityId entityKind id GraceIds.Default
+
+        match entityKind with
+        | ValidateIdsDecisions.EntityKind.Owner ->
+            Assert.That(result.OwnerIdString, Is.EqualTo(id))
+            Assert.That(result.OwnerId, Is.EqualTo(Guid.Parse(id)))
+            Assert.That(result.HasOwner, Is.True)
+        | ValidateIdsDecisions.EntityKind.Organization ->
+            Assert.That(result.OrganizationIdString, Is.EqualTo(id))
+            Assert.That(result.OrganizationId, Is.EqualTo(Guid.Parse(id)))
+            Assert.That(result.HasOrganization, Is.True)
+        | ValidateIdsDecisions.EntityKind.Repository ->
+            Assert.That(result.RepositoryIdString, Is.EqualTo(id))
+            Assert.That(result.RepositoryId, Is.EqualTo(Guid.Parse(id)))
+            Assert.That(result.HasRepository, Is.True)
+        | ValidateIdsDecisions.EntityKind.Branch ->
+            Assert.That(result.BranchIdString, Is.EqualTo(id))
+            Assert.That(result.BranchId, Is.EqualTo(Guid.Parse(id)))
+            Assert.That(result.HasBranch, Is.True)
+        | _ -> failwith "Unexpected test case."

--- a/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
@@ -1,6 +1,9 @@
 namespace Grace.Server.Middleware
 
 open Grace.Types.Types
+open Grace.Shared.Validation
+open Grace.Shared.Validation.Errors
+open Grace.Shared.Validation.Utilities
 open Microsoft.AspNetCore.Http
 open System
 open System.Reflection
@@ -31,6 +34,16 @@ type EntityProperties =
         }
 
 module ValidateIdsDecisions =
+
+    type EntityKind =
+        | Owner = 0
+        | Organization = 1
+        | Repository = 2
+        | Branch = 3
+
+    type EntityValidationMode =
+        | Create = 0
+        | Existing = 1
 
     /// Paths that we want to ignore, because they won't have Ids and Names in the body.
     let ignoredPaths =
@@ -74,3 +87,144 @@ module ValidateIdsDecisions =
             BranchId = findProperty (nameof BranchId)
             BranchName = findProperty (nameof BranchName)
         }
+
+    let private pathEquals expectedPath (path: string) = path.Equals(expectedPath, StringComparison.InvariantCultureIgnoreCase)
+
+    let validationModeForPath entityKind path =
+        match entityKind with
+        | EntityKind.Owner when pathEquals "/owner/create" path -> EntityValidationMode.Create
+        | EntityKind.Organization when pathEquals "/organization/create" path -> EntityValidationMode.Create
+        | EntityKind.Repository when pathEquals "/repository/create" path -> EntityValidationMode.Create
+        | EntityKind.Branch when pathEquals "/branch/create" path -> EntityValidationMode.Create
+        | _ -> EntityValidationMode.Existing
+
+    let shouldValidateEntity currentError idProperty nameProperty =
+        currentError |> Option.isNone
+        && idProperty |> Option.isSome
+        && nameProperty |> Option.isSome
+
+    let getEntityValidationErrorMessage entityKind validationMode id name =
+        task {
+            match entityKind, validationMode with
+            | EntityKind.Owner, EntityValidationMode.Create ->
+                let validations =
+                    [|
+                        Common.String.isNotEmpty id OwnerError.OwnerIdIsRequired
+                        Common.Guid.isValidAndNotEmptyGuid id OwnerError.InvalidOwnerId
+                        Common.String.isNotEmpty name OwnerError.OwnerNameIsRequired
+                        Common.String.isValidGraceName name OwnerError.InvalidOwnerName
+                        Common.Input.eitherIdOrNameMustBeProvided id name OwnerError.EitherOwnerIdOrOwnerNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(OwnerError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Owner, EntityValidationMode.Existing ->
+                let validations =
+                    [|
+                        Common.Guid.isValidAndNotEmptyGuid id OwnerError.InvalidOwnerId
+                        Common.String.isValidGraceName name OwnerError.InvalidOwnerName
+                        Common.Input.eitherIdOrNameMustBeProvided id name OwnerError.EitherOwnerIdOrOwnerNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(OwnerError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Organization, EntityValidationMode.Create ->
+                let validations =
+                    [|
+                        Common.String.isNotEmpty id OrganizationError.OrganizationIdIsRequired
+                        Common.Guid.isValidAndNotEmptyGuid id OrganizationError.InvalidOrganizationId
+                        Common.String.isNotEmpty name OrganizationError.OrganizationNameIsRequired
+                        Common.String.isValidGraceName name OrganizationError.InvalidOrganizationName
+                        Common.Input.eitherIdOrNameMustBeProvided id name OrganizationError.EitherOrganizationIdOrOrganizationNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(OrganizationError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Organization, EntityValidationMode.Existing ->
+                let validations =
+                    [|
+                        Common.Guid.isValidAndNotEmptyGuid id OrganizationError.InvalidOrganizationId
+                        Common.String.isValidGraceName name OrganizationError.InvalidOrganizationName
+                        Common.Input.eitherIdOrNameMustBeProvided id name OrganizationError.EitherOrganizationIdOrOrganizationNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(OrganizationError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Repository, EntityValidationMode.Create ->
+                let validations =
+                    [|
+                        Common.String.isNotEmpty id RepositoryError.RepositoryIdIsRequired
+                        Common.Guid.isValidAndNotEmptyGuid id RepositoryError.InvalidRepositoryId
+                        Common.String.isNotEmpty name RepositoryError.RepositoryNameIsRequired
+                        Common.String.isValidGraceName name RepositoryError.InvalidRepositoryName
+                        Common.Input.eitherIdOrNameMustBeProvided id name RepositoryError.EitherRepositoryIdOrRepositoryNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(RepositoryError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Repository, EntityValidationMode.Existing ->
+                let validations =
+                    [|
+                        Common.Guid.isValidAndNotEmptyGuid id RepositoryError.InvalidRepositoryId
+                        Common.String.isValidGraceName name RepositoryError.InvalidRepositoryName
+                        Common.Input.eitherIdOrNameMustBeProvided id name RepositoryError.EitherRepositoryIdOrRepositoryNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(RepositoryError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Branch, EntityValidationMode.Create ->
+                let validations =
+                    [|
+                        Common.String.isNotEmpty id BranchError.BranchIdIsRequired
+                        Common.Guid.isValidAndNotEmptyGuid id BranchError.InvalidBranchId
+                        Common.String.isNotEmpty name BranchError.BranchNameIsRequired
+                        Common.String.isValidGraceName name BranchError.InvalidBranchName
+                        Common.Input.eitherIdOrNameMustBeProvided id name BranchError.EitherBranchIdOrBranchNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(BranchError.getErrorMessage error)
+                | None -> return None
+            | EntityKind.Branch, EntityValidationMode.Existing ->
+                let validations =
+                    [|
+                        Common.Guid.isValidAndNotEmptyGuid id BranchError.InvalidBranchId
+                        Common.String.isValidGraceName name BranchError.InvalidBranchName
+                        Common.Input.eitherIdOrNameMustBeProvided id name BranchError.EitherBranchIdOrBranchNameRequired
+                    |]
+
+                match! getFirstError validations with
+                | Some error -> return Some(BranchError.getErrorMessage error)
+                | None -> return None
+            | _ -> return invalidArg (nameof entityKind) $"Unknown entity validation decision: {entityKind}/{validationMode}."
+        }
+
+    let notFoundErrorMessage entityKind id =
+        let byId = not <| String.IsNullOrEmpty(id)
+
+        match entityKind, byId with
+        | EntityKind.Owner, true -> OwnerError.getErrorMessage OwnerError.OwnerIdDoesNotExist
+        | EntityKind.Owner, false -> OwnerError.getErrorMessage OwnerError.OwnerDoesNotExist
+        | EntityKind.Organization, true -> OrganizationError.getErrorMessage OrganizationError.OrganizationIdDoesNotExist
+        | EntityKind.Organization, false -> OrganizationError.getErrorMessage OrganizationError.OrganizationDoesNotExist
+        | EntityKind.Repository, true -> RepositoryError.getErrorMessage RepositoryError.RepositoryIdDoesNotExist
+        | EntityKind.Repository, false -> RepositoryError.getErrorMessage RepositoryError.RepositoryDoesNotExist
+        | EntityKind.Branch, true -> BranchError.getErrorMessage BranchError.BranchIdDoesNotExist
+        | EntityKind.Branch, false -> BranchError.getErrorMessage BranchError.BranchDoesNotExist
+        | _ -> invalidArg (nameof entityKind) $"Unknown entity kind: {entityKind}."
+
+    let withEntityId entityKind (id: string) graceIds =
+        let parsedId = Guid.Parse(id)
+
+        match entityKind with
+        | EntityKind.Owner -> { graceIds with OwnerId = parsedId; OwnerIdString = id; HasOwner = true }
+        | EntityKind.Organization -> { graceIds with OrganizationId = parsedId; OrganizationIdString = id; HasOrganization = true }
+        | EntityKind.Repository -> { graceIds with RepositoryId = parsedId; RepositoryIdString = id; HasRepository = true }
+        | EntityKind.Branch -> { graceIds with BranchId = parsedId; BranchIdString = id; HasBranch = true }
+        | _ -> invalidArg (nameof entityKind) $"Unknown entity kind: {entityKind}."

--- a/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
@@ -7,9 +7,6 @@ open Grace.Server.Validations
 open Grace.Shared
 open Grace.Types.Types
 open Grace.Shared.Utilities
-open Grace.Shared.Validation
-open Grace.Shared.Validation.Errors
-open Grace.Shared.Validation.Utilities
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Caching.Memory
 open Microsoft.Extensions.Logging
@@ -128,201 +125,128 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
                             |> ignore
 
                         // Get Owner information.
-                        if entityProperties.OwnerId.IsSome
-                           && entityProperties.OwnerName.IsSome then
+                        if ValidateIdsDecisions.shouldValidateEntity None entityProperties.OwnerId entityProperties.OwnerName then
                             // Get the values from the request body.
                             let ownerIdString = entityProperties.OwnerId.Value.GetValue(requestBody) :?> string
                             let ownerName = entityProperties.OwnerName.Value.GetValue(requestBody) :?> string
 
-                            let validations =
-                                if path.Equals("/owner/create", StringComparison.InvariantCultureIgnoreCase) then
-                                    [|
-                                        Common.String.isNotEmpty ownerIdString OwnerError.OwnerIdIsRequired
-                                        Common.Guid.isValidAndNotEmptyGuid ownerIdString OwnerError.InvalidOwnerId
-                                        Common.String.isNotEmpty ownerName OwnerError.OwnerNameIsRequired
-                                        Common.String.isValidGraceName ownerName OwnerError.InvalidOwnerName
-                                        Common.Input.eitherIdOrNameMustBeProvided ownerIdString ownerName OwnerError.EitherOwnerIdOrOwnerNameRequired
-                                    |]
-                                else
-                                    [|
-                                        Common.Guid.isValidAndNotEmptyGuid ownerIdString OwnerError.InvalidOwnerId
-                                        Common.String.isValidGraceName ownerName OwnerError.InvalidOwnerName
-                                        Common.Input.eitherIdOrNameMustBeProvided ownerIdString ownerName OwnerError.EitherOwnerIdOrOwnerNameRequired
-                                    |]
+                            let validationMode = ValidateIdsDecisions.validationModeForPath ValidateIdsDecisions.EntityKind.Owner path
 
-                            match! getFirstError validations with
-                            | Some error -> badRequest <- Some(GraceError.Create (OwnerError.getErrorMessage error) correlationId)
+                            match!
+                                ValidateIdsDecisions.getEntityValidationErrorMessage
+                                    ValidateIdsDecisions.EntityKind.Owner
+                                    validationMode
+                                    ownerIdString
+                                    ownerName
+                                with
+                            | Some error -> badRequest <- Some(GraceError.Create error correlationId)
                             | None ->
-                                if path.Equals("/owner/create", StringComparison.InvariantCultureIgnoreCase) then
+                                if validationMode = ValidateIdsDecisions.EntityValidationMode.Create then
                                     // If we're creating a new Owner, we don't need to resolve the Id.
-                                    graceIds <- { graceIds with OwnerId = Guid.Parse(ownerIdString); OwnerIdString = ownerIdString; HasOwner = true }
+                                    graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Owner ownerIdString graceIds
                                 else
                                     // Resolve the OwnerId based on the provided Id and Name.
                                     match! resolveOwnerId ownerIdString ownerName correlationId with
                                     | Some resolvedOwnerId ->
-                                        graceIds <- { graceIds with OwnerId = Guid.Parse(resolvedOwnerId); OwnerIdString = resolvedOwnerId; HasOwner = true }
+                                        graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Owner resolvedOwnerId graceIds
                                     | None ->
-                                        badRequest <-
-                                            if not <| String.IsNullOrEmpty(ownerIdString) then
-                                                Some(GraceError.Create (getErrorMessage OwnerError.OwnerIdDoesNotExist) correlationId)
-                                            else
-                                                Some(GraceError.Create (getErrorMessage OwnerError.OwnerDoesNotExist) correlationId)
+                                        let error = ValidateIdsDecisions.notFoundErrorMessage ValidateIdsDecisions.EntityKind.Owner ownerIdString
+
+                                        badRequest <- Some(GraceError.Create error correlationId)
 
                         // Get Organization information.
-                        if badRequest.IsNone
-                           && entityProperties.OrganizationId.IsSome
-                           && entityProperties.OrganizationName.IsSome then
+                        if ValidateIdsDecisions.shouldValidateEntity badRequest entityProperties.OrganizationId entityProperties.OrganizationName then
                             // Get the values from the request body.
                             let organizationIdString = entityProperties.OrganizationId.Value.GetValue(requestBody) :?> string
                             let organizationName = entityProperties.OrganizationName.Value.GetValue(requestBody) :?> string
 
-                            let validations =
-                                if path.Equals("/organization/create", StringComparison.InvariantCultureIgnoreCase) then
-                                    [|
-                                        Common.String.isNotEmpty organizationIdString OrganizationError.OrganizationIdIsRequired
-                                        Common.Guid.isValidAndNotEmptyGuid organizationIdString OrganizationError.InvalidOrganizationId
-                                        Common.String.isNotEmpty organizationName OrganizationError.OrganizationNameIsRequired
-                                        Common.String.isValidGraceName organizationName OrganizationError.InvalidOrganizationName
-                                        Common.Input.eitherIdOrNameMustBeProvided
-                                            organizationIdString
-                                            organizationName
-                                            OrganizationError.EitherOrganizationIdOrOrganizationNameRequired
-                                    |]
-                                else
-                                    [|
-                                        Common.Guid.isValidAndNotEmptyGuid organizationIdString OrganizationError.InvalidOrganizationId
-                                        Common.String.isValidGraceName organizationName OrganizationError.InvalidOrganizationName
-                                        Common.Input.eitherIdOrNameMustBeProvided
-                                            organizationIdString
-                                            organizationName
-                                            OrganizationError.EitherOrganizationIdOrOrganizationNameRequired
-                                    |]
+                            let validationMode = ValidateIdsDecisions.validationModeForPath ValidateIdsDecisions.EntityKind.Organization path
 
-                            match! getFirstError validations with
-                            | Some error -> badRequest <- Some(GraceError.Create (OrganizationError.getErrorMessage error) correlationId)
+                            match!
+                                ValidateIdsDecisions.getEntityValidationErrorMessage
+                                    ValidateIdsDecisions.EntityKind.Organization
+                                    validationMode
+                                    organizationIdString
+                                    organizationName
+                                with
+                            | Some error -> badRequest <- Some(GraceError.Create error correlationId)
                             | None ->
-                                if path.Equals("/organization/create", StringComparison.InvariantCultureIgnoreCase) then
+                                if validationMode = ValidateIdsDecisions.EntityValidationMode.Create then
                                     // If we're creating a new Organization, we don't need to resolve the Id.
-                                    graceIds <-
-                                        { graceIds with
-                                            OrganizationId = Guid.Parse(organizationIdString)
-                                            OrganizationIdString = organizationIdString
-                                            HasOrganization = true
-                                        }
+                                    graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Organization organizationIdString graceIds
                                 else
                                     // Resolve the OrganizationId based on the provided Id and Name.
                                     match! resolveOrganizationId graceIds.OwnerId organizationIdString organizationName correlationId with
                                     | Some resolvedOrganizationId ->
                                         graceIds <-
-                                            { graceIds with
-                                                OrganizationId = Guid.Parse(resolvedOrganizationId)
-                                                OrganizationIdString = resolvedOrganizationId
-                                                HasOrganization = true
-                                            }
+                                            ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Organization resolvedOrganizationId graceIds
                                     | None ->
-                                        badRequest <-
-                                            if not <| String.IsNullOrEmpty(organizationIdString) then
-                                                Some(GraceError.Create (getErrorMessage OrganizationError.OrganizationIdDoesNotExist) correlationId)
-                                            else
-                                                Some(GraceError.Create (getErrorMessage OrganizationError.OrganizationDoesNotExist) correlationId)
+                                        let error = ValidateIdsDecisions.notFoundErrorMessage ValidateIdsDecisions.EntityKind.Organization organizationIdString
+
+                                        badRequest <- Some(GraceError.Create error correlationId)
 
                         // Get repository information.
-                        if badRequest.IsNone
-                           && entityProperties.RepositoryId.IsSome
-                           && entityProperties.RepositoryName.IsSome then
+                        if ValidateIdsDecisions.shouldValidateEntity badRequest entityProperties.RepositoryId entityProperties.RepositoryName then
                             // Get the values from the request body.
                             let repositoryIdString = entityProperties.RepositoryId.Value.GetValue(requestBody) :?> string
                             let repositoryName = entityProperties.RepositoryName.Value.GetValue(requestBody) :?> string
 
-                            let validations =
-                                if path.Equals("/repository/create", StringComparison.InvariantCultureIgnoreCase) then
-                                    [|
-                                        Common.String.isNotEmpty repositoryIdString RepositoryError.RepositoryIdIsRequired
-                                        Common.Guid.isValidAndNotEmptyGuid repositoryIdString RepositoryError.InvalidRepositoryId
-                                        Common.String.isNotEmpty repositoryName RepositoryError.RepositoryNameIsRequired
-                                        Common.String.isValidGraceName repositoryName RepositoryError.InvalidRepositoryName
-                                        Common.Input.eitherIdOrNameMustBeProvided repositoryIdString repositoryName EitherRepositoryIdOrRepositoryNameRequired
-                                    |]
-                                else
-                                    [|
-                                        Common.Guid.isValidAndNotEmptyGuid repositoryIdString RepositoryError.InvalidRepositoryId
-                                        Common.String.isValidGraceName repositoryName RepositoryError.InvalidRepositoryName
-                                        Common.Input.eitherIdOrNameMustBeProvided repositoryIdString repositoryName EitherRepositoryIdOrRepositoryNameRequired
-                                    |]
+                            let validationMode = ValidateIdsDecisions.validationModeForPath ValidateIdsDecisions.EntityKind.Repository path
 
-                            match! getFirstError validations with
-                            | Some error -> badRequest <- Some(GraceError.Create (RepositoryError.getErrorMessage error) correlationId)
+                            match!
+                                ValidateIdsDecisions.getEntityValidationErrorMessage
+                                    ValidateIdsDecisions.EntityKind.Repository
+                                    validationMode
+                                    repositoryIdString
+                                    repositoryName
+                                with
+                            | Some error -> badRequest <- Some(GraceError.Create error correlationId)
                             | None ->
-                                if path.Equals("/repository/create", StringComparison.InvariantCultureIgnoreCase) then
+                                if validationMode = ValidateIdsDecisions.EntityValidationMode.Create then
                                     // If we're creating a new Repository, we don't need to resolve the Id.
-                                    graceIds <-
-                                        { graceIds with
-                                            RepositoryId = Guid.Parse(repositoryIdString)
-                                            RepositoryIdString = repositoryIdString
-                                            HasRepository = true
-                                        }
+                                    graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Repository repositoryIdString graceIds
                                 else
                                     // Resolve the RepositoryId based on the provided Id and Name.
                                     match! resolveRepositoryId graceIds.OwnerId graceIds.OrganizationId repositoryIdString repositoryName correlationId with
                                     | Some resolvedRepositoryId ->
                                         graceIds <-
-                                            { graceIds with
-                                                RepositoryId = resolvedRepositoryId
-                                                RepositoryIdString = $"{resolvedRepositoryId}"
-                                                HasRepository = true
-                                            }
+                                            ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Repository $"{resolvedRepositoryId}" graceIds
                                     | None ->
-                                        badRequest <-
-                                            if not <| String.IsNullOrEmpty(repositoryIdString) then
-                                                Some(GraceError.Create (getErrorMessage RepositoryError.RepositoryIdDoesNotExist) correlationId)
-                                            else
-                                                Some(GraceError.Create (getErrorMessage RepositoryError.RepositoryDoesNotExist) correlationId)
+                                        let error = ValidateIdsDecisions.notFoundErrorMessage ValidateIdsDecisions.EntityKind.Repository repositoryIdString
+
+                                        badRequest <- Some(GraceError.Create error correlationId)
 
                         // Get branch information.
-                        if badRequest.IsNone
-                           && entityProperties.BranchId.IsSome
-                           && entityProperties.BranchName.IsSome then
+                        if ValidateIdsDecisions.shouldValidateEntity badRequest entityProperties.BranchId entityProperties.BranchName then
                             // Get the values from the request body.
                             let branchIdString = entityProperties.BranchId.Value.GetValue(requestBody) :?> string
                             let branchName = entityProperties.BranchName.Value.GetValue(requestBody) :?> string
 
-                            let validations =
-                                if path.Equals("/branch/create", StringComparison.InvariantCultureIgnoreCase) then
-                                    [|
-                                        Common.String.isNotEmpty branchIdString BranchError.BranchIdIsRequired
-                                        Common.Guid.isValidAndNotEmptyGuid branchIdString BranchError.InvalidBranchId
-                                        Common.String.isNotEmpty branchName BranchError.BranchNameIsRequired
-                                        Common.String.isValidGraceName branchName BranchError.InvalidBranchName
-                                        Common.Input.eitherIdOrNameMustBeProvided branchIdString branchName BranchError.EitherBranchIdOrBranchNameRequired
-                                    |]
-                                else
-                                    [|
-                                        Common.Guid.isValidAndNotEmptyGuid branchIdString BranchError.InvalidBranchId
-                                        Common.String.isValidGraceName branchName BranchError.InvalidBranchName
-                                        Common.Input.eitherIdOrNameMustBeProvided branchIdString branchName BranchError.EitherBranchIdOrBranchNameRequired
-                                    |]
+                            let validationMode = ValidateIdsDecisions.validationModeForPath ValidateIdsDecisions.EntityKind.Branch path
 
-                            match! getFirstError validations with
-                            | Some error -> badRequest <- Some(GraceError.Create (BranchError.getErrorMessage error) correlationId)
+                            match!
+                                ValidateIdsDecisions.getEntityValidationErrorMessage
+                                    ValidateIdsDecisions.EntityKind.Branch
+                                    validationMode
+                                    branchIdString
+                                    branchName
+                                with
+                            | Some error -> badRequest <- Some(GraceError.Create error correlationId)
                             | None ->
                                 // If we're creating a new Branch, we don't need to resolve the Id.
-                                if path.Equals("/branch/create", StringComparison.InvariantCultureIgnoreCase) then
-                                    let mutable branchId = Guid.Empty
-                                    Guid.TryParse(branchIdString, &branchId) |> ignore
-                                    graceIds <- { graceIds with BranchId = branchId; BranchIdString = branchIdString; HasBranch = true }
+                                if validationMode = ValidateIdsDecisions.EntityValidationMode.Create then
+                                    graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Branch branchIdString graceIds
                                 else
                                     // Resolve the BranchId based on the provided Id and Name.
                                     match!
                                         resolveBranchId graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId branchIdString branchName correlationId
                                         with
                                     | Some resolvedBranchId ->
-                                        graceIds <- { graceIds with BranchId = resolvedBranchId; BranchIdString = $"{resolvedBranchId}"; HasBranch = true }
+                                        graceIds <- ValidateIdsDecisions.withEntityId ValidateIdsDecisions.EntityKind.Branch $"{resolvedBranchId}" graceIds
                                     | None ->
-                                        badRequest <-
-                                            if not <| String.IsNullOrEmpty(branchIdString) then
-                                                Some(GraceError.Create (getErrorMessage BranchError.BranchIdDoesNotExist) correlationId)
-                                            else
-                                                Some(GraceError.Create (getErrorMessage BranchError.BranchDoesNotExist) correlationId)
+                                        let error = ValidateIdsDecisions.notFoundErrorMessage ValidateIdsDecisions.EntityKind.Branch branchIdString
+
+                                        badRequest <- Some(GraceError.Create error correlationId)
 
                     // Add the parsed Id's and Names to the HttpContext.
                     context.Items.Add(nameof GraceIds, graceIds)


### PR DESCRIPTION
## Summary

- Extends the ValidateIds decision seam for create-vs-existing entity validation.
- Keeps resolver calls in middleware while delegating validation error selection, not-found choice, GraceIds population, and later-scope skipping decisions to pure helpers.
- Adds no-Aspire unit coverage for owner, organization, repository, and branch decision paths without real resolver calls.

## Linked Issue

Closes #191.

## Validation

Initial implementation evidence, captured before the #209 workflow correction:

- `dotnet tool run fantomas -- src/Grace.Server/Middleware/ValidateIds.Decisions.fs src/Grace.Server/Middleware/ValidateIds.Middleware.fs src/Grace.Server.Unit.Tests/ValidateIds.Decisions.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~ValidateIds`: passed, `49/49`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Current freshness validation, using the corrected one-build/test-gate rule:

- `pwsh ./scripts/validate.ps1 -Fast`: passed as the sole final build/test gate.
- `git diff --check`: passed.
- No focused build or project-specific focused test was run because `validate -Fast` was the selected gate.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is no-Aspire middleware decision extraction and does not touch Aspire, hosted tests, storage, Service Bus, Redis, deployment, or cross-service runtime behavior.

## Review Status

- Implementation worker completed commit `146369c` and pushed `agent/191-validateids-entity-decisions`.
- Initial implementation validation included focused project build/test evidence before the workflow correction in #209; retained as historical evidence only, not as the current prompt pattern.
- Freshness gates completed through `656f321`: branch is `4 0` ahead/behind current `origin/main`, has no deleted files in the PR diff, and diff paths are limited to #191 ValidateIds files.
- Corrected freshness validation used `pwsh ./scripts/validate.ps1 -Fast` as the sole final build/test gate, then `git diff --check`.
- Fresh review-only sibling subagent completed with no findings; details are in the PR comment "Fresh review-only pass for #191 / PR #204".
- Open findings: none.
- Final no-issues review: complete.
- GitHub Validate check: passed.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify behavior preservation for create/existing validation, not-found error choice, GraceIds population, and short-circuiting after earlier bad requests.


