### PR TITLE
SDK/OpenAPI S06: polish owner organization repository directory contracts

### DIFF
--- a/src/OpenAPI/Directory.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Directory.Components.OpenAPI.yaml
@@ -1,66 +1,167 @@
+    DirectoryVersionId:
+      type: string
+      format: uuid
+      example: 33a4e36b-828f-4fae-9343-50b6560dc842
     DirectoryParameters:
-      description: Parameters for many endpoints in the /directory path.
+      description: Parameters shared by public endpoints in the /directory route family.
       type: object
-      properties:
-        DirectoryId:
-          type: string
-          description: Unique identifier of the directory.
       allOf:
         - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
-    
+      properties:
+        OwnerId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
+        OwnerName:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
+        OrganizationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
+        OrganizationName:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
+        RepositoryId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
+        DirectoryVersionId:
+          $ref: '#/DirectoryVersionId'
+      example: &directoryBaseExample
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
     CreateParameters:
       description: Parameters for the /directory/create endpoint.
+      allOf:
+        - $ref: '#/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersion:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
+    GetParameters:
+      description: Parameters for /directory/get and recursive directory-version lookups.
+      allOf:
+        - $ref: '#/DirectoryParameters'
+    GetByDirectoryIdsParameters:
+      description: Parameters for the /directory/getByDirectoryIds endpoint.
+      allOf:
+        - $ref: '#/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryIds:
+              type: array
+              items:
+                $ref: '#/DirectoryVersionId'
+    GetBySha256HashParameters:
+      description: Parameters for the /directory/getBySha256Hash endpoint.
+      allOf:
+        - $ref: '#/DirectoryParameters'
+        - type: object
+          properties:
+            Sha256Hash:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+    SaveDirectoryVersionsParameters:
+      description: Parameters for the /directory/saveDirectoryVersions endpoint.
+      allOf:
+        - $ref: '#/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersions:
+              type: array
+              items:
+                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
+    DirectoryVersionApiDto:
+      description: Public directory version DTO returned by directory query endpoints.
       type: object
       properties:
         DirectoryVersion:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
-      allOf:
-        - $ref: './Directory.Components.OpenAPI.yaml#/DirectoryParameters'
-    
-    GetParameters:
-      description: Parameters for the /directory/get endpoint.
+        RecursiveSize:
+          type: integer
+          format: int64
+          example: 4096
+        DeletedAt:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+          example: ''
+        HashesValidated:
+          type: boolean
+          example: true
+    DirectoryCommandReturnValue:
+      description: Grace response envelope returned by directory command endpoints.
       type: object
       properties:
-        RepositoryId:
+        ReturnValue:
           type: string
-          description: Unique identifier of the repository.
-      allOf:
-        - $ref: './Directory.Components.OpenAPI.yaml#/DirectoryParameters'
-    
-    GetByDirectoryIdsParameters:
-      description: Parameters for the /directory/getByDirectoryIds endpoint.
+          example: Uploaded new directory versions.
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &directoryCommandReturnValueExample
+        ReturnValue: Uploaded new directory versions.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /directory/saveDirectoryVersions
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    DirectoryVersionReturnValue:
+      description: Grace response envelope whose ReturnValue contains a directory version DTO.
       type: object
       properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        DirectoryIds:
+        ReturnValue:
+          $ref: '#/DirectoryVersionApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    DirectoryVersionListReturnValue:
+      description: Grace response envelope whose ReturnValue contains directory version DTOs.
+      type: object
+      properties:
+        ReturnValue:
           type: array
           items:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryId'
-      allOf:
-        - $ref: './Directory.Components.OpenAPI.yaml#/DirectoryParameters'
-    
-    GetBySha256HashParameters:
-      description: Parameters for the /directory/getBySha256Hash endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        Sha256Hash:
-          type: string
-          description: The SHA256 hash value.
-      allOf:
-        - $ref: './Directory.Components.OpenAPI.yaml#/DirectoryParameters'
-    
-    SaveDirectoryVersionsParameters:
-      description: Parameters for the /directory/saveDirectoryVersions endpoint.
-      type: object
-      properties:
-        DirectoryVersions:
-          type: array
-          items:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
-      allOf:
-        - $ref: './Directory.Components.OpenAPI.yaml#/DirectoryParameters'
+            $ref: '#/DirectoryVersionApiDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    DirectoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/DirectoryCommandReturnValue'
+          examples:
+            directoryCommand:
+              summary: Directory command response envelope
+              value: *directoryCommandReturnValueExample
+    DirectoryVersionResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/DirectoryVersionReturnValue'
+    DirectoryVersionListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/DirectoryVersionListReturnValue'

--- a/src/OpenAPI/Directory.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Directory.Paths.OpenAPI.yaml
@@ -1,27 +1,42 @@
   /directory/create:
     post:
+      tags:
+        - Directories
       summary: Create a new directory version.
-      description: |
-        ### Validation rules
-
-        - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-        - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Creates a directory version for the repository.
+      operationId: CreateDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/CreateParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/CreateParameters'
+            examples:
+              createDirectoryVersion:
+                summary: Create a directory version
+                value: &directoryCreateExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersion:
+                    Class: DirectoryVersion
+                    DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                    OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                    OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                    RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                    RelativePath: src
+                    Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                    Directories: []
+                    Files: []
+                    Size: 0
+                    CreatedAt: '2026-06-04T18:15:00Z'
+                    HashesValidated: true
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -29,33 +44,30 @@
 
   /directory/get:
     post:
+      tags:
+        - Directories
       summary: Get a directory version.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Gets a directory version DTO.
+      operationId: GetDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/GetParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/GetParameters'
+            examples:
+              getDirectoryVersion:
+                summary: Get a directory version
+                value: &directoryBaseExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryVersionResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -63,34 +75,24 @@
 
   /directory/getDirectoryVersionsRecursive:
     post:
-      summary: Get a directory version and all of its children.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Directories
+      summary: List a directory version and its children.
+      description: Gets a directory version and all recursive child directory versions.
+      operationId: ListDirectoryVersionsRecursive
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/GetParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/GetParameters'
+            examples:
+              listDirectoryVersionsRecursive:
+                summary: List recursive directory versions
+                value: *directoryBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryVersionListResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -98,33 +100,27 @@
 
   /directory/getByDirectoryIds:
     post:
-      summary: Get a list of directory versions by directory IDs.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directories specified by `DirectoryIds` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Directories
+      summary: List directory versions by id.
+      description: Gets directory version DTOs by directory version ids.
+      operationId: ListDirectoryVersionsById
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/GetByDirectoryIdsParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/GetByDirectoryIdsParameters'
+            examples:
+              listDirectoryVersionsById:
+                summary: List directory versions by id
+                value:
+                  <<: *directoryBaseExample
+                  DirectoryIds:
+                    - 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryVersion'
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryVersionListResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -132,33 +128,26 @@
 
   /directory/getBySha256Hash:
     post:
-      summary: Get a directory version by its SHA256 hash.
-      description: |
-        ### Validation rules
-
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `Sha256Hash` should not be empty.
-        - The repository specified by `RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Directories
+      summary: Get a directory version by SHA-256 hash.
+      description: Gets a directory version DTO by SHA-256 hash.
+      operationId: GetDirectoryVersionBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/GetBySha256HashParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/GetBySha256HashParameters'
+            examples:
+              getDirectoryVersionBySha256Hash:
+                summary: Get a directory version by SHA-256
+                value:
+                  <<: *directoryBaseExample
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryVersionResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -166,31 +155,38 @@
 
   /directory/saveDirectoryVersions:
     post:
-      summary: Save a list of directory versions.
-      description: |
-        ### Validation rules
-
-        - Each `DirectoryVersion` in the `DirectoryVersions` list should have valid properties:
-          - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.Sha256Hash` should not be empty.
-          - `DirectoryVersion.RelativePath` must not be empty.
-          - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Directories
+      summary: Save directory versions.
+      description: Saves a list of directory versions.
+      operationId: SaveDirectoryVersions
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Directory.Components.OpenAPI.yaml#/SaveDirectoryVersionsParameters
-
+              $ref: './Directory.Components.OpenAPI.yaml#/SaveDirectoryVersionsParameters'
+            examples:
+              saveDirectoryVersions:
+                summary: Save directory versions
+                value:
+                  <<: *directoryBaseExample
+                  DirectoryVersions:
+                    - Class: DirectoryVersion
+                      DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                      OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                      OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                      RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                      RelativePath: src
+                      Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                      Directories: []
+                      Files: []
+                      Size: 0
+                      CreatedAt: '2026-06-04T18:15:00Z'
+                      HashesValidated: true
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Directory.Components.OpenAPI.yaml#/DirectoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Dto.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Dto.Components.OpenAPI.yaml
@@ -90,10 +90,6 @@
           type: string
         SearchVisibility:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/SearchVisibility
-        Repositories:
-          type: object
-          additionalProperties:
-            $ref: Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName
         CreatedAt:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Instant
         UpdatedAt:
@@ -125,10 +121,6 @@
           type: string
         SearchVisibility:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/SearchVisibility
-        Organizations:
-          type: object
-          additionalProperties:
-            $ref: Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName
         CreatedAt:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Instant
         UpdatedAt:
@@ -202,4 +194,3 @@
           format: double
         CheckpointDays:
           type: number
-         

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -3721,10 +3721,6 @@ components:
           type: string
         SearchVisibility:
           $ref: '#/components/schemas/SearchVisibility'
-        Repositories:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/RepositoryName'
         CreatedAt:
           $ref: '#/components/schemas/Instant'
         UpdatedAt:
@@ -3755,10 +3751,6 @@ components:
           type: string
         SearchVisibility:
           $ref: '#/components/schemas/SearchVisibility'
-        Organizations:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/OrganizationName'
         CreatedAt:
           $ref: '#/components/schemas/Instant'
         UpdatedAt:

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -1351,1179 +1351,1250 @@ paths:
           $ref: '#/components/responses/500'
   /directory/create:
     post:
+      tags:
+        - Directories
       summary: Create a new directory version.
-      description: |
-        ### Validation rules
-
-        - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-        - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates a directory version for the repository.
+      operationId: CreateDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateParameters'
+            examples:
+              createDirectoryVersion:
+                summary: Create a directory version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersion:
+                    Class: DirectoryVersion
+                    DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                    OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                    OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                    RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                    RelativePath: src
+                    Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                    Directories: []
+                    Files: []
+                    Size: 0
+                    CreatedAt: '2026-06-04T18:15:00Z'
+                    HashesValidated: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/DirectoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/get:
     post:
+      tags:
+        - Directories
       summary: Get a directory version.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets a directory version DTO.
+      operationId: GetDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetParameters'
+            examples:
+              getDirectoryVersion:
+                summary: Get a directory version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getDirectoryVersionsRecursive:
     post:
-      summary: Get a directory version and all of its children.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: List a directory version and its children.
+      description: Gets a directory version and all recursive child directory versions.
+      operationId: ListDirectoryVersionsRecursive
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetParameters'
+            examples:
+              listDirectoryVersionsRecursive:
+                summary: List recursive directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionListResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getByDirectoryIds:
     post:
-      summary: Get a list of directory versions by directory IDs.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directories specified by `DirectoryIds` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: List directory versions by id.
+      description: Gets directory version DTOs by directory version ids.
+      operationId: ListDirectoryVersionsById
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetByDirectoryIdsParameters'
+            examples:
+              listDirectoryVersionsById:
+                summary: List directory versions by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryIds:
+                    - 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionListResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getBySha256Hash:
     post:
-      summary: Get a directory version by its SHA256 hash.
-      description: |
-        ### Validation rules
-
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `Sha256Hash` should not be empty.
-        - The repository specified by `RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: Get a directory version by SHA-256 hash.
+      description: Gets a directory version DTO by SHA-256 hash.
+      operationId: GetDirectoryVersionBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBySha256HashParameters'
+            examples:
+              getDirectoryVersionBySha256Hash:
+                summary: Get a directory version by SHA-256
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Sha256Hash'
+          $ref: '#/components/responses/DirectoryVersionResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/saveDirectoryVersions:
     post:
-      summary: Save a list of directory versions.
-      description: |
-        ### Validation rules
-
-        - Each `DirectoryVersion` in the `DirectoryVersions` list should have valid properties:
-          - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.Sha256Hash` should not be empty.
-          - `DirectoryVersion.RelativePath` must not be empty.
-          - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: Save directory versions.
+      description: Saves a list of directory versions.
+      operationId: SaveDirectoryVersions
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SaveDirectoryVersionsParameters'
+            examples:
+              saveDirectoryVersions:
+                summary: Save directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersions:
+                    - Class: DirectoryVersion
+                      DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                      OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                      OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                      RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                      RelativePath: src
+                      Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                      Directories: []
+                      Files: []
+                      Size: 0
+                      CreatedAt: '2026-06-04T18:15:00Z'
+                      HashesValidated: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/DirectoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/create:
     post:
+      tags:
+        - Organizations
       summary: Create an organization.
-      description: |
-        ### Validation rules
-        - `OwnerId` must be a valid non-empty `Guid`.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` is required and must not be empty.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OwnerId` or `OwnerName` must exist.
-        - The specified `OrganizationId` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates an organization under an owner.
+      operationId: CreateOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateOrganizationParameters'
+            examples:
+              createOrganization:
+                summary: Create an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setName:
     post:
+      tags:
+        - Organizations
       summary: Set the name of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `NewName` is required and must not be empty.
-        - `NewName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Renames an organization that exists and has not been deleted.
+      operationId: SetOrganizationName
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationNameParameters'
+            examples:
+              setOrganizationName:
+                summary: Rename an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  NewName: alice-platform
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setType:
     post:
-      summary: Set the type of an organization (Public, Private).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `OrganizationType` is required and must be a valid organization type.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set the organization type.
+      description: Sets the organization type to a public or private value accepted by the server.
+      operationId: SetOrganizationType
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationTypeParameters'
+            examples:
+              setOrganizationType:
+                summary: Set organization type
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  OrganizationType: Public
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setSearchVisibility:
     post:
-      summary: Set the search visibility of an organization (Visible, Hidden).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `SearchVisibility` is required and must be a valid search visibility option.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set organization search visibility.
+      description: Sets whether the organization appears in search results.
+      operationId: SetOrganizationSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationSearchVisibilityParameters'
+            examples:
+              setOrganizationSearchVisibility:
+                summary: Set organization search visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setDescription:
     post:
-      summary: Set the description of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `Description` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set the organization's description.
+      description: Sets the organization description.
+      operationId: SetOrganizationDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationDescriptionParameters'
+            examples:
+              setOrganizationDescription:
+                summary: Set organization description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  Description: Engineering organization for Alice's projects.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/listRepositories:
     post:
-      summary: List the repositories of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: List repositories of an organization.
+      description: Lists repositories associated with the organization.
+      operationId: ListOrganizationRepositories
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ListRepositoriesParameters'
+            examples:
+              listOrganizationRepositories:
+                summary: List repositories for an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: array
-                  $ref: '#/components/schemas/RepositoryDto'
+          $ref: '#/components/responses/OrganizationRepositoriesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/delete:
     post:
+      tags:
+        - Organizations
       summary: Delete an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `DeleteReason` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Logically deletes an organization that exists and has not already been deleted.
+      operationId: DeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteOrganizationParameters'
+            examples:
+              deleteOrganization:
+                summary: Delete an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  Force: false
+                  DeleteReason: Organization retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/undelete:
     post:
+      tags:
+        - Organizations
       summary: Undelete a previously deleted organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Restores a logically deleted organization.
+      operationId: UndeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationParameters'
+              $ref: '#/components/schemas/UndeleteOrganizationParameters'
+            examples:
+              undeleteOrganization:
+                summary: Restore an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/get:
     post:
+      tags:
+        - Organizations
       summary: Get an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets organization metadata.
+      operationId: GetOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetOrganizationParameters'
+            examples:
+              getOrganization:
+                summary: Get an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  IncludeDeleted: false
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/create:
     post:
+      tags:
+        - Owners
       summary: Create an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must not be empty.
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must not be empty.
-        - `OwnerName` must be a valid Grace name.
-        - Owner with the same `OwnerId` must not already exist.
-        - Owner with the same `OwnerName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates an owner with the specified id and name.
+      operationId: CreateOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateOwnerParameters'
+            examples:
+              createOwner:
+                summary: Create an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setName:
     post:
+      tags:
+        - Owners
       summary: Set the name of an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `NewName` must not be empty.
-        - `NewName` must be a valid Grace name.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-        - Owner with the specified `NewName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Renames an owner that exists and has not been deleted.
+      operationId: SetOwnerName
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerNameParameters'
+            examples:
+              setOwnerName:
+                summary: Rename an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  NewName: alice-renamed
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setType:
     post:
-      summary: Set the owner type (Public, Private).
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OwnerType` must not be empty.
-        - `OwnerType` must be a valid owner type.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set the owner type.
+      description: Sets the owner type to a public or private value accepted by the server.
+      operationId: SetOwnerType
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerTypeParameters'
+            examples:
+              setOwnerType:
+                summary: Set owner type
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  OwnerType: Public
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setSearchVisibility:
     post:
-      summary: Set the owner search visibility (Visible, NotVisible).
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `SearchVisibility` must be a valid search visibility.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set owner search visibility.
+      description: Sets whether the owner appears in search results.
+      operationId: SetOwnerSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerSearchVisibilityParameters'
+            examples:
+              setOwnerSearchVisibility:
+                summary: Set owner search visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setDescription:
     post:
+      tags:
+        - Owners
       summary: Set the owner's description.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `Description` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Sets the owner description.
