### PR TITLE
Extract WorkItem attachment helper decisions

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="Queue.Server.Tests.fs" />
     <Compile Include="OrleansFilters.Server.Tests.fs" />
     <Compile Include="WorkItem.Server.Tests.fs" />
+    <Compile Include="WorkItem.Attachments.Tests.fs" />
     <Compile Include="ApprovalRequest.Actor.Tests.fs" />
     <Compile Include="Validations.Server.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Server.Unit.Tests/WorkItem.Attachments.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WorkItem.Attachments.Tests.fs
@@ -1,0 +1,122 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Types.Artifact
+open Grace.Types.Types
+open NodaTime
+open NUnit.Framework
+open System
+
+[<Parallelizable(ParallelScope.All)>]
+type WorkItemAttachmentUnitTests() =
+    let artifactId = Guid.Parse("7d535f96-e634-4313-b5ff-d9293ee9db57")
+
+    let metadata artifactType mimeType size createdAt =
+        { ArtifactMetadata.Default with ArtifactId = artifactId; ArtifactType = artifactType; MimeType = mimeType; Size = size; CreatedAt = createdAt }
+
+    [<Test>]
+    member _.ReviewerAttachmentClassificationMapsSupportedArtifactTypesAndAliases() =
+        let cases =
+            [
+                Unchecked.defaultof<ArtifactType>, "summary"
+                ArtifactType.AgentSummary, "summary"
+                ArtifactType.Prompt, "prompt"
+                ArtifactType.ReviewNotes, "notes"
+                ArtifactType.Other "summary", "summary"
+                ArtifactType.Other "agentsummary", "summary"
+                ArtifactType.Other "prompt", "prompt"
+                ArtifactType.Other "notes", "notes"
+                ArtifactType.Other "reviewnotes", "notes"
+                ArtifactType.Other "AgEnTsUmMaRy", "summary"
+                ArtifactType.Other "ReViEwNoTeS", "notes"
+            ]
+
+        for artifactType, expectedAttachmentType in cases do
+            Assert.That(
+                WorkItemAttachments.tryGetReviewerAttachmentTypeName artifactType,
+                Is.EqualTo(Some expectedAttachmentType),
+                $"Expected {artifactType} to classify as {expectedAttachmentType}."
+            )
+
+            Assert.That(
+                WorkItemAttachments.getAttachmentTypeName artifactType,
+                Is.EqualTo(expectedAttachmentType),
+                $"Expected {artifactType} display type to be {expectedAttachmentType}."
+            )
+
+    [<Test>]
+    member _.ReviewerAttachmentClassificationExcludesUnsupportedOtherArtifactTypes() =
+        let unsupportedTypes =
+            [
+                ArtifactType.Other "unknown"
+                ArtifactType.Other "summary-report"
+                ArtifactType.Other "binary"
+                ArtifactType.ConflictReport
+                ArtifactType.ValidationOutput
+            ]
+
+        for artifactType in unsupportedTypes do
+            Assert.That(
+                WorkItemAttachments.tryGetReviewerAttachmentTypeName artifactType,
+                Is.EqualTo(None),
+                $"Expected {artifactType} to be excluded from reviewer attachments."
+            )
+
+            Assert.That(
+                WorkItemAttachments.getAttachmentTypeName artifactType,
+                Is.EqualTo("other"),
+                $"Expected {artifactType} display type to fall back to other."
+            )
+
+    [<Test>]
+    member _.TextMimeDetectionAcceptsTextJsonXmlYamlTomlAndJavascript() =
+        let textMimeTypes =
+            [
+                "text/plain"
+                " text/markdown "
+                "TEXT/HTML"
+                "application/json"
+                "application/problem+json"
+                "application/xml"
+                "application/atom+xml"
+                "application/yaml"
+                "application/x-yaml"
+                "application/toml"
+                "application/javascript"
+                "application/x-javascript"
+            ]
+
+        for mimeType in textMimeTypes do
+            Assert.That(WorkItemAttachments.isTextMimeType mimeType, Is.True, $"Expected '{mimeType}' to be text-readable.")
+
+    [<Test>]
+    member _.TextMimeDetectionRejectsBinaryAndBlankMimeValues() =
+        let binaryMimeTypes =
+            [
+                null
+                String.Empty
+                "   "
+                "application/octet-stream"
+                "image/png"
+                "application/pdf"
+                "application/zip"
+                "application/x-protobuf"
+            ]
+
+        for mimeType in binaryMimeTypes do
+            Assert.That(WorkItemAttachments.isTextMimeType mimeType, Is.False, $"Expected '{mimeType}' to be non-text.")
+
+    [<Test>]
+    member _.AttachmentDescriptorPreservesIdentityTypeMimeSizeAndTimestamp() =
+        let createdAt = Instant.FromUtc(2026, 6, 3, 12, 34, 56)
+
+        let attachment: WorkItemAttachments.WorkItemAttachment =
+            { ArtifactId = artifactId; Metadata = metadata ArtifactType.Prompt "application/json" 4096L createdAt; AttachmentType = "prompt" }
+
+        let descriptor = WorkItemAttachments.toAttachmentDescriptor attachment
+
+        Assert.That(descriptor.ArtifactId, Is.EqualTo(artifactId.ToString()))
+        Assert.That(descriptor.AttachmentType, Is.EqualTo("prompt"))
+        Assert.That(descriptor.MimeType, Is.EqualTo("application/json"))
+        Assert.That(descriptor.Size, Is.EqualTo(4096L))
+        Assert.That(descriptor.CreatedAt, Is.EqualTo(createdAt.ToString()))

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -82,6 +82,7 @@
                 <Compile Include="PromotionSet.Server.fs" />
                 <Compile Include="Webhook.Server.fs" />
                 <Compile Include="WebhookDispatch.Server.fs" />
