### PR TITLE
SDK/OpenAPI S13: add protocol docs and vectors

### DIFF
--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,0 +1,42 @@
+# Grace Protocol
+
+This folder defines the portable Grace Protocol contract for content-addressed storage. It is written for SDK authors,
+cache implementers, and reviewers who need deterministic behavior without reading the .NET implementation.
+
+Grace Protocol v1 covers:
+
+- [Content addresses](addresses.md): lowercase BLAKE3 address format, ContentBlock preimages, and FileManifest
+  preimages.
+- [Manifest verification](manifests.md): how clients and caches reconstruct bytes and reject corruption or tampering.
+- [Manifest eligibility](eligibility.md): when Grace stores a file as repository-scoped `WholeFileContent` versus
+  manifest-backed `FileManifest` content.
+- [Golden vectors](../../test-vectors/protocol/README.md): versioned JSON fixtures that portable implementations can
+  use to verify deterministic behavior.
+
+The protocol docs describe portable behavior. They do not declare TypeScript, Python, Rust, or other non-.NET SDKs
+complete. Implementations in those languages should treat the golden vectors as compatibility fixtures, not as runtime
+permission to shell out to .NET.
+
+## Versioning
+
+Every protocol fixture has a `schemaVersion` field. Grace Protocol v1 uses the current address families:
+
+- `grace.cas.v1.content-block`
+- `grace.cas.v1.file-manifest`
+- `grace-contentblock-v1`
+
+Changing address preimages, compact block payload validation, reconstruction semantics, or manifest eligibility
+boundaries requires updating the docs and vectors together.
+
+## Identity Boundaries
+
+Grace keeps repository meaning separate from content identity:
+
+- `WholeFileContent` is repository-scoped and does not participate in StoragePool-wide dedupe.
+- `ContentBlockAddress` is derived from compact block format version plus the ordered logical chunk addresses.
+- `ManifestAddress` is derived from the ordered reconstruction contract.
+- Repository id, file path, upload session id, actor id, storage provider, object key, and eligibility policy are not
+  part of `ContentBlockAddress` or `ManifestAddress`.
+
+The server remains authoritative for authorization, physical range presence, range claims, and final manifest
+acceptance. Dedupe discovery is an optimization and must not be treated as a content-existence oracle.

--- a/docs/protocol/addresses.md
+++ b/docs/protocol/addresses.md
@@ -1,0 +1,68 @@
+# Content Addresses
+
+Grace Protocol v1 uses lowercase 64-character hexadecimal BLAKE3 addresses for chunks, ContentBlocks, manifests, and
+file content hashes. Uppercase hex, shortened values, non-hex characters, empty strings, and null values are invalid.
+
+## ChunkAddress
+
+`ChunkAddress` is the BLAKE3 hash of one logical chunk's unencoded bytes.
+
+The hash excludes:
+
+- Repository id.
+- Path.
+- Upload session id.
+- Compression and transfer encoding.
+- Storage provider, object key, ETag, or shard.
+- Manifest eligibility policy.
+
+## ContentBlockAddress
+
+`ContentBlockAddress` is the BLAKE3 hash of this UTF-8 preimage:
+
+```text
+grace.cas.v1.content-block
+format:<compact-block-format>
+chunk-count:<count>
+chunk:0:<chunk-address-0>
+chunk:1:<chunk-address-1>
+...
+```
+
+Each line ends with `\n`, including the final line. The chunk sequence is ordered. Reordering chunks changes the
+address even when the same chunk addresses are present.
+
+The ContentBlock address includes the compact block format name because decoders need the same logical payload
+contract. It excludes physical offsets, encoded lengths, lifecycle metadata, active manifest counts, object keys, and
+repository policy.
+
+## ManifestAddress
+
+`ManifestAddress` is the BLAKE3 hash of this UTF-8 preimage:
+
+```text
+grace.cas.v1.file-manifest
+chunking-suite:<chunking-suite-id>
+file-content-hash:<file-content-hash>
+size:<total-unencoded-file-size>
+block-count:<count>
+block:0:<content-block-address-0>:<offset-0>:<size-0>
+block:1:<content-block-address-1>:<offset-1>:<size-1>
+...
+```
+
+Each line ends with `\n`, including the final line. Block ranges are ordered, positive, and contiguous from offset zero.
+The final covered byte count must equal `size`.
+
+`ManifestAddress` comes from the reconstruction contract. It excludes repository id, path, upload session id, actor id,
+storage provider, object key, compression, transfer encoding, and the repository policy that selected the manifest path.
+
+## Canonical Address Validation
+
+Portable implementations should reject an address unless it matches this exact regular expression:
+
+```text
+^[0-9a-f]{64}$
+```
+
+The golden vectors include valid and invalid examples for this boundary.

