### PR TITLE
SDK/OpenAPI S05: polish branch reference diff contracts

### DIFF
--- a/src/OpenAPI/Branch.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Branch.Components.OpenAPI.yaml
@@ -178,6 +178,28 @@
             IncludeDeleted:
               type: boolean
               example: false
+    BranchCommandReturnValue:
+      description: Grace response envelope returned by branch command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Branch command succeeded.
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &branchCommandReturnValueExample
+        ReturnValue: Branch command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/create
     ReferenceApiDto:
       description: Public reference DTO returned through branch reference endpoints.
       type: object
@@ -397,6 +419,16 @@
         CorrelationId: cli-20260604T181500Z-0001
         Properties:
           Path: /branch/getReferences
+    BranchCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/BranchCommandReturnValue'
+          examples:
+            branchCommand:
+              summary: Branch command response envelope
+              value: *branchCommandReturnValueExample
     BranchResponse:
       description: OK
       content:

--- a/src/OpenAPI/Branch.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Branch.Components.OpenAPI.yaml
@@ -1,121 +1,170 @@
     BranchParameters:
-      description: Parameters for many endpoints in the /branch path.
+      description: Parameters shared by public endpoints in the /branch route family.
       type: object
+      allOf:
+        - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
       properties:
-        ownerId:
-          type: string
-        ownerName:
+        OwnerId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+        OwnerName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
-        organizationId:
-          type: string
-        organizationName:
+        OrganizationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+        OrganizationName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
-        repositoryId:
-          type: string
-        repositoryName:
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        RepositoryName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
-        branchId:
-          type: string
-        branchName:
+        BranchId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+        BranchName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
+      example: &branchBaseExample
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
     BranchQueryParameters:
-      description: Base class for parameters for branch queries.
+      description: Parameters for branch query endpoints that can resolve a branch or reference by hash or reference id.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            sha256Hash:
+            Sha256Hash:
               $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
-            referenceId:
-              type: string
+            ReferenceId:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
     CreateBranchParameters:
       description: Parameters for the /branch/create endpoint.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            parentBranchId:
-              type: string
-            parentBranchName:
+            ParentBranchId:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+            ParentBranchName:
               $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
+            InitialPermissions:
+              type: array
+              items:
+                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType'
     RebaseParameters:
       description: Parameters for the /branch/rebase endpoint.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            basedOn:
+            BasedOn:
               $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
     CreateReferenceParameters:
-      description: Parameters for the various /branch/create[reference] endpoints.
+      description: Parameters for /branch/promote, /branch/commit, /branch/checkpoint, /branch/save, and /branch/tag.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            directoryId:
-              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryId'
-            sha256Hash:
-              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
-            message:
+            DirectoryVersionId:
               type: string
+              format: uuid
+              example: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+            Message:
+              type: string
+              example: Capture release candidate.
     SetBranchNameParameters:
       description: Parameters for the /branch/setName endpoint.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            newName:
+            NewName:
               type: string
+              example: ReleaseCandidate
     EnableFeatureParameters:
-      description: Parameters for the various /branch/enable[feature] endpoints.
+      description: Parameters for branch feature-toggle endpoints.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            enabled:
+            Enabled:
               type: boolean
+              example: true
     DeleteBranchParameters:
       description: Parameters for the /branch/delete endpoint.
       allOf:
         - $ref: '#/BranchParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Superseded by release branch.
+            ReassignChildBranches:
+              type: boolean
+              example: true
+            NewParentBranchId:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+            NewParentBranchName:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
     GetReferenceParameters:
       description: Parameters for the /branch/getReference endpoint.
       allOf:
         - $ref: '#/BranchQueryParameters'
     GetReferencesParameters:
-      description: Parameters for the /branch/getReferences and /branch/get[reference] endpoints.
+      description: Parameters for /branch/getReferences and reference-type list endpoints.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            fullSha:
+            FullSha:
               type: boolean
-            maxCount:
+              example: false
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferenceTypeParameters:
       description: Parameters for the /branch/getDiffsForReferenceType endpoint.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            referenceType:
-              type: string
-            maxCount:
+            ReferenceType:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType'
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferencesParameters:
       description: Parameters for the /branch/getDiffsForReferences endpoint.
       allOf:
         - $ref: '#/BranchParameters'
         - type: object
           properties:
-            references:
+            References:
               type: string
-            maxCount:
+              description: Comma-separated reference identifiers for diff lookup.
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetBranchParameters:
       description: Parameters for the /branch/get endpoint.
       allOf:
         - $ref: '#/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     SwitchParameters:
       description: Parameters for the /branch/switch endpoint.
       allOf:
@@ -124,3 +173,253 @@
       description: Parameters for the /branch/getVersion endpoint.
       allOf:
         - $ref: '#/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
+    ReferenceApiDto:
+      description: Public reference DTO returned through branch reference endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: ReferenceDto
+        ReferenceId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
+        OwnerId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        BranchId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+        DirectoryId:
+          type: string
+          format: uuid
+          description: DirectoryVersionId represented by the current server DTO field name.
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Sha256Hash:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+        ReferenceType:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceText'
+        Links:
+          type: array
+          items:
+            type: string
+        CreatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchApiDto:
+      description: Public branch DTO returned through branch endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: BranchDto
+        BranchId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+        BranchName:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
+        ParentBranchId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+        OwnerId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        BasedOn:
+          $ref: '#/ReferenceApiDto'
+        UserId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/UserId'
+        AssignEnabled:
+          type: boolean
+        PromotionEnabled:
+          type: boolean
+        CommitEnabled:
+          type: boolean
+        CheckpointEnabled:
+          type: boolean
+        SaveEnabled:
+          type: boolean
+        TagEnabled:
+          type: boolean
+        ExternalEnabled:
+          type: boolean
+        AutoRebaseEnabled:
+          type: boolean
+        PromotionMode:
+          type: string
+          example: IndividualOnly
+        LatestReference:
+          $ref: '#/ReferenceApiDto'
+        LatestPromotion:
+          $ref: '#/ReferenceApiDto'
+        LatestCommit:
+          $ref: '#/ReferenceApiDto'
+        LatestCheckpoint:
+          $ref: '#/ReferenceApiDto'
+        LatestSave:
+          $ref: '#/ReferenceApiDto'
+        ShouldRecomputeLatestReferences:
+          type: boolean
+        CreatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchReturnValue:
+      description: Grace response envelope whose ReturnValue contains a branch.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/BranchApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &branchReturnValueExample
+        ReturnValue:
+          Class: BranchDto
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          BranchName: main
+          ParentBranchId: 00000000-0000-0000-0000-000000000000
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          BasedOn:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          UserId: user:alice
+          AssignEnabled: false
+          PromotionEnabled: true
+          CommitEnabled: true
+          CheckpointEnabled: true
+          SaveEnabled: true
+          TagEnabled: true
+          ExternalEnabled: false
+          AutoRebaseEnabled: true
+          PromotionMode: IndividualOnly
+          LatestReference:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestPromotion:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCommit:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCheckpoint:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestSave:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          ShouldRecomputeLatestReferences: false
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/get
+    ReferenceReturnValue:
+      description: Grace response envelope whose ReturnValue contains a reference.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/ReferenceApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &referenceReturnValueExample
+        ReturnValue:
+          Class: ReferenceDto
+          ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          ReferenceType: Commit
+          ReferenceText: Capture release candidate.
+          CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReference
+    ReferenceListReturnValue:
+      description: Grace response envelope whose ReturnValue contains references.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/ReferenceApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example:
+        ReturnValue:
+          - Class: ReferenceDto
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+            BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+            DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            ReferenceType: Commit
+            ReferenceText: Capture release candidate.
+            CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReferences
+    BranchResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/BranchReturnValue'
+          examples:
+            branch:
+              summary: Branch response envelope
+              value: *branchReturnValueExample
+    ReferenceResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/ReferenceReturnValue'
+          examples:
+            reference:
+              summary: Reference response envelope
+              value: *referenceReturnValueExample
+    ReferenceListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/ReferenceListReturnValue'

--- a/src/OpenAPI/Branch.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Branch.Paths.OpenAPI.yaml
@@ -1,413 +1,409 @@
   /branch/create:
     post:
-      summary: Creates a new branch.
-      description: Creates a new branch with the specified name, based on the specified parent branch.
-      operationId: Create
+      tags:
+        - Branches
+      summary: Create a branch.
+      description: Creates a branch with the specified name, based on the specified parent branch.
+      operationId: CreateBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_13
-                - allOf: &ref_0
-                    - type: object
-                      properties: &ref_10
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    ParentBranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    ParentBranchName:
-                      type: string
-                      example: MyBranch
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateBranchParameters'
+            examples:
+              createBranch:
+                summary: Create a release branch
+                value: &branchCreateExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchName: release-2026-06
+                  ParentBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  InitialPermissions:
+                    - Commit
+                    - Checkpoint
+                    - Save
+                    - Tag
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/rebase:
     post:
-      summary: Rebases a branch on its parent branch.
-      description: Rebases a branch on its parent branch.
-      operationId: Rebase
+      tags:
+        - Branches
+      summary: Rebase a branch.
+      description: Rebases a branch on the specified reference from its parent branch.
+      operationId: RebaseBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_14
-                - allOf: *ref_0
-                - type: object
-                  properties:
-                    BasedOn:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: './Branch.Components.OpenAPI.yaml#/RebaseParameters'
+            examples:
+              rebaseBranch:
+                summary: Rebase a branch to a parent reference
+                value:
+                  <<: *branchCreateExample
+                  BranchName: release-2026-06
+                  BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/promote:
     post:
-      summary: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      description: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      operationId: Promote
+      tags:
+        - Branches
+      summary: Promote the current branch content.
+      description: Creates a promotion reference in the parent of the specified branch, based on the current directory version.
+      operationId: PromoteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_1
-                - allOf: *ref_0
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateReferenceParameters'
+            examples:
+              createReference:
+                summary: Create a branch reference
+                value: &createReferenceExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Capture release candidate.
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/commit:
     post:
-      summary: Creates a commit reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Commit the current branch content.
       description: Creates a commit reference pointing to the current root directory version in the branch.
+      operationId: CommitBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf: *ref_1
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateReferenceParameters'
+            examples:
+              commitBranch:
+                summary: Create a commit reference
+                value:
+                  <<: *createReferenceExample
+                  Message: Commit release candidate.
       responses:
         '200':
-          description: Success
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/checkpoint:
     post:
-      summary: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Checkpoint the current branch content.
       description: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      operationId: CheckpointBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf: *ref_1
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateReferenceParameters'
+            examples:
+              checkpointBranch:
+                summary: Create a checkpoint reference
+                value:
+                  <<: *createReferenceExample
+                  Message: Checkpoint release candidate.
       responses:
         '200':
-          description: Success
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/save:
     post:
-      summary: Creates a save reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Save the current branch content.
       description: Creates a save reference pointing to the current root directory version in the branch.
+      operationId: SaveBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf: *ref_1
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateReferenceParameters'
+            examples:
+              saveBranch:
+                summary: Create a save reference
+                value:
+                  <<: *createReferenceExample
+                  Message: Save release candidate.
       responses:
         '200':
-          description: Success
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/tag:
     post:
-      summary: Creates a tag reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Tag the current branch content.
       description: Creates a tag reference pointing to the current root directory version in the branch.
+      operationId: TagBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf: *ref_1
+              $ref: './Branch.Components.OpenAPI.yaml#/CreateReferenceParameters'
+            examples:
+              tagBranch:
+                summary: Create a tag reference
+                value:
+                  <<: *createReferenceExample
+                  Message: Tag release candidate.
       responses:
         '200':
-          description: Success
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/enablePromotion:
     post:
-      summary: Enables or disables promotion for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable promotion references.
       description: Enables or disables promotion for the specified branch.
-      operationId: EnablePromotion
+      operationId: EnableBranchPromotion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_2
-                - allOf: *ref_0
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: './Branch.Components.OpenAPI.yaml#/EnableFeatureParameters'
+            examples:
+              enableFeature:
+                summary: Enable a branch feature
+                value: &enableFeatureExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/enableCommit:
     post:
-      summary: Enables or disables commit for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable commit references.
       description: Enables or disables commit for the specified branch.
-      operationId: EnableCommit
+      operationId: EnableBranchCommit
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_2
+              $ref: './Branch.Components.OpenAPI.yaml#/EnableFeatureParameters'
+            examples:
+              enableCommit:
+                summary: Enable commit references
+                value: *enableFeatureExample
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/enableCheckpoint:
     post:
-      summary: Enables or disables checkpoint for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable checkpoint references.
       description: Enables or disables checkpoint for the specified branch.
-      operationId: EnableCheckpoint
+      operationId: EnableBranchCheckpoint
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_2
+              $ref: './Branch.Components.OpenAPI.yaml#/EnableFeatureParameters'
+            examples:
+              enableCheckpoint:
+                summary: Enable checkpoint references
+                value: *enableFeatureExample
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/enableSave:
     post:
-      summary: Enables or disables save for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable save references.
       description: Enables or disables save for the specified branch.
-      operationId: EnableSave
+      operationId: EnableBranchSave
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_2
+              $ref: './Branch.Components.OpenAPI.yaml#/EnableFeatureParameters'
+            examples:
+              enableSave:
+                summary: Enable save references
+                value: *enableFeatureExample
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/enableTag:
     post:
-      summary: Enables or disables tag for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable tag references.
       description: Enables or disables tag for the specified branch.
-      operationId: EnableTag
+      operationId: EnableBranchTag
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_2
+              $ref: './Branch.Components.OpenAPI.yaml#/EnableFeatureParameters'
+            examples:
+              enableTag:
+                summary: Enable tag references
+                value: *enableFeatureExample
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/delete:
     post:
-      summary: Deletes the specified branch.
+      tags:
+        - Branches
+      summary: Delete a branch.
       description: Deletes the specified branch.
-      operationId: Delete
+      operationId: DeleteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_15
-                - allOf: *ref_0
+              $ref: './Branch.Components.OpenAPI.yaml#/DeleteBranchParameters'
+            examples:
+              deleteBranch:
+                summary: Delete a branch and reassign child branches
+                value:
+                  <<: *enableFeatureExample
+                  Force: false
+                  DeleteReason: Superseded by release branch.
+                  ReassignChildBranches: true
+                  NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          description: OK
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/get:
     post:
