### PR TITLE
SDK/OpenAPI S12: implement TypeScript Node Tier 2 file transfer

### DIFF
--- a/sdk/typescript/grace/README.md
+++ b/sdk/typescript/grace/README.md
@@ -1,8 +1,7 @@
 # Grace TypeScript Node SDK
 
-`@grace/sdk` exposes the first TypeScript Node facade for Grace Tier 1 API calls. The public compatibility promise lives
-on `GraceClient`; generated raw-client artifacts stay internal unless a future diagnostic export explicitly says
-otherwise.
+`@grace/sdk` exposes the first TypeScript Node facade for Grace API calls. The public compatibility promise lives on
+`GraceClient`; generated raw-client artifacts stay internal unless a future diagnostic export explicitly says otherwise.
 
 Browser TypeScript support is out of scope for this milestone.
 
@@ -35,6 +34,38 @@ const owner = await grace.request({
 console.log(owner.body);
 ```
 
+## Tier 2 Simple File Transfer
+
+The TypeScript Node facade includes Tier 2 whole-file compatibility helpers:
+
+- `uploadFile` reads one local file, computes its SHA-256 hash, asks Grace for a server-issued whole-file upload URI,
+  and uploads the bytes to that URI.
+- `downloadFile` asks Grace for a raw text whole-file download URI and writes the downloaded bytes to an existing output
+  directory.
+
+These helpers are intentionally simple. They do not implement the manifest protocol, ContentBlock transfer,
+deduplication, or Tier 3/Tier 4 behavior.
+
+```ts
+const upload = await grace.uploadFile({
+  filePath: "C:/work/hello.txt",
+  relativePath: "docs/hello.txt",
+  repositoryName: "repo",
+});
+
+const download = await grace.downloadFile({
+  fileVersion: upload.fileVersion,
+  outputPath: "C:/work/downloaded-hello.txt",
+  repositoryName: "repo",
+});
+
+console.log(download.bytesWritten);
+```
+
+Grace auth, API version, correlation, lifecycle, and client identity headers apply to the Grace API requests that issue
+transfer URIs. The follow-up storage transfer uses only the server-issued URI and does not attach Grace bearer tokens or
+client identity headers to the storage request.
+
 ## Transport Defaults
 
 `GraceClient` sends these headers on every request:
@@ -61,5 +92,5 @@ Non-2xx responses throw `GraceError`. The error preserves:
 
 ## Current Scope
 
-This package is a TypeScript Node Tier 1 facade. Tier 2 file transfer and Tier 3 protocol behavior are intentionally not
-implemented here.
+This package is a TypeScript Node facade with Tier 1 API request support and Tier 2 simple whole-file transfer helpers.
+Tier 3 manifest protocol behavior is intentionally not implemented here.

--- a/sdk/typescript/grace/package-lock.json
+++ b/sdk/typescript/grace/package-lock.json
@@ -8,10 +8,21 @@
       "name": "@grace/sdk",
       "version": "0.0.0-s11",
       "devDependencies": {
+        "@types/node": "^22.19.19",
         "typescript": "5.8.3"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/typescript": {
@@ -27,6 +38,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/sdk/typescript/grace/package.json
+++ b/sdk/typescript/grace/package.json
@@ -18,6 +18,7 @@
     "test": "npm run build && node --test test/*.mjs"
   },
   "devDependencies": {
+    "@types/node": "^22.19.19",
     "typescript": "5.8.3"
   },
   "engines": {

--- a/sdk/typescript/grace/src/facade/grace-client.ts
+++ b/sdk/typescript/grace/src/facade/grace-client.ts
@@ -1,5 +1,8 @@
 import { rawClientMetadata } from "../internal/generated/grace-raw-client-metadata.js";
 import { GraceRawClient } from "../internal/generated/grace-raw-client.js";
+import { createHash } from "node:crypto";
+import { stat, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { GraceError } from "./grace-error.js";
 import {
   DEFAULT_GRACE_BASE_URL,
@@ -44,6 +47,72 @@ export interface GraceClientResponse<TBody = unknown> {
   readonly lifecycle: GraceLifecycleDiagnostics;
 }
 
+export interface GraceStorageScope {
+  readonly ownerId?: string;
+  readonly ownerName?: string;
+  readonly organizationId?: string;
+  readonly organizationName?: string;
+  readonly repositoryId?: string;
+  readonly repositoryName?: string;
+  readonly principal?: string;
+}
+
+export interface GraceFileVersion {
+  readonly Class?: "FileVersion" | string;
+  readonly RelativePath: string;
+  readonly Sha256Hash: string;
+  readonly IsBinary?: boolean;
+  readonly Size?: number;
+  readonly CreatedAt?: string;
+  readonly BlobUri?: string;
+  readonly ContentReference?: GraceFileContentReference;
+}
+
+export interface GraceFileContentReference {
+  readonly Class?: "FileContentReference" | string;
+  readonly ReferenceType: "WholeFileContent" | "FileManifest" | string;
+  readonly Manifest?: unknown;
+}
+
+export interface GraceUploadFileRequest extends GraceStorageScope {
+  readonly filePath: string;
+  readonly relativePath: string;
+  readonly correlationId?: string;
+  readonly contentType?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface GraceDownloadFileRequest extends GraceStorageScope {
+  readonly fileVersion: GraceFileVersion;
+  readonly outputPath: string;
+  readonly correlationId?: string;
+  readonly allowOverwrite?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export interface GraceTransferStep {
+  readonly status: number;
+  readonly headers: Headers;
+  readonly lifecycle: GraceLifecycleDiagnostics;
+}
+
+export interface GraceUploadFileResult {
+  readonly fileVersion: GraceFileVersion;
+  readonly relativePath: string;
+  readonly sha256Hash: string;
+  readonly size: number;
+  readonly uriRequest: GraceClientResponse<Record<string, string>>;
+  readonly transfer: GraceTransferStep;
+}
+
+export interface GraceDownloadFileResult {
+  readonly fileVersion: GraceFileVersion;
+  readonly outputPath: string;
+  readonly bytesWritten: number;
+  readonly uriRequest: GraceClientResponse<string>;
+  readonly transfer: GraceTransferStep;
+}
+
 export class GraceClient {
   public readonly contract: GraceClientContractMetadata;
   public readonly baseUrl: string;
@@ -53,6 +122,7 @@ export class GraceClient {
   private readonly correlationId?: string | (() => string | Promise<string>);
   private readonly defaultHeaders: Headers;
   private readonly rawClient: GraceRawClient;
+  private readonly transferFetch: typeof fetch;
 
   public constructor(options: GraceClientOptions = {}) {
     this.contract = {
@@ -66,6 +136,7 @@ export class GraceClient {
     this.correlationId = options.correlationId;
     this.defaultHeaders = new Headers(options.headers);
     this.rawClient = new GraceRawClient(options.fetch);
+    this.transferFetch = options.fetch ?? globalThis.fetch;
   }
 
   public async request<TBody = unknown>(request: GraceClientRequest): Promise<GraceClientResponse<TBody>> {
@@ -97,8 +168,83 @@ export class GraceClient {
     };
   }
 
-  public unsupportedFileTransfer(): never {
-    throw new Error("Tier 2 file transfer is not implemented by the TypeScript Node Tier 1 facade.");
+  public async uploadFile(request: GraceUploadFileRequest): Promise<GraceUploadFileResult> {
+    const fileVersion = await createWholeFileVersion(request.filePath, request.relativePath);
+    const correlationId = request.correlationId ?? (await resolveValue(this.correlationId));
+    const uriRequest = await this.request<Record<string, string>>({
+      body: createStorageParameters({ ...request, correlationId }, {
+        FileVersions: [fileVersion],
+      }),
+      correlationId,
+      path: "/storage/getUploadUri",
+      signal: request.signal,
+    });
+
+    const uploadUri = readUploadUri(uriRequest.body, request.relativePath);
+    const fileBytes = await readFile(request.filePath);
+    const response = await this.transferFetch(uploadUri, {
+      body: new Blob([fileBytes]),
+      headers: createUploadHeaders(request.contentType),
+      method: "PUT",
+      signal: request.signal,
+    });
+
+    const transfer = await readTransferStep(response);
+
+    if (!response.ok) {
+      throw GraceError.fromResponse(response, transfer.body, transfer.lifecycle);
+    }
+
+    return {
+      fileVersion,
+      relativePath: fileVersion.RelativePath,
+      sha256Hash: fileVersion.Sha256Hash,
+      size: fileVersion.Size ?? fileBytes.byteLength,
+      uriRequest,
+      transfer,
+    };
+  }
+
+  public async downloadFile(request: GraceDownloadFileRequest): Promise<GraceDownloadFileResult> {
+    await assertOutputPathIsWritable(request.outputPath, request.allowOverwrite ?? false);
+    const correlationId = request.correlationId ?? (await resolveValue(this.correlationId));
+
+    const uriRequest = await this.request<string>({
+      body: createStorageParameters({ ...request, correlationId }, {
+        FileVersion: normalizeFileVersion(request.fileVersion),
+      }),
+      correlationId,
+      headers: {
+        Accept: "text/plain",
+      },
+      path: "/storage/getDownloadUri",
+      signal: request.signal,
+    });
+
+    if (typeof uriRequest.body !== "string" || uriRequest.body.trim() === "") {
+      throw new Error("Grace did not return a download URI.");
+    }
+
+    const response = await this.transferFetch(uriRequest.body, {
+      method: "GET",
+      signal: request.signal,
+    });
+    const transfer = await readTransferStep(response);
+
+    if (!response.ok) {
+      throw GraceError.fromResponse(response, transfer.body, transfer.lifecycle);
+    }
+
+    const bytes = transfer.bytes ?? new Uint8Array();
+    await writeFile(request.outputPath, bytes);
+
+    return {
+      bytesWritten: bytes.byteLength,
+      fileVersion: normalizeFileVersion(request.fileVersion),
+      outputPath: request.outputPath,
+      uriRequest,
+      transfer,
+    };
   }
 
   private createUrl(path: string, query?: GraceClientRequest["query"]): URL {
@@ -174,4 +320,166 @@ function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
   }
 
   return JSON.stringify(body);
+}
+
+async function createWholeFileVersion(filePath: string, relativePath: string): Promise<GraceFileVersion> {
+  let fileInfo;
+
+  try {
+    fileInfo = await stat(filePath);
+  } catch {
+    throw new Error("Input file does not exist.");
+  }
+
+  if (!fileInfo.isFile()) {
+    throw new Error("Input path must be a file.");
+  }
+
+  if (!relativePath || relativePath.trim() === "") {
+    throw new Error("Relative path is required.");
+  }
+
+  const fileBytes = await readFile(filePath);
+  const sha256Hash = createHash("sha256").update(fileBytes).digest("hex");
+
+  return {
+    BlobUri: "",
+    Class: "FileVersion",
+    ContentReference: {
+      Class: "FileContentReference",
+      Manifest: null,
+      ReferenceType: "WholeFileContent",
+    },
+    CreatedAt: fileInfo.mtime.toISOString(),
+    IsBinary: true,
+    RelativePath: normalizeRelativePath(relativePath),
+    Sha256Hash: sha256Hash,
+    Size: fileInfo.size,
+  };
+}
+
+function normalizeFileVersion(fileVersion: GraceFileVersion): GraceFileVersion {
+  if (!fileVersion.RelativePath || fileVersion.RelativePath.trim() === "") {
+    throw new Error("FileVersion.RelativePath is required.");
+  }
+
+  if (!fileVersion.Sha256Hash || fileVersion.Sha256Hash.trim() === "") {
+    throw new Error("FileVersion.Sha256Hash is required.");
+  }
+
+  return {
+    BlobUri: fileVersion.BlobUri ?? "",
+    Class: fileVersion.Class ?? "FileVersion",
+    ContentReference: fileVersion.ContentReference ?? {
+      Class: "FileContentReference",
+      Manifest: null,
+      ReferenceType: "WholeFileContent",
+    },
+    CreatedAt: fileVersion.CreatedAt,
+    IsBinary: fileVersion.IsBinary ?? true,
+    RelativePath: normalizeRelativePath(fileVersion.RelativePath),
+    Sha256Hash: fileVersion.Sha256Hash,
+    Size: fileVersion.Size,
+  };
+}
+
+function createStorageParameters(scope: GraceStorageScope & { readonly correlationId?: string }, body: Record<string, unknown>): Record<string, unknown> {
+  return removeUndefined({
+    CorrelationId: scope.correlationId,
+    OwnerId: scope.ownerId,
+    OwnerName: scope.ownerName,
+    OrganizationId: scope.organizationId,
+    OrganizationName: scope.organizationName,
+    Principal: scope.principal,
+    RepositoryId: scope.repositoryId,
+    RepositoryName: scope.repositoryName,
+    ...body,
+  });
+}
+
+function readUploadUri(uriMap: Record<string, string>, relativePath: string): string {
+  const normalizedRelativePath = normalizeRelativePath(relativePath);
+  const uploadUri = uriMap[normalizedRelativePath] ?? uriMap[`/${normalizedRelativePath}`];
+
+  if (!uploadUri || uploadUri.trim() === "") {
+    throw new Error("Grace did not return an upload URI for the requested file.");
+  }
+
+  return uploadUri;
+}
+
+function createUploadHeaders(contentType?: string): Headers {
+  const headers = new Headers();
+  headers.set("Content-Type", contentType ?? "application/octet-stream");
+  headers.set("x-ms-blob-type", "BlockBlob");
+  return headers;
+}
+
+async function readTransferStep(response: Response): Promise<GraceTransferStep & { readonly body?: unknown; readonly bytes?: Uint8Array }> {
+  const lifecycle = parseLifecycleDiagnostics(response.headers);
+  const contentType = response.headers.get("Content-Type") ?? "";
+
+  if (!response.ok) {
+    const text = await response.text();
+    const body = contentType.toLowerCase().includes("application/json") && text ? JSON.parse(text) : text;
+    return {
+      body,
+      headers: response.headers,
+      lifecycle,
+      status: response.status,
+    };
+  }
+
+  if (response.status === 204 || response.status === 201) {
+    return {
+      headers: response.headers,
+      lifecycle,
+      status: response.status,
+    };
+  }
+
+  return {
+    bytes: new Uint8Array(await response.arrayBuffer()),
+    headers: response.headers,
+    lifecycle,
+    status: response.status,
+  };
+}
+
+async function assertOutputPathIsWritable(outputPath: string, allowOverwrite: boolean): Promise<void> {
+  if (!outputPath || outputPath.trim() === "") {
+    throw new Error("Output path is required.");
+  }
+
+  try {
+    const parent = await stat(dirname(outputPath));
+    if (!parent.isDirectory()) {
+      throw new Error("Output directory does not exist.");
+    }
+  } catch {
+    throw new Error("Output directory does not exist.");
+  }
+
+  try {
+    const existingOutput = await stat(outputPath);
+    if (existingOutput.isDirectory()) {
+      throw new Error("Output path must be a file.");
+    }
+
+    if (!allowOverwrite) {
+      throw new Error("Output file already exists.");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Output ")) {
+      throw error;
+    }
+  }
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function removeUndefined(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter((entry) => entry[1] !== undefined));
 }

--- a/sdk/typescript/grace/src/index.ts
+++ b/sdk/typescript/grace/src/index.ts
@@ -5,6 +5,14 @@ export {
   type GraceClientRequest,
   type GraceClientResponse,
   type GraceClientAuthProvider,
+  type GraceDownloadFileRequest,
+  type GraceDownloadFileResult,
+  type GraceFileContentReference,
+  type GraceFileVersion,
+  type GraceStorageScope,
+  type GraceTransferStep,
+  type GraceUploadFileRequest,
+  type GraceUploadFileResult,
 } from "./facade/grace-client.js";
 export { GraceError, type GraceErrorBody } from "./facade/grace-error.js";
 export {

--- a/sdk/typescript/grace/test/facade.test.mjs
+++ b/sdk/typescript/grace/test/facade.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import {
   GraceClient,
@@ -108,16 +111,240 @@ test("GraceError preserves non-2xx lifecycle headers and unsupported-client deta
   );
 });
 
-test("Tier 2 file transfer is explicitly out of scope", () => {
-  const client = new GraceClient({ fetch: async () => jsonResponse({}) });
+test("Tier 2 upload requests a server-issued URI and uploads local bytes without leaking Grace auth", async () => {
+  const temp = await mkdtemp(join(tmpdir(), "grace-upload-"));
+  const sourcePath = join(temp, "hello.txt");
+  await writeFile(sourcePath, "hello grace");
 
-  assert.throws(() => client.unsupportedFileTransfer(), /Tier 2 file transfer is not implemented/);
+  const calls = [];
+  const client = new GraceClient({
+    auth: "secret-token",
+    correlationId: () => "corr-upload",
+    fetch: async (url, init) => {
+      calls.push({ init, url });
+
+      if (url.toString() === "http://localhost:5000/storage/getUploadUri") {
+        const body = JSON.parse(init.body);
+        assert.equal(init.headers.get(GRACE_HEADER_NAMES.apiVersion), "2023-10-01");
+        assert.equal(init.headers.get(GRACE_HEADER_NAMES.clientType), GRACE_CLIENT_TYPE);
+        assert.equal(init.headers.get(GRACE_HEADER_NAMES.clientVersion), GRACE_CLIENT_VERSION);
+        assert.equal(init.headers.get("Authorization"), "Bearer secret-token");
+        assert.equal(init.headers.get(GRACE_HEADER_NAMES.correlationId), "corr-upload");
+        assert.equal(body.CorrelationId, "corr-upload");
+        assert.equal(body.RepositoryName, "repo");
+        assert.equal(body.FileVersions[0].RelativePath, "docs/hello.txt");
+        assert.equal(body.FileVersions[0].Class, "FileVersion");
+        assert.equal(body.FileVersions[0].IsBinary, true);
+        assert.equal(body.FileVersions[0].Size, 11);
+        assert.match(body.FileVersions[0].Sha256Hash, /^[a-f0-9]{64}$/);
+        assert.equal(body.FileVersions[0].ContentReference.ReferenceType, "WholeFileContent");
+        return jsonResponse({ "docs/hello.txt": "https://storage.example.test/upload?sig=hidden" }, {
+          "X-Correlation-Id": "corr-upload-response",
+          "X-Grace-Client-Support-Status": "supported",
+        });
+      }
+
+      assert.equal(url.toString(), "https://storage.example.test/upload?sig=hidden");
+      assert.equal(init.method, "PUT");
+      assert.equal(init.headers.get("Authorization"), null);
+      assert.equal(init.headers.get(GRACE_HEADER_NAMES.apiVersion), null);
+      assert.equal(await init.body.text(), "hello grace");
+      return new Response(undefined, {
+        headers: { UploadSessionLifecycleState: "WholeFileUploaded" },
+        status: 201,
+      });
+    },
+  });
+
+  try {
+    const result = await client.uploadFile({
+      filePath: sourcePath,
+      relativePath: "docs/hello.txt",
+      repositoryName: "repo",
+    });
+
+    assert.equal(result.relativePath, "docs/hello.txt");
+    assert.match(result.sha256Hash, /^[a-f0-9]{64}$/);
+    assert.equal(result.size, 11);
+    assert.equal(result.uriRequest.correlationId, "corr-upload-response");
+    assert.equal(result.uriRequest.lifecycle.supportStatus, "supported");
+    assert.equal(result.transfer.status, 201);
+    assert.equal(result.transfer.lifecycle.uploadSessionState, "WholeFileUploaded");
+    assert.equal(calls.length, 2);
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("Tier 2 download requests a raw text URI and writes bytes to an existing output path", async () => {
+  const temp = await mkdtemp(join(tmpdir(), "grace-download-"));
+  const outputPath = join(temp, "hello.txt");
+
+  const calls = [];
+  const client = new GraceClient({
+    fetch: async (url, init) => {
+      calls.push({ init, url });
+
+      if (url.toString() === "http://localhost:5000/storage/getDownloadUri") {
+        const body = JSON.parse(init.body);
+        assert.equal(init.headers.get("Accept"), "text/plain");
+        assert.equal(body.FileVersion.RelativePath, "docs/hello.txt");
+        assert.equal(body.FileVersion.Sha256Hash, "abc123");
+        return textResponse("https://storage.example.test/download?sig=hidden", {
+          "X-Correlation-Id": "corr-download-response",
+          "X-Grace-Client-Recommended-Version": "0.0.0-s12",
+        });
+      }
+
+      assert.equal(url.toString(), "https://storage.example.test/download?sig=hidden");
+      assert.equal(init.method, "GET");
+      assert.equal(init.headers?.get?.("Authorization") ?? null, null);
+      return new Response("downloaded bytes", {
+        headers: { UploadSessionLifecycleReason: "whole-file-download" },
+      });
+    },
+  });
+
+  try {
+    const result = await client.downloadFile({
+      fileVersion: {
+        RelativePath: "docs/hello.txt",
+        Sha256Hash: "abc123",
+        IsBinary: true,
+        Size: 16,
+      },
+      outputPath,
+      repositoryName: "repo",
+    });
+
+    assert.equal(await readFile(outputPath, "utf8"), "downloaded bytes");
+    assert.equal(result.bytesWritten, 16);
+    assert.equal(result.uriRequest.body, "https://storage.example.test/download?sig=hidden");
+    assert.equal(result.uriRequest.lifecycle.recommendedVersion, "0.0.0-s12");
+    assert.equal(result.transfer.lifecycle.uploadSessionReason, "whole-file-download");
+    assert.equal(calls.length, 2);
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("Tier 2 transfer failures are surfaced as GraceError", async () => {
+  const temp = await mkdtemp(join(tmpdir(), "grace-transfer-fail-"));
+  const sourcePath = join(temp, "hello.txt");
+  await writeFile(sourcePath, "hello grace");
+
+  const client = new GraceClient({
+    fetch: async (url) => {
+      if (url.toString() === "http://localhost:5000/storage/getUploadUri") {
+        return jsonResponse({ "docs/hello.txt": "https://storage.example.test/upload?sig=expired" });
+      }
+
+      return textResponse("expired", {
+        "X-Grace-Client-Support-Status": "unsupported",
+      }, 403);
+    },
+  });
+
+  try {
+    await assert.rejects(
+      client.uploadFile({
+        filePath: sourcePath,
+        relativePath: "docs/hello.txt",
+        repositoryName: "repo",
+      }),
+      (error) => {
+        assert.ok(error instanceof GraceError);
+        assert.equal(error.status, 403);
+        assert.equal(error.message, "expired");
+        assert.equal(error.unsupportedClient, true);
+        return true;
+      },
+    );
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("Tier 2 transfer rejects local path problems before contacting Grace", async () => {
+  const calls = [];
+  const client = new GraceClient({
+    fetch: async (...args) => {
+      calls.push(args);
+      return jsonResponse({});
+    },
+  });
+
+  await assert.rejects(
+    client.uploadFile({
+      filePath: join(tmpdir(), "grace-missing-file.txt"),
+      relativePath: "docs/missing.txt",
+      repositoryName: "repo",
+    }),
+    /Input file does not exist/,
+  );
+
+  await assert.rejects(
+    client.downloadFile({
+      fileVersion: { RelativePath: "docs/hello.txt", Sha256Hash: "abc123" },
+      outputPath: join(tmpdir(), "missing-parent", "hello.txt"),
+      repositoryName: "repo",
+    }),
+    /Output directory does not exist/,
+  );
+
+  assert.equal(calls.length, 0);
+});
+
+test("Tier 2 transfer honors cancellation signals", async () => {
+  const temp = await mkdtemp(join(tmpdir(), "grace-transfer-cancel-"));
+  const sourcePath = join(temp, "hello.txt");
+  await writeFile(sourcePath, "hello grace");
+  const abortController = new AbortController();
+  const seenSignals = [];
+
+  const client = new GraceClient({
+    fetch: async (url, init) => {
+      seenSignals.push(init.signal);
+
+      if (url.toString() === "http://localhost:5000/storage/getUploadUri") {
+        abortController.abort();
+        return jsonResponse({ "docs/hello.txt": "https://storage.example.test/upload" });
+      }
+
+      throw new DOMException("The operation was aborted.", "AbortError");
+    },
+  });
+
+  try {
+    await assert.rejects(
+      client.uploadFile({
+        filePath: sourcePath,
+        relativePath: "docs/hello.txt",
+        repositoryName: "repo",
+        signal: abortController.signal,
+      }),
+      /aborted/i,
+    );
+    assert.deepEqual(seenSignals, [abortController.signal, abortController.signal]);
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
 });
 
 function jsonResponse(body, headers = {}, status = 200) {
   return new Response(JSON.stringify(body), {
     headers: {
       "Content-Type": "application/json",
+      ...headers,
+    },
+    status,
+  });
+}
+
+function textResponse(body, headers = {}, status = 200) {
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
       ...headers,
     },
     status,


### PR DESCRIPTION
## Summary

- Implements TypeScript Node Tier 2 simple whole-file upload/download helpers on `GraceClient`.
- Uses Grace API requests to obtain server-issued whole-file transfer URIs, preserving existing auth, API version, correlation, lifecycle, and client identity policy.
- Keeps manifest protocol, ContentBlock transfer, deduplication, and Tier 3/Tier 4 behavior explicitly out of scope.

Linked issue: #223
Parent epic: #211

## Behavior

- `uploadFile` reads a local file, computes SHA-256, builds a WholeFileContent `FileVersion`, calls `/storage/getUploadUri`, and uploads bytes to the returned URI.
- `downloadFile` calls `/storage/getDownloadUri` with `Accept: text/plain`, treats the returned URI as raw text, downloads bytes, and writes them to an existing output directory.
- Follow-up storage transfer requests do not attach Grace bearer tokens, API version, or client identity headers to server-issued storage URIs.
- Failed transfer responses are surfaced as `GraceError` with lifecycle diagnostics when headers are present.

## Validation

- `npm test` in `sdk/typescript/grace`: passed, 9 tests passed.
- `npm run smoke` in `sdk/typescript/grace`: passed, `TypeScript facade import OK (2023-10-01)`.
- `npx --yes markdownlint-cli2 "sdk/typescript/grace/README.md"`: passed, 0 errors.
- `git diff --check`: passed.
- Final review-only subagent ran `npm test`, `npm run smoke`, MarkdownLint from repo root, `git diff --check origin/epic/211-sdk-openapi...HEAD`, scope/freshness checks, and artifact checks: passed.
- GitHub `Validate / full` on `133f081`: passed.

## Skipped Validation

- No broad .NET `validate.ps1 -Fast` or `-Full` run. This slice only changes the TypeScript SDK package/docs/tests and did not require server/OpenAPI/F# changes or hosted storage/Aspire execution.

## Docs Impact

- Updated `sdk/typescript/grace/README.md` with Tier 2 simple file-transfer usage and explicit out-of-scope notes for manifest protocol and Tier 3/Tier 4 behavior.

## Residual Risk

- The tests use mocked Grace/storage fetch responses rather than a live storage provider. Server/OpenAPI contracts were inspected and left unchanged.
- The upload helper uses whole-file bytes with `IsBinary: true`; text compression/manifest parity remains out of scope for this tier.
- Additional tests for failed download transfer and existing-output overwrite refusal would be useful follow-up hardening, but were not required for this slice's completion.

## Review Status

- Implementation complete in `133f081`.
- Worker focused validation passed locally; evidence listed above.
- Final review-only sibling subagent found no blocking issues and verified Tier 2 whole-file/server-mediated semantics, Grace API request policy, storage URI header hygiene, plain URI handling, lifecycle/error propagation, honest Tier 2-only docs, test coverage, scope/freshness, and green GitHub validation.
- Open findings: none.
- Final no-issues review-only sibling pass: complete.