+      operationId: SetOwnerDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerDescriptionParameters'
+            examples:
+              setOwnerDescription:
+                summary: Set owner description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  Description: Source control owner for Alice's projects.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/listOrganizations:
     post:
+      tags:
+        - Owners
       summary: List the organizations for an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Lists organizations associated with the owner.
+      operationId: ListOwnerOrganizations
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ListOrganizationsParameters'
+            examples:
+              listOwnerOrganizations:
+                summary: List organizations for an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/OrganizationDto'
+          $ref: '#/components/responses/OwnerOrganizationsResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/delete:
     post:
+      tags:
+        - Owners
       summary: Delete an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `DeleteReason` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Logically deletes an owner that exists and has not already been deleted.
+      operationId: DeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteOwnerParameters'
+            examples:
+              deleteOwner:
+                summary: Delete an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  Force: false
+                  DeleteReason: Owner retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/undelete:
     post:
-      summary: Undelete a previously-deleted owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Undelete a previously deleted owner.
+      description: Restores a logically deleted owner.
+      operationId: UndeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OwnerParameters'
+              $ref: '#/components/schemas/UndeleteOwnerParameters'
+            examples:
+              undeleteOwner:
+                summary: Restore an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/get:
     post:
+      tags:
+        - Owners
       summary: Get an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets owner metadata.
+      operationId: GetOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetOwnerParameters'
+            examples:
+              getOwner:
+                summary: Get an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OwnerDto'
+          $ref: '#/components/responses/OwnerResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/create:
     post:
+      tags:
+        - Repositories
       summary: Create a new repository.
-      description: |
-        This endpoint creates a new repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must not be empty.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The `RepositoryName` must be a valid Grace name.
-        - The `OwnerId` must correspond to an existing owner.
-        - The `OrganizationId` must correspond to an existing organization.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates a repository in an organization.
+      operationId: CreateRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateRepositoryParameters'
+            examples:
+              createRepository:
+                summary: Create a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setVisibility:
     post:
-      summary: Sets the search visibility of the repository.
-      description: |
-        This endpoint sets the search visibility of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Visibility` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository visibility.
+      description: Sets whether the repository is public or private.
+      operationId: SetRepositoryVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryVisibilityParameters'
+            examples:
+              setRepositoryVisibility:
+                summary: Set repository visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Visibility: Private
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setSaveDays:
     post:
-      summary: Sets the number of days to keep saves in the repository.
-      description: |
-        This endpoint sets the number of days to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `SaveDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set save retention.
+      description: Sets the number of days to keep saves in the repository.
+      operationId: SetRepositorySaveDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetSaveDaysParameters'
+            examples:
+              setRepositorySaveDays:
+                summary: Set save retention
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  SaveDays: 30
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setCheckpointDays:
     post:
-      summary: Sets the number of days to keep checkpoints in the repository.
-      description: |
-        This endpoint sets the number of days to keep checkpoints in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `CheckpointDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set checkpoint retention.
+      description: Sets the number of days to keep checkpoints in the repository.
+      operationId: SetRepositoryCheckpointDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetCheckpointDaysParameters'
+            examples:
+              setRepositoryCheckpointDays:
+                summary: Set checkpoint retention
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  CheckpointDays: 90
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setStatus:
     post:
-      summary: Sets the status of the repository (Public, Private).
-      description: |
-        This endpoint sets the status of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Status` value must be a valid repository status.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository status.
+      description: Sets the repository operational status.
+      operationId: SetRepositoryStatus
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryStatusParameters'
+            examples:
+              setRepositoryStatus:
+                summary: Set repository status
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Status: Active
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setDefaultServerApiVersion:
     post:
-      summary: Sets the default server API version for the repository.
-      description: |
-        This endpoint sets the default server API version for a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DefaultServerApiVersion` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set the default server API version.
+      description: Sets the default server API version clients should use for the repository.
+      operationId: SetRepositoryDefaultServerApiVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetDefaultServerApiVersionParameters'
+            examples:
+              setRepositoryDefaultServerApiVersion:
+                summary: Set default server API version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  DefaultServerApiVersion: '2026-06-04'
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setRecordSaves:
     post:
-      summary: Sets whether or not to keep saves in the repository.
-      description: |
-        This endpoint sets whether or not to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set whether saves are recorded.
+      description: Sets the repository default for whether save references should be kept.
+      operationId: SetRepositoryRecordSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RecordSavesParameters'
+            examples:
+              setRepositoryRecordSaves:
+                summary: Enable save recording
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  RecordSaves: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setDescription:
     post:
-      summary: Sets the description of the repository.
-      description: |
-        This endpoint sets the description of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Description` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository description.
+      description: Sets the repository description.
+      operationId: SetRepositoryDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryDescriptionParameters'
+            examples:
+              setRepositoryDescription:
+                summary: Set repository description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Description: Repository for release candidates.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/delete:
     post:
-      summary: Deletes the repository.
-      description: |
-        This endpoint deletes a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DeleteReason` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Delete a repository.
+      description: Logically deletes a repository that exists and has not already been deleted.
+      operationId: DeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteRepositoryParameters'
+            examples:
+              deleteRepository:
+                summary: Delete a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Force: false
+                  DeleteReason: Repository retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/undelete:
     post:
-      summary: Undeletes a previously-deleted repository.
-      description: |
-        This endpoint undeletes a previously-deleted repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Undelete a previously deleted repository.
+      description: Restores a logically deleted repository.
+      operationId: UndeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RepositoryParameters'
+              $ref: '#/components/schemas/UndeleteRepositoryParameters'
+            examples:
+              undeleteRepository:
+                summary: Restore a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/exists:
     post:
-      summary: Checks if a repository exists with the given parameters.
-      description: |
-        This endpoint checks if a repository exists based on the provided parameters.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Check whether a repository exists.
+      description: Checks whether a repository exists for the supplied selector values.
+      operationId: RepositoryExists
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RepositoryParameters'
+            examples:
+              repositoryExists:
+                summary: Check repository existence
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: '#/components/responses/RepositoryBooleanResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/isEmpty:
     post:
-      summary: Checks if a repository is empty.
-      description: |
-        This endpoint checks if a repository is empty, meaning it has just been created and has no data.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Check whether a repository is empty.
+      description: Checks whether a repository has no content yet.
+      operationId: RepositoryIsEmpty
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RepositoryParameters'
+              $ref: '#/components/schemas/IsEmptyParameters'
+            examples:
+              repositoryIsEmpty:
+                summary: Check whether a repository is empty
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: '#/components/responses/RepositoryBooleanResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/get:
     post:
-      summary: Gets a repository.
-      description: |
-        This endpoint retrieves the details of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Get a repository.
+      description: Gets repository metadata.
+      operationId: GetRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RepositoryParameters'
+            examples:
+              getRepository:
+                summary: Get a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RepositoryDto'
+          $ref: '#/components/responses/RepositoryResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getBranches:
     post:
-      summary: Gets a repository's branches.
-      description: |
-        This endpoint retrieves the branches of a repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List repository branches.
+      description: Gets branches for the repository.
+      operationId: ListRepositoryBranches
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBranchesParameters'
+            examples:
+              listRepositoryBranches:
+                summary: List repository branches
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  IncludeDeleted: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/BranchDto'
+          $ref: '#/components/responses/RepositoryBranchesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getReferencesByReferenceId:
     post:
-      summary: Gets a list of references by reference IDs.
-      description: |
-        This endpoint retrieves a list of references based on the provided reference IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `ReferenceIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List references by reference id.
+      description: Gets references in the repository by reference ids.
+      operationId: ListRepositoryReferencesByReferenceId
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetReferencesByReferenceIdParameters'
+            examples:
+              listRepositoryReferencesByReferenceId:
+                summary: List references by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  ReferenceIds:
+                    - c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/ReferenceDto'
+          $ref: '#/components/responses/RepositoryReferencesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getBranchesByBranchId:
     post:
-      summary: Gets a list of branches by branch IDs.
-      description: |
-        This endpoint retrieves a list of branches based on the provided branch IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `BranchIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List branches by branch id.
+      description: Gets branches in the repository by branch ids.
+      operationId: ListRepositoryBranchesByBranchId
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBranchesByBranchIdParameters'
+            examples:
+              listRepositoryBranchesByBranchId:
+                summary: List branches by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  IncludeDeleted: false
+                  MaxCount: 50
+                  BranchIds:
+                    - de7bf47d-23ae-4599-af68-68a317ea390d
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/BranchDto'
+          $ref: '#/components/responses/RepositoryBranchesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3462,66 +3533,72 @@ components:
             Sha256Hash2:
               $ref: '#/components/schemas/Sha256Hash'
     DirectoryParameters:
-      description: Parameters for many endpoints in the /directory path.
+      description: Parameters shared by public endpoints in the /directory route family.
       type: object
-      properties:
-        DirectoryId:
-          type: string
-          description: Unique identifier of the directory.
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
+      properties:
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OwnerName:
+          $ref: '#/components/schemas/OwnerName'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        OrganizationName:
+          $ref: '#/components/schemas/OrganizationName'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+        DirectoryVersionId:
+          $ref: '#/components/schemas/DirectoryVersionId'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
     CreateParameters:
       description: Parameters for the /directory/create endpoint.
-      type: object
-      properties:
-        DirectoryVersion:
-          $ref: '#/components/schemas/DirectoryVersion'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersion:
+              $ref: '#/components/schemas/DirectoryVersion'
     GetParameters:
-      description: Parameters for the /directory/get endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
+      description: Parameters for /directory/get and recursive directory-version lookups.
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
     GetByDirectoryIdsParameters:
       description: Parameters for the /directory/getByDirectoryIds endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        DirectoryIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/DirectoryId'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/DirectoryVersionId'
     GetBySha256HashParameters:
       description: Parameters for the /directory/getBySha256Hash endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        Sha256Hash:
-          type: string
-          description: The SHA256 hash value.
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            Sha256Hash:
+              $ref: '#/components/schemas/Sha256Hash'
     SaveDirectoryVersionsParameters:
       description: Parameters for the /directory/saveDirectoryVersions endpoint.
-      type: object
-      properties:
-        DirectoryVersions:
-          type: array
-          items:
-            $ref: '#/components/schemas/DirectoryVersion'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersions:
+              type: array
+              items:
+                $ref: '#/components/schemas/DirectoryVersion'
     BranchDto:
       description: (automatically generated)
       type: object
@@ -3722,18 +3799,24 @@ components:
         CheckpointDays:
           type: number
     OrganizationParameters:
-      description: Parameters for many endpoints in the /organization path.
+      description: Parameters shared by public endpoints in the /organization route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: '#/components/schemas/OrganizationName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
     CreateOrganizationParameters:
       description: Parameters for the /organization/create endpoint.
       allOf:
@@ -3742,39 +3825,48 @@ components:
       description: Parameters for the /organization/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/OrganizationName'
     SetOrganizationTypeParameters:
       description: Parameters for the /organization/setType endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        OrganizationType:
-          type: string
+        - type: object
+          properties:
+            OrganizationType:
+              $ref: '#/components/schemas/OrganizationType'
     SetOrganizationSearchVisibilityParameters:
       description: Parameters for the /organization/setSearchVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: '#/components/schemas/SearchVisibility'
     SetOrganizationDescriptionParameters:
       description: Parameters for the /organization/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Engineering organization for Alice's projects.
     DeleteOrganizationParameters:
       description: Parameters for the /organization/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Organization retired.
     UndeleteOrganizationParameters:
       description: Parameters for the /organization/undelete endpoint.
       allOf:
@@ -3783,19 +3875,29 @@ components:
       description: Parameters for the /organization/get endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     ListRepositoriesParameters:
       description: Parameters for the /organization/listRepositories endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
     OwnerParameters:
-      description: Parameters for many endpoints in the /owner path.
+      description: Parameters shared by public endpoints in the /owner route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
     CreateOwnerParameters:
       description: Parameters for the /owner/create endpoint.
       allOf:
@@ -3804,39 +3906,48 @@ components:
       description: Parameters for the /owner/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/OwnerName'
     SetOwnerTypeParameters:
       description: Parameters for the /owner/setType endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        OwnerType:
-          type: string
+        - type: object
+          properties:
+            OwnerType:
+              $ref: '#/components/schemas/OwnerType'
     SetOwnerSearchVisibilityParameters:
       description: Parameters for the /owner/setSearchVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: '#/components/schemas/SearchVisibility'
     SetOwnerDescriptionParameters:
       description: Parameters for the /owner/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Source control owner for Alice's projects.
     DeleteOwnerParameters:
       description: Parameters for the /owner/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Owner retired.
     UndeleteOwnerParameters:
       description: Parameters for the /owner/undelete endpoint.
       allOf:
@@ -3845,6 +3956,11 @@ components:
       description: Parameters for the /owner/get endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     ListOrganizationsParameters:
       description: Parameters for the /owner/listOrganizations endpoint.
       allOf:
@@ -3873,25 +3989,37 @@ components:
         ReferenceType: Commit
         ReferenceText: Capture release candidate.
     RepositoryParameters:
-      description: Parameters for many endpoints in the /repository path.
+      description: Parameters shared by public endpoints in the /repository route family.
       type: object
+      allOf:
+        - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: '#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: '#/components/schemas/RepositoryId'
         RepositoryName:
-          type: string
+          $ref: '#/components/schemas/RepositoryName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
     CreateRepositoryParameters:
       description: Parameters for the /repository/create endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
+        - type: object
+          properties:
+            ObjectStorageProvider:
+              $ref: '#/components/schemas/ObjectStorageProvider'
     IsEmptyParameters:
       description: Parameters for the /repository/isEmpty endpoint.
       allOf:
@@ -3900,114 +4028,156 @@ components:
       description: Parameters for the /repository/init endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        GraceConfig:
-          type: string
+        - type: object
+          properties:
+            GraceConfig:
+              type: string
+              example: '{}'
     SetRepositoryVisibilityParameters:
       description: Parameters for the /repository/setVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Visibility:
-          type: string
+        - type: object
+          properties:
+            Visibility:
+              $ref: '#/components/schemas/RepositoryVisibility'
     SetRepositoryStatusParameters:
       description: Parameters for the /repository/setStatus endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Status:
-          type: string
+        - type: object
+          properties:
+            Status:
+              $ref: '#/components/schemas/RepositoryStatus'
     RecordSavesParameters:
-      description: Parameters for the /repository/recordSaves endpoint.
+      description: Parameters for the /repository/setRecordSaves endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        RecordSaves:
-          type: boolean
+        - type: object
+          properties:
+            RecordSaves:
+              type: boolean
+              example: true
     SetSaveDaysParameters:
       description: Parameters for the /repository/setSaveDays endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        SaveDays:
-          type: number
+        - type: object
+          properties:
+            SaveDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 30
     SetCheckpointDaysParameters:
-      description: Parameters for the /repository/setCheckpointDays
+      description: Parameters for the /repository/setCheckpointDays endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        CheckpointDays:
-          type: number
+        - type: object
+          properties:
+            CheckpointDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 90
     SetRepositoryDescriptionParameters:
       description: Parameters for the /repository/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Repository for release candidates.
     SetDefaultServerApiVersionParameters:
       description: Parameters for the /repository/setDefaultServerApiVersion endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        DefaultServerApiVersion:
-          type: string
+        - type: object
+          properties:
+            DefaultServerApiVersion:
+              type: string
+              example: '2026-06-04'
     SetRepositoryNameParameters:
       description: Parameters for the /repository/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/RepositoryName'
     DeleteRepositoryParameters:
       description: Parameters for the /repository/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Repository retired.
     EnablePromotionTypeParameters:
-      description: Parameters for enabling promotion type.
+      description: Parameters for repository promotion type feature toggles.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Enabled:
-          type: boolean
+        - type: object
+          properties:
+            Enabled:
+              type: boolean
+              example: true
     GetReferencesByReferenceIdParameters:
       description: Parameters for the /repository/getReferencesByReferenceId endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        ReferenceIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/ReferenceId'
-        MaxCount:
-          type: integer
+        - type: object
+          properties:
+            ReferenceIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReferenceId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesParameters:
-      description: Parameters for the /repository/getBranched endpoint.
+      description: Parameters for the /repository/getBranches endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        IncludeDeleted:
-          type: boolean
-        MaxCount:
-          type: integer
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesByBranchIdParameters:
       description: Parameters for the /repository/getBranchesByBranchId endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        BranchIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/BranchId'
-        MaxCount:
-          type: integer
-        IncludeDeleted:
-          type: boolean
+        - type: object
+          properties:
+            BranchIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/BranchId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
+            IncludeDeleted:
+              type: boolean
+              example: false
     UndeleteRepositoryParameters:
       description: Parameters for the /repository/undelete endpoint.
       allOf:
@@ -5137,6 +5307,377 @@ components:
         Properties:
           DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
           DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DirectoryVersionId:
+      type: string
+      format: uuid
+      example: 33a4e36b-828f-4fae-9343-50b6560dc842
+    DirectoryCommandReturnValue:
+      description: Grace response envelope returned by directory command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Uploaded new directory versions.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Uploaded new directory versions.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /directory/saveDirectoryVersions
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    DirectoryVersionApiDto:
+      description: Public directory version DTO returned by directory query endpoints.
+      type: object
+      properties:
+        DirectoryVersion:
+          $ref: '#/components/schemas/DirectoryVersion'
+        RecursiveSize:
+          type: integer
+          format: int64
+          example: 4096
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+          example: ''
+        HashesValidated:
+          type: boolean
+          example: true
+    DirectoryVersionReturnValue:
+      description: Grace response envelope whose ReturnValue contains a directory version DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/DirectoryVersionApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    DirectoryVersionListReturnValue:
+      description: Grace response envelope whose ReturnValue contains directory version DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/DirectoryVersionApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OrganizationCommandReturnValue:
+      description: Grace response envelope returned by organization command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Organization command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Organization command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationRepositoriesReturnValue:
+      description: Grace response envelope whose ReturnValue contains repositories for an organization.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/RepositoryDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OrganizationReturnValue:
+      description: Grace response envelope whose ReturnValue contains an organization DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/OrganizationDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: OrganizationDto
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          OrganizationName: alice-org
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationType: Public
+          Description: Engineering organization for Alice's projects.
+          SearchVisibility: Visible
+          Repositories:
+            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OwnerCommandReturnValue:
+      description: Grace response envelope returned by owner command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Owner command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Owner command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerOrganizationsReturnValue:
+      description: Grace response envelope whose ReturnValue contains the owner's organizations.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OwnerReturnValue:
+      description: Grace response envelope whose ReturnValue contains an owner DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/OwnerDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: OwnerDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OwnerName: alice
+          OwnerType: Public
+          Description: Source control owner for Alice's projects.
+          SearchVisibility: Visible
+          Organizations:
+            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    RepositoryCommandReturnValue:
+      description: Grace response envelope returned by repository command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Repository command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Repository command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /repository/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    RepositoryBooleanReturnValue:
+      description: Grace response envelope whose ReturnValue contains a boolean repository query result.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+          example: true
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryReturnValue:
+      description: Grace response envelope whose ReturnValue contains a repository DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/RepositoryDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryBranchesReturnValue:
+      description: Grace response envelope whose ReturnValue contains branch DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/BranchDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryReferencesReturnValue:
+      description: Grace response envelope whose ReturnValue contains reference DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
     GraceReturnValueBase:
       description: Common metadata returned with successful Grace responses.
       type: object
@@ -5860,12 +6401,6 @@ components:
       scheme: bearer
       bearerFormat: JWT
   responses:
-    '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GraceReturnValue'
     '400':
       description: Bad Request
       content:
@@ -6115,3 +6650,172 @@ components:
                 Properties:
                   DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
                   DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DirectoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryCommandReturnValue'
+          examples:
+            directoryCommand:
+              summary: Directory command response envelope
+              value:
+                ReturnValue: Uploaded new directory versions.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /directory/saveDirectoryVersions
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    DirectoryVersionResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryVersionReturnValue'
+    DirectoryVersionListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryVersionListReturnValue'
+    OrganizationCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationCommandReturnValue'
+          examples:
+            organizationCommand:
+              summary: Organization command response envelope
+              value:
+                ReturnValue: Organization command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /organization/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationRepositoriesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationRepositoriesReturnValue'
+    OrganizationResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationReturnValue'
+          examples:
+            organization:
+              summary: Organization response envelope
+              value:
+                ReturnValue:
+                  Class: OrganizationDto
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationType: Public
+                  Description: Engineering organization for Alice's projects.
+                  SearchVisibility: Visible
+                  Repositories:
+                    sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /organization/get
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OwnerCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerCommandReturnValue'
+          examples:
+            ownerCommand:
+              summary: Owner command response envelope
+              value:
+                ReturnValue: Owner command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerOrganizationsResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerOrganizationsReturnValue'
+    OwnerResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerReturnValue'
+          examples:
+            owner:
+              summary: Owner response envelope
+              value:
+                ReturnValue:
+                  Class: OwnerDto
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  OwnerType: Public
+                  Description: Source control owner for Alice's projects.
+                  SearchVisibility: Visible
+                  Organizations:
+                    alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/get
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    RepositoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryCommandReturnValue'
+          examples:
+            repositoryCommand:
+              summary: Repository command response envelope
+              value:
+                ReturnValue: Repository command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /repository/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    RepositoryBooleanResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryBooleanReturnValue'
+    RepositoryResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryReturnValue'
+    RepositoryBranchesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryBranchesReturnValue'
+    RepositoryReferencesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryReferencesReturnValue'

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -2148,6 +2148,38 @@ paths:
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
+  /repository/setName:
+    post:
+      tags:
+        - Repositories
+      summary: Set the name of a repository.
+      description: Renames a repository that exists and has not been deleted.
+      operationId: SetRepositoryName
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetRepositoryNameParameters'
+            examples:
+              setRepositoryName:
+                summary: Rename a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  NewName: sample-repository-renamed
+      responses:
+        '200':
+          $ref: '#/components/responses/RepositoryCommandResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
   /repository/setSaveDays:
     post:
       tags:
@@ -5425,27 +5457,6 @@ components:
           Path: /organization/create
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
           OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
-    OrganizationRepositoriesReturnValue:
-      description: Grace response envelope whose ReturnValue contains repositories for an organization.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: '#/components/schemas/RepositoryDto'
-        EventTime:
-          $ref: '#/components/schemas/Instant'
-        CorrelationId:
-          $ref: '#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required:
-        - ReturnValue
-        - EventTime
-        - CorrelationId
-        - Properties
     OrganizationReturnValue:
       description: Grace response envelope whose ReturnValue contains an organization DTO.
       type: object
@@ -5474,8 +5485,6 @@ components:
           OrganizationType: Public
           Description: Engineering organization for Alice's projects.
           SearchVisibility: Visible
-          Repositories:
-            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -5511,27 +5520,6 @@ components:
         Properties:
           Path: /owner/create
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
-    OwnerOrganizationsReturnValue:
-      description: Grace response envelope whose ReturnValue contains the owner's organizations.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: '#/components/schemas/OrganizationDto'
-        EventTime:
-          $ref: '#/components/schemas/Instant'
-        CorrelationId:
-          $ref: '#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required:
-        - ReturnValue
-        - EventTime
-        - CorrelationId
-        - Properties
     OwnerReturnValue:
       description: Grace response envelope whose ReturnValue contains an owner DTO.
       type: object
@@ -5559,8 +5547,6 @@ components:
           OwnerType: Public
           Description: Source control owner for Alice's projects.
           SearchVisibility: Visible
-          Organizations:
-            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -6700,7 +6686,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganizationRepositoriesReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            repositories:
+              summary: Organization repository id-to-name dictionary
+              value:
+                ab6f35ef-6e01-440b-8f9b-c343a5272095: sample-repository
     OrganizationResponse:
       description: OK
       content:
@@ -6719,8 +6712,6 @@ components:
                   OrganizationType: Public
                   Description: Engineering organization for Alice's projects.
                   SearchVisibility: Visible
-                  Repositories:
-                    sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
                   CreatedAt: '2026-06-04T18:15:00Z'
                   DeleteReason: ''
                 EventTime: '2026-06-04T18:15:00Z'
@@ -6750,7 +6741,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OwnerOrganizationsReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            organizations:
+              summary: Owner organization id-to-name dictionary
+              value:
+                e35d64a9-b990-44f5-bf02-32ad7d15630c: alice-org
     OwnerResponse:
       description: OK
       content:
@@ -6768,8 +6766,6 @@ components:
                   OwnerType: Public
                   Description: Source control owner for Alice's projects.
                   SearchVisibility: Visible
-                  Organizations:
-                    alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
                   CreatedAt: '2026-06-04T18:15:00Z'
                   DeleteReason: ''
                 EventTime: '2026-06-04T18:15:00Z'

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -3721,10 +3721,6 @@ components:
           type: string
         SearchVisibility:
           $ref: '#/components/schemas/SearchVisibility'
-        Repositories:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/RepositoryName'
         CreatedAt:
           $ref: '#/components/schemas/Instant'
         UpdatedAt:
@@ -3755,10 +3751,6 @@ components:
           type: string
         SearchVisibility:
           $ref: '#/components/schemas/SearchVisibility'
-        Organizations:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/OrganizationName'
         CreatedAt:
           $ref: '#/components/schemas/Instant'
         UpdatedAt:

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -1351,1179 +1351,1250 @@ paths:
           $ref: '#/components/responses/500'
   /directory/create:
     post:
+      tags:
+        - Directories
       summary: Create a new directory version.
-      description: |
-        ### Validation rules
-
-        - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-        - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates a directory version for the repository.
+      operationId: CreateDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateParameters'
+            examples:
+              createDirectoryVersion:
+                summary: Create a directory version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersion:
+                    Class: DirectoryVersion
+                    DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                    OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                    OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                    RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                    RelativePath: src
+                    Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                    Directories: []
+                    Files: []
+                    Size: 0
+                    CreatedAt: '2026-06-04T18:15:00Z'
+                    HashesValidated: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/DirectoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/get:
     post:
+      tags:
+        - Directories
       summary: Get a directory version.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets a directory version DTO.
+      operationId: GetDirectoryVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetParameters'
+            examples:
+              getDirectoryVersion:
+                summary: Get a directory version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getDirectoryVersionsRecursive:
     post:
-      summary: Get a directory version and all of its children.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directory specified by `DirectoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: List a directory version and its children.
+      description: Gets a directory version and all recursive child directory versions.
+      operationId: ListDirectoryVersionsRecursive
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetParameters'
+            examples:
+              listDirectoryVersionsRecursive:
+                summary: List recursive directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionListResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getByDirectoryIds:
     post:
