### PR TITLE
SDK/OpenAPI S02: pin API contract version

### DIFF
--- a/docs/API versioning.md
+++ b/docs/API versioning.md
@@ -1,0 +1,15 @@
+# API Versioning
+
+Grace keeps these version identifiers separate:
+
+- HTTP API contract version: a date-based `X-Api-Version` value such as `2023-10-01`.
+- SDK package version: the SemVer version of a released SDK package.
+- Product build version: the build identity shown by CLI and server diagnostics.
+- Protocol vector suite version: the version for protocol compatibility fixtures.
+
+Released SDK clients send the current released HTTP API contract version by default. A client may opt into `latest` or
+`edge`, but those aliases are explicit overrides for development and compatibility testing, not release defaults.
+
+The static OpenAPI document uses the HTTP API contract version in `info.version`. When the HTTP contract changes, update
+the shared API contract version constant and the OpenAPI version together so generated clients and runtime defaults stay
+aligned.

--- a/docs/API versioning.md
+++ b/docs/API versioning.md
@@ -8,7 +8,8 @@ Grace keeps these version identifiers separate:
 - Protocol vector suite version: the version for protocol compatibility fixtures.
 
 Released SDK clients send the current released HTTP API contract version by default. A client may opt into `latest` or
-`edge`, but those aliases are explicit overrides for development and compatibility testing, not release defaults.
+`edge`, but those aliases are explicit overrides for development and compatibility testing, not release defaults. Grace
+Server maps those aliases to the current released API contract version before ASP.NET API version parsing.
 
 The static OpenAPI document uses the HTTP API contract version in `info.version`. When the HTTP contract changes, update
 the shared API contract version constant and the OpenAPI version together so generated clients and runtime defaults stay

--- a/docs/SDK and OpenAPI architecture.md
+++ b/docs/SDK and OpenAPI architecture.md
@@ -159,14 +159,14 @@ The scope includes:
 - Product/build/package identity is centralized at `src/Directory.Build.props:3-25`, with base version `0.2.0`.
   `docs/Build versioning.md:3-35` documents the current build version model and distinguishes runtime identity
   from configuration schema identity at `docs/Build versioning.md:59-72`.
-- Static OpenAPI source currently declares `openapi: 3.1.0` and `info.version: "0.1"` at
-  `src/OpenAPI/Main.OpenAPI.yaml:1-35`. Runtime OpenAPI metadata declares `v0.2` at
-  `src/Grace.Server/Startup.Server.fs:1641-1644`. The intended future model must resolve this by separating
-  product build version from HTTP API contract version.
-- Server API versioning packages and wiring already exist. `src/Grace.Server/Startup.Server.fs:1858-1878` sets
-  API version readers and explorer defaults. `src/Grace.Shared/Constants.Shared.fs:189` defines
-  `X-Api-Version`. `src/Grace.Types/Common.Types.fs:1210-1217` defines `ServerApiVersions` as
-  `V2022-02-01`, `Latest`, and `Edge`.
+- Static OpenAPI source currently declares `openapi: 3.1.0` and `info.version: "2023-10-01"` in the committed
+  entrypoints at `src/OpenAPI/Main.OpenAPI.yaml` and `src/OpenAPI/Grace.OpenAPI.yaml`. That value is the HTTP API
+  contract version, not the Grace product build version or an SDK package version.
+- Server API versioning packages and wiring already exist. `src/Grace.Server/Startup.Server.fs` sets API version
+  readers and explorer defaults from the shared `2023-10-01` contract. `src/Grace.Shared/Constants.Shared.fs` defines
+  `X-Api-Version`, and `src/Grace.Shared/ApiContractVersion.Shared.fs` defines the current released date plus explicit
+  `latest` and `edge` aliases. `src/Grace.Server/Middleware/ApiVersionAlias.Middleware.fs` maps those aliases to the
+  current released date before ASP.NET API version parsing.
 - Client identity headers already exist. `src/Grace.Shared/Constants.Shared.fs:193-197` defines
   `X-Grace-Client-Type` and `X-Grace-Client-Version`; `src/Grace.SDK/ClientIdentity.SDK.fs:21-37` applies
   configured client identity headers to SDK HTTP clients. The current `ClientType` mapping only showed CLI

