### PR TITLE
SDK/OpenAPI S11: implement TypeScript Node Tier 1 facade

### DIFF
--- a/sdk/typescript/grace/README.md
+++ b/sdk/typescript/grace/README.md
@@ -1,0 +1,65 @@
+# Grace TypeScript Node SDK
+
+`@grace/sdk` exposes the first TypeScript Node facade for Grace Tier 1 API calls. The public compatibility promise lives
+on `GraceClient`; generated raw-client artifacts stay internal unless a future diagnostic export explicitly says
+otherwise.
+
+Browser TypeScript support is out of scope for this milestone.
+
+## Install And Import
+
+```powershell
+npm install
+npm run build
+```
+
+```bash
+npm install
+npm run build
+```
+
+```ts
+import { GraceClient } from "@grace/sdk";
+
+const grace = new GraceClient({
+  auth: () => process.env.GRACE_TOKEN ?? "",
+  baseUrl: process.env.GRACE_SERVER_URI ?? "http://localhost:5000",
+  correlationId: () => crypto.randomUUID(),
+});
+
+const owner = await grace.request({
+  path: "/owner/get",
+  query: { ownerName: "scott" },
+});
+
+console.log(owner.body);
+```
+
+## Transport Defaults
+
+`GraceClient` sends these headers on every request:
+
+- `X-Api-Version`: defaults to the released contract version `2023-10-01`.
+- `X-Grace-Client-Type`: `TypeScriptNode`.
+- `X-Grace-Client-Version`: the package version.
+- `X-Correlation-Id`: included when configured globally or for an individual request.
+- `Authorization`: included as a bearer token when `auth` is configured.
+
+Set `apiVersion` to a released date version or an explicit server-supported alias when testing contract negotiation. The
+facade does not use `edge` as its default.
+
+## Errors And Lifecycle Diagnostics
+
+Non-2xx responses throw `GraceError`. The error preserves:
+
+- HTTP status and parsed response body.
+- Transport correlation ID from `X-Correlation-Id`, when present.
+- Grace error properties from the JSON error envelope.
+- SDK lifecycle headers such as `X-Grace-Client-Support-Status`,
+  `X-Grace-Client-Recommended-Version`, and `X-Grace-Client-Update-Url`.
+- Upload-session lifecycle diagnostics when returned by storage endpoints.
+
+## Current Scope
+
+This package is a TypeScript Node Tier 1 facade. Tier 2 file transfer and Tier 3 protocol behavior are intentionally not
+implemented here.

--- a/sdk/typescript/grace/package-lock.json
+++ b/sdk/typescript/grace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grace/sdk",
-  "version": "0.0.0-s09",
+  "version": "0.0.0-s11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grace/sdk",
-      "version": "0.0.0-s09",
+      "version": "0.0.0-s11",
       "devDependencies": {
         "typescript": "5.8.3"
       },