--- a/docs/protocol/eligibility.md
+++ b/docs/protocol/eligibility.md
@@ -1,0 +1,54 @@
+# Manifest Eligibility
+
+`ManifestEligibilityPolicy` decides whether a new file version is stored as repository-scoped `WholeFileContent` or as
+manifest-backed `FileManifest` content.
+
+The decision is a creation-time gate. Grace stores the resulting `FileContentReference` shape as the source of truth.
+Later policy changes do not reinterpret old file versions.
+
+## Default Policy
+
+Grace Protocol v1 uses this default policy:
+
+```json
+{
+  "class": "ManifestEligibilityPolicy",
+  "thresholdBytes": 1048576,
+  "binaryScanBytes": 8192
+}
+```
+
+The default boundary is:
+
+- Binary files enter the manifest-backed path when uncompressed size is greater than or equal to 1 MiB.
+- Text files enter the manifest-backed path when the Grace-defined compressed size is greater than or equal to 1 MiB.
+- Binary detection scans the first 8 KiB for a NUL byte.
+- Files below the relevant threshold stay on `WholeFileContent`.
+
+## Identity Separation
+
+Eligibility affects which content reference shape a new file version uses. It does not participate in:
+
+- `ChunkAddress`.
+- `ContentBlockAddress`.
+- `ManifestAddress`.
+- The chunking suite.
+- Manifest reconstruction.
+- Physical ContentBlock payload validation.
+
+This separation is important. Two repositories can choose different eligibility policies without changing the identity
+of the same manifest-backed content.
+
+## Boundary Vectors
+
+The eligibility vectors document representative boundaries for portable SDKs:
+
+- Small text content remains `WholeFileContent`.
+- Binary content just below 1 MiB remains `WholeFileContent`.
+- Binary content exactly at 1 MiB becomes `FileManifest`.
+- Text content whose compressed size is below 1 MiB remains `WholeFileContent`.
+- Text content whose compressed size is exactly 1 MiB becomes `FileManifest`.
+- A NUL byte inside the first 8 KiB marks content as binary.
+- A NUL byte after the scan window does not mark content as binary by itself.
+
+Portable implementations should keep this as a selection rule, not a persisted second eligibility decision.

--- a/docs/protocol/manifests.md
+++ b/docs/protocol/manifests.md
@@ -55,9 +55,40 @@ happy-path-only.
 
 `grace-contentblock-v1` payloads are `chunk-bytes || trailer || footer`.
 
-The data section is the logical chunk payloads concatenated in order. The trailer records the format magic, version,
-flags, chunk count, physical offsets, chunk lengths, and chunk addresses. The footer records the trailer length, BLAKE3
-checksum of the trailer, and footer magic.
+The data section is the logical chunk payloads concatenated in ordinal order. It has no per-chunk delimiter; chunk
+lengths come from the trailer. The trailer and footer use fixed-width little-endian integer fields. BLAKE3 addresses
+and checksums are the raw 32-byte digest bytes, not UTF-8 hex strings.
+
+Trailer layout:
+
+| Offset | Width | Encoding | Field |
+| ------ | ----- | -------- | ----- |
+| 0 | 8 | ASCII bytes | Trailer magic `GCB1META` |
+| 8 | 2 | UInt16 little-endian | Version, currently `1` |
+| 10 | 2 | UInt16 little-endian | Reserved flags, currently `0` |
+| 12 | 4 | UInt32 little-endian | Chunk count |
+| 16 | 44 * chunk count | Repeated record | Chunk table |
+
+Each 44-byte chunk record is:
+
+| Offset Within Record | Width | Encoding | Field |
+| -------------------- | ----- | -------- | ----- |
+| 0 | 8 | Int64 little-endian | Source physical offset for the chunk |
+| 8 | 4 | UInt32 little-endian | Logical chunk length in bytes |
+| 12 | 32 | Raw bytes | ChunkAddress digest bytes |
+
+Footer layout:
+
+| Offset | Width | Encoding | Field |
+| ------ | ----- | -------- | ----- |
+| 0 | 4 | UInt32 little-endian | Trailer length in bytes |
+| 4 | 32 | Raw bytes | BLAKE3 digest bytes of the complete trailer |
+| 36 | 8 | ASCII bytes | Footer magic `GCB1END!` |
+
+The footer is always 44 bytes. To decode a payload, read the last 44 bytes as the footer, verify the footer magic, read
+the trailer length, locate the trailer immediately before the footer, verify the trailer checksum, parse the trailer
+magic/version/flags/count, and then use each chunk record's length to slice the data section from offset zero in ordinal
+order. The concatenated slices are the decoded logical payload.
 
 Physical offsets and encoded lengths validate the payload; they do not affect `ContentBlockAddress` except through the
 compact block format name in the address preimage.

--- a/docs/protocol/manifests.md
+++ b/docs/protocol/manifests.md
@@ -1,0 +1,63 @@
+# Manifest Verification
+
+Grace accepts a `FileManifest` only when its bytes can be reconstructed from validated ContentBlock payloads and the
+manifest identity matches that reconstruction contract.
+
+Portable SDKs and caches should implement these checks before treating a manifest as valid.
+
+## Validation Inputs
+
+Manifest verification needs:
+
+- The expected `ChunkingSuiteId`.
+- The `FileManifest`.
+- A set of physical ContentBlock payloads keyed by `ContentBlockAddress`.
+
+The validator does not read storage by itself. Callers load the physical payloads they already have permission to use.
+
+## Required Checks
+
+Validate in this order:
+
+1. The manifest exists and has a positive `Size`.
+1. `ChunkingSuiteId` is present and equals the expected suite.
+1. `FileContentHash`, `ManifestAddress`, and each `ContentBlockAddress` are canonical lowercase 64-hex addresses.
+1. The manifest has at least one block.
+1. Block ranges are ordered, positive, contiguous from offset zero, and cover exactly `Size`.
+1. The manifest address equals the address recomputed from the manifest preimage.
+1. Each referenced ContentBlock payload is present.
+1. Each ContentBlock payload decodes as `grace-contentblock-v1`.
+1. Each decoded ContentBlock address equals the expected `ContentBlockAddress`.
+1. Each decoded ContentBlock logical payload length equals the manifest block range size.
+1. Concatenated decoded payload bytes hash to `FileContentHash`.
+
+The successful result is the reconstructed unencoded file bytes.
+
+## Corruption And Tampering Rejection
+
+Portable implementations must reject:
+
+- Tampered payload bytes.
+- Invalid compact block footer or trailer.
+- Trailer checksum mismatch.
+- Chunk address mismatch inside a compact block.
+- ContentBlock address mismatch.
+- Reordered manifest blocks.
+- Gaps, overlaps, zero-sized ranges, and size mismatches.
+- Stale manifests whose `ManifestAddress` no longer matches the reconstruction fields.
+- File content hash mismatch.
+- Wrong chunking suite.
+
+The golden vectors include happy-path reconstruction and representative rejection cases. They are intentionally not
+happy-path-only.
+
+## Compact ContentBlock Payload
+
+`grace-contentblock-v1` payloads are `chunk-bytes || trailer || footer`.
+
+The data section is the logical chunk payloads concatenated in order. The trailer records the format magic, version,
+flags, chunk count, physical offsets, chunk lengths, and chunk addresses. The footer records the trailer length, BLAKE3
+checksum of the trailer, and footer magic.
+
+Physical offsets and encoded lengths validate the payload; they do not affect `ContentBlockAddress` except through the
+compact block format name in the address preimage.

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="ContentAddress.Types.Tests.fs" />
     <Compile Include="ContentBlockFormat.Shared.Tests.fs" />
     <Compile Include="ManifestValidation.Shared.Tests.fs" />