--- a/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
+++ b/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
@@ -1,5 +1,6 @@
 namespace Grace.Authorization.Tests
 
+open Grace.Shared
 open NUnit.Framework
 open System
 open System.IO
@@ -11,6 +12,14 @@ type OpenApiRouteCoverageTests() =
     let openApiMainPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "OpenAPI", "Main.OpenAPI.yaml"))
 
     let openApiPathRegex = Regex("^  (?<path>/[^:]+):\\s*$", RegexOptions.Compiled)
+    let openApiVersionRegex = Regex("""^  version: "(?<version>[^"]+)"\s*$""", RegexOptions.Compiled)
+
+    let openApiVersion () =
+        File.ReadAllLines(openApiMainPath)
+        |> Array.pick (fun line ->
+            let matchItem = openApiVersionRegex.Match(line)
+
+            if matchItem.Success then Some matchItem.Groups["version"].Value else None)
 
     let openApiPaths () =
         File.ReadAllLines(openApiMainPath)
@@ -48,3 +57,6 @@ type OpenApiRouteCoverageTests() =
                 |> String.concat Environment.NewLine
 
             Assert.Fail($"OpenAPI is missing ADR-0001 storage routes:{Environment.NewLine}{missingText}")
+
+    [<Test>]
+    member _.OpenApiInfoVersionMatchesCurrentApiContractVersion() = Assert.That(openApiVersion (), Is.EqualTo(ApiContractVersion.CurrentReleased))