--- a/sdk/typescript/grace/package.json
+++ b/sdk/typescript/grace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grace/sdk",
-  "version": "0.0.0-s09",
+  "version": "0.0.0-s11",
   "description": "Facade-first Grace TypeScript Node SDK package harness.",
   "type": "module",
   "private": true,
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "smoke": "npm run build && node smoke/import-facade.mjs"
+    "smoke": "npm run build && node smoke/import-facade.mjs",
+    "test": "npm run build && node --test test/*.mjs"
   },
   "devDependencies": {
     "typescript": "5.8.3"

--- a/sdk/typescript/grace/smoke/import-facade.mjs
+++ b/sdk/typescript/grace/smoke/import-facade.mjs
@@ -1,4 +1,4 @@
-import { GraceClient } from "@grace/sdk";
+import { GraceClient, GraceError } from "@grace/sdk";
 
 const client = new GraceClient();
 
@@ -8,6 +8,14 @@ if (!client.contract.apiContractVersion) {
 
 if (!client.contract.openApiProjectionSha256 || client.contract.openApiProjectionSha256.length !== 64) {
   throw new Error("GraceClient facade did not expose OpenAPI projection provenance.");
+}
+
+if (client.apiVersion !== "2023-10-01") {
+  throw new Error(`GraceClient facade defaulted to unexpected API version: ${client.apiVersion}.`);
+}
+
+if (typeof GraceError !== "function") {
+  throw new Error("GraceError facade export was not available.");
 }
 
 try {

--- a/sdk/typescript/grace/src/facade/grace-client.ts
+++ b/sdk/typescript/grace/src/facade/grace-client.ts
@@ -1,0 +1,177 @@
+import { rawClientMetadata } from "../internal/generated/grace-raw-client-metadata.js";
+import { GraceRawClient } from "../internal/generated/grace-raw-client.js";
+import { GraceError } from "./grace-error.js";
+import {
+  DEFAULT_GRACE_BASE_URL,
+  GRACE_CLIENT_TYPE,
+  GRACE_CLIENT_VERSION,
+  GRACE_HEADER_NAMES,
+  normalizeBaseUrl,
+} from "./headers.js";
+import { parseLifecycleDiagnostics, type GraceLifecycleDiagnostics } from "./lifecycle.js";
+
+export interface GraceClientContractMetadata {
+  readonly apiContractVersion: string;
+  readonly openApiProjectionSha256: string;
+}
+
+export type GraceClientAuthProvider = string | (() => string | Promise<string>);
+
+export interface GraceClientOptions {
+  readonly baseUrl?: string | URL;
+  readonly apiVersion?: string;
+  readonly auth?: GraceClientAuthProvider;
+  readonly correlationId?: string | (() => string | Promise<string>);
+  readonly fetch?: typeof fetch;
+  readonly headers?: HeadersInit;
+}
+
+export interface GraceClientRequest {
+  readonly method?: string;
+  readonly path: string;
+  readonly query?: URLSearchParams | Record<string, string | number | boolean | undefined>;
+  readonly body?: unknown;
+  readonly correlationId?: string;
+  readonly headers?: HeadersInit;
+  readonly signal?: AbortSignal;
+}
+
+export interface GraceClientResponse<TBody = unknown> {
+  readonly body: TBody;
+  readonly status: number;
+  readonly headers: Headers;
+  readonly correlationId?: string;
+  readonly lifecycle: GraceLifecycleDiagnostics;
+}
+
+export class GraceClient {
+  public readonly contract: GraceClientContractMetadata;
+  public readonly baseUrl: string;
+  public readonly apiVersion: string;
+
+  private readonly auth?: GraceClientAuthProvider;
+  private readonly correlationId?: string | (() => string | Promise<string>);
+  private readonly defaultHeaders: Headers;
+  private readonly rawClient: GraceRawClient;
+
+  public constructor(options: GraceClientOptions = {}) {
+    this.contract = {
+      apiContractVersion: rawClientMetadata.apiContractVersion,
+      openApiProjectionSha256: rawClientMetadata.openApiProjectionSha256,
+    };
+
+    this.baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_GRACE_BASE_URL);
+    this.apiVersion = options.apiVersion ?? rawClientMetadata.apiContractVersion;
+    this.auth = options.auth;
+    this.correlationId = options.correlationId;
+    this.defaultHeaders = new Headers(options.headers);
+    this.rawClient = new GraceRawClient(options.fetch);
+  }
+
+  public async request<TBody = unknown>(request: GraceClientRequest): Promise<GraceClientResponse<TBody>> {
+    const url = this.createUrl(request.path, request.query);
+    const headers = await this.createHeaders(request);
+    const response = await this.rawClient.request({
+      init: {
+        body: serializeBody(request.body, headers),
+        headers,
+        method: request.method ?? (request.body === undefined ? "GET" : "POST"),
+        signal: request.signal,
+      },
+      url,
+    });
+
+    const lifecycle = parseLifecycleDiagnostics(response.headers);
+    const correlationId = response.headers.get(GRACE_HEADER_NAMES.correlationId) ?? undefined;
+
+    if (!response.ok) {
+      throw GraceError.fromResponse(response, response.body, lifecycle, correlationId);
+    }
+
+    return {
+      body: response.body as TBody,
+      status: response.status,
+      headers: response.headers,
+      correlationId,
+      lifecycle,
+    };
+  }
+
+  public unsupportedFileTransfer(): never {
+    throw new Error("Tier 2 file transfer is not implemented by the TypeScript Node Tier 1 facade.");
+  }
+
+  private createUrl(path: string, query?: GraceClientRequest["query"]): URL {
+    const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+    const url = new URL(normalizedPath, `${this.baseUrl}/`);
+
+    if (query instanceof URLSearchParams) {
+      query.forEach((value, key) => url.searchParams.append(key, value));
+    } else if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) {
+          url.searchParams.append(key, String(value));
+        }
+      }
+    }
+
+    return url;
+  }
+
+  private async createHeaders(request: GraceClientRequest): Promise<Headers> {
+    const headers = new Headers(this.defaultHeaders);
+    mergeHeaders(headers, request.headers);
+
+    if (!headers.has("Accept")) {
+      headers.set("Accept", "application/json");
+    }
+
+    headers.set(GRACE_HEADER_NAMES.apiVersion, this.apiVersion);
+    headers.set(GRACE_HEADER_NAMES.clientType, GRACE_CLIENT_TYPE);
+    headers.set(GRACE_HEADER_NAMES.clientVersion, GRACE_CLIENT_VERSION);
+
+    const correlationId = request.correlationId ?? (await resolveValue(this.correlationId));
+    if (correlationId) {
+      headers.set(GRACE_HEADER_NAMES.correlationId, correlationId);
+    }
+
+    const token = await resolveValue(this.auth);
+    if (token && !headers.has("Authorization")) {
+      headers.set("Authorization", token.startsWith("Bearer ") ? token : `Bearer ${token}`);
+    }
+
+    return headers;
+  }
+}
+
+function mergeHeaders(target: Headers, source?: HeadersInit): void {
+  if (!source) {
+    return;
+  }
+
+  new Headers(source).forEach((value, key) => target.set(key, value));
+}
+
+async function resolveValue(value?: string | (() => string | Promise<string>)): Promise<string | undefined> {
+  if (typeof value === "function") {
+    return value();
+  }
+
+  return value;
+}
+
+function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  if (typeof body === "string" || body instanceof FormData || body instanceof Blob || body instanceof ArrayBuffer) {
+    return body;
+  }
+
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  return JSON.stringify(body);
+}