-      summary: Gets the specified branch.
+      tags:
+        - Branches
+      summary: Get a branch.
       description: Gets the specified branch.
-      operationId: Get
+      operationId: GetBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_3
-                - allOf: *ref_0
-                - type: object
-                  properties:
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: './Branch.Components.OpenAPI.yaml#/GetBranchParameters'
+            examples:
+              getBranch:
+                summary: Get a branch by id
+                value: &getBranchExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: &ref_4
-                  Class:
-                    type: string
-                    example: BranchDto
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BranchName:
-                    type: string
-                    example: MyBranch
-                  ParentBranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BasedOn:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  RepositoryId:
-                    type: string
-                    format: uuid
-                    example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                  UserId:
-                    type: string
-                  PromotionEnabled:
-                    type: boolean
-                  CommitEnabled:
-                    type: boolean
-                  CheckpointEnabled:
-                    type: boolean
-                  SaveEnabled:
-                    type: boolean
-                  TagEnabled:
-                    type: boolean
-                  LatestPromotion:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCommit:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCheckpoint:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestSave:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                  UpdatedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                  DeletedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                required: &ref_5
-                  - Class
-                  - BranchId
-                  - BranchName
-                  - ParentBranchId
-                  - BasedOn
-                  - RepositoryId
-                  - UserId
-                  - PromotionEnabled
-                  - CommitEnabled
-                  - CheckpointEnabled
-                  - SaveEnabled
-                  - TagEnabled
-                  - LatestPromotion
-                  - LatestCommit
-                  - LatestCheckpoint
-                  - LatestSave
-                  - CreatedAt
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getParentBranch:
     post:
-      summary: Gets the parent branch of the specified branch.
+      tags:
+        - Branches
+      summary: Get the parent branch.
       description: Gets the parent branch of the specified branch.
       operationId: GetParentBranch
       requestBody:
@@ -415,245 +411,200 @@
         content:
           application/json:
             schema:
-              allOf: *ref_3
+              $ref: './Branch.Components.OpenAPI.yaml#/GetBranchParameters'
+            examples:
+              getParentBranch:
+                summary: Get the parent branch
+                value: *getBranchExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: *ref_4
-                required: *ref_5
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getReference:
     post:
-      summary: Gets the specified reference.
-      description: Gets the specified reference.
-      operationId: GetReference
+      tags:
+        - Branches
+      summary: Get a branch reference.
+      description: Gets the specified reference from the branch.
+      operationId: GetBranchReference
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_17
-                - allOf: *ref_3
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferenceParameters'
+            examples:
+              getReference:
+                summary: Get a reference by id
+                value:
+                  <<: *getBranchExample
+                  ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: &ref_6
-                  Class:
-                    type: string
-                    example: ReferenceDto
-                  ReferenceId:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  DirectoryId:
-                    type: string
-                    format: uuid
-                    example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                  Sha256Hash:
-                    type: string
-                    example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  ReferenceType:
-                    type: string
-                    enum: &ref_9
-                      - Promotion
-                      - Commit
-                      - Checkpoint
-                      - Save
-                      - Tag
-                    example: Commit
-                  ReferenceText:
-                    type: string
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                required: &ref_7
-                  - Class
-                  - ReferenceId
-                  - BranchId
-                  - DirectoryId
-                  - Sha256Hash
-                  - ReferenceType
-                  - ReferenceText
-                  - CreatedAt
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getReferences:
     post:
-      summary: Gets the references for the specified branch.
+      tags:
+        - Branches
+      summary: List branch references.
       description: Gets the references for the specified branch.
-      operationId: GetReferences
+      operationId: ListBranchReferences
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: &ref_8
-                - allOf: *ref_0
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listReferences:
+                summary: List references for a branch
+                value: &listReferencesExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getPromotions:
     post:
-      summary: Gets the promotions for the specified branch.
-      description: Gets the promotions for the specified branch.
-      operationId: GetPromotions
+      tags:
+        - Branches
+      summary: List branch promotions.
+      description: Gets the promotion references for the specified branch.
+      operationId: ListBranchPromotions
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_8
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listPromotions:
+                summary: List promotion references
+                value: *listReferencesExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getCommits:
     post:
-      summary: Gets the commits for the specified branch.
-      description: Gets the commits for the specified branch.
-      operationId: GetCommits
+      tags:
+        - Branches
+      summary: List branch commits.
+      description: Gets the commit references for the specified branch.
+      operationId: ListBranchCommits
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_8
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listCommits:
+                summary: List commit references
+                value: *listReferencesExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getCheckpoints:
     post:
-      summary: Gets the checkpoints for the specified branch.
-      description: Gets the checkpoints for the specified branch.
-      operationId: GetCheckpoints
+      tags:
+        - Branches
+      summary: List branch checkpoints.
+      description: Gets the checkpoint references for the specified branch.
+      operationId: ListBranchCheckpoints
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_8
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listCheckpoints:
+                summary: List checkpoint references
+                value: *listReferencesExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getSaves:
     post:
-      summary: Gets the saves for the specified branch.
-      description: Gets the saves for the specified branch.
-      operationId: GetSaves
+      tags:
+        - Branches
+      summary: List branch saves.
+      description: Gets the save references for the specified branch.
+      operationId: ListBranchSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_8
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listSaves:
+                summary: List save references
+                value: *listReferencesExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /branch/getTags:
     post:
-      summary: Gets the tags for the specified branch.
-      description: Gets the tags for the specified branch.
-      operationId: GetTags
+      tags:
+        - Branches
+      summary: List branch tags.
+      description: Gets the tag references for the specified branch.
+      operationId: ListBranchTags
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf: *ref_8
+              $ref: './Branch.Components.OpenAPI.yaml#/GetReferencesParameters'
+            examples:
+              listTags:
+                summary: List tag references
+                value: *listReferencesExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties: *ref_6
-                  required: *ref_7
+          $ref: './Branch.Components.OpenAPI.yaml#/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: './Responses.OpenAPI.yaml#/400'
         '500':
-          description: Internal Server Error
+          $ref: './Responses.OpenAPI.yaml#/500'

--- a/src/OpenAPI/Branch.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Branch.Paths.OpenAPI.yaml
@@ -29,7 +29,7 @@
                     - Tag
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -57,7 +57,7 @@
                   BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -91,7 +91,7 @@
                   Message: Capture release candidate.
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -118,7 +118,7 @@
                   Message: Commit release candidate.
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -145,7 +145,7 @@
                   Message: Checkpoint release candidate.
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -172,7 +172,7 @@
                   Message: Save release candidate.
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -199,7 +199,7 @@
                   Message: Tag release candidate.
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -231,7 +231,7 @@
                   Enabled: true
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -256,7 +256,7 @@
                 value: *enableFeatureExample
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -281,7 +281,7 @@
                 value: *enableFeatureExample
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -306,7 +306,7 @@
                 value: *enableFeatureExample
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -331,7 +331,7 @@
                 value: *enableFeatureExample
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -361,7 +361,7 @@
                   NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          $ref: './Branch.Components.OpenAPI.yaml#/BranchResponse'
+          $ref: './Branch.Components.OpenAPI.yaml#/BranchCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Diff.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Diff.Components.OpenAPI.yaml
@@ -1,24 +1,29 @@
     DiffParameters:
-      description: Parameters for diff endpoints.
+      description: Parameters shared by public endpoints in the /diff route family.
+      type: object
       allOf:
         - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
         OwnerName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
         OrganizationName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
         RepositoryName:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
-        DirectoryId1:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryId'
-        DirectoryId2:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     PopulateParameters:
       description: Parameters for diff population.
       allOf:
@@ -31,17 +36,125 @@
       description: Parameters for retrieving a diff by reference type.
       allOf:
         - $ref: './Diff.Components.OpenAPI.yaml#/DiffParameters'
-      properties:
-        BranchId:
-          type: string
-        BranchName:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
+        - type: object
+          properties:
+            BranchId:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+            BranchName:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchName'
     GetDiffBySha256HashParameters:
-      description: Parameters for retrieving a diff by SHA256 hash.
+      description: Parameters for retrieving a diff by SHA-256 hash.
       allOf:
         - $ref: './Diff.Components.OpenAPI.yaml#/DiffParameters'
+        - type: object
+          properties:
+            Sha256Hash1:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+            Sha256Hash2:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+    DiffApiDto:
+      description: Public diff DTO returned through diff endpoints.
+      type: object
       properties:
-        Sha256Hash1:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
-        Sha256Hash2:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+        Class:
+          type: string
+          example: DiffDto
+        OwnerId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Directory1CreatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+        Directory2CreatedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        HasDifferences:
+          type: boolean
+        Differences:
+          type: array
+          items:
+            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileSystemDifference'
+        FileDiffs:
+          type: array
+          items:
+            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/FileDiff'
+    DiffReturnValue:
+      description: Grace response envelope whose ReturnValue contains a diff.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: './Diff.Components.OpenAPI.yaml#/DiffApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &diffReturnValueExample
+        ReturnValue:
+          Class: DiffDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          HasDifferences: true
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Directory1CreatedAt: '2026-06-04T18:14:00Z'
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+          Directory2CreatedAt: '2026-06-04T18:15:00Z'
+          Differences: []
+          FileDiffs: []
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DiffPopulateReturnValue:
+      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example:
+        ReturnValue: true
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DiffResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './Diff.Components.OpenAPI.yaml#/DiffReturnValue'
+          examples:
+            diff:
+              summary: Diff response envelope
+              value: *diffReturnValueExample
+    DiffPopulateResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './Diff.Components.OpenAPI.yaml#/DiffPopulateReturnValue'

--- a/src/OpenAPI/Diff.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Diff.Components.OpenAPI.yaml
@@ -121,11 +121,12 @@
           DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
           DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     DiffPopulateReturnValue:
-      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      description: Grace response envelope returned when the diff actor is populated.
       type: object
       properties:
         ReturnValue:
-          type: boolean
+          type: string
+          example: 'DiffActor.Compute: populated.'
         EventTime:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
         CorrelationId:
@@ -136,7 +137,7 @@
             type: string
       required: [ReturnValue, EventTime, CorrelationId, Properties]
       example:
-        ReturnValue: true
+        ReturnValue: 'DiffActor.Compute: populated.'
         EventTime: '2026-06-04T18:15:00Z'
         CorrelationId: cli-20260604T181500Z-0001
         Properties:

--- a/src/OpenAPI/Diff.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Diff.Paths.OpenAPI.yaml
@@ -1,23 +1,32 @@
   /diff/populate:
     post:
-      summary: Populates the diff actor without returning the diff.
+      tags:
+        - Diffs
+      summary: Populate a diff actor.
       description: |
-        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff through reacting to an event.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff
+        through reacting to an event.
+      operationId: PopulateDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Diff.Components.OpenAPI.yaml#/PopulateParameters
+              $ref: './Diff.Components.OpenAPI.yaml#/PopulateParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value: &diffByDirectoryVersionExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Diff.Components.OpenAPI.yaml#/DiffPopulateResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -25,24 +34,24 @@
 
   /diff/getDiff:
     post:
-      summary: Retrieves the contents of the diff.
-      description: |
-        Retrieves the contents of the diff between two directories.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff.
+      description: Retrieves the contents of the diff between two directory versions.
+      operationId: GetDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Diff.Components.OpenAPI.yaml#/GetDiffParameters
+              $ref: './Diff.Components.OpenAPI.yaml#/GetDiffParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value: *diffByDirectoryVersionExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Diff.Components.OpenAPI.yaml#/DiffResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -50,24 +59,27 @@
 
   /diff/getDiffBySha256Hash:
     post:
-      summary: Retrieves a diff taken by comparing two DirectoryVersions by Sha256Hash.
-      description: |
-        Retrieves a diff taken by comparing two DirectoryVersions identified by their SHA-256 hash.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff by SHA-256 hash.
+      description: Retrieves a diff by comparing two directory versions identified by SHA-256 hash.
+      operationId: GetDiffBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Diff.Components.OpenAPI.yaml#/GetDiffBySha256HashParameters
+              $ref: './Diff.Components.OpenAPI.yaml#/GetDiffBySha256HashParameters'
+            examples:
+              bySha256Hash:
+                summary: Compare two directory versions by hash
+                value:
+                  <<: *diffByDirectoryVersionExample
+                  Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Diff.Components.OpenAPI.yaml#/DiffResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Diff.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Diff.Paths.OpenAPI.yaml
@@ -76,7 +76,7 @@
                 value:
                   <<: *diffByDirectoryVersionExample
                   Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857240
       responses:
         '200':
           $ref: './Diff.Components.OpenAPI.yaml#/DiffResponse'

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -1341,7 +1341,7 @@ paths:
                   DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
                   DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
                   Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857240
       responses:
         '200':
           $ref: '#/components/responses/DiffResponse'

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -569,7 +569,7 @@ paths:
                     - Tag
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -606,7 +606,7 @@ paths:
                   BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -639,7 +639,7 @@ paths:
                   Message: Capture release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -672,7 +672,7 @@ paths:
                   Message: Commit release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -705,7 +705,7 @@ paths:
                   Message: Checkpoint release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -738,7 +738,7 @@ paths:
                   Message: Save release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -771,7 +771,7 @@ paths:
                   Message: Tag release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -802,7 +802,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -833,7 +833,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -864,7 +864,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -895,7 +895,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -926,7 +926,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -961,7 +961,7 @@ paths:
                   NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -4781,6 +4781,32 @@ components:
         - RetryScheduled
         - Failed
         - DeadLettered
+    BranchCommandReturnValue:
+      description: Grace response envelope returned by branch command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Branch command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Branch command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/create
     ReferenceApiDto:
       description: Public reference DTO returned through branch reference endpoints.
       type: object
@@ -5013,11 +5039,12 @@ components:
         Properties:
           Path: /branch/getReferences
     DiffPopulateReturnValue:
-      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      description: Grace response envelope returned when the diff actor is populated.
       type: object
       properties:
         ReturnValue:
-          type: boolean
+          type: string
+          example: 'DiffActor.Compute: populated.'
         EventTime:
           $ref: '#/components/schemas/Instant'
         CorrelationId:
@@ -5032,7 +5059,7 @@ components:
         - CorrelationId
         - Properties
       example:
