### PR TITLE
Extract metrics authorization decisions

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="MetricsAuthorization.Unit.Tests.fs" />
     <Compile Include="StorageAuthorizationResources.Unit.Tests.fs" />
     <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/MetricsAuthorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MetricsAuthorization.Unit.Tests.fs
@@ -1,0 +1,65 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Types.Authorization
+open Microsoft.AspNetCore.Http
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type MetricsAuthorizationUnitTests() =
+
+    let assertPassThrough decision =
+        match decision with
+        | PassThrough -> ()
+        | _ -> Assert.Fail($"Expected PassThrough but got {decision}.")
+
+    let assertReject (expectedStatus: int) (expectedMessage: string) decision =
+        match decision with
+        | RejectRequest (statusCode, message) ->
+            Assert.That(statusCode, Is.EqualTo(expectedStatus))
+            Assert.That(message, Is.EqualTo(expectedMessage))
+        | _ -> Assert.Fail($"Expected RejectRequest but got {decision}.")
+
+    [<Test>]
+    member _.NonMetricsPathPassesThrough() =
+        let decision = MetricsAuthorization.decideBeforePermissionCheck (PathString("/owner/create")) None
+
+        assertPassThrough decision
+
+    [<Test>]
+    member _.MetricsUnauthenticatedReturns401AndAuthenticationMessage() =
+        let decision = MetricsAuthorization.decideBeforePermissionCheck (PathString("/metrics")) None
+
+        assertReject StatusCodes.Status401Unauthorized "Authentication required." decision
+
+    [<Test>]
+    member _.MetricsAuthenticatedRequiresPermissionCheck() =
+        let decision = MetricsAuthorization.decideBeforePermissionCheck (PathString("/metrics")) (Some "user-1")
+
+        match decision with
+        | RequirePermissionCheck -> ()
+        | _ -> Assert.Fail($"Expected RequirePermissionCheck but got {decision}.")
+
+    [<Test>]
+    member _.MetricsDeniedReturns403AndGenericForbiddenMessageByDefault() =
+        let decision = MetricsAuthorization.decideAfterPermissionCheck false (Denied "SystemAdmin required.")
+
+        assertReject StatusCodes.Status403Forbidden "Forbidden." decision
+
+    [<Test>]
+    member _.MetricsDeniedIncludesReasonWhenTestingFlagIsTrue() =
+        let decision = MetricsAuthorization.decideAfterPermissionCheck true (Denied "SystemAdmin required.")
+
+        assertReject StatusCodes.Status403Forbidden "SystemAdmin required." decision
+
+    [<Test>]
+    member _.MetricsDeniedWithBlankReasonFallsBackToGenericForbiddenMessage() =
+        let decision = MetricsAuthorization.decideAfterPermissionCheck true (Denied "   ")
+
+        assertReject StatusCodes.Status403Forbidden "Forbidden." decision
+
+    [<Test>]
+    member _.MetricsAllowedPassesThrough() =
+        let decision = MetricsAuthorization.decideAfterPermissionCheck false (Allowed "SystemAdmin")
+
+        assertPassThrough decision

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -62,6 +62,7 @@
 		<Compile Include="Security\AuthSchemeSelection.Server.fs" />
 		<Compile Include="Security\OutboundUrlSafety.Server.fs" />
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
+		<Compile Include="Security\MetricsAuthorization.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />
 		<Compile Include="Security\EndpointAuthorizationManifest.Server.fs" />
 		<Compile Include="Security\StorageAuthorizationResources.Server.fs" />