+                <Compile Include="WorkItem.Attachments.Server.fs" />
                 <Compile Include="WorkItem.Server.fs" />
                 <Compile Include="Policy.Server.fs" />
                 <Compile Include="ReviewModels.Server.fs" />

--- a/src/Grace.Server/WorkItem.Attachments.Server.fs
+++ b/src/Grace.Server/WorkItem.Attachments.Server.fs
@@ -1,0 +1,67 @@
+namespace Grace.Server
+
+open Grace.Shared.Parameters.WorkItem
+open Grace.Types.Artifact
+open Grace.Types.Types
+open System
+
+module WorkItemAttachments =
+    type internal WorkItemAttachment = { ArtifactId: ArtifactId; Metadata: ArtifactMetadata; AttachmentType: string }
+
+    let private equalsIgnoreCase (expected: string) (actual: string) =
+        not (isNull actual)
+        && actual.Equals(expected, StringComparison.OrdinalIgnoreCase)
+
+    let private tryClassifyArtifactType (artifactType: ArtifactType) =
+        if isNull (box artifactType) then
+            Some "summary"
+        else
+            match artifactType with
+            | ArtifactType.AgentSummary -> Some "summary"
+            | ArtifactType.Prompt -> Some "prompt"
+            | ArtifactType.ReviewNotes -> Some "notes"
+            | ArtifactType.Other kind when
+                equalsIgnoreCase "summary" kind
+                || equalsIgnoreCase "agentsummary" kind
+                ->
+                Some "summary"
+            | ArtifactType.Other kind when equalsIgnoreCase "prompt" kind -> Some "prompt"
+            | ArtifactType.Other kind when
+                equalsIgnoreCase "notes" kind
+                || equalsIgnoreCase "reviewnotes" kind
+                ->
+                Some "notes"
+            | _ -> None
+
+    let internal getAttachmentTypeName (artifactType: ArtifactType) =
+        match tryClassifyArtifactType artifactType with
+        | Some attachmentType -> attachmentType
+        | None -> "other"
+
+    let internal tryGetReviewerAttachmentTypeName (artifactType: ArtifactType) = tryClassifyArtifactType artifactType
+
+    let internal isTextMimeType (mimeType: string) =
+        if String.IsNullOrWhiteSpace(mimeType) then
+            false
+        else
+            let normalized = mimeType.Trim().ToLowerInvariant()
+
+            normalized.StartsWith("text/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("+json", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("+xml", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/json", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/xml", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/yaml", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/x-yaml", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/toml", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/javascript", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("application/x-javascript", StringComparison.OrdinalIgnoreCase)
+
+    let internal toAttachmentDescriptor (attachment: WorkItemAttachment) =
+        WorkItemAttachmentDescriptor(
+            ArtifactId = attachment.ArtifactId.ToString(),
+            AttachmentType = attachment.AttachmentType,
+            MimeType = attachment.Metadata.MimeType,
+            Size = attachment.Metadata.Size,
+            CreatedAt = attachment.Metadata.CreatedAt.ToString()
+        )

--- a/src/Grace.Server/WorkItem.Server.fs
+++ b/src/Grace.Server/WorkItem.Server.fs
@@ -7,6 +7,7 @@ open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Server.ApplicationContext
 open Grace.Server.Services
+open Grace.Server.WorkItemAttachments
 open Grace.Shared
 open Grace.Shared.Extensions
 open Grace.Shared.Parameters.WorkItem
@@ -906,76 +907,6 @@ module WorkItem =
                 context.Items[ "Command" ] <- "Get"
                 return! processQuery context parameters validations query
             }