-        ReturnValue: true
+        ReturnValue: 'DiffActor.Compute: populated.'
         EventTime: '2026-06-04T18:15:00Z'
         CorrelationId: cli-20260604T181500Z-0001
         Properties:
@@ -5964,6 +5991,21 @@ components:
                     type: array
                     items:
                       $ref: '#/components/schemas/WebhookDelivery'
+    BranchCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BranchCommandReturnValue'
+          examples:
+            branchCommand:
+              summary: Branch command response envelope
+              value:
+                ReturnValue: Branch command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/create
     BranchResponse:
       description: OK
       content:

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -540,924 +540,468 @@ paths:
           $ref: '#/components/responses/500'
   /branch/create:
     post:
-      summary: Creates a new branch.
-      description: Creates a new branch with the specified name, based on the specified parent branch.
-      operationId: Create
+      tags:
+        - Branches
+      summary: Create a branch.
+      description: Creates a branch with the specified name, based on the specified parent branch.
+      operationId: CreateBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    ParentBranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    ParentBranchName:
-                      type: string
-                      example: MyBranch
+              $ref: '#/components/schemas/CreateBranchParameters'
+            examples:
+              createBranch:
+                summary: Create a release branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchName: release-2026-06
+                  ParentBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  InitialPermissions:
+                    - Commit
+                    - Checkpoint
+                    - Save
+                    - Tag
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/rebase:
     post:
-      summary: Rebases a branch on its parent branch.
-      description: Rebases a branch on its parent branch.
-      operationId: Rebase
+      tags:
+        - Branches
+      summary: Rebase a branch.
+      description: Rebases a branch on the specified reference from its parent branch.
+      operationId: RebaseBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    BasedOn:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/RebaseParameters'
+            examples:
+              rebaseBranch:
+                summary: Rebase a branch to a parent reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchName: release-2026-06
+                  ParentBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  InitialPermissions:
+                    - Commit
+                    - Checkpoint
+                    - Save
+                    - Tag
+                  BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/promote:
     post:
-      summary: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      description: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      operationId: Promote
+      tags:
+        - Branches
+      summary: Promote the current branch content.
+      description: Creates a promotion reference in the parent of the specified branch, based on the current directory version.
+      operationId: PromoteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              createReference:
+                summary: Create a branch reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Capture release candidate.
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/commit:
     post:
-      summary: Creates a commit reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Commit the current branch content.
       description: Creates a commit reference pointing to the current root directory version in the branch.
+      operationId: CommitBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              commitBranch:
+                summary: Create a commit reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Commit release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/checkpoint:
     post:
-      summary: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Checkpoint the current branch content.
       description: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      operationId: CheckpointBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              checkpointBranch:
+                summary: Create a checkpoint reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Checkpoint release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/save:
     post:
-      summary: Creates a save reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Save the current branch content.
       description: Creates a save reference pointing to the current root directory version in the branch.
+      operationId: SaveBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              saveBranch:
+                summary: Create a save reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Save release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/tag:
     post:
-      summary: Creates a tag reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Tag the current branch content.
       description: Creates a tag reference pointing to the current root directory version in the branch.
+      operationId: TagBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              tagBranch:
+                summary: Create a tag reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Tag release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/enablePromotion:
     post:
-      summary: Enables or disables promotion for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable promotion references.
       description: Enables or disables promotion for the specified branch.
-      operationId: EnablePromotion
+      operationId: EnableBranchPromotion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableFeature:
+                summary: Enable a branch feature
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableCommit:
     post:
-      summary: Enables or disables commit for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable commit references.
       description: Enables or disables commit for the specified branch.
-      operationId: EnableCommit
+      operationId: EnableBranchCommit
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableCommit:
+                summary: Enable commit references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableCheckpoint:
     post:
-      summary: Enables or disables checkpoint for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable checkpoint references.
       description: Enables or disables checkpoint for the specified branch.
-      operationId: EnableCheckpoint
+      operationId: EnableBranchCheckpoint
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableCheckpoint:
+                summary: Enable checkpoint references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableSave:
     post:
-      summary: Enables or disables save for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable save references.
       description: Enables or disables save for the specified branch.
-      operationId: EnableSave
+      operationId: EnableBranchSave
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableSave:
+                summary: Enable save references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableTag:
     post:
-      summary: Enables or disables tag for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable tag references.
       description: Enables or disables tag for the specified branch.
-      operationId: EnableTag
+      operationId: EnableBranchTag
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableTag:
+                summary: Enable tag references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/delete:
     post:
-      summary: Deletes the specified branch.
+      tags:
+        - Branches
+      summary: Delete a branch.
       description: Deletes the specified branch.
-      operationId: Delete
+      operationId: DeleteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
+              $ref: '#/components/schemas/DeleteBranchParameters'
+            examples:
+              deleteBranch:
+                summary: Delete a branch and reassign child branches
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
+                  Force: false
+                  DeleteReason: Superseded by release branch.
+                  ReassignChildBranches: true
+                  NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/get:
     post:
-      summary: Gets the specified branch.
+      tags:
+        - Branches
+      summary: Get a branch.
       description: Gets the specified branch.
-      operationId: Get
+      operationId: GetBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetBranchParameters'
+            examples:
+              getBranch:
+                summary: Get a branch by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: BranchDto
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BranchName:
-                    type: string
-                    example: MyBranch
-                  ParentBranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BasedOn:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  RepositoryId:
-                    type: string
-                    format: uuid
-                    example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                  UserId:
-                    type: string
-                  PromotionEnabled:
-                    type: boolean
-                  CommitEnabled:
-                    type: boolean
-                  CheckpointEnabled:
-                    type: boolean
-                  SaveEnabled:
-                    type: boolean
-                  TagEnabled:
-                    type: boolean
-                  LatestPromotion:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCommit:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCheckpoint:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestSave:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                  UpdatedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                  DeletedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                required:
-                  - Class
-                  - BranchId
-                  - BranchName
-                  - ParentBranchId
-                  - BasedOn
-                  - RepositoryId
-                  - UserId
-                  - PromotionEnabled
-                  - CommitEnabled
-                  - CheckpointEnabled
-                  - SaveEnabled
-                  - TagEnabled
-                  - LatestPromotion
-                  - LatestCommit
-                  - LatestCheckpoint
-                  - LatestSave
-                  - CreatedAt
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getParentBranch:
     post:
-      summary: Gets the parent branch of the specified branch.
+      tags:
+        - Branches
+      summary: Get the parent branch.
       description: Gets the parent branch of the specified branch.
       operationId: GetParentBranch
       requestBody:
@@ -1465,961 +1009,342 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetBranchParameters'
+            examples:
+              getParentBranch:
+                summary: Get the parent branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: BranchDto
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BranchName:
-                    type: string
-                    example: MyBranch
-                  ParentBranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BasedOn:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  RepositoryId:
-                    type: string
-                    format: uuid
-                    example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                  UserId:
-                    type: string
-                  PromotionEnabled:
-                    type: boolean
-                  CommitEnabled:
-                    type: boolean
-                  CheckpointEnabled:
-                    type: boolean
-                  SaveEnabled:
-                    type: boolean
-                  TagEnabled:
-                    type: boolean
-                  LatestPromotion:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCommit:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCheckpoint:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestSave:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                  UpdatedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                  DeletedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                required:
-                  - Class
-                  - BranchId
-                  - BranchName
-                  - ParentBranchId
-                  - BasedOn
-                  - RepositoryId
-                  - UserId
-                  - PromotionEnabled
-                  - CommitEnabled
-                  - CheckpointEnabled
-                  - SaveEnabled
-                  - TagEnabled
-                  - LatestPromotion
-                  - LatestCommit
-                  - LatestCheckpoint
-                  - LatestSave
-                  - CreatedAt
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getReference:
     post:
-      summary: Gets the specified reference.
-      description: Gets the specified reference.
-      operationId: GetReference
+      tags:
+        - Branches
+      summary: Get a branch reference.
+      description: Gets the specified reference from the branch.
+      operationId: GetBranchReference
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - allOf:
-                        - type: object
-                          properties:
-                            CorrelationId:
-                              type: string
-                              description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                            Principal:
-                              type: string
-                        - type: object
-                          properties:
-                            BranchId:
-                              type: string
-                              format: uuid
-                              example: de7bf47d-23ae-4599-af68-68a317ea390d
-                            BranchName:
-                              type: string
-                              example: MyBranch
-                            OwnerId:
-                              type: string
-                              format: uuid
-                              example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                            OwnerName:
-                              type: string
-                            OrganizationId:
-                              type: string
-                              format: uuid
-                              example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                            OrganizationName:
-                              type: string
-                            RepositoryId:
-                              type: string
-                              format: uuid
-                              example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                            RepositoryName:
-                              type: string
-                    - type: object
-                      properties:
-                        Sha256Hash:
-                          type: string
-                          example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                        ReferenceId:
-                          type: string
-                          format: uuid
-                          example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetReferenceParameters'
+            examples:
+              getReference:
+                summary: Get a reference by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
+                  ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: ReferenceDto
-                  ReferenceId:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  DirectoryId:
-                    type: string
-                    format: uuid
-                    example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                  Sha256Hash:
-                    type: string
-                    example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  ReferenceType:
-                    type: string
-                    enum:
-                      - Promotion
-                      - Commit
-                      - Checkpoint
-                      - Save
-                      - Tag
-                    example: Commit
-                  ReferenceText:
-                    type: string
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                required:
-                  - Class
-                  - ReferenceId
-                  - BranchId
-                  - DirectoryId
-                  - Sha256Hash
-                  - ReferenceType
-                  - ReferenceText
-                  - CreatedAt
+          $ref: '#/components/responses/ReferenceResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getReferences:
     post:
-      summary: Gets the references for the specified branch.
+      tags:
+        - Branches
+      summary: List branch references.
       description: Gets the references for the specified branch.
-      operationId: GetReferences
+      operationId: ListBranchReferences
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listReferences:
+                summary: List references for a branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getPromotions:
     post:
-      summary: Gets the promotions for the specified branch.
-      description: Gets the promotions for the specified branch.
-      operationId: GetPromotions
+      tags:
+        - Branches
+      summary: List branch promotions.
+      description: Gets the promotion references for the specified branch.
+      operationId: ListBranchPromotions
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listPromotions:
+                summary: List promotion references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getCommits:
     post:
-      summary: Gets the commits for the specified branch.
-      description: Gets the commits for the specified branch.
-      operationId: GetCommits
+      tags:
+        - Branches
+      summary: List branch commits.
+      description: Gets the commit references for the specified branch.
+      operationId: ListBranchCommits
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listCommits:
+                summary: List commit references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getCheckpoints:
     post:
-      summary: Gets the checkpoints for the specified branch.
-      description: Gets the checkpoints for the specified branch.
-      operationId: GetCheckpoints
+      tags:
+        - Branches
+      summary: List branch checkpoints.
+      description: Gets the checkpoint references for the specified branch.
+      operationId: ListBranchCheckpoints
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listCheckpoints:
+                summary: List checkpoint references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getSaves:
     post:
-      summary: Gets the saves for the specified branch.
-      description: Gets the saves for the specified branch.
-      operationId: GetSaves
+      tags:
+        - Branches
+      summary: List branch saves.
+      description: Gets the save references for the specified branch.
+      operationId: ListBranchSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listSaves:
+                summary: List save references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getTags:
     post:
-      summary: Gets the tags for the specified branch.
-      description: Gets the tags for the specified branch.
-      operationId: GetTags
+      tags:
+        - Branches
+      summary: List branch tags.
+      description: Gets the tag references for the specified branch.
+      operationId: ListBranchTags
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listTags:
+                summary: List tag references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /diff/populate:
     post:
-      summary: Populates the diff actor without returning the diff.
+      tags:
+        - Diffs
+      summary: Populate a diff actor.
       description: |
-        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff through reacting to an event.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff
+        through reacting to an event.
+      operationId: PopulateDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PopulateParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffPopulateResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /diff/getDiff:
     post:
-      summary: Retrieves the contents of the diff.
-      description: |
-        Retrieves the contents of the diff between two directories.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff.
+      description: Retrieves the contents of the diff between two directory versions.
+      operationId: GetDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetDiffParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /diff/getDiffBySha256Hash:
     post:
-      summary: Retrieves a diff taken by comparing two DirectoryVersions by Sha256Hash.
-      description: |
-        Retrieves a diff taken by comparing two DirectoryVersions identified by their SHA-256 hash.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff by SHA-256 hash.
+      description: Retrieves a diff by comparing two directory versions identified by SHA-256 hash.
+      operationId: GetDiffBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetDiffBySha256HashParameters'
+            examples:
+              bySha256Hash:
+                summary: Compare two directory versions by hash
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+                  Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3881,12 +2806,6 @@ paths:
           $ref: '#/components/responses/500'
 components:
   schemas:
-    '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GraceReturnValue'
     ApprovalPolicyParameters:
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
@@ -4309,123 +3228,172 @@ components:
         CreatedAt:
           $ref: '#/components/schemas/Instant'
     BranchParameters:
-      description: Parameters for many endpoints in the /branch path.
+      description: Parameters shared by public endpoints in the /branch route family.
       type: object
+      allOf:
+        - $ref: '#/components/schemas/CommonParameters'
       properties:
-        ownerId:
-          type: string
-        ownerName:
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OwnerName:
           $ref: '#/components/schemas/OwnerName'
-        organizationId:
-          type: string
-        organizationName:
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        OrganizationName:
           $ref: '#/components/schemas/OrganizationName'
-        repositoryId:
-          type: string
-        repositoryName:
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
           $ref: '#/components/schemas/RepositoryName'
-        branchId:
-          type: string
-        branchName:
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        BranchName:
           $ref: '#/components/schemas/BranchName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
     BranchQueryParameters:
-      description: Base class for parameters for branch queries.
+      description: Parameters for branch query endpoints that can resolve a branch or reference by hash or reference id.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            sha256Hash:
+            Sha256Hash:
               $ref: '#/components/schemas/Sha256Hash'
-            referenceId:
-              type: string
+            ReferenceId:
+              $ref: '#/components/schemas/ReferenceId'
     CreateBranchParameters:
       description: Parameters for the /branch/create endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            parentBranchId:
-              type: string
-            parentBranchName:
+            ParentBranchId:
+              $ref: '#/components/schemas/BranchId'
+            ParentBranchName:
               $ref: '#/components/schemas/BranchName'