--- a/sdk/typescript/grace/src/facade/grace-error.ts
+++ b/sdk/typescript/grace/src/facade/grace-error.ts
@@ -1,0 +1,65 @@
+import { type GraceLifecycleDiagnostics } from "./lifecycle.js";
+
+export interface GraceErrorBody {
+  readonly Error?: string;
+  readonly EventTime?: string;
+  readonly CorrelationId?: string;
+  readonly Properties?: Record<string, unknown>;
+}
+
+interface GraceErrorResponse {
+  readonly status: number;
+  readonly statusText: string;
+}
+
+export class GraceError extends Error {
+  public readonly status: number;
+  public readonly body: unknown;
+  public readonly correlationId?: string;
+  public readonly lifecycle: GraceLifecycleDiagnostics;
+  public readonly properties: Record<string, unknown>;
+  public readonly unsupportedClient: boolean;
+
+  private constructor(
+    message: string,
+    status: number,
+    body: unknown,
+    lifecycle: GraceLifecycleDiagnostics,
+    correlationId?: string,
+    properties: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = "GraceError";
+    this.status = status;
+    this.body = body;
+    this.correlationId = correlationId;
+    this.lifecycle = lifecycle;
+    this.properties = properties;
+    this.unsupportedClient = message === "UnsupportedClientVersion" || lifecycle.supportStatus === "unsupported";
+  }
+
+  public static fromResponse(
+    response: GraceErrorResponse,
+    body: unknown,
+    lifecycle: GraceLifecycleDiagnostics,
+    correlationId?: string,
+  ): GraceError {
+    if (isGraceErrorBody(body)) {
+      return new GraceError(
+        body.Error ?? response.statusText,
+        response.status,
+        body,
+        lifecycle,
+        correlationId ?? body.CorrelationId,
+        body.Properties ?? {},
+      );
+    }
+
+    const message = typeof body === "string" && body ? body : response.statusText || `HTTP ${response.status}`;
+    return new GraceError(message, response.status, body, lifecycle, correlationId);
+  }
+}
+
+function isGraceErrorBody(body: unknown): body is GraceErrorBody {
+  return typeof body === "object" && body !== null && "Error" in body;
+}

