### PR TITLE
Clarify validation gates and merge-aware parallelism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,12 +61,26 @@ completed sub-issues are checked.
 - Prefer vertical slices with focused tests and `pwsh ./scripts/validate.ps1 -Fast` as the normal validation gate.
 - Use `pwsh ./scripts/validate.ps1 -Full` when Aspire, emulators, storage, Service Bus, Cosmos DB, Redis,
   deployment/runtime behavior, or cross-service integration is affected.
-- Order validation to avoid duplicate builds. Run formatters before validation. If the slice will run
-  `pwsh ./scripts/validate.ps1 -Fast`, do not also run separate full-solution `dotnet build` or broad `dotnet test`
-  commands unless there is a specific diagnostic reason; prefer only the narrow focused tests that prove the changed
-  behavior, then `validate -Fast`.
-- When a focused test command uses `--no-build`, run the matching Release build for that project after formatting and
-  before the `--no-build` test command.
+- Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched
+  F# files, then choose exactly one final build/test gate. If the slice will run
+  `pwsh ./scripts/validate.ps1 -Fast` or `pwsh ./scripts/validate.ps1 -Full`, do not also ask workers to routinely run
+  project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
+- Focused project build/test is appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
+  outside the selected validate profile, or issues that explicitly require a focused-only gate. When a focused test
+  command uses `--no-build`, run the matching Release build for that project after formatting and before the
+  `--no-build` test command.
+- Freshness or generated-file update workers follow the same validation ladder: formatting or freshness checks first,
+  then exactly one final build/test gate. If `validate -Fast` or `validate -Full` runs, do not also run routine focused
+  build/test commands.
+- Treat parallel work as two separate decisions: product/DAG independence and merge/write-set independence. Run
+  branches in parallel only when their write sets are disjoint enough to avoid predictable churn. Serialize or
+  merge-queue branches that touch shared project files such as `*.fsproj`, `Startup.Server.fs`, or the same test/helper
+  files. For broad waves, consider a preparatory compile-item or file-scaffold slice before later branches edit
+  separate files.
+- Before the Grace completion review gate, update the branch against current `origin/main`, verify ahead/behind,
+  verify the scoped diff and that no unexpected deletions are present, run the chosen validation gate, then spawn the
+  final review-only sibling. Review on a stale branch is exploratory pre-review and does not satisfy the completion
+  gate.
 - Commit after each completed slice and keep pull requests focused and reviewable.
 - When acting as the main implementation orchestrator, delegate all coding and fixing tasks to worker subagents and use
   fresh review-only subagents for code review. The main orchestrator must not implement, repair, inspect or validate

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -40,6 +40,15 @@ The parent issue for a multi-step implementation plan must include a DAG that sh
 - steps that can run in parallel
 - the expected integration order when parallel branches converge
 
+Treat that product DAG as necessary but not sufficient for parallel execution. A step can be behaviorally independent
+while still creating predictable merge churn. Before assigning parallel branches, compare the expected write sets:
+
+- Parallelize only when branches are disjoint enough to avoid routine conflict resolution.
+- Serialize or merge-queue branches that touch shared project files such as `*.fsproj`, `Startup.Server.fs`, or the
+  same test/helper files.
+- For broad waves, consider a preparatory compile-item or file-scaffold slice, then let later branches edit separate
+  files.
+
 The parent issue must also include a sub-issue checklist. As sub-issues complete, update that checklist so completed
 sub-issues are checked.
 
@@ -394,20 +403,30 @@ pwsh ./scripts/validate.ps1 -Full
 Use `-Fast` for the normal development loop. Use `-Full` when the change touches Aspire integration coverage, emulators,
 storage, Cosmos DB, Service Bus, Redis, cross-service behavior, or deployment/runtime behavior.
 
-Avoid duplicate builds. `validate.ps1 -Fast` already restores, builds the solution, and runs the configured fast test
-projects. If a worker is going to run `validate -Fast`, it should not also run a separate full-solution
-`dotnet build` or broad `dotnet test` as a routine step. Use this efficient order instead:
+Avoid duplicate builds. The validation ladder is:
 
 1. Run Fantomas formatting or targeted Fantomas checks for touched F# files.
-2. Run the narrow focused test command that proves the changed behavior, if that focused test is outside the fast gate
-   or gives faster defect localization. When the focused command uses `--no-build`, first run the matching
-   `dotnet build --configuration Release <project>` command so the test assembly exists and reflects the current
-   source.
-3. Run `pwsh ./scripts/validate.ps1 -Fast`.
+2. Run any required freshness or generated-file checks.
+3. Choose exactly one final build/test gate.
 4. Run `git diff --check`.
 