+            InitialPermissions:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReferenceType'
     RebaseParameters:
       description: Parameters for the /branch/rebase endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            basedOn:
+            BasedOn:
               $ref: '#/components/schemas/ReferenceId'
     CreateReferenceParameters:
-      description: Parameters for the various /branch/create[reference] endpoints.
+      description: Parameters for /branch/promote, /branch/commit, /branch/checkpoint, /branch/save, and /branch/tag.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            directoryId:
-              $ref: '#/components/schemas/DirectoryId'
-            sha256Hash:
-              $ref: '#/components/schemas/Sha256Hash'
-            message:
+            DirectoryVersionId:
               type: string
+              format: uuid
+              example: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash:
+              $ref: '#/components/schemas/Sha256Hash'
+            Message:
+              type: string
+              example: Capture release candidate.
     SetBranchNameParameters:
       description: Parameters for the /branch/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            newName:
+            NewName:
               type: string
+              example: ReleaseCandidate
     EnableFeatureParameters:
-      description: Parameters for the various /branch/enable[feature] endpoints.
+      description: Parameters for branch feature-toggle endpoints.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            enabled:
+            Enabled:
               type: boolean
+              example: true
     DeleteBranchParameters:
       description: Parameters for the /branch/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Superseded by release branch.
+            ReassignChildBranches:
+              type: boolean
+              example: true
+            NewParentBranchId:
+              $ref: '#/components/schemas/BranchId'
+            NewParentBranchName:
+              $ref: '#/components/schemas/BranchName'
     GetReferenceParameters:
       description: Parameters for the /branch/getReference endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
     GetReferencesParameters:
-      description: Parameters for the /branch/getReferences and /branch/get[reference] endpoints.
+      description: Parameters for /branch/getReferences and reference-type list endpoints.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            fullSha:
+            FullSha:
               type: boolean
-            maxCount:
+              example: false
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferenceTypeParameters:
       description: Parameters for the /branch/getDiffsForReferenceType endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            referenceType:
-              type: string
-            maxCount:
+            ReferenceType:
+              $ref: '#/components/schemas/ReferenceType'
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferencesParameters:
       description: Parameters for the /branch/getDiffsForReferences endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            references:
+            References:
               type: string
-            maxCount:
+              description: Comma-separated reference identifiers for diff lookup.
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetBranchParameters:
       description: Parameters for the /branch/get endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     SwitchParameters:
       description: Parameters for the /branch/switch endpoint.
       allOf:
@@ -4434,27 +3402,37 @@ components:
       description: Parameters for the /branch/getVersion endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     DiffParameters:
-      description: Parameters for diff endpoints.
+      description: Parameters shared by public endpoints in the /diff route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
           $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
           $ref: '#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: '#/components/schemas/RepositoryId'
         RepositoryName:
           $ref: '#/components/schemas/RepositoryName'
-        DirectoryId1:
-          $ref: '#/components/schemas/DirectoryId'
-        DirectoryId2:
-          $ref: '#/components/schemas/DirectoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     PopulateParameters:
       description: Parameters for diff population.
       allOf:
@@ -4467,20 +3445,22 @@ components:
       description: Parameters for retrieving a diff by reference type.
       allOf:
         - $ref: '#/components/schemas/DiffParameters'
-      properties:
-        BranchId:
-          type: string
-        BranchName:
-          $ref: '#/components/schemas/BranchName'
+        - type: object
+          properties:
+            BranchId:
+              $ref: '#/components/schemas/BranchId'
+            BranchName:
+              $ref: '#/components/schemas/BranchName'
     GetDiffBySha256HashParameters:
-      description: Parameters for retrieving a diff by SHA256 hash.
+      description: Parameters for retrieving a diff by SHA-256 hash.
       allOf:
         - $ref: '#/components/schemas/DiffParameters'
-      properties:
-        Sha256Hash1:
-          $ref: '#/components/schemas/Sha256Hash'
-        Sha256Hash2:
-          $ref: '#/components/schemas/Sha256Hash'
+        - type: object
+          properties:
+            Sha256Hash1:
+              $ref: '#/components/schemas/Sha256Hash'
+            Sha256Hash2:
+              $ref: '#/components/schemas/Sha256Hash'
     DirectoryParameters:
       description: Parameters for many endpoints in the /directory path.
       type: object
@@ -4870,23 +3850,28 @@ components:
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
     ReferenceParameters:
-      description: Parameters for many endpoints in the /reference path.
+      description: Public reference identity fields used when a route accepts or returns reference selectors.
       type: object
-      properties:
-        ReferenceId:
-          type: string
-          description: Unique identifier of the reference.
-        ReferenceType:
-          type: string
-          description: Type of the reference.
-        RepositoryText:
-          type: string
-          description: Textual representation of the repository.
-        RepositoryName:
-          type: string
-          description: Name of the repository.
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
+      properties:
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
+        ReferenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: '#/components/schemas/ReferenceText'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+        ReferenceType: Commit
+        ReferenceText: Capture release candidate.
     RepositoryParameters:
       description: Parameters for many endpoints in the /repository path.
       type: object
@@ -5796,6 +4781,335 @@ components:
         - RetryScheduled
         - Failed
         - DeadLettered
+    ReferenceApiDto:
+      description: Public reference DTO returned through branch reference endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: ReferenceDto
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        DirectoryId:
+          type: string
+          format: uuid
+          description: DirectoryVersionId represented by the current server DTO field name.
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Sha256Hash:
+          $ref: '#/components/schemas/Sha256Hash'
+        ReferenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: '#/components/schemas/ReferenceText'
+        Links:
+          type: array
+          items:
+            type: string
+        CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchApiDto:
+      description: Public branch DTO returned through branch endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: BranchDto
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        BranchName:
+          $ref: '#/components/schemas/BranchName'
+        ParentBranchId:
+          $ref: '#/components/schemas/BranchId'
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        BasedOn:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        UserId:
+          $ref: '#/components/schemas/UserId'
+        AssignEnabled:
+          type: boolean
+        PromotionEnabled:
+          type: boolean
+        CommitEnabled:
+          type: boolean
+        CheckpointEnabled:
+          type: boolean
+        SaveEnabled:
+          type: boolean
+        TagEnabled:
+          type: boolean
+        ExternalEnabled:
+          type: boolean
+        AutoRebaseEnabled:
+          type: boolean
+        PromotionMode:
+          type: string
+          example: IndividualOnly
+        LatestReference:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestPromotion:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestCommit:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestCheckpoint:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestSave:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        ShouldRecomputeLatestReferences:
+          type: boolean
+        CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchReturnValue:
+      description: Grace response envelope whose ReturnValue contains a branch.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/BranchApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: BranchDto
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          BranchName: main
+          ParentBranchId: 00000000-0000-0000-0000-000000000000
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          BasedOn:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          UserId: user:alice
+          AssignEnabled: false
+          PromotionEnabled: true
+          CommitEnabled: true
+          CheckpointEnabled: true
+          SaveEnabled: true
+          TagEnabled: true
+          ExternalEnabled: false
+          AutoRebaseEnabled: true
+          PromotionMode: IndividualOnly
+          LatestReference:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestPromotion:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCommit:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCheckpoint:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestSave:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          ShouldRecomputeLatestReferences: false
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/get
+    ReferenceReturnValue:
+      description: Grace response envelope whose ReturnValue contains a reference.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: ReferenceDto
+          ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          ReferenceType: Commit
+          ReferenceText: Capture release candidate.
+          CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReference
+    ReferenceListReturnValue:
+      description: Grace response envelope whose ReturnValue contains references.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          - Class: ReferenceDto
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+            BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+            DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            ReferenceType: Commit
+            ReferenceText: Capture release candidate.
+            CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReferences
+    DiffPopulateReturnValue:
+      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: true
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DiffApiDto:
+      description: Public diff DTO returned through diff endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: DiffDto
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Directory1CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+        Directory2CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        HasDifferences:
+          type: boolean
+        Differences:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileSystemDifference'
+        FileDiffs:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileDiff'
+    DiffReturnValue:
+      description: Grace response envelope whose ReturnValue contains a diff.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/DiffApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: DiffDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          HasDifferences: true
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Directory1CreatedAt: '2026-06-04T18:14:00Z'
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+          Directory2CreatedAt: '2026-06-04T18:15:00Z'
+          Differences: []
+          FileDiffs: []
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     GraceReturnValueBase:
       description: Common metadata returned with successful Grace responses.
       type: object
@@ -6650,3 +5964,112 @@ components:
                     type: array
                     items:
                       $ref: '#/components/schemas/WebhookDelivery'
+    BranchResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BranchReturnValue'
+          examples:
+            branch:
+              summary: Branch response envelope
+              value:
+                ReturnValue:
+                  Class: BranchDto
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  BranchName: main
+                  ParentBranchId: 00000000-0000-0000-0000-000000000000
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BasedOn:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  UserId: user:alice
+                  AssignEnabled: false
+                  PromotionEnabled: true
+                  CommitEnabled: true
+                  CheckpointEnabled: true
+                  SaveEnabled: true
+                  TagEnabled: true
+                  ExternalEnabled: false
+                  AutoRebaseEnabled: true
+                  PromotionMode: IndividualOnly
+                  LatestReference:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestPromotion:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestCommit:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestCheckpoint:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestSave:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  ShouldRecomputeLatestReferences: false
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/get
+    ReferenceResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceReturnValue'
+          examples:
+            reference:
+              summary: Reference response envelope
+              value:
+                ReturnValue:
+                  Class: ReferenceDto
+                  ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  ReferenceType: Commit
+                  ReferenceText: Capture release candidate.
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/getReference
+    ReferenceListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceListReturnValue'
+    DiffPopulateResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DiffPopulateReturnValue'
+    DiffResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DiffReturnValue'
+          examples:
+            diff:
+              summary: Diff response envelope
+              value:
+                ReturnValue:
+                  Class: DiffDto
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  HasDifferences: true
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Directory1CreatedAt: '2026-06-04T18:14:00Z'
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+                  Directory2CreatedAt: '2026-06-04T18:15:00Z'
+                  Differences: []
+                  FileDiffs: []
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -1341,7 +1341,7 @@ paths:
                   DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
                   DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
                   Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857240
       responses:
         '200':
           $ref: '#/components/responses/DiffResponse'

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -569,7 +569,7 @@ paths:
                     - Tag
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -606,7 +606,7 @@ paths:
                   BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -639,7 +639,7 @@ paths:
                   Message: Capture release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -672,7 +672,7 @@ paths:
                   Message: Commit release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -705,7 +705,7 @@ paths:
                   Message: Checkpoint release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -738,7 +738,7 @@ paths:
                   Message: Save release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -771,7 +771,7 @@ paths:
                   Message: Tag release candidate.
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -802,7 +802,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -833,7 +833,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -864,7 +864,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -895,7 +895,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -926,7 +926,7 @@ paths:
                   Enabled: true
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -961,7 +961,7 @@ paths:
                   NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          $ref: '#/components/responses/BranchResponse'
+          $ref: '#/components/responses/BranchCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -4781,6 +4781,32 @@ components:
         - RetryScheduled
         - Failed
         - DeadLettered
+    BranchCommandReturnValue:
+      description: Grace response envelope returned by branch command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Branch command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Branch command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/create
     ReferenceApiDto:
       description: Public reference DTO returned through branch reference endpoints.
       type: object
@@ -5013,11 +5039,12 @@ components:
         Properties:
           Path: /branch/getReferences
     DiffPopulateReturnValue:
-      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      description: Grace response envelope returned when the diff actor is populated.
       type: object
       properties:
         ReturnValue:
-          type: boolean
+          type: string
+          example: 'DiffActor.Compute: populated.'
         EventTime:
           $ref: '#/components/schemas/Instant'
         CorrelationId:
@@ -5032,7 +5059,7 @@ components:
         - CorrelationId
         - Properties
       example:
-        ReturnValue: true
+        ReturnValue: 'DiffActor.Compute: populated.'
         EventTime: '2026-06-04T18:15:00Z'
         CorrelationId: cli-20260604T181500Z-0001
         Properties:
@@ -5964,6 +5991,21 @@ components:
                     type: array
                     items:
                       $ref: '#/components/schemas/WebhookDelivery'
+    BranchCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BranchCommandReturnValue'
+          examples:
+            branchCommand:
+              summary: Branch command response envelope
+              value:
+                ReturnValue: Branch command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/create
     BranchResponse:
       description: OK
       content:

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -540,924 +540,468 @@ paths:
           $ref: '#/components/responses/500'
   /branch/create:
     post:
-      summary: Creates a new branch.
-      description: Creates a new branch with the specified name, based on the specified parent branch.
-      operationId: Create
+      tags:
+        - Branches
+      summary: Create a branch.
+      description: Creates a branch with the specified name, based on the specified parent branch.
+      operationId: CreateBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    ParentBranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    ParentBranchName:
-                      type: string
-                      example: MyBranch
+              $ref: '#/components/schemas/CreateBranchParameters'
+            examples:
+              createBranch:
+                summary: Create a release branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchName: release-2026-06
+                  ParentBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  InitialPermissions:
+                    - Commit
+                    - Checkpoint
+                    - Save
+                    - Tag
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/rebase:
     post:
-      summary: Rebases a branch on its parent branch.
-      description: Rebases a branch on its parent branch.
-      operationId: Rebase
+      tags:
+        - Branches
+      summary: Rebase a branch.
+      description: Rebases a branch on the specified reference from its parent branch.
+      operationId: RebaseBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    BasedOn:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/RebaseParameters'
+            examples:
+              rebaseBranch:
+                summary: Rebase a branch to a parent reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchName: release-2026-06
+                  ParentBranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  InitialPermissions:
+                    - Commit
+                    - Checkpoint
+                    - Save
+                    - Tag
+                  BasedOn: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/promote:
     post:
-      summary: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      description: Creates a promotion reference in the parent of the specified branch, based on the most-recent commit.
-      operationId: Promote
+      tags:
+        - Branches
+      summary: Promote the current branch content.
+      description: Creates a promotion reference in the parent of the specified branch, based on the current directory version.
+      operationId: PromoteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              createReference:
+                summary: Create a branch reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Capture release candidate.
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/commit:
     post:
-      summary: Creates a commit reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Commit the current branch content.
       description: Creates a commit reference pointing to the current root directory version in the branch.