--- a/sdk/typescript/grace/src/facade/headers.ts
+++ b/sdk/typescript/grace/src/facade/headers.ts
@@ -1,0 +1,22 @@
+export const DEFAULT_GRACE_BASE_URL = "http://localhost:5000";
+export const GRACE_CLIENT_TYPE = "TypeScriptNode";
+export const GRACE_CLIENT_VERSION = "0.0.0-s11";
+
+export const GRACE_HEADER_NAMES = {
+  apiVersion: "X-Api-Version",
+  clientType: "X-Grace-Client-Type",
+  clientVersion: "X-Grace-Client-Version",
+  correlationId: "X-Correlation-Id",
+  lifecycleStatus: "X-Grace-Client-Support-Status",
+  lifecycleUnsupportedAfter: "X-Grace-Client-Unsupported-After",
+  lifecycleMinimumVersion: "X-Grace-Client-Min-Version",
+  lifecycleRecommendedVersion: "X-Grace-Client-Recommended-Version",
+  lifecycleUpdateUrl: "X-Grace-Client-Update-Url",
+  uploadSessionLifecycleState: "UploadSessionLifecycleState",
+  uploadSessionLifecycleReason: "UploadSessionLifecycleReason",
+} as const;
+
+export function normalizeBaseUrl(value: string | URL): string {
+  const url = value instanceof URL ? value : new URL(value);
+  return url.toString().replace(/\/+$/, "");
+}

--- a/sdk/typescript/grace/src/facade/lifecycle.ts
+++ b/sdk/typescript/grace/src/facade/lifecycle.ts
@@ -1,0 +1,27 @@
+import { GRACE_HEADER_NAMES } from "./headers.js";
+
+export interface GraceLifecycleDiagnostics {
+  readonly supportStatus?: string;
+  readonly unsupportedAfter?: string;
+  readonly minimumVersion?: string;
+  readonly recommendedVersion?: string;
+  readonly updateUrl?: string;
+  readonly uploadSessionState?: string;
+  readonly uploadSessionReason?: string;
+}
+
+export function parseLifecycleDiagnostics(headers: Headers): GraceLifecycleDiagnostics {
+  return removeUndefinedValues({
+    supportStatus: headers.get(GRACE_HEADER_NAMES.lifecycleStatus) ?? undefined,
+    unsupportedAfter: headers.get(GRACE_HEADER_NAMES.lifecycleUnsupportedAfter) ?? undefined,
+    minimumVersion: headers.get(GRACE_HEADER_NAMES.lifecycleMinimumVersion) ?? undefined,
+    recommendedVersion: headers.get(GRACE_HEADER_NAMES.lifecycleRecommendedVersion) ?? undefined,
+    updateUrl: headers.get(GRACE_HEADER_NAMES.lifecycleUpdateUrl) ?? undefined,
+    uploadSessionState: headers.get(GRACE_HEADER_NAMES.uploadSessionLifecycleState) ?? undefined,
+    uploadSessionReason: headers.get(GRACE_HEADER_NAMES.uploadSessionLifecycleReason) ?? undefined,
+  });
+}
+
+function removeUndefinedValues<T extends Record<string, string | undefined>>(value: T): Partial<T> {
+  return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => entry[1] !== undefined)) as Partial<T>;
+}