-Use separate `dotnet build` or broad `dotnet test` commands only when diagnosing a failure, when `validate -Fast` is
-being intentionally skipped, or when a required focused test project is not covered by the fast gate.
+`validate.ps1 -Fast` and `validate.ps1 -Full` already restore, build the solution, and run the selected test projects.
+If a worker is going to run `validate -Fast` or `validate -Full`, do not also prompt it to routinely run a
+project-specific `dotnet build` plus `dotnet test --no-build`. The selected `validate` command is the final build/test
+gate.
+
+Focused project build/test is still appropriate when it is the right evidence for the slice:
+
+- RED evidence before a code change.
+- Failure diagnosis or faster defect localization after a failing broad gate.
+- A skipped-validate workflow where the task record explicitly accepts the narrower gate.
+- Tests outside the selected validate profile.
+- Issues that explicitly require focused-only validation.
+
+When a focused command uses `--no-build`, first run the matching
+`dotnet build --configuration Release <project>` command so the test assembly exists and reflects the current source.
+Use separate broad `dotnet build` or broad `dotnet test` commands only when diagnosing a failure or when `validate` is
+being intentionally skipped.
 
 If running commands manually, the high-level fallback is:
 
@@ -430,9 +449,10 @@ order is:
 
 1. Apply the code change.
 2. Run Fantomas on the touched files, or run the repo-standard recursive Fantomas command when the edit is broad.
-3. Build the focused project before any focused `dotnet test --no-build` command, then run focused tests and
-   `validate -Fast` using the non-duplicative validation order above.
-4. Run `git diff --check`.
+3. Run focused project build/test only when it is needed for RED evidence, failure diagnosis, tests outside the selected
+   validate profile, skipped-validate workflows, or explicitly focused-only issues.
+4. Run exactly one final build/test gate, normally `validate -Fast` or `validate -Full`.
+5. Run `git diff --check`.
 
 Avoid running the full test suite before formatting, then discovering Fantomas rewrote files and forcing another
 build/test cycle.
@@ -473,6 +493,16 @@ comments as the review loop continues:
 - residual risk
 - rollback or recovery notes when the change touches runtime or data
 - useful AI prompts used for diagnosis or implementation, when contributing externally
+
+Before the Grace completion review gate, update the branch against current `origin/main`, then verify:
+
+- ahead/behind status shows the branch is current enough for a blocking review decision
+- the scoped diff still contains only the intended write set
+- no unexpected deletions were introduced during the update
+- the chosen validation gate has passed on the refreshed branch
+
+Only then spawn the final fresh local review-only sibling subagent. A review-only pass on a stale branch is useful
+exploratory pre-review, but it does not satisfy the completion review gate.
 
 Open normal ready-for-review pull requests for Grace implementation work. Do not open draft pull requests unless the
 maintainer explicitly asks for a draft.

--- a/skills/grace/references/workflow.md
+++ b/skills/grace/references/workflow.md
@@ -33,9 +33,14 @@ For non-trivial tracked work:
 1. Claim the issue and create an issue-owned branch/worktree from latest `origin/main`.
 1. Inspect `git status --short --branch` before editing.
 1. Work in vertical slices through the closest stable public boundary.
-1. Run the focused validation first, then the selected repo validation profile.
+1. Run formatting or freshness checks first, then exactly one final build/test gate.
 1. Commit after each completed slice.
 1. Open a normal ready-for-review PR. Do not open draft PRs unless the user asks for a draft.
+
+For parallel work, separate product/DAG independence from merge/write-set independence. Parallelize only when the
+expected write sets are disjoint enough to avoid predictable churn. Serialize or merge-queue branches that touch shared
+project files such as `*.fsproj`, `Startup.Server.fs`, or the same test/helper files. For broad waves, consider a
+preparatory compile-item or file-scaffold slice before later branches edit separate files.
 
 ## Orchestration And Review
 
@@ -77,6 +82,19 @@ git diff --check
 
 Run `-Full` for Aspire integration, emulators, storage, Cosmos DB, Service Bus, Redis, runtime delivery, or
 cross-service behavior.
