### PR TITLE
Classify Grace.Server routes before OpenAPI expansion

### DIFF
--- a/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
+++ b/src/Grace.Authorization.Tests/OpenApiRouteCoverage.Tests.fs
@@ -1,18 +1,42 @@
 namespace Grace.Authorization.Tests
 
 open Grace.Shared
+open Grace.Server.Security.EndpointAuthorizationManifest
+open Grace.Types.Authorization
 open NUnit.Framework
 open System
 open System.IO
+open System.Text.Json
 open System.Text.RegularExpressions
+
+type Route = { Method: string; Path: string }
+
+type ClassificationGroup = { Classification: string; Reason: string; TraceIds: string list; Routes: Route list }
 
 [<Parallelizable(ParallelScope.All)>]
 type OpenApiRouteCoverageTests() =
 
     let openApiMainPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "OpenAPI", "Main.OpenAPI.yaml"))
+    let routeClassificationRegistryPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "OpenAPI", "RouteClassification.json"))
+    let startupPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Startup.Server.fs"))
 
     let openApiPathRegex = Regex("^  (?<path>/[^:]+):\\s*$", RegexOptions.Compiled)
     let openApiVersionRegex = Regex("""^  version: "(?<version>[^"]+)"\s*$""", RegexOptions.Compiled)
+
+    let startupRouteTokenRegex =
+        Regex("(?<method>\\bGET\\b|\\bPOST\\b|\\bPUT\\b)\\s*\\[|(?<kind>subRoute|routef|route)\\s+\"(?<path>[^\"]+)\"", RegexOptions.Multiline)
+
+    let route method_ path = { Method = method_; Path = path }
+
+    let formatRoute route = $"{route.Method} {route.Path}"
+
+    let formatRoutes routes =
+        routes
+        |> Seq.sortBy (fun route -> route.Method, route.Path)
+        |> Seq.map formatRoute
+        |> String.concat Environment.NewLine
+
+    let failWithRoutes message routes = Assert.Fail($"{message}:{Environment.NewLine}{formatRoutes routes}")
 
     let openApiVersion () =
         File.ReadAllLines(openApiMainPath)
@@ -28,6 +52,99 @@ type OpenApiRouteCoverageTests() =
 
             if matchItem.Success then Some matchItem.Groups["path"].Value else None)
         |> Set.ofArray
+
+    let parseStartupRoutes () =
+        let text = File.ReadAllText(startupPath)
+        let matches = startupRouteTokenRegex.Matches(text)
+        let mutable currentPrefix = String.Empty
+        let mutable currentMethod = String.Empty
+        let routes = ResizeArray<Route>()
+
+        for matchItem in matches do
+            if matchItem.Groups["method"].Success then
+                currentMethod <- matchItem.Groups["method"].Value
+            elif matchItem.Groups["kind"].Success then
+                let kind = matchItem.Groups["kind"].Value
+                let path = matchItem.Groups["path"].Value
+
+                if kind = "subRoute" then
+                    currentPrefix <- path
+                else if String.IsNullOrWhiteSpace currentMethod then
+                    invalidOp $"Missing HTTP method before route '{path}'."
+                else
+                    let fullPath =
+                        if String.IsNullOrWhiteSpace currentPrefix then
+                            path
+                        else
+                            $"{currentPrefix}{path}"
+
+                    routes.Add(route currentMethod fullPath)
+
+        routes
+        |> Seq.toList
+        |> List.append [ route "GET" "/metrics"
+                         route "GET" "/notifications" ]
+
+    let getRequiredString (parent: JsonElement) (propertyName: string) =
+        let value = parent.GetProperty(propertyName).GetString()
+
+        if String.IsNullOrWhiteSpace value then
+            invalidOp $"RouteClassification.json entry has a blank '{propertyName}' value."
+
+        value
+
+    let routeClassificationGroups () =
+        use document = JsonDocument.Parse(File.ReadAllText(routeClassificationRegistryPath))
+
+        document
+            .RootElement
+            .GetProperty("classifications")
+            .EnumerateArray()
+        |> Seq.map (fun classificationElement ->
+            let traceIds =
+                classificationElement
+                    .GetProperty("traceIds")
+                    .EnumerateArray()
+                |> Seq.map (fun traceIdElement ->
+                    let traceId = traceIdElement.GetString()
+
+                    if String.IsNullOrWhiteSpace traceId then
+                        invalidOp "RouteClassification.json entry has a blank trace id."
+
+                    traceId)
+                |> Seq.toList
+
+            let routes =
+                classificationElement
+                    .GetProperty("routes")
+                    .EnumerateArray()
+                |> Seq.map (fun routeElement -> { Method = getRequiredString routeElement "method"; Path = getRequiredString routeElement "path" })
+                |> Seq.toList
+
+            {
+                Classification = getRequiredString classificationElement "classification"
+                Reason = getRequiredString classificationElement "reason"
+                TraceIds = traceIds
+                Routes = routes
+            })
+        |> Seq.toList
+
+    let assertRouteSecurity method_ path (expectedSecurity: EndpointSecurity) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
+
+        match matchingDefinitions with
+        | [ definition ] ->
+            Assert.That(
+                definition.Security,
+                Is.EqualTo(expectedSecurity),
+                $"Expected {method_} {path} to use {expectedSecurity}, but manifest uses {definition.Security}."
+            )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
 
     [<Test>]
     member _.OpenApiCoversAdrStorageRoutes() =