--- a/src/Grace.CLI.Tests/ClientIdentity.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ClientIdentity.SDK.Tests.fs
@@ -1,0 +1,86 @@
+namespace Grace.CLI.Tests
+
+open Grace.SDK
+open Grace.Shared
+open Grace.Types.Common
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type ApiContractVersionSharedTests() =
+
+    [<Test>]
+    member _.CurrentReleasedVersionUsesDateOnlyContractFormat() =
+        Assert.That(ApiContractVersion.CurrentReleased, Is.EqualTo("2023-10-01"))
+        Assert.That(ApiContractVersion.CurrentReleasedDate, Is.EqualTo(System.DateOnly(2023, 10, 1)))
+
+    [<Test>]
+    member _.NormalizePinsReleasedVersionAndAliases() =
+        match ApiContractVersion.normalize "2023-10-01" with
+        | Ok value -> Assert.That(value, Is.EqualTo(ApiContractVersion.CurrentReleased))
+        | Error message -> Assert.Fail($"Expected the current released version to normalize, but got: {message}.")
+
+        match ApiContractVersion.normalize "EDGE" with
+        | Ok value -> Assert.That(value, Is.EqualTo(ApiContractVersion.Edge))
+        | Error message -> Assert.Fail($"Expected the edge alias to normalize, but got: {message}.")
+
+        match ApiContractVersion.normalize " Latest " with
+        | Ok value -> Assert.That(value, Is.EqualTo(ApiContractVersion.Latest))
+        | Error message -> Assert.Fail($"Expected the latest alias to normalize, but got: {message}.")
+
+    [<Test>]
+    member _.NormalizeRejectsStaleDatesAndInvalidPreviewSuffixes() =
+        match ApiContractVersion.normalize "2022-01-01" with
+        | Error message -> Assert.That(message, Does.Contain("Unsupported API contract version"))
+        | Ok value -> Assert.Fail($"Expected a stale date to be rejected, but got {value}.")
+
+        match ApiContractVersion.normalize "2023-10-01-preview" with
+        | Error message -> Assert.That(message, Does.Contain("Invalid API contract version"))
+        | Ok value -> Assert.Fail($"Expected a preview suffix to be rejected, but got {value}.")
+
+[<NonParallelizable>]
+type ClientIdentitySdkTests() =
+
+    [<SetUp>]
+    member _.SetUp() = ClientIdentity.clear ()
+
+    [<TearDown>]
+    member _.TearDown() = ClientIdentity.clear ()
+
+    [<Test>]
+    member _.GetHttpClientPinsReleasedApiContractVersionByDefault() =
+        use httpClient = ClientIdentity.getHttpClient "corr-sdk-default"
+
+        let values = httpClient.DefaultRequestHeaders.GetValues(Constants.ServerApiVersionHeaderKey)
+
+        Assert.That(values, Is.EquivalentTo([ ApiContractVersion.CurrentReleased ]))
+
+    [<Test>]
+    member _.GetHttpClientUsesExplicitEdgeAndLatestOverrides() =
+        ClientIdentity.configureApiContractVersion ApiContractVersion.Edge
+
+        use edgeClient = ClientIdentity.getHttpClient "corr-sdk-edge"
+
+        Assert.That(edgeClient.DefaultRequestHeaders.GetValues(Constants.ServerApiVersionHeaderKey), Is.EquivalentTo([ ApiContractVersion.Edge ]))
+
+        ClientIdentity.configureApiContractVersion ApiContractVersion.Latest
+
+        use latestClient = ClientIdentity.getHttpClient "corr-sdk-latest"
+
+        Assert.That(latestClient.DefaultRequestHeaders.GetValues(Constants.ServerApiVersionHeaderKey), Is.EquivalentTo([ ApiContractVersion.Latest ]))
+
+    [<Test>]
+    member _.ConfigureApiContractVersionRejectsInvalidAndStaleVersions() =
+        Assert.Throws<System.ArgumentException>(System.Action(fun () -> ClientIdentity.configureApiContractVersion "2022-01-01"))
+        |> ignore
+
+        Assert.Throws<System.ArgumentException>(System.Action(fun () -> ClientIdentity.configureApiContractVersion "2023-10-01-preview"))
+        |> ignore
+
+    [<Test>]
+    member _.ClientIdentityHeadersRemainSeparateFromApiContractVersion() =
+        ClientIdentity.configure (ClientType.CLI "1.2.3")
+
+        use httpClient = ClientIdentity.getHttpClient "corr-sdk-identity"
+
+        Assert.That(httpClient.DefaultRequestHeaders.GetValues(Constants.ServerApiVersionHeaderKey), Is.EquivalentTo([ ApiContractVersion.CurrentReleased ]))
+        Assert.That(httpClient.DefaultRequestHeaders.GetValues(Constants.ClientVersionHeaderKey), Is.EquivalentTo([ "1.2.3" ]))

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Connect.CLI.Parsing.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
     <Compile Include="BuildInfo.Tests.fs" />
+    <Compile Include="ClientIdentity.SDK.Tests.fs" />
     <Compile Include="Program.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />
     <Compile Include="HistoryStorage.CLI.Tests.fs" />

--- a/src/Grace.SDK/ClientIdentity.SDK.fs
+++ b/src/Grace.SDK/ClientIdentity.SDK.fs
@@ -7,18 +7,39 @@ open System.Net.Http
 module ClientIdentity =
 
     let mutable private configuredClientType: ClientType option = None
+    let mutable private configuredApiContractVersion: string option = None
 
     let configure (clientType: ClientType) = configuredClientType <- Some clientType
 
-    let clear () = configuredClientType <- None
+    let configureApiContractVersion apiContractVersion =
+        match ApiContractVersion.normalize apiContractVersion with
+        | Ok normalized -> configuredApiContractVersion <- Some normalized
+        | Error message -> invalidArg (nameof apiContractVersion) message
+
+    let clearApiContractVersionOverride () = configuredApiContractVersion <- None
+
+    let clear () =
+        configuredClientType <- None
+        configuredApiContractVersion <- None
 
     let tryGetConfiguredClientType () = configuredClientType