-      summary: Get a list of directory versions by directory IDs.
-      description: |
-        ### Validation rules
-
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - The repository specified by `RepositoryId` should exist.
-        - The directories specified by `DirectoryIds` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: List directory versions by id.
+      description: Gets directory version DTOs by directory version ids.
+      operationId: ListDirectoryVersionsById
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetByDirectoryIdsParameters'
+            examples:
+              listDirectoryVersionsById:
+                summary: List directory versions by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryIds:
+                    - 33a4e36b-828f-4fae-9343-50b6560dc842
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/DirectoryVersion'
+          $ref: '#/components/responses/DirectoryVersionListResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/getBySha256Hash:
     post:
-      summary: Get a directory version by its SHA256 hash.
-      description: |
-        ### Validation rules
-
-        - `DirectoryId` should be a valid and non-empty GUID.
-        - `RepositoryId` should be a valid and non-empty GUID.
-        - `Sha256Hash` should not be empty.
-        - The repository specified by `RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: Get a directory version by SHA-256 hash.
+      description: Gets a directory version DTO by SHA-256 hash.
+      operationId: GetDirectoryVersionBySha256Hash
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBySha256HashParameters'
+            examples:
+              getDirectoryVersionBySha256Hash:
+                summary: Get a directory version by SHA-256
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Sha256Hash'
+          $ref: '#/components/responses/DirectoryVersionResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /directory/saveDirectoryVersions:
     post:
-      summary: Save a list of directory versions.
-      description: |
-        ### Validation rules
-
-        - Each `DirectoryVersion` in the `DirectoryVersions` list should have valid properties:
-          - `DirectoryVersion.DirectoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.RepositoryId` should be a valid and non-empty GUID.
-          - `DirectoryVersion.Sha256Hash` should not be empty.
-          - `DirectoryVersion.RelativePath` must not be empty.
-          - The repository specified by `DirectoryVersion.RepositoryId` should exist.
-
-        ### Errors and Problem Details
-
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Directories
+      summary: Save directory versions.
+      description: Saves a list of directory versions.
+      operationId: SaveDirectoryVersions
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SaveDirectoryVersionsParameters'
+            examples:
+              saveDirectoryVersions:
+                summary: Save directory versions
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                  DirectoryVersions:
+                    - Class: DirectoryVersion
+                      DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
+                      OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                      OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                      RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                      RelativePath: src
+                      Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                      Directories: []
+                      Files: []
+                      Size: 0
+                      CreatedAt: '2026-06-04T18:15:00Z'
+                      HashesValidated: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/DirectoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/create:
     post:
+      tags:
+        - Organizations
       summary: Create an organization.
-      description: |
-        ### Validation rules
-        - `OwnerId` must be a valid non-empty `Guid`.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` is required and must not be empty.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OwnerId` or `OwnerName` must exist.
-        - The specified `OrganizationId` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates an organization under an owner.
+      operationId: CreateOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateOrganizationParameters'
+            examples:
+              createOrganization:
+                summary: Create an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setName:
     post:
+      tags:
+        - Organizations
       summary: Set the name of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `NewName` is required and must not be empty.
-        - `NewName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Renames an organization that exists and has not been deleted.
+      operationId: SetOrganizationName
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationNameParameters'
+            examples:
+              setOrganizationName:
+                summary: Rename an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  NewName: alice-platform
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setType:
     post:
-      summary: Set the type of an organization (Public, Private).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `OrganizationType` is required and must be a valid organization type.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set the organization type.
+      description: Sets the organization type to a public or private value accepted by the server.
+      operationId: SetOrganizationType
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationTypeParameters'
+            examples:
+              setOrganizationType:
+                summary: Set organization type
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  OrganizationType: Public
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setSearchVisibility:
     post:
-      summary: Set the search visibility of an organization (Visible, Hidden).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `SearchVisibility` is required and must be a valid search visibility option.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set organization search visibility.
+      description: Sets whether the organization appears in search results.
+      operationId: SetOrganizationSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationSearchVisibilityParameters'
+            examples:
+              setOrganizationSearchVisibility:
+                summary: Set organization search visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/setDescription:
     post:
-      summary: Set the description of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `Description` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: Set the organization's description.
+      description: Sets the organization description.
+      operationId: SetOrganizationDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOrganizationDescriptionParameters'
+            examples:
+              setOrganizationDescription:
+                summary: Set organization description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  Description: Engineering organization for Alice's projects.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/listRepositories:
     post:
-      summary: List the repositories of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Organizations
+      summary: List repositories of an organization.
+      description: Lists repositories associated with the organization.
+      operationId: ListOrganizationRepositories
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ListRepositoriesParameters'
+            examples:
+              listOrganizationRepositories:
+                summary: List repositories for an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: array
-                  $ref: '#/components/schemas/RepositoryDto'
+          $ref: '#/components/responses/OrganizationRepositoriesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/delete:
     post:
+      tags:
+        - Organizations
       summary: Delete an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `DeleteReason` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Logically deletes an organization that exists and has not already been deleted.
+      operationId: DeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteOrganizationParameters'
+            examples:
+              deleteOrganization:
+                summary: Delete an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  Force: false
+                  DeleteReason: Organization retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/undelete:
     post:
+      tags:
+        - Organizations
       summary: Undelete a previously deleted organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Restores a logically deleted organization.
+      operationId: UndeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationParameters'
+              $ref: '#/components/schemas/UndeleteOrganizationParameters'
+            examples:
+              undeleteOrganization:
+                summary: Restore an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /organization/get:
     post:
+      tags:
+        - Organizations
       summary: Get an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets organization metadata.
+      operationId: GetOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetOrganizationParameters'
+            examples:
+              getOrganization:
+                summary: Get an organization
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  IncludeDeleted: false
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OrganizationResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/create:
     post:
+      tags:
+        - Owners
       summary: Create an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must not be empty.
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must not be empty.
-        - `OwnerName` must be a valid Grace name.
-        - Owner with the same `OwnerId` must not already exist.
-        - Owner with the same `OwnerName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates an owner with the specified id and name.
+      operationId: CreateOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateOwnerParameters'
+            examples:
+              createOwner:
+                summary: Create an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setName:
     post:
+      tags:
+        - Owners
       summary: Set the name of an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `NewName` must not be empty.
-        - `NewName` must be a valid Grace name.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-        - Owner with the specified `NewName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Renames an owner that exists and has not been deleted.
+      operationId: SetOwnerName
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerNameParameters'
+            examples:
+              setOwnerName:
+                summary: Rename an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  NewName: alice-renamed
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setType:
     post:
-      summary: Set the owner type (Public, Private).
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OwnerType` must not be empty.
-        - `OwnerType` must be a valid owner type.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set the owner type.
+      description: Sets the owner type to a public or private value accepted by the server.
+      operationId: SetOwnerType
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerTypeParameters'
+            examples:
+              setOwnerType:
+                summary: Set owner type
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  OwnerType: Public
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setSearchVisibility:
     post:
-      summary: Set the owner search visibility (Visible, NotVisible).
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `SearchVisibility` must be a valid search visibility.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set owner search visibility.
+      description: Sets whether the owner appears in search results.
+      operationId: SetOwnerSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerSearchVisibilityParameters'
+            examples:
+              setOwnerSearchVisibility:
+                summary: Set owner search visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/setDescription:
     post:
+      tags:
+        - Owners
       summary: Set the owner's description.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `Description` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Sets the owner description.
+      operationId: SetOwnerDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetOwnerDescriptionParameters'
+            examples:
+              setOwnerDescription:
+                summary: Set owner description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  Description: Source control owner for Alice's projects.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/listOrganizations:
     post:
+      tags:
+        - Owners
       summary: List the organizations for an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Lists organizations associated with the owner.
+      operationId: ListOwnerOrganizations
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ListOrganizationsParameters'
+            examples:
+              listOwnerOrganizations:
+                summary: List organizations for an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/OrganizationDto'
+          $ref: '#/components/responses/OwnerOrganizationsResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/delete:
     post:
+      tags:
+        - Owners
       summary: Delete an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `DeleteReason` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Logically deletes an owner that exists and has not already been deleted.
+      operationId: DeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteOwnerParameters'
+            examples:
+              deleteOwner:
+                summary: Delete an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  Force: false
+                  DeleteReason: Owner retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/undelete:
     post:
-      summary: Undelete a previously-deleted owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Undelete a previously deleted owner.
+      description: Restores a logically deleted owner.
+      operationId: UndeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OwnerParameters'
+              $ref: '#/components/schemas/UndeleteOwnerParameters'
+            examples:
+              undeleteOwner:
+                summary: Restore an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/OwnerCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /owner/get:
     post:
+      tags:
+        - Owners
       summary: Get an owner.
-      description: |
-        ### Validation rules
-
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets owner metadata.
+      operationId: GetOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetOwnerParameters'
+            examples:
+              getOwner:
+                summary: Get an owner
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OwnerDto'
+          $ref: '#/components/responses/OwnerResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/create:
     post:
+      tags:
+        - Repositories
       summary: Create a new repository.
-      description: |
-        This endpoint creates a new repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must not be empty.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The `RepositoryName` must be a valid Grace name.
-        - The `OwnerId` must correspond to an existing owner.
-        - The `OrganizationId` must correspond to an existing organization.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates a repository in an organization.
+      operationId: CreateRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateRepositoryParameters'
+            examples:
+              createRepository:
+                summary: Create a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setVisibility:
     post:
-      summary: Sets the search visibility of the repository.
-      description: |
-        This endpoint sets the search visibility of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Visibility` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository visibility.
+      description: Sets whether the repository is public or private.
+      operationId: SetRepositoryVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryVisibilityParameters'
+            examples:
+              setRepositoryVisibility:
+                summary: Set repository visibility
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Visibility: Private
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setSaveDays:
     post:
