### PR TITLE
Resolve Full fixture diagnostics decisions

### DIFF
--- a/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
@@ -1,0 +1,117 @@
+namespace Grace.Server.TestDiagnostics
+
+open Grace.Server.Tests
+open Grace.Shared
+open NUnit.Framework
+open System
+
+[<TestFixture>]
+type AspireTestHostDiagnosticsTests() =
+
+    [<Test>]
+    member _.RedactsConnectionStringSecretsButKeepsActionableEndpoints() =
+        let cosmos =
+            AspireTestHost.FixtureDiagnostics.redactCosmosConnectionString "AccountEndpoint=https://localhost:8081/;AccountKey=cosmos-secret;Version=1;"
+
+        let storage =
+            AspireTestHost.FixtureDiagnostics.redactStorageConnectionString
+                "DefaultEndpointsProtocol=http;AccountName=gracevcsdevelopment;AccountKey=storage-secret;BlobEndpoint=http://127.0.0.1:10000/gracevcsdevelopment;"
+
+        let serviceBus =
+            AspireTestHost.FixtureDiagnostics.redactServiceBusConnectionString
+                "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=service-bus-secret;UseDevelopmentEmulator=true;"
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(cosmos, Does.Contain("AccountEndpoint=https://localhost:8081/"))
+                Assert.That(cosmos, Does.Contain("AccountKey=***"))
+                Assert.That(cosmos, Does.Not.Contain("cosmos-secret"))
+                Assert.That(storage, Does.Contain("BlobEndpoint=http://127.0.0.1:10000/gracevcsdevelopment"))
+                Assert.That(storage, Does.Contain("AccountKey=***"))
+                Assert.That(storage, Does.Not.Contain("storage-secret"))
+                Assert.That(serviceBus, Does.Contain("Endpoint=sb://localhost:5672"))
+                Assert.That(serviceBus, Does.Contain("SharedAccessKey=***"))
+                Assert.That(serviceBus, Does.Not.Contain("service-bus-secret")))
+        )
+
+    [<Test>]
+    member _.FormatEnvDiagnosticsUsesSelectedRedactedValuesOnly() =
+        let env =
+            [
+                Constants.EnvironmentVariables.GraceLogDirectory, "C:\\Temp\\GraceLogs"
+                Constants.EnvironmentVariables.AzureCosmosDBConnectionString, "AccountEndpoint=https://localhost:8081/;AccountKey=cosmos-secret;"
+                Constants.EnvironmentVariables.AzureStorageConnectionString, "DefaultEndpointsProtocol=http;AccountName=grace;AccountKey=storage-secret;"
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString, "Endpoint=sb://localhost:5672;SharedAccessKey=service-bus-secret;"
+                "unrelated_secret", "must-not-appear"
+            ]
+            |> Map.ofList
+
+        let diagnostics = AspireTestHost.FixtureDiagnostics.formatEnvDiagnostics env
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(diagnostics, Does.Contain($"{Constants.EnvironmentVariables.GraceLogDirectory}=C:\\Temp\\GraceLogs"))
+
+                Assert.That(
+                    diagnostics,
+                    Does.Contain($"{Constants.EnvironmentVariables.AzureCosmosDBConnectionString}=AccountEndpoint=https://localhost:8081/;AccountKey=***")
+                )
+
+                Assert.That(
+                    diagnostics,
+                    Does.Contain(
+                        $"{Constants.EnvironmentVariables.AzureStorageConnectionString}=DefaultEndpointsProtocol=http;AccountName=grace;AccountKey=***"
+                    )
+                )
+
+                Assert.That(
+                    diagnostics,
+                    Does.Contain($"{Constants.EnvironmentVariables.AzureServiceBusConnectionString}=Endpoint=sb://localhost:5672;SharedAccessKey=***")
+                )
+
+                Assert.That(diagnostics, Does.Not.Contain("cosmos-secret"))
+                Assert.That(diagnostics, Does.Not.Contain("storage-secret"))
+                Assert.That(diagnostics, Does.Not.Contain("service-bus-secret"))
+                Assert.That(diagnostics, Does.Not.Contain("unrelated_secret"))
+                Assert.That(diagnostics, Does.Not.Contain("must-not-appear")))
+        )
+
+    [<Test>]
+    member _.MissingStartupKeysNameRequiredCosmosStorageAndServiceBusSources() =
+        let env =
+            [
+                Constants.EnvironmentVariables.AzureCosmosDBConnectionString, "AccountEndpoint=https://localhost:8081/;AccountKey=cosmos-secret;"
+                Constants.EnvironmentVariables.AzureCosmosDBDatabaseName, "grace-dev"
+                Constants.EnvironmentVariables.AzureStorageConnectionString, "DefaultEndpointsProtocol=http;AccountName=grace;AccountKey=storage-secret;"
+                Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream"
+            ]
+            |> Map.ofList
+
+        let missing = AspireTestHost.FixtureDiagnostics.getMissingStartupKeys false env
+        let diagnostics = AspireTestHost.FixtureDiagnostics.formatEnvDiagnostics env
+
+        let expectedMissing =
+            [|
+                Constants.EnvironmentVariables.AzureCosmosDBContainerName
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusSubscription
+            |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(String.Join("|", missing), Is.EqualTo(String.Join("|", expectedMissing)))
+                Assert.That(diagnostics, Does.Contain("AccountKey=***"))
+                Assert.That(diagnostics, Does.Not.Contain("cosmos-secret"))
+                Assert.That(diagnostics, Does.Not.Contain("storage-secret")))
+        )
+
+    [<Test>]
+    member _.ServiceBusSkipModeIsClassifiedUnsupportedForSharedServerSetup() =
+        let message = AspireTestHost.FixtureDiagnostics.serviceBusSkipModeMessage
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(message, Does.Contain("GRACE_TEST_SKIP_SERVICEBUS=1"))
+                Assert.That(message, Does.Contain("unsupported for Grace.Server.Tests"))
+                Assert.That(message, Does.Contain("Owner Created event")))
+        )

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -436,46 +436,117 @@ module AspireTestHost =
                 raise (Exception($"{resourceName} failed to start. {details}{Environment.NewLine}{logDetails}", ex))
         }
 
