### PR TITLE
SDK/OpenAPI S04: tighten shared OpenAPI contracts

### DIFF
--- a/src/OpenAPI/Approval.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Approval.Paths.OpenAPI.yaml
@@ -10,6 +10,24 @@
         application/json:
           schema:
             $ref: './Approval.Components.OpenAPI.yaml#/CreateApprovalPolicyParameters'
+          examples:
+            promotionSetPolicy:
+              summary: Require an approver before promotion-set apply
+              value:
+                CorrelationId: cli-20260604T181500Z-0001
+                Principal: user:alice
+                OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                Name: Main branch release approval
+                Subject: promotion-set.apply
+                RequiredResponder: user:bob
+                NotificationUrl: https://approvals.example.net/grace
+                NotificationUrlSafety: PublicHttps
+                AcknowledgeUnsafeLocalDevelopment: false
+                TimeoutSeconds: 3600
+                OnTimeout: Reject
     responses:
       '200':
         $ref: './Approval.Components.OpenAPI.yaml#/ApprovalPolicyResponse'
@@ -200,6 +218,19 @@
         application/json:
           schema:
             $ref: './Approval.Components.OpenAPI.yaml#/ApproveApprovalRequestParameters'
+          examples:
+            approveRequest:
+              summary: Approve a workflow-generated approval request
+              value:
+                CorrelationId: cli-20260604T181500Z-0001
+                Principal: user:bob
+                OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                ApprovalRequestId: 5f9ed4df-d6df-4a65-a5d0-2830d62512c1
+                Reason: Release criteria satisfied.
+                ClientDecisionId: bob-approval-20260604-001
     responses:
       '200':
         $ref: './Approval.Components.OpenAPI.yaml#/ApprovalRequestResponse'

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -6433,6 +6433,66 @@ components:
       schema:
         type: string
       example: 0.42.0
+    WebhookDeliveryIdHeader:
+      name: x-grace-webhook-delivery-id
+      in: header
+      required: true
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventNameHeader:
+      name: x-grace-webhook-event-name
+      in: header
+      required: true
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersionHeader:
+      name: x-grace-webhook-event-version
+      in: header
+      required: true
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestampHeader:
+      name: x-grace-webhook-timestamp
+      in: header
+      required: true
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyIdHeader:
+      name: x-grace-webhook-signature-key-id
+      in: header
+      required: true
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256Header:
+      name: x-grace-webhook-payload-sha256
+      in: header
+      required: true
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: ^[a-f0-9]{64}$
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignatureHeader:
+      name: x-grace-webhook-signature
+      in: header
+      required: true
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: ^sha256=[a-f0-9]{64}$
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   headers:
     CorrelationId:
       description: Transport correlation id for the HTTP request/response exchange.
@@ -6449,45 +6509,6 @@ components:
       schema:
         type: string
       example: manifest-finalized
-    WebhookDeliveryId:
-      description: Unique webhook delivery id included with outbound webhook requests.
-      schema:
-        type: string
-        format: uuid
-      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
-    WebhookEventName:
-      description: Grace event name included with outbound webhook requests.
-      schema:
-        type: string
-      example: promotion-set.applied
-    WebhookEventVersion:
-      description: Grace event contract version included with outbound webhook requests.
-      schema:
-        type: integer
-      example: 1
-    WebhookTimestamp:
-      description: UTC timestamp used in webhook signature material.
-      schema:
-        type: string
-        format: date-time
-      example: '2026-06-04T18:15:00Z'
-    WebhookSignatureKeyId:
-      description: Webhook signing secret version used to compute the signature.
-      schema:
-        type: string
-      example: secret-v1
-    WebhookPayloadSha256:
-      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
-      schema:
-        type: string
-        pattern: ^[a-f0-9]{64}$
-      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
-    WebhookSignature:
-      description: HMAC-SHA256 webhook signature over the signed delivery material.
-      schema:
-        type: string
-        pattern: ^sha256=[a-f0-9]{64}$
-      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   securitySchemes:
     api_key:
       type: apiKey

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -50,6 +50,24 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateApprovalPolicyParameters'
+            examples:
+              promotionSetPolicy:
+                summary: Require an approver before promotion-set apply
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Name: Main branch release approval
+                  Subject: promotion-set.apply
+                  RequiredResponder: user:bob
+                  NotificationUrl: https://approvals.example.net/grace
+                  NotificationUrlSafety: PublicHttps
+                  AcknowledgeUnsafeLocalDevelopment: false
+                  TimeoutSeconds: 3600
+                  OnTimeout: Reject
       responses:
         '200':
           $ref: '#/components/responses/ApprovalPolicyResponse'
@@ -240,6 +258,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApproveApprovalRequestParameters'
+            examples:
+              approveRequest:
+                summary: Approve a workflow-generated approval request
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:bob
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  ApprovalRequestId: 5f9ed4df-d6df-4a65-a5d0-2830d62512c1
+                  Reason: Release criteria satisfied.
+                  ClientDecisionId: bob-approval-20260604-001
       responses:
         '200':
           $ref: '#/components/responses/ApprovalRequestResponse'
@@ -297,6 +328,26 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateWebhookRuleParameters'
+            examples:
+              promotionSetWebhook:
+                summary: Deliver promotion-set events to an HTTPS endpoint
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Name: Promotion applied webhook
+                  EventName: promotion-set.applied
+                  EventVersion: 1
+                  Url: https://hooks.example.net/grace
+                  UrlSafety: PublicHttps
+                  AcknowledgeUnsafeLocalDevelopment: false
+                  SigningSecretVersion: secret-v1
+                  MaxAttempts: 8
+                  InitialDelaySeconds: 30
+                  MaxDelaySeconds: 3600
       responses:
         '200':
           $ref: '#/components/responses/WebhookRuleResponse'
@@ -430,6 +481,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TestWebhookRuleParameters'
+            examples:
+              testDelivery:
+                summary: Create a test webhook delivery
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  WebhookRuleId: 73c9c3c8-5159-4e31-9280-e1b95e20db77
+                  DedupeKey: manual-test-20260604-001
       responses:
         '200':
           $ref: '#/components/responses/WebhookDeliveryResponse'
@@ -3602,6 +3665,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedDownloadUri:
+                  summary: Raw object-storage download URI
+                  value: https://storage.example.net/grace/repo/file.txt?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3624,6 +3691,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedContentBlockUploadUri:
+                  summary: Raw ContentBlock upload URI
+                  value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3646,6 +3717,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedContentBlockDownloadUri:
+                  summary: Raw ContentBlock download URI
+                  value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -5276,7 +5351,8 @@ components:
       example: MyBranch
     CorrelationId:
       type: string