-      summary: Sets the number of days to keep saves in the repository.
-      description: |
-        This endpoint sets the number of days to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `SaveDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set save retention.
+      description: Sets the number of days to keep saves in the repository.
+      operationId: SetRepositorySaveDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetSaveDaysParameters'
+            examples:
+              setRepositorySaveDays:
+                summary: Set save retention
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  SaveDays: 30
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setCheckpointDays:
     post:
-      summary: Sets the number of days to keep checkpoints in the repository.
-      description: |
-        This endpoint sets the number of days to keep checkpoints in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `CheckpointDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set checkpoint retention.
+      description: Sets the number of days to keep checkpoints in the repository.
+      operationId: SetRepositoryCheckpointDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetCheckpointDaysParameters'
+            examples:
+              setRepositoryCheckpointDays:
+                summary: Set checkpoint retention
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  CheckpointDays: 90
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setStatus:
     post:
-      summary: Sets the status of the repository (Public, Private).
-      description: |
-        This endpoint sets the status of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Status` value must be a valid repository status.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository status.
+      description: Sets the repository operational status.
+      operationId: SetRepositoryStatus
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryStatusParameters'
+            examples:
+              setRepositoryStatus:
+                summary: Set repository status
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Status: Active
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setDefaultServerApiVersion:
     post:
-      summary: Sets the default server API version for the repository.
-      description: |
-        This endpoint sets the default server API version for a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DefaultServerApiVersion` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set the default server API version.
+      description: Sets the default server API version clients should use for the repository.
+      operationId: SetRepositoryDefaultServerApiVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetDefaultServerApiVersionParameters'
+            examples:
+              setRepositoryDefaultServerApiVersion:
+                summary: Set default server API version
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  DefaultServerApiVersion: '2026-06-04'
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setRecordSaves:
     post:
-      summary: Sets whether or not to keep saves in the repository.
-      description: |
-        This endpoint sets whether or not to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set whether saves are recorded.
+      description: Sets the repository default for whether save references should be kept.
+      operationId: SetRepositoryRecordSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RecordSavesParameters'
+            examples:
+              setRepositoryRecordSaves:
+                summary: Enable save recording
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  RecordSaves: true
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/setDescription:
     post:
-      summary: Sets the description of the repository.
-      description: |
-        This endpoint sets the description of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Description` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Set repository description.
+      description: Sets the repository description.
+      operationId: SetRepositoryDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SetRepositoryDescriptionParameters'
+            examples:
+              setRepositoryDescription:
+                summary: Set repository description
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Description: Repository for release candidates.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/delete:
     post:
-      summary: Deletes the repository.
-      description: |
-        This endpoint deletes a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DeleteReason` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Delete a repository.
+      description: Logically deletes a repository that exists and has not already been deleted.
+      operationId: DeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteRepositoryParameters'
+            examples:
+              deleteRepository:
+                summary: Delete a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  Force: false
+                  DeleteReason: Repository retired.
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/undelete:
     post:
-      summary: Undeletes a previously-deleted repository.
-      description: |
-        This endpoint undeletes a previously-deleted repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Undelete a previously deleted repository.
+      description: Restores a logically deleted repository.
+      operationId: UndeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RepositoryParameters'
+              $ref: '#/components/schemas/UndeleteRepositoryParameters'
+            examples:
+              undeleteRepository:
+                summary: Restore a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/RepositoryCommandResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/exists:
     post:
-      summary: Checks if a repository exists with the given parameters.
-      description: |
-        This endpoint checks if a repository exists based on the provided parameters.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Check whether a repository exists.
+      description: Checks whether a repository exists for the supplied selector values.
+      operationId: RepositoryExists
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RepositoryParameters'
+            examples:
+              repositoryExists:
+                summary: Check repository existence
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: '#/components/responses/RepositoryBooleanResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/isEmpty:
     post:
-      summary: Checks if a repository is empty.
-      description: |
-        This endpoint checks if a repository is empty, meaning it has just been created and has no data.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Check whether a repository is empty.
+      description: Checks whether a repository has no content yet.
+      operationId: RepositoryIsEmpty
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RepositoryParameters'
+              $ref: '#/components/schemas/IsEmptyParameters'
+            examples:
+              repositoryIsEmpty:
+                summary: Check whether a repository is empty
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: '#/components/responses/RepositoryBooleanResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/get:
     post:
-      summary: Gets a repository.
-      description: |
-        This endpoint retrieves the details of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: Get a repository.
+      description: Gets repository metadata.
+      operationId: GetRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RepositoryParameters'
+            examples:
+              getRepository:
+                summary: Get a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RepositoryDto'
+          $ref: '#/components/responses/RepositoryResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getBranches:
     post:
-      summary: Gets a repository's branches.
-      description: |
-        This endpoint retrieves the branches of a repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List repository branches.
+      description: Gets branches for the repository.
+      operationId: ListRepositoryBranches
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBranchesParameters'
+            examples:
+              listRepositoryBranches:
+                summary: List repository branches
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  IncludeDeleted: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/BranchDto'
+          $ref: '#/components/responses/RepositoryBranchesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getReferencesByReferenceId:
     post:
-      summary: Gets a list of references by reference IDs.
-      description: |
-        This endpoint retrieves a list of references based on the provided reference IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `ReferenceIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List references by reference id.
+      description: Gets references in the repository by reference ids.
+      operationId: ListRepositoryReferencesByReferenceId
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetReferencesByReferenceIdParameters'
+            examples:
+              listRepositoryReferencesByReferenceId:
+                summary: List references by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  ReferenceIds:
+                    - c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/ReferenceDto'
+          $ref: '#/components/responses/RepositoryReferencesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
   /repository/getBranchesByBranchId:
     post:
-      summary: Gets a list of branches by branch IDs.
-      description: |
-        This endpoint retrieves a list of branches based on the provided branch IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `BranchIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Repositories
+      summary: List branches by branch id.
+      description: Gets branches in the repository by branch ids.
+      operationId: ListRepositoryBranchesByBranchId
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GetBranchesByBranchIdParameters'
+            examples:
+              listRepositoryBranchesByBranchId:
+                summary: List branches by id
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  IncludeDeleted: false
+                  MaxCount: 50
+                  BranchIds:
+                    - de7bf47d-23ae-4599-af68-68a317ea390d
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: '#/components/schemas/BranchDto'
+          $ref: '#/components/responses/RepositoryBranchesResponse'
         '400':
           $ref: '#/components/responses/400'
         '500':
@@ -3462,66 +3533,72 @@ components:
             Sha256Hash2:
               $ref: '#/components/schemas/Sha256Hash'
     DirectoryParameters:
-      description: Parameters for many endpoints in the /directory path.
+      description: Parameters shared by public endpoints in the /directory route family.
       type: object
-      properties:
-        DirectoryId:
-          type: string
-          description: Unique identifier of the directory.
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
+      properties:
+        OwnerId:
+          $ref: '#/components/schemas/OwnerId'
+        OwnerName:
+          $ref: '#/components/schemas/OwnerName'
+        OrganizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        OrganizationName:
+          $ref: '#/components/schemas/OrganizationName'
+        RepositoryId:
+          $ref: '#/components/schemas/RepositoryId'
+        RepositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+        DirectoryVersionId:
+          $ref: '#/components/schemas/DirectoryVersionId'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+        DirectoryVersionId: 33a4e36b-828f-4fae-9343-50b6560dc842
     CreateParameters:
       description: Parameters for the /directory/create endpoint.
-      type: object
-      properties:
-        DirectoryVersion:
-          $ref: '#/components/schemas/DirectoryVersion'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersion:
+              $ref: '#/components/schemas/DirectoryVersion'
     GetParameters:
-      description: Parameters for the /directory/get endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
+      description: Parameters for /directory/get and recursive directory-version lookups.
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
     GetByDirectoryIdsParameters:
       description: Parameters for the /directory/getByDirectoryIds endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        DirectoryIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/DirectoryId'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/DirectoryVersionId'
     GetBySha256HashParameters:
       description: Parameters for the /directory/getBySha256Hash endpoint.
-      type: object
-      properties:
-        RepositoryId:
-          type: string
-          description: Unique identifier of the repository.
-        Sha256Hash:
-          type: string
-          description: The SHA256 hash value.
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            Sha256Hash:
+              $ref: '#/components/schemas/Sha256Hash'
     SaveDirectoryVersionsParameters:
       description: Parameters for the /directory/saveDirectoryVersions endpoint.
-      type: object
-      properties:
-        DirectoryVersions:
-          type: array
-          items:
-            $ref: '#/components/schemas/DirectoryVersion'
       allOf:
         - $ref: '#/components/schemas/DirectoryParameters'
+        - type: object
+          properties:
+            DirectoryVersions:
+              type: array
+              items:
+                $ref: '#/components/schemas/DirectoryVersion'
     BranchDto:
       description: (automatically generated)
       type: object
@@ -3722,18 +3799,24 @@ components:
         CheckpointDays:
           type: number
     OrganizationParameters:
-      description: Parameters for many endpoints in the /organization path.
+      description: Parameters shared by public endpoints in the /organization route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: '#/components/schemas/OrganizationName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
     CreateOrganizationParameters:
       description: Parameters for the /organization/create endpoint.
       allOf:
@@ -3742,39 +3825,48 @@ components:
       description: Parameters for the /organization/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/OrganizationName'
     SetOrganizationTypeParameters:
       description: Parameters for the /organization/setType endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        OrganizationType:
-          type: string
+        - type: object
+          properties:
+            OrganizationType:
+              $ref: '#/components/schemas/OrganizationType'
     SetOrganizationSearchVisibilityParameters:
       description: Parameters for the /organization/setSearchVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: '#/components/schemas/SearchVisibility'
     SetOrganizationDescriptionParameters:
       description: Parameters for the /organization/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Engineering organization for Alice's projects.
     DeleteOrganizationParameters:
       description: Parameters for the /organization/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Organization retired.
     UndeleteOrganizationParameters:
       description: Parameters for the /organization/undelete endpoint.
       allOf:
@@ -3783,19 +3875,29 @@ components:
       description: Parameters for the /organization/get endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     ListRepositoriesParameters:
       description: Parameters for the /organization/listRepositories endpoint.
       allOf:
         - $ref: '#/components/schemas/OrganizationParameters'
     OwnerParameters:
-      description: Parameters for many endpoints in the /owner path.
+      description: Parameters shared by public endpoints in the /owner route family.
+      type: object
       allOf:
         - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
     CreateOwnerParameters:
       description: Parameters for the /owner/create endpoint.
       allOf:
@@ -3804,39 +3906,48 @@ components:
       description: Parameters for the /owner/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/OwnerName'
     SetOwnerTypeParameters:
       description: Parameters for the /owner/setType endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        OwnerType:
-          type: string
+        - type: object
+          properties:
+            OwnerType:
+              $ref: '#/components/schemas/OwnerType'
     SetOwnerSearchVisibilityParameters:
       description: Parameters for the /owner/setSearchVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: '#/components/schemas/SearchVisibility'
     SetOwnerDescriptionParameters:
       description: Parameters for the /owner/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Source control owner for Alice's projects.
     DeleteOwnerParameters:
       description: Parameters for the /owner/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Owner retired.
     UndeleteOwnerParameters:
       description: Parameters for the /owner/undelete endpoint.
       allOf:
@@ -3845,6 +3956,11 @@ components:
       description: Parameters for the /owner/get endpoint.
       allOf:
         - $ref: '#/components/schemas/OwnerParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     ListOrganizationsParameters:
       description: Parameters for the /owner/listOrganizations endpoint.
       allOf:
@@ -3873,25 +3989,37 @@ components:
         ReferenceType: Commit
         ReferenceText: Capture release candidate.
     RepositoryParameters:
-      description: Parameters for many endpoints in the /repository path.
+      description: Parameters shared by public endpoints in the /repository route family.
       type: object
+      allOf:
+        - $ref: '#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: '#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: '#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: '#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: '#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: '#/components/schemas/RepositoryId'
         RepositoryName:
-          type: string
+          $ref: '#/components/schemas/RepositoryName'
+      example:
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
     CreateRepositoryParameters:
       description: Parameters for the /repository/create endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
+        - type: object
+          properties:
+            ObjectStorageProvider:
+              $ref: '#/components/schemas/ObjectStorageProvider'
     IsEmptyParameters:
       description: Parameters for the /repository/isEmpty endpoint.
       allOf:
@@ -3900,114 +4028,156 @@ components:
       description: Parameters for the /repository/init endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        GraceConfig:
-          type: string
+        - type: object
+          properties:
+            GraceConfig:
+              type: string
+              example: '{}'
     SetRepositoryVisibilityParameters:
       description: Parameters for the /repository/setVisibility endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Visibility:
-          type: string
+        - type: object
+          properties:
+            Visibility:
+              $ref: '#/components/schemas/RepositoryVisibility'
     SetRepositoryStatusParameters:
       description: Parameters for the /repository/setStatus endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Status:
-          type: string
+        - type: object
+          properties:
+            Status:
+              $ref: '#/components/schemas/RepositoryStatus'
     RecordSavesParameters:
-      description: Parameters for the /repository/recordSaves endpoint.
+      description: Parameters for the /repository/setRecordSaves endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        RecordSaves:
-          type: boolean
+        - type: object
+          properties:
+            RecordSaves:
+              type: boolean
+              example: true
     SetSaveDaysParameters:
       description: Parameters for the /repository/setSaveDays endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        SaveDays:
-          type: number
+        - type: object
+          properties:
+            SaveDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 30
     SetCheckpointDaysParameters:
-      description: Parameters for the /repository/setCheckpointDays
+      description: Parameters for the /repository/setCheckpointDays endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        CheckpointDays:
-          type: number
+        - type: object
+          properties:
+            CheckpointDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 90
     SetRepositoryDescriptionParameters:
       description: Parameters for the /repository/setDescription endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Description:
-          type: string
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Repository for release candidates.
     SetDefaultServerApiVersionParameters:
       description: Parameters for the /repository/setDefaultServerApiVersion endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        DefaultServerApiVersion:
-          type: string
+        - type: object
+          properties:
+            DefaultServerApiVersion:
+              type: string
+              example: '2026-06-04'
     SetRepositoryNameParameters:
       description: Parameters for the /repository/setName endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        NewName:
-          type: string
+        - type: object
+          properties:
+            NewName:
+              $ref: '#/components/schemas/RepositoryName'
     DeleteRepositoryParameters:
       description: Parameters for the /repository/delete endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Repository retired.
     EnablePromotionTypeParameters:
-      description: Parameters for enabling promotion type.
+      description: Parameters for repository promotion type feature toggles.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        Enabled:
-          type: boolean
+        - type: object
+          properties:
+            Enabled:
+              type: boolean
+              example: true
     GetReferencesByReferenceIdParameters:
       description: Parameters for the /repository/getReferencesByReferenceId endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        ReferenceIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/ReferenceId'
-        MaxCount:
-          type: integer
+        - type: object
+          properties:
+            ReferenceIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReferenceId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesParameters:
-      description: Parameters for the /repository/getBranched endpoint.
+      description: Parameters for the /repository/getBranches endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        IncludeDeleted:
-          type: boolean
-        MaxCount:
-          type: integer
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesByBranchIdParameters:
       description: Parameters for the /repository/getBranchesByBranchId endpoint.
       allOf:
         - $ref: '#/components/schemas/RepositoryParameters'
-      properties:
-        BranchIds:
-          type: array
-          items:
-            $ref: '#/components/schemas/BranchId'
-        MaxCount:
-          type: integer
-        IncludeDeleted:
-          type: boolean
+        - type: object
+          properties:
+            BranchIds:
+              type: array
+              items:
+                $ref: '#/components/schemas/BranchId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
+            IncludeDeleted:
+              type: boolean
+              example: false
     UndeleteRepositoryParameters:
       description: Parameters for the /repository/undelete endpoint.
       allOf:
@@ -5137,6 +5307,377 @@ components:
         Properties:
           DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
           DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DirectoryVersionId:
+      type: string
+      format: uuid
+      example: 33a4e36b-828f-4fae-9343-50b6560dc842
+    DirectoryCommandReturnValue:
+      description: Grace response envelope returned by directory command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Uploaded new directory versions.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Uploaded new directory versions.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /directory/saveDirectoryVersions
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    DirectoryVersionApiDto:
+      description: Public directory version DTO returned by directory query endpoints.
+      type: object
+      properties:
+        DirectoryVersion:
+          $ref: '#/components/schemas/DirectoryVersion'
+        RecursiveSize:
+          type: integer
+          format: int64
+          example: 4096
+        DeletedAt:
+          $ref: '#/components/schemas/Instant'
+          nullable: true
+        DeleteReason:
+          type: string
+          example: ''
+        HashesValidated:
+          type: boolean
+          example: true
+    DirectoryVersionReturnValue:
+      description: Grace response envelope whose ReturnValue contains a directory version DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/DirectoryVersionApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    DirectoryVersionListReturnValue:
+      description: Grace response envelope whose ReturnValue contains directory version DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/DirectoryVersionApiDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OrganizationCommandReturnValue:
+      description: Grace response envelope returned by organization command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Organization command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Organization command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationRepositoriesReturnValue:
+      description: Grace response envelope whose ReturnValue contains repositories for an organization.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/RepositoryDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OrganizationReturnValue:
+      description: Grace response envelope whose ReturnValue contains an organization DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/OrganizationDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: OrganizationDto
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          OrganizationName: alice-org
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationType: Public
+          Description: Engineering organization for Alice's projects.
+          SearchVisibility: Visible
+          Repositories:
+            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OwnerCommandReturnValue:
+      description: Grace response envelope returned by owner command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Owner command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Owner command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerOrganizationsReturnValue:
+      description: Grace response envelope whose ReturnValue contains the owner's organizations.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    OwnerReturnValue:
+      description: Grace response envelope whose ReturnValue contains an owner DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/OwnerDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue:
+          Class: OwnerDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OwnerName: alice
+          OwnerType: Public
+          Description: Source control owner for Alice's projects.
+          SearchVisibility: Visible
+          Organizations:
+            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    RepositoryCommandReturnValue:
+      description: Grace response envelope returned by repository command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Repository command succeeded.
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+      example:
+        ReturnValue: Repository command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /repository/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    RepositoryBooleanReturnValue:
+      description: Grace response envelope whose ReturnValue contains a boolean repository query result.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+          example: true
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryReturnValue:
+      description: Grace response envelope whose ReturnValue contains a repository DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: '#/components/schemas/RepositoryDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryBranchesReturnValue:
+      description: Grace response envelope whose ReturnValue contains branch DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/BranchDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
+    RepositoryReferencesReturnValue:
+      description: Grace response envelope whose ReturnValue contains reference DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferenceDto'
+        EventTime:
+          $ref: '#/components/schemas/Instant'
+        CorrelationId:
+          $ref: '#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - ReturnValue
+        - EventTime
+        - CorrelationId
+        - Properties
     GraceReturnValueBase:
       description: Common metadata returned with successful Grace responses.
       type: object
@@ -5860,12 +6401,6 @@ components:
       scheme: bearer
       bearerFormat: JWT
   responses:
-    '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GraceReturnValue'
     '400':
       description: Bad Request
       content:
@@ -6115,3 +6650,172 @@ components:
                 Properties:
                   DirectoryVersionId1: 33a4e36b-828f-4fae-9343-50b6560dc842
                   DirectoryVersionId2: 66b7b8c2-8d2f-4f04-951c-6b3486c4e5d1
+    DirectoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryCommandReturnValue'
+          examples:
+            directoryCommand:
+              summary: Directory command response envelope
+              value:
+                ReturnValue: Uploaded new directory versions.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /directory/saveDirectoryVersions
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    DirectoryVersionResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryVersionReturnValue'
+    DirectoryVersionListResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DirectoryVersionListReturnValue'
+    OrganizationCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationCommandReturnValue'
+          examples:
+            organizationCommand:
+              summary: Organization command response envelope
+              value:
+                ReturnValue: Organization command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /organization/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationRepositoriesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationRepositoriesReturnValue'
+    OrganizationResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OrganizationReturnValue'
+          examples:
+            organization:
+              summary: Organization response envelope
+              value:
+                ReturnValue:
+                  Class: OrganizationDto
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationType: Public
+                  Description: Engineering organization for Alice's projects.
+                  SearchVisibility: Visible
+                  Repositories:
+                    sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /organization/get
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OwnerCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerCommandReturnValue'
+          examples:
+            ownerCommand:
+              summary: Owner command response envelope
+              value:
+                ReturnValue: Owner command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerOrganizationsResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerOrganizationsReturnValue'
+    OwnerResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OwnerReturnValue'
+          examples:
+            owner:
+              summary: Owner response envelope
+              value:
+                ReturnValue:
+                  Class: OwnerDto
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
+                  OwnerType: Public
+                  Description: Source control owner for Alice's projects.
+                  SearchVisibility: Visible
+                  Organizations:
+                    alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  CreatedAt: '2026-06-04T18:15:00Z'
+                  DeleteReason: ''
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /owner/get
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    RepositoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryCommandReturnValue'
+          examples:
+            repositoryCommand:
+              summary: Repository command response envelope
+              value:
+                ReturnValue: Repository command succeeded.
+                EventTime: '2026-06-04T18:15:00Z'
+                CorrelationId: cli-20260604T181500Z-0001
+                Properties:
+                  Path: /repository/create
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    RepositoryBooleanResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryBooleanReturnValue'
+    RepositoryResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryReturnValue'
+    RepositoryBranchesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryBranchesReturnValue'
+    RepositoryReferencesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RepositoryReferencesReturnValue'

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -2148,6 +2148,38 @@ paths:
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
+  /repository/setName:
+    post:
+      tags:
+        - Repositories
+      summary: Set the name of a repository.
+      description: Renames a repository that exists and has not been deleted.
+      operationId: SetRepositoryName
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetRepositoryNameParameters'
+            examples:
+              setRepositoryName:
+                summary: Rename a repository
+                value:
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
+                  NewName: sample-repository-renamed
+      responses:
+        '200':
+          $ref: '#/components/responses/RepositoryCommandResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
   /repository/setSaveDays:
     post:
       tags:
@@ -5425,27 +5457,6 @@ components:
           Path: /organization/create
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
           OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
-    OrganizationRepositoriesReturnValue:
-      description: Grace response envelope whose ReturnValue contains repositories for an organization.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: '#/components/schemas/RepositoryDto'
-        EventTime:
-          $ref: '#/components/schemas/Instant'
-        CorrelationId:
-          $ref: '#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required:
-        - ReturnValue
-        - EventTime
-        - CorrelationId
-        - Properties
     OrganizationReturnValue:
       description: Grace response envelope whose ReturnValue contains an organization DTO.
       type: object
@@ -5474,8 +5485,6 @@ components:
           OrganizationType: Public
           Description: Engineering organization for Alice's projects.
           SearchVisibility: Visible
-          Repositories:
-            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -5511,27 +5520,6 @@ components:
         Properties:
           Path: /owner/create
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
-    OwnerOrganizationsReturnValue:
-      description: Grace response envelope whose ReturnValue contains the owner's organizations.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: '#/components/schemas/OrganizationDto'
-        EventTime:
-          $ref: '#/components/schemas/Instant'
-        CorrelationId:
-          $ref: '#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required:
-        - ReturnValue
-        - EventTime
-        - CorrelationId
-        - Properties
     OwnerReturnValue:
       description: Grace response envelope whose ReturnValue contains an owner DTO.
       type: object
@@ -5559,8 +5547,6 @@ components:
           OwnerType: Public
           Description: Source control owner for Alice's projects.
           SearchVisibility: Visible
-          Organizations:
-            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -6700,7 +6686,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganizationRepositoriesReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            repositories:
+              summary: Organization repository id-to-name dictionary
+              value:
+                ab6f35ef-6e01-440b-8f9b-c343a5272095: sample-repository
     OrganizationResponse:
       description: OK
       content:
@@ -6719,8 +6712,6 @@ components:
                   OrganizationType: Public
                   Description: Engineering organization for Alice's projects.
                   SearchVisibility: Visible
-                  Repositories:
-                    sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
                   CreatedAt: '2026-06-04T18:15:00Z'
                   DeleteReason: ''
                 EventTime: '2026-06-04T18:15:00Z'
@@ -6750,7 +6741,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OwnerOrganizationsReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            organizations:
+              summary: Owner organization id-to-name dictionary
+              value:
+                e35d64a9-b990-44f5-bf02-32ad7d15630c: alice-org
     OwnerResponse:
       description: OK
       content:
@@ -6768,8 +6766,6 @@ components:
                   OwnerType: Public
                   Description: Source control owner for Alice's projects.
                   SearchVisibility: Visible
-                  Organizations:
-                    alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
                   CreatedAt: '2026-06-04T18:15:00Z'
                   DeleteReason: ''
                 EventTime: '2026-06-04T18:15:00Z'

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -203,6 +203,8 @@ paths:
     $ref: './Repository.Paths.OpenAPI.yaml#/~1repository~1create'
   /repository/setVisibility:
     $ref: './Repository.Paths.OpenAPI.yaml#/~1repository~1setVisibility'