+    <Compile Include="ProtocolVectors.Tests.fs" />
     <Compile Include="RabinChunking.Shared.Tests.fs" />
     <Compile Include="Queue.Types.Tests.fs" />
     <Compile Include="WorkItem.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/ProtocolVectors.Tests.fs
+++ b/src/Grace.Types.Tests/ProtocolVectors.Tests.fs
@@ -133,6 +133,7 @@ type ProtocolVectorsTests() =
                 address)
 
         let blockFormat = ProtocolVectorsTests.StringProperty "format" contentBlock
+        Assert.That(blockFormat, Is.EqualTo(ContentBlockFormat.FormatName))
 
         Assert.That(ContentAddress.contentBlockPreimage blockFormat chunkAddresses, Is.EqualTo(ProtocolVectorsTests.StringProperty "preimage" contentBlock))
 

--- a/src/Grace.Types.Tests/ProtocolVectors.Tests.fs
+++ b/src/Grace.Types.Tests/ProtocolVectors.Tests.fs
@@ -1,0 +1,337 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Text.Json
+
+[<Parallelizable(ParallelScope.All)>]
+type ProtocolVectorsTests() =
+    static member private FindRepoRoot() =
+        let mutable directory = DirectoryInfo(TestContext.CurrentContext.TestDirectory)
+        let mutable result = None
+
+        while Option.isNone result && not (isNull directory) do
+            let vectorPath = Path.Combine(directory.FullName, "test-vectors", "protocol")
+
+            if Directory.Exists vectorPath then
+                result <- Some directory.FullName
+            else
+                directory <- directory.Parent
+
+        match result with
+        | Some path -> path
+        | None -> failwith "Could not find repository root containing test-vectors/protocol."
+
+    static member private VectorPath(fileName: string) = Path.Combine(ProtocolVectorsTests.FindRepoRoot(), "test-vectors", "protocol", fileName)
+
+    static member private LoadJson(fileName: string) =
+        File.ReadAllText(ProtocolVectorsTests.VectorPath fileName)
+        |> JsonDocument.Parse
+
+    static member private RequiredProperty (name: string) (element: JsonElement) = element.GetProperty(name)
+
+    static member private StringProperty name element =
+        (ProtocolVectorsTests.RequiredProperty name element)
+            .GetString()
+
+    static member private Int64Property name element =
+        (ProtocolVectorsTests.RequiredProperty name element)
+            .GetInt64()
+
+    static member private ArrayProperty name element =
+        (ProtocolVectorsTests.RequiredProperty name element)
+            .EnumerateArray()
+        |> Seq.toArray
+
+    static member private Bytes(value: string) = Encoding.UTF8.GetBytes(value)
+
+    static member private ExpectEncodedOk(result: Result<ContentBlockFormat.EncodedContentBlock, ContentBlockFormat.ContentBlockFormatError>) =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected ContentBlockFormat.encode Ok but got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    static member private EncodedBlock physicalOffset utf8 =
+        ContentBlockFormat.encode [ ContentBlockFormat.createChunk physicalOffset (ProtocolVectorsTests.Bytes utf8) ]
+        |> ProtocolVectorsTests.ExpectEncodedOk
+
+    static member private BuildManifest chunkingSuiteId fileBytes (blocks: (ContentBlockFormat.EncodedContentBlock * int64 * int64) array) =
+        let contentBlocks =
+            blocks
+            |> Array.map (fun (block, offset, size) -> ContentBlock.Create(block.Address, offset, size))
+            |> Array.toList
+
+        let fileContentHash =
+            ContentAddress.computeBlake3Hex fileBytes
+            |> FileContentHash
+
+        let manifest = FileManifest.Create(ManifestAddress String.Empty, chunkingSuiteId, fileContentHash, int64 fileBytes.Length, contentBlocks)
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    static member private PayloadReference(block: ContentBlockFormat.EncodedContentBlock) = ManifestValidation.createBlockPayload block.Address block.Payload
+
+    static member private ErrorKind(error: ManifestValidation.ManifestValidationError) =
+        match error with
+        | ManifestValidation.NullManifest -> "NullManifest"
+        | ManifestValidation.NullBlockPayloadSequence -> "NullBlockPayloadSequence"
+        | ManifestValidation.NullBlockPayload _ -> "NullBlockPayload"
+        | ManifestValidation.NullBlockPayloadBytes _ -> "NullBlockPayloadBytes"
+        | ManifestValidation.EmptyManifest -> "EmptyManifest"
+        | ManifestValidation.InvalidManifestSize -> "InvalidManifestSize"
+        | ManifestValidation.InvalidChunkingSuiteId _ -> "InvalidChunkingSuiteId"
+        | ManifestValidation.InvalidFileContentHash _ -> "InvalidFileContentHash"
+        | ManifestValidation.InvalidManifestAddress _ -> "InvalidManifestAddress"
+        | ManifestValidation.NullContentBlock _ -> "NullContentBlock"
+        | ManifestValidation.InvalidContentBlockAddress _ -> "InvalidContentBlockAddress"
+        | ManifestValidation.ChunkingSuiteMismatch _ -> "ChunkingSuiteMismatch"
+        | ManifestValidation.ManifestAddressMismatch _ -> "ManifestAddressMismatch"
+        | ManifestValidation.BlockRangeOutOfOrder _ -> "BlockRangeOutOfOrder"
+        | ManifestValidation.BlockRangeNotPositive _ -> "BlockRangeNotPositive"
+        | ManifestValidation.MissingContentBlockPayload _ -> "MissingContentBlockPayload"
+        | ManifestValidation.ContentBlockPayloadInvalid _ -> "ContentBlockPayloadInvalid"
+        | ManifestValidation.ContentBlockPayloadSizeMismatch _ -> "ContentBlockPayloadSizeMismatch"
+        | ManifestValidation.FileContentHashMismatch _ -> "FileContentHashMismatch"
+        | ManifestValidation.ManifestSizeMismatch _ -> "ManifestSizeMismatch"
+
+    [<Test>]
+    member _.ContentAddressVectorsMatchDeterministicHelpers() =
+        use document = ProtocolVectorsTests.LoadJson "content-addresses.v1.json"
+        let root = document.RootElement
+        Assert.That(ProtocolVectorsTests.Int64Property "schemaVersion" root, Is.EqualTo(1L))
+
+        let vectors = root.GetProperty("vectors")
+
+        for vector in ProtocolVectorsTests.ArrayProperty "blake3" vectors do
+            let utf8 = ProtocolVectorsTests.StringProperty "utf8" vector
+            let expectedHash = ProtocolVectorsTests.StringProperty "hash" vector
+            Assert.That(ContentAddress.computeBlake3Hex (ProtocolVectorsTests.Bytes utf8), Is.EqualTo(expectedHash))
+
+        let validation = vectors.GetProperty("addressValidation")
+
+        for address in ProtocolVectorsTests.ArrayProperty "valid" validation do
+            Assert.That(ContentAddress.isValidAddress (address.GetString()), Is.True)
+
+        for address in ProtocolVectorsTests.ArrayProperty "invalid" validation do
+            Assert.That(ContentAddress.isValidAddress (address.GetString()), Is.False)
+
+        let contentBlock = vectors.GetProperty("contentBlock")
+        let chunks = ProtocolVectorsTests.ArrayProperty "chunks" contentBlock
+
+        let chunkAddresses =
+            chunks
+            |> Array.map (fun chunk ->
+                let utf8 = ProtocolVectorsTests.StringProperty "utf8" chunk
+                let address = ContentAddress.computeChunkAddress (ProtocolVectorsTests.Bytes utf8)
+                Assert.That(address, Is.EqualTo(ChunkAddress(ProtocolVectorsTests.StringProperty "address" chunk)))
+                address)
+
+        let blockFormat = ProtocolVectorsTests.StringProperty "format" contentBlock
+
+        Assert.That(ContentAddress.contentBlockPreimage blockFormat chunkAddresses, Is.EqualTo(ProtocolVectorsTests.StringProperty "preimage" contentBlock))
+
+        Assert.That(
+            ContentAddress.computeContentBlockAddress blockFormat chunkAddresses,
+            Is.EqualTo(ContentBlockAddress(ProtocolVectorsTests.StringProperty "address" contentBlock))
+        )
+
+        Assert.That(
+            ContentAddress.computeContentBlockAddress blockFormat (Array.rev chunkAddresses),
+            Is.EqualTo(ContentBlockAddress(ProtocolVectorsTests.StringProperty "reorderedAddress" contentBlock))
+        )
+
+        let fileManifest = vectors.GetProperty("fileManifest")
+
+        let blocks =
+            ProtocolVectorsTests.ArrayProperty "blocks" fileManifest
+            |> Array.map (fun block ->
+                ContentBlock.Create(
+                    ContentBlockAddress(ProtocolVectorsTests.StringProperty "address" block),
+                    ProtocolVectorsTests.Int64Property "offset" block,
+                    ProtocolVectorsTests.Int64Property "size" block
+                ))
+            |> Array.toList
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                ChunkingSuiteId(ProtocolVectorsTests.StringProperty "chunkingSuiteId" fileManifest),
+                FileContentHash(ProtocolVectorsTests.StringProperty "fileContentHash" fileManifest),
+                ProtocolVectorsTests.Int64Property "size" fileManifest,
+                blocks
+            )
+
+        Assert.That(
+            ContentAddress.manifestPreimage manifest.ChunkingSuiteId manifest.FileContentHash manifest.Size manifest.Blocks,
+            Is.EqualTo(ProtocolVectorsTests.StringProperty "preimage" fileManifest)
+        )
+
+        Assert.That(
+            ContentAddress.computeManifestAddressForManifest manifest,
+            Is.EqualTo(ManifestAddress(ProtocolVectorsTests.StringProperty "manifestAddress" fileManifest))
+        )
+
+    [<Test>]
+    member _.ManifestValidationVectorsMatchPayloadAndRejectionContract() =
+        use document = ProtocolVectorsTests.LoadJson "manifest-validation.v1.json"
+        let root = document.RootElement
+        Assert.That(ProtocolVectorsTests.Int64Property "schemaVersion" root, Is.EqualTo(1L))
+
+        let chunkingSuiteId = ChunkingSuiteId(ProtocolVectorsTests.StringProperty "chunkingSuiteId" root)
+        let file = root.GetProperty("file")
+        let fileBytes = ProtocolVectorsTests.Bytes(ProtocolVectorsTests.StringProperty "utf8" file)
+
+        Assert.That(ContentAddress.computeBlake3Hex fileBytes, Is.EqualTo(ProtocolVectorsTests.StringProperty "fileContentHash" file))
+        Assert.That(int64 fileBytes.Length, Is.EqualTo(ProtocolVectorsTests.Int64Property "size" file))
+
+        let encodedByName = Dictionary<string, ContentBlockFormat.EncodedContentBlock>(StringComparer.Ordinal)
+
+        for blockVector in ProtocolVectorsTests.ArrayProperty "contentBlocks" root do
+            let name = ProtocolVectorsTests.StringProperty "name" blockVector
+
+            let encoded =
+                ProtocolVectorsTests.EncodedBlock
+                    (ProtocolVectorsTests.Int64Property "physicalOffset" blockVector)
+                    (ProtocolVectorsTests.StringProperty "utf8" blockVector)
+
+            encodedByName.Add(name, encoded)
+            Assert.That(encoded.Address, Is.EqualTo(ContentBlockAddress(ProtocolVectorsTests.StringProperty "address" blockVector)))
+            Assert.That(Convert.ToBase64String encoded.Payload, Is.EqualTo(ProtocolVectorsTests.StringProperty "payloadBase64" blockVector))
+            Assert.That(int64 encoded.Payload.Length, Is.GreaterThan(ProtocolVectorsTests.Int64Property "logicalSize" blockVector))
+
+        let manifestVector = root.GetProperty("manifest")
+
+        let manifestBlocks =
+            ProtocolVectorsTests.ArrayProperty "blocks" manifestVector
+            |> Array.map (fun block ->
+                let encoded = encodedByName[ProtocolVectorsTests.StringProperty "name" block]
+                encoded, ProtocolVectorsTests.Int64Property "offset" block, ProtocolVectorsTests.Int64Property "size" block)
+
+        let manifest = ProtocolVectorsTests.BuildManifest chunkingSuiteId fileBytes manifestBlocks
+
+        Assert.That(manifest.ManifestAddress, Is.EqualTo(ManifestAddress(ProtocolVectorsTests.StringProperty "manifestAddress" manifestVector)))
+        Assert.That(manifest.Size, Is.EqualTo(ProtocolVectorsTests.Int64Property "size" manifestVector))
+
+        let payloads =
+            encodedByName.Values
+            |> Seq.map ProtocolVectorsTests.PayloadReference
+            |> Seq.toList
+
+        match ManifestValidation.validate chunkingSuiteId manifest payloads with
+        | Ok reconstructed ->
+            Assert.That(
+                Encoding.UTF8.GetString reconstructed,
+                Is.EqualTo(
+                    root
+                        .GetProperty("success")
+                        .GetProperty("expectedUtf8")
+                        .GetString()
+                )
+            )
+        | Error error -> Assert.Fail($"Expected manifest vector to validate but got {error}.")
+
+        let expectedCases =
+            ProtocolVectorsTests.ArrayProperty "rejectionCases" root
+            |> Array.map (fun item -> ProtocolVectorsTests.StringProperty "name" item, ProtocolVectorsTests.StringProperty "expectedErrorKind" item)
+            |> dict
+
+        let alpha = encodedByName["alpha"]
+        let beta = encodedByName["beta"]
+
+        let tamperedPayload = Array.copy alpha.Payload
+        tamperedPayload[0] <- tamperedPayload[0] ^^^ 0x01uy
+
+        let invalidFooter = Array.copy alpha.Payload
+        invalidFooter[invalidFooter.Length - 1] <- invalidFooter[invalidFooter.Length - 1] ^^^ 0x01uy
+
+        let staleManifest = { manifest with FileContentHash = FileContentHash(ContentAddress.computeBlake3Hex (ProtocolVectorsTests.Bytes "different bytes")) }
+
+        let hashMismatch = { staleManifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest staleManifest }
+
+        let reordered =
+            { manifest with
+                Blocks =
+                    [
+                        ContentBlock.Create(beta.Address, int64 alpha.Chunks[0].Length, int64 beta.Chunks[0].Length)
+                        ContentBlock.Create(alpha.Address, 0L, int64 alpha.Chunks[0].Length)
+                    ]
+                    |> List<ContentBlock>
+            }
+
+        let mismatchedPayload =
+            ManifestValidation.createBlockPayload (ContentBlockAddress(ProtocolVectorsTests.StringProperty "manifestAddress" manifestVector)) alpha.Payload
+
+        let cases =
+            [
+                "tampered-payload-byte",
+                manifest,
+                [
+                    ManifestValidation.createBlockPayload alpha.Address tamperedPayload
+                    ProtocolVectorsTests.PayloadReference beta
+                ]
+                "invalid-compact-block-footer",
+                manifest,
+                [
+                    ManifestValidation.createBlockPayload alpha.Address invalidFooter
+                    ProtocolVectorsTests.PayloadReference beta
+                ]
+                "reordered-manifest-blocks", reordered, payloads
+                "stale-manifest-address", staleManifest, payloads
+                "file-content-hash-mismatch", hashMismatch, payloads
+                "missing-content-block",
+                manifest,
+                [
+                    ProtocolVectorsTests.PayloadReference alpha
+                ]
+                "content-block-address-mismatch",
+                manifest,
+                [
+                    mismatchedPayload
+                    ProtocolVectorsTests.PayloadReference beta
+                ]
+            ]
+
+        for name, manifest, payloads in cases do
+            match ManifestValidation.validate chunkingSuiteId manifest payloads with
+            | Error error -> Assert.That(ProtocolVectorsTests.ErrorKind error, Is.EqualTo(expectedCases[name]), name)
+            | Ok _ -> Assert.Fail($"Expected {name} to be rejected.")
+
+    [<Test>]
+    member _.EligibilityVectorsDocumentDefaultBoundary() =
+        use document = ProtocolVectorsTests.LoadJson "eligibility.v1.json"
+        let root = document.RootElement
+        let policy = root.GetProperty("policy")
+
+        Assert.That(ProtocolVectorsTests.Int64Property "thresholdBytes" policy, Is.EqualTo(ManifestEligibilityPolicy.Default.ThresholdBytes))
+        Assert.That(int (ProtocolVectorsTests.Int64Property "binaryScanBytes" policy), Is.EqualTo(ManifestEligibilityPolicy.Default.BinaryScanBytes))
+
+        let decide kind uncompressedSize compressedSize =
+            let isBinary = String.Equals(kind, "binary", StringComparison.Ordinal)
+            let relevantSize = if isBinary then uncompressedSize else compressedSize
+
+            if relevantSize
+               >= ManifestEligibilityPolicy.Default.ThresholdBytes then
+                "FileManifest"
+            else
+                "WholeFileContent"
+
+        for vector in ProtocolVectorsTests.ArrayProperty "vectors" root do
+            let kind = ProtocolVectorsTests.StringProperty "kind" vector
+            let uncompressedSize = ProtocolVectorsTests.Int64Property "uncompressedSize" vector
+
+            let compressedSize =
+                match vector.GetProperty("compressedSize").ValueKind with
+                | JsonValueKind.Null -> uncompressedSize
+                | _ -> ProtocolVectorsTests.Int64Property "compressedSize" vector
+
+            Assert.That(
+                decide kind uncompressedSize compressedSize,
+                Is.EqualTo(ProtocolVectorsTests.StringProperty "expectedReferenceType" vector),
+                ProtocolVectorsTests.StringProperty "name" vector
+            )