-      description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
+      description: Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is distinct from the X-Correlation-Id transport header, which correlates the HTTP request/response exchange.
+      example: cli-20260604T181500Z-0001
     ContainerName:
       type: string
       description: The name of the container must be a valid Grace name. (See the Grace documentation for more information.)
@@ -5364,7 +5440,7 @@ components:
       properties:
         CorrelationId:
           type: string
-          description: A unique identifier for correlating logs and telemetry.
+          description: Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is distinct from the X-Correlation-Id transport header.
         Principal:
           type: string
           description: The entity on whose behalf the action is being performed.
@@ -5451,19 +5527,34 @@ components:
           additionalProperties:
             type: string
     GraceError:
+      description: Grace domain error envelope returned by command handlers. Authentication challenges and framework authorization failures use their HTTP-specific response shapes instead of this domain error envelope.
       type: object
       properties:
         Error:
           type: string
+          example: OwnerId is required.
         EventTime:
           type: string
           format: date-time
+          example: '2026-06-04T18:15:00Z'
         CorrelationId:
           type: string
+          example: cli-20260604T181500Z-0001
         Properties:
           type: object
           additionalProperties:
             type: string
+      required:
+        - Error
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        Error: OwnerId is required.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
     GraceResult:
       oneOf:
         - - $ref: '#/components/schemas/GraceReturnValue'
@@ -6267,7 +6358,7 @@ components:
         - $ref: '#/components/schemas/UploadSessionDedupeDiscoveryIssuedEvent'
         - $ref: '#/components/schemas/UploadSessionReuseRangesClaimedEvent'
     ClientType:
-      description: The Grace client version string for the client that initiated an API request.
+      description: The Grace client identity type/version recorded for diagnostics. Client identity headers are not authentication proof and must not be used as authorization evidence.
       type: string
     UploadSessionEvent:
       description: Event emitted by the upload-session actor, paired with event metadata.
@@ -6308,6 +6399,95 @@ components:
         - Rejected
         - Expired
         - Stale
+  parameters:
+    CorrelationIdHeader:
+      name: X-Correlation-Id
+      in: header
+      required: false
+      description: Optional transport correlation header. When omitted, Grace generates a correlation id and returns it in the response header. This transport header is distinct from body DTO CorrelationId fields, which are copied into command/event metadata after request parsing.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    ApiVersionHeader:
+      name: X-Api-Version
+      in: header
+      required: false
+      description: Optional Grace API contract version requested by SDK clients. Supported values are released date versions such as 2023-10-01 or explicit override aliases such as latest and edge.
+      schema:
+        type: string
+        pattern: ^(20[0-9]{2}-[0-9]{2}-[0-9]{2}|latest|edge)$
+      example: '2023-10-01'
+    ClientTypeHeader:
+      name: X-Grace-Client-Type
+      in: header
+      required: false
+      description: Optional client identity type used for diagnostics and event metadata. This header is not authentication proof; authorization is evaluated from the configured authentication principal and Grace authorization policy.
+      schema:
+        type: string
+      example: CLI
+    ClientVersionHeader:
+      name: X-Grace-Client-Version
+      in: header
+      required: false
+      description: Optional client identity version paired with X-Grace-Client-Type for diagnostics and event metadata. This header is not authentication proof.
+      schema:
+        type: string
+      example: 0.42.0
+  headers:
+    CorrelationId:
+      description: Transport correlation id for the HTTP request/response exchange.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    UploadSessionLifecycleState:
+      description: Diagnostic lifecycle state for manifest upload-session responses. Invalid or unknown values must be treated as diagnostics only and must not be used as authentication or authorization proof.
+      schema:
+        $ref: '#/components/schemas/UploadSessionLifecycleState'
+      example: Finalized
+    UploadSessionLifecycleReason:
+      description: Optional diagnostic explanation for a lifecycle-state response header.
+      schema:
+        type: string
+      example: manifest-finalized
+    WebhookDeliveryId:
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventName:
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersion:
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestamp:
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyId:
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256:
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: ^[a-f0-9]{64}$
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignature:
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: ^sha256=[a-f0-9]{64}$
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   securitySchemes:
     api_key:
       type: apiKey
@@ -6329,13 +6509,30 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            $ref: '#/components/schemas/GraceError'
+          examples:
+            domainValidation:
+              summary: Grace domain validation error
+              value:
+                Error: OwnerId is required.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/get
     '500':
       description: Internal Server Error
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            $ref: '#/components/schemas/GraceError'
+          examples:
+            domainException:
+              summary: Grace domain exception envelope
+              value:
+                Error: Object storage provider failed.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties: {}
     ApprovalPolicyResponse:
       description: OK
       content:

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -6433,6 +6433,66 @@ components:
       schema:
         type: string
       example: 0.42.0
+    WebhookDeliveryIdHeader:
+      name: x-grace-webhook-delivery-id
+      in: header
+      required: true
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventNameHeader:
+      name: x-grace-webhook-event-name
+      in: header
+      required: true
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersionHeader:
+      name: x-grace-webhook-event-version
+      in: header
+      required: true
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestampHeader:
+      name: x-grace-webhook-timestamp
+      in: header
+      required: true
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyIdHeader:
+      name: x-grace-webhook-signature-key-id
+      in: header
+      required: true
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256Header:
+      name: x-grace-webhook-payload-sha256
+      in: header
+      required: true
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: ^[a-f0-9]{64}$
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignatureHeader:
+      name: x-grace-webhook-signature
+      in: header
+      required: true
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: ^sha256=[a-f0-9]{64}$
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   headers:
     CorrelationId:
       description: Transport correlation id for the HTTP request/response exchange.
@@ -6449,45 +6509,6 @@ components:
       schema:
         type: string
       example: manifest-finalized
