### PR TITLE
Repair OpenAPI generated-client proof

### DIFF
--- a/sdk/generated/matrix/generator-matrix-evidence.json
+++ b/sdk/generated/matrix/generator-matrix-evidence.json
@@ -196,6 +196,16 @@
     }
   ],
   "overallConclusion": "OpenAPI Generator is the only evaluated tool that produced compile/importable TS, Python, and Rust output, and only with --skip-validate-spec. Kiota and NSwag are rejected until OpenAPI schema-shape debt is fixed.",
+  "acceptedTier": "raw-openapi-generator-behind-facades",
+  "sdkGradeGeneratedClientAccepted": false,
+  "pendingSdkGradeRationale": "OpenAPI Generator TypeScript, Python, and Rust compile/import probes pass only with --skip-validate-spec; Kiota and NSwag remain rejected on schema-shape debt, so no SDK-grade generated-client package is accepted.",
+  "traceability": {
+    "B-043": "OpenAPI proof now validates committed generator matrix evidence as the raw generated-client acceptance path.",
+    "B-044": "Stable SDK package export/import proof remains pending until package metadata, facade exports, import execution, and generator isolation are verified.",
+    "drift-002": "Canonical source and generator projection SHA-256 values are rechecked before accepting matrix evidence.",
+    "drift-006": "Kiota and NSwag rejection evidence is retained and prevents any SDK-grade generated-client claim.",
+    "drift-008": "OpenAPI Generator TypeScript, Python, and Rust compile/import probes define the accepted guardrailed raw-client tier."
+  },
   "residualRisks": [
     "OpenAPI validation errors remain in DirectoryVersion, FileVersion, DiffPiece, FileDiff, FileSystemDifference, and GraceResult shapes.",
     "OpenAPI Generator output is accepted only as a raw-client proof point behind facades, not as a stable package surface.",

--- a/sdk/scripts/invoke-generator-matrix.ps1
+++ b/sdk/scripts/invoke-generator-matrix.ps1
@@ -403,6 +403,34 @@ if (-not $SkipGeneration) {
         'Facade required; raw Rust surface is broad and not ready for stable package publication.' `
         $openApiRustPath))
 }
+else {
+    $existingEvidencePath = Join-Path $matrixRoot 'generator-matrix-evidence.json'
+    if (-not (Test-Path -LiteralPath $existingEvidencePath -PathType Leaf)) {
+        throw "Cannot skip generation because existing matrix evidence is missing: $existingEvidencePath"
+    }
+
+    $existingEvidence = Get-Content -LiteralPath $existingEvidencePath -Raw | ConvertFrom-Json
+    $existingProjectionHash = [string] $existingEvidence.sourceProjectionSha256
+    $currentProjectionHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $projection).Hash.ToLowerInvariant()
+    if ($existingProjectionHash.ToLowerInvariant() -ne $currentProjectionHash) {
+        throw "Cannot skip generation because existing matrix evidence is stale for $projection. Expected $existingProjectionHash, actual $currentProjectionHash."
+    }
+
+    foreach ($entry in @($existingEvidence.matrix | Where-Object { $_.generator -eq 'OpenAPI Generator' })) {
+        $entries.Add([ordered]@{
+            generator = [string] $entry.generator
+            language = [string] $entry.language
+            command = [string] $entry.command
+            exitCode = [int] $entry.exitCode
+            outcome = [string] $entry.outcome
+            conclusion = [string] $entry.conclusion
+            outputPath = [string] $entry.outputPath
+            evidence = @($entry.evidence)
+            transportPolicySupport = [string] $entry.transportPolicySupport
+            facadeFit = [string] $entry.facadeFit
+        })
+    }
+}
 
 if (-not $SkipProbes) {
     $npmInstall = Invoke-CapturedNative $npmExecutable @('install', '--ignore-scripts') `
@@ -545,6 +573,28 @@ else {
     $residualRisks.Add('Rust feasibility is not proven by this run until the Rust cargo-check probe passes.')
 }
 
+$acceptedTier = if ($acceptanceFailures.Count -eq 0) {
+    'raw-openapi-generator-behind-facades'
+}
+else {
+    'none'
+}
+
+$pendingSdkGradeRationale = if ($acceptanceFailures.Count -eq 0) {
+    'OpenAPI Generator TypeScript, Python, and Rust compile/import probes pass only with --skip-validate-spec; Kiota and NSwag remain rejected on schema-shape debt, so no SDK-grade generated-client package is accepted.'
+}
+else {
+    'At least one accepted OpenAPI Generator raw-client proof point failed generation or compile/import probing; no generated-client tier is accepted by this run.'
+}
+
+$traceability = [ordered]@{
+    'B-043' = 'OpenAPI proof now validates committed generator matrix evidence as the raw generated-client acceptance path.'
+    'B-044' = 'Stable SDK package export/import proof remains pending until package metadata, facade exports, import execution, and generator isolation are verified.'
+    'drift-002' = 'Canonical source and generator projection SHA-256 values are rechecked before accepting matrix evidence.'
+    'drift-006' = 'Kiota and NSwag rejection evidence is retained and prevents any SDK-grade generated-client claim.'
+    'drift-008' = 'OpenAPI Generator TypeScript, Python, and Rust compile/import probes define the accepted guardrailed raw-client tier.'
+}
+
 $evidence = [ordered]@{
     schemaVersion = 1
     issue = 221
@@ -556,6 +606,10 @@ $evidence = [ordered]@{
     probes = $probes
     deterministicRegeneration = $deterministicRegeneration
     overallConclusion = $overallConclusion
+    acceptedTier = $acceptedTier
+    sdkGradeGeneratedClientAccepted = $false
+    pendingSdkGradeRationale = $pendingSdkGradeRationale
+    traceability = $traceability
     residualRisks = @($residualRisks.ToArray())
 }
 

--- a/src/OpenAPI/prove-openapi.ps1
+++ b/src/OpenAPI/prove-openapi.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('All', 'Freshness', 'CanonicalVersion', 'Projections', 'Quality', 'SdkPackage', 'ProtocolVectors')]
+    [ValidateSet('All', 'Freshness', 'CanonicalVersion', 'Projections', 'Quality', 'GeneratedClientMatrix', 'SdkPackage', 'ProtocolVectors')]
     [string] $Check = 'All',
 
     [switch] $AllowPending
@@ -65,6 +65,27 @@ function Get-StringSha256 {
     finally {
         $sha.Dispose()
     }
+}
+
+function Get-DirectoryManifestHash {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return $null
+    }
+
+    $lines = Get-ChildItem -Path $Path -Recurse -File |
+        Where-Object { $_.FullName -notmatch '\\(node_modules|target|dist|build|__pycache__|\.pytest_cache)\\' } |
+        Where-Object { $_.Name -notin @('package-lock.json', 'Cargo.lock') } |
+        Sort-Object FullName |
+        ForEach-Object {
+            $relative = [IO.Path]::GetRelativePath($Path, $_.FullName).Replace('\', '/')
+            $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $_.FullName).Hash.ToLowerInvariant()
+            "$relative $hash"
+        }
+
+    $manifestText = ($lines -join "`n") + "`n"
+    return Get-StringSha256 $manifestText
 }
 
 function Get-OpenApiManifest {
@@ -1318,11 +1339,151 @@ function Test-SdkPackageProof {
     Write-Host '== SDK package export/import proof =='
     $packageProofPath = Join-Path $RepoRoot 'sdk/package-proof.json'
     if (-not (Test-Path -LiteralPath $packageProofPath -PathType Leaf)) {
-        Add-Pending 'No SDK package export/import proof exists; no SDK package or tier is accepted by this slice.'
+        Add-Pending 'No stable SDK package export/import proof exists; raw generated-client matrix acceptance remains limited to guardrailed OpenAPI Generator proof artifacts behind facades.'
         return
     }
 
     Add-Pending "SDK package export/import proof is not accepted yet. A future verifier must validate package metadata, exported facade surface, import execution evidence, and generator isolation before this gate can pass. Placeholder path: $packageProofPath"
+}
+
+function Get-RequiredJsonProperty {
+    param(
+        [object] $Object,
+        [string] $PropertyName,
+        [string] $Context
+    )
+
+    if ($null -eq $Object) {
+        Add-Failure "$Context is missing; expected property '$PropertyName'."
+        return $null
+    }
+
+    $property = $Object.PSObject.Properties[$PropertyName]
+    if ($null -eq $property) {
+        Add-Failure "$Context is missing required property '$PropertyName'."
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Test-GeneratedClientMatrixProof {
+    param([string] $RepoRoot)
+
+    Write-Host '== Generated-client matrix proof =='
+    $matrixPath = Join-Path $RepoRoot 'sdk/generated/matrix/generator-matrix-evidence.json'
+    if (-not (Test-Path -LiteralPath $matrixPath -PathType Leaf)) {
+        Add-Failure "Missing generated-client matrix evidence: $matrixPath"
+        return
+    }
+
+    $evidence = Get-Content -LiteralPath $matrixPath -Raw | ConvertFrom-Json
+    $projectionRelativePath = Get-RequiredJsonProperty $evidence 'sourceProjection' 'Generator matrix evidence'
+    if ([string]::IsNullOrWhiteSpace([string] $projectionRelativePath)) {
+        Add-Failure 'Generator matrix evidence is missing sourceProjection.'
+        return
+    }
+
+    $projectionPath = Join-Path $RepoRoot ([string] $projectionRelativePath)
+    if (-not (Test-Path -LiteralPath $projectionPath -PathType Leaf)) {
+        Add-Failure "Generator matrix source projection is missing: $projectionRelativePath"
+    }
+    else {
+        $actualProjectionHash = Get-FileSha256 $projectionPath
+        $recordedProjectionHash = [string] (Get-RequiredJsonProperty $evidence 'sourceProjectionSha256' 'Generator matrix evidence')
+        if ($actualProjectionHash -ne $recordedProjectionHash.ToLowerInvariant()) {
+            Add-Failure "Generator matrix evidence is stale for $projectionRelativePath. Expected $recordedProjectionHash, actual $actualProjectionHash."
+        }
+    }
+
+    $acceptedTier = [string] (Get-RequiredJsonProperty $evidence 'acceptedTier' 'Generator matrix evidence')
+    if ($acceptedTier -ne 'raw-openapi-generator-behind-facades') {
+        Add-Failure "Generator matrix acceptedTier must be 'raw-openapi-generator-behind-facades'; actual '$acceptedTier'."
+    }
+
+    $sdkGrade = Get-RequiredJsonProperty $evidence 'sdkGradeGeneratedClientAccepted' 'Generator matrix evidence'
+    if ($sdkGrade -ne $false) {
+        Add-Failure 'Generator matrix evidence must not claim SDK-grade generated-client acceptance while strict generator validation remains rejected.'
+    }
+
+    $pendingRationale = [string] (Get-RequiredJsonProperty $evidence 'pendingSdkGradeRationale' 'Generator matrix evidence')
+    if ([string]::IsNullOrWhiteSpace($pendingRationale)) {
+        Add-Failure 'Generator matrix evidence must record why SDK-grade generated-client acceptance remains pending.'
+    }
+
+    foreach ($traceId in @('B-043', 'B-044', 'drift-002', 'drift-006', 'drift-008')) {
+        if ($null -eq $evidence.traceability -or $null -eq $evidence.traceability.PSObject.Properties[$traceId]) {
+            Add-Failure "Generator matrix traceability is missing '$traceId'."
+        }
+    }
+
+    $matrixEntries = @($evidence.matrix)
+    $acceptedLanguages = @('TypeScript', 'Python', 'Rust')
+    foreach ($language in $acceptedLanguages) {
+        $entry = $matrixEntries |
+            Where-Object { $_.generator -eq 'OpenAPI Generator' -and $_.language -eq $language } |
+            Select-Object -First 1
+
+        if ($null -eq $entry) {
+            Add-Failure "Generator matrix is missing OpenAPI Generator $language entry."
+            continue
+        }
+
+        if ($entry.outcome -ne 'Accepted with guardrails' -or $entry.exitCode -ne 0) {
+            Add-Failure "OpenAPI Generator $language must be accepted with guardrails and exit code 0; actual outcome '$($entry.outcome)' exitCode '$($entry.exitCode)'."
+        }
+
+        if ([string]::IsNullOrWhiteSpace([string] $entry.outputPath)) {
+            Add-Failure "OpenAPI Generator $language entry is missing outputPath."
+        }
+        else {
+            $outputPath = Join-Path $RepoRoot ([string] $entry.outputPath)
+            if (-not (Test-Path -LiteralPath $outputPath -PathType Container)) {
+                Add-Failure "OpenAPI Generator $language output path is missing: $($entry.outputPath)"
+            }
+        }
+    }
+
+    foreach ($rejected in @(
+            @{ generator = 'Kiota'; language = '.NET' },
+            @{ generator = 'Kiota'; language = 'TypeScript' },
+            @{ generator = 'NSwag'; language = '.NET' }
+        )) {
+        $entry = $matrixEntries |
+            Where-Object { $_.generator -eq $rejected.generator -and $_.language -eq $rejected.language } |
+            Select-Object -First 1
+
+        if ($null -eq $entry) {
+            Add-Failure "Generator matrix is missing $($rejected.generator) $($rejected.language) rejection evidence."
+        }
+        elseif ($entry.outcome -ne 'Rejected') {
+            Add-Failure "$($rejected.generator) $($rejected.language) must remain rejected until schema-shape debt is fixed; actual outcome '$($entry.outcome)'."
+        }
+    }
+
+    foreach ($probeName in @(
+            'TypeScript generated client import/build',
+            'Python generated client import/build',
+            'Rust generated client cargo check'
+        )) {
+        $probe = @($evidence.probes) | Where-Object { $_.name -eq $probeName } | Select-Object -First 1
+        if ($null -eq $probe) {
+            Add-Failure "Generator matrix is missing required probe '$probeName'."
+        }
+        elseif ($probe.exitCode -ne 0) {
+            Add-Failure "Generator matrix probe '$probeName' failed with exit code $($probe.exitCode)."
+        }
+    }
+
+    foreach ($entry in @($evidence.deterministicRegeneration)) {
+        $path = Join-Path $RepoRoot ([string] $entry.path)
+        $actualHash = Get-DirectoryManifestHash $path
+        if ($actualHash -ne ([string] $entry.manifestSha256).ToLowerInvariant()) {
+            Add-Failure "Generator matrix deterministic hash is stale for $($entry.path). Expected $($entry.manifestSha256), actual $actualHash."
+        }
+    }
+
+    Add-Pass 'Generated-client matrix accepts OpenAPI Generator TypeScript, Python, and Rust raw-client proof points with guardrails; Kiota and NSwag remain explicitly rejected.'
 }
 
 function Test-ProtocolVectorProof {
@@ -1346,6 +1507,7 @@ switch ($Check) {
         Test-OpenApiCanonicalVersion $repoRoot
         Test-OpenApiProjections $repoRoot
         Test-OpenApiQuality $repoRoot
+        Test-GeneratedClientMatrixProof $repoRoot
         Test-SdkPackageProof $repoRoot
         Test-ProtocolVectorProof $repoRoot
     }
@@ -1353,6 +1515,7 @@ switch ($Check) {
     'CanonicalVersion' { Test-OpenApiCanonicalVersion $repoRoot }
     'Projections' { Test-OpenApiProjections $repoRoot }
     'Quality' { Test-OpenApiQuality $repoRoot }
+    'GeneratedClientMatrix' { Test-GeneratedClientMatrixProof $repoRoot }
     'SdkPackage' { Test-SdkPackageProof $repoRoot }
     'ProtocolVectors' { Test-ProtocolVectorProof $repoRoot }
 }


### PR DESCRIPTION
## Summary

- Adds generated-client matrix verification as a first-class `prove-openapi.ps1` proof gate.
- Fixes generator matrix check mode so committed OpenAPI Generator evidence is reused only when the source projection hash matches the current projection, then compile/import probes rerun.
- Records the accepted generated-client tier as raw OpenAPI Generator artifacts behind handwritten facades, while keeping SDK-grade readiness explicitly false.

## Issue

Closes #251.
Part of #249.

## Research Trace

- `B-043`: `prove-openapi.ps1 -Check All` now validates committed generator matrix evidence instead of leaving generated-client acceptance implicit.
- `B-044`: stable SDK package export/import proof remains pending with clearer wording distinguishing it from raw generated-client matrix acceptance.
- `drift-002`: generator matrix `sourceProjectionSha256` is checked against current `src/OpenAPI/Grace.OpenAPI.3.1.2.yaml`.
- `drift-006`: Kiota .NET, Kiota TypeScript, and NSwag .NET remain explicit `Rejected` entries until schema-shape debt is fixed; SDK-grade generated-client acceptance remains false.
- `drift-008`: OpenAPI Generator TypeScript, Python, and Rust must be `Accepted with guardrails`, exit code `0`, have output paths, and pass compile/import probes.

## Validation

- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`: passed. Existing pending gates remain visible: storage operation tag coverage, `/openApi` 400/500 coverage, stable SDK package export/import proof, and protocol vector proof.
- `pwsh ./sdk/scripts/generate-sdk-clients.ps1 -Mode Check`: passed.
- `pwsh ./sdk/scripts/invoke-generator-matrix.ps1`: passed.
- `pwsh ./sdk/scripts/invoke-generator-matrix.ps1 -SkipGeneration`: passed.
- `git diff --check`: passed in worker and review.
- `pwsh ./scripts/validate.ps1 -Fast`: skipped because this slice changed PowerShell proof scripts and generated proof metadata only; no F# code, Fast contract tests, or OpenAPI route tests changed.

## Review Status

- Implementation worker: Franklin, GPT-5.5 Medium.
- Branch freshness: branch is `1 0` ahead/behind current `origin/main` before PR creation and review.
- Local review-only sibling: Heisenberg, GPT-5.5 High, completed with no issues.
- Open findings: none.
- Final no-issues review: documented in https://github.com/ScottArbeit/Grace/pull/269#issuecomment-4627737706.

## Docs Impact

No docs update. The accepted tier and pending rationale are recorded in `sdk/generated/matrix/generator-matrix-evidence.json` and enforced by `src/OpenAPI/prove-openapi.ps1`.

## Residual Risk

The proof still reports pending tag coverage for 13 storage operations, pending `/openApi` error response coverage, no stable SDK package export/import proof, and pending protocol vector proof. These remain visible under `-AllowPending` and are not hidden or downgraded.