+    module FixtureDiagnostics =
+        let private redactConnectionStringSegments (sensitivePrefixes: string list) (connectionString: string) =
+            if String.IsNullOrWhiteSpace connectionString then
+                connectionString
+            else
+                connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                |> Array.map (fun part ->
+                    match sensitivePrefixes
+                          |> List.tryFind (fun prefix -> part.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                        with
+                    | Some prefix -> $"{prefix}***"
+                    | None -> part)
+                |> String.concat ";"
+
+        let redactServiceBusConnectionString (connectionString: string) =
+            redactConnectionStringSegments
+                [
+                    "SharedAccessKey="
+                    "SharedAccessSignature="
+                ]
+                connectionString
+
+        let redactStorageConnectionString (connectionString: string) =
+            redactConnectionStringSegments
+                [
+                    "AccountKey="
+                    "SharedAccessSignature="
+                ]
+                connectionString
+
+        let redactCosmosConnectionString (connectionString: string) =
+            redactConnectionStringSegments
+                [
+                    "AccountKey="
+                    "SharedAccessSignature="
+                ]
+                connectionString
+
+        let formatEnvDiagnostics (env: Map<string, string>) =
+            let get key =
+                match env |> Map.tryFind key with
+                | Some value when not (String.IsNullOrWhiteSpace value) -> value
+                | _ -> "<missing>"
+
+            [
+                Constants.EnvironmentVariables.GraceLogDirectory
+                Constants.EnvironmentVariables.OrleansClusterId
+                Constants.EnvironmentVariables.OrleansServiceId
+                Constants.EnvironmentVariables.DiffContainerName
+                Constants.EnvironmentVariables.DirectoryVersionContainerName
+                Constants.EnvironmentVariables.ZipFileContainerName
+                Constants.EnvironmentVariables.AzureCosmosDBConnectionString
+                Constants.EnvironmentVariables.AzureStorageConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+            ]
+            |> List.map (fun key ->
+                if key.Equals(Constants.EnvironmentVariables.AzureCosmosDBConnectionString, StringComparison.OrdinalIgnoreCase) then
+                    let value =
+                        env
+                        |> Map.tryFind key
+                        |> Option.defaultValue String.Empty
+
+                    $"{key}={redactCosmosConnectionString value}"
+                else if key.Equals(Constants.EnvironmentVariables.AzureStorageConnectionString, StringComparison.OrdinalIgnoreCase) then
+                    let value =
+                        env
+                        |> Map.tryFind key
+                        |> Option.defaultValue String.Empty
+
+                    $"{key}={redactStorageConnectionString value}"
+                else if key.Equals(Constants.EnvironmentVariables.AzureServiceBusConnectionString, StringComparison.OrdinalIgnoreCase) then
+                    let value =
+                        env
+                        |> Map.tryFind key
+                        |> Option.defaultValue String.Empty
+
+                    $"{key}={redactServiceBusConnectionString value}"
+                else
+                    $"{key}={get key}")
+            |> String.concat "; "
+
+        let getRequiredStartupKeys skipServiceBus =
+            [
+                Constants.EnvironmentVariables.AzureCosmosDBConnectionString
+                Constants.EnvironmentVariables.AzureCosmosDBDatabaseName
+                Constants.EnvironmentVariables.AzureCosmosDBContainerName
+                Constants.EnvironmentVariables.AzureStorageConnectionString
+                if not skipServiceBus then
+                    Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                    Constants.EnvironmentVariables.AzureServiceBusTopic
+                    Constants.EnvironmentVariables.AzureServiceBusSubscription
+            ]
+
+        let getMissingStartupKeys skipServiceBus (env: Map<string, string>) =
+            getRequiredStartupKeys skipServiceBus
+            |> List.filter (fun key ->
+                env
+                |> Map.tryFind key
+                |> Option.forall String.IsNullOrWhiteSpace)
+
+        let serviceBusSkipModeMessage =
+            "GRACE_TEST_SKIP_SERVICEBUS=1 is unsupported for Grace.Server.Tests because the shared setup drains the Service Bus test subscription and proves the Owner Created event."
+
     let private requireEnv (resourceName: string) (key: string) (env: Map<string, string>) =
         env
         |> Map.tryFind key
         |> Option.defaultWith (fun () -> failwith $"Missing env var '{key}' for resource '{resourceName}'.")
 
-    let private redactServiceBusConnectionString (connectionString: string) =
-        if String.IsNullOrWhiteSpace connectionString then
-            connectionString
-        else
-            connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
-            |> Array.map (fun part ->
-                if part.StartsWith("SharedAccessKey=", StringComparison.OrdinalIgnoreCase) then
-                    "SharedAccessKey=***"
-                else
-                    part)
-            |> String.concat ";"
-
-    let private redactStorageConnectionString (connectionString: string) =
-        if String.IsNullOrWhiteSpace connectionString then
-            connectionString
-        else
-            connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
-            |> Array.map (fun part ->
-                if part.StartsWith("AccountKey=", StringComparison.OrdinalIgnoreCase) then
-                    "AccountKey=***"
-                else
-                    part)
-            |> String.concat ";"
-
-    let private redactCosmosConnectionString (connectionString: string) =
-        if String.IsNullOrWhiteSpace connectionString then
-            connectionString
-        else
-            connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries)
-            |> Array.map (fun part ->
-                if part.StartsWith("AccountKey=", StringComparison.OrdinalIgnoreCase) then
-                    "AccountKey=***"
-                else
-                    part)
-            |> String.concat ";"
+    let private redactServiceBusConnectionString = FixtureDiagnostics.redactServiceBusConnectionString
+    let private redactStorageConnectionString = FixtureDiagnostics.redactStorageConnectionString
+    let private redactCosmosConnectionString = FixtureDiagnostics.redactCosmosConnectionString
 
     let private tryGetConnValue (prefix: string) (value: string) =
         value.Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -581,48 +652,16 @@ module AspireTestHost =
         options.ServerCertificateCustomValidationCallback <- Func<X509Certificate2, X509Chain, SslPolicyErrors, bool>(fun _ _ _ -> true)
         options
 