-    WebhookDeliveryId:
-      description: Unique webhook delivery id included with outbound webhook requests.
-      schema:
-        type: string
-        format: uuid
-      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
-    WebhookEventName:
-      description: Grace event name included with outbound webhook requests.
-      schema:
-        type: string
-      example: promotion-set.applied
-    WebhookEventVersion:
-      description: Grace event contract version included with outbound webhook requests.
-      schema:
-        type: integer
-      example: 1
-    WebhookTimestamp:
-      description: UTC timestamp used in webhook signature material.
-      schema:
-        type: string
-        format: date-time
-      example: '2026-06-04T18:15:00Z'
-    WebhookSignatureKeyId:
-      description: Webhook signing secret version used to compute the signature.
-      schema:
-        type: string
-      example: secret-v1
-    WebhookPayloadSha256:
-      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
-      schema:
-        type: string
-        pattern: ^[a-f0-9]{64}$
-      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
-    WebhookSignature:
-      description: HMAC-SHA256 webhook signature over the signed delivery material.
-      schema:
-        type: string
-        pattern: ^sha256=[a-f0-9]{64}$
-      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   securitySchemes:
     api_key:
       type: apiKey

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -50,6 +50,24 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateApprovalPolicyParameters'
+            examples:
+              promotionSetPolicy:
+                summary: Require an approver before promotion-set apply
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Name: Main branch release approval
+                  Subject: promotion-set.apply
+                  RequiredResponder: user:bob
+                  NotificationUrl: https://approvals.example.net/grace
+                  NotificationUrlSafety: PublicHttps
+                  AcknowledgeUnsafeLocalDevelopment: false
+                  TimeoutSeconds: 3600
+                  OnTimeout: Reject
       responses:
         '200':
           $ref: '#/components/responses/ApprovalPolicyResponse'
@@ -240,6 +258,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ApproveApprovalRequestParameters'
+            examples:
+              approveRequest:
+                summary: Approve a workflow-generated approval request
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:bob
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  ApprovalRequestId: 5f9ed4df-d6df-4a65-a5d0-2830d62512c1
+                  Reason: Release criteria satisfied.
+                  ClientDecisionId: bob-approval-20260604-001
       responses:
         '200':
           $ref: '#/components/responses/ApprovalRequestResponse'
@@ -297,6 +328,26 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateWebhookRuleParameters'
+            examples:
+              promotionSetWebhook:
+                summary: Deliver promotion-set events to an HTTPS endpoint
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Name: Promotion applied webhook
+                  EventName: promotion-set.applied
+                  EventVersion: 1
+                  Url: https://hooks.example.net/grace
+                  UrlSafety: PublicHttps
+                  AcknowledgeUnsafeLocalDevelopment: false
+                  SigningSecretVersion: secret-v1
+                  MaxAttempts: 8
+                  InitialDelaySeconds: 30
+                  MaxDelaySeconds: 3600
       responses:
         '200':
           $ref: '#/components/responses/WebhookRuleResponse'
@@ -430,6 +481,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TestWebhookRuleParameters'
+            examples:
+              testDelivery:
+                summary: Create a test webhook delivery
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  WebhookRuleId: 73c9c3c8-5159-4e31-9280-e1b95e20db77
+                  DedupeKey: manual-test-20260604-001
       responses:
         '200':
           $ref: '#/components/responses/WebhookDeliveryResponse'
@@ -3602,6 +3665,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedDownloadUri:
+                  summary: Raw object-storage download URI
+                  value: https://storage.example.net/grace/repo/file.txt?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3624,6 +3691,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedContentBlockUploadUri:
+                  summary: Raw ContentBlock upload URI
+                  value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3646,6 +3717,10 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/UriString'
+              examples:
+                signedContentBlockDownloadUri:
+                  summary: Raw ContentBlock download URI
+                  value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -5276,7 +5351,8 @@ components:
       example: MyBranch
     CorrelationId:
       type: string
-      description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
+      description: Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is distinct from the X-Correlation-Id transport header, which correlates the HTTP request/response exchange.
+      example: cli-20260604T181500Z-0001
     ContainerName:
       type: string
       description: The name of the container must be a valid Grace name. (See the Grace documentation for more information.)
@@ -5364,7 +5440,7 @@ components:
       properties:
         CorrelationId:
           type: string
-          description: A unique identifier for correlating logs and telemetry.
+          description: Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is distinct from the X-Correlation-Id transport header.
         Principal:
           type: string
           description: The entity on whose behalf the action is being performed.
@@ -5451,19 +5527,34 @@ components:
           additionalProperties:
             type: string
     GraceError:
+      description: Grace domain error envelope returned by command handlers. Authentication challenges and framework authorization failures use their HTTP-specific response shapes instead of this domain error envelope.
       type: object
       properties:
         Error:
           type: string
+          example: OwnerId is required.
         EventTime:
           type: string
           format: date-time
+          example: '2026-06-04T18:15:00Z'
         CorrelationId:
           type: string
+          example: cli-20260604T181500Z-0001
         Properties:
           type: object
           additionalProperties:
             type: string
+      required:
+        - Error
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        Error: OwnerId is required.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
     GraceResult:
       oneOf:
         - - $ref: '#/components/schemas/GraceReturnValue'
@@ -6267,7 +6358,7 @@ components:
         - $ref: '#/components/schemas/UploadSessionDedupeDiscoveryIssuedEvent'
         - $ref: '#/components/schemas/UploadSessionReuseRangesClaimedEvent'
     ClientType:
-      description: The Grace client version string for the client that initiated an API request.
+      description: The Grace client identity type/version recorded for diagnostics. Client identity headers are not authentication proof and must not be used as authorization evidence.
       type: string
     UploadSessionEvent:
       description: Event emitted by the upload-session actor, paired with event metadata.
@@ -6308,6 +6399,95 @@ components:
         - Rejected
         - Expired
         - Stale
+  parameters:
+    CorrelationIdHeader:
+      name: X-Correlation-Id
+      in: header
+      required: false
+      description: Optional transport correlation header. When omitted, Grace generates a correlation id and returns it in the response header. This transport header is distinct from body DTO CorrelationId fields, which are copied into command/event metadata after request parsing.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    ApiVersionHeader:
+      name: X-Api-Version
+      in: header
+      required: false
+      description: Optional Grace API contract version requested by SDK clients. Supported values are released date versions such as 2023-10-01 or explicit override aliases such as latest and edge.
+      schema:
+        type: string
+        pattern: ^(20[0-9]{2}-[0-9]{2}-[0-9]{2}|latest|edge)$
+      example: '2023-10-01'
+    ClientTypeHeader:
+      name: X-Grace-Client-Type
+      in: header
+      required: false
+      description: Optional client identity type used for diagnostics and event metadata. This header is not authentication proof; authorization is evaluated from the configured authentication principal and Grace authorization policy.
+      schema:
+        type: string
+      example: CLI
+    ClientVersionHeader:
+      name: X-Grace-Client-Version
+      in: header
+      required: false
+      description: Optional client identity version paired with X-Grace-Client-Type for diagnostics and event metadata. This header is not authentication proof.
+      schema:
+        type: string
+      example: 0.42.0
+  headers:
+    CorrelationId:
+      description: Transport correlation id for the HTTP request/response exchange.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    UploadSessionLifecycleState:
+      description: Diagnostic lifecycle state for manifest upload-session responses. Invalid or unknown values must be treated as diagnostics only and must not be used as authentication or authorization proof.
+      schema:
+        $ref: '#/components/schemas/UploadSessionLifecycleState'
+      example: Finalized
+    UploadSessionLifecycleReason:
+      description: Optional diagnostic explanation for a lifecycle-state response header.
+      schema:
+        type: string
+      example: manifest-finalized
+    WebhookDeliveryId:
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventName:
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersion:
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestamp:
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyId:
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256:
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: ^[a-f0-9]{64}$
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignature:
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: ^sha256=[a-f0-9]{64}$
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   securitySchemes:
     api_key:
       type: apiKey