+      operationId: CommitBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              commitBranch:
+                summary: Create a commit reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Commit release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/checkpoint:
     post:
-      summary: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Checkpoint the current branch content.
       description: Creates a checkpoint reference pointing to the current root directory version in the branch.
+      operationId: CheckpointBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              checkpointBranch:
+                summary: Create a checkpoint reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Checkpoint release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/save:
     post:
-      summary: Creates a save reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Save the current branch content.
       description: Creates a save reference pointing to the current root directory version in the branch.
+      operationId: SaveBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              saveBranch:
+                summary: Create a save reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Save release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/tag:
     post:
-      summary: Creates a tag reference pointing to the current root directory version in the branch.
+      tags:
+        - Branches
+      summary: Tag the current branch content.
       description: Creates a tag reference pointing to the current root directory version in the branch.
+      operationId: TagBranch
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    Message:
-                      type: string
+              $ref: '#/components/schemas/CreateReferenceParameters'
+            examples:
+              tagBranch:
+                summary: Create a tag reference
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Message: Tag release candidate.
       responses:
         '200':
-          description: Success
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Server Error
+          $ref: '#/components/responses/500'
   /branch/enablePromotion:
     post:
-      summary: Enables or disables promotion for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable promotion references.
       description: Enables or disables promotion for the specified branch.
-      operationId: EnablePromotion
+      operationId: EnableBranchPromotion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableFeature:
+                summary: Enable a branch feature
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableCommit:
     post:
-      summary: Enables or disables commit for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable commit references.
       description: Enables or disables commit for the specified branch.
-      operationId: EnableCommit
+      operationId: EnableBranchCommit
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableCommit:
+                summary: Enable commit references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableCheckpoint:
     post:
-      summary: Enables or disables checkpoint for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable checkpoint references.
       description: Enables or disables checkpoint for the specified branch.
-      operationId: EnableCheckpoint
+      operationId: EnableBranchCheckpoint
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableCheckpoint:
+                summary: Enable checkpoint references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableSave:
     post:
-      summary: Enables or disables save for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable save references.
       description: Enables or disables save for the specified branch.
-      operationId: EnableSave
+      operationId: EnableBranchSave
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableSave:
+                summary: Enable save references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/enableTag:
     post:
-      summary: Enables or disables tag for the specified branch.
+      tags:
+        - Branches
+      summary: Enable or disable tag references.
       description: Enables or disables tag for the specified branch.
-      operationId: EnableTag
+      operationId: EnableBranchTag
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Enabled:
-                      type: boolean
+              $ref: '#/components/schemas/EnableFeatureParameters'
+            examples:
+              enableTag:
+                summary: Enable tag references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/delete:
     post:
-      summary: Deletes the specified branch.
+      tags:
+        - Branches
+      summary: Delete a branch.
       description: Deletes the specified branch.
-      operationId: Delete
+      operationId: DeleteBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
+              $ref: '#/components/schemas/DeleteBranchParameters'
+            examples:
+              deleteBranch:
+                summary: Delete a branch and reassign child branches
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  Enabled: true
+                  Force: false
+                  DeleteReason: Superseded by release branch.
+                  ReassignChildBranches: true
+                  NewParentBranchId: 11111111-1111-1111-1111-111111111111
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/get:
     post:
-      summary: Gets the specified branch.
+      tags:
+        - Branches
+      summary: Get a branch.
       description: Gets the specified branch.
-      operationId: Get
+      operationId: GetBranch
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetBranchParameters'
+            examples:
+              getBranch:
+                summary: Get a branch by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: BranchDto
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BranchName:
-                    type: string
-                    example: MyBranch
-                  ParentBranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BasedOn:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  RepositoryId:
-                    type: string
-                    format: uuid
-                    example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                  UserId:
-                    type: string
-                  PromotionEnabled:
-                    type: boolean
-                  CommitEnabled:
-                    type: boolean
-                  CheckpointEnabled:
-                    type: boolean
-                  SaveEnabled:
-                    type: boolean
-                  TagEnabled:
-                    type: boolean
-                  LatestPromotion:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCommit:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCheckpoint:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestSave:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                  UpdatedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                  DeletedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                required:
-                  - Class
-                  - BranchId
-                  - BranchName
-                  - ParentBranchId
-                  - BasedOn
-                  - RepositoryId
-                  - UserId
-                  - PromotionEnabled
-                  - CommitEnabled
-                  - CheckpointEnabled
-                  - SaveEnabled
-                  - TagEnabled
-                  - LatestPromotion
-                  - LatestCommit
-                  - LatestCheckpoint
-                  - LatestSave
-                  - CreatedAt
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getParentBranch:
     post:
-      summary: Gets the parent branch of the specified branch.
+      tags:
+        - Branches
+      summary: Get the parent branch.
       description: Gets the parent branch of the specified branch.
       operationId: GetParentBranch
       requestBody:
@@ -1465,961 +1009,342 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetBranchParameters'
+            examples:
+              getParentBranch:
+                summary: Get the parent branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: BranchDto
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BranchName:
-                    type: string
-                    example: MyBranch
-                  ParentBranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  BasedOn:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  RepositoryId:
-                    type: string
-                    format: uuid
-                    example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                  UserId:
-                    type: string
-                  PromotionEnabled:
-                    type: boolean
-                  CommitEnabled:
-                    type: boolean
-                  CheckpointEnabled:
-                    type: boolean
-                  SaveEnabled:
-                    type: boolean
-                  TagEnabled:
-                    type: boolean
-                  LatestPromotion:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCommit:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestCheckpoint:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  LatestSave:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                  UpdatedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                  DeletedAt:
-                    type: string
-                    format: date-time
-                    nullable: true
-                required:
-                  - Class
-                  - BranchId
-                  - BranchName
-                  - ParentBranchId
-                  - BasedOn
-                  - RepositoryId
-                  - UserId
-                  - PromotionEnabled
-                  - CommitEnabled
-                  - CheckpointEnabled
-                  - SaveEnabled
-                  - TagEnabled
-                  - LatestPromotion
-                  - LatestCommit
-                  - LatestCheckpoint
-                  - LatestSave
-                  - CreatedAt
+          $ref: '#/components/responses/BranchResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getReference:
     post:
-      summary: Gets the specified reference.
-      description: Gets the specified reference.
-      operationId: GetReference
+      tags:
+        - Branches
+      summary: Get a branch reference.
+      description: Gets the specified reference from the branch.
+      operationId: GetBranchReference
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - allOf:
-                        - type: object
-                          properties:
-                            CorrelationId:
-                              type: string
-                              description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                            Principal:
-                              type: string
-                        - type: object
-                          properties:
-                            BranchId:
-                              type: string
-                              format: uuid
-                              example: de7bf47d-23ae-4599-af68-68a317ea390d
-                            BranchName:
-                              type: string
-                              example: MyBranch
-                            OwnerId:
-                              type: string
-                              format: uuid
-                              example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                            OwnerName:
-                              type: string
-                            OrganizationId:
-                              type: string
-                              format: uuid
-                              example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                            OrganizationName:
-                              type: string
-                            RepositoryId:
-                              type: string
-                              format: uuid
-                              example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                            RepositoryName:
-                              type: string
-                    - type: object
-                      properties:
-                        Sha256Hash:
-                          type: string
-                          example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                        ReferenceId:
-                          type: string
-                          format: uuid
-                          example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+              $ref: '#/components/schemas/GetReferenceParameters'
+            examples:
+              getReference:
+                summary: Get a reference by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  IncludeDeleted: false
+                  ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  Class:
-                    type: string
-                    example: ReferenceDto
-                  ReferenceId:
-                    type: string
-                    format: uuid
-                    example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                  BranchId:
-                    type: string
-                    format: uuid
-                    example: de7bf47d-23ae-4599-af68-68a317ea390d
-                  DirectoryId:
-                    type: string
-                    format: uuid
-                    example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                  Sha256Hash:
-                    type: string
-                    example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                  ReferenceType:
-                    type: string
-                    enum:
-                      - Promotion
-                      - Commit
-                      - Checkpoint
-                      - Save
-                      - Tag
-                    example: Commit
-                  ReferenceText:
-                    type: string
-                  CreatedAt:
-                    type: string
-                    format: date-time
-                required:
-                  - Class
-                  - ReferenceId
-                  - BranchId
-                  - DirectoryId
-                  - Sha256Hash
-                  - ReferenceType
-                  - ReferenceText
-                  - CreatedAt
+          $ref: '#/components/responses/ReferenceResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getReferences:
     post:
-      summary: Gets the references for the specified branch.
+      tags:
+        - Branches
+      summary: List branch references.
       description: Gets the references for the specified branch.
-      operationId: GetReferences
+      operationId: ListBranchReferences
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listReferences:
+                summary: List references for a branch
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getPromotions:
     post:
-      summary: Gets the promotions for the specified branch.
-      description: Gets the promotions for the specified branch.
-      operationId: GetPromotions
+      tags:
+        - Branches
+      summary: List branch promotions.
+      description: Gets the promotion references for the specified branch.
+      operationId: ListBranchPromotions
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listPromotions:
+                summary: List promotion references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getCommits:
     post:
-      summary: Gets the commits for the specified branch.
-      description: Gets the commits for the specified branch.
-      operationId: GetCommits
+      tags:
+        - Branches
+      summary: List branch commits.
+      description: Gets the commit references for the specified branch.
+      operationId: ListBranchCommits
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listCommits:
+                summary: List commit references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getCheckpoints:
     post:
-      summary: Gets the checkpoints for the specified branch.
-      description: Gets the checkpoints for the specified branch.
-      operationId: GetCheckpoints
+      tags:
+        - Branches
+      summary: List branch checkpoints.
+      description: Gets the checkpoint references for the specified branch.
+      operationId: ListBranchCheckpoints
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listCheckpoints:
+                summary: List checkpoint references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getSaves:
     post:
-      summary: Gets the saves for the specified branch.
-      description: Gets the saves for the specified branch.
-      operationId: GetSaves
+      tags:
+        - Branches
+      summary: List branch saves.
+      description: Gets the save references for the specified branch.
+      operationId: ListBranchSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listSaves:
+                summary: List save references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /branch/getTags:
     post:
-      summary: Gets the tags for the specified branch.
-      description: Gets the tags for the specified branch.
-      operationId: GetTags
+      tags:
+        - Branches
+      summary: List branch tags.
+      description: Gets the tag references for the specified branch.
+      operationId: ListBranchTags
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              allOf:
-                - allOf:
-                    - type: object
-                      properties:
-                        CorrelationId:
-                          type: string
-                          description: If you don't provide a CorrelationId, a Guid will be generated for you. (You're welcome.) CorrelationId's are just strings; feel free to send any kind of CorrelationId you prefer.
-                        Principal:
-                          type: string
-                    - type: object
-                      properties:
-                        BranchId:
-                          type: string
-                          format: uuid
-                          example: de7bf47d-23ae-4599-af68-68a317ea390d
-                        BranchName:
-                          type: string
-                          example: MyBranch
-                        OwnerId:
-                          type: string
-                          format: uuid
-                          example: 9dd5f81f-dc43-4839-9173-85d09394f30f
-                        OwnerName:
-                          type: string
-                        OrganizationId:
-                          type: string
-                          format: uuid
-                          example: e35d64a9-b990-44f5-bf02-32ad7d15630c
-                        OrganizationName:
-                          type: string
-                        RepositoryId:
-                          type: string
-                          format: uuid
-                          example: ab6f35ef-6e01-440b-8f9b-c343a5272095
-                        RepositoryName:
-                          type: string
-                - type: object
-                  properties:
-                    FullSha:
-                      type: boolean
-                    MaxCount:
-                      type: integer
+              $ref: '#/components/schemas/GetReferencesParameters'
+            examples:
+              listTags:
+                summary: List tag references
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  FullSha: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    Class:
-                      type: string
-                      example: ReferenceDto
-                    ReferenceId:
-                      type: string
-                      format: uuid
-                      example: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
-                    BranchId:
-                      type: string
-                      format: uuid
-                      example: de7bf47d-23ae-4599-af68-68a317ea390d
-                    DirectoryId:
-                      type: string
-                      format: uuid
-                      example: 33a4e36b-828f-4fae-9343-50b6560dc842
-                    Sha256Hash:
-                      type: string
-                      example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
-                    ReferenceType:
-                      type: string
-                      enum:
-                        - Promotion
-                        - Commit
-                        - Checkpoint
-                        - Save
-                        - Tag
-                      example: Commit
-                    ReferenceText:
-                      type: string
-                    CreatedAt:
-                      type: string
-                      format: date-time
-                  required:
-                    - Class
-                    - ReferenceId
-                    - BranchId
-                    - DirectoryId
-                    - Sha256Hash
-                    - ReferenceType
-                    - ReferenceText
-                    - CreatedAt
+          $ref: '#/components/responses/ReferenceListResponse'
         '400':
-          description: Bad Request
+          $ref: '#/components/responses/400'
         '500':
-          description: Internal Server Error
+          $ref: '#/components/responses/500'
   /diff/populate:
     post:
-      summary: Populates the diff actor without returning the diff.
+      tags:
+        - Diffs
+      summary: Populate a diff actor.
       description: |
-        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff through reacting to an event.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+        Populates the diff actor without returning the diff. This endpoint is meant to be used when generating the diff
+        through reacting to an event.
+      operationId: PopulateDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PopulateParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffPopulateResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /diff/getDiff:
     post:
-      summary: Retrieves the contents of the diff.
-      description: |
-        Retrieves the contents of the diff between two directories.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff.
+      description: Retrieves the contents of the diff between two directory versions.
+      operationId: GetDiff
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetDiffParameters'
+            examples:
+              byDirectoryVersion:
+                summary: Compare two directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /diff/getDiffBySha256Hash:
     post:
-      summary: Retrieves a diff taken by comparing two DirectoryVersions by Sha256Hash.
-      description: |
-        Retrieves a diff taken by comparing two DirectoryVersions identified by their SHA-256 hash.
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Diffs
+      summary: Get a diff by SHA-256 hash.
+      description: Retrieves a diff by comparing two directory versions identified by SHA-256 hash.
+      operationId: GetDiffBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetDiffBySha256HashParameters'
+            examples:
+              bySha256Hash:
+                summary: Compare two directory versions by hash
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+                  Sha256Hash1: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Sha256Hash2: A05331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E185724
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          $ref: '#/components/responses/DiffResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3881,12 +2806,6 @@ paths:
           $ref: '#/components/responses/500'
 components:
   schemas:
