### PR TITLE
Add Fast security and privacy seam coverage

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
+    <Compile Include="SecurityPrivacy.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />
     <Compile Include="ApiVersionAlias.Middleware.Tests.fs" />
     <Compile Include="SdkLifecycle.Middleware.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/OutboundUrlSafety.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OutboundUrlSafety.Unit.Tests.fs
@@ -5,6 +5,7 @@ open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.Net
+open System.Net.Sockets
 open System.Text
 open Grace.Shared.Utilities
 
@@ -226,6 +227,26 @@ type OutboundUrlSafetyUnit() =
 
         validateOutsideDevelopment emptyConfiguration (publicRequest "https://mapped-public.example.test/events")
         |> assertRejected (ValidationFailure.UnsafeHostRejected "8.8.8.8")
+
+    [<Test>]
+    member _.ResolverFailureRejectsHostWithoutAcceptingOutboundUrl() =
+        let mutable resolverCalls = 0
+
+        let resolver (host: string) =
+            resolverCalls <- resolverCalls + 1
+            Assert.That(host, Is.EqualTo("timeout.example.test"))
+            raise (SocketException(11001))
+
+        let result = OutboundUrlPolicy.validateWithResolver resolver false emptyConfiguration (publicRequest "https://timeout.example.test/events?token=secret")
+
+        Assert.That(resolverCalls, Is.EqualTo(1))
+
+        match result with
+        | Error (ValidationFailure.UnsafeHostRejected host) ->
+            Assert.That(host, Is.EqualTo("timeout.example.test"))
+            Assert.That(host, Does.Not.Contain("secret"))
+        | Error failure -> Assert.Fail(sprintf "Expected UnsafeHostRejected but got %A." failure)
+        | Ok value -> Assert.Fail($"Expected URL to be rejected but got {value.ScopedUrl.Url}.")
 
     [<Test>]
     member _.PublicHostnamesCarryResolvedAddressesForAddressPinning() =

--- a/src/Grace.Server.Unit.Tests/SecurityPrivacy.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SecurityPrivacy.Unit.Tests.fs
@@ -42,7 +42,7 @@ type SecurityPrivacyUnitTests() =
         let parsed = PersonalAccessTokenAuth.parseAuthorizationHeader $"Bearer {token}"
 
         match parsed with