+
+Use the validation ladder from `docs/Development process.md`: run targeted Fantomas formatting or checks before
+validation for touched F# files, run freshness checks when needed, then choose exactly one final build/test gate. If
+`validate -Fast` or `validate -Full` will run, do not also ask workers to routinely run project-specific
+`dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
+
+Focused project build/test remains appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
+outside the selected validate profile, or explicitly focused-only issues. Freshness/update workers follow the same
+rule: formatting or freshness checks first, then one final build/test gate.
+
+Before the Grace completion review gate, update the branch against current `origin/main`, verify ahead/behind, verify
+the scoped diff and that no unexpected deletions are present, run the chosen validation gate, then spawn the final
+review-only sibling. Review on a stale branch is exploratory pre-review and does not satisfy completion.
 
 ## Merge Cleanup
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -34,11 +34,25 @@ update the issue before editing the new paths.
   absolute path under the assigned worktree. After the first patch, verify git status in both locations.
 - Prefer vertical slices that prove one public behavior at a time through the closest stable boundary.
 - Validate changes with `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration coverage).
-- Order validation to avoid duplicate builds. Run formatters before validation. If `validate -Fast` will run, do not
-  also run separate full-solution `dotnet build` or broad `dotnet test` commands unless there is a specific diagnostic
-  reason; prefer only the narrow focused tests that prove the changed behavior, then `validate -Fast`.
-- If running commands manually instead of `validate -Fast`, use `dotnet build --configuration Release` and
-  `dotnet test --no-build`; build the focused project before any project-specific `--no-build` test command.
+- Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched
+  F# files, then choose exactly one final build/test gate. If `validate -Fast` or `validate -Full` will run, do not also
+  ask workers to routinely run project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final
+  build/test gate.
+- Focused project build/test is appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
+  outside the selected validate profile, or explicitly focused-only issues. If running commands manually instead of
+  `validate`, use `dotnet build --configuration Release` and `dotnet test --no-build`; build the focused project before
+  any project-specific `--no-build` test command.
+- Freshness or generated-file update workers follow the same validation ladder: formatting or freshness checks first,
+  then exactly one final build/test gate. If `validate -Fast` or `validate -Full` runs, do not also run routine focused
+  build/test commands.
+- Product/DAG independence is not the same as merge/write-set independence. Parallelize branches only when their write
+  sets are disjoint enough to avoid predictable churn. Serialize or merge-queue branches that touch shared project
+  files such as `*.fsproj`, `Startup.Server.fs`, or the same test/helper files. For broad waves, consider a
+  preparatory compile-item or file-scaffold slice before later branches edit separate files.
+- Before the Grace completion review gate, update the branch against current `origin/main`, verify ahead/behind,
+  verify the scoped diff and that no unexpected deletions are present, run the chosen validation gate, then spawn the
+  final review-only sibling. Review on a stale branch is exploratory pre-review and does not satisfy the completion
+  gate.
 - Resolve all compilation errors before considering a task complete.
 - Run impacted tests for each task and fix failures introduced by your changes.
 - Create a new git commit after each completed task to keep review scope clear.


### PR DESCRIPTION
## Summary

- Adds a mutually exclusive validation ladder: format/check first, then exactly one final build/test gate.
- Clarifies that workers should not routinely run focused project build/test when `validate -Fast` or `validate -Full` will run.
- Adds merge-aware parallelism guidance that separates product DAG independence from write-set/merge independence.
- Adds freshness-before-completion-review guidance and states stale-branch reviews are exploratory only.

## Linked Issue

Closes #209.

## Validation

- `npx --yes markdownlint-cli2 "AGENTS.md" "src/AGENTS.md" "docs/Development process.md" "skills/grace/references/workflow.md"`: passed, `0 error(s)`.
- `git diff --check -- AGENTS.md src/AGENTS.md "docs/Development process.md" skills/grace/references/workflow.md`: passed.
- Focused build/test and `pwsh ./scripts/validate.ps1 -Fast`: skipped because this is docs-only and #209 specifically updates the rules to avoid redundant validation gates.

## Review Status

- Implementation worker completed commit `bc4ac80` and pushed `agent/209-validation-parallelism-docs`.
- Freshness gate completed in `e0397ec`: branch is `2 0` ahead/behind current `origin/main`, has no deleted files, and diff paths are limited to #209 docs files.
- Fresh local review-only sibling subagent completed with no actionable issues: https://github.com/ScottArbeit/Grace/pull/210#issuecomment-4617836966
- Open findings: none.
- Final no-issues review: complete.

## Docs Impact

Docs-only workflow correction across root agent guidance, src agent guidance, development process, and Grace skill workflow reference.

## Residual Risk

Low. The review should verify the guidance prevents redundant validation gates without removing targeted Fantomas, diagnostic focused tests, or the required fresh review-only sibling gate.