--- a/sdk/typescript/grace/src/index.ts
+++ b/sdk/typescript/grace/src/index.ts
@@ -1,17 +1,16 @@
-import { rawClientMetadata } from "./internal/generated/grace-raw-client-metadata.js";
-
-export interface GraceClientContractMetadata {
-  readonly apiContractVersion: string;
-  readonly openApiProjectionSha256: string;
-}
-
-export class GraceClient {
-  public readonly contract: GraceClientContractMetadata;
-
-  public constructor() {
-    this.contract = {
-      apiContractVersion: rawClientMetadata.apiContractVersion,
-      openApiProjectionSha256: rawClientMetadata.openApiProjectionSha256,
-    };
-  }
-}
+export {
+  GraceClient,
+  type GraceClientContractMetadata,
+  type GraceClientOptions,
+  type GraceClientRequest,
+  type GraceClientResponse,
+  type GraceClientAuthProvider,
+} from "./facade/grace-client.js";
+export { GraceError, type GraceErrorBody } from "./facade/grace-error.js";
+export {
+  DEFAULT_GRACE_BASE_URL,
+  GRACE_CLIENT_TYPE,
+  GRACE_CLIENT_VERSION,
+  GRACE_HEADER_NAMES,
+} from "./facade/headers.js";
+export type { GraceLifecycleDiagnostics } from "./facade/lifecycle.js";

--- a/sdk/typescript/grace/src/internal/generated/grace-raw-client.ts
+++ b/sdk/typescript/grace/src/internal/generated/grace-raw-client.ts
@@ -1,0 +1,54 @@
+export interface GraceRawClientRequest {
+  readonly url: URL;
+  readonly init: RequestInit;
+}
+
+export interface GraceRawClientResponse {
+  readonly body: unknown;
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+}
+
+export class GraceRawClient {
+  private readonly customFetch: typeof fetch;
+
+  public constructor(customFetch: typeof fetch = globalThis.fetch) {
+    if (!customFetch) {
+      throw new TypeError("GraceClient requires a fetch implementation. Use Node 20+ or pass options.fetch.");
+    }
+
+    this.customFetch = customFetch;
+  }
+
+  public async request(request: GraceRawClientRequest): Promise<GraceRawClientResponse> {
+    const response = await this.customFetch(request.url, request.init);
+
+    return {
+      body: await readResponseBody(response),
+      headers: response.headers,
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+    };
+  }
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (contentType.toLowerCase().includes("application/json")) {
+    return JSON.parse(text);
+  }
+
+  return text;
+}