@@ -6329,13 +6509,30 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            $ref: '#/components/schemas/GraceError'
+          examples:
+            domainValidation:
+              summary: Grace domain validation error
+              value:
+                Error: OwnerId is required.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/get
     '500':
       description: Internal Server Error
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemDetails'
+            $ref: '#/components/schemas/GraceError'
+          examples:
+            domainException:
+              summary: Grace domain exception envelope
+              value:
+                Error: Object storage provider failed.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties: {}
     ApprovalPolicyResponse:
       description: OK
       content:

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -616,6 +616,38 @@ components:
     RepositoryStatus:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryStatus'
 
+  parameters:
+    CorrelationIdHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/CorrelationIdHeader'
+    ApiVersionHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/ApiVersionHeader'
+    ClientTypeHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/ClientTypeHeader'
+    ClientVersionHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/ClientVersionHeader'
+
+  headers:
+    CorrelationId:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/CorrelationId'
+    UploadSessionLifecycleState:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/UploadSessionLifecycleState'
+    UploadSessionLifecycleReason:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/UploadSessionLifecycleReason'
+    WebhookDeliveryId:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookDeliveryId'
+    WebhookEventName:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookEventName'
+    WebhookEventVersion:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookEventVersion'
+    WebhookTimestamp:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookTimestamp'
+    WebhookSignatureKeyId:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookSignatureKeyId'
+    WebhookPayloadSha256:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookPayloadSha256'
+    WebhookSignature:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookSignature'
+
   securitySchemes:
     api_key:
       type: apiKey

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -625,6 +625,20 @@ components:
       $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/ClientTypeHeader'
     ClientVersionHeader:
       $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/ClientVersionHeader'
+    WebhookDeliveryIdHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookDeliveryIdHeader'
+    WebhookEventNameHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookEventNameHeader'
+    WebhookEventVersionHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookEventVersionHeader'
+    WebhookTimestampHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookTimestampHeader'
+    WebhookSignatureKeyIdHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookSignatureKeyIdHeader'
+    WebhookPayloadSha256Header:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookPayloadSha256Header'
+    WebhookSignatureHeader:
+      $ref: 'Transport.Headers.OpenAPI.yaml#/components/parameters/WebhookSignatureHeader'
 
   headers:
     CorrelationId:
@@ -633,20 +647,6 @@ components:
       $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/UploadSessionLifecycleState'
     UploadSessionLifecycleReason:
       $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/UploadSessionLifecycleReason'