--- a/src/Grace.Server/Security/MetricsAuthorization.Server.fs
+++ b/src/Grace.Server/Security/MetricsAuthorization.Server.fs
@@ -1,0 +1,46 @@
+namespace Grace.Server.Security
+
+open Grace.Types.Authorization
+open Microsoft.AspNetCore.Http
+open System
+
+type MetricsAuthorizationGateDecision =
+    | PassThrough
+    | RequirePermissionCheck
+    | RejectRequest of statusCode: int * message: string
+
+module MetricsAuthorization =
+
+    [<Literal>]
+    let private MetricsPath = "/metrics"
+
+    [<Literal>]
+    let AuthenticationRequiredMessage = "Authentication required."
+
+    [<Literal>]
+    let ForbiddenMessage = "Forbidden."
+
+    let isMetricsPath (path: PathString) = path.StartsWithSegments(PathString(MetricsPath))
+
+    let decideBeforePermissionCheck (path: PathString) (userId: string option) =
+        if not (isMetricsPath path) then
+            PassThrough
+        else
+            match userId with
+            | None -> RejectRequest(StatusCodes.Status401Unauthorized, AuthenticationRequiredMessage)
+            | Some _ -> RequirePermissionCheck
+
+    let decideAfterPermissionCheck (includeDeniedReason: bool) (permissionResult: PermissionCheckResult) =
+        match permissionResult with
+        | Allowed _ -> PassThrough
+        | Denied reason ->
+            let message =
+                if
+                    includeDeniedReason
+                    && not (String.IsNullOrWhiteSpace reason)
+                then
+                    reason
+                else
+                    ForbiddenMessage
+
+            RejectRequest(StatusCodes.Status403Forbidden, message)

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1933,36 +1933,27 @@ module Application =
                 .Use(
                     Func<HttpContext, RequestDelegate, Task> (fun (context: HttpContext) (next: RequestDelegate) ->
                         task {
-                            if context.Request.Path.StartsWithSegments(PathString("/metrics")) then
+                            let gateDecision = MetricsAuthorization.decideBeforePermissionCheck context.Request.Path (PrincipalMapper.tryGetUserId context.User)
+
+                            match gateDecision with
+                            | PassThrough -> return! next.Invoke(context)
+                            | RequirePermissionCheck ->
                                 let includeReason = Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
+                                let principals = PrincipalMapper.getPrincipals context.User
+                                let claims = PrincipalMapper.getEffectiveClaims context.User
+                                let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+                                let! permissionDecision = evaluator.CheckAsync(principals, claims, Operation.SystemAdmin, Resource.System)
+                                let finalDecision = MetricsAuthorization.decideAfterPermissionCheck includeReason permissionDecision
 
-                                match PrincipalMapper.tryGetUserId context.User with
-                                | None ->
-                                    context.Response.StatusCode <- StatusCodes.Status401Unauthorized
-                                    do! context.Response.WriteAsync("Authentication required.")
-                                | Some _ ->
-                                    let principals = PrincipalMapper.getPrincipals context.User
-                                    let claims = PrincipalMapper.getEffectiveClaims context.User
-                                    let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
-                                    let! decision = evaluator.CheckAsync(principals, claims, Operation.SystemAdmin, Resource.System)
-
-                                    match decision with
-                                    | Allowed _ -> return! next.Invoke(context)
-                                    | Denied reason ->
-                                        context.Response.StatusCode <- StatusCodes.Status403Forbidden
-
-                                        let message =
-                                            if
-                                                includeReason
-                                                && not (String.IsNullOrWhiteSpace reason)
-                                            then
-                                                reason
-                                            else
-                                                "Forbidden."
-
-                                        do! context.Response.WriteAsync(message)
-                            else
-                                return! next.Invoke(context)
+                                match finalDecision with
+                                | PassThrough -> return! next.Invoke(context)
+                                | RejectRequest (statusCode, message) ->
+                                    context.Response.StatusCode <- statusCode
+                                    do! context.Response.WriteAsync(message)
+                                | RequirePermissionCheck -> invalidOp "Metrics authorization produced an unexpected repeated permission check."
+                            | RejectRequest (statusCode, message) ->
+                                context.Response.StatusCode <- statusCode
+                                do! context.Response.WriteAsync(message)
                         }
                         :> Task)
                 )


### PR DESCRIPTION
## Summary

- Extracts `/metrics` authorization response decisions into a pure internal helper.
- Keeps `GRACE_TESTING` lookup and the real permission evaluator in Startup middleware while delegating only the status/message decision.
- Adds no-Aspire unit coverage for non-metrics pass-through, unauthenticated, denied, testing-denial-reason, and allowed decisions.

## Linked Issue

Closes #189.

## Validation

- `dotnet tool run fantomas -- src/Grace.Server/Security/MetricsAuthorization.Server.fs src/Grace.Server/Startup.Server.fs src/Grace.Server.Unit.Tests/MetricsAuthorization.Unit.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~MetricsAuthorization`: passed, `7/7`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: skipped because this is server-unit/auth-decision extraction work and does not touch Aspire, emulators, hosted HTTP tests, Service Bus, Redis, or cross-service runtime behavior.

## Review Status

- Implementation worker completed commit `c4c8d3c` and pushed `agent/189-metrics-authorization-decisions`.
- Freshness gate completed in `a6b1517`: branch includes current `origin/main` after #193, has no known deleted-file diff, and diff paths are limited to #189 metrics authorization files.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/207#issuecomment-4617732957
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

No docs update expected or made.

## Residual Risk

Moderate. The review should verify denial reasons only appear in explicit testing mode, non-metrics paths pass through, authenticated denied users receive 403 rather than 401, and Startup middleware ordering/permission evaluator usage is preserved.