--- a/sdk/typescript/grace/test/facade.test.mjs
+++ b/sdk/typescript/grace/test/facade.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  GraceClient,
+  GraceError,
+  GRACE_CLIENT_TYPE,
+  GRACE_CLIENT_VERSION,
+  GRACE_HEADER_NAMES,
+} from "../dist/index.js";
+
+test("public exports stay facade-first", async () => {
+  const exports = Object.keys(await import("../dist/index.js")).sort();
+
+  assert.deepEqual(exports, [
+    "DEFAULT_GRACE_BASE_URL",
+    "GRACE_CLIENT_TYPE",
+    "GRACE_CLIENT_VERSION",
+    "GRACE_HEADER_NAMES",
+    "GraceClient",
+    "GraceError",
+  ]);
+});
+
+test("default request policy sends pinned API version and TypeScript Node identity", async () => {
+  const calls = [];
+  const client = new GraceClient({
+    fetch: async (url, init) => {
+      calls.push({ init, url });
+      return jsonResponse({ ReturnValue: "ok" }, { "X-Correlation-Id": "corr-response" });
+    },
+  });
+
+  const response = await client.request({ path: "/owner/get", query: { ownerName: "scott", include: true } });
+
+  assert.equal(client.contract.apiContractVersion, "2023-10-01");
+  assert.notEqual(client.apiVersion, "edge");
+  assert.equal(calls[0].url.toString(), "http://localhost:5000/owner/get?ownerName=scott&include=true");
+  assert.equal(calls[0].init.headers.get(GRACE_HEADER_NAMES.apiVersion), "2023-10-01");
+  assert.equal(calls[0].init.headers.get(GRACE_HEADER_NAMES.clientType), GRACE_CLIENT_TYPE);
+  assert.equal(calls[0].init.headers.get(GRACE_HEADER_NAMES.clientVersion), GRACE_CLIENT_VERSION);
+  assert.equal(response.correlationId, "corr-response");
+});
+
+test("explicit base URL, API version, bearer auth, and correlation ID are applied", async () => {
+  const calls = [];
+  const client = new GraceClient({
+    apiVersion: "latest",
+    auth: async () => "token-value",
+    baseUrl: "https://grace.example.test/api/",
+    correlationId: () => "corr-option",
+    fetch: async (url, init) => {
+      calls.push({ init, url });
+      return jsonResponse({ ReturnValue: { id: 1 } });
+    },
+  });
+
+  await client.request({ body: { Name: "sample" }, path: "repository/create", correlationId: "corr-request" });
+
+  assert.equal(calls[0].url.toString(), "https://grace.example.test/api/repository/create");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[0].init.headers.get(GRACE_HEADER_NAMES.apiVersion), "latest");
+  assert.equal(calls[0].init.headers.get("Authorization"), "Bearer token-value");
+  assert.equal(calls[0].init.headers.get(GRACE_HEADER_NAMES.correlationId), "corr-request");
+  assert.equal(calls[0].init.headers.get("Content-Type"), "application/json");
+  assert.equal(calls[0].init.body, '{"Name":"sample"}');
+});
+
+test("GraceError preserves non-2xx lifecycle headers and unsupported-client details", async () => {
+  const client = new GraceClient({
+    fetch: async () =>
+      jsonResponse(
+        {
+          Error: "UnsupportedClientVersion",
+          CorrelationId: "corr-body",
+          Properties: {
+            recommendedVersion: "0.2.0",
+          },
+        },
+        {
+          "X-Correlation-Id": "corr-header",
+          "X-Grace-Client-Support-Status": "unsupported",
+          "X-Grace-Client-Unsupported-After": "2026-12-01",
+          "X-Grace-Client-Min-Version": "0.1.0",
+          "X-Grace-Client-Recommended-Version": "0.2.0",
+          "X-Grace-Client-Update-Url": "https://github.com/ScottArbeit/Grace/releases",
+          UploadSessionLifecycleState: "Finalized",
+          UploadSessionLifecycleReason: "manifest-finalized",
+        },
+        426,
+      ),
+  });
+
+  await assert.rejects(
+    client.request({ path: "/storage/startUploadSession" }),
+    (error) => {
+      assert.ok(error instanceof GraceError);
+      assert.equal(error.status, 426);
+      assert.equal(error.message, "UnsupportedClientVersion");
+      assert.equal(error.correlationId, "corr-header");
+      assert.equal(error.unsupportedClient, true);
+      assert.equal(error.lifecycle.supportStatus, "unsupported");
+      assert.equal(error.lifecycle.recommendedVersion, "0.2.0");
+      assert.equal(error.lifecycle.uploadSessionState, "Finalized");
+      assert.equal(error.lifecycle.uploadSessionReason, "manifest-finalized");
+      assert.equal(error.properties.recommendedVersion, "0.2.0");
+      return true;
+    },
+  );
+});
+
+test("Tier 2 file transfer is explicitly out of scope", () => {
+  const client = new GraceClient({ fetch: async () => jsonResponse({}) });
+
+  assert.throws(() => client.unsupportedFileTransfer(), /Tier 2 file transfer is not implemented/);
+});
+
+function jsonResponse(body, headers = {}, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    status,
+  });
+}