--- a/test-vectors/protocol/README.md
+++ b/test-vectors/protocol/README.md
@@ -1,0 +1,26 @@
+# Grace Protocol Golden Vectors
+
+This folder contains deterministic Grace Protocol fixtures for portable implementations.
+
+The fixtures are versioned JSON files:
+
+- [content-addresses.v1.json](content-addresses.v1.json): BLAKE3 address, ContentBlock preimage, and Manifest preimage
+  vectors.
+- [manifest-validation.v1.json](manifest-validation.v1.json): compact block payload and manifest reconstruction vectors,
+  including corruption and mismatch rejection cases.
+- [eligibility.v1.json](eligibility.v1.json): manifest eligibility boundary vectors.
+
+The vectors are compatibility fixtures. They do not declare any non-.NET SDK complete, and portable SDKs must not shell
+out to .NET at runtime to satisfy them.
+
+## Determinism Contract
+
+For each fixture:
+
+- `schemaVersion` identifies the fixture schema.
+- `protocolVersion` identifies the Grace Protocol contract.
+- `generatedBy` records the Grace helper surface that produced the expected values.
+- Address values are lowercase 64-character hexadecimal BLAKE3 strings.
+- Binary payloads are base64 encoded.
+
+The `Grace.Types.Tests` protocol vector proof tests compare these files against the live deterministic helper functions.