-    let private formatEnvDiagnostics (env: Map<string, string>) =
-        let get key =
-            match env |> Map.tryFind key with
-            | Some value when not (String.IsNullOrWhiteSpace value) -> value
-            | _ -> "<missing>"
+    let private formatEnvDiagnostics = FixtureDiagnostics.formatEnvDiagnostics
 
-        [
-            Constants.EnvironmentVariables.GraceLogDirectory
-            Constants.EnvironmentVariables.OrleansClusterId
-            Constants.EnvironmentVariables.OrleansServiceId
-            Constants.EnvironmentVariables.DiffContainerName
-            Constants.EnvironmentVariables.DirectoryVersionContainerName
-            Constants.EnvironmentVariables.ZipFileContainerName
-            Constants.EnvironmentVariables.AzureCosmosDBConnectionString
-            Constants.EnvironmentVariables.AzureStorageConnectionString
-            Constants.EnvironmentVariables.AzureServiceBusConnectionString
-        ]
-        |> List.map (fun key ->
-            if key.Equals(Constants.EnvironmentVariables.AzureCosmosDBConnectionString, StringComparison.OrdinalIgnoreCase) then
-                let value =
-                    env
-                    |> Map.tryFind key
-                    |> Option.defaultValue String.Empty
+    let private requireStartupEnvironment (resourceName: string) (skipServiceBus: bool) (env: Map<string, string>) =
+        let missing = FixtureDiagnostics.getMissingStartupKeys skipServiceBus env
 
-                $"{key}={redactCosmosConnectionString value}"
-            else if key.Equals(Constants.EnvironmentVariables.AzureStorageConnectionString, StringComparison.OrdinalIgnoreCase) then
-                let value =
-                    env
-                    |> Map.tryFind key
-                    |> Option.defaultValue String.Empty
+        if not missing.IsEmpty then
+            let missingText = String.Join(", ", missing)
+            let envDetails = formatEnvDiagnostics env
 
-                $"{key}={redactStorageConnectionString value}"
-            else if key.Equals(Constants.EnvironmentVariables.AzureServiceBusConnectionString, StringComparison.OrdinalIgnoreCase) then
-                let value =
-                    env
-                    |> Map.tryFind key
-                    |> Option.defaultValue String.Empty
-
-                $"{key}={redactServiceBusConnectionString value}"
-            else
-                $"{key}={get key}")
-        |> String.concat "; "
+            failwith $"Missing required startup env var(s) for resource '{resourceName}': {missingText}. Env: {envDetails}"
 
     let private tryGetLatestLogTail (logDirectory: string) =
         try