+
+    let tryGetConfiguredApiContractVersion () = configuredApiContractVersion
 
     let private toHeaderValues clientType =
         match clientType with
         | ClientType.CLI version -> "CLI", version
 
     let applyHeaders (httpClient: HttpClient) =
+        match configuredApiContractVersion with
+        | Some apiContractVersion ->
+            httpClient.DefaultRequestHeaders.Remove(Constants.ServerApiVersionHeaderKey)
+            |> ignore
+
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ServerApiVersionHeaderKey, apiContractVersion)
+            |> ignore
+        | None -> ()
+
         match configuredClientType with
         | Some clientType ->
             let clientTypeName, clientVersion = toHeaderValues clientType

--- a/src/Grace.Server.Unit.Tests/ApiVersionAlias.Middleware.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ApiVersionAlias.Middleware.Tests.fs
@@ -1,0 +1,80 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Middleware
+open Grace.Shared
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Primitives
+open NUnit.Framework
+open System.Threading.Tasks
+
+[<Parallelizable(ParallelScope.All)>]
+type ApiVersionAliasMiddlewareTests() =
+
+    let invokeWithHeader (headerValue: string option) =
+        task {
+            let context = DefaultHttpContext()
+
+            match headerValue with
+            | Some value -> context.Request.Headers[ Constants.ServerApiVersionHeaderKey ] <- StringValues(value)
+            | None -> ()
+
+            let mutable nextInvoked = false
+
+            let middleware =
+                ApiVersionAliasMiddleware(
+                    RequestDelegate (fun _ ->
+                        nextInvoked <- true
+                        Task.CompletedTask)
+                )
+
+            do! middleware.Invoke(context)
+
+            return
+                context
+                    .Request
+                    .Headers[ Constants.ServerApiVersionHeaderKey ]
+                    .ToString(),
+                nextInvoked
+        }
+
+    [<TestCase("edge")>]
+    [<TestCase("latest")>]
+    [<TestCase("EDGE")>]
+    member _.AliasApiVersionHeaderMapsToCurrentReleasedVersionBeforeNext(headerValue: string) =
+        task {
+            let! mappedHeader, nextInvoked = invokeWithHeader (Some headerValue)
+            let mappedHeader: string = mappedHeader
+
+            Assert.That(nextInvoked, Is.True)
+            Assert.That(mappedHeader, Is.EqualTo(ApiContractVersion.CurrentReleased))
+        }
+
+    [<Test>]
+    member _.ReleasedApiVersionHeaderPassesThroughUnchanged() =
+        task {
+            let! mappedHeader, nextInvoked = invokeWithHeader (Some ApiContractVersion.CurrentReleased)
+            let mappedHeader: string = mappedHeader
+
+            Assert.That(nextInvoked, Is.True)
+            Assert.That(mappedHeader, Is.EqualTo(ApiContractVersion.CurrentReleased))
+        }
+
+    [<TestCase("2022-01-01")>]
+    [<TestCase("2023-10-01-preview")>]
+    member _.UnsupportedApiVersionHeaderPassesThroughForVersioningRejection(headerValue: string) =
+        task {
+            let! mappedHeader, nextInvoked = invokeWithHeader (Some headerValue)
+            let mappedHeader: string = mappedHeader
+
+            Assert.That(nextInvoked, Is.True)
+            Assert.That(mappedHeader, Is.EqualTo(headerValue))
+        }
+
+    [<Test>]
+    member _.MissingApiVersionHeaderStaysMissingForServerDefaulting() =
+        task {
+            let! mappedHeader, nextInvoked = invokeWithHeader None
+
+            Assert.That(nextInvoked, Is.True)
+            Assert.That(mappedHeader, Is.EqualTo(""))
+        }

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
+    <Compile Include="ApiVersionAlias.Middleware.Tests.fs" />
     <Compile Include="MetricsAuthorization.Unit.Tests.fs" />
     <Compile Include="StorageAuthorizationResources.Unit.Tests.fs" />
     <Compile Include="ValidateIds.Decisions.Tests.fs" />

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -70,6 +70,7 @@
 		<Compile Include="Middleware\Fake.Middleware.fs" />
 		<Compile Include="Middleware\HttpSecurityHeaders.Middleware.fs" />
 		<Compile Include="Middleware\CorrelationId.Middleware.fs" />