-        | PersonalAccessTokenAuth.ParsedGracePersonalAccessToken (userId, tokenId, secret) ->
+        | PersonalAccessTokenAuth.ParsedGracePersonalAccessToken(userId, tokenId, secret) ->
             Assert.That(userId, Is.EqualTo("user-1"))
             Assert.That(tokenId, Is.EqualTo(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")))
             Assert.That(secret, Has.Length.EqualTo(32))
@@ -63,31 +63,26 @@ type SecurityPrivacyUnitTests() =
         Assert.That(
             claims |> Seq.map (fun claim -> claim.Type),
             Is.EquivalentTo(
-                [
-                    PrincipalMapper.GraceUserIdClaim
-                    PrincipalMapper.GraceClaim
-                    PrincipalMapper.GraceClaim
-                    PrincipalMapper.GraceGroupIdClaim
-                ]
+                [ PrincipalMapper.GraceUserIdClaim
+                  PrincipalMapper.GraceClaim
+                  PrincipalMapper.GraceClaim
+                  PrincipalMapper.GraceGroupIdClaim ]
             )
         )
 
-        Assert.That(
-            claims
-            |> Seq.exists (fun claim -> claim.Value = "user-1"),
-            Is.True
-        )
+        Assert.That(claims |> Seq.exists (fun claim -> claim.Value = "user-1"), Is.True)
 
     [<Test>]
     member _.TelemetryClaimsAllowlistRedactsIdentityAndDropsSecretBearingClaims() =
         let principal =
-            createPrincipal [ Claim(PrincipalMapper.GraceUserIdClaim, "user-secret-id")
-                              Claim(PrincipalMapper.GraceClaim, "RepositoryRead")
-                              Claim(PrincipalMapper.GraceGroupIdClaim, "group-1")
-                              Claim("roles", "Admin")
-                              Claim("email", "person@example.test")
-                              Claim("access_token", "raw-provider-token")
-                              Claim("Authorization", "Bearer raw-pat") ]
+            createPrincipal
+                [ Claim(PrincipalMapper.GraceUserIdClaim, "user-secret-id")
+                  Claim(PrincipalMapper.GraceClaim, "RepositoryRead")
+                  Claim(PrincipalMapper.GraceGroupIdClaim, "group-1")
+                  Claim("roles", "Admin")
+                  Claim("email", "person@example.test")
+                  Claim("access_token", "raw-provider-token")
+                  Claim("Authorization", "Bearer raw-pat") ]
 
         let claimsTag = TelemetryEnrichment.safeClaimsTag principal
 
@@ -111,6 +106,25 @@ type SecurityPrivacyUnitTests() =
         Assert.That(cookie, Is.EqualTo("[REDACTED]"))
         Assert.That(customToken, Is.EqualTo("[REDACTED]"))
         Assert.That(safe, Is.EqualTo("correlation-1"))
+
+    [<TestCase("X-API-Key", "provider-key")>]
+    [<TestCase("Api-Key", "provider-key")>]
+    [<TestCase("OpenAI-Api-Key", "provider-key")>]
+    [<TestCase("Client-Secret", "client-secret")>]
+    [<TestCase("client_secret", "client-secret")>]
+    [<TestCase("X-Signing-Secret", "signing-secret")>]
+    [<TestCase("X-Grace-Webhook-Signature", "sha256=signature")>]
+    [<TestCase("X-Amz-Credential", "aws-credential")>]
+    member _.RequestHeaderRedactionCoversProviderKeysSigningSecretsSignaturesAndCredentials(headerName: string, value: string) =
+        let redacted = RequestHeaderRedaction.redactHeaderValue headerName value
+
+        Assert.That(redacted, Is.EqualTo("[REDACTED]"))
+
+    [<Test>]
+    member _.RequestHeaderRedactionKeepsUsefulNonSensitiveHeadersVisible() =
+        let correlationId = RequestHeaderRedaction.redactHeaderValue "X-Correlation-Id" "correlation-1"
+
+        Assert.That(correlationId, Is.EqualTo("correlation-1"))
 
     [<TestCase(ValidateIdsDecisions.EntityKind.Owner, true)>]
     [<TestCase(ValidateIdsDecisions.EntityKind.Owner, false)>]

--- a/src/Grace.Server.Unit.Tests/SecurityPrivacy.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SecurityPrivacy.Unit.Tests.fs
@@ -1,0 +1,133 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Middleware
+open Grace.Server.Security
+open Grace.Shared.Validation.Errors
+open Grace.Types.Common
+open Grace.Types.PersonalAccessToken
+open Microsoft.AspNetCore.Http
+open NUnit.Framework
+open System
+open System.Security.Claims
+
+[<Parallelizable(ParallelScope.All)>]
+type SecurityPrivacyUnitTests() =
+
+    let validPatFor userId =
+        let tokenId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        let secret = [| for index in 0..31 -> byte index |]
+        formatToken userId tokenId secret
+
+    let createPrincipal claims = ClaimsPrincipal(ClaimsIdentity(claims, "test"))
+
+    [<Test>]
+    member _.MalformedGracePatFailsClosedWithoutEchoingTokenMaterial() =
+        let rawToken = $"{TokenPrefix}not-valid-token-material"
+
+        let result = PersonalAccessTokenAuth.parseAuthorizationHeader $"Bearer {rawToken}"
+
+        Assert.That(result, Is.EqualTo(PersonalAccessTokenAuth.MalformedGracePersonalAccessToken))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain(rawToken))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain(TokenPrefix))
+
+    [<Test>]
+    member _.ExternalBearerIsLeftForOtherAuthSchemes() =
+        let result = PersonalAccessTokenAuth.parseAuthorizationHeader "Bearer external.jwt.token"
+
+        Assert.That(result, Is.EqualTo(PersonalAccessTokenAuth.NotGracePersonalAccessToken))
+
+    [<Test>]
+    member _.RevokedExpiredOrWrongOwnerActorMissesUseGenericFailureMessage() =
+        let token = validPatFor "user-1"
+        let parsed = PersonalAccessTokenAuth.parseAuthorizationHeader $"Bearer {token}"
+
+        match parsed with
+        | PersonalAccessTokenAuth.ParsedGracePersonalAccessToken (userId, tokenId, secret) ->
+            Assert.That(userId, Is.EqualTo("user-1"))
+            Assert.That(tokenId, Is.EqualTo(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")))
+            Assert.That(secret, Has.Length.EqualTo(32))
+        | other -> Assert.Fail($"Expected parsed PAT, got {other}.")
+
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Is.EqualTo("Invalid token."))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain("revoked"))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain("expired"))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain("owner"))
+        Assert.That(PersonalAccessTokenAuth.InvalidTokenFailure, Does.Not.Contain(token))
+
+    [<Test>]
+    member _.SuccessfulPatProjectionKeepsOnlyGraceClaimsAndGroups() =
+        let validation = { TokenId = Guid.NewGuid(); UserId = "user-1"; Claims = [ "RepositoryRead"; "RepositoryWrite" ]; GroupIds = [ "group-1" ] }
+
+        let claims = PersonalAccessTokenAuth.toAuthenticationClaims validation
+
+        Assert.That(
+            claims |> Seq.map (fun claim -> claim.Type),
+            Is.EquivalentTo(
+                [
+                    PrincipalMapper.GraceUserIdClaim
+                    PrincipalMapper.GraceClaim
+                    PrincipalMapper.GraceClaim
+                    PrincipalMapper.GraceGroupIdClaim
+                ]
+            )
+        )
+
+        Assert.That(
+            claims
+            |> Seq.exists (fun claim -> claim.Value = "user-1"),
+            Is.True
+        )
+
+    [<Test>]
+    member _.TelemetryClaimsAllowlistRedactsIdentityAndDropsSecretBearingClaims() =
+        let principal =
+            createPrincipal [ Claim(PrincipalMapper.GraceUserIdClaim, "user-secret-id")
+                              Claim(PrincipalMapper.GraceClaim, "RepositoryRead")
+                              Claim(PrincipalMapper.GraceGroupIdClaim, "group-1")
+                              Claim("roles", "Admin")
+                              Claim("email", "person@example.test")
+                              Claim("access_token", "raw-provider-token")
+                              Claim("Authorization", "Bearer raw-pat") ]
+
+        let claimsTag = TelemetryEnrichment.safeClaimsTag principal
+
+        Assert.That(TelemetryEnrichment.safeEndUserId principal, Is.EqualTo("REDACTED"))
+        Assert.That(claimsTag, Does.Contain($"{PrincipalMapper.GraceUserIdClaim}:REDACTED"))
+        Assert.That(claimsTag, Does.Contain($"{PrincipalMapper.GraceClaim}:RepositoryRead"))
+        Assert.That(claimsTag, Does.Contain($"{PrincipalMapper.GraceGroupIdClaim}:group-1"))
+        Assert.That(claimsTag, Does.Contain("roles:Admin"))
+        Assert.That(claimsTag, Does.Not.Contain("person@example.test"))
+        Assert.That(claimsTag, Does.Not.Contain("raw-provider-token"))
+        Assert.That(claimsTag, Does.Not.Contain("raw-pat"))
+
+    [<Test>]
+    member _.RequestHeaderRedactionCoversAuthorizationCookieAndTokenNamedHeaders() =
+        let authorization = RequestHeaderRedaction.redactHeaderValue "Authorization" "Bearer grace_pat_v1_secret"
+        let cookie = RequestHeaderRedaction.redactHeaderValue "Cookie" "session=secret"
+        let customToken = RequestHeaderRedaction.redactHeaderValue "x-api-token" "token-secret"
+        let safe = RequestHeaderRedaction.redactHeaderValue "X-Correlation-Id" "correlation-1"
+
+        Assert.That(authorization, Is.EqualTo("[REDACTED]"))
+        Assert.That(cookie, Is.EqualTo("[REDACTED]"))
+        Assert.That(customToken, Is.EqualTo("[REDACTED]"))
+        Assert.That(safe, Is.EqualTo("correlation-1"))
+
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Owner, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Organization, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Repository, false)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, true)>]
+    [<TestCase(ValidateIdsDecisions.EntityKind.Branch, false)>]
+    member _.ValidateIdsNotFoundContractIsBadRequestWithOriginalCorrelation(entityKind: ValidateIdsDecisions.EntityKind, hasId: bool) =
+        let correlationId = "corr-validate-1"
+        let id = if hasId then Guid.NewGuid().ToString() else ""
+        let message = ValidateIdsDecisions.notFoundErrorMessage entityKind id
+        let error = GraceError.Create message correlationId
+
+        let contract = ValidateIdsDecisions.badRequestResponse error
+
+        Assert.That(contract.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest))
+        Assert.That(contract.Error.Error, Is.EqualTo(message))
+        Assert.That(contract.Error.CorrelationId, Is.EqualTo(correlationId))

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -54,6 +54,7 @@
 		<Compile Include="Services.Server.fs" />
 		<Compile Include="Validations.Server.fs" />
 		<Compile Include="Security\PrincipalMapper.Server.fs" />