@@ -896,6 +935,9 @@ module AspireTestHost =
             if not <| String.IsNullOrWhiteSpace bootstrapUserId then
                 Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, bootstrapUserId)
 
+            if shouldSkipServiceBus () then
+                invalidOp FixtureDiagnostics.serviceBusSkipModeMessage
+
             do! cleanupDockerContainersAsync ()
             let! builder = DistributedApplicationTestingBuilder.CreateAsync<Projects.Grace_Aspire_AppHost>()
             let! app = builder.BuildAsync()
@@ -982,6 +1024,8 @@ module AspireTestHost =
                 with
             | Some value when not (String.IsNullOrWhiteSpace value) -> Console.WriteLine($"AzureCosmosDBConnectionString: {redactCosmosConnectionString value}")
             | _ -> Console.WriteLine("AzureCosmosDBConnectionString: <missing>")
+
+            requireStartupEnvironment graceServerResourceName (shouldSkipServiceBus ()) env
 
             let cosmosConnectionString =
                 env

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="AspireTestHost.fs" />
+    <Compile Include="AspireTestHost.Diagnostics.Tests.fs" />
     <Compile Include="General.Server.Tests.fs" />
     <Compile Include="Smoke.Server.Tests.fs" />
     <Compile Include="Slop.Server.Tests.fs" />

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -62,11 +62,16 @@ Open `http://localhost:18888` and confirm the following resources show
 
 - `azurite` – Azure Storage emulator (blob/queue/table) on ports `10000-10002`
 - `redis` – Redis cache on port `6379`
-- `cosmos-emulator` – Cosmos DB emulator on port `8081`
+- `cosmos` – Cosmos DB emulator on port `8081`
 - `servicebus-sql` – SQL Server container required by the Service Bus emulator
-- `service-bus-emulator` – Service Bus emulator (AMQP on `5672`, management UI
-  on `9200`)
+- `servicebus-emulator` – Service Bus emulator (AMQP on `5672`, management
+  endpoint on `5300`)
 - `grace-server` – HTTP `5000` / HTTPS `5001`
+
+Redis is provisioned by AppHost and its host/port are forwarded to
+`Grace.Server`. Current startup code does not enable Redis-backed SignalR, so
+Redis remains an explicit AppHost dependency pending a follow-up runtime
+decision rather than a prerequisite proven by the integration tests.
 
 ## Smoke Tests
 