-    WebhookDeliveryId:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookDeliveryId'
-    WebhookEventName:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookEventName'
-    WebhookEventVersion:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookEventVersion'
-    WebhookTimestamp:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookTimestamp'
-    WebhookSignatureKeyId:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookSignatureKeyId'
-    WebhookPayloadSha256:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookPayloadSha256'
-    WebhookSignature:
-      $ref: 'Transport.Headers.OpenAPI.yaml#/components/headers/WebhookSignature'
 
   securitySchemes:
     api_key:

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "203c48168cd2127575e320894453ddb191bbbc0eab45af5a12831dbc0aa1fa1b"
+      "sha256": "64526e82e1be370452c72b612d2a23fb66f5b6dbb832ae474b5db5eaba274cf9"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
@@ -93,7 +93,7 @@
     },
     {
       "path": "Transport.Headers.OpenAPI.yaml",
-      "sha256": "4dd4310096f7ba96f3a7a73eab66affbfe2c96a6d86c2b471aaa8fc750548b47"
+      "sha256": "ef793c1f1985f51189dee9d61ca6be6134d9c1fd808d987df88da7f769425115"
     },
     {
       "path": "Webhook.Components.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
+      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "192878ba804d36a08dc077fea7992690b6817f83d7671b3477509286e7559bcc"
+      "sha256": "b59a30f52d924b6a3385b8f567efa28676833761b1ea9459fd33fffafd14d783"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
+      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "87a6a1f8ef78c95049a2fd25a816d13834f87cdd96b61ff7a6c470d28d7d5ce8"
+      "sha256": "a61816a609b93c8c85aa41959d3a8a372ef41d6a178fe096e49890aa97f4b3a4"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
+      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -9,7 +9,7 @@
     },
     {
       "path": "Approval.Paths.OpenAPI.yaml",
-      "sha256": "b31f21d1ba523013b2a38d01c8fab254f2dee5e11e865437d579d9fb346a4073"
+      "sha256": "d85318904eefd24953d8585e8ed7553b8c89c9ca7f33b3b22e2b864034ede54b"
     },
     {
       "path": "Branch.Components.OpenAPI.yaml",
@@ -41,7 +41,7 @@
     },
     {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "be64dd541f0ccf2d033cdad13b479712e5169c781674ab53e78390cb1d0c156e"
+      "sha256": "203c48168cd2127575e320894453ddb191bbbc0eab45af5a12831dbc0aa1fa1b"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
@@ -73,11 +73,11 @@
     },
     {
       "path": "Responses.OpenAPI.yaml",
-      "sha256": "94f8b1ae3e0d90ec021c45b9690fbc1ded371934b58b5fb675dbe19c009ee201"
+      "sha256": "b02b72fb02b26ab5fea92d8072585d0c675db9abc354445642befa1880f84244"
     },
     {
       "path": "Shared.Components.OpenAPI.yaml",
-      "sha256": "9158efe1d2cd838078e7946e456e3bce4b6d1426b76750763dabfc231232c20c"
+      "sha256": "314fb2dbc050a12adee8f0c36e79ac26bc4bb3f98fca7ea76eee275e04791c53"
     },
     {
       "path": "Shared2.Components.OpenAPI.yaml",
@@ -89,7 +89,11 @@
     },
     {
       "path": "Storage.Paths.OpenAPI.yaml",
-      "sha256": "4c651c02dd6cb8661acd78bd538c366db0439ce15ac485e79b9249212add7759"
+      "sha256": "b29050ecbce781ae2dc52ad287768f470627c788130701a1f171ffb9ec5339c3"
+    },
+    {
+      "path": "Transport.Headers.OpenAPI.yaml",
+      "sha256": "4dd4310096f7ba96f3a7a73eab66affbfe2c96a6d86c2b471aaa8fc750548b47"
     },
     {
       "path": "Webhook.Components.OpenAPI.yaml",
@@ -97,33 +101,33 @@
     },
     {
       "path": "Webhook.Paths.OpenAPI.yaml",
-      "sha256": "86370a041b63500f604ef7920783be6d85f82c97b62f9aaf1216f701a29572fb"
+      "sha256": "d143611ec15ea55bd8f4178b2e7eb1cd46cf67a12f862f88456d05fc5bda8926"
     }
   ],
   "generatedArtifacts": [
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "90aa6488234f3cdd06cd5e7cf7cf5903d6af23c1f2d292f9cb988598df261138"
+      "sha256": "192878ba804d36a08dc077fea7992690b6817f83d7671b3477509286e7559bcc"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "f3a2423582999b93df0b7c0a72f29f424d2186b5d63c905e04edb4635e5220da"
+      "sha256": "87a6a1f8ef78c95049a2fd25a816d13834f87cdd96b61ff7a6c470d28d7d5ce8"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "189b6c5342b57ed77139228672d1fde322a12bb3c18ca90006ca511ba5a37ca4",
+      "sourceDigest": "6884ed374d0c2ef2f7b8feb7f233e2b2ddbc9e17b5378e739bbe89a8f3bfffbe",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/Responses.OpenAPI.yaml
+++ b/src/OpenAPI/Responses.OpenAPI.yaml
@@ -11,13 +11,56 @@
       content:
         application/json:
           schema:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ProblemDetails'
+            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/GraceError'
+          examples:
+            domainValidation:
+              summary: Grace domain validation error
+              value:
+                Error: OwnerId is required.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/get
+    '401':
+      description: Unauthorized
+      headers:
+        WWW-Authenticate:
+          description: Authentication challenge emitted by the configured ASP.NET Core authentication handler.
+          schema:
+            type: string
+          example: Bearer
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            emptyChallenge:
+              summary: Framework authentication challenge
+              value: ''
+    '403':
+      description: Forbidden
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            forbidden:
+              summary: Framework authorization failure
+              value: Forbidden.
     '500':
       description: Internal Server Error
       content:
         application/json:
           schema:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ProblemDetails'
+            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/GraceError'
+          examples:
+            domainException:
+              summary: Grace domain exception envelope
+              value:
+                Error: Object storage provider failed.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties: {}
     'OK':
       description: OK
       content:

--- a/src/OpenAPI/Shared.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Shared.Components.OpenAPI.yaml
@@ -36,7 +36,10 @@ components:
       example: MyBranch
     CorrelationId:
       type: string
-      description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
+      description: >-
+        Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is distinct
+        from the X-Correlation-Id transport header, which correlates the HTTP request/response exchange.
+      example: cli-20260604T181500Z-0001
     ContainerName:
       type: string
       description: The name of the container must be a valid Grace name. (See the Grace documentation for more information.)
@@ -118,7 +121,9 @@ components:
       properties:
         CorrelationId:
           type: string
-          description: A unique identifier for correlating logs and telemetry.
+          description: >-
+            Body DTO correlation id copied into Grace command/event metadata after request parsing. This field is
+            distinct from the X-Correlation-Id transport header.
         Principal:
           type: string
           description: The entity on whose behalf the action is being performed.
@@ -195,7 +200,9 @@ components:
             type: string
 
     ClientType:
-      description: The Grace client version string for the client that initiated an API request.
+      description: >-
+        The Grace client identity type/version recorded for diagnostics. Client identity headers are not authentication
+        proof and must not be used as authorization evidence.
       type: string
 
     GraceReturnValue:
@@ -214,19 +221,36 @@ components:
             type: string
 
     GraceError:
+      description: >-
+        Grace domain error envelope returned by command handlers. Authentication challenges and framework authorization
+        failures use their HTTP-specific response shapes instead of this domain error envelope.
       type: object
       properties:
         Error:
           type: string
+          example: OwnerId is required.
         EventTime:
           type: string
           format: date-time
+          example: '2026-06-04T18:15:00Z'
         CorrelationId:
           type: string
+          example: cli-20260604T181500Z-0001
         Properties:
           type: object
           additionalProperties:
             type: string
+      required:
+        - Error
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        Error: OwnerId is required.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
 
     GraceResult:
       oneOf:

--- a/src/OpenAPI/Storage.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Paths.OpenAPI.yaml
@@ -62,6 +62,10 @@
           text/plain:
             schema:
               $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
+            examples:
+              signedDownloadUri:
+                summary: Raw object-storage download URI
+                value: https://storage.example.net/grace/repo/file.txt?sv=2023-11-03&sig=example
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -85,6 +89,10 @@
           text/plain:
             schema:
               $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
+            examples:
+              signedContentBlockUploadUri:
+                summary: Raw ContentBlock upload URI
+                value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':
@@ -108,6 +116,10 @@
           text/plain:
             schema:
               $ref: 'Storage.Components.OpenAPI.yaml#/UriString'
+            examples:
+              signedContentBlockDownloadUri:
+                summary: Raw ContentBlock download URI
+                value: https://storage.example.net/grace/content-blocks/ab/cd?sv=2023-11-03&sig=example
       '400':
         $ref: './Responses.OpenAPI.yaml#/400'
       '500':

--- a/src/OpenAPI/Transport.Headers.OpenAPI.yaml
+++ b/src/OpenAPI/Transport.Headers.OpenAPI.yaml
@@ -42,6 +42,66 @@ components:
       schema:
         type: string
       example: 0.42.0
+    WebhookDeliveryIdHeader:
+      name: x-grace-webhook-delivery-id
+      in: header
+      required: true
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventNameHeader:
+      name: x-grace-webhook-event-name
+      in: header
+      required: true
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersionHeader:
+      name: x-grace-webhook-event-version
+      in: header
+      required: true
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestampHeader:
+      name: x-grace-webhook-timestamp
+      in: header
+      required: true
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyIdHeader:
+      name: x-grace-webhook-signature-key-id
+      in: header
+      required: true
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256Header:
+      name: x-grace-webhook-payload-sha256
+      in: header
+      required: true
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: '^[a-f0-9]{64}$'
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignatureHeader:
+      name: x-grace-webhook-signature
+      in: header
+      required: true
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: '^sha256=[a-f0-9]{64}$'
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c
   headers:
     CorrelationId:
       description: Transport correlation id for the HTTP request/response exchange.
@@ -60,42 +120,3 @@ components:
       schema:
         type: string
       example: manifest-finalized
-    WebhookDeliveryId:
-      description: Unique webhook delivery id included with outbound webhook requests.
-      schema:
-        type: string
-        format: uuid
-      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
-    WebhookEventName:
-      description: Grace event name included with outbound webhook requests.
-      schema:
-        type: string
-      example: promotion-set.applied
-    WebhookEventVersion:
-      description: Grace event contract version included with outbound webhook requests.
-      schema:
-        type: integer
-      example: 1
-    WebhookTimestamp:
-      description: UTC timestamp used in webhook signature material.
-      schema:
-        type: string
-        format: date-time
-      example: '2026-06-04T18:15:00Z'
-    WebhookSignatureKeyId:
-      description: Webhook signing secret version used to compute the signature.
-      schema:
-        type: string
-      example: secret-v1
-    WebhookPayloadSha256:
-      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
-      schema:
-        type: string
-        pattern: '^[a-f0-9]{64}$'
-      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
-    WebhookSignature:
-      description: HMAC-SHA256 webhook signature over the signed delivery material.
-      schema:
-        type: string
-        pattern: '^sha256=[a-f0-9]{64}$'
-      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c

--- a/src/OpenAPI/Transport.Headers.OpenAPI.yaml
+++ b/src/OpenAPI/Transport.Headers.OpenAPI.yaml
@@ -1,0 +1,101 @@
+components:
+  parameters:
+    CorrelationIdHeader:
+      name: X-Correlation-Id
+      in: header
+      required: false
+      description: >-
+        Optional transport correlation header. When omitted, Grace generates a correlation id and returns it in the
+        response header. This transport header is distinct from body DTO CorrelationId fields, which are copied into
+        command/event metadata after request parsing.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    ApiVersionHeader:
+      name: X-Api-Version
+      in: header
+      required: false
+      description: >-
+        Optional Grace API contract version requested by SDK clients. Supported values are released date versions such
+        as 2023-10-01 or explicit override aliases such as latest and edge.
+      schema:
+        type: string
+        pattern: '^(20[0-9]{2}-[0-9]{2}-[0-9]{2}|latest|edge)$'
+      example: '2023-10-01'
+    ClientTypeHeader:
+      name: X-Grace-Client-Type
+      in: header
+      required: false
+      description: >-
+        Optional client identity type used for diagnostics and event metadata. This header is not authentication proof;
+        authorization is evaluated from the configured authentication principal and Grace authorization policy.
+      schema:
+        type: string
+      example: CLI
+    ClientVersionHeader:
+      name: X-Grace-Client-Version
+      in: header
+      required: false
+      description: >-
+        Optional client identity version paired with X-Grace-Client-Type for diagnostics and event metadata. This header
+        is not authentication proof.
+      schema:
+        type: string
+      example: 0.42.0
+  headers:
+    CorrelationId:
+      description: Transport correlation id for the HTTP request/response exchange.
+      schema:
+        type: string
+      example: cli-20260604T181500Z-0001
+    UploadSessionLifecycleState:
+      description: >-
+        Diagnostic lifecycle state for manifest upload-session responses. Invalid or unknown values must be treated as
+        diagnostics only and must not be used as authentication or authorization proof.
+      schema:
+        $ref: 'Storage.Components.OpenAPI.yaml#/UploadSessionLifecycleState'
+      example: Finalized
+    UploadSessionLifecycleReason:
+      description: Optional diagnostic explanation for a lifecycle-state response header.
+      schema:
+        type: string
+      example: manifest-finalized
+    WebhookDeliveryId:
+      description: Unique webhook delivery id included with outbound webhook requests.
+      schema:
+        type: string
+        format: uuid
+      example: 7a93f7b4-df35-49eb-86e1-49d95745f2e4
+    WebhookEventName:
+      description: Grace event name included with outbound webhook requests.
+      schema:
+        type: string
+      example: promotion-set.applied
+    WebhookEventVersion:
+      description: Grace event contract version included with outbound webhook requests.
+      schema:
+        type: integer
+      example: 1
+    WebhookTimestamp:
+      description: UTC timestamp used in webhook signature material.
+      schema:
+        type: string
+        format: date-time
+      example: '2026-06-04T18:15:00Z'
+    WebhookSignatureKeyId:
+      description: Webhook signing secret version used to compute the signature.
+      schema:
+        type: string
+      example: secret-v1
+    WebhookPayloadSha256:
+      description: Lowercase SHA-256 hex digest of the outbound webhook payload bytes.
+      schema:
+        type: string
+        pattern: '^[a-f0-9]{64}$'
+      example: 8f2a559490e4a9bb1a4fcd73d4a0fb701ff61e942d7b6b3f42e4612d48e6a7fb
+    WebhookSignature:
+      description: HMAC-SHA256 webhook signature over the signed delivery material.
+      schema:
+        type: string
+        pattern: '^sha256=[a-f0-9]{64}$'
+      example: sha256=2a98f6d8e9be1e9b6d1bd06c0de24d73a6d73c1f9f8ce845f7b8cb11d7e4b15c

--- a/src/OpenAPI/Webhook.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Webhook.Paths.OpenAPI.yaml
@@ -10,6 +10,26 @@
         application/json:
           schema:
             $ref: './Webhook.Components.OpenAPI.yaml#/CreateWebhookRuleParameters'
+          examples:
+            promotionSetWebhook:
+              summary: Deliver promotion-set events to an HTTPS endpoint
+              value:
+                CorrelationId: cli-20260604T181500Z-0001
+                Principal: user:alice
+                OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                Name: Promotion applied webhook
+                EventName: promotion-set.applied
+                EventVersion: 1
+                Url: https://hooks.example.net/grace
+                UrlSafety: PublicHttps
+                AcknowledgeUnsafeLocalDevelopment: false
+                SigningSecretVersion: secret-v1
+                MaxAttempts: 8
+                InitialDelaySeconds: 30
+                MaxDelaySeconds: 3600
     responses:
       '200':
         $ref: './Webhook.Components.OpenAPI.yaml#/WebhookRuleResponse'
@@ -143,6 +163,18 @@
         application/json:
           schema:
             $ref: './Webhook.Components.OpenAPI.yaml#/TestWebhookRuleParameters'
+          examples:
+            testDelivery:
+              summary: Create a test webhook delivery
+              value:
+                CorrelationId: cli-20260604T181500Z-0001
+                Principal: user:alice
+                OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                TargetBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                WebhookRuleId: 73c9c3c8-5159-4e31-9280-e1b95e20db77
+                DedupeKey: manual-test-20260604-001
     responses:
       '200':
         $ref: './Webhook.Components.OpenAPI.yaml#/WebhookDeliveryResponse'

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -373,6 +373,7 @@ function Get-OpenApiOperations {
                 Method = $method
                 LineNumber = $index + 1
                 OperationId = if ($operationIdMatch.Success) { $operationIdMatch.Groups['id'].Value } else { $null }
+                OperationText = $operationText
                 HasTag = $operationText -match "(?m)^\s+tags:\s*$" -and $operationText -match "(?m)^\s+-\s+[A-Za-z][A-Za-z0-9 ._-]*\s*$"
                 HasResponses = $responsesMatch.Success
                 Has400 = $operationText -match "(?m)^\s+'400':\s*$"
@@ -425,8 +426,43 @@ function Assert-TextContains {
     }
 }
 
+function Get-RequiredOpenApiOperation {
+    param(
+        [object[]] $Operations,
+        [string] $File,
+        [string] $OperationId
+    )
+
+    $matches = @($Operations | Where-Object { $_.File -eq $File -and $_.OperationId -eq $OperationId })
+    if ($matches.Count -eq 1) {
+        return $matches[0]
+    }
+
+    Add-Failure "Expected exactly one OpenAPI operation '$OperationId' in $File, found $($matches.Count)."
+    return $null
+}
+
+function Assert-OperationTextMatches {
+    param(
+        [object] $Operation,
+        [string] $Pattern,
+        [string] $Message
+    )
+
+    if ($null -eq $Operation) {
+        return
+    }
+
+    if ([string] $Operation.OperationText -notmatch $Pattern) {
+        Add-Failure $Message
+    }
+}
+
 function Test-OpenApiSharedContractDetails {
-    param([string] $OpenApiRoot)
+    param(
+        [string] $OpenApiRoot,
+        [object[]] $Operations
+    )
 
     $headersFile = Join-Path $OpenApiRoot 'Transport.Headers.OpenAPI.yaml'
     if (-not (Test-Path -LiteralPath $headersFile -PathType Leaf)) {
@@ -441,10 +477,20 @@ function Test-OpenApiSharedContractDetails {
             'name: X-Grace-Client-Type',
             'name: X-Grace-Client-Version',
             'UploadSessionLifecycleState:',
-            'WebhookSignature:',
+            'name: x-grace-webhook-delivery-id',
+            'name: x-grace-webhook-event-name',
+            'name: x-grace-webhook-event-version',
+            'name: x-grace-webhook-timestamp',
+            'name: x-grace-webhook-signature-key-id',
+            'name: x-grace-webhook-payload-sha256',
+            'name: x-grace-webhook-signature',
             'not authentication proof'
         )) {
         Assert-TextContains $headersText $requiredHeader "Reusable header contract is missing '$requiredHeader'."
+    }
+
+    if ($headersText -match '(?m)^\s+Webhook(?:DeliveryId|EventName|EventVersion|Timestamp|SignatureKeyId|PayloadSha256|Signature):\s*$') {
+        Add-Failure 'Outbound webhook headers must not be represented only as components.headers aliases without exact wire names.'
     }
 
     $sharedText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Shared.Components.OpenAPI.yaml') -Raw
@@ -469,28 +515,28 @@ function Test-OpenApiSharedContractDetails {
     Assert-TextContains $responsesText "'403':" 'Reusable 403 authorization response must be present.'
     Assert-TextContains $responsesText 'value: Forbidden.' 'Reusable 403 response must stay distinct from GraceError.'
 
-    $storageText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Storage.Paths.OpenAPI.yaml') -Raw
     foreach ($operationId in @('GetDownloadUri', 'GetContentBlockUploadUri', 'GetContentBlockDownloadUri')) {
-        $pattern = "(?s)operationId:\s*$operationId\b.*?responses:\s*.*?'200':\s*.*?content:\s*.*?text/plain:"
-        if ($storageText -notmatch $pattern) {
-            Add-Failure "Storage raw URI operation '$operationId' must keep its 200 response as text/plain."
-        }
+        $operation = Get-RequiredOpenApiOperation $Operations 'Storage.Paths.OpenAPI.yaml' $operationId
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?content:\s*.*?text/plain:" `
+            "Storage raw URI operation '$operationId' must keep its own 200 response as text/plain."
     }
 
     foreach ($operationId in @('CreateApprovalPolicy', 'ApproveApprovalRequest')) {
-        $approvalText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Approval.Paths.OpenAPI.yaml') -Raw
-        $pattern = "(?s)operationId:\s*$operationId\b.*?content:\s*.*?application/json:\s*.*?examples:"
-        if ($approvalText -notmatch $pattern) {
-            Add-Failure "Approval operation '$operationId' must include an application/json example."
-        }
+        $operation = Get-RequiredOpenApiOperation $Operations 'Approval.Paths.OpenAPI.yaml' $operationId
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)requestBody:\s*.*?content:\s*.*?application/json:\s*.*?examples:" `
+            "Approval operation '$operationId' must include an application/json example in its own request body."
     }
 
     foreach ($operationId in @('CreateWebhookRule', 'TestWebhookRule')) {
-        $webhookText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Webhook.Paths.OpenAPI.yaml') -Raw
-        $pattern = "(?s)operationId:\s*$operationId\b.*?content:\s*.*?application/json:\s*.*?examples:"
-        if ($webhookText -notmatch $pattern) {
-            Add-Failure "Webhook operation '$operationId' must include an application/json example."
-        }
+        $operation = Get-RequiredOpenApiOperation $Operations 'Webhook.Paths.OpenAPI.yaml' $operationId
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)requestBody:\s*.*?content:\s*.*?application/json:\s*.*?examples:" `
+            "Webhook operation '$operationId' must include an application/json example in its own request body."
     }
 }
 