@@ -60,3 +177,159 @@ type OpenApiRouteCoverageTests() =
 
     [<Test>]
     member _.OpenApiInfoVersionMatchesCurrentApiContractVersion() = Assert.That(openApiVersion (), Is.EqualTo(ApiContractVersion.CurrentReleased))
+
+    [<Test>]
+    member _.RouteClassificationRegistryUsesKnownClassificationsAndHasNoDuplicateRoutes() =
+        let knownClassifications =
+            [
+                "debugTestOnlyRoute"
+                "incompleteUnimplementedSurface"
+                "internalOnlyContract"
+                "intentionallyExcludedOperationalSurface"
+                "staleArtifact"
+            ]
+            |> Set.ofList
+
+        let groups = routeClassificationGroups ()
+
+        for group in groups do
+            Assert.That(
+                knownClassifications.Contains group.Classification,
+                Is.True,
+                $"RouteClassification.json uses unknown classification '{group.Classification}'."
+            )
+
+            Assert.That(group.Reason.Trim().Length, Is.GreaterThan(0), $"Route classification '{group.Classification}' has a blank reason.")
+            Assert.That(group.TraceIds, Is.Not.Empty, $"Route classification '{group.Classification}' has no trace ids.")
+            Assert.That(group.Routes, Is.Not.Empty, $"Route classification '{group.Classification}' has no routes.")
+
+        let duplicates =
+            groups
+            |> List.collect (fun group -> group.Routes)
+            |> List.groupBy id
+            |> List.choose (fun (route, entries) -> if entries.Length > 1 then Some route else None)
+
+        if not duplicates.IsEmpty then
+            failWithRoutes "RouteClassification.json classifies routes more than once" duplicates
+
+    [<Test>]
+    member _.RouteClassificationRegistryCoversImplementedManifestAndOpenApiSurfaces() =
+        let startupRoutes = parseStartupRoutes () |> Set.ofList
+
+        let manifestRoutes =
+            definitions
+            |> List.map (fun definition -> route definition.Method definition.Path)
+            |> Set.ofList
+
+        let missingFromManifest = startupRoutes - manifestRoutes
+
+        if missingFromManifest.Count > 0 then
+            failWithRoutes "EndpointAuthorizationManifest is missing Startup.Server.fs routes" missingFromManifest
+
+        let extraInManifest = manifestRoutes - startupRoutes
+
+        if extraInManifest.Count > 0 then
+            failWithRoutes "EndpointAuthorizationManifest includes routes not in Startup.Server.fs" extraInManifest
+
+        let groups = routeClassificationGroups ()
+        let openApiPaths = openApiPaths ()
+
+        let registryNonPublicRoutes =
+            groups
+            |> List.filter (fun group -> group.Classification <> "staleArtifact")
+            |> List.collect (fun group -> group.Routes)
+            |> Set.ofList
+
+        let implementedRoutesAbsentFromOpenApi =
+            startupRoutes
+            |> Set.filter (fun route -> not (openApiPaths.Contains route.Path))
+
+        let missingRegistryClassifications =
+            implementedRoutesAbsentFromOpenApi
+            - registryNonPublicRoutes
+
+        if missingRegistryClassifications.Count > 0 then
+            failWithRoutes "Implemented non-OpenAPI routes need explicit RouteClassification.json exclusion reasons" missingRegistryClassifications
+
+        let registryRoutesNotImplemented =
+            registryNonPublicRoutes
+            - implementedRoutesAbsentFromOpenApi
+
+        if registryRoutesNotImplemented.Count > 0 then
+            failWithRoutes "RouteClassification.json non-public routes must match implemented non-OpenAPI routes" registryRoutesNotImplemented
+
+        let publicRoutesAlsoClassifiedNonPublic =
+            startupRoutes
+            |> Set.filter (fun route -> openApiPaths.Contains route.Path)
+            |> Set.intersect registryNonPublicRoutes
+
+        if publicRoutesAlsoClassifiedNonPublic.Count > 0 then
+            failWithRoutes "Implemented routes present in OpenAPI must not also be classified as non-public" publicRoutesAlsoClassifiedNonPublic
+
+    [<Test>]
+    member _.OpenApiStalePathsAreExplicitlyClassified() =
+        let implementedPaths =
+            parseStartupRoutes ()
+            |> Seq.map (fun route -> route.Path)
+            |> Set.ofSeq
+
+        let staleOpenApiPaths = openApiPaths () - implementedPaths
+
+        let staleRegistryPaths =
+            routeClassificationGroups ()
+            |> List.filter (fun group -> group.Classification = "staleArtifact")
+            |> List.collect (fun group -> group.Routes)
+            |> List.map (fun route -> route.Path)
+            |> Set.ofList
+
+        let missingStaleClassifications = staleOpenApiPaths - staleRegistryPaths
+
+        if missingStaleClassifications.Count > 0 then
+            let missingText =
+                missingStaleClassifications
+                |> Seq.sort
+                |> String.concat Environment.NewLine
+
+            Assert.Fail($"OpenAPI paths not implemented by Startup.Server.fs must be classified as stale:{Environment.NewLine}{missingText}")
+
+        Assert.That(staleRegistryPaths.Contains "/openApi", Is.True, "The legacy /openApi OpenAPI path must remain explicitly classified as stale.")
+
+    [<Test>]
+    member _.NonOpenApiRoutesHaveExplicitExclusionReasons() =
+        let groups =
+            routeClassificationGroups ()
+            |> List.filter (fun group -> group.Classification <> "staleArtifact")
+
+        let routesWithoutExplanatoryReasons =
+            groups
+            |> List.filter (fun group -> String.IsNullOrWhiteSpace group.Reason)
+            |> List.collect (fun group -> group.Routes)
+
+        if not routesWithoutExplanatoryReasons.IsEmpty then
+            failWithRoutes "Non-OpenAPI routes need machine-readable exclusion reasons" routesWithoutExplanatoryReasons
+
+    [<Test>]
+    member _.DebugAdminRoutesRequireSystemAdminAndStayOutOfOpenApi() =
+        let openApiPaths = openApiPaths ()
+        let groups = routeClassificationGroups ()
+
+        let debugAdminRoutes =
+            groups
+            |> List.collect (fun group ->
+                group.Routes
+                |> List.map (fun route -> group.Classification, route))
+            |> List.choose (fun (classification, route) ->
+                if
+                    classification = "debugTestOnlyRoute"
+                    && route.Path.StartsWith("/admin/", StringComparison.Ordinal)
+                then
+                    Some route
+                else
+                    None)
+
+        for route in debugAdminRoutes do
+            Assert.That(openApiPaths.Contains route.Path, Is.False, $"{formatRoute route} must not be silently public in OpenAPI.")
+            assertRouteSecurity route.Method route.Path (Authorized(Operation.SystemAdmin, ResourceKind.System))
+
+        Assert.That(openApiPaths.Contains "/metrics", Is.False, "GET /metrics is an operational surface, not a public OpenAPI path.")
+        assertRouteSecurity "GET" "/metrics" (Authorized(Operation.SystemAdmin, ResourceKind.System))

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "description": "Classifies implemented Grace.Server routes against the public OpenAPI contract. Public contract routes are the implemented routes present in Main.OpenAPI.yaml; every implemented route omitted from OpenAPI must appear here with an explanatory non-public classification.",
+  "classifications": [
+    {
+      "classification": "staleArtifact",
+      "reason": "The legacy OpenAPI document advertises GET /openApi, but Startup.Server.fs no longer implements that route.",
+      "traceIds": [ "B-020", "B-024", "drift-001", "drift-003" ],
+      "routes": [
+        { "method": "GET", "path": "/openApi" }
+      ]
+    },
+    {
+      "classification": "intentionallyExcludedOperationalSurface",
+      "reason": "Operational liveness, metrics, root HTML, and SignalR notification surfaces are runtime operations, not the public JSON API contract.",
+      "traceIds": [ "B-024", "B-041", "surf-host", "surf-startup-admin" ],
+      "routes": [
+        { "method": "GET", "path": "/" },
+        { "method": "GET", "path": "/healthz" },
+        { "method": "GET", "path": "/metrics" },
+        { "method": "GET", "path": "/notifications" }
+      ]
+    },
+    {
+      "classification": "debugTestOnlyRoute",
+      "reason": "Debug or test support routes are implemented for local maintenance or generated approval-request seeding and are intentionally excluded from the public OpenAPI contract.",
+      "traceIds": [ "B-035", "B-041", "drift-004", "surf-approval", "surf-startup-admin" ],
+      "routes": [
+        { "method": "POST", "path": "/admin/deleteAllFromCosmosDB" },
+        { "method": "POST", "path": "/admin/deleteAllRemindersFromCosmosDB" },
+        { "method": "POST", "path": "/approval/request/_seedGenerated" }
+      ]
+    },
+    {
+      "classification": "incompleteUnimplementedSurface",
+      "reason": "The route is wired but Review.Deepen currently returns a not-implemented response, so it must not be promoted into the public OpenAPI contract yet.",
+      "traceIds": [ "B-056", "drift-005", "split-005", "surf-review-queue-promotion" ],
+      "routes": [
+        { "method": "POST", "path": "/review/deepen" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Access-control administration and permission-inspection routes are internal authorization operations, not public OpenAPI expansion targets for this slice.",
+      "traceIds": [ "B-020", "B-024", "B-041", "surf-startup-admin" ],
+      "routes": [
+        { "method": "GET", "path": "/access/listRoles" },
+        { "method": "POST", "path": "/access/checkPermission" },
+        { "method": "POST", "path": "/access/grantRole" },
+        { "method": "POST", "path": "/access/listPathPermissions" },
+        { "method": "POST", "path": "/access/listRoleAssignments" },
+        { "method": "POST", "path": "/access/removePathPermission" },
+        { "method": "POST", "path": "/access/revokeRole" },
+        { "method": "POST", "path": "/access/upsertPathPermission" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Authentication, personal access token, and OIDC bootstrap routes are server identity flows kept outside the current public OpenAPI route expansion.",
+      "traceIds": [ "B-020", "B-024", "drift-003", "surf-host" ],
+      "routes": [
+        { "method": "GET", "path": "/auth/login" },
+        { "method": "GET", "path": "/auth/login/%s" },
+        { "method": "GET", "path": "/auth/logout" },
+        { "method": "GET", "path": "/auth/me" },
+        { "method": "GET", "path": "/auth/oidc/config" },
+        { "method": "POST", "path": "/auth/token/create" },
+        { "method": "POST", "path": "/auth/token/list" },
+        { "method": "POST", "path": "/auth/token/revoke" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Agent session and queue routes are orchestration surfaces for Grace runtime workflows, not public OpenAPI contract routes in this issue.",
+      "traceIds": [ "B-020", "B-042", "B-056", "surf-review-queue-promotion" ],
+      "routes": [
+        { "method": "POST", "path": "/agent/session/active" },
+        { "method": "POST", "path": "/agent/session/listActive" },
+        { "method": "POST", "path": "/agent/session/start" },
+        { "method": "POST", "path": "/agent/session/status" },
+        { "method": "POST", "path": "/agent/session/stop" },
+        { "method": "POST", "path": "/queue/dequeue" },
+        { "method": "POST", "path": "/queue/enqueue" },
+        { "method": "POST", "path": "/queue/pause" },
+        { "method": "POST", "path": "/queue/resume" },
+        { "method": "POST", "path": "/queue/status" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Additional branch and repository management routes are implemented server operations but are not part of the current public OpenAPI surface.",
+      "traceIds": [ "B-020", "B-024", "drift-003" ],
+      "routes": [
+        { "method": "POST", "path": "/branch/assign" },
+        { "method": "POST", "path": "/branch/createExternal" },
+        { "method": "POST", "path": "/branch/enableAssign" },
+        { "method": "POST", "path": "/branch/enableAutoRebase" },
+        { "method": "POST", "path": "/branch/enableExternal" },
+        { "method": "POST", "path": "/branch/getDiffsForReferenceType" },
+        { "method": "POST", "path": "/branch/getEvents" },
+        { "method": "POST", "path": "/branch/getExternals" },
+        { "method": "POST", "path": "/branch/getRecursiveSize" },
+        { "method": "POST", "path": "/branch/getVersion" },
+        { "method": "POST", "path": "/branch/listContents" },
+        { "method": "POST", "path": "/branch/setPromotionMode" },
+        { "method": "POST", "path": "/branch/updateParentBranch" },
+        { "method": "POST", "path": "/repository/setAllowsLargeFiles" },
+        { "method": "POST", "path": "/repository/setAnonymousAccess" },
+        { "method": "POST", "path": "/repository/setConflictResolutionPolicy" },
+        { "method": "POST", "path": "/repository/setDiffCacheDays" },
+        { "method": "POST", "path": "/repository/setDirectoryVersionCacheDays" },
+        { "method": "POST", "path": "/repository/setLogicalDeleteDays" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Artifact, directory ZIP, policy, reminder, promotion-set, and validation-set operations are implemented internal workflow surfaces pending a separate public-contract decision.",
+      "traceIds": [ "B-020", "B-024", "B-042", "surf-review-queue-promotion" ],
+      "routes": [
+        { "method": "GET", "path": "/artifact/%O/download-uri" },
+        { "method": "POST", "path": "/artifact/create" },
+        { "method": "POST", "path": "/directory/getZipFile" },
+        { "method": "POST", "path": "/policy/acknowledge" },
+        { "method": "POST", "path": "/policy/current" },
+        { "method": "POST", "path": "/promotion-set/%O/resolve-conflicts" },
+        { "method": "POST", "path": "/promotion-set/apply" },
+        { "method": "POST", "path": "/promotion-set/create" },
+        { "method": "POST", "path": "/promotion-set/delete" },
+        { "method": "POST", "path": "/promotion-set/get" },
+        { "method": "POST", "path": "/promotion-set/get-events" },
+        { "method": "POST", "path": "/promotion-set/recompute" },
+        { "method": "POST", "path": "/promotion-set/update-input-promotions" },
+        { "method": "POST", "path": "/reminder/create" },
+        { "method": "POST", "path": "/reminder/delete" },
+        { "method": "POST", "path": "/reminder/get" },
+        { "method": "POST", "path": "/reminder/list" },
+        { "method": "POST", "path": "/reminder/reschedule" },
+        { "method": "POST", "path": "/reminder/updateTime" },
+        { "method": "POST", "path": "/validation-result/record" },
+        { "method": "POST", "path": "/validation-set/create" },
+        { "method": "POST", "path": "/validation-set/delete" },
+        { "method": "POST", "path": "/validation-set/get" },
+        { "method": "POST", "path": "/validation-set/update" }
+      ]
+    },
+    {
+      "classification": "internalOnlyContract",
+      "reason": "Review-candidate and work-item routes are implemented workflow surfaces, but their public-contract shape is deferred to a dedicated review/work planning slice.",
+      "traceIds": [ "B-020", "B-042", "B-056", "split-005", "surf-review-queue-promotion" ],
+      "routes": [
+        { "method": "POST", "path": "/review/candidate/attestations" },
+        { "method": "POST", "path": "/review/candidate/cancel" },
+        { "method": "POST", "path": "/review/candidate/gate-rerun" },
+        { "method": "POST", "path": "/review/candidate/get" },
+        { "method": "POST", "path": "/review/candidate/required-actions" },
+        { "method": "POST", "path": "/review/candidate/resolve" },
+        { "method": "POST", "path": "/review/candidate/retry" },
+        { "method": "POST", "path": "/review/checkpoint" },
+        { "method": "POST", "path": "/review/notes" },
+        { "method": "POST", "path": "/review/report/get" },
+        { "method": "POST", "path": "/review/resolve" },
+        { "method": "POST", "path": "/work/add-summary" },
+        { "method": "POST", "path": "/work/attachments/download" },
+        { "method": "POST", "path": "/work/attachments/list" },
+        { "method": "POST", "path": "/work/attachments/show" },
+        { "method": "POST", "path": "/work/create" },
+        { "method": "POST", "path": "/work/get" },
+        { "method": "POST", "path": "/work/link/artifact" },
+        { "method": "POST", "path": "/work/link/promotion-set" },
+        { "method": "POST", "path": "/work/link/reference" },
+        { "method": "POST", "path": "/work/links/list" },
+        { "method": "POST", "path": "/work/links/remove/artifact" },
+        { "method": "POST", "path": "/work/links/remove/artifact-type" },
+        { "method": "POST", "path": "/work/links/remove/promotion-set" },
+        { "method": "POST", "path": "/work/links/remove/reference" },
+        { "method": "POST", "path": "/work/update" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `src/OpenAPI/RouteClassification.json` as the machine-readable implemented-route classification registry.
- Extends Fast authorization coverage to compare the route table, endpoint authorization manifest, OpenAPI paths, and route classifications.
- Pins stale, internal-only, debug/test-only, operational, and incomplete surfaces before any broad OpenAPI expansion.

## Issue

Closes #250.
Part of #249.

## Research Trace

- `B-020`: every implemented route is either represented in OpenAPI or explicitly classified.
- `B-024`: public/non-public OpenAPI decisions are explicit and stale OpenAPI paths are checked.
- `B-035`: debug/test-only entries cover admin delete routes and `/approval/request/_seedGenerated`.
- `B-041`: operational/admin classifications cover root, health, metrics, notifications, and startup-admin surfaces.
- `B-042`: internal-only classifications cover queue, promotion-set, validation-set, and related workflow routes.
- `B-056`: review/workflow classification pins `/review/deepen` as incomplete/unimplemented.

## Validation

- `dotnet C:\Users\scott\.nuget\packages\fantomas-tool\4.7.9\tools\netcoreapp3.1\any\fantomas-tool.dll C:\Source\GraceWorktrees\gh-250-route-classification\src\Grace.Authorization.Tests\OpenApiRouteCoverage.Tests.fs`: passed.
- `dotnet test --configuration Release src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj`: passed, 36 passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --cached --check`: passed.

## Review Status

- Implementation worker: Singer, GPT-5.5 Medium.
- Local review-only sibling: James, GPT-5.5 High, completed with no issues.
- Open findings: none.
- Final no-issues review: documented in https://github.com/ScottArbeit/Grace/pull/267#issuecomment-4627595486.

## Docs Impact

No docs update. This slice adds test-backed source data for the next OpenAPI expansion issue.

## Residual Risk

The registry is intentionally explicit and static. Future route additions should fail Fast until classified; later OpenAPI expansion must still decide which classified routes become public contract routes instead of mechanically adding every route.