### PR DESCRIPTION
## Summary

Refs #222.

Implements the first TypeScript Node Tier 1 `GraceClient` facade for `@grace/sdk`:

- Adds a facade-first public export surface with `GraceClient`, `GraceError`, header constants, and lifecycle types.
- Keeps the raw transport boundary internal under `sdk/typescript/grace/src/internal/generated/**` and leaves generated endpoint classes undocumented.
- Defaults `X-Api-Version` to the pinned released contract version `2023-10-01`, not `edge`.
- Adds request policy for base URL normalization, API version override, client identity, bearer auth, correlation IDs, JSON request bodies, and lifecycle parsing.
- Preserves non-2xx lifecycle headers in `GraceError`, including unsupported-client and upload-session diagnostics.
- Adds an explicit Tier 2 file-transfer unsupported stub so the Tier 1 boundary is clear.

## Changed Paths

- `sdk/typescript/grace/README.md`
- `sdk/typescript/grace/package.json`
- `sdk/typescript/grace/package-lock.json`
- `sdk/typescript/grace/smoke/import-facade.mjs`
- `sdk/typescript/grace/src/**`
- `sdk/typescript/grace/test/facade.test.mjs`

No shared `sdk/scripts/**`, root package metadata, Python/Rust SDK files, matrix evidence, server code, or proof-status docs were changed.

## Validation

- `npm test` from `sdk/typescript/grace`: passed. Covers build, public export snapshot, default headers, explicit API override, auth/base URL/correlation behavior, `GraceError`, unsupported-client lifecycle diagnostics, non-2xx lifecycle headers, and Tier 2 out-of-scope behavior.
- `npm run smoke` from `sdk/typescript/grace`: passed. Covers package import smoke and confirms the internal generated metadata subpath remains unexported.
- `npx --yes markdownlint-cli2 sdk/typescript/grace/README.md`: passed.
- `git diff --check`: passed.
- Final review-only subagent ran `npm test`, `npm run smoke`, MarkdownLint with repo config, `git diff --check origin/epic/211-sdk-openapi...HEAD`, scope/freshness checks, and artifact checks: passed.
- GitHub `Validate / full` on `5b3b3c3`: passed.

## Skipped Validation

- `pwsh ./scripts/validate.ps1 -Fast` was not run because this slice changed only the TypeScript SDK package and Markdown docs; no repo-integrated .NET/F# files changed.
- Full/Aspire validation was not run because the change does not touch Aspire, emulators, storage runtime, Service Bus, Cosmos DB, Redis, deployment, or server behavior.

## Docs Impact

Added `sdk/typescript/grace/README.md` documenting the TypeScript Node facade, transport defaults, errors/lifecycle diagnostics, package import shape, and explicit browser/Tier 2/Tier 3 out-of-scope notes.

## Residual Risk

- The facade currently exposes a generic Tier 1 `request` method rather than typed endpoint convenience methods. That keeps this slice small and facade-first while later SDK issues can add domain-specific methods.
- The raw client boundary is minimal and internal; it does not expose generated endpoint classes as a public API.

## Review Status

- Implementation complete in `5b3b3c3`.
- Worker validation passed locally; evidence listed above.
- Final review-only sibling subagent found no blocking issues and verified facade export shape, internal raw-client boundary, pinned API version, Tier 1 transport policy, lifecycle preservation on non-2xx responses, honest out-of-scope browser/Tier 2/Tier 3 behavior, README examples, scope, and artifact hygiene.
- GitHub `Validate / full` on `5b3b3c3`: passed.
- Open findings: none.
- Final no-issues review-only sibling pass: complete.
