### PR TITLE
SDK/OpenAPI S03: add OpenAPI 3.2 projections

### DIFF
--- a/docs/SDK OpenAPI proof scaffolding.md
+++ b/docs/SDK OpenAPI proof scaffolding.md
@@ -16,6 +16,8 @@ Run individual gates when a later issue is ready to turn a placeholder into a ha
 
 ```powershell
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness
+pwsh ./src/OpenAPI/prove-openapi.ps1 -Check CanonicalVersion
+pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check SdkPackage
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check ProtocolVectors
@@ -26,17 +28,35 @@ bash / zsh:
 ```bash
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness
+pwsh ./src/OpenAPI/prove-openapi.ps1 -Check CanonicalVersion
+pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check SdkPackage
 pwsh ./src/OpenAPI/prove-openapi.ps1 -Check ProtocolVectors
+```
+
+Generate the canonical bundle and generator compatibility projection before updating OpenAPI artifacts:
+
+```powershell
+pwsh ./src/OpenAPI/generate-openapi-projections.ps1
+```
+
+bash / zsh:
+
+```bash
+pwsh ./src/OpenAPI/generate-openapi-projections.ps1
 ```
 
 ## What the scaffold proves
 
 - `Freshness` checks `src/OpenAPI/OpenAPI.ProofManifest.json` against every canonical
   `src/OpenAPI/*.OpenAPI.yaml` file by SHA-256 hash. OpenAPI source changes must update the manifest in the same
-  reviewable change. This scaffold does not accept generated clients or derived OpenAPI artifacts yet. If future work
-  declares generated artifacts in the manifest before adding a real verifier, the gate remains pending/failing.
+  reviewable change. It also checks every declared derived artifact hash and source digest, so hand edits to derived
+  artifacts or canonical source edits without regeneration fail the gate.
+- `CanonicalVersion` checks the canonical OpenAPI entrypoint and manifest for OpenAPI 3.2.0.
+- `Projections` checks the generated canonical bundle, the OpenAPI 3.1.2 generator compatibility projection, and the
+  projection loss report. The current projection is intentionally narrow: it changes only the root `openapi` version
+  line from 3.2.0 to 3.1.2 and records that loss for generator compatibility.
 - `Quality` scans represented operations for missing or duplicate `operationId` values, missing operation tags,
   response blocks, 400/500 error response coverage, and reusable transport header components.
 - `SdkPackage` is a placeholder gate. It remains pending/failing even if `sdk/package-proof.json` appears, until a
@@ -47,8 +67,9 @@ pwsh ./src/OpenAPI/prove-openapi.ps1 -Check ProtocolVectors
 
 ## Acceptance rules
 
-Do not treat a generated artifact as fresh in this S01 scaffold. A later issue must add verifier support that
-recomputes source digests from current canonical sources, validates generator/tool-version provenance, and rejects
-hand-edited derived output before generated artifacts can pass. Do not describe OpenAPI as SDK-grade while the
-`Quality` gate reports pending tag, header, or error-shape coverage. Do not claim SDK package acceptance from the
-`SdkPackage` placeholder, and do not claim protocol parity from the `ProtocolVectors` placeholder.
+Do not edit `src/OpenAPI/Grace.OpenAPI.yaml`, `src/OpenAPI/Grace.OpenAPI.3.1.2.yaml`, or
+`src/OpenAPI/Grace.OpenAPI.3.1.2.loss-report.json` by hand. Change canonical source, then run
+`pwsh ./src/OpenAPI/generate-openapi-projections.ps1` so the bundle, projection, loss report, and proof manifest are
+refreshed together. Do not describe OpenAPI as SDK-grade while the `Quality` gate reports pending tag, header, or
+error-shape coverage. Do not claim SDK package acceptance from the `SdkPackage` placeholder, and do not claim protocol
+parity from the `ProtocolVectors` placeholder.

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.loss-report.json
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.loss-report.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "sourceArtifact": "Grace.OpenAPI.yaml",
+  "projectionArtifact": "Grace.OpenAPI.3.1.2.yaml",
+  "projectionTarget": "openapi-generator-compatibility",
+  "projectionOpenApiVersion": "3.1.2",
+  "generatorTool": "@redocly/cli",
+  "generatorToolVersion": "2.31.6",
+  "transformations": [
+    {
+      "kind": "openapi-version-downgrade",
+      "from": "3.2.0",
+      "to": "3.1.2",
+      "lossCategory": "compatibility-metadata",
+      "description": "The generator projection declares OpenAPI 3.1.2 because some SDK generators lag canonical OpenAPI 3.2.0 support."
+    }
+  ],
+  "lostSemantics": [
+    "The projection does not advertise that the canonical Grace API contract is OpenAPI 3.2.0."
+  ],
+  "nonLossChanges": [
+    "All content other than the root openapi version line is copied from the freshly bundled canonical artifact."
+  ]
+}

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -1,4 +1,4 @@
-openapi: 3.2.0
+openapi: 3.1.2
 info:
   title: Grace Server API
   description: |-

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.2.0
 info:
   title: Grace Server API
   description: >-

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -1,6 +1,7 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "canonicalSourceRoot": "src/OpenAPI",
+  "canonicalOpenApiVersion": "3.2.0",
   "canonicalSourceFiles": [
     {
       "path": "Approval.Components.OpenAPI.yaml",
@@ -39,12 +40,8 @@
       "sha256": "f9bd41b00867ca40b94a99a6590739f421649409bcbbe28bad92063f7be227ed"
     },
     {
-      "path": "Grace.OpenAPI.yaml",
-      "sha256": "9a00870e06320e7ea0b00b604da2d8429168197533b5bde47df10c37d9f137ca"
-    },
-    {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "8ac337d0d7b866447fc8d6dac30d6d74d775619f28e87487b12103af33ae8922"
+      "sha256": "be64dd541f0ccf2d033cdad13b479712e5169c781674ab53e78390cb1d0c156e"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
@@ -103,7 +100,36 @@
       "sha256": "86370a041b63500f604ef7920783be6d85f82c97b62f9aaf1216f701a29572fb"
     }
   ],
-  "generatedArtifacts": [],
+  "generatedArtifacts": [
+    {
+      "path": "Grace.OpenAPI.yaml",
+      "kind": "canonical-bundle",
+      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "generator": "@redocly/cli",
+      "generatorVersion": "2.31.6",
+      "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
+      "sha256": "90aa6488234f3cdd06cd5e7cf7cf5903d6af23c1f2d292f9cb988598df261138"
+    },
+    {
+      "path": "Grace.OpenAPI.3.1.2.yaml",
+      "kind": "generator-projection",
+      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "generator": "@redocly/cli",
+      "generatorVersion": "2.31.6",
+      "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
+      "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
+      "sha256": "f3a2423582999b93df0b7c0a72f29f424d2186b5d63c905e04edb4635e5220da"
+    },
+    {
+      "path": "Grace.OpenAPI.3.1.2.loss-report.json",
+      "kind": "projection-loss-report",
+      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "generator": "@redocly/cli",
+      "generatorVersion": "2.31.6",
+      "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
+      "sha256": "2531e2ce16a69f3b77ae58187af10cad3119a222fb54a5320bfa729f1dfd0eb8"
+    }
+  ],
   "pendingProofs": [
     "SDK package export/import proof",
     "Protocol vector proof"

--- a/src/OpenAPI/generate-openapi-projections.ps1
+++ b/src/OpenAPI/generate-openapi-projections.ps1
@@ -1,0 +1,190 @@
+[CmdletBinding()]
+param(
+    [string] $RedoclyVersion = '2.31.6'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    $root = git rev-parse --show-toplevel
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) {
+        throw 'Unable to resolve repository root with git rev-parse.'
+    }
+
+    return $root.Trim()
+}
+
+function Get-OpenApiRoot {
+    param([string] $RepoRoot)
+    return Join-Path $RepoRoot 'src/OpenAPI'
+}
+
+function Get-FileSha256 {
+    param([string] $Path)
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-StringSha256 {
+    param([string] $Text)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+        return [System.Convert]::ToHexString($sha.ComputeHash($bytes)).ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Write-Utf8NoBomLfFile {
+    param(
+        [string] $Path,
+        [string] $Text
+    )
+
+    $normalizedText = $Text -replace "`r`n", "`n"
+    $encoding = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Path, $normalizedText, $encoding)
+}
+
+function Get-CanonicalSourceFiles {
+    param([string] $OpenApiRoot)
+
+    Get-ChildItem -LiteralPath $OpenApiRoot -Filter '*.OpenAPI.yaml' -File |
+        Where-Object { $_.Name -notin @('Grace.OpenAPI.yaml', 'Grace.OpenAPI.3.1.2.yaml') } |
+        Sort-Object Name |
+        ForEach-Object {
+            [pscustomobject]@{
+                path = $_.Name
+                sha256 = Get-FileSha256 $_.FullName
+            }
+        }
+}
+
+function Get-CanonicalSourceDigest {
+    param([object[]] $CanonicalSourceFiles)
+
+    $digestInput = ($CanonicalSourceFiles |
+        Sort-Object path |
+        ForEach-Object { "$($_.path):$($_.sha256)" }) -join "`n"
+
+    return Get-StringSha256 $digestInput
+}
+
+function Assert-OpenApiVersion {
+    param(
+        [string] $Path,
+        [string] $ExpectedVersion
+    )
+
+    $firstLine = (Get-Content -LiteralPath $Path -TotalCount 1)
+    if ($firstLine -ne "openapi: $ExpectedVersion") {
+        throw "Expected $Path to start with 'openapi: $ExpectedVersion', but found '$firstLine'."
+    }
+}
+
+$repoRoot = Get-RepoRoot
+$openApiRoot = Get-OpenApiRoot $repoRoot
+$mainPath = Join-Path $openApiRoot 'Main.OpenAPI.yaml'
+$bundlePath = Join-Path $openApiRoot 'Grace.OpenAPI.yaml'
+$projectionPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.yaml'
+$lossReportPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.loss-report.json'
+$manifestPath = Join-Path $openApiRoot 'OpenAPI.ProofManifest.json'
+
+Assert-OpenApiVersion $mainPath '3.2.0'
+
+Write-Host "Bundling canonical OpenAPI 3.2 source with @redocly/cli@$RedoclyVersion..."
+npx --yes "@redocly/cli@$RedoclyVersion" bundle $mainPath --output $bundlePath
+if ($LASTEXITCODE -ne 0) {
+    throw "Redocly bundle failed with exit code $LASTEXITCODE."
+}
+
+Assert-OpenApiVersion $bundlePath '3.2.0'
+
+$bundleText = Get-Content -LiteralPath $bundlePath -Raw
+$projectionText = $bundleText -replace '\Aopenapi:\s*3\.2\.0', 'openapi: 3.1.2'
+Write-Utf8NoBomLfFile $projectionPath $projectionText
+Assert-OpenApiVersion $projectionPath '3.1.2'
+
+$lossReport = [ordered]@{
+    schemaVersion = 1
+    sourceArtifact = 'Grace.OpenAPI.yaml'
+    projectionArtifact = 'Grace.OpenAPI.3.1.2.yaml'
+    projectionTarget = 'openapi-generator-compatibility'
+    projectionOpenApiVersion = '3.1.2'
+    generatorTool = '@redocly/cli'
+    generatorToolVersion = $RedoclyVersion
+    transformations = @(
+        [ordered]@{
+            kind = 'openapi-version-downgrade'
+            from = '3.2.0'
+            to = '3.1.2'
+            lossCategory = 'compatibility-metadata'
+            description = 'The generator projection declares OpenAPI 3.1.2 because some SDK generators lag canonical OpenAPI 3.2.0 support.'
+        }
+    )
+    lostSemantics = @(
+        'The projection does not advertise that the canonical Grace API contract is OpenAPI 3.2.0.'
+    )
+    nonLossChanges = @(
+        'All content other than the root openapi version line is copied from the freshly bundled canonical artifact.'
+    )
+}
+
+$lossReportJson = $lossReport | ConvertTo-Json -Depth 10
+Write-Utf8NoBomLfFile $lossReportPath "$lossReportJson`n"
+
+$canonicalSourceFiles = @(Get-CanonicalSourceFiles $openApiRoot)
+$canonicalSourceDigest = Get-CanonicalSourceDigest $canonicalSourceFiles
+$generatedArtifacts = @(
+    [ordered]@{
+        path = 'Grace.OpenAPI.yaml'
+        kind = 'canonical-bundle'
+        sourceDigest = $canonicalSourceDigest
+        generator = '@redocly/cli'
+        generatorVersion = $RedoclyVersion
+        command = 'pwsh ./src/OpenAPI/generate-openapi-projections.ps1'
+        sha256 = Get-FileSha256 $bundlePath
+    },
+    [ordered]@{
+        path = 'Grace.OpenAPI.3.1.2.yaml'
+        kind = 'generator-projection'
+        sourceDigest = $canonicalSourceDigest
+        generator = '@redocly/cli'
+        generatorVersion = $RedoclyVersion
+        command = 'pwsh ./src/OpenAPI/generate-openapi-projections.ps1'
+        lossReport = 'Grace.OpenAPI.3.1.2.loss-report.json'
+        sha256 = Get-FileSha256 $projectionPath
+    },
+    [ordered]@{
+        path = 'Grace.OpenAPI.3.1.2.loss-report.json'
+        kind = 'projection-loss-report'
+        sourceDigest = $canonicalSourceDigest
+        generator = '@redocly/cli'
+        generatorVersion = $RedoclyVersion
+        command = 'pwsh ./src/OpenAPI/generate-openapi-projections.ps1'
+        sha256 = Get-FileSha256 $lossReportPath
+    }
+)
+
+$manifest = [ordered]@{
+    schemaVersion = 2
+    canonicalSourceRoot = 'src/OpenAPI'
+    canonicalOpenApiVersion = '3.2.0'
+    canonicalSourceFiles = $canonicalSourceFiles
+    generatedArtifacts = $generatedArtifacts
+    pendingProofs = @(
+        'SDK package export/import proof',
+        'Protocol vector proof'
+    )
+}
+
+$manifestJson = $manifest | ConvertTo-Json -Depth 10
+Write-Utf8NoBomLfFile $manifestPath "$manifestJson`n"
+
+Write-Host "Generated $([IO.Path]::GetRelativePath($repoRoot, $bundlePath))."
+Write-Host "Generated $([IO.Path]::GetRelativePath($repoRoot, $projectionPath))."
+Write-Host "Generated $([IO.Path]::GetRelativePath($repoRoot, $lossReportPath))."
+Write-Host "Updated $([IO.Path]::GetRelativePath($repoRoot, $manifestPath))."

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -193,6 +193,10 @@ function Test-OpenApiFreshness {
                 Add-Failure "Generated OpenAPI artifact is missing generator provenance: $($artifact.path)"
             }
 
+            if ($null -eq $artifact.generatorVersion -or [string]::IsNullOrWhiteSpace([string] $artifact.generatorVersion)) {
+                Add-Failure "Generated OpenAPI artifact is missing generatorVersion provenance: $($artifact.path)"
+            }
+
             if ($null -eq $artifact.command -or [string]::IsNullOrWhiteSpace([string] $artifact.command)) {
                 Add-Failure "Generated OpenAPI artifact is missing regeneration command provenance: $($artifact.path)"
             }

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('All', 'Freshness', 'Quality', 'SdkPackage', 'ProtocolVectors')]
+    [ValidateSet('All', 'Freshness', 'CanonicalVersion', 'Projections', 'Quality', 'SdkPackage', 'ProtocolVectors')]
     [string] $Check = 'All',
 
     [switch] $AllowPending
@@ -49,21 +49,92 @@ function Get-OpenApiRoot {
     return Join-Path $RepoRoot 'src/OpenAPI'
 }
 
+function Get-FileSha256 {
+    param([string] $Path)
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-StringSha256 {
+    param([string] $Text)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+        return [System.Convert]::ToHexString($sha.ComputeHash($bytes)).ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-OpenApiManifest {
+    param([string] $OpenApiRoot)
+
+    $manifestPath = Join-Path $OpenApiRoot 'OpenAPI.ProofManifest.json'
+
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        Add-Failure "Missing OpenAPI proof manifest: $manifestPath"
+        return $null
+    }
+
+    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+    if ($manifest.schemaVersion -notin @(1, 2)) {
+        Add-Failure "Unsupported OpenAPI proof manifest schemaVersion '$($manifest.schemaVersion)'."
+    }
+
+    return $manifest
+}
+
+function Get-GeneratedArtifactPaths {
+    param([object] $Manifest)
+
+    $artifactPaths = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    if ($null -eq $Manifest) {
+        return $artifactPaths
+    }
+
+    $generatedArtifactsProperty = $Manifest.PSObject.Properties['generatedArtifacts']
+    if ($null -eq $generatedArtifactsProperty -or $null -eq $generatedArtifactsProperty.Value) {
+        return $artifactPaths
+    }
+
+    foreach ($artifact in $Manifest.generatedArtifacts) {
+        [void] $artifactPaths.Add([string] $artifact.path)
+    }
+
+    return $artifactPaths
+}
+
+function Get-CanonicalSourceDigest {
+    param([object[]] $CanonicalSourceFiles)
+
+    $digestInput = ($CanonicalSourceFiles |
+        Sort-Object path |
+        ForEach-Object { "$($_.path):$($_.sha256)" }) -join "`n"
+
+    return Get-StringSha256 $digestInput
+}
+
+function Get-OpenApiVersion {
+    param([string] $Path)
+
+    $firstLine = Get-Content -LiteralPath $Path -TotalCount 1
+    $match = [regex]::Match($firstLine, '^openapi:\s*(?<version>\S+)\s*$')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return $match.Groups['version'].Value
+}
+
 function Test-OpenApiFreshness {
     param([string] $RepoRoot)
 
     Write-Host '== OpenAPI freshness =='
     $openApiRoot = Get-OpenApiRoot $RepoRoot
-    $manifestPath = Join-Path $openApiRoot 'OpenAPI.ProofManifest.json'
-
-    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
-        Add-Failure "Missing OpenAPI proof manifest: $manifestPath"
+    $manifest = Get-OpenApiManifest $openApiRoot
+    if ($null -eq $manifest) {
         return
-    }
-
-    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-    if ($manifest.schemaVersion -ne 1) {
-        Add-Failure "Unsupported OpenAPI proof manifest schemaVersion '$($manifest.schemaVersion)'."
     }
 
     $expectedFiles = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
@@ -76,13 +147,15 @@ function Test-OpenApiFreshness {
             continue
         }
 
-        $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $sourcePath).Hash.ToLowerInvariant()
+        $actualHash = Get-FileSha256 $sourcePath
         if ($actualHash -ne ([string] $entry.sha256).ToLowerInvariant()) {
             Add-Failure "OpenAPI source hash is stale for $($entry.path). Expected $($entry.sha256), actual $actualHash."
         }
     }
 
+    $generatedArtifactPaths = Get-GeneratedArtifactPaths $manifest
     $actualFiles = Get-ChildItem -LiteralPath $openApiRoot -Filter '*.OpenAPI.yaml' -File |
+        Where-Object { -not $generatedArtifactPaths.Contains($_.Name) } |
         Sort-Object Name |
         ForEach-Object { $_.Name }
 
@@ -96,11 +169,125 @@ function Test-OpenApiFreshness {
         Write-Host '[INFO] No generated OpenAPI/client artifacts are declared; this scaffold accepts no generated-client freshness.'
     }
     else {
-        $declaredArtifacts = ($manifest.generatedArtifacts | ForEach-Object { [string] $_.path }) -join ', '
-        Add-Pending "Generated artifact freshness is not accepted yet. Declared artifacts require a future verifier that recomputes source digests, validates generator/tool-version provenance, and rejects hand-edited derived output. Declared: $declaredArtifacts"
+        $canonicalSourceDigest = Get-CanonicalSourceDigest @($manifest.canonicalSourceFiles)
+        foreach ($artifact in $manifest.generatedArtifacts) {
+            $artifactPath = Join-Path $openApiRoot ([string] $artifact.path)
+            if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
+                Add-Failure "Generated OpenAPI artifact is missing: $($artifact.path)"
+                continue
+            }
+
+            $actualHash = Get-FileSha256 $artifactPath
+            if ($actualHash -ne ([string] $artifact.sha256).ToLowerInvariant()) {
+                Add-Failure "Generated OpenAPI artifact hash is stale for $($artifact.path). Expected $($artifact.sha256), actual $actualHash."
+            }
+
+            if ($null -eq $artifact.sourceDigest -or [string]::IsNullOrWhiteSpace([string] $artifact.sourceDigest)) {
+                Add-Failure "Generated OpenAPI artifact is missing sourceDigest provenance: $($artifact.path)"
+            }
+            elseif (([string] $artifact.sourceDigest).ToLowerInvariant() -ne $canonicalSourceDigest) {
+                Add-Failure "Generated OpenAPI artifact sourceDigest is stale for $($artifact.path). Expected $($artifact.sourceDigest), actual $canonicalSourceDigest."
+            }
+
+            if ($null -eq $artifact.generator -or [string]::IsNullOrWhiteSpace([string] $artifact.generator)) {
+                Add-Failure "Generated OpenAPI artifact is missing generator provenance: $($artifact.path)"
+            }
+
+            if ($null -eq $artifact.command -or [string]::IsNullOrWhiteSpace([string] $artifact.command)) {
+                Add-Failure "Generated OpenAPI artifact is missing regeneration command provenance: $($artifact.path)"
+            }
+        }
     }
 
     Add-Pass "OpenAPI proof manifest covers $($expectedFiles.Count) canonical source files."
+}
+
+function Test-OpenApiCanonicalVersion {
+    param([string] $RepoRoot)
+
+    Write-Host '== OpenAPI canonical version =='
+    $openApiRoot = Get-OpenApiRoot $RepoRoot
+    $manifest = Get-OpenApiManifest $openApiRoot
+    if ($null -eq $manifest) {
+        return
+    }
+
+    $canonicalOpenApiVersionProperty = $manifest.PSObject.Properties['canonicalOpenApiVersion']
+    if ($null -eq $canonicalOpenApiVersionProperty) {
+        Add-Failure 'OpenAPI manifest is missing canonicalOpenApiVersion.'
+    }
+    elseif ($canonicalOpenApiVersionProperty.Value -ne '3.2.0') {
+        Add-Failure "OpenAPI manifest canonicalOpenApiVersion is '$($canonicalOpenApiVersionProperty.Value)' instead of '3.2.0'."
+    }
+
+    foreach ($entry in $manifest.canonicalSourceFiles) {
+        $sourcePath = Join-Path $openApiRoot ([string] $entry.path)
+        if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+            continue
+        }
+
+        $version = Get-OpenApiVersion $sourcePath
+        if ($null -ne $version -and $version -ne '3.2.0') {
+            Add-Failure "Canonical OpenAPI entrypoint $($entry.path) declares '$version' instead of '3.2.0'."
+        }
+    }
+
+    Add-Pass 'Canonical OpenAPI source declares OpenAPI 3.2.0.'
+}
+
+function Test-OpenApiProjections {
+    param([string] $RepoRoot)
+
+    Write-Host '== OpenAPI projections =='
+    $openApiRoot = Get-OpenApiRoot $RepoRoot
+    $manifest = Get-OpenApiManifest $openApiRoot
+    if ($null -eq $manifest) {
+        return
+    }
+
+    $bundlePath = Join-Path $openApiRoot 'Grace.OpenAPI.yaml'
+    $projectionPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.yaml'
+    $lossReportPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.loss-report.json'
+
+    foreach ($requiredPath in @($bundlePath, $projectionPath, $lossReportPath)) {
+        if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+            Add-Failure "Missing required OpenAPI derived artifact: $requiredPath"
+            return
+        }
+    }
+
+    $bundleVersion = Get-OpenApiVersion $bundlePath
+    if ($bundleVersion -ne '3.2.0') {
+        Add-Failure "Canonical OpenAPI bundle declares '$bundleVersion' instead of '3.2.0'."
+    }
+
+    $projectionVersion = Get-OpenApiVersion $projectionPath
+    if ($projectionVersion -ne '3.1.2') {
+        Add-Failure "Generator compatibility projection declares '$projectionVersion' instead of '3.1.2'."
+    }
+
+    $bundleText = Get-Content -LiteralPath $bundlePath -Raw
+    $projectionText = Get-Content -LiteralPath $projectionPath -Raw
+    $reconstitutedCanonical = $projectionText -replace '\Aopenapi:\s*3\.1\.2', 'openapi: 3.2.0'
+    if ($reconstitutedCanonical -ne $bundleText) {
+        Add-Failure 'Generator projection drifted beyond the recorded OpenAPI version downgrade.'
+    }
+
+    $lossReport = Get-Content -LiteralPath $lossReportPath -Raw | ConvertFrom-Json
+    $downgrade = @($lossReport.transformations | Where-Object { $_.kind -eq 'openapi-version-downgrade' })
+    if ($downgrade.Count -ne 1) {
+        Add-Failure 'Projection loss report must record exactly one openapi-version-downgrade transformation.'
+    }
+
+    if ($lossReport.projectionArtifact -ne 'Grace.OpenAPI.3.1.2.yaml') {
+        Add-Failure "Projection loss report points at '$($lossReport.projectionArtifact)' instead of 'Grace.OpenAPI.3.1.2.yaml'."
+    }
+
+    if ($lossReport.lostSemantics.Count -lt 1) {
+        Add-Failure 'Projection loss report must describe lost semantics.'
+    }
+
+    Add-Pass 'OpenAPI derived bundle, generator projection, and loss report are present and loss-aware.'
 }
 
 function Get-OpenApiOperations {
@@ -305,11 +492,15 @@ $repoRoot = Get-RepoRoot
 switch ($Check) {
     'All' {
         Test-OpenApiFreshness $repoRoot
+        Test-OpenApiCanonicalVersion $repoRoot
+        Test-OpenApiProjections $repoRoot
         Test-OpenApiQuality $repoRoot
         Test-SdkPackageProof $repoRoot
         Test-ProtocolVectorProof $repoRoot
     }
     'Freshness' { Test-OpenApiFreshness $repoRoot }
+    'CanonicalVersion' { Test-OpenApiCanonicalVersion $repoRoot }
+    'Projections' { Test-OpenApiProjections $repoRoot }
     'Quality' { Test-OpenApiQuality $repoRoot }
     'SdkPackage' { Test-SdkPackageProof $repoRoot }
     'ProtocolVectors' { Test-ProtocolVectorProof $repoRoot }

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -252,11 +252,23 @@ function Test-OpenApiProjections {
     $bundlePath = Join-Path $openApiRoot 'Grace.OpenAPI.yaml'
     $projectionPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.yaml'
     $lossReportPath = Join-Path $openApiRoot 'Grace.OpenAPI.3.1.2.loss-report.json'
+    $generatedArtifactPaths = Get-GeneratedArtifactPaths $manifest
+    $requiredDerivedArtifacts = @(
+        'Grace.OpenAPI.yaml',
+        'Grace.OpenAPI.3.1.2.yaml',
+        'Grace.OpenAPI.3.1.2.loss-report.json'
+    )
 
     foreach ($requiredPath in @($bundlePath, $projectionPath, $lossReportPath)) {
         if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
             Add-Failure "Missing required OpenAPI derived artifact: $requiredPath"
             return
+        }
+    }
+
+    foreach ($requiredArtifact in $requiredDerivedArtifacts) {
+        if (-not $generatedArtifactPaths.Contains($requiredArtifact)) {
+            Add-Failure "Required OpenAPI derived artifact is not represented in generatedArtifacts: $requiredArtifact"
         }
     }
 


### PR DESCRIPTION
## Summary

- Moves canonical OpenAPI source to `openapi: 3.2.0`.
- Adds scripted derived generation for the canonical bundle and a 3.1.2 generator-compatibility projection.
- Adds a projection loss report and generated artifact provenance/freshness enforcement in the OpenAPI proof manifest.
- Extends `prove-openapi.ps1` with canonical-version and projection checks.

## Issue

Refs #214
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- RED/freshness evidence: `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness` failed after the canonical version edit because `Main.OpenAPI.yaml` hash was stale.
- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed; generated bundle, projection, loss report, and proof manifest.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check CanonicalVersion`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`: passed with expected pre-existing pending gates.
- `npx --yes markdownlint-cli2 "docs/SDK OpenAPI proof scaffolding.md"`: passed, 0 errors.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commit.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings and 0 errors.

## Review Status

- Implementation worker completed initial OpenAPI 3.2/projection commit `db308e0`.
- First review found generated artifact Freshness verification did not require non-empty `generatorVersion` provenance; fixed in `d450ab0` and documented in a standalone review/fix comment.
- Fresh follow-up review-only sibling subagent: pending against `origin/epic/211-sdk-openapi..d450ab0`.
- Open review findings: none pending worker handoff; awaiting review confirmation.
- Final no-issues review: pending.

## Generated Artifact BoundaryDerived OpenAPI artifacts must be regenerated with `src/OpenAPI/generate-openapi-projections.ps1`; they must not be edited by hand. The proof manifest records source digests, artifact hashes, generator provenance, and regeneration commands so stale or hand-edited outputs are rejected by focused proof checks.

## Docs Impact

- Updates `docs/SDK OpenAPI proof scaffolding.md` with generation/proof commands and acceptance boundaries.

## Residual Risk

- Redocly lint still reports pre-existing OpenAPI structural/quality issues; this slice uses Redocly for deterministic bundling and leaves the existing Quality proof pending where appropriate.
- The 3.1.2 projection intentionally only downgrades the root OpenAPI version and records that semantic loss; generator acceptance remains a later issue.