-    '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GraceReturnValue'
     ApprovalPolicyParameters:
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
@@ -4309,123 +3228,172 @@ components:
         CreatedAt:
           $ref: '#/components/schemas/Instant'
     BranchParameters:
-      description: Parameters for many endpoints in the /branch path.
+      description: Parameters shared by public endpoints in the /branch route family.
       type: object
+      allOf:
+        - $ref: '#/components/schemas/CommonParameters'
       properties:
-        ownerId:
-          type: string
-        ownerName:
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OwnerName:
           $ref: '#/components/schemas/OwnerName'
-        organizationId:
-          type: string
-        organizationName:
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        OrganizationName:
           $ref: '#/components/schemas/OrganizationName'
-        repositoryId:
-          type: string
-        repositoryName:
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
           $ref: '#/components/schemas/RepositoryName'
-        branchId:
-          type: string
-        branchName:
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        BranchName:
           $ref: '#/components/schemas/BranchName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
     BranchQueryParameters:
-      description: Base class for parameters for branch queries.
+      description: Parameters for branch query endpoints that can resolve a branch or reference by hash or reference id.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            sha256Hash:
+            Sha256Hash:
               $ref: '#/components/schemas/Sha256Hash'
-            referenceId:
-              type: string
+            ReferenceId:
+              $ref: '#/components/schemas/ReferenceId'
     CreateBranchParameters:
       description: Parameters for the /branch/create endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            parentBranchId:
-              type: string
-            parentBranchName:
+            ParentBranchId:
+              $ref: '#/components/schemas/BranchId'
+            ParentBranchName:
               $ref: '#/components/schemas/BranchName'
+            InitialPermissions:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReferenceType'
     RebaseParameters:
       description: Parameters for the /branch/rebase endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            basedOn:
+            BasedOn:
               $ref: '#/components/schemas/ReferenceId'
     CreateReferenceParameters:
-      description: Parameters for the various /branch/create[reference] endpoints.
+      description: Parameters for /branch/promote, /branch/commit, /branch/checkpoint, /branch/save, and /branch/tag.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            directoryId:
-              $ref: '#/components/schemas/DirectoryId'
-            sha256Hash:
-              $ref: '#/components/schemas/Sha256Hash'
-            message:
+            DirectoryVersionId:
               type: string
+              format: uuid
+              example: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash:
+              $ref: '#/components/schemas/Sha256Hash'
+            Message:
+              type: string
+              example: Capture release candidate.
     SetBranchNameParameters:
       description: Parameters for the /branch/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            newName:
+            NewName:
               type: string
+              example: ReleaseCandidate
     EnableFeatureParameters:
-      description: Parameters for the various /branch/enable[feature] endpoints.
+      description: Parameters for branch feature-toggle endpoints.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            enabled:
+            Enabled:
               type: boolean
+              example: true
     DeleteBranchParameters:
       description: Parameters for the /branch/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Superseded by release branch.
+            ReassignChildBranches:
+              type: boolean
+              example: true
+            NewParentBranchId:
+              $ref: '#/components/schemas/BranchId'
+            NewParentBranchName:
+              $ref: '#/components/schemas/BranchName'
     GetReferenceParameters:
       description: Parameters for the /branch/getReference endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
     GetReferencesParameters:
-      description: Parameters for the /branch/getReferences and /branch/get[reference] endpoints.
+      description: Parameters for /branch/getReferences and reference-type list endpoints.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            fullSha:
+            FullSha:
               type: boolean
-            maxCount:
+              example: false
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferenceTypeParameters:
       description: Parameters for the /branch/getDiffsForReferenceType endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            referenceType:
-              type: string
-            maxCount:
+            ReferenceType:
+              $ref: '#/components/schemas/ReferenceType'
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetDiffsForReferencesParameters:
       description: Parameters for the /branch/getDiffsForReferences endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchParameters'
         - type: object
           properties:
-            references:
+            References:
               type: string
-            maxCount:
+              description: Comma-separated reference identifiers for diff lookup.
+            MaxCount:
               type: integer
+              format: int32
+              minimum: 1
+              example: 50
     GetBranchParameters:
       description: Parameters for the /branch/get endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     SwitchParameters:
       description: Parameters for the /branch/switch endpoint.
       allOf:
@@ -4434,27 +3402,37 @@ components:
       description: Parameters for the /branch/getVersion endpoint.
       allOf:
         - $ref: '#/components/schemas/BranchQueryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     DiffParameters:
-      description: Parameters for diff endpoints.
+      description: Parameters shared by public endpoints in the /diff route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
           $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
           $ref: '#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: '#/components/schemas/RepositoryId'
         RepositoryName:
           $ref: '#/components/schemas/RepositoryName'
-        DirectoryId1:
-          $ref: '#/components/schemas/DirectoryId'
-        DirectoryId2:
-          $ref: '#/components/schemas/DirectoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     PopulateParameters:
       description: Parameters for diff population.
       allOf:
@@ -4467,20 +3445,22 @@ components:
       description: Parameters for retrieving a diff by reference type.
       allOf:
         - $ref: '#/components/schemas/DiffParameters'
-      properties:
-        BranchId:
-          type: string
-        BranchName:
-          $ref: '#/components/schemas/BranchName'
+        - type: object
+          properties:
+            BranchId:
+              $ref: '#/components/schemas/BranchId'
+            BranchName:
+              $ref: '#/components/schemas/BranchName'
     GetDiffBySha256HashParameters:
-      description: Parameters for retrieving a diff by SHA256 hash.
+      description: Parameters for retrieving a diff by SHA-256 hash.
       allOf:
         - $ref: '#/components/schemas/DiffParameters'
-      properties:
-        Sha256Hash1:
-          $ref: '#/components/schemas/Sha256Hash'
-        Sha256Hash2:
-          $ref: '#/components/schemas/Sha256Hash'
+        - type: object
+          properties:
+            Sha256Hash1:
+              $ref: '#/components/schemas/Sha256Hash'
+            Sha256Hash2:
+              $ref: '#/components/schemas/Sha256Hash'
     DirectoryParameters:
       description: Parameters for many endpoints in the /directory path.
       type: object
@@ -4870,23 +3850,28 @@ components:
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
     ReferenceParameters:
-      description: Parameters for many endpoints in the /reference path.
+      description: Public reference identity fields used when a route accepts or returns reference selectors.
       type: object
-      properties:
-        ReferenceId:
-          type: string
-          description: Unique identifier of the reference.
-        ReferenceType:
-          type: string
-          description: Type of the reference.
-        RepositoryText:
-          type: string
-          description: Textual representation of the repository.
-        RepositoryName:
-          type: string
-          description: Name of the repository.
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
+      properties:
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
+        ReferenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: '#/components/schemas/ReferenceText'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+        ReferenceType: Commit
+        ReferenceText: Capture release candidate.
     RepositoryParameters:
       description: Parameters for many endpoints in the /repository path.
       type: object
@@ -5796,6 +4781,335 @@ components:
         - RetryScheduled
         - Failed
         - DeadLettered
+    ReferenceApiDto:
+      description: Public reference DTO returned through branch reference endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: ReferenceDto
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        DirectoryId:
+          type: string
+          format: uuid
+          description: DirectoryVersionId represented by the current server DTO field name.
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Sha256Hash:
+          $ref: '#/components/schemas/Sha256Hash'
+        ReferenceType:
+          $ref: '#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: '#/components/schemas/ReferenceText'
+        Links:
+          type: array
+          items:
+            type: string
+        CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchApiDto:
+      description: Public branch DTO returned through branch endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: BranchDto
+        BranchId:
+          $ref: '#/components/schemas/BranchId'
+        BranchName:
+          $ref: '#/components/schemas/BranchName'
+        ParentBranchId:
+          $ref: '#/components/schemas/BranchId'
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        BasedOn:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        UserId:
+          $ref: '#/components/schemas/UserId'
+        AssignEnabled:
+          type: boolean
+        PromotionEnabled:
+          type: boolean
+        CommitEnabled:
+          type: boolean
+        CheckpointEnabled:
+          type: boolean
+        SaveEnabled:
+          type: boolean
+        TagEnabled:
+          type: boolean
+        ExternalEnabled:
+          type: boolean
+        AutoRebaseEnabled:
+          type: boolean
+        PromotionMode:
+          type: string
+          example: IndividualOnly
+        LatestReference:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestPromotion:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestCommit:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestCheckpoint:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        LatestSave:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        ShouldRecomputeLatestReferences:
+          type: boolean
+        CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        UpdatedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+    BranchReturnValue:
+      description: Grace response envelope whose ReturnValue contains a branch.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/BranchApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: BranchDto
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          BranchName: main
+          ParentBranchId: 00000000-0000-0000-0000-000000000000
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          BasedOn:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          UserId: user:alice
+          AssignEnabled: false
+          PromotionEnabled: true
+          CommitEnabled: true
+          CheckpointEnabled: true
+          SaveEnabled: true
+          TagEnabled: true
+          ExternalEnabled: false
+          AutoRebaseEnabled: true
+          PromotionMode: IndividualOnly
+          LatestReference:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestPromotion:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCommit:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestCheckpoint:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          LatestSave:
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          ShouldRecomputeLatestReferences: false
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/get
+    ReferenceReturnValue:
+      description: Grace response envelope whose ReturnValue contains a reference.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/ReferenceApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: ReferenceDto
+          ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+          BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+          DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          ReferenceType: Commit
+          ReferenceText: Capture release candidate.
+          CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReference
+    ReferenceListReturnValue:
+      description: Grace response envelope whose ReturnValue contains references.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          - Class: ReferenceDto
+            ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+            BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+            DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+            Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            ReferenceType: Commit
+            ReferenceText: Capture release candidate.
+            CreatedAt: '2026-06-04T18:15:00Z'
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /branch/getReferences
+    DiffPopulateReturnValue:
+      description: Grace response envelope whose ReturnValue indicates whether the diff actor was populated.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: true
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DiffApiDto:
+      description: Public diff DTO returned through diff endpoints.
+      type: object
+      properties:
+        Class:
+          type: string
+          example: DiffDto
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        DirectoryVersionId1:
+          type: string
+          format: uuid
+          example: 33a4e36b-828f-4fae-9343-50b6560dc842
+        Directory1CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        DirectoryVersionId2:
+          type: string
+          format: uuid
+          example: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+        Directory2CreatedAt:
+          $ref: '#/components/schemas/Instant'
+        HasDifferences:
+          type: boolean
+        Differences:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileSystemDifference'
+        FileDiffs:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileDiff'
+    DiffReturnValue:
+      description: Grace response envelope whose ReturnValue contains a diff.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/DiffApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: DiffDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          HasDifferences: true
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          Directory1CreatedAt: '2026-06-04T18:14:00Z'
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+          Directory2CreatedAt: '2026-06-04T18:15:00Z'
+          Differences: []
+          FileDiffs: []
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+          DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
     GraceReturnValueBase:
       description: Common metadata returned with successful Grace responses.
       type: object
@@ -6650,3 +5964,112 @@ components:
                     type: array
                     items:
                       $ref: '#/components/schemas/WebhookDelivery'