+  /repository/setName:
+    $ref: './Repository.Paths.OpenAPI.yaml#/~1repository~1setName'
   /repository/setSaveDays:
     $ref: './Repository.Paths.OpenAPI.yaml#/~1repository~1setSaveDays'
   /repository/setCheckpointDays:

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -41,11 +41,11 @@
     },
     {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "64526e82e1be370452c72b612d2a23fb66f5b6dbb832ae474b5db5eaba274cf9"
+      "sha256": "2f8c7898d86bd51421d758f4e02c8486fd97f7cc74cf9b8c3e5889575122e3b2"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
-      "sha256": "8da4a3e380b1e2eebbf9f4b432af20d9b7b0dfd217fa4fe002158b690e11612e"
+      "sha256": "b0992dd1bc3c591f57364884bbe3e7dd8d740a1cac374d9ff1eef61d1e97806a"
     },
     {
       "path": "Organization.Paths.OpenAPI.yaml",
@@ -53,7 +53,7 @@
     },
     {
       "path": "Owner.Components.OpenAPI.yaml",
-      "sha256": "9194999c67dc4974935c7a5efb68a6a38b5b9d8aed894a0e13edb2d74b1690fa"
+      "sha256": "3aea1dcb6afe284a636da3b18f293fbacbb807bc98947b115fb5ca49cec4cd7f"
     },
     {
       "path": "Owner.Paths.OpenAPI.yaml",
@@ -69,7 +69,7 @@
     },
     {
       "path": "Repository.Paths.OpenAPI.yaml",
-      "sha256": "f5f50f719614df64c36868d63176b4fa991f07429fc9eba5e383fd8889b1f9fe"
+      "sha256": "74a43fbf752a74347b580ef45d2dca51b5a6dcf21cb73cb7134969741a8a839c"
     },
     {
       "path": "Responses.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
+      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "68fd034e2edcbb9bafb35a9a89ef3f6da12abaf263b14deb54fd16860a95c15c"
+      "sha256": "34eb2028488b4592e158d697053b2bb4a9d253853dd946993485c06b0a240b4d"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
+      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "342514595e604e4d08cc6e238709a6aff3399826b6ed7b6dabfb7509ee421d30"
+      "sha256": "b2c17fa56b878e866e512f39929e88088dd48f1462b78182d82e363ef7597b38"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
+      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -37,7 +37,7 @@
     },
     {
       "path": "Dto.Components.OpenAPI.yaml",
-      "sha256": "f9bd41b00867ca40b94a99a6590739f421649409bcbbe28bad92063f7be227ed"
+      "sha256": "886f072e857098fa93c038e681d506b243a102f4fc81bfdd339653cfe61f7ac3"
     },
     {
       "path": "Main.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
+      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "34eb2028488b4592e158d697053b2bb4a9d253853dd946993485c06b0a240b4d"
+      "sha256": "eecad416391e6bc462dcfa032f39c9da7c57717403eac37a5fe6ca890c4a3e57"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
+      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "b2c17fa56b878e866e512f39929e88088dd48f1462b78182d82e363ef7597b38"
+      "sha256": "e2be4a02d2f63a3b9f4cdabe7f615ba0a5c98673618c132d063b9bbf4273f590"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "c2788b782d3b0af372837865ad5b77de2edafd2d0c6e212bc0bbfad6a99fb652",
+      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -29,11 +29,11 @@
     },
     {
       "path": "Directory.Components.OpenAPI.yaml",
-      "sha256": "d696ab0589dee5f321b041a90aec20e61c7ee80cd9ead7c6fd8a51657173038a"
+      "sha256": "a6194a71864ce710d6da96d64ed4696ec2f1ad47f29283db38f3a71658b99c21"
     },
     {
       "path": "Directory.Paths.OpenAPI.yaml",
-      "sha256": "669ee20859628404b597907c53034b2cba3e21c20a5a5dc116ce682c7bdf0817"
+      "sha256": "a54ba56e7bfc32d4e34eeb54a9977f6123abbc426fd2f4e31ea6e3eeccff0a56"
     },
     {
       "path": "Dto.Components.OpenAPI.yaml",
@@ -45,19 +45,19 @@
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
-      "sha256": "6dc80c9e15ca314e14e264f23f742ff669b11f9887105d589e7c1371584efe16"
+      "sha256": "8da4a3e380b1e2eebbf9f4b432af20d9b7b0dfd217fa4fe002158b690e11612e"
     },
     {
       "path": "Organization.Paths.OpenAPI.yaml",
-      "sha256": "41de66035db6846ba7414cd49dab306ea49795c2806d85ee40af17933bbc99e1"
+      "sha256": "c8cb4826d1c45dc0adc7743159e3310f125f85bbcc75a72a78472743b2e2ebd9"
     },
     {
       "path": "Owner.Components.OpenAPI.yaml",
-      "sha256": "ab94095469fab50b4895db3ad341fe281b61c3336089b40848fbb2a5cffab794"
+      "sha256": "9194999c67dc4974935c7a5efb68a6a38b5b9d8aed894a0e13edb2d74b1690fa"
     },
     {
       "path": "Owner.Paths.OpenAPI.yaml",
-      "sha256": "e885e320fa6ba99c1539b4529400c2fb614301c4a001e6a6b648876b967d6e42"
+      "sha256": "b9a5a3cb0c5626c9894342b796aa6f124318bb5920ccb847bdcef0cab9cbc824"
     },
     {
       "path": "Reference.Components.OpenAPI.yaml",
@@ -65,11 +65,11 @@
     },
     {
       "path": "Repository.Components.OpenAPI.yaml",
-      "sha256": "9c3f1e5a2474bea3f242c7bd25b61b650c982bd53b799fb0736272298eab1c45"
+      "sha256": "d984ce039c0d7a2b7c761e4da20448d67f2171eff7a540291030d578881c42f3"
     },
     {
       "path": "Repository.Paths.OpenAPI.yaml",
-      "sha256": "11e2c20a8cd2f408615e85be5e3825a83f03b47513c13e14781b090c5c9662f0"
+      "sha256": "f5f50f719614df64c36868d63176b4fa991f07429fc9eba5e383fd8889b1f9fe"
     },
     {
       "path": "Responses.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
+      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "692b28bb00653d72424216c5c741d331ed7bee3c9a5fcf03ec79653690ce159e"
+      "sha256": "68fd034e2edcbb9bafb35a9a89ef3f6da12abaf263b14deb54fd16860a95c15c"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
+      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "2bca8ae6d235badbee913db130b138d08785e645a504bc20ecd984112ae5e10c"
+      "sha256": "342514595e604e4d08cc6e238709a6aff3399826b6ed7b6dabfb7509ee421d30"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "c6ec61ebb9ca3b34af37894b020ec6da1017c4f8022d8a3e937a6b8eb142d90d",
+      "sourceDigest": "654de7f174dd9d5759c28974535b0eaf6c7601a2175cc946e4804432e1a3316a",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/Organization.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Organization.Components.OpenAPI.yaml
@@ -1,66 +1,187 @@
     OrganizationParameters:
-      description: Parameters for many endpoints in the /organization path.
+      description: Parameters shared by public endpoints in the /organization route family.
+      type: object
       allOf:
         - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
+      example: &organizationBaseExample
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
     CreateOrganizationParameters:
       description: Parameters for the /organization/create endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
+        - $ref: '#/OrganizationParameters'
     SetOrganizationNameParameters:
       description: Parameters for the /organization/setName endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
-      properties:
-        NewName:
-          type: string
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            NewName:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
     SetOrganizationTypeParameters:
       description: Parameters for the /organization/setType endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
-      properties:
-        OrganizationType:
-          type: string
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            OrganizationType:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationType'
     SetOrganizationSearchVisibilityParameters:
       description: Parameters for the /organization/setSearchVisibility endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/SearchVisibility'
     SetOrganizationDescriptionParameters:
       description: Parameters for the /organization/setDescription endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
-      properties:
-        Description:
-          type: string
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Engineering organization for Alice's projects.
     DeleteOrganizationParameters:
       description: Parameters for the /organization/delete endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Organization retired.
     UndeleteOrganizationParameters:
       description: Parameters for the /organization/undelete endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
+        - $ref: '#/OrganizationParameters'
     GetOrganizationParameters:
       description: Parameters for the /organization/get endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
+        - $ref: '#/OrganizationParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     ListRepositoriesParameters:
       description: Parameters for the /organization/listRepositories endpoint.
       allOf:
-        - $ref: 'Organization.Components.OpenAPI.yaml#/OrganizationParameters'
+        - $ref: '#/OrganizationParameters'
+    OrganizationCommandReturnValue:
+      description: Grace response envelope returned by organization command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Organization command succeeded.
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &organizationCommandReturnValueExample
+        ReturnValue: Organization command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationReturnValue:
+      description: Grace response envelope whose ReturnValue contains an organization DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: 'Dto.Components.OpenAPI.yaml#/OrganizationDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &organizationReturnValueExample
+        ReturnValue:
+          Class: OrganizationDto
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          OrganizationName: alice-org
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationType: Public
+          Description: Engineering organization for Alice's projects.
+          SearchVisibility: Visible
+          Repositories:
+            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /organization/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+    OrganizationRepositoriesReturnValue:
+      description: Grace response envelope whose ReturnValue contains repositories for an organization.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: 'Dto.Components.OpenAPI.yaml#/RepositoryDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    OrganizationCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OrganizationCommandReturnValue'
+          examples:
+            organizationCommand:
+              summary: Organization command response envelope
+              value: *organizationCommandReturnValueExample
+    OrganizationResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OrganizationReturnValue'
+          examples:
+            organization:
+              summary: Organization response envelope
+              value: *organizationReturnValueExample
+    OrganizationRepositoriesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OrganizationRepositoriesReturnValue'

--- a/src/OpenAPI/Organization.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Organization.Components.OpenAPI.yaml
@@ -132,8 +132,6 @@
           OrganizationType: Public
           Description: Engineering organization for Alice's projects.
           SearchVisibility: Visible
-          Repositories:
-            sample-repository: ab6f35ef-6e01-440b-8f9b-c343a5272095
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -142,23 +140,6 @@
           Path: /organization/get
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
           OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
-    OrganizationRepositoriesReturnValue:
-      description: Grace response envelope whose ReturnValue contains repositories for an organization.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: 'Dto.Components.OpenAPI.yaml#/RepositoryDto'
-        EventTime:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
-        CorrelationId:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required: [ReturnValue, EventTime, CorrelationId, Properties]
     OrganizationCommandResponse:
       description: OK
       content:
@@ -184,4 +165,11 @@
       content:
         application/json:
           schema:
-            $ref: '#/OrganizationRepositoriesReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            repositories:
+              summary: Organization repository id-to-name dictionary
+              value:
+                ab6f35ef-6e01-440b-8f9b-c343a5272095: sample-repository

--- a/src/OpenAPI/Organization.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Organization.Paths.OpenAPI.yaml
@@ -1,30 +1,28 @@
   /organization/create:
     post:
+      tags:
+        - Organizations
       summary: Create an organization.
-      description: |
-        ### Validation rules
-        - `OwnerId` must be a valid non-empty `Guid`.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` is required and must not be empty.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OwnerId` or `OwnerName` must exist.
-        - The specified `OrganizationId` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Creates an organization under an owner.
+      operationId: CreateOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/CreateOrganizationParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/CreateOrganizationParameters'
+            examples:
+              createOrganization:
+                summary: Create an organization
+                value: &organizationBaseExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  OrganizationName: alice-org
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -32,29 +30,26 @@
 
   /organization/setName:
     post:
+      tags:
+        - Organizations
       summary: Set the name of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `NewName` is required and must not be empty.
-        - `NewName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Renames an organization that exists and has not been deleted.
+      operationId: SetOrganizationName
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/SetOrganizationNameParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/SetOrganizationNameParameters'
+            examples:
+              setOrganizationName:
+                summary: Rename an organization
+                value:
+                  <<: *organizationBaseExample
+                  NewName: alice-platform
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -62,28 +57,26 @@
 
   /organization/setType:
     post:
-      summary: Set the type of an organization (Public, Private).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `OrganizationType` is required and must be a valid organization type.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Organizations
+      summary: Set the organization type.
+      description: Sets the organization type to a public or private value accepted by the server.
+      operationId: SetOrganizationType
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/SetOrganizationTypeParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/SetOrganizationTypeParameters'
+            examples:
+              setOrganizationType:
+                summary: Set organization type
+                value:
+                  <<: *organizationBaseExample
+                  OrganizationType: Public
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -91,28 +84,26 @@
 
   /organization/setSearchVisibility:
     post:
-      summary: Set the search visibility of an organization (Visible, Hidden).
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `SearchVisibility` is required and must be a valid search visibility option.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Organizations
+      summary: Set organization search visibility.
+      description: Sets whether the organization appears in search results.
+      operationId: SetOrganizationSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/SetOrganizationSearchVisibilityParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/SetOrganizationSearchVisibilityParameters'
+            examples:
+              setOrganizationSearchVisibility:
+                summary: Set organization search visibility
+                value:
+                  <<: *organizationBaseExample
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -120,27 +111,26 @@
 
   /organization/setDescription:
     post:
-      summary: Set the description of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `Description` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Organizations
+      summary: Set the organization's description.
+      description: Sets the organization description.
+      operationId: SetOrganizationDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/SetOrganizationDescriptionParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/SetOrganizationDescriptionParameters'
+            examples:
+              setOrganizationDescription:
+                summary: Set organization description
+                value:
+                  <<: *organizationBaseExample
+                  Description: Engineering organization for Alice's projects.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -148,35 +138,24 @@
 
   /organization/listRepositories:
     post:
-      summary: List the repositories of an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Organizations
+      summary: List repositories of an organization.
+      description: Lists repositories associated with the organization.
+      operationId: ListOrganizationRepositories
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/ListRepositoriesParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/ListRepositoriesParameters'
+            examples:
+              listOrganizationRepositories:
+                summary: List repositories for an organization
+                value: *organizationBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: array
-                  $ref: Dto.Components.OpenAPI.yaml#/RepositoryDto
-
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationRepositoriesResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -184,28 +163,27 @@
 
   /organization/delete:
     post:
+      tags:
+        - Organizations
       summary: Delete an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - `DeleteReason` is required and must not be empty.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Logically deletes an organization that exists and has not already been deleted.
+      operationId: DeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/DeleteOrganizationParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/DeleteOrganizationParameters'
+            examples:
+              deleteOrganization:
+                summary: Delete an organization
+                value:
+                  <<: *organizationBaseExample
+                  Force: false
+                  DeleteReason: Organization retired.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -213,28 +191,24 @@
 
   /organization/undelete:
     post:
+      tags:
+        - Organizations
       summary: Undelete a previously deleted organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Restores a logically deleted organization.
+      operationId: UndeleteOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/OrganizationParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/UndeleteOrganizationParameters'
+            examples:
+              undeleteOrganization:
+                summary: Restore an organization
+                value: *organizationBaseExample
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -242,27 +216,26 @@
 
   /organization/get:
     post:
+      tags:
+        - Organizations
       summary: Get an organization.
-      description: |
-        ### Validation rules
-        - `OrganizationId` is required and must not be empty.
-        - `OrganizationId` must be a valid non-empty `Guid`.
-        - `OrganizationName` must be a valid Grace name.
-        - The specified `OrganizationId` must exist.
-        - The specified organization must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Gets organization metadata.
+      operationId: GetOrganization
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Organization.Components.OpenAPI.yaml#/GetOrganizationParameters
+              $ref: './Organization.Components.OpenAPI.yaml#/GetOrganizationParameters'
+            examples:
+              getOrganization:
+                summary: Get an organization
+                value:
+                  <<: *organizationBaseExample
+                  IncludeDeleted: false
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Organization.Components.OpenAPI.yaml#/OrganizationResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Owner.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Owner.Components.OpenAPI.yaml
@@ -1,62 +1,179 @@
     OwnerParameters:
-      description: Parameters for many endpoints in the /owner path.
+      description: Parameters shared by public endpoints in the /owner route family.
+      type: object
       allOf:
         - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
+      example: &ownerBaseExample
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
     CreateOwnerParameters:
       description: Parameters for the /owner/create endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
+        - $ref: '#/OwnerParameters'
     SetOwnerNameParameters:
       description: Parameters for the /owner/setName endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
-      properties:
-        NewName:
-          type: string
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            NewName:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
     SetOwnerTypeParameters:
       description: Parameters for the /owner/setType endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
-      properties:
-        OwnerType:
-          type: string
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            OwnerType:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerType'
     SetOwnerSearchVisibilityParameters:
       description: Parameters for the /owner/setSearchVisibility endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
-      properties:
-        SearchVisibility:
-          type: string
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            SearchVisibility:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/SearchVisibility'
     SetOwnerDescriptionParameters:
       description: Parameters for the /owner/setDescription endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
-      properties:
-        Description:
-          type: string
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Source control owner for Alice's projects.
     GetOwnerParameters:
       description: Parameters for the /owner/get endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
     DeleteOwnerParameters:
       description: Parameters for the /owner/delete endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - $ref: '#/OwnerParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Owner retired.
     UndeleteOwnerParameters:
       description: Parameters for the /owner/undelete endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
+        - $ref: '#/OwnerParameters'
     ListOrganizationsParameters:
       description: Parameters for the /owner/listOrganizations endpoint.
       allOf:
-        - $ref: 'Owner.Components.OpenAPI.yaml#/OwnerParameters'
+        - $ref: '#/OwnerParameters'
+    OwnerCommandReturnValue:
+      description: Grace response envelope returned by owner command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Owner command succeeded.
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &ownerCommandReturnValueExample
+        ReturnValue: Owner command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerReturnValue:
+      description: Grace response envelope whose ReturnValue contains an owner DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: 'Dto.Components.OpenAPI.yaml#/OwnerDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &ownerReturnValueExample
+        ReturnValue:
+          Class: OwnerDto
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OwnerName: alice
+          OwnerType: Public
+          Description: Source control owner for Alice's projects.
+          SearchVisibility: Visible
+          Organizations:
+            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          CreatedAt: '2026-06-04T18:15:00Z'
+          DeleteReason: ''
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /owner/get
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+    OwnerOrganizationsReturnValue:
+      description: Grace response envelope whose ReturnValue contains the owner's organizations.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: 'Dto.Components.OpenAPI.yaml#/OrganizationDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    OwnerCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OwnerCommandReturnValue'
+          examples:
+            ownerCommand:
+              summary: Owner command response envelope
+              value: *ownerCommandReturnValueExample
+    OwnerResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OwnerReturnValue'
+          examples:
+            owner:
+              summary: Owner response envelope
+              value: *ownerReturnValueExample
+    OwnerOrganizationsResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/OwnerOrganizationsReturnValue'

--- a/src/OpenAPI/Owner.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Owner.Components.OpenAPI.yaml
@@ -125,8 +125,6 @@
           OwnerType: Public
           Description: Source control owner for Alice's projects.
           SearchVisibility: Visible
-          Organizations:
-            alice-org: e35d64a9-b990-44f5-bf02-32ad7d15630c
           CreatedAt: '2026-06-04T18:15:00Z'
           DeleteReason: ''
         EventTime: '2026-06-04T18:15:00Z'
@@ -134,23 +132,6 @@
         Properties:
           Path: /owner/get
           OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
-    OwnerOrganizationsReturnValue:
-      description: Grace response envelope whose ReturnValue contains the owner's organizations.
-      type: object
-      properties:
-        ReturnValue:
-          type: array
-          items:
-            $ref: 'Dto.Components.OpenAPI.yaml#/OrganizationDto'
-        EventTime:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
-        CorrelationId:
-          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
-        Properties:
-          type: object
-          additionalProperties:
-            type: string
-      required: [ReturnValue, EventTime, CorrelationId, Properties]
     OwnerCommandResponse:
       description: OK
       content:
@@ -176,4 +157,11 @@
       content:
         application/json:
           schema:
-            $ref: '#/OwnerOrganizationsReturnValue'
+            type: object
+            additionalProperties:
+              type: string
+          examples:
+            organizations:
+              summary: Owner organization id-to-name dictionary
+              value:
+                e35d64a9-b990-44f5-bf02-32ad7d15630c: alice-org

--- a/src/OpenAPI/Owner.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Owner.Paths.OpenAPI.yaml
@@ -1,246 +1,240 @@
   /owner/create:
     post:
+      tags:
+        - Owners
       summary: Create an owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must not be empty.
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must not be empty.
-        - `OwnerName` must be a valid Grace name.
-        - Owner with the same `OwnerId` must not already exist.
-        - Owner with the same `OwnerName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Creates an owner with the specified id and name.
+      operationId: CreateOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: 'Owner.Components.OpenAPI.yaml#/CreateOwnerParameters'
+              $ref: './Owner.Components.OpenAPI.yaml#/CreateOwnerParameters'
+            examples:
+              createOwner:
+                summary: Create an owner
+                value: &ownerBaseExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OwnerName: alice
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/setName:
     post:
+      tags:
+        - Owners
       summary: Set the name of an owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `NewName` must not be empty.
-        - `NewName` must be a valid Grace name.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-        - Owner with the specified `NewName` must not already exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Renames an owner that exists and has not been deleted.
+      operationId: SetOwnerName
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/SetOwnerNameParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/SetOwnerNameParameters'
+            examples:
+              setOwnerName:
+                summary: Rename an owner
+                value:
+                  <<: *ownerBaseExample
+                  NewName: alice-renamed
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/setType:
     post:
-      summary: Set the owner type (Public, Private).
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `OwnerType` must not be empty.
-        - `OwnerType` must be a valid owner type.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set the owner type.
+      description: Sets the owner type to a public or private value accepted by the server.
+      operationId: SetOwnerType
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/SetOwnerTypeParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/SetOwnerTypeParameters'
+            examples:
+              setOwnerType:
+                summary: Set owner type
+                value:
+                  <<: *ownerBaseExample
+                  OwnerType: Public
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/setSearchVisibility:
     post:
-      summary: Set the owner search visibility (Visible, NotVisible).
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `SearchVisibility` must be a valid search visibility.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Set owner search visibility.
+      description: Sets whether the owner appears in search results.
+      operationId: SetOwnerSearchVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/SetOwnerSearchVisibilityParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/SetOwnerSearchVisibilityParameters'
+            examples:
+              setOwnerSearchVisibility:
+                summary: Set owner search visibility
+                value:
+                  <<: *ownerBaseExample
+                  SearchVisibility: Visible
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/setDescription:
     post:
+      tags:
+        - Owners
       summary: Set the owner's description.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `Description` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Sets the owner description.
+      operationId: SetOwnerDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/SetOwnerDescriptionParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/SetOwnerDescriptionParameters'
+            examples:
+              setOwnerDescription:
+                summary: Set owner description
+                value:
+                  <<: *ownerBaseExample
+                  Description: Source control owner for Alice's projects.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/listOrganizations:
     post:
+      tags:
+        - Owners
       summary: List the organizations for an owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Lists organizations associated with the owner.
+      operationId: ListOwnerOrganizations
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/ListOrganizationsParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/ListOrganizationsParameters'
+            examples:
+              listOwnerOrganizations:
+                summary: List organizations for an owner
+                value: *ownerBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: Dto.Components.OpenAPI.yaml#/OrganizationDto
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerOrganizationsResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/delete:
     post:
+      tags:
+        - Owners
       summary: Delete an owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - `DeleteReason` must not be empty.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Logically deletes an owner that exists and has not already been deleted.
+      operationId: DeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/DeleteOwnerParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/DeleteOwnerParameters'
+            examples:
+              deleteOwner:
+                summary: Delete an owner
+                value:
+                  <<: *ownerBaseExample
+                  Force: false
+                  DeleteReason: Owner retired.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/undelete:
     post:
-      summary: Undelete a previously-deleted owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-        - `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - Owner with the specified `OwnerId` or `OwnerName` must exist and be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      tags:
+        - Owners
+      summary: Undelete a previously deleted owner.
+      description: Restores a logically deleted owner.
+      operationId: UndeleteOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/OwnerParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/UndeleteOwnerParameters'
+            examples:
+              undeleteOwner:
+                summary: Restore an owner
+                value: *ownerBaseExample
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
+
   /owner/get:
     post:
+      tags:
+        - Owners
       summary: Get an owner.
-      description: |
-        ### Validation rules
-        
-        - `OwnerId` must be a valid GUID.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
+      description: Gets owner metadata.
+      operationId: GetOwner
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Owner.Components.OpenAPI.yaml#/GetOwnerParameters
+              $ref: './Owner.Components.OpenAPI.yaml#/GetOwnerParameters'
+            examples:
+              getOwner:
+                summary: Get an owner
+                value:
+                  <<: *ownerBaseExample
+                  IncludeDeleted: false
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: Dto.Components.OpenAPI.yaml#/OwnerDto
+          $ref: './Owner.Components.OpenAPI.yaml#/OwnerResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Repository.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Repository.Components.OpenAPI.yaml
@@ -1,140 +1,318 @@
     RepositoryParameters:
-      description: Parameters for many endpoints in the /repository path.
+      description: Parameters shared by public endpoints in the /repository route family.
       type: object
+      allOf:
+        - $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CommonParameters'
       properties:
         OwnerId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerId'
         OwnerName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OwnerName'
         OrganizationId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationId'
         OrganizationName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/OrganizationName'
         RepositoryId:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryId'
         RepositoryName:
-          type: string
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
+      example: &repositoryBaseExample
+        CorrelationId: cli-20260604T181500Z-0001
+        Principal: user:alice
+        OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+        OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+        RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
     CreateRepositoryParameters:
       description: Parameters for the /repository/create endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            ObjectStorageProvider:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ObjectStorageProvider'
     IsEmptyParameters:
       description: Parameters for the /repository/isEmpty endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
+        - $ref: '#/RepositoryParameters'
     InitParameters:
       description: Parameters for the /repository/init endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        GraceConfig:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            GraceConfig:
+              type: string
+              example: '{}'
     SetRepositoryVisibilityParameters:
       description: Parameters for the /repository/setVisibility endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        Visibility:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            Visibility:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryVisibility'
     SetRepositoryStatusParameters:
       description: Parameters for the /repository/setStatus endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        Status:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            Status:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryStatus'
     RecordSavesParameters:
-      description: Parameters for the /repository/recordSaves endpoint.
+      description: Parameters for the /repository/setRecordSaves endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        RecordSaves:
-          type: boolean
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            RecordSaves:
+              type: boolean
+              example: true
     SetSaveDaysParameters:
       description: Parameters for the /repository/setSaveDays endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        SaveDays:
-          type: number
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            SaveDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 30
     SetCheckpointDaysParameters:
-      description: Parameters for the /repository/setCheckpointDays
+      description: Parameters for the /repository/setCheckpointDays endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        CheckpointDays:
-          type: number
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            CheckpointDays:
+              type: number
+              format: float
+              minimum: 0
+              example: 90
     SetRepositoryDescriptionParameters:
       description: Parameters for the /repository/setDescription endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        Description:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            Description:
+              type: string
+              maxLength: 2048
+              example: Repository for release candidates.
     SetDefaultServerApiVersionParameters:
       description: Parameters for the /repository/setDefaultServerApiVersion endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        DefaultServerApiVersion:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            DefaultServerApiVersion:
+              type: string
+              example: '2026-06-04'
     SetRepositoryNameParameters:
       description: Parameters for the /repository/setName endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        NewName:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            NewName:
+              $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RepositoryName'
     DeleteRepositoryParameters:
       description: Parameters for the /repository/delete endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        Force:
-          type: boolean
-        DeleteReason:
-          type: string
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            Force:
+              type: boolean
+              example: false
+            DeleteReason:
+              type: string
+              example: Repository retired.
     EnablePromotionTypeParameters:
-      description: Parameters for enabling promotion type.
+      description: Parameters for repository promotion type feature toggles.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        Enabled:
-          type: boolean
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            Enabled:
+              type: boolean
+              example: true
     GetReferencesByReferenceIdParameters:
       description: Parameters for the /repository/getReferencesByReferenceId endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        ReferenceIds:
-          type: array
-          items:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
-        MaxCount:
-          type: integer
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            ReferenceIds:
+              type: array
+              items:
+                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesParameters:
-      description: Parameters for the /repository/getBranched endpoint.
+      description: Parameters for the /repository/getBranches endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        IncludeDeleted:
-          type: boolean
-        MaxCount:
-          type: integer
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            IncludeDeleted:
+              type: boolean
+              example: false
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
     GetBranchesByBranchIdParameters:
       description: Parameters for the /repository/getBranchesByBranchId endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
-      properties:
-        BranchIds:
-          type: array
-          items:
-            $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
-        MaxCount:
-          type: integer
-        IncludeDeleted:
-          type: boolean
+        - $ref: '#/RepositoryParameters'
+        - type: object
+          properties:
+            BranchIds:
+              type: array
+              items:
+                $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/BranchId'
+            MaxCount:
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 1000
+              example: 50
+            IncludeDeleted:
+              type: boolean
+              example: false
     UndeleteRepositoryParameters:
       description: Parameters for the /repository/undelete endpoint.
       allOf:
-        - $ref: 'Repository.Components.OpenAPI.yaml#/RepositoryParameters'
+        - $ref: '#/RepositoryParameters'
+    RepositoryCommandReturnValue:
+      description: Grace response envelope returned by repository command endpoints.
+      type: object
+      properties:
+        ReturnValue:
+          type: string
+          example: Repository command succeeded.
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+      example: &repositoryCommandReturnValueExample
+        ReturnValue: Repository command succeeded.
+        EventTime: '2026-06-04T18:15:00Z'
+        CorrelationId: cli-20260604T181500Z-0001
+        Properties:
+          Path: /repository/create
+          OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+          OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+          RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+    RepositoryReturnValue:
+      description: Grace response envelope whose ReturnValue contains a repository DTO.
+      type: object
+      properties:
+        ReturnValue:
+          $ref: 'Dto.Components.OpenAPI.yaml#/RepositoryDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    RepositoryBooleanReturnValue:
+      description: Grace response envelope whose ReturnValue contains a boolean repository query result.
+      type: object
+      properties:
+        ReturnValue:
+          type: boolean
+          example: true
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    RepositoryBranchesReturnValue:
+      description: Grace response envelope whose ReturnValue contains branch DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: 'Dto.Components.OpenAPI.yaml#/BranchDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    RepositoryReferencesReturnValue:
+      description: Grace response envelope whose ReturnValue contains reference DTOs.
+      type: object
+      properties:
+        ReturnValue:
+          type: array
+          items:
+            $ref: 'Dto.Components.OpenAPI.yaml#/ReferenceDto'
+        EventTime:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Instant'
+        CorrelationId:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/CorrelationId'
+        Properties:
+          type: object
+          additionalProperties:
+            type: string
+      required: [ReturnValue, EventTime, CorrelationId, Properties]
+    RepositoryCommandResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/RepositoryCommandReturnValue'
+          examples:
+            repositoryCommand:
+              summary: Repository command response envelope
+              value: *repositoryCommandReturnValueExample
+    RepositoryResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/RepositoryReturnValue'
+    RepositoryBooleanResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/RepositoryBooleanReturnValue'
+    RepositoryBranchesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/RepositoryBranchesReturnValue'
+    RepositoryReferencesResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/RepositoryReferencesReturnValue'

--- a/src/OpenAPI/Repository.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Repository.Paths.OpenAPI.yaml
@@ -1,36 +1,30 @@
   /repository/create:
     post:
+      tags:
+        - Repositories
       summary: Create a new repository.
-      description: |
-        This endpoint creates a new repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must not be empty.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The `RepositoryName` must be a valid Grace name.
-        - The `OwnerId` must correspond to an existing owner.
-        - The `OrganizationId` must correspond to an existing organization.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      description: Creates a repository in an organization.
+      operationId: CreateRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/CreateRepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/CreateRepositoryParameters'
+            examples:
+              createRepository:
+                summary: Create a repository
+                value: &repositoryBaseExample
+                  CorrelationId: cli-20260604T181500Z-0001
+                  Principal: user:alice
+                  OwnerId: 9dd5f81f-dc43-4839-9173-85d09394f30f
+                  OrganizationId: e35d64a9-b990-44f5-bf02-32ad7d15630c
+                  RepositoryId: ab6f35ef-6e01-440b-8f9b-c343a5272095
+                  RepositoryName: sample-repository
+                  ObjectStorageProvider: AzureBlobStorage
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -38,29 +32,26 @@
 
   /repository/setVisibility:
     post:
-      summary: Sets the search visibility of the repository.
-      description: |
-        This endpoint sets the search visibility of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Visibility` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set repository visibility.
+      description: Sets whether the repository is public or private.
+      operationId: SetRepositoryVisibility
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetRepositoryVisibilityParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetRepositoryVisibilityParameters'
+            examples:
+              setRepositoryVisibility:
+                summary: Set repository visibility
+                value:
+                  <<: *repositoryBaseExample
+                  Visibility: Private
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -68,29 +59,26 @@
 
   /repository/setSaveDays:
     post:
-      summary: Sets the number of days to keep saves in the repository.
-      description: |
-        This endpoint sets the number of days to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `SaveDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set save retention.
+      description: Sets the number of days to keep saves in the repository.
+      operationId: SetRepositorySaveDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetSaveDaysParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetSaveDaysParameters'
+            examples:
+              setRepositorySaveDays:
+                summary: Set save retention
+                value:
+                  <<: *repositoryBaseExample
+                  SaveDays: 30
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -98,29 +86,26 @@
 
   /repository/setCheckpointDays:
     post:
-      summary: Sets the number of days to keep checkpoints in the repository.
-      description: |
-        This endpoint sets the number of days to keep checkpoints in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `CheckpointDays` value must be valid.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set checkpoint retention.
+      description: Sets the number of days to keep checkpoints in the repository.
+      operationId: SetRepositoryCheckpointDays
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetCheckpointDaysParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetCheckpointDaysParameters'
+            examples:
+              setRepositoryCheckpointDays:
+                summary: Set checkpoint retention
+                value:
+                  <<: *repositoryBaseExample
+                  CheckpointDays: 90
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -128,29 +113,26 @@
 
   /repository/setStatus:
     post:
-      summary: Sets the status of the repository (Public, Private).
-      description: |
-        This endpoint sets the status of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Status` value must be a valid repository status.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set repository status.
+      description: Sets the repository operational status.
+      operationId: SetRepositoryStatus
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetRepositoryStatusParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetRepositoryStatusParameters'
+            examples:
+              setRepositoryStatus:
+                summary: Set repository status
+                value:
+                  <<: *repositoryBaseExample
+                  Status: Active
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -158,29 +140,26 @@
 
   /repository/setDefaultServerApiVersion:
     post:
-      summary: Sets the default server API version for the repository.
-      description: |
-        This endpoint sets the default server API version for a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DefaultServerApiVersion` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set the default server API version.
+      description: Sets the default server API version clients should use for the repository.
+      operationId: SetRepositoryDefaultServerApiVersion
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetDefaultServerApiVersionParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetDefaultServerApiVersionParameters'
+            examples:
+              setRepositoryDefaultServerApiVersion:
+                summary: Set default server API version
+                value:
+                  <<: *repositoryBaseExample
+                  DefaultServerApiVersion: '2026-06-04'
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -188,28 +167,26 @@
 
   /repository/setRecordSaves:
     post:
-      summary: Sets whether or not to keep saves in the repository.
-      description: |
-        This endpoint sets whether or not to keep saves in a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set whether saves are recorded.
+      description: Sets the repository default for whether save references should be kept.
+      operationId: SetRepositoryRecordSaves
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/RecordSavesParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/RecordSavesParameters'
+            examples:
+              setRepositoryRecordSaves:
+                summary: Enable save recording
+                value:
+                  <<: *repositoryBaseExample
+                  RecordSaves: true
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -217,29 +194,26 @@
 
   /repository/setDescription:
     post:
-      summary: Sets the description of the repository.
-      description: |
-        This endpoint sets the description of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `Description` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Set repository description.
+      description: Sets the repository description.
+      operationId: SetRepositoryDescription
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/SetRepositoryDescriptionParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/SetRepositoryDescriptionParameters'
+            examples:
+              setRepositoryDescription:
+                summary: Set repository description
+                value:
+                  <<: *repositoryBaseExample
+                  Description: Repository for release candidates.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -247,29 +221,27 @@
 
   /repository/delete:
     post:
-      summary: Deletes the repository.
-      description: |
-        This endpoint deletes a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `DeleteReason` must not be empty.
-        - The repository must exist.
-        - The repository must not be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Delete a repository.
+      description: Logically deletes a repository that exists and has not already been deleted.
+      operationId: DeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/DeleteRepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/DeleteRepositoryParameters'
+            examples:
+              deleteRepository:
+                summary: Delete a repository
+                value:
+                  <<: *repositoryBaseExample
+                  Force: false
+                  DeleteReason: Repository retired.
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -277,28 +249,24 @@
 
   /repository/undelete:
     post:
-      summary: Undeletes a previously-deleted repository.
-      description: |
-        This endpoint undeletes a previously-deleted repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The repository must exist.
-        - The repository must be deleted.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Undelete a previously deleted repository.
+      description: Restores a logically deleted repository.
+      operationId: UndeleteRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/RepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/UndeleteRepositoryParameters'
+            examples:
+              undeleteRepository:
+                summary: Restore a repository
+                value: *repositoryBaseExample
       responses:
         '200':
-          $ref: './Responses.OpenAPI.yaml#/200'
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -306,77 +274,49 @@
 
   /repository/exists:
     post:
-      summary: Checks if a repository exists with the given parameters.
-      description: |
-        This endpoint checks if a repository exists based on the provided parameters.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Check whether a repository exists.
+      description: Checks whether a repository exists for the supplied selector values.
+      operationId: RepositoryExists
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/RepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/RepositoryParameters'
+            examples:
+              repositoryExists:
+                summary: Check repository existence
+                value: *repositoryBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryBooleanResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
-  
+
   /repository/isEmpty:
     post:
-      summary: Checks if a repository is empty.
-      description: |
-        This endpoint checks if a repository is empty, meaning it has just been created and has no data.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Check whether a repository is empty.
+      description: Checks whether a repository has no content yet.
+      operationId: RepositoryIsEmpty
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/RepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/IsEmptyParameters'
+            examples:
+              repositoryIsEmpty:
+                summary: Check whether a repository is empty
+                value: *repositoryBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryBooleanResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -384,39 +324,24 @@
 
   /repository/get:
     post:
-      summary: Gets a repository.
-      description: |
-        This endpoint retrieves the details of a repository.
-
-        ### Validation rules
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - The `RepositoryName` must not be empty.
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: Get a repository.
+      description: Gets repository metadata.
+      operationId: GetRepository
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/RepositoryParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/RepositoryParameters'
+            examples:
+              getRepository:
+                summary: Get a repository
+                value: *repositoryBaseExample
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: Dto.Components.OpenAPI.yaml#/RepositoryDto
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -424,40 +349,27 @@
 
   /repository/getBranches:
     post:
-      summary: Gets a repository's branches.
-      description: |
-        This endpoint retrieves the branches of a repository.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: List repository branches.
+      description: Gets branches for the repository.
+      operationId: ListRepositoryBranches
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/GetBranchesParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/GetBranchesParameters'
+            examples:
+              listRepositoryBranches:
+                summary: List repository branches
+                value: &repositoryListBranchesExample
+                  <<: *repositoryBaseExample
+                  IncludeDeleted: false
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: Dto.Components.OpenAPI.yaml#/BranchDto
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryBranchesResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -465,41 +377,28 @@
 
   /repository/getReferencesByReferenceId:
     post:
-      summary: Gets a list of references by reference IDs.
-      description: |
-        This endpoint retrieves a list of references based on the provided reference IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `ReferenceIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: List references by reference id.
+      description: Gets references in the repository by reference ids.
+      operationId: ListRepositoryReferencesByReferenceId
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/GetReferencesByReferenceIdParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/GetReferencesByReferenceIdParameters'
+            examples:
+              listRepositoryReferencesByReferenceId:
+                summary: List references by id
+                value:
+                  <<: *repositoryBaseExample
+                  ReferenceIds:
+                    - c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+                  MaxCount: 50
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: Dto.Components.OpenAPI.yaml#/ReferenceDto
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryReferencesResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':
@@ -507,41 +406,27 @@
 
   /repository/getBranchesByBranchId:
     post:
-      summary: Gets a list of branches by branch IDs.
-      description: |
-        This endpoint retrieves a list of branches based on the provided branch IDs.
-
-        ### Validation rules
-        - The `OwnerId` must be a valid and non-empty GUID.
-        - The `OwnerName` must be a valid Grace name.
-        - Either `OwnerId` or `OwnerName` must be provided.
-        - The `OrganizationId` must be a valid and non-empty GUID.
-        - The `OrganizationName` must be a valid Grace name.
-        - Either `OrganizationId` or `OrganizationName` must be provided.
-        - The `RepositoryId` must be a valid and non-empty GUID.
-        - Either `RepositoryId` or `RepositoryName` must be provided.
-        - The `BranchIds` must not be empty.
-        - The `MaxCount` must be a number between 1 and 1000 (inclusive).
-        - The repository ID must not exist.
-
-        ### Errors and Problem Details
-        Error responses will be in the problem details JSON format, as defined in [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807).
-
+      tags:
+        - Repositories
+      summary: List branches by branch id.
+      description: Gets branches in the repository by branch ids.
+      operationId: ListRepositoryBranchesByBranchId
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: Repository.Components.OpenAPI.yaml#/GetBranchesByBranchIdParameters
-
+              $ref: './Repository.Components.OpenAPI.yaml#/GetBranchesByBranchIdParameters'
+            examples:
+              listRepositoryBranchesByBranchId:
+                summary: List branches by id
+                value:
+                  <<: *repositoryListBranchesExample
+                  BranchIds:
+                    - de7bf47d-23ae-4599-af68-68a317ea390d
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                $ref: Dto.Components.OpenAPI.yaml#/BranchDto
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryBranchesResponse'
         '400':
           $ref: './Responses.OpenAPI.yaml#/400'
         '500':

--- a/src/OpenAPI/Repository.Paths.OpenAPI.yaml
+++ b/src/OpenAPI/Repository.Paths.OpenAPI.yaml
@@ -57,6 +57,33 @@
         '500':
           $ref: './Responses.OpenAPI.yaml#/500'
 
+  /repository/setName:
+    post:
+      tags:
+        - Repositories
+      summary: Set the name of a repository.
+      description: Renames a repository that exists and has not been deleted.
+      operationId: SetRepositoryName
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: './Repository.Components.OpenAPI.yaml#/SetRepositoryNameParameters'
+            examples:
+              setRepositoryName:
+                summary: Rename a repository
+                value:
+                  <<: *repositoryBaseExample
+                  NewName: sample-repository-renamed
+      responses:
+        '200':
+          $ref: './Repository.Components.OpenAPI.yaml#/RepositoryCommandResponse'
+        '400':
+          $ref: './Responses.OpenAPI.yaml#/400'
+        '500':
+          $ref: './Responses.OpenAPI.yaml#/500'
+
   /repository/setSaveDays:
     post:
       tags:

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -458,6 +458,105 @@ function Assert-OperationTextMatches {
     }
 }
 