+		<Compile Include="Security\TelemetryEnrichment.Server.fs" />
 		<Compile Include="Security\ExternalAuthConfig.Server.fs" />
                 <Compile Include="Security\ClaimMapping.Server.fs" />
                 <Compile Include="Security\ClaimsTransformation.Server.fs" />

--- a/src/Grace.Server/Middleware/LogRequestHeaders.Middleware.fs
+++ b/src/Grace.Server/Middleware/LogRequestHeaders.Middleware.fs
@@ -14,9 +14,16 @@ open System.Text
 module RequestHeaderRedaction =
 
     let isSensitiveHeader (name: string) =
+        let normalizedName = name.Replace("-", String.Empty).Replace("_", String.Empty)
+
         name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)
         || name.Equals("Cookie", StringComparison.OrdinalIgnoreCase)
-        || name.Contains("token", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("token", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("apikey", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("clientsecret", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("signingsecret", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("signature", StringComparison.OrdinalIgnoreCase)
+        || normalizedName.Contains("credential", StringComparison.OrdinalIgnoreCase)
 
     let redactHeaderValue name value = if isSensitiveHeader name then "[REDACTED]" else value
 
@@ -32,7 +39,7 @@ type LogRequestHeadersMiddleware(next: RequestDelegate) =
 #if DEBUG
         let middlewareTraceHeader = context.Request.Headers["X-MiddlewareTraceIn"]
 
-        context.Request.Headers[ "X-MiddlewareTraceIn" ] <- $"{middlewareTraceHeader}{nameof LogRequestHeadersMiddleware} --> "
+        context.Request.Headers["X-MiddlewareTraceIn"] <- $"{middlewareTraceHeader}{nameof LogRequestHeadersMiddleware} --> "
 #endif
         //let path = context.Request.Path.ToString()
 
@@ -61,6 +68,6 @@ type LogRequestHeadersMiddleware(next: RequestDelegate) =
 #if DEBUG
         let middlewareTraceOutHeader = context.Request.Headers["X-MiddlewareTraceOut"]
 
-        context.Request.Headers[ "X-MiddlewareTraceOut" ] <- $"{middlewareTraceOutHeader}{nameof LogRequestHeadersMiddleware} --> "
+        context.Request.Headers["X-MiddlewareTraceOut"] <- $"{middlewareTraceOutHeader}{nameof LogRequestHeadersMiddleware} --> "
 #endif
         nextTask

--- a/src/Grace.Server/Middleware/LogRequestHeaders.Middleware.fs
+++ b/src/Grace.Server/Middleware/LogRequestHeaders.Middleware.fs
@@ -11,6 +11,15 @@ open Microsoft.Extensions.ObjectPool
 open System
 open System.Text
 
+module RequestHeaderRedaction =
+
+    let isSensitiveHeader (name: string) =
+        name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("Cookie", StringComparison.OrdinalIgnoreCase)
+        || name.Contains("token", StringComparison.OrdinalIgnoreCase)
+
+    let redactHeaderValue name value = if isSensitiveHeader name then "[REDACTED]" else value
+
 /// Checks the incoming request for an X-Correlation-Id header. If there's no CorrelationId header, it generates one and adds it to the response headers.
 type LogRequestHeadersMiddleware(next: RequestDelegate) =
 
@@ -34,14 +43,9 @@ type LogRequestHeadersMiddleware(next: RequestDelegate) =
             let sb = stringBuilderPool.Get()
 
             try
-                let isSensitiveHeader (name: string) =
-                    name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)
-                    || name.Equals("Cookie", StringComparison.OrdinalIgnoreCase)
-                    || name.Contains("token", StringComparison.OrdinalIgnoreCase)
-
                 context.Request.Headers
                 |> Seq.iter (fun kv ->
-                    let value = if isSensitiveHeader kv.Key then "[REDACTED]" else kv.Value.ToString()
+                    let value = RequestHeaderRedaction.redactHeaderValue kv.Key (kv.Value.ToString())
                     sb.AppendLine($"{kv.Key} = {value}") |> ignore)
 
                 log.LogDebug("Request headers: {headers}", sb.ToString())

--- a/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Decisions.fs
@@ -45,6 +45,10 @@ module ValidateIdsDecisions =
         | Create = 0
         | Existing = 1
 
+    type BadRequestResponseContract = { StatusCode: int; Error: GraceError }
+
+    let badRequestResponse error = { StatusCode = StatusCodes.Status400BadRequest; Error = error }
+
     /// Paths that we want to ignore, because they won't have Ids and Names in the body.
     let ignoredPaths =
         [

--- a/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
+++ b/src/Grace.Server/Middleware/ValidateIds.Middleware.fs
@@ -258,8 +258,9 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
                 let duration_ms = getDurationRightAligned_ms startTime
 
                 if Option.isSome badRequest then
-                    let error = badRequest.Value
-                    context.Items.Add("BadRequest", error.Error)
+                    let contract = ValidateIdsDecisions.badRequestResponse badRequest.Value
+                    let error = contract.Error
+                    context.Items.Add("BadRequest", contract.Error.Error)
 
                     log.LogWarning(
                         "{CurrentInstant}: Node: {hostName}; CorrelationId: {correlationId}; {currentFunction}: Path: {path}; {message}; Duration: {duration_ms}ms.",
@@ -272,7 +273,7 @@ type ValidateIdsMiddleware(next: RequestDelegate) =
                         duration_ms
                     )
 
-                    let! _ = (context |> result400BadRequest error)
+                    let! _ = (context |> result400BadRequest contract.Error)
                     ()
                 else
                     if graceIds.HasBranch then

--- a/src/Grace.Server/Security/PersonalAccessTokenAuth.Server.fs
+++ b/src/Grace.Server/Security/PersonalAccessTokenAuth.Server.fs
@@ -18,6 +18,44 @@ module PersonalAccessTokenAuth =
     [<Literal>]
     let SchemeName = "GracePat"
 
+    [<Literal>]
+    let InvalidTokenFailure = "Invalid token."
+
+    type ParsedAuthorization =
+        | NoToken
+        | NotGracePersonalAccessToken
+        | MalformedGracePersonalAccessToken
+        | ParsedGracePersonalAccessToken of userId: string * tokenId: PersonalAccessTokenId * secret: byte array
+
+    let parseAuthorizationHeader (authorization: string) =
+        if String.IsNullOrWhiteSpace authorization then
+            NoToken
+        elif not (authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) then
+            NoToken
+        else
+            let token = authorization.Substring("Bearer ".Length).Trim()
+
+            if String.IsNullOrWhiteSpace token then
+                NoToken
+            elif not (token.StartsWith(TokenPrefix, StringComparison.Ordinal)) then
+                NotGracePersonalAccessToken
+            else
+                match tryParseToken token with
+                | None -> MalformedGracePersonalAccessToken
+                | Some (userId, tokenId, secret) -> ParsedGracePersonalAccessToken(userId, tokenId, secret)
+
+    let toAuthenticationClaims (result: PersonalAccessTokenValidationResult) =
+        let claims = ResizeArray<Claim>()
+        claims.Add(Claim(PrincipalMapper.GraceUserIdClaim, result.UserId))
+
+        result.Claims
+        |> List.iter (fun claimValue -> claims.Add(Claim(PrincipalMapper.GraceClaim, claimValue)))
+
+        result.GroupIds
+        |> List.iter (fun groupId -> claims.Add(Claim(PrincipalMapper.GraceGroupIdClaim, groupId)))
+
+        claims |> Seq.toList
+
     type PersonalAccessTokenAuthHandler(options: IOptionsMonitor<AuthenticationSchemeOptions>, loggerFactory: ILoggerFactory, encoder: UrlEncoder) =
         inherit AuthenticationHandler<AuthenticationSchemeOptions>(options, loggerFactory, encoder)
 
@@ -36,39 +74,21 @@ module PersonalAccessTokenAuth =
             task {
                 let authorization = request.Headers.Authorization.ToString()
 
-                if String.IsNullOrWhiteSpace authorization then
-                    return AuthenticateResult.NoResult()
-                elif not (authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) then
-                    return AuthenticateResult.NoResult()
-                else
-                    let token = authorization.Substring("Bearer ".Length).Trim()
+                match parseAuthorizationHeader authorization with
+                | NoToken -> return AuthenticateResult.NoResult()
+                | NotGracePersonalAccessToken -> return AuthenticateResult.NoResult()
+                | MalformedGracePersonalAccessToken -> return AuthenticateResult.Fail(InvalidTokenFailure)
+                | ParsedGracePersonalAccessToken (userId, tokenId, secret) ->
+                    let correlationId = tryGetCorrelationId httpContext
+                    let actor = PersonalAccessToken.CreateActorProxy userId correlationId
+                    let! validation = actor.ValidateToken tokenId secret (getCurrentInstant ()) correlationId
 
-                    if String.IsNullOrWhiteSpace token then
-                        return AuthenticateResult.NoResult()
-                    elif not (token.StartsWith(TokenPrefix, StringComparison.Ordinal)) then
-                        return AuthenticateResult.NoResult()
-                    else
-                        match tryParseToken token with
-                        | None -> return AuthenticateResult.Fail("Invalid token.")
-                        | Some (userId, tokenId, secret) ->
-                            let correlationId = tryGetCorrelationId httpContext
-                            let actor = PersonalAccessToken.CreateActorProxy userId correlationId
-                            let! validation = actor.ValidateToken tokenId secret (getCurrentInstant ()) correlationId
-
-                            match validation with
-                            | None -> return AuthenticateResult.Fail("Invalid token.")
-                            | Some result ->
-                                let claims = ResizeArray<Claim>()
-                                claims.Add(Claim(PrincipalMapper.GraceUserIdClaim, result.UserId))
-
-                                result.Claims
-                                |> List.iter (fun claimValue -> claims.Add(Claim(PrincipalMapper.GraceClaim, claimValue)))
-
-                                result.GroupIds
-                                |> List.iter (fun groupId -> claims.Add(Claim(PrincipalMapper.GraceGroupIdClaim, groupId)))
-
-                                let identity = ClaimsIdentity(claims, SchemeName)
-                                let principal = ClaimsPrincipal(identity)
-                                let ticket = AuthenticationTicket(principal, SchemeName)
-                                return AuthenticateResult.Success(ticket)
+                    match validation with
+                    | None -> return AuthenticateResult.Fail(InvalidTokenFailure)
+                    | Some result ->
+                        let claims = toAuthenticationClaims result
+                        let identity = ClaimsIdentity(claims, SchemeName)
+                        let principal = ClaimsPrincipal(identity)
+                        let ticket = AuthenticationTicket(principal, SchemeName)
+                        return AuthenticateResult.Success(ticket)
             }

--- a/src/Grace.Server/Security/TelemetryEnrichment.Server.fs
+++ b/src/Grace.Server/Security/TelemetryEnrichment.Server.fs
@@ -1,0 +1,33 @@
+namespace Grace.Server.Security
+
+open System
+open System.Security.Claims
+
+module TelemetryEnrichment =
+
+    let private allowedClaimTypes =
+        Set.ofList [ PrincipalMapper.GraceUserIdClaim
+                     PrincipalMapper.GraceGroupIdClaim
+                     PrincipalMapper.GraceClaim
+                     "roles"
+                     ClaimTypes.Role ]
+
+    let private redactClaimValue (claimType: string) (value: string) =
+        if claimType = PrincipalMapper.GraceUserIdClaim then "REDACTED"
+        elif String.IsNullOrWhiteSpace value then String.Empty
+        else value.Trim()
+
+    let safeEndUserId (principal: ClaimsPrincipal) =
+        PrincipalMapper.tryGetUserId principal
+        |> Option.map (fun _ -> "REDACTED")
+        |> Option.defaultValue "anonymous"
+
+    let safeClaimsTag (principal: ClaimsPrincipal) =
+        if isNull principal || isNull principal.Claims then
+            String.Empty
+        else
+            principal.Claims
+            |> Seq.filter (fun claim -> allowedClaimTypes.Contains claim.Type)
+            |> Seq.map (fun claim -> $"{claim.Type}:{redactClaimValue claim.Type claim.Value}")
+            |> Seq.filter (fun value -> not (String.IsNullOrWhiteSpace value))
+            |> String.concat ";"

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1574,24 +1574,10 @@ module Application =
             let user = context.User
 
             if user.Identity.IsAuthenticated then
-                let claimsList = stringBuilderPool.Get()
-
-                try
-                    if not <| isNull user.Claims then
-                        for claim in user.Claims do
-                            claimsList.Append($"{claim.Type}:{claim.Value};")
-                            |> ignore
-
-                    if claimsList.Length > 1 then
-                        claimsList.Remove(claimsList.Length - 1, 1)
-                        |> ignore
-
-                    activity
-                        .AddTag("enduser.id", user.Identity.Name)
-                        .AddTag("enduser.claims", claimsList.ToString())
-                    |> ignore
-                finally
-                    stringBuilderPool.Return(claimsList)
+                activity
+                    .AddTag("enduser.id", Security.TelemetryEnrichment.safeEndUserId user)
+                    .AddTag("enduser.claims", Security.TelemetryEnrichment.safeClaimsTag user)
+                |> ignore
 
             activity
                 .AddTag("working_set", currentWorkingSet)


### PR DESCRIPTION
## Summary

- Adds Fast seam coverage for PAT auth failure privacy, ValidateIds error contracts, telemetry claim redaction, request header redaction, and outbound URL resolver failures.
- Extracts narrow pure seams for telemetry enrichment, request-header redaction, and ValidateIds bad-request response construction.
- Records `B-053` as source-verified only, with provider-failure behavior left to a future owned slice.

## Issue

Closes #253.
Part of #249.

## Research Trace

- `B-033`: added Fast PAT authorization parsing/failure-message coverage for malformed, revoked, expired, and wrong-owner actor misses without leaking token or lifecycle details.
- `B-036`: added pure ValidateIds status/body/correlation coverage for not-found decisions.
- `B-037`: added telemetry claim allowlist/redaction tests and wired startup through safe telemetry helpers.
- `B-038`: added request-header redaction seam and tests for Authorization, Cookie, token-named, API-key, client-secret, signing-secret, signature, and credential-shaped headers.
- `B-046`: added no-network fake-resolver failure coverage for outbound URL safety.
- `B-053`: source-verified only; review/model-provider failure behavior needs a dedicated provider-failure slice with expanded owned paths.

## Validation

- `dotnet tool run fantomas src/Grace.Server/Security/PersonalAccessTokenAuth.Server.fs src/Grace.Server/Security/TelemetryEnrichment.Server.fs src/Grace.Server/Startup.Server.fs src/Grace.Server/Middleware/LogRequestHeaders.Middleware.fs src/Grace.Server/Middleware/ValidateIds.Decisions.fs src/Grace.Server/Middleware/ValidateIds.Middleware.fs src/Grace.Server.Unit.Tests/SecurityPrivacy.Unit.Tests.fs src/Grace.Server.Unit.Tests/OutboundUrlSafety.Unit.Tests.fs`: passed before PR.
- `fantomas --verbosity d src\Grace.Server\Middleware\LogRequestHeaders.Middleware.fs src\Grace.Server.Unit.Tests\SecurityPrivacy.Unit.Tests.fs`: passed for review fix.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed before PR.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed, 429 passed before PR.
- `dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "Name~RequestHeaderRedaction"`: passed after review fix, 10 passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed before PR and after review fix; after fix Server.Unit 438 passed and CLI 272 passed / 1 skipped.
- `git diff --check`: passed before PR, after review fix, and during final review.
- `pwsh ./scripts/validate.ps1 -Full`: skipped; no hosted PAT HTTP variants or Aspire/resource behavior were added.

## Freshness

- Main advanced during implementation via #251 / PR #269 to `8a57709b5e2cb4353e190a2c3b0b7637ecd70fef`.
- Branch was refreshed with `git fetch origin` plus `git merge origin/main --no-edit`, no conflicts.
- Final branch state after review fix: `origin/main` is an ancestor; branch is ahead and not behind.

## Review Status

- Implementation worker: Descartes, GPT-5.5 Medium.
- Local review-only sibling: Pascal, GPT-5.5 High, found one request-header redaction gap.
- Review report: https://github.com/ScottArbeit/Grace/pull/270#issuecomment-4627820238.
- Fix worker: Peirce, GPT-5.5 Medium, fixed in `e4300cf0cb4f6f2337516bf80cd03c1596d8ac4d`.
- Review/fix note: https://github.com/ScottArbeit/Grace/pull/270#issuecomment-4627878995.
- Final review-only sibling: Sartre, GPT-5.5 High, completed with no issues.
- Open findings: none.
- Final no-issues review: documented in https://github.com/ScottArbeit/Grace/pull/270#issuecomment-4627941385.

## Docs Impact

No docs update. This slice adds internal seam extraction plus Fast coverage; public auth/API semantics are intended to remain unchanged.

## Residual Risk

PAT lifecycle itself remains actor/hosted coverage. This slice pins the server auth decision seam and generic failure surface, but does not simulate the Orleans PAT actor in Fast tests. `B-053` should get a focused provider-failure issue if production provider failure behavior is desired.