+		<Compile Include="Middleware\ApiVersionAlias.Middleware.fs" />
 		<Compile Include="Middleware\ValidateIds.Decisions.fs" />
 		<Compile Include="Middleware\ValidateIds.Middleware.fs" />
 		<Compile Include="Middleware\LogRequestHeaders.Middleware.fs" />

--- a/src/Grace.Server/Middleware/ApiVersionAlias.Middleware.fs
+++ b/src/Grace.Server/Middleware/ApiVersionAlias.Middleware.fs
@@ -1,0 +1,25 @@
+namespace Grace.Server.Middleware
+
+open Grace.Shared
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Primitives
+open System.Threading.Tasks
+
+module ApiVersionAlias =
+
+    let tryMapToSupportedVersion value =
+        match ApiContractVersion.normalize value with
+        | Ok normalized when ApiContractVersion.isExplicitOverrideAlias normalized -> Some ApiContractVersion.CurrentReleased
+        | _ -> None
+
+type ApiVersionAliasMiddleware(next: RequestDelegate) =
+
+    member _.Invoke(context: HttpContext) =
+        match context.Request.Headers.TryGetValue(Constants.ServerApiVersionHeaderKey) with
+        | true, values ->
+            match ApiVersionAlias.tryMapToSupportedVersion (values.ToString()) with
+            | Some mappedVersion -> context.Request.Headers[ Constants.ServerApiVersionHeaderKey ] <- StringValues(mappedVersion)
+            | None -> ()
+        | false, _ -> ()
+
+        next.Invoke(context)

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1858,21 +1858,21 @@ module Application =
             let apiVersioningBuilder =
                 services.AddApiVersioning (fun options ->
                     options.ReportApiVersions <- true
-                    options.DefaultApiVersion <- new ApiVersion(1, 0)
+                    options.DefaultApiVersion <- ApiVersion(ApiContractVersion.CurrentReleasedDate)
                     options.AssumeDefaultVersionWhenUnspecified <- true
                     // Use whatever reader you want
                     options.ApiVersionReader <-
                         ApiVersionReader.Combine(
                             new UrlSegmentApiVersionReader(),
-                            new HeaderApiVersionReader("x-api-version"),
-                            new MediaTypeApiVersionReader("x-api-version")
+                            new HeaderApiVersionReader(Constants.ServerApiVersionHeaderKey),
+                            new MediaTypeApiVersionReader(Constants.ServerApiVersionHeaderKey)
                         ))
 
             apiVersioningBuilder.AddApiExplorer (fun options ->
                 // add the versioned api explorer, which also adds IApiVersionDescriptionProvider service
                 // note: the specified format code will format the version as "'v'major[.minor][-status]"
                 options.GroupNameFormat <- "'v'VVV"
-                options.DefaultApiVersion <- ApiVersion(DateOnly(2023, 10, 1))
+                options.DefaultApiVersion <- ApiVersion(ApiContractVersion.CurrentReleasedDate)
                 options.AssumeDefaultVersionWhenUnspecified <- true
                 options.ApiVersionParameterSource <- HeaderApiVersionReader(Constants.ServerApiVersionHeaderKey)
 

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1926,6 +1926,7 @@ module Application =
                 .UseMiddleware<CorrelationIdMiddleware>()
                 .UseMiddleware<LogRequestHeadersMiddleware>()
                 .UseStaticFiles()
+                .UseMiddleware<ApiVersionAliasMiddleware>()
                 .UseRouting()
                 .UseAuthentication()
                 .UseMiddleware<LogAuthorizationFailureMiddleware>()

--- a/src/Grace.Shared/ApiContractVersion.Shared.fs
+++ b/src/Grace.Shared/ApiContractVersion.Shared.fs
@@ -1,0 +1,66 @@
+namespace Grace.Shared
+
+open System
+open System.Globalization
+
+[<RequireQualifiedAccess>]
+module ApiContractVersion =
+
+    [<Literal>]
+    let DateFormat = "yyyy-MM-dd"
+
+    [<Literal>]
+    let CurrentReleased = "2023-10-01"
+
+    [<Literal>]
+    let Latest = "latest"
+
+    [<Literal>]
+    let Edge = "edge"
+
+    let CurrentReleasedDate = DateOnly(2023, 10, 1)
+
+    let ReleasedVersions = [| CurrentReleased |]
+
+    let ExplicitOverrideAliases = [| Latest; Edge |]
+
+    let private comparer = StringComparer.OrdinalIgnoreCase
+
+    let private equals expected actual = comparer.Equals(expected, actual)
+
+    let isReleased value =
+        not (String.IsNullOrWhiteSpace value)
+        && ReleasedVersions
+           |> Array.exists (fun released -> equals released (value.Trim()))
+
+    let isExplicitOverrideAlias value =
+        not (String.IsNullOrWhiteSpace value)
+        && ExplicitOverrideAliases
+           |> Array.exists (fun alias -> equals alias (value.Trim()))
+
+    let isSupported value = isReleased value || isExplicitOverrideAlias value
+
+    let private tryParseDate value =
+        let mutable parsed = DateOnly.MinValue
+
+        if DateOnly.TryParseExact(value, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, &parsed) then
+            Some parsed
+        else
+            None
+
+    let normalize value =
+        if String.IsNullOrWhiteSpace value then
+            Error "API contract version is required."
+        else
+            let trimmed = value.Trim()
+
+            if equals CurrentReleased trimmed then
+                Ok CurrentReleased
+            elif equals Latest trimmed then
+                Ok Latest
+            elif equals Edge trimmed then
+                Ok Edge
+            else
+                match tryParseDate trimmed with
+                | Some _ -> Error $"Unsupported API contract version '{trimmed}'. Supported released version: {CurrentReleased}."
+                | None -> Error $"Invalid API contract version '{trimmed}'. Use {DateFormat}, '{Latest}', or '{Edge}'."

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -18,6 +18,7 @@
         <None Include="instructions.md" />
         <Compile Include="Extensions.Shared.fs" />
         <Compile Include="Constants.Shared.fs" />
+        <Compile Include="ApiContractVersion.Shared.fs" />
         <Compile Include="AzureEnvironment.Shared.fs" />
         <Compile Include="Resources\Text\Languages.Resources.fs" />
         <Compile Include="Resources\Text\en-US.fs" />

--- a/src/Grace.Shared/Utilities.Shared.fs
+++ b/src/Grace.Shared/Utilities.Shared.fs
@@ -591,7 +591,7 @@ module Utilities =
         httpClient.DefaultRequestHeaders.Add(Constants.Traceparent, $"00-{traceId}-{parentId}-01")
         httpClient.DefaultRequestHeaders.Add(Constants.Tracestate, $"graceserver-{parentId}")
         httpClient.DefaultRequestHeaders.Add(Constants.CorrelationIdHeaderKey, $"{correlationId}")
-        httpClient.DefaultRequestHeaders.Add(Constants.ServerApiVersionHeaderKey, "Edge")
+        httpClient.DefaultRequestHeaders.Add(Constants.ServerApiVersionHeaderKey, ApiContractVersion.CurrentReleased)
         //httpClient.DefaultVersionPolicy <- HttpVersionPolicy.RequestVersionOrHigher
 #if DEBUG
         httpClient.Timeout <- TimeSpan.FromSeconds(1800.0) // Keeps client commands open while debugging.

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <None Include="instructions.md" />
         <Compile Include="..\Grace.Shared\Constants.Shared.fs" Link="Constants.Shared.fs" />
+        <Compile Include="..\Grace.Shared\ApiContractVersion.Shared.fs" Link="ApiContractVersion.Shared.fs" />
         <Compile Include="..\Grace.Shared\Utilities.Shared.fs" Link="Utilities.Shared.fs" />
         <Compile Include="Common.Types.fs" />
         <Compile Include="ContentBlockMetadata.Types.fs" />

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -21,7 +21,7 @@ info:
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
-  version: '0.1'
+  version: '2023-10-01'
 servers:
   - url: http://localhost:5000
     description: Local development server

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -32,7 +32,7 @@ info:
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
-  version: "0.1"
+  version: "2023-10-01"
 servers:
   - url: "http://localhost:5000"
     description: "Local development server"

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -40,11 +40,11 @@
     },
     {
       "path": "Grace.OpenAPI.yaml",
-      "sha256": "8473aba3021394ac423d973f3404b44d26ee7743ad08fe9cfe54f704517a1145"
+      "sha256": "9a00870e06320e7ea0b00b604da2d8429168197533b5bde47df10c37d9f137ca"
     },
     {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "6f16430397a78769c29aeb6316ccfb34ad2d80c6aeb001e2a0453f2e5ba79ea6"
+      "sha256": "8ac337d0d7b866447fc8d6dac30d6d74d775619f28e87487b12103af33ae8922"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",


### PR DESCRIPTION
## Summary

- Defines the released HTTP API contract version as a date-based contract separate from SDK SemVer and product build versions.
- Pins released SDK defaults to the explicit API contract version instead of silently tracking `edge`.
- Keeps `latest` and `edge` as explicit opt-in aliases while rejecting stale/invalid overrides.
- Aligns static OpenAPI `info.version` with the HTTP API contract version.

## Issue

Refs #213
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- `dotnet tool run fantomas src\Grace.Shared\ApiContractVersion.Shared.fs src\Grace.Shared\Utilities.Shared.fs src\Grace.SDK\ClientIdentity.SDK.fs src\Grace.Server\Startup.Server.fs src\Grace.CLI.Tests\ClientIdentity.SDK.Tests.fs src\Grace.Authorization.Tests\OpenApiRouteCoverage.Tests.fs`: passed.
- `npx --yes markdownlint-cli2 "docs/API versioning.md"`: passed, 0 errors.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ApiContractVersion|FullyQualifiedName~ClientIdentitySdkTests"`: passed, 7 tests.
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release --filter OpenApiInfoVersionMatchesCurrentApiContractVersion`: passed, 1 test.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings and 0 errors and Fast tests passed.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commit.

## Review Status

- Implementation worker completed initial API-version commit `30ae05b`.
- First review found SDK/server alias mismatch for `latest` and `edge`; fixed in `cd40e15` and documented in a standalone review/fix comment.
- Branch refreshed onto `origin/epic/211-sdk-openapi` at `8d6b87c` after #224 merged.
- Fresh follow-up review-only sibling subagent: pending against `origin/epic/211-sdk-openapi..cd40e15`.
- Open review findings: none pending worker handoff; awaiting review confirmation.
- Final no-issues review: pending.

## Merge Queue NoteThis branch no longer touches `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`, but it was developed in parallel with #224. If #224 lands first, refresh this branch against the updated `epic/211-sdk-openapi` and rerun required validation before the blocking completion review/merge.

## Docs Impact

- Adds `docs/API versioning.md` documenting the separation between HTTP API contract version, SDK package SemVer, product build version, and protocol vector suite version.

## Residual Risk

- This slice intentionally does not audit route-family OpenAPI coverage beyond the minimal `info.version` consistency check.
- It aligns server API version defaults/readers with the date contract but does not add broad runtime route-version or auth-flow integration coverage.