-
-    type private WorkItemAttachment = { ArtifactId: ArtifactId; Metadata: ArtifactMetadata; AttachmentType: string }
-
-    let private getAttachmentTypeName (artifactType: ArtifactType) =
-        if isNull (box artifactType) then
-            "summary"
-        else
-            match artifactType with
-            | ArtifactType.AgentSummary -> "summary"
-            | ArtifactType.Prompt -> "prompt"
-            | ArtifactType.ReviewNotes -> "notes"
-            | ArtifactType.Other kind when
-                kind.Equals("summary", StringComparison.OrdinalIgnoreCase)
-                || kind.Equals("agentsummary", StringComparison.OrdinalIgnoreCase)
-                ->
-                "summary"
-            | ArtifactType.Other kind when kind.Equals("prompt", StringComparison.OrdinalIgnoreCase) -> "prompt"
-            | ArtifactType.Other kind when
-                kind.Equals("notes", StringComparison.OrdinalIgnoreCase)
-                || kind.Equals("reviewnotes", StringComparison.OrdinalIgnoreCase)
-                ->
-                "notes"
-            | _ -> "other"
-
-    let private tryGetReviewerAttachmentTypeName (artifactType: ArtifactType) =
-        if isNull (box artifactType) then
-            Some "summary"
-        else
-            match artifactType with
-            | ArtifactType.AgentSummary -> Some "summary"
-            | ArtifactType.Prompt -> Some "prompt"
-            | ArtifactType.ReviewNotes -> Some "notes"
-            | ArtifactType.Other kind when
-                kind.Equals("summary", StringComparison.OrdinalIgnoreCase)
-                || kind.Equals("agentsummary", StringComparison.OrdinalIgnoreCase)
-                ->
-                Some "summary"
-            | ArtifactType.Other kind when kind.Equals("prompt", StringComparison.OrdinalIgnoreCase) -> Some "prompt"
-            | ArtifactType.Other kind when
-                kind.Equals("notes", StringComparison.OrdinalIgnoreCase)
-                || kind.Equals("reviewnotes", StringComparison.OrdinalIgnoreCase)
-                ->
-                Some "notes"
-            | _ -> None
-
-    let private isTextMimeType (mimeType: string) =
-        if String.IsNullOrWhiteSpace(mimeType) then
-            false
-        else
-            let normalized = mimeType.Trim().ToLowerInvariant()
-
-            normalized.StartsWith("text/", StringComparison.OrdinalIgnoreCase)
-            || normalized.Contains("+json", StringComparison.OrdinalIgnoreCase)
-            || normalized.Contains("+xml", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/json", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/xml", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/yaml", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/x-yaml", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/toml", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/javascript", StringComparison.OrdinalIgnoreCase)
-            || normalized.Equals("application/x-javascript", StringComparison.OrdinalIgnoreCase)
-
-    let private toAttachmentDescriptor (attachment: WorkItemAttachment) =
-        WorkItemAttachmentDescriptor(
-            ArtifactId = attachment.ArtifactId.ToString(),
-            AttachmentType = attachment.AttachmentType,
-            MimeType = attachment.Metadata.MimeType,
-            Size = attachment.Metadata.Size,
-            CreatedAt = attachment.Metadata.CreatedAt.ToString()
-        )
 
     let private selectAttachmentDeterministically (attachments: WorkItemAttachment list) (latest: bool) =
         if List.isEmpty attachments then


### PR DESCRIPTION
## Summary

- Extracts WorkItem reviewer attachment classification, text MIME detection, and descriptor formatting into a pure internal helper.
- Keeps WorkItem handler flow intact while making helper decisions directly testable.
- Adds no-Aspire unit coverage for supported aliases, unsupported `Other` exclusion, text/binary MIME decisions, and descriptor preservation.

## Linked Issue

Closes #193.

## Validation

- `dotnet tool run fantomas src\Grace.Server\WorkItem.Attachments.Server.fs src\Grace.Server\WorkItem.Server.fs src\Grace.Server.Unit.Tests\WorkItem.Attachments.Tests.fs`: passed.
- `dotnet build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~WorkItem`: passed, `38` tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is pure helper extraction/unit coverage and does not touch hosted HTTP, blob storage, actors, Aspire, Service Bus, Redis, or runtime integration behavior.

## Review Status

- Implementation worker completed commit `e80f52f` and pushed `agent/193-workitem-attachment-classification`.
- Freshness gate completed in `c84d477` after #188 and again in `6c89406` after #187: branch is `3 0` ahead/behind current `origin/main`, has no deleted files in the PR diff, and diff paths are limited to #193 WorkItem attachment helper files.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/206#issuecomment-4617666057
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify classification/MIME parity with the original handler behavior and no blob/HTTP/actor behavior leaked into Server.Unit.