@@ -550,7 +596,7 @@ function Test-OpenApiQuality {
         Add-Pending "Error response coverage is not yet accepted. Missing 400/500 pairs: $($missingErrorResponses.Count). Examples: $examples"
     }
 
-    Test-OpenApiSharedContractDetails $openApiRoot
+    Test-OpenApiSharedContractDetails $openApiRoot $operations
 
     Add-Pass "Scanned $($operations.Count) OpenAPI operations for operationId, tag, response, and header proof scaffolding."
 }

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -413,6 +413,87 @@ function Get-OpenApiMethodDeclarationCount {
     return $count
 }
 
+function Assert-TextContains {
+    param(
+        [string] $Text,
+        [string] $Needle,
+        [string] $Message
+    )
+
+    if (-not $Text.Contains($Needle, [StringComparison]::Ordinal)) {
+        Add-Failure $Message
+    }
+}
+
+function Test-OpenApiSharedContractDetails {
+    param([string] $OpenApiRoot)
+
+    $headersFile = Join-Path $OpenApiRoot 'Transport.Headers.OpenAPI.yaml'
+    if (-not (Test-Path -LiteralPath $headersFile -PathType Leaf)) {
+        Add-Failure 'Reusable transport header components are not represented yet; no header contract is accepted.'
+        return
+    }
+
+    $headersText = Get-Content -LiteralPath $headersFile -Raw
+    foreach ($requiredHeader in @(
+            'name: X-Correlation-Id',
+            'name: X-Api-Version',
+            'name: X-Grace-Client-Type',
+            'name: X-Grace-Client-Version',
+            'UploadSessionLifecycleState:',
+            'WebhookSignature:',
+            'not authentication proof'
+        )) {
+        Assert-TextContains $headersText $requiredHeader "Reusable header contract is missing '$requiredHeader'."
+    }
+
+    $sharedText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Shared.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredGraceErrorPart in @(
+            'Grace domain error envelope',
+            'Authentication challenges and framework authorization',
+            'required:',
+            '- Error',
+            '- EventTime',
+            '- CorrelationId',
+            '- Properties'
+        )) {
+        Assert-TextContains $sharedText $requiredGraceErrorPart "GraceError contract is missing '$requiredGraceErrorPart'."
+    }
+
+    Assert-TextContains $sharedText 'distinct from the X-Correlation-Id transport header' 'Body CorrelationId must be documented as distinct from the transport header.'
+
+    $responsesText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Responses.OpenAPI.yaml') -Raw
+    Assert-TextContains $responsesText "Shared.Components.OpenAPI.yaml#/components/schemas/GraceError" 'Reusable 400/500 responses must reference GraceError.'
+    Assert-TextContains $responsesText "'401':" 'Reusable 401 authentication response must be present.'
+    Assert-TextContains $responsesText 'WWW-Authenticate:' 'Reusable 401 response must document the auth challenge header.'
+    Assert-TextContains $responsesText "'403':" 'Reusable 403 authorization response must be present.'
+    Assert-TextContains $responsesText 'value: Forbidden.' 'Reusable 403 response must stay distinct from GraceError.'
+
+    $storageText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Storage.Paths.OpenAPI.yaml') -Raw
+    foreach ($operationId in @('GetDownloadUri', 'GetContentBlockUploadUri', 'GetContentBlockDownloadUri')) {
+        $pattern = "(?s)operationId:\s*$operationId\b.*?responses:\s*.*?'200':\s*.*?content:\s*.*?text/plain:"
+        if ($storageText -notmatch $pattern) {
+            Add-Failure "Storage raw URI operation '$operationId' must keep its 200 response as text/plain."
+        }
+    }
+
+    foreach ($operationId in @('CreateApprovalPolicy', 'ApproveApprovalRequest')) {
+        $approvalText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Approval.Paths.OpenAPI.yaml') -Raw
+        $pattern = "(?s)operationId:\s*$operationId\b.*?content:\s*.*?application/json:\s*.*?examples:"
+        if ($approvalText -notmatch $pattern) {
+            Add-Failure "Approval operation '$operationId' must include an application/json example."
+        }
+    }
+
+    foreach ($operationId in @('CreateWebhookRule', 'TestWebhookRule')) {
+        $webhookText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Webhook.Paths.OpenAPI.yaml') -Raw
+        $pattern = "(?s)operationId:\s*$operationId\b.*?content:\s*.*?application/json:\s*.*?examples:"
+        if ($webhookText -notmatch $pattern) {
+            Add-Failure "Webhook operation '$operationId' must include an application/json example."
+        }
+    }
+}
+
 function Test-OpenApiQuality {
     param([string] $RepoRoot)
 
@@ -469,10 +550,7 @@ function Test-OpenApiQuality {
         Add-Pending "Error response coverage is not yet accepted. Missing 400/500 pairs: $($missingErrorResponses.Count). Examples: $examples"
     }
 
-    $headersFile = Join-Path $openApiRoot 'Transport.Headers.OpenAPI.yaml'
-    if (-not (Test-Path -LiteralPath $headersFile -PathType Leaf)) {
-        Add-Pending 'Reusable transport header components are not represented yet; no header contract is accepted.'
-    }
+    Test-OpenApiSharedContractDetails $openApiRoot
 
     Add-Pass "Scanned $($operations.Count) OpenAPI operations for operationId, tag, response, and header proof scaffolding."
 }