+    BranchResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BranchReturnValue'
+          examples:
+            branch:
+              summary: Branch response envelope
+              value:
+                ReturnValue:
+                  Class: BranchDto
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  BranchName: main
+                  ParentBranchId: 00000000-0000-0000-0000-000000000000
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  BasedOn:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  UserId: user:alice
+                  AssignEnabled: false
+                  PromotionEnabled: true
+                  CommitEnabled: true
+                  CheckpointEnabled: true
+                  SaveEnabled: true
+                  TagEnabled: true
+                  ExternalEnabled: false
+                  AutoRebaseEnabled: true
+                  PromotionMode: IndividualOnly
+                  LatestReference:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestPromotion:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestCommit:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestCheckpoint:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  LatestSave:
+                    ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  ShouldRecomputeLatestReferences: false
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/get
+    ReferenceResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceReturnValue'
+          examples:
+            reference:
+              summary: Reference response envelope
+              value:
+                ReturnValue:
+                  Class: ReferenceDto
+                  ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
+                  DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  ReferenceType: Commit
+                  ReferenceText: Capture release candidate.
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /branch/getReference
+    ReferenceListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceListReturnValue'
+    DiffPopulateResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DiffPopulateReturnValue'
+    DiffResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DiffReturnValue'
+          examples:
+            diff:
+              summary: Diff response envelope
+              value:
+                ReturnValue:
+                  Class: DiffDto
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  HasDifferences: true
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Directory1CreatedAt: '2026-06-04T18:14:00Z'
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+                  Directory2CreatedAt: '2026-06-04T18:15:00Z'
+                  Differences: []
+                  FileDiffs: []
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -13,15 +13,15 @@
     },
     {
       "path": "Branch.Components.OpenAPI.yaml",
-      "sha256": "e738a6557c323445a02c21f27ee46ef86713bd5507ee77d394671da6a92cd052"
+      "sha256": "f7e27ea72767b07a89b6f396d67ef8a6624fc929c5e154d92775a4c3a66b2b8b"
     },
     {
       "path": "Branch.Paths.OpenAPI.yaml",
-      "sha256": "ae485c9ad9ade3733fd1a925377bf27d562bc6e572698dbc03a53d0b96b8e002"
+      "sha256": "c834751ec44778de26016e2399283f70201707c7d46ccd38b4ddff29523c2a4c"
     },
     {
       "path": "Diff.Components.OpenAPI.yaml",
-      "sha256": "533d8d9cf701faa4777960bb755a6ab413c1422b1a73943fc1c5a180a7698c65"
+      "sha256": "1a64e75c9e0f8bdb83735b50647381ecd5d9076ae0a96ebca73fbfe6a1c015cc"
     },
     {
       "path": "Diff.Paths.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
+      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "b718dfb1db18165d0bdccfc30754fd55509ca49b202277111fc5babfe168245c"
+      "sha256": "692b28bb00653d72424216c5c741d331ed7bee3c9a5fcf03ec79653690ce159e"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
+      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "ccd0df8fd8705cbfbe5190138ef10cec1d5190e43657750b44ffb1df2c1295f4"
+      "sha256": "2bca8ae6d235badbee913db130b138d08785e645a504bc20ecd984112ae5e10c"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
+      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -13,19 +13,19 @@
     },
     {
       "path": "Branch.Components.OpenAPI.yaml",
-      "sha256": "fdf8683cd64552708779f9777aadf8389afc9dd84363622f476b9e015d054b4e"
+      "sha256": "e738a6557c323445a02c21f27ee46ef86713bd5507ee77d394671da6a92cd052"
     },
     {
       "path": "Branch.Paths.OpenAPI.yaml",
-      "sha256": "2cd3e76766031419663328c7b640900000f50df1e1690f5ba7c814777ea56eda"
+      "sha256": "ae485c9ad9ade3733fd1a925377bf27d562bc6e572698dbc03a53d0b96b8e002"
     },
     {
       "path": "Diff.Components.OpenAPI.yaml",
-      "sha256": "26d2d7b5381fb88fbedec3bcd5a133ec6bd13f738ba39f7abe0871b3e5f3f5d3"
+      "sha256": "533d8d9cf701faa4777960bb755a6ab413c1422b1a73943fc1c5a180a7698c65"
     },
     {
       "path": "Diff.Paths.OpenAPI.yaml",
-      "sha256": "d35c91ae7a894db61703627b25f5583c6bf9159cca065a3e9abd8273dd714e67"
+      "sha256": "6de87e0d23cd1ab014a5beffbfda0f7d063ddb7287b359fd0199c7c5dfe7393f"
     },
     {
       "path": "Directory.Components.OpenAPI.yaml",
@@ -61,7 +61,7 @@
     },
     {
       "path": "Reference.Components.OpenAPI.yaml",
-      "sha256": "b4ddef354bd804dbc297054b81bde947ef8e3847dd2ca50cfaaf3bce49eb34d5"
+      "sha256": "87468e6d2b9904291e2f2b70c5bdb2f0625f246b37b6c40c0aef81bd7eabe501"
     },
     {
       "path": "Repository.Components.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
+      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "b59a30f52d924b6a3385b8f567efa28676833761b1ea9459fd33fffafd14d783"
+      "sha256": "ce81d0b0302b44fce63242d2acaa24ec89729806b77ebb78b81b16931d536987"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
+      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "a61816a609b93c8c85aa41959d3a8a372ef41d6a178fe096e49890aa97f4b3a4"
+      "sha256": "49f163911395ce6b11dee8c45d4b7538284102783e6fa0a77388a5fafec82a2c"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "a8b7de8bbcd3ace0aab87c07c238242bdd2395db2afaff9566c398811deb6949",
+      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -25,7 +25,7 @@
     },
     {
       "path": "Diff.Paths.OpenAPI.yaml",
-      "sha256": "6de87e0d23cd1ab014a5beffbfda0f7d063ddb7287b359fd0199c7c5dfe7393f"
+      "sha256": "46b0404cecb459aab43d3e3d9500e3f1fe179a88ad09f74c7b6df07789f6ecc0"
     },
     {
       "path": "Directory.Components.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
+      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "ce81d0b0302b44fce63242d2acaa24ec89729806b77ebb78b81b16931d536987"
+      "sha256": "b718dfb1db18165d0bdccfc30754fd55509ca49b202277111fc5babfe168245c"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
+      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "49f163911395ce6b11dee8c45d4b7538284102783e6fa0a77388a5fafec82a2c"
+      "sha256": "ccd0df8fd8705cbfbe5190138ef10cec1d5190e43657750b44ffb1df2c1295f4"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "83e110a8c822bd57301c7ab54b39f5f5268e551a3adcbd56c35a5d578a5824a7",
+      "sourceDigest": "3d93cee34af359a21a1d01d6066ab76797b64cdf11227f9680a8dbd6350c48dd",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/Reference.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Reference.Components.OpenAPI.yaml
@@ -1,18 +1,23 @@
     ReferenceParameters:
-      description: Parameters for many endpoints in the /reference path.
+      description: Public reference identity fields used when a route accepts or returns reference selectors.
       type: object
-      properties:
-        ReferenceId:
-          type: string
-          description: Unique identifier of the reference.
-        ReferenceType:
-          type: string
-          description: Type of the reference.
-        RepositoryText:
-          type: string
-          description: Textual representation of the repository.
-        RepositoryName:
-          type: string
-          description: Name of the repository.
       allOf:
         - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
+      properties:
+        ReferenceId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
+        ReferenceType:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType'
+        ReferenceText:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceText'
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        ReferenceId: c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+        ReferenceType: Commit
+        ReferenceText: Capture release candidate.

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -458,6 +458,143 @@ function Assert-OperationTextMatches {
     }
 }
 