--- a/test-vectors/protocol/content-addresses.v1.json
+++ b/test-vectors/protocol/content-addresses.v1.json
@@ -32,7 +32,7 @@
       ]
     },
     "contentBlock": {
-      "format": "raw-chunks",
+      "format": "grace-contentblock-v1",
       "chunks": [
         {
           "ordinal": 0,
@@ -45,9 +45,9 @@
           "address": "2da114e540d4af623dfe76635e77dfe7630ba425021e13e47b46dfa9fea184b3"
         }
       ],
-      "preimage": "grace.cas.v1.content-block\nformat:raw-chunks\nchunk-count:2\nchunk:0:292e1ffe8d05890ad016853e3dfee1b6f612165bc4dae763c1167d9fcef9d0e8\nchunk:1:2da114e540d4af623dfe76635e77dfe7630ba425021e13e47b46dfa9fea184b3\n",
-      "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
-      "reorderedAddress": "7f1a68bf50d82206d212bf60e10fdad4fd8d397bde2f1d164ad7976da5f45668"
+      "preimage": "grace.cas.v1.content-block\nformat:grace-contentblock-v1\nchunk-count:2\nchunk:0:292e1ffe8d05890ad016853e3dfee1b6f612165bc4dae763c1167d9fcef9d0e8\nchunk:1:2da114e540d4af623dfe76635e77dfe7630ba425021e13e47b46dfa9fea184b3\n",
+      "address": "4e8af33a5e5aaf5a1f72700366d5c6f9456e535519adb63f10497ffec0040d0b",
+      "reorderedAddress": "6d23181971b557dbde988f1a7f1d0b7c1805e24eea76170e2291e0ec675c1104"
     },
     "fileManifest": {
       "chunkingSuiteId": "grace-rabin-blake3-64k-v1",
@@ -56,19 +56,19 @@
       "blocks": [
         {
           "ordinal": 0,
-          "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
+          "address": "4e8af33a5e5aaf5a1f72700366d5c6f9456e535519adb63f10497ffec0040d0b",
           "offset": 0,
           "size": 4096
         },
         {
           "ordinal": 1,
-          "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
+          "address": "4e8af33a5e5aaf5a1f72700366d5c6f9456e535519adb63f10497ffec0040d0b",
           "offset": 4096,
           "size": 4096
         }
       ],
-      "preimage": "grace.cas.v1.file-manifest\nchunking-suite:grace-rabin-blake3-64k-v1\nfile-content-hash:fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae\nsize:8192\nblock-count:2\nblock:0:75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f:0:4096\nblock:1:75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f:4096:4096\n",
-      "manifestAddress": "5dd11fdb1534c0f1c4fecca3c07498f9b59a7dff26d69fe78e43f7ce50d90895"
+      "preimage": "grace.cas.v1.file-manifest\nchunking-suite:grace-rabin-blake3-64k-v1\nfile-content-hash:fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae\nsize:8192\nblock-count:2\nblock:0:4e8af33a5e5aaf5a1f72700366d5c6f9456e535519adb63f10497ffec0040d0b:0:4096\nblock:1:4e8af33a5e5aaf5a1f72700366d5c6f9456e535519adb63f10497ffec0040d0b:4096:4096\n",
+      "manifestAddress": "3e760d14adcbfa5a2bd5c8a26bfb49968372b83c51cb453fc4bb167e8eba9ccc"
     }
   }
 }