### PR DESCRIPTION
## Summary

- Adds reusable OpenAPI transport/header components for correlation, API version, client identity, lifecycle diagnostics, and webhook delivery/signing.
- Tightens `GraceError` and response components so Grace domain errors are distinct from framework auth challenges.
- Preserves storage raw URI responses as `text/plain` and adds examples for storage, approval, and webhook contracts.
- Regenerates OpenAPI bundle/projection/loss report and updates proof manifest.

## Issue

Refs #215
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness`: passed with no pending gates.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections`: passed with no pending gates.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality -AllowPending`: passed for this slice's accepted checks; pre-existing pending operationId/tag/error-response gaps remain outside #215 scope.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings and 0 errors.
- `git diff --check`: passed.

## Review Status

- Implementation worker completed initial shared OpenAPI contract commit `ae291e1`.
- First review found outbound webhook header components needed exact wire-name modeling and S04 proof assertions needed operation-local checks.
- Fix commit `265a659` addressed the review findings and was pushed to the PR branch.
- Fresh follow-up review-only sibling subagent completed against `origin/epic/211-sdk-openapi..265a659` with no actionable issues.
- Open review findings: none.
- Final no-issues review: documented in the PR conversation.

## Parallel Work Note

Issue #218 is active in parallel on server lifecycle policy. This PR intentionally limits lifecycle work to reusable OpenAPI diagnostic contract components and does not implement runtime lifecycle behavior.

## Docs Impact

- No Markdown docs changed. OpenAPI proof/generated artifacts were regenerated through the S03 projection script.

## Residual Risk

- New reusable `401`/`403` responses are defined but not wired into every operation; broad route-family response wiring remains outside this slice.
- Changing reusable `400`/`500` from `ProblemDetails` to `GraceError` is the main generated-client contract clarification and should receive focused review.