+function Assert-OperationHasJsonRequestExample {
+    param(
+        [object] $Operation,
+        [string] $Message
+    )
+
+    if ($null -eq $Operation) {
+        return
+    }
+
+    if ([string] $Operation.OperationText -match '(?m)^\s+requestBody:\s*$') {
+        Assert-OperationTextMatches `
+            $Operation `
+            '(?s)requestBody:\s*.*?content:\s*.*?application/json:\s*.*?examples:' `
+            $Message
+    }
+}
+
+function Test-OpenApiBranchReferenceDiffDetails {
+    param(
+        [string] $OpenApiRoot,
+        [object[]] $Operations
+    )
+
+    $expectedOperations = @(
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'CreateBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'RebaseBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'PromoteBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'CommitBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'CheckpointBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'SaveBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'TagBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'EnableBranchPromotion'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'EnableBranchCommit'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'EnableBranchCheckpoint'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'EnableBranchSave'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'EnableBranchTag'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'DeleteBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'GetBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'GetParentBranch'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'GetBranchReference'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchReferences'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchPromotions'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchCommits'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchCheckpoints'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchSaves'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Branch.Paths.OpenAPI.yaml'; OperationId = 'ListBranchTags'; Tag = 'Branches' },
+        [pscustomobject]@{ File = 'Diff.Paths.OpenAPI.yaml'; OperationId = 'PopulateDiff'; Tag = 'Diffs' },
+        [pscustomobject]@{ File = 'Diff.Paths.OpenAPI.yaml'; OperationId = 'GetDiff'; Tag = 'Diffs' },
+        [pscustomobject]@{ File = 'Diff.Paths.OpenAPI.yaml'; OperationId = 'GetDiffBySha256Hash'; Tag = 'Diffs' }
+    )
+
+    $familyFiles = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($file in @('Branch.Paths.OpenAPI.yaml', 'Diff.Paths.OpenAPI.yaml')) {
+        [void] $familyFiles.Add($file)
+    }
+
+    $familyOperations = @($Operations | Where-Object { $familyFiles.Contains($_.File) })
+    $genericOperationIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($operationId in @('Create', 'Get', 'Delete', 'List', 'Update', 'Enable', 'Disable', 'Promote', 'Rebase')) {
+        [void] $genericOperationIds.Add($operationId)
+    }
+
+    foreach ($operation in $familyOperations) {
+        $location = "$($operation.File):$($operation.LineNumber) $($operation.Method.ToUpperInvariant()) $($operation.Path)"
+
+        if ([string]::IsNullOrWhiteSpace([string] $operation.OperationId)) {
+            Add-Failure "Branch/diff OpenAPI operation is missing an SDK-friendly operationId: $location"
+            continue
+        }
+
+        if ($genericOperationIds.Contains([string] $operation.OperationId)) {
+            Add-Failure "Branch/diff OpenAPI operationId '$($operation.OperationId)' is too generic for SDK generation: $location"
+        }
+
+        if (-not $operation.HasTag) {
+            Add-Failure "Branch/diff OpenAPI operation is missing its primary SDK tag: $location"
+        }
+
+        if (-not ($operation.Has400 -and $operation.Has500)) {
+            Add-Failure "Branch/diff OpenAPI operation is missing reusable 400/500 error responses: $location"
+        }
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./(?:Branch|Diff)\.Components\.OpenAPI\.yaml#/" `
+            "Branch/diff OpenAPI operation must use a family success response component: $location"
+
+        Assert-OperationHasJsonRequestExample `
+            $operation `
+            "Branch/diff OpenAPI operation with a JSON request body must include an example: $location"
+    }
+
+    foreach ($expected in $expectedOperations) {
+        $operation = Get-RequiredOpenApiOperation $Operations $expected.File $expected.OperationId
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)tags:\s*-\s+$($expected.Tag)\b" `
+            "Operation '$($expected.OperationId)' must carry primary SDK tag '$($expected.Tag)'."
+    }
+
+    $branchComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Branch.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredBranchContract in @(
+            'DirectoryVersionId:',
+            'BranchReturnValue:',
+            'ReferenceReturnValue:',
+            'ReferenceListReturnValue:'
+        )) {
+        Assert-TextContains $branchComponentsText $requiredBranchContract "Branch OpenAPI components are missing '$requiredBranchContract'."
+    }
+
+    $diffComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Diff.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredDiffContract in @(
+            'DirectoryVersionId1:',
+            'DirectoryVersionId2:',
+            'DiffReturnValue:',
+            'DiffPopulateReturnValue:'
+        )) {
+        Assert-TextContains $diffComponentsText $requiredDiffContract "Diff OpenAPI components are missing '$requiredDiffContract'."
+    }
+
+    $referenceComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Reference.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredReferenceContract in @(
+            'ReferenceParameters:',
+            'ReferenceId:',
+            'ReferenceType:',
+            'ReferenceText:'
+        )) {
+        Assert-TextContains $referenceComponentsText $requiredReferenceContract "Reference OpenAPI components are missing '$requiredReferenceContract'."
+    }
+
+    if ($referenceComponentsText -match '(RepositoryText|ReferenceCommand|ReferenceEvent|Actor)') {
+        Add-Failure 'Reference OpenAPI components must expose public selector fields, not internal actor command/event shapes or stale RepositoryText naming.'
+    }
+}
+
 function Test-OpenApiSharedContractDetails {
     param(
         [string] $OpenApiRoot,
@@ -538,6 +675,8 @@ function Test-OpenApiSharedContractDetails {
             "(?s)requestBody:\s*.*?content:\s*.*?application/json:\s*.*?examples:" `
             "Webhook operation '$operationId' must include an application/json example in its own request body."
     }
+
+    Test-OpenApiBranchReferenceDiffDetails $OpenApiRoot $Operations
 }
 
 function Test-OpenApiQuality {

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -544,6 +544,34 @@ function Test-OpenApiBranchReferenceDiffDetails {
         [pscustomobject]@{ File = 'Diff.Paths.OpenAPI.yaml'; OperationId = 'GetDiffBySha256Hash'; Tag = 'Diffs' }
     )
 
+    $branchCommandOperationIds = @(
+        'CreateBranch',
+        'RebaseBranch',
+        'PromoteBranch',
+        'CommitBranch',
+        'CheckpointBranch',
+        'SaveBranch',
+        'TagBranch',
+        'EnableBranchPromotion',
+        'EnableBranchCommit',
+        'EnableBranchCheckpoint',
+        'EnableBranchSave',
+        'EnableBranchTag',
+        'DeleteBranch'
+    )
+
+    $branchQueryResponses = @(
+        [pscustomobject]@{ OperationId = 'GetBranch'; Response = 'BranchResponse' },
+        [pscustomobject]@{ OperationId = 'GetParentBranch'; Response = 'BranchResponse' },
+        [pscustomobject]@{ OperationId = 'GetBranchReference'; Response = 'ReferenceResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchReferences'; Response = 'ReferenceListResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchPromotions'; Response = 'ReferenceListResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchCommits'; Response = 'ReferenceListResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchCheckpoints'; Response = 'ReferenceListResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchSaves'; Response = 'ReferenceListResponse' },
+        [pscustomobject]@{ OperationId = 'ListBranchTags'; Response = 'ReferenceListResponse' }
+    )
+
     $familyFiles = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     foreach ($file in @('Branch.Paths.OpenAPI.yaml', 'Diff.Paths.OpenAPI.yaml')) {
         [void] $familyFiles.Add($file)
@@ -602,15 +630,59 @@ function Test-OpenApiBranchReferenceDiffDetails {
     $getDiffBySha256HashOperation = Get-RequiredOpenApiOperation $Operations 'Diff.Paths.OpenAPI.yaml' 'GetDiffBySha256Hash'
     Assert-OperationSha256ExamplesAreValid $getDiffBySha256HashOperation @('Sha256Hash1', 'Sha256Hash2')
 
+    foreach ($operationId in $branchCommandOperationIds) {
+        $operation = Get-RequiredOpenApiOperation $Operations 'Branch.Paths.OpenAPI.yaml' $operationId
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./Branch\.Components\.OpenAPI\.yaml#/BranchCommandResponse'" `
+            "Branch command operation '$operationId' must use the string-returning BranchCommandResponse envelope."
+
+        if ($null -ne $operation -and [string] $operation.OperationText -match 'Branch\.Components\.OpenAPI\.yaml#/BranchResponse') {
+            Add-Failure "Branch command operation '$operationId' must not use the BranchApiDto BranchResponse envelope."
+        }
+    }
+
+    foreach ($expectedResponse in $branchQueryResponses) {
+        $operation = Get-RequiredOpenApiOperation $Operations 'Branch.Paths.OpenAPI.yaml' $expectedResponse.OperationId
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./Branch\.Components\.OpenAPI\.yaml#/$($expectedResponse.Response)'" `
+            "Branch query operation '$($expectedResponse.OperationId)' must use '$($expectedResponse.Response)' instead of a command string envelope."
+
+        if ($null -ne $operation -and [string] $operation.OperationText -match 'Branch\.Components\.OpenAPI\.yaml#/BranchCommandResponse') {
+            Add-Failure "Branch query operation '$($expectedResponse.OperationId)' must not use the string-returning BranchCommandResponse envelope."
+        }
+    }
+
+    $populateDiffOperation = Get-RequiredOpenApiOperation $Operations 'Diff.Paths.OpenAPI.yaml' 'PopulateDiff'
+    Assert-OperationTextMatches `
+        $populateDiffOperation `
+        "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./Diff\.Components\.OpenAPI\.yaml#/DiffPopulateResponse'" `
+        "PopulateDiff must use the string-returning DiffPopulateResponse envelope."
+
     $branchComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Branch.Components.OpenAPI.yaml') -Raw
     foreach ($requiredBranchContract in @(
             'DirectoryVersionId:',
+            'BranchCommandReturnValue:',
+            'BranchCommandResponse:',
             'BranchReturnValue:',
             'ReferenceReturnValue:',
             'ReferenceListReturnValue:'
         )) {
         Assert-TextContains $branchComponentsText $requiredBranchContract "Branch OpenAPI components are missing '$requiredBranchContract'."
     }
+
+    Assert-OperationTextMatches `
+        ([pscustomobject]@{ OperationText = $branchComponentsText }) `
+        "(?s)BranchCommandReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*string" `
+        'BranchCommandReturnValue must model command success ReturnValue as a string.'
+
+    Assert-OperationTextMatches `
+        ([pscustomobject]@{ OperationText = $branchComponentsText }) `
+        "(?s)BranchReturnValue:\s*.*?ReturnValue:\s*.*?\`$ref:\s*'#/BranchApiDto'" `
+        'BranchReturnValue must keep branch query ReturnValue as BranchApiDto.'
 
     $diffComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Diff.Components.OpenAPI.yaml') -Raw
     foreach ($requiredDiffContract in @(
@@ -620,6 +692,15 @@ function Test-OpenApiBranchReferenceDiffDetails {
             'DiffPopulateReturnValue:'
         )) {
         Assert-TextContains $diffComponentsText $requiredDiffContract "Diff OpenAPI components are missing '$requiredDiffContract'."
+    }
+
+    Assert-OperationTextMatches `
+        ([pscustomobject]@{ OperationText = $diffComponentsText }) `
+        "(?s)DiffPopulateReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*string" `
+        'DiffPopulateReturnValue must model populate success ReturnValue as a string.'
+
+    if ($diffComponentsText -match '(?s)DiffPopulateReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*boolean') {
+        Add-Failure 'DiffPopulateReturnValue must not model populate success ReturnValue as boolean.'
     }
 
     $referenceComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Reference.Components.OpenAPI.yaml') -Raw

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -458,6 +458,154 @@ function Assert-OperationTextMatches {
     }
 }
 
+function Get-YamlIndentLength {
+    param([string] $Line)
+
+    $match = [regex]::Match($Line, '^(?<indent>\s*)')
+    return $match.Groups['indent'].Value.Length
+}
+
+function Get-OpenApiSchemaPropertyBlock {
+    param(
+        [string] $Text,
+        [string] $SchemaName,
+        [string] $PropertyName
+    )
+
+    $lines = [regex]::Split($Text, '\r?\n')
+    $schemaLinePattern = "^(?<indent>\s*)$([regex]::Escape($SchemaName)):\s*(?:#.*)?$"
+    $schemaStart = -1
+    $schemaIndent = -1
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $match = [regex]::Match($lines[$i], $schemaLinePattern)
+        if ($match.Success) {
+            $schemaStart = $i
+            $schemaIndent = $match.Groups['indent'].Value.Length
+            break
+        }
+    }
+
+    if ($schemaStart -lt 0) {
+        return $null
+    }
+
+    $schemaEnd = $lines.Count
+    for ($i = $schemaStart + 1; $i -lt $lines.Count; $i++) {
+        if ([string]::IsNullOrWhiteSpace($lines[$i])) {
+            continue
+        }
+
+        $indent = Get-YamlIndentLength $lines[$i]
+        if ($indent -le $schemaIndent) {
+            $schemaEnd = $i
+            break
+        }
+    }
+
+    $propertiesStart = -1
+    $propertiesIndent = $schemaIndent + 2
+    $propertiesLinePattern = "^\s{$propertiesIndent}properties:\s*(?:#.*)?$"
+    for ($i = $schemaStart + 1; $i -lt $schemaEnd; $i++) {
+        if ([regex]::IsMatch($lines[$i], $propertiesLinePattern)) {
+            $propertiesStart = $i
+            break
+        }
+    }
+
+    if ($propertiesStart -lt 0) {
+        return $null
+    }
+
+    $propertiesEnd = $schemaEnd
+    for ($i = $propertiesStart + 1; $i -lt $schemaEnd; $i++) {
+        if ([string]::IsNullOrWhiteSpace($lines[$i])) {
+            continue
+        }
+
+        $indent = Get-YamlIndentLength $lines[$i]
+        if ($indent -le $propertiesIndent) {
+            $propertiesEnd = $i
+            break
+        }
+    }
+
+    $propertyStart = -1
+    $propertyIndent = $propertiesIndent + 2
+    $propertyLinePattern = "^\s{$propertyIndent}$([regex]::Escape($PropertyName)):\s*(?:#.*)?$"
+    for ($i = $propertiesStart + 1; $i -lt $propertiesEnd; $i++) {
+        if ([regex]::IsMatch($lines[$i], $propertyLinePattern)) {
+            $propertyStart = $i
+            break
+        }
+    }
+
+    if ($propertyStart -lt 0) {
+        return $null
+    }
+
+    $propertyEnd = $propertiesEnd
+    for ($i = $propertyStart + 1; $i -lt $propertiesEnd; $i++) {
+        if ([string]::IsNullOrWhiteSpace($lines[$i])) {
+            continue
+        }
+
+        $indent = Get-YamlIndentLength $lines[$i]
+        if ($indent -le $propertyIndent) {
+            $propertyEnd = $i
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        Lines = @($lines[$propertyStart..($propertyEnd - 1)])
+        PropertyIndent = $propertyIndent
+    }
+}
+
+function Assert-OpenApiSchemaPropertyIsString {
+    param(
+        [string] $Text,
+        [string] $SchemaName,
+        [string] $PropertyName,
+        [string] $Message
+    )
+
+    $propertyBlock = Get-OpenApiSchemaPropertyBlock $Text $SchemaName $PropertyName
+    if ($null -eq $propertyBlock) {
+        Add-Failure $Message
+        return
+    }
+
+    $directChildIndent = $propertyBlock.PropertyIndent + 2
+    $directTypeValues = [System.Collections.Generic.List[string]]::new()
+    $hasDirectRef = $false
+
+    foreach ($line in @($propertyBlock.Lines | Select-Object -Skip 1)) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $indent = Get-YamlIndentLength $line
+        if ($indent -ne $directChildIndent) {
+            continue
+        }
+
+        $typeMatch = [regex]::Match($line, "^\s{$directChildIndent}type:\s*['""]?(?<type>[^'""\s#]+)['""]?\s*(?:#.*)?$")
+        if ($typeMatch.Success) {
+            $directTypeValues.Add($typeMatch.Groups['type'].Value)
+        }
+
+        if ([regex]::IsMatch($line, "^\s{$directChildIndent}\`$ref:\s*")) {
+            $hasDirectRef = $true
+        }
+    }
+
+    if ($directTypeValues.Count -ne 1 -or $directTypeValues[0] -ne 'string' -or $hasDirectRef) {
+        Add-Failure $Message
+    }
+}
+
 function Assert-OperationHasJsonRequestExample {
     param(
         [object] $Operation,
@@ -674,9 +822,10 @@ function Test-OpenApiBranchReferenceDiffDetails {
         Assert-TextContains $branchComponentsText $requiredBranchContract "Branch OpenAPI components are missing '$requiredBranchContract'."
     }
 
-    Assert-OperationTextMatches `
-        ([pscustomobject]@{ OperationText = $branchComponentsText }) `
-        "(?s)BranchCommandReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*string" `
+    Assert-OpenApiSchemaPropertyIsString `
+        $branchComponentsText `
+        'BranchCommandReturnValue' `
+        'ReturnValue' `
         'BranchCommandReturnValue must model command success ReturnValue as a string.'
 
     Assert-OperationTextMatches `
@@ -694,9 +843,10 @@ function Test-OpenApiBranchReferenceDiffDetails {
         Assert-TextContains $diffComponentsText $requiredDiffContract "Diff OpenAPI components are missing '$requiredDiffContract'."
     }
 
-    Assert-OperationTextMatches `
-        ([pscustomobject]@{ OperationText = $diffComponentsText }) `
-        "(?s)DiffPopulateReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*string" `
+    Assert-OpenApiSchemaPropertyIsString `
+        $diffComponentsText `
+        'DiffPopulateReturnValue' `
+        'ReturnValue' `
         'DiffPopulateReturnValue must model populate success ReturnValue as a string.'
 
     if ($diffComponentsText -match '(?s)DiffPopulateReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*boolean') {

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -476,6 +476,40 @@ function Assert-OperationHasJsonRequestExample {
     }
 }
 
+function Assert-OperationSha256ExamplesAreValid {
+    param(
+        [object] $Operation,
+        [string[]] $RequiredFields
+    )
+
+    if ($null -eq $Operation) {
+        return
+    }
+
+    $location = "$($Operation.File):$($Operation.LineNumber) $($Operation.Method.ToUpperInvariant()) $($Operation.Path)"
+    $exampleMatches = [regex]::Matches(
+        [string] $Operation.OperationText,
+        "(?m)^\s+(?<name>Sha256Hash(?:1|2)?):\s*(?<value>['""]?[A-Za-z0-9]+['""]?)\s*$"
+    )
+    $fieldsSeen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+
+    foreach ($match in $exampleMatches) {
+        $fieldName = $match.Groups['name'].Value
+        $fieldValue = $match.Groups['value'].Value.Trim("'`"")
+        [void] $fieldsSeen.Add($fieldName)
+
+        if ($fieldValue -notmatch '^[A-Fa-f0-9]{64}$') {
+            Add-Failure "OpenAPI example field '$fieldName' must be a valid 64-character SHA-256 hex value: $location has '$fieldValue'."
+        }
+    }
+
+    foreach ($requiredField in $RequiredFields) {
+        if (-not $fieldsSeen.Contains($requiredField)) {
+            Add-Failure "OpenAPI operation '$($Operation.OperationId)' must include a literal '$requiredField' example for S05 SHA-256 proof coverage: $location"
+        }
+    }
+}
+
 function Test-OpenApiBranchReferenceDiffDetails {
     param(
         [string] $OpenApiRoot,
@@ -549,6 +583,8 @@ function Test-OpenApiBranchReferenceDiffDetails {
         Assert-OperationHasJsonRequestExample `
             $operation `
             "Branch/diff OpenAPI operation with a JSON request body must include an example: $location"
+
+        Assert-OperationSha256ExamplesAreValid $operation @()
     }
 
     foreach ($expected in $expectedOperations) {
@@ -559,6 +595,12 @@ function Test-OpenApiBranchReferenceDiffDetails {
             "(?s)tags:\s*-\s+$($expected.Tag)\b" `
             "Operation '$($expected.OperationId)' must carry primary SDK tag '$($expected.Tag)'."
     }
+
+    $promoteBranchOperation = Get-RequiredOpenApiOperation $Operations 'Branch.Paths.OpenAPI.yaml' 'PromoteBranch'
+    Assert-OperationSha256ExamplesAreValid $promoteBranchOperation @('Sha256Hash')
+
+    $getDiffBySha256HashOperation = Get-RequiredOpenApiOperation $Operations 'Diff.Paths.OpenAPI.yaml' 'GetDiffBySha256Hash'
+    Assert-OperationSha256ExamplesAreValid $getDiffBySha256HashOperation @('Sha256Hash1', 'Sha256Hash2')
 
     $branchComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Branch.Components.OpenAPI.yaml') -Raw
     foreach ($requiredBranchContract in @(


### PR DESCRIPTION
## Summary

- Polishes branch, reference, and diff OpenAPI route-family contracts for SDK-friendly generation.
- Replaces generic/colliding operation IDs with stable route-family operation IDs.
- Adds primary SDK tags, examples, explicit success responses, and reusable `400`/`500` error response coverage for the audited families.
- Regenerates OpenAPI bundles/projections and extends proof checks for branch/reference/diff regressions.

## Issue

Refs #216
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed after implementation and source OpenAPI fixes.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness`: passed with no pending gates after implementation/source OpenAPI fixes and after refresh.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections`: passed with no pending gates after implementation/source OpenAPI fixes and after refresh.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality -AllowPending`: passed after implementation and each fix/refresh; pending items are unrelated existing repo-wide OpenAPI debt for Directory/Organization operation IDs/tags and `/openApi` missing the `400`/`500` pair.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`: passed during implementation; additional pending gates are existing future SDK package export/import proof and protocol vector proof.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after implementation and each fix/refresh.
- `git diff --check`: passed after implementation and each fix/refresh.
- GitHub `Validate / full` on `7dd4d8a`: in progress.

## Review Status

- Implementation worker completed and pushed `9707df0`.
- First review found one example-validity issue: `/diff/getDiffBySha256Hash` had a 63-character `Sha256Hash2` example that the server would reject.
- Fix commit `fdfa169` replaced the invalid example, regenerated derived OpenAPI artifacts, and strengthened S05 proof coverage for `Sha256Hash`, `Sha256Hash1`, and `Sha256Hash2` examples.
- Freshness merge commit `a25089d` brought the branch up to current `origin/epic/211-sdk-openapi` after S07 merged; merge was clean, generated artifacts remained fresh, and validation passed.
- Refreshed-diff review found two response-envelope mismatches with current server/SDK behavior: branch command endpoints should return string envelopes, and `/diff/populate` should return a string envelope rather than a boolean envelope.
- Fix commit `ae69225` corrected branch command and diff populate response envelopes and strengthened proof coverage for those shapes.
- Follow-up review verified the response-envelope contract fix and found one remaining proof loophole: component-level string-envelope regexes could be satisfied by later `Properties.additionalProperties.type: string` instead of the immediate `ReturnValue` field.
- Fix commit `7dd4d8a` tightened the proof helper to inspect the immediate `properties.ReturnValue` block for string envelope components.
- Final follow-up review-only sibling subagent completed against `origin/epic/211-sdk-openapi..7dd4d8a` with no actionable issues.
- Detailed reviews, fix evidence, freshness evidence, and final no-issues review are documented in the PR conversation.
- Open review findings: none.
- Final no-issues review: complete.

## Parallel Work Note

Issue #218 merged into the epic branch while this PR was active. This PR is OpenAPI/proof-only and intentionally avoids server runtime and SDK facade behavior; the branch has been refreshed against the current epic branch before final review.

## Docs Impact

- No Markdown docs changed.

## Residual Risk

- Existing unrelated OpenAPI quality debt remains pending for Directory/Organization operation IDs/tags and `/openApi` reusable `400`/`500` response coverage.
- This slice models the current branch/reference/diff server contract and does not change server behavior.