+function Get-OpenApiNamedBlock {
+    param(
+        [string] $Text,
+        [string] $Name
+    )
+
+    $lines = [regex]::Split($Text, '\r?\n')
+    $blockLinePattern = "^(?<indent>\s*)$([regex]::Escape($Name)):\s*(?:#.*)?$"
+    $blockStart = -1
+    $blockIndent = -1
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $match = [regex]::Match($lines[$i], $blockLinePattern)
+        if ($match.Success) {
+            $blockStart = $i
+            $blockIndent = $match.Groups['indent'].Value.Length
+            break
+        }
+    }
+
+    if ($blockStart -lt 0) {
+        return $null
+    }
+
+    $blockEnd = $lines.Count
+    for ($i = $blockStart + 1; $i -lt $lines.Count; $i++) {
+        if ([string]::IsNullOrWhiteSpace($lines[$i])) {
+            continue
+        }
+
+        $indent = Get-YamlIndentLength $lines[$i]
+        if ($indent -le $blockIndent) {
+            $blockEnd = $i
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        Lines = @($lines[$blockStart..($blockEnd - 1)])
+        Text = ($lines[$blockStart..($blockEnd - 1)] -join [Environment]::NewLine)
+        Indent = $blockIndent
+    }
+}
+
+function Assert-OpenApiResponseIsRawStringDictionary {
+    param(
+        [string] $Text,
+        [string] $ResponseName,
+        [string] $MessagePrefix
+    )
+
+    $responseBlock = Get-OpenApiNamedBlock $Text $ResponseName
+    if ($null -eq $responseBlock) {
+        Add-Failure "$MessagePrefix response component is missing."
+        return
+    }
+
+    $responseText = [string] $responseBlock.Text
+    foreach ($forbiddenProperty in @('ReturnValue', 'EventTime', 'CorrelationId', 'Properties')) {
+        if ($responseText -match "(?m)^\s+$([regex]::Escape($forbiddenProperty)):\s*") {
+            Add-Failure "$MessagePrefix response must be a raw id-to-name dictionary, not an envelope or DTO array."
+            return
+        }
+    }
+
+    foreach ($forbiddenReference in @('OrganizationDto', 'RepositoryDto')) {
+        if ($responseText.Contains($forbiddenReference, [StringComparison]::Ordinal)) {
+            Add-Failure "$MessagePrefix response must be a raw id-to-name dictionary, not an envelope or DTO array."
+            return
+        }
+    }
+
+    if ($responseText -notmatch "(?m)^\s+schema:\s*$" -or
+        $responseText -notmatch "(?m)^\s+type:\s*object\s*$" -or
+        $responseText -notmatch "(?m)^\s+additionalProperties:\s*$" -or
+        $responseText -notmatch "(?m)^\s+type:\s*string\s*$") {
+        Add-Failure "$MessagePrefix response must model application/json as a raw object with string additionalProperties."
+    }
+}
+
+function Assert-OpenApiNamedBlockDoesNotContain {
+    param(
+        [string] $Text,
+        [string] $BlockName,
+        [string] $ForbiddenNeedle,
+        [string] $Message
+    )
+
+    $block = Get-OpenApiNamedBlock $Text $BlockName
+    if ($null -eq $block) {
+        Add-Failure "OpenAPI block '$BlockName' is missing."
+        return
+    }
+
+    if ([string] $block.Text -match "(?m)^\s+$([regex]::Escape($ForbiddenNeedle)):\s*") {
+        Add-Failure $Message
+    }
+}
+
 function Get-YamlIndentLength {
     param([string] $Line)
 
@@ -897,6 +996,7 @@ function Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails {
 
         [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'CreateRepository'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
         [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryVisibility'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryName'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
         [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositorySaveDays'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
         [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryCheckpointDays'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
         [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryStatus'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
@@ -1019,6 +1119,31 @@ function Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails {
     if ($directoryComponentsText -match '(DirectoryVersionCommand|DirectoryVersionEvent|DirectoryEvent|Actor)') {
         Add-Failure 'Directory OpenAPI components must expose public parameter/DTO shapes, not internal actor command/event shapes.'
     }
+
+    $ownerComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Owner.Components.OpenAPI.yaml') -Raw
+    $organizationComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Organization.Components.OpenAPI.yaml') -Raw
+
+    Assert-OpenApiResponseIsRawStringDictionary `
+        $ownerComponentsText `
+        'OwnerOrganizationsResponse' `
+        '/owner/listOrganizations'
+
+    Assert-OpenApiResponseIsRawStringDictionary `
+        $organizationComponentsText `
+        'OrganizationRepositoriesResponse' `
+        '/organization/listRepositories'
+
+    Assert-OpenApiNamedBlockDoesNotContain `
+        $ownerComponentsText `
+        'OwnerReturnValue' `
+        'Organizations' `
+        'OwnerReturnValue examples must not include non-existent OwnerDto.Organizations.'
+
+    Assert-OpenApiNamedBlockDoesNotContain `
+        $organizationComponentsText `
+        'OrganizationReturnValue' `
+        'Repositories' `
+        'OrganizationReturnValue examples must not include non-existent OrganizationDto.Repositories.'
 
     $getBySha256HashOperation = Get-RequiredOpenApiOperation $Operations 'Directory.Paths.OpenAPI.yaml' 'GetDirectoryVersionBySha256Hash'
     Assert-OperationSha256ExamplesAreValid $getBySha256HashOperation @('Sha256Hash')

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -1122,6 +1122,7 @@ function Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails {
 
     $ownerComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Owner.Components.OpenAPI.yaml') -Raw
     $organizationComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Organization.Components.OpenAPI.yaml') -Raw
+    $dtoComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Dto.Components.OpenAPI.yaml') -Raw
 
     Assert-OpenApiResponseIsRawStringDictionary `
         $ownerComponentsText `
@@ -1144,6 +1145,18 @@ function Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails {
         'OrganizationReturnValue' `
         'Repositories' `
         'OrganizationReturnValue examples must not include non-existent OrganizationDto.Repositories.'
+
+    Assert-OpenApiNamedBlockDoesNotContain `
+        $dtoComponentsText `
+        'OwnerDto' `
+        'Organizations' `
+        'OwnerDto schema must not include non-existent Organizations.'
+
+    Assert-OpenApiNamedBlockDoesNotContain `
+        $dtoComponentsText `
+        'OrganizationDto' `
+        'Repositories' `
+        'OrganizationDto schema must not include non-existent Repositories.'
 
     $getBySha256HashOperation = Get-RequiredOpenApiOperation $Operations 'Directory.Paths.OpenAPI.yaml' 'GetDirectoryVersionBySha256Hash'
     Assert-OperationSha256ExamplesAreValid $getBySha256HashOperation @('Sha256Hash')

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -868,6 +868,166 @@ function Test-OpenApiBranchReferenceDiffDetails {
     }
 }
 
+function Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails {
+    param(
+        [string] $OpenApiRoot,
+        [object[]] $Operations
+    )
+
+    $expectedOperations = @(
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'CreateOwner'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'SetOwnerName'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'SetOwnerType'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'SetOwnerSearchVisibility'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'SetOwnerDescription'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'ListOwnerOrganizations'; Tag = 'Owners'; Response = 'OwnerOrganizationsResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'DeleteOwner'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'UndeleteOwner'; Tag = 'Owners'; Response = 'OwnerCommandResponse' },
+        [pscustomobject]@{ File = 'Owner.Paths.OpenAPI.yaml'; OperationId = 'GetOwner'; Tag = 'Owners'; Response = 'OwnerResponse' },
+
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'CreateOrganization'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'SetOrganizationName'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'SetOrganizationType'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'SetOrganizationSearchVisibility'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'SetOrganizationDescription'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'ListOrganizationRepositories'; Tag = 'Organizations'; Response = 'OrganizationRepositoriesResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'DeleteOrganization'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'UndeleteOrganization'; Tag = 'Organizations'; Response = 'OrganizationCommandResponse' },
+        [pscustomobject]@{ File = 'Organization.Paths.OpenAPI.yaml'; OperationId = 'GetOrganization'; Tag = 'Organizations'; Response = 'OrganizationResponse' },
+
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'CreateRepository'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryVisibility'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositorySaveDays'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryCheckpointDays'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryStatus'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryDefaultServerApiVersion'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryRecordSaves'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'SetRepositoryDescription'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'DeleteRepository'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'UndeleteRepository'; Tag = 'Repositories'; Response = 'RepositoryCommandResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'RepositoryExists'; Tag = 'Repositories'; Response = 'RepositoryBooleanResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'RepositoryIsEmpty'; Tag = 'Repositories'; Response = 'RepositoryBooleanResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'GetRepository'; Tag = 'Repositories'; Response = 'RepositoryResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'ListRepositoryBranches'; Tag = 'Repositories'; Response = 'RepositoryBranchesResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'ListRepositoryReferencesByReferenceId'; Tag = 'Repositories'; Response = 'RepositoryReferencesResponse' },
+        [pscustomobject]@{ File = 'Repository.Paths.OpenAPI.yaml'; OperationId = 'ListRepositoryBranchesByBranchId'; Tag = 'Repositories'; Response = 'RepositoryBranchesResponse' },
+
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'CreateDirectoryVersion'; Tag = 'Directories'; Response = 'DirectoryCommandResponse' },
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'GetDirectoryVersion'; Tag = 'Directories'; Response = 'DirectoryVersionResponse' },
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'ListDirectoryVersionsRecursive'; Tag = 'Directories'; Response = 'DirectoryVersionListResponse' },
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'ListDirectoryVersionsById'; Tag = 'Directories'; Response = 'DirectoryVersionListResponse' },
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'GetDirectoryVersionBySha256Hash'; Tag = 'Directories'; Response = 'DirectoryVersionResponse' },
+        [pscustomobject]@{ File = 'Directory.Paths.OpenAPI.yaml'; OperationId = 'SaveDirectoryVersions'; Tag = 'Directories'; Response = 'DirectoryCommandResponse' }
+    )
+
+    $familyFiles = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($file in @('Owner.Paths.OpenAPI.yaml', 'Organization.Paths.OpenAPI.yaml', 'Repository.Paths.OpenAPI.yaml', 'Directory.Paths.OpenAPI.yaml')) {
+        [void] $familyFiles.Add($file)
+    }
+
+    $genericOperationIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($operationId in @('Create', 'Get', 'Delete', 'List', 'Update', 'Set', 'Exists', 'IsEmpty', 'Save')) {
+        [void] $genericOperationIds.Add($operationId)
+    }
+
+    foreach ($operation in @($Operations | Where-Object { $familyFiles.Contains($_.File) })) {
+        $location = "$($operation.File):$($operation.LineNumber) $($operation.Method.ToUpperInvariant()) $($operation.Path)"
+
+        if ([string]::IsNullOrWhiteSpace([string] $operation.OperationId)) {
+            Add-Failure "Owner/organization/repository/directory OpenAPI operation is missing an SDK-friendly operationId: $location"
+            continue
+        }
+
+        if ($genericOperationIds.Contains([string] $operation.OperationId)) {
+            Add-Failure "Owner/organization/repository/directory OpenAPI operationId '$($operation.OperationId)' is too generic for SDK generation: $location"
+        }
+
+        if (-not $operation.HasTag) {
+            Add-Failure "Owner/organization/repository/directory OpenAPI operation is missing its primary SDK tag: $location"
+        }
+
+        if (-not ($operation.Has400 -and $operation.Has500)) {
+            Add-Failure "Owner/organization/repository/directory OpenAPI operation is missing reusable 400/500 error responses: $location"
+        }
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./(?:Owner|Organization|Repository|Directory)\.Components\.OpenAPI\.yaml#/" `
+            "Owner/organization/repository/directory operation must use a family success response component: $location"
+
+        Assert-OperationHasJsonRequestExample `
+            $operation `
+            "Owner/organization/repository/directory operation with a JSON request body must include an example: $location"
+
+        Assert-OperationSha256ExamplesAreValid $operation @()
+    }
+
+    foreach ($expected in $expectedOperations) {
+        $operation = Get-RequiredOpenApiOperation $Operations $expected.File $expected.OperationId
+
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)tags:\s*-\s+$($expected.Tag)\b" `
+            "Operation '$($expected.OperationId)' must carry primary SDK tag '$($expected.Tag)'."
+
+        $componentFilePrefix = $expected.File -replace '\.Paths\.OpenAPI\.yaml$', ''
+        Assert-OperationTextMatches `
+            $operation `
+            "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./$([regex]::Escape($componentFilePrefix))\.Components\.OpenAPI\.yaml#/$($expected.Response)'" `
+            "Operation '$($expected.OperationId)' must use '$($expected.Response)' for its 200 envelope."
+    }
+
+    foreach ($commandExpectation in @(
+            [pscustomobject]@{ File = 'Owner.Components.OpenAPI.yaml'; Schema = 'OwnerCommandReturnValue' },
+            [pscustomobject]@{ File = 'Organization.Components.OpenAPI.yaml'; Schema = 'OrganizationCommandReturnValue' },
+            [pscustomobject]@{ File = 'Repository.Components.OpenAPI.yaml'; Schema = 'RepositoryCommandReturnValue' },
+            [pscustomobject]@{ File = 'Directory.Components.OpenAPI.yaml'; Schema = 'DirectoryCommandReturnValue' }
+        )) {
+        $componentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot $commandExpectation.File) -Raw
+        Assert-OpenApiSchemaPropertyIsString `
+            $componentsText `
+            $commandExpectation.Schema `
+            'ReturnValue' `
+            "$($commandExpectation.Schema) must model command success ReturnValue as a string."
+    }
+
+    $repositoryComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Repository.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredRepositoryContract in @(
+            'ObjectStorageProvider:',
+            'RepositoryBooleanReturnValue:',
+            'RepositoryBranchesReturnValue:',
+            'RepositoryReferencesReturnValue:'
+        )) {
+        Assert-TextContains $repositoryComponentsText $requiredRepositoryContract "Repository OpenAPI components are missing '$requiredRepositoryContract'."
+    }
+
+    Assert-OperationTextMatches `
+        ([pscustomobject]@{ OperationText = $repositoryComponentsText }) `
+        "(?s)RepositoryBooleanReturnValue:\s*.*?ReturnValue:\s*.*?type:\s*boolean" `
+        'RepositoryBooleanReturnValue must keep exists/isEmpty ReturnValue as boolean.'
+
+    $directoryComponentsText = Get-Content -LiteralPath (Join-Path $OpenApiRoot 'Directory.Components.OpenAPI.yaml') -Raw
+    foreach ($requiredDirectoryContract in @(
+            'DirectoryVersionId:',
+            'DirectoryVersionApiDto:',
+            'DirectoryVersionReturnValue:',
+            'DirectoryVersionListReturnValue:'
+        )) {
+        Assert-TextContains $directoryComponentsText $requiredDirectoryContract "Directory OpenAPI components are missing '$requiredDirectoryContract'."
+    }
+
+    if ($directoryComponentsText -match '(DirectoryVersionCommand|DirectoryVersionEvent|DirectoryEvent|Actor)') {
+        Add-Failure 'Directory OpenAPI components must expose public parameter/DTO shapes, not internal actor command/event shapes.'
+    }
+
+    $getBySha256HashOperation = Get-RequiredOpenApiOperation $Operations 'Directory.Paths.OpenAPI.yaml' 'GetDirectoryVersionBySha256Hash'
+    Assert-OperationSha256ExamplesAreValid $getBySha256HashOperation @('Sha256Hash')
+    Assert-OperationTextMatches `
+        $getBySha256HashOperation `
+        "(?s)responses:\s*.*?'200':\s*.*?\`$ref:\s*'\./Directory\.Components\.OpenAPI\.yaml#/DirectoryVersionResponse'" `
+        'GetDirectoryVersionBySha256Hash must use the server-returned directory-version DTO envelope.'
+}
+
 function Test-OpenApiSharedContractDetails {
     param(
         [string] $OpenApiRoot,
@@ -950,6 +1110,7 @@ function Test-OpenApiSharedContractDetails {
     }
 
     Test-OpenApiBranchReferenceDiffDetails $OpenApiRoot $Operations
+    Test-OpenApiOwnerOrganizationRepositoryDirectoryDetails $OpenApiRoot $Operations
 }
 
 function Test-OpenApiQuality {


### PR DESCRIPTION
## Summary

- Polishes owner, organization, repository, and directory OpenAPI route-family contracts for SDK-friendly generation.
- Adds stable operation IDs, primary tags, request examples, explicit response envelopes, and reusable error response coverage for these route families.
- Regenerates OpenAPI bundles/projections and extends proof checks for the audited families.

## Issue

Refs #217
Parent epic: #211

## Target Branch

This PR targets `epic/211-sdk-openapi` as part of the epic integration branch flow. The final epic-to-`main` PR will be the production release candidate.

## Validation

- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed after implementation and each review fix.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness`: passed with no pending gates after implementation and each review fix.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Projections`: passed with no pending gates after implementation and each review fix.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality -AllowPending`: passed after implementation and each review fix; known unrelated pending gates remain for Storage operation tags and `/openApi` missing the reusable `400`/`500` response pair.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after implementation and each review fix.
- `git diff --check`: passed after implementation and each review fix.
- GitHub `Validate / full` on `88a9d7b`: in progress.

## Review Status

- Implementation worker completed the OpenAPI/proof edits and validation, then continuation worker committed and pushed `dc21810`.
- First review found three contract issues: owner/organization list endpoints should be raw id-to-name dictionaries rather than enveloped DTO arrays; `/repository/setName` was missing from OpenAPI and proof expectations; and owner/organization GET examples included non-existent DTO properties.
- Fix commit `9fc4d3b` corrected owner/organization list response shapes, added `/repository/setName`, removed invalid GET example fields, regenerated artifacts, and tightened proof coverage.
- Follow-up review verified the first three fixes and found one remaining contract issue: `OrganizationDto` and `OwnerDto` schemas still published stale non-existent `Repositories` / `Organizations` properties.
- Fix commit `88a9d7b` removed the stale DTO schema properties, regenerated artifacts, and added proof coverage for the DTO schemas themselves.
- Final follow-up review-only sibling subagent completed against `origin/epic/211-sdk-openapi..88a9d7b` with no actionable issues.
- Detailed reviews, fix evidence, and final no-issues review are documented in the PR conversation.
- Open review findings: none.
- Final no-issues review: complete.

## Docs Impact

- No Markdown docs changed.

## Residual Risk

- This slice intentionally models `/directory/getBySha256Hash` as returning the live server directory-version DTO envelope, not the stale `string` type currently declared in `DirectoryVersion.SDK.fs`.
- Existing unrelated OpenAPI quality debt remains pending for Storage operation tags and `/openApi` reusable `400`/`500` response coverage.