@@ -88,7 +93,7 @@ Open `http://localhost:18888` and confirm the following resources show
 The .NET SDK expects a connection string that ends with
 `UseDevelopmentEmulator=true`. After the emulator finishes booting:
 
-1. Browse to `http://localhost:9200` (Service Bus emulator management portal).
+1. Browse to `http://localhost:5300` (Service Bus emulator management endpoint).
 2. Copy the `RootManageSharedAccessKey` connection string shown in the portal.
 3. Before launching Aspire, set the lowercase environment variable so
    `Grace.Server` can connect:
@@ -109,21 +114,24 @@ Linux hosts.
 
 ## Run Tests
 
-After the host is up:
+Use the repository validation script for the Aspire-backed integration suite:
 
-```bash
-cd ..\Grace.Server.Tests
-DOTNET_ENVIRONMENT=Development dotnet test --no-build
+```powershell
+pwsh ./scripts/validate.ps1 -Full
 ```
 
-Integration tests reuse the running emulators. Shut down Aspire when tests
-finish to release containers and ports.
+`Grace.Server.Tests` starts its own Aspire host, then proves storage, Cosmos DB,
+and Service Bus readiness before running server integration tests. The
+`GRACE_TEST_SKIP_SERVICEBUS=1` environment variable is not a supported
+`Grace.Server.Tests` profile today because the shared setup drains the Service
+Bus test subscription and verifies the Owner Created event.
 
 ## Troubleshooting
 
 - **Port conflicts** – Update bindings inside
-  `Grace.Aspire.AppHost/Program.cs` if ports `5000`, `5001`, `10000–10002`,
-  `8081`, `10251–10255`, `5672`, `9200`, or `21433` are already used.
+  `Grace.Aspire.AppHost/Program.Aspire.AppHost.cs` if ports `5000`, `5001`,
+  `10000–10002`, `8081`, `10251–10255`, `5672`, `5300`, or `21433` are already
+  used.
 - **Cosmos DB emulator** – First launch can take several minutes. Inspect logs
   with `docker logs cosmos-emulator`.
 - **Service Bus emulator** – The Service Bus container waits for SQL Server. If

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -133,7 +133,7 @@ Bus test subscription and verifies the Owner Created event.
   `10000–10002`, `8081`, `10251–10255`, `5672`, `5300`, or `21433` are already
   used.
 - **Cosmos DB emulator** – First launch can take several minutes. Inspect logs
-  with `docker logs cosmos-emulator`.
+  with `docker logs cosmosdb-emulator`, or `docker logs cosmosdb-emulator-<suffix>` for suffixed test runs.
 - **Service Bus emulator** – The Service Bus container waits for SQL Server. If
   startup fails, check `docker logs servicebus-sql` for password or EULA issues.
 - **Missing telemetry** – `OTLP_ENDPOINT_URL` must reach

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -91,18 +91,20 @@ decision rather than a prerequisite proven by the integration tests.
 ## Service Bus Emulator Connection String
 
 The .NET SDK expects a connection string that ends with
-`UseDevelopmentEmulator=true`. After the emulator finishes booting:
+`UseDevelopmentEmulator=true`. AppHost exposes the Service Bus emulator AMQP
+endpoint on `localhost:5672` and the management endpoint on `localhost:5300`;
+the management endpoint is not a portal that shows keys.
 
-1. Browse to `http://localhost:5300` (Service Bus emulator management endpoint).
-2. Copy the `RootManageSharedAccessKey` connection string shown in the portal.
-3. Before launching Aspire, set the lowercase environment variable so
-   `Grace.Server` can connect:
+When AppHost launches `grace-server`, it provides the local emulator connection
+string automatically with `SharedAccessKey=SAS_KEY_VALUE`. To launch
+`Grace.Server` manually against the local emulator, set the lowercase
+environment variable before starting the server:
 
 ```powershell
 $env:azureservicebusconnectionstring =
   "Endpoint=sb://localhost/;" +
   "SharedAccessKeyName=RootManageSharedAccessKey;" +
-  "SharedAccessKey=<SAS_KEY>;" +
+  "SharedAccessKey=SAS_KEY_VALUE;" +
   "UseDevelopmentEmulator=true;"
 
 dotnet run


### PR DESCRIPTION
## Summary

- Adds focused diagnostics tests for redacted Cosmos, storage, and Service Bus configuration output.
- Makes missing Full fixture startup configuration diagnostics actionable without dumping unredacted environment state.
- Records Service Bus skip-mode and Redis dependency decisions, and updates Aspire setup documentation for current resource names and management port.

## Issue

Closes #265.
Part of #249.

## Research Trace

- `B-039`: diagnostics formatter tests prove Cosmos, storage, and Service Bus connection strings redact secrets while preserving actionable endpoints/resource names.
- `B-040`: startup required-key classification names missing Cosmos, storage, and Service Bus settings with selected redacted diagnostics.
- `B-047`: `GRACE_TEST_SKIP_SERVICEBUS=1` is classified unsupported for the current shared setup and fails early with an explicit message.
- `B-048`: Redis remains provisioned and forwarded by AppHost, but is documented as pending a future runtime/product decision because current server startup has Redis-backed SignalR commented out.
- `B-055`: fixture startup diagnostics are more actionable for failed startup/readiness paths while staying redacted.
- `drift-007`: `src/docs/ASPIRE_SETUP.md` now aligns Service Bus management endpoint documentation with AppHost evidence (`5300`) and current resource names.
- `split-006`: diagnostics proof is pure and isolated in `Grace.Server.TestDiagnostics` so it does not trigger the Aspire `SetUpFixture`.

## Validation

- `dotnet tool restore`: passed after sandboxed network failure was rerun with escalation.
- `dotnet tool run fantomas -- src\Grace.Server.Tests\AspireTestHost.fs src\Grace.Server.Tests\AspireTestHost.Diagnostics.Tests.fs`: passed.
- `npx --yes markdownlint-cli2 src/docs/ASPIRE_SETUP.md`: passed before PR, after both docs review fixes, after freshness merge, and during final review.
- `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter FullyQualifiedName~Grace.Server.TestDiagnostics`: passed, 4 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed on original refreshed implementation branch; Authorization 36, Types 65, Server.Unit 414, CLI 272 passed / 1 skipped, Server integration 139.
- `git diff --check`: passed before PR, after both docs review fixes, after freshness merge, and during final review.

## Freshness

- Main advanced during implementation via #251 / PR #269 to `8a57709b5e2cb4353e190a2c3b0b7637ecd70fef`.
- Main advanced again when #253 / PR #270 merged to `4756af856a33a65fbe6313ad8be64edd1c2c7b0c`.
- Branch was refreshed with a normal merge from current `origin/main` in `a142e0ae11574802cb82bb2623041170dd1ec8b7`.
- Final ahead/behind after freshness merge and final review: `0 4` using `origin/main...HEAD`; branch is ahead and not behind.
- Freshness evidence: https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4627974194.

## Review Status

- Implementation worker: Harvey, GPT-5.5 Medium.
- Local review-only sibling: Halley, GPT-5.5 High, found one stale Cosmos troubleshooting command in `src/docs/ASPIRE_SETUP.md`.
- First review report: https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4627828191.
- First fix worker: Bacon, GPT-5.5 Medium, fixed in `458d92dfe7053b9e0f44d12ebc2732e18dba9e5c`.
- First review/fix note: https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4627849282.
- Second review-only sibling: Pasteur, GPT-5.5 High, found one Service Bus management endpoint docs issue.
- Second review report: https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4627881717.
- Second fix worker: Archimedes, GPT-5.5 Medium, fixed in `be1ff222f6469f025d2046460a7b85c349742f86`.
- Second review/fix note: https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4627932164.
- Freshness worker: Leibniz, GPT-5.5 Medium, refreshed branch in `a142e0ae11574802cb82bb2623041170dd1ec8b7`.
- Final review-only sibling: Hubble, GPT-5.5 High, completed with no issues.
- Open findings: none.
- Final no-issues review: documented in https://github.com/ScottArbeit/Grace/pull/271#issuecomment-4628001435.

## Docs Impact

Updated `src/docs/ASPIRE_SETUP.md` for current AppHost resource names, Service Bus management endpoint, emulator connection-string behavior, Redis dependency decision, Full validation guidance, and Cosmos emulator troubleshooting command.

## Residual Risk

Redis still needs a future product/runtime decision: enable and prove a Redis-backed feature, make it explicitly optional/degraded, or remove it from the AppHost/test profile in a separately owned slice.