### PR TITLE
Extract auth scheme selection helper

### DIFF
--- a/src/Grace.Server.Unit.Tests/AuthSchemeSelection.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AuthSchemeSelection.Unit.Tests.fs
@@ -1,0 +1,47 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Types.PersonalAccessToken
+open Microsoft.AspNetCore.Authentication.JwtBearer
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type AuthSchemeSelectionUnitTests() =
+
+    let gracePatHeader = $"Bearer {TokenPrefix}user.token.secret"
+
+    let assertScheme (expected: string) isTesting hasOidc (authorization: string) =
+        Assert.That(AuthSchemeSelection.selectScheme isTesting hasOidc authorization, Is.EqualTo(expected))
+
+    [<Test>]
+    member _.TestingModeWithNoAuthHeaderSelectsTestAuth() = assertScheme TestAuth.SchemeName true false null
+
+    [<Test>]
+    member _.TestingModeWithGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName true false gracePatHeader
+
+    [<Test>]
+    member _.TestingModeWithNonPatBearerSelectsTestAuth() = assertScheme TestAuth.SchemeName true false "Bearer external-jwt-token"
+
+    [<Test>]
+    member _.ProductionWithOidcAndNonPatBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true "Bearer external-jwt-token"
+
+    [<Test>]
+    member _.ProductionWithOidcAndGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName false true gracePatHeader
+
+    [<Test>]
+    member _.ProductionWithOidcAndNoBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true null
+
+    [<Test>]
+    member _.ProductionWithoutOidcSelectsPat() =
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "Bearer external-jwt-token"
+
+        assertScheme PersonalAccessTokenAuth.SchemeName false false null
+
+    [<Test>]
+    member _.WhitespaceAndMalformedHeadersSelectExistingFallback() =
+        assertScheme TestAuth.SchemeName true false "   "
+        assertScheme TestAuth.SchemeName true false "Basic abc123"
+        assertScheme JwtBearerDefaults.AuthenticationScheme false true "   "
+        assertScheme JwtBearerDefaults.AuthenticationScheme false true "Basic abc123"
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "   "
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "Basic abc123"

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
+    <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -59,6 +59,7 @@
                 <Compile Include="Security\ClaimsTransformation.Server.fs" />
                 <Compile Include="Security\TestAuth.Server.fs" />
 		<Compile Include="Security\PersonalAccessTokenAuth.Server.fs" />
+		<Compile Include="Security\AuthSchemeSelection.Server.fs" />
 		<Compile Include="Security\OutboundUrlSafety.Server.fs" />
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />

--- a/src/Grace.Server/Security/AuthSchemeSelection.Server.fs
+++ b/src/Grace.Server/Security/AuthSchemeSelection.Server.fs
@@ -1,0 +1,30 @@
+namespace Grace.Server.Security
+
+open Grace.Types.PersonalAccessToken
+open Microsoft.AspNetCore.Authentication.JwtBearer
+open System
+
+module AuthSchemeSelection =
+
+    [<Literal>]
+    let private BearerPrefix = "Bearer "
+
+    let private isGracePatBearer (authorization: string) =
+        if
+            not (String.IsNullOrWhiteSpace authorization)
+            && authorization.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase)
+        then
+            let token =
+                authorization
+                    .Substring(BearerPrefix.Length)
+                    .Trim()
+
+            token.StartsWith(TokenPrefix, StringComparison.Ordinal)
+        else
+            false
+
+    let selectScheme (isTesting: bool) (hasOidc: bool) (authorization: string) =
+        if isGracePatBearer authorization then PersonalAccessTokenAuth.SchemeName
+        else if isTesting then TestAuth.SchemeName
+        else if hasOidc then JwtBearerDefaults.AuthenticationScheme
+        else PersonalAccessTokenAuth.SchemeName

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1747,19 +1747,7 @@ module Application =
                             options.ForwardDefaultSelector <-
                                 fun context ->
                                     let authorization = context.Request.Headers.Authorization.ToString()
-
-                                    if
-                                        not (String.IsNullOrWhiteSpace authorization)
-                                        && authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-                                    then
-                                        let token = authorization.Substring("Bearer ".Length).Trim()
-
-                                        if token.StartsWith(TokenPrefix, StringComparison.Ordinal) then
-                                            PersonalAccessTokenAuth.SchemeName
-                                        else
-                                            TestAuth.SchemeName
-                                    else
-                                        TestAuth.SchemeName
+                                    AuthSchemeSelection.selectScheme true false authorization
                     )
                     .AddScheme<AuthenticationSchemeOptions, GraceTestAuthHandler>(TestAuth.SchemeName, (fun _ -> ()))
                     .AddScheme<AuthenticationSchemeOptions, PersonalAccessTokenAuth.PersonalAccessTokenAuthHandler>(
@@ -1784,23 +1772,7 @@ module Application =
                             options.ForwardDefaultSelector <-
                                 fun context ->
                                     let authorization = context.Request.Headers.Authorization.ToString()
-
-                                    if
-                                        not (String.IsNullOrWhiteSpace authorization)
-                                        && authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-                                    then
-                                        let token = authorization.Substring("Bearer ".Length).Trim()
-
-                                        if token.StartsWith(TokenPrefix, StringComparison.Ordinal) then
-                                            PersonalAccessTokenAuth.SchemeName
-                                        else if hasOidc then
-                                            JwtBearerDefaults.AuthenticationScheme
-                                        else
-                                            PersonalAccessTokenAuth.SchemeName
-                                    else if hasOidc then
-                                        JwtBearerDefaults.AuthenticationScheme
-                                    else
-                                        PersonalAccessTokenAuth.SchemeName
+                                    AuthSchemeSelection.selectScheme false hasOidc authorization
                     )
                     .AddScheme<AuthenticationSchemeOptions, PersonalAccessTokenAuth.PersonalAccessTokenAuthHandler>(
                         PersonalAccessTokenAuth.SchemeName,


### PR DESCRIPTION
## Summary

- Extracts authentication policy-scheme selection into a pure internal helper.
- Updates Startup testing and production `ForwardDefaultSelector` paths to delegate to the helper without changing token validation internals or challenge defaults.
- Adds no-Aspire unit coverage for testing mode, production OIDC/non-OIDC, PAT routing, malformed headers, and production OIDC PAT routing.

## Linked Issue

Closes #187.

## Validation

- `dotnet tool run fantomas src/Grace.Server/Security/AuthSchemeSelection.Server.fs src/Grace.Server/Startup.Server.fs src/Grace.Server.Unit.Tests/AuthSchemeSelection.Unit.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~AuthSchemeSelection`: passed, `8/8`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is pure selector extraction plus no-Aspire unit coverage and no hosted auth/runtime integration behavior changed beyond extraction.

## Review Status

- Implementation worker completed commit `b2c193e` and pushed `agent/187-auth-scheme-selection`.
- Freshness gate completed in `dc4b162`: branch is `2 0` ahead/behind current `origin/main`, has no deleted files in the PR diff, and diff paths are limited to #187 auth selector files.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/205#issuecomment-4617615056
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify PAT-vs-JWT routing, production OIDC fallback behavior, malformed header fallback behavior, and that token validation/challenge behavior was not changed beyond selector extraction.