--- a/test-vectors/protocol/content-addresses.v1.json
+++ b/test-vectors/protocol/content-addresses.v1.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "protocolVersion": "grace-protocol-v1",
+  "generatedBy": "Grace.Shared.ContentAddress",
+  "vectors": {
+    "blake3": [
+      {
+        "name": "empty",
+        "utf8": "",
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+      },
+      {
+        "name": "abc",
+        "utf8": "abc",
+        "hash": "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+      },
+      {
+        "name": "BLAKE3",
+        "utf8": "BLAKE3",
+        "hash": "f890484173e516bfd935ef3d22b912dc9738de38743993cfedf2c9473b3216a4"
+      }
+    ],
+    "addressValidation": {
+      "valid": [
+        "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+      ],
+      "invalid": [
+        "",
+        "AF1349B9F5F9A1A6A0404DEA36DCC9499BCB25C9ADC112B7CC9A93CAE41F3262",
+        "af1349",
+        "gf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+      ]
+    },
+    "contentBlock": {
+      "format": "raw-chunks",
+      "chunks": [
+        {
+          "ordinal": 0,
+          "utf8": "alpha chunk",
+          "address": "292e1ffe8d05890ad016853e3dfee1b6f612165bc4dae763c1167d9fcef9d0e8"
+        },
+        {
+          "ordinal": 1,
+          "utf8": "beta chunk",
+          "address": "2da114e540d4af623dfe76635e77dfe7630ba425021e13e47b46dfa9fea184b3"
+        }
+      ],
+      "preimage": "grace.cas.v1.content-block\nformat:raw-chunks\nchunk-count:2\nchunk:0:292e1ffe8d05890ad016853e3dfee1b6f612165bc4dae763c1167d9fcef9d0e8\nchunk:1:2da114e540d4af623dfe76635e77dfe7630ba425021e13e47b46dfa9fea184b3\n",
+      "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
+      "reorderedAddress": "7f1a68bf50d82206d212bf60e10fdad4fd8d397bde2f1d164ad7976da5f45668"
+    },
+    "fileManifest": {
+      "chunkingSuiteId": "grace-rabin-blake3-64k-v1",
+      "fileContentHash": "fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae",
+      "size": 8192,
+      "blocks": [
+        {
+          "ordinal": 0,
+          "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
+          "offset": 0,
+          "size": 4096
+        },
+        {
+          "ordinal": 1,
+          "address": "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f",
+          "offset": 4096,
+          "size": 4096
+        }
+      ],
+      "preimage": "grace.cas.v1.file-manifest\nchunking-suite:grace-rabin-blake3-64k-v1\nfile-content-hash:fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae\nsize:8192\nblock-count:2\nblock:0:75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f:0:4096\nblock:1:75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f:4096:4096\n",
+      "manifestAddress": "5dd11fdb1534c0f1c4fecca3c07498f9b59a7dff26d69fe78e43f7ce50d90895"
+    }
+  }
+}

--- a/test-vectors/protocol/eligibility.v1.json
+++ b/test-vectors/protocol/eligibility.v1.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "protocolVersion": "grace-protocol-v1",
+  "generatedBy": "Grace.Types.Common.ManifestEligibilityPolicy.Default",
+  "policy": {
+    "class": "ManifestEligibilityPolicy",
+    "thresholdBytes": 1048576,
+    "binaryScanBytes": 8192
+  },
+  "vectors": [
+    {
+      "name": "small-text-whole-file",
+      "kind": "text",
+      "uncompressedSize": 1048575,
+      "compressedSize": 1024,
+      "containsNulWithinBinaryScanWindow": false,
+      "expectedReferenceType": "WholeFileContent"
+    },
+    {
+      "name": "binary-one-byte-below-threshold-whole-file",
+      "kind": "binary",
+      "uncompressedSize": 1048575,
+      "compressedSize": null,
+      "containsNulWithinBinaryScanWindow": true,
+      "expectedReferenceType": "WholeFileContent"
+    },
+    {
+      "name": "binary-at-threshold-manifest",
+      "kind": "binary",
+      "uncompressedSize": 1048576,
+      "compressedSize": null,
+      "containsNulWithinBinaryScanWindow": true,
+      "expectedReferenceType": "FileManifest"
+    },
+    {
+      "name": "text-compressed-one-byte-below-threshold-whole-file",
+      "kind": "text",
+      "uncompressedSize": 2097152,
+      "compressedSize": 1048575,
+      "containsNulWithinBinaryScanWindow": false,
+      "expectedReferenceType": "WholeFileContent"
+    },
+    {
+      "name": "text-compressed-at-threshold-manifest",
+      "kind": "text",
+      "uncompressedSize": 2097152,
+      "compressedSize": 1048576,
+      "containsNulWithinBinaryScanWindow": false,
+      "expectedReferenceType": "FileManifest"
+    },
+    {
+      "name": "nul-after-scan-window-is-not-binary-by-itself",
+      "kind": "text",
+      "uncompressedSize": 2097152,
+      "compressedSize": 1024,
+      "containsNulWithinBinaryScanWindow": false,
+      "nulOffset": 8192,
+      "expectedReferenceType": "WholeFileContent"
+    }
+  ]
+}

--- a/test-vectors/protocol/manifest-validation.v1.json
+++ b/test-vectors/protocol/manifest-validation.v1.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": 1,
+  "protocolVersion": "grace-protocol-v1",
+  "generatedBy": "Grace.Shared.ContentBlockFormat and Grace.Shared.ManifestValidation",
+  "chunkingSuiteId": "grace-rabin-blake3-64k-v1",
+  "file": {
+    "utf8": "alpha logical rangebeta logical range",
+    "fileContentHash": "a03273f3243999d98b2d5d9a05ace27d58cde56371792c84357c567401150d37",
+    "size": 37
+  },
+  "contentBlocks": [
+    {
+      "name": "alpha",
+      "physicalOffset": 4096,
+      "utf8": "alpha logical range",
+      "address": "d2c76649b2fce14038b618ed0b86b984df9a0a51b7c075b3a069ab1dab8d9e88",
+      "logicalSize": 19,
+      "payloadBase64": "YWxwaGEgbG9naWNhbCByYW5nZUdDQjFNRVRBAQAAAAEAAAAAEAAAAAAAABMAAAA9YEEkfxcK7vSNGaHJcvqEdZgbkxSZUC/vt+K3upaj6jwAAAA2p5GObH3vmfMQdCg17FZZEfLGpaMxA3TytjoCG14G2EdDQjFFTkQh"
+    },
+    {
+      "name": "beta",
+      "physicalOffset": 8192,
+      "utf8": "beta logical range",
+      "address": "b1b4059ce29bca5ba07bc3583629d12bb4eabf52dc2afe15922f15587891566b",
+      "logicalSize": 18,
+      "payloadBase64": "YmV0YSBsb2dpY2FsIHJhbmdlR0NCMU1FVEEBAAAAAQAAAAAgAAAAAAAAEgAAAC90N9ohRI80/l77dtlNtzW+rnAyqEe+2ppwiD+dqXxyPAAAACdmdi5Gf9QUA0WQ9iD22abv1fL8B4WaCE8ygys60R4GR0NCMUVORCE="
+    }
+  ],
+  "manifest": {
+    "manifestAddress": "fb04c59db6110ad5fee108a84f325711a560927a452147de2682480eb2c0b7d9",
+    "size": 37,
+    "blocks": [
+      {
+        "ordinal": 0,
+        "name": "alpha",
+        "offset": 0,
+        "size": 19
+      },
+      {
+        "ordinal": 1,
+        "name": "beta",
+        "offset": 19,
+        "size": 18
+      }
+    ]
+  },
+  "success": {
+    "expectedUtf8": "alpha logical rangebeta logical range"
+  },
+  "rejectionCases": [
+    {
+      "name": "tampered-payload-byte",
+      "expectedErrorKind": "ContentBlockPayloadInvalid"
+    },
+    {
+      "name": "invalid-compact-block-footer",
+      "expectedErrorKind": "ContentBlockPayloadInvalid"
+    },
+    {
+      "name": "reordered-manifest-blocks",
+      "expectedErrorKind": "BlockRangeOutOfOrder"
+    },
+    {
+      "name": "stale-manifest-address",
+      "expectedErrorKind": "ManifestAddressMismatch"
+    },
+    {
+      "name": "file-content-hash-mismatch",
+      "expectedErrorKind": "FileContentHashMismatch"
+    },
+    {
+      "name": "missing-content-block",
+      "expectedErrorKind": "MissingContentBlockPayload"
+    },
+    {
+      "name": "content-block-address-mismatch",
+      "expectedErrorKind": "ContentBlockPayloadInvalid"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds first-class Grace Protocol documentation for address preimages, manifest reconstruction, corruption rejection, and eligibility semantics.
- Adds deterministic protocol golden vectors for content addresses, manifest validation, and eligibility boundaries.
- Adds focused vector proof coverage in `Grace.Types.Tests` without claiming TypeScript, Python, Rust, Tier 3, or Tier 4 implementation acceptance.

## Issue

Refs #224
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- `dotnet tool run fantomas C:\Source\Grace-gh-224\src\Grace.Types.Tests\ProtocolVectors.Tests.fs`: passed.
- `dotnet test C:\Source\Grace-gh-224\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter ProtocolVectorsTests`: passed, 3 tests.
- `npx --yes markdownlint-cli2 "docs/protocol/*.md" "test-vectors/protocol/README.md"`: passed, 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings/errors and Fast test set passed.
- `git diff --check`: passed.

## Review Status

- Implementation worker completed initial protocol docs/vector commit `bcbf535`.
- First review found ContentBlock format-vector mismatch and underspecified compact payload binary layout; fixed in `0b91025` and documented in a standalone review/fix comment.
- Fresh follow-up review-only sibling subagent: pending against `origin/epic/211-sdk-openapi..0b91025`.
- Open review findings: none pending worker handoff; awaiting review confirmation.
- Final no-issues review: pending.

## Merge Queue NoteThis PR touches `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`, which is also touched by active issue #213. Treat #213 and #224 as merge-queued; the second branch to land must be refreshed against the updated epic branch and revalidated before its blocking review.

## Docs Impact

- Adds `docs/protocol/**` as first-class protocol documentation.
- Adds `test-vectors/protocol/**` for deterministic vector fixtures and vector README.

## Residual Risk

- The vectors are the first deterministic protocol proof slice; later SDK issues still need language-specific vector consumers before Tier 3 or Tier 4 claims.
- This PR intentionally avoids TypeScript/Python/Rust protocol implementations and does not endorse shelling out to .NET at runtime.