### PR TITLE
Strengthen hosted server route assertions

### DIFF
--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -562,6 +562,38 @@ type AccessControl() =
             return returnValue.ReturnValue
         }
 
+    let revokeRoleAsync (client: HttpClient) ownerId organizationId repositoryId scopeKind roleId principalId =
+        task {
+            let parameters = Parameters.Access.RevokeRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- scopeKind
+            parameters.RoleId <- roleId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/access/revokeRole", createJsonContent parameters)
+            response.EnsureSuccessStatusCode() |> ignore
+        }
+
+    let listRoleAssignmentsAsync (client: HttpClient) ownerId organizationId repositoryId scopeKind =
+        task {
+            let parameters = Parameters.Access.ListRoleAssignmentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.ScopeKind <- scopeKind
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            let returnValue = deserialize<GraceReturnValue<RoleAssignment list>> responseText
+            return returnValue.ReturnValue
+        }
+
     let createClientWithClaims (claims: string list) =
         let client = new HttpClient()
         client.BaseAddress <- Client.BaseAddress
@@ -624,6 +656,60 @@ type AccessControl() =
             match repoBRead with
             | Allowed _ -> ()
             | Denied reason -> Assert.Fail($"Expected repoB read to be allowed. {reason}")
+        }
+
+    [<Test>]
+    member _.GrantListRevokeUpdatesStoredAssignmentsAndPermissionCheck() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+            let! repositoryId = createRepositoryAsync Client organizationId
+            let principalId = $"{Guid.NewGuid()}"
+
+            do! grantRoleAsync Client ownerId organizationId "" "org" "OrgAdmin" testUserId
+            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+
+            let! afterGrant = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
+
+            let granted =
+                afterGrant
+                |> List.tryFind (fun assignment ->
+                    assignment.Principal.PrincipalId = principalId
+                    && assignment.RoleId = "RepoReader"
+                    && assignment.Source = "test")
+
+            Assert.That(granted.IsSome, Is.True)
+
+            match granted.Value.Scope with
+            | Scope.Repository (storedOwnerId, storedOrganizationId, storedRepositoryId) ->
+                Assert.That(storedOwnerId, Is.EqualTo(Guid.Parse(ownerId)))
+                Assert.That(storedOrganizationId, Is.EqualTo(Guid.Parse(organizationId)))
+                Assert.That(storedRepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+            | other -> Assert.Fail($"Expected repository scope, got {other}.")
+
+            use principalClient = createClientWithUserId principalId
+            let! allowedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+
+            match allowedPermission with
+            | Allowed reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Denied reason -> Assert.Fail($"Expected repo read to be allowed after grant. {reason}")
+
+            do! revokeRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+
+            let! afterRevoke = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
+
+            let stillPresent =
+                afterRevoke
+                |> List.exists (fun assignment ->
+                    assignment.Principal.PrincipalId = principalId
+                    && assignment.RoleId = "RepoReader")
+
+            Assert.That(stillPresent, Is.False)
+
+            let! deniedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+
+            match deniedPermission with
+            | Denied reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Allowed reason -> Assert.Fail($"Expected repo read to be denied after revoke. {reason}")
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -163,6 +163,15 @@ module private ApprovalTestHelpers =
             return! deserializeContent<ApprovalPolicy> createResponse
         }
 
+    let assertPolicyMatchesScope (repositoryId: string) (branchId: string) (policy: ApprovalPolicy) =
+        Assert.That(policy.Class, Is.EqualTo(nameof ApprovalPolicy))
+        Assert.That(policy.Scope.OwnerId, Is.EqualTo(Guid.Parse(ownerId)))
+        Assert.That(policy.Scope.OrganizationId, Is.EqualTo(Guid.Parse(organizationId)))
+        Assert.That(policy.Scope.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+        Assert.That(policy.Scope.TargetBranchId, Is.EqualTo(Guid.Parse(branchId)))
+        Assert.That(policy.Subject, Is.EqualTo("promotion"))
+        Assert.That(policy.RequiredResponder, Is.EqualTo("role:ApprovalResponder"))
+
 [<NonParallelizable>]
 type ApprovalApiIntegrationTests() =
 
@@ -188,6 +197,9 @@ type ApprovalApiIntegrationTests() =
 
             let! created = deserializeContent<ApprovalPolicy> createResponse
             Assert.That(created.Status, Is.EqualTo(ApprovalPolicyStatus.Disabled))
+            ApprovalTestHelpers.assertPolicyMatchesScope repositoryId branchId created
+            Assert.That(created.Version, Is.EqualTo(1))
+            Assert.That(created.CreatedBy, Is.EqualTo(adminUser))
 
             let showParameters = ApprovalTestHelpers.showPolicyParameters repositoryId branchId (created.ApprovalPolicyId.ToString())
             let! enableResponse = adminClient.PostAsync("/approval/policy/enable", createJsonContent showParameters)
@@ -195,17 +207,52 @@ type ApprovalApiIntegrationTests() =
 
             let! showResponse = adminClient.PostAsync("/approval/policy/show", createJsonContent showParameters)
             Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! enabled = deserializeContent<ApprovalPolicy> showResponse
+            ApprovalTestHelpers.assertPolicyMatchesScope repositoryId branchId enabled
+            Assert.That(enabled.ApprovalPolicyId, Is.EqualTo(created.ApprovalPolicyId))
+            Assert.That(enabled.Status, Is.EqualTo(ApprovalPolicyStatus.Enabled))
 
             let! evaluateResponse =
                 adminClient.PostAsync("/approval/policy/evaluate", createJsonContent (ApprovalTestHelpers.createPolicyParameters repositoryId branchId))
 
             Assert.That(evaluateResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! evaluated = deserializeContent<ApprovalPolicy array> evaluateResponse
+
+            Assert.That(
+                evaluated
+                |> Array.map (fun policy -> policy.ApprovalPolicyId),
+                Does.Contain(created.ApprovalPolicyId)
+            )
+
+            let evaluatedPolicy =
+                evaluated
+                |> Array.find (fun policy -> policy.ApprovalPolicyId = created.ApprovalPolicyId)
+
+            Assert.That(evaluatedPolicy.Status, Is.EqualTo(ApprovalPolicyStatus.Enabled))
+            ApprovalTestHelpers.assertPolicyMatchesScope repositoryId branchId evaluatedPolicy
+
+            let! listResponse =
+                adminClient.PostAsync("/approval/policy/list", createJsonContent (ApprovalTestHelpers.listPolicyParameters repositoryId branchId))
+
+            Assert.That(listResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! listed = deserializeContent<ApprovalPolicy array> listResponse
+
+            Assert.That(
+                listed
+                |> Array.map (fun policy -> policy.ApprovalPolicyId),
+                Does.Contain(created.ApprovalPolicyId)
+            )
 
             let! disableResponse = adminClient.PostAsync("/approval/policy/disable", createJsonContent showParameters)
             Assert.That(disableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! disabled = deserializeContent<ApprovalPolicy> disableResponse
+            Assert.That(disabled.Status, Is.EqualTo(ApprovalPolicyStatus.Disabled))
+            Assert.That(disabled.UpdatedAt.IsSome, Is.True)
 
             let! deleteResponse = adminClient.PostAsync("/approval/policy/delete", createJsonContent showParameters)
             Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! deleted = deserializeContent<ApprovalPolicy> deleteResponse
+            Assert.That(deleted.Status, Is.EqualTo(ApprovalPolicyStatus.Deleted))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -26,15 +26,21 @@ type AuthEndpoints() =
         task {
             let! response = Client.GetAsync("/auth/login")
             response.EnsureSuccessStatusCode() |> ignore
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/html"))
             let! body = response.Content.ReadAsStringAsync()
+            Assert.That(body, Does.StartWith("<!doctype html>"))
+            Assert.That(body, Does.Contain("<title>Grace Login</title>"))
             Assert.That(body, Does.Contain("Interactive browser login is not available on the server in this phase."))
+            Assert.That(body, Does.Contain("grace auth login"))
         }
 
     [<Test>]
     member _.LoginProviderReturnsNotFoundWhenNotConfigured() =
         task {
             let! response = Client.GetAsync("/auth/login/microsoft")
+            let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
+            Assert.That(body, Does.Contain("Login provider not available."))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/General.Server.Tests.fs
+++ b/src/Grace.Server.Tests/General.Server.Tests.fs
@@ -305,7 +305,6 @@ type General() =
 
             let! response = client.GetAsync("/metrics")
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
-            Assert.That(response.Content.Headers.ContentLength.GetValueOrDefault(), Is.EqualTo(0L))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/General.Server.Tests.fs
+++ b/src/Grace.Server.Tests/General.Server.Tests.fs
@@ -277,9 +277,23 @@ type General() =
     [<Test>]
     member public _.RootPathReturnsValue() =
         task {
-            let! response = Services.Client.GetAsync("/")
+            let correlationId = generateCorrelationId ()
+            use request = new HttpRequestMessage(HttpMethod.Get, "/")
+            request.Headers.Add(Constants.CorrelationIdHeaderKey, correlationId)
+
+            let! response = Services.Client.SendAsync(request)
             let! content = response.Content.ReadAsStringAsync()
             Console.WriteLine($"{content}")
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/html"))
+            Assert.That(response.Headers.Contains(Constants.CorrelationIdHeaderKey), Is.True)
+
+            Assert.That(
+                response.Headers.GetValues(Constants.CorrelationIdHeaderKey)
+                |> Seq.head,
+                Is.EqualTo(correlationId)
+            )
+
             Assert.That(content, Does.Contain("Grace"))
         }
 
@@ -291,4 +305,25 @@ type General() =
 
             let! response = client.GetAsync("/metrics")
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
+            Assert.That(response.Content.Headers.ContentLength.GetValueOrDefault(), Is.EqualTo(0L))
+        }
+
+    [<Test>]
+    member public _.MetricsRequiresSystemAdminAndReturnsPrometheusText() =
+        task {
+            use nonAdminClient = new HttpClient()
+            nonAdminClient.BaseAddress <- Services.Client.BaseAddress
+            nonAdminClient.DefaultRequestHeaders.Add("x-grace-user-id", $"{Guid.NewGuid()}")
+
+            let! denied = nonAdminClient.GetAsync("/metrics")
+            Assert.That(denied.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+            let! deniedBody = denied.Content.ReadAsStringAsync()
+            Assert.That(deniedBody, Does.Contain("SystemAdmin"))
+
+            let! response = Services.Client.GetAsync("/metrics")
+            let! content = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/plain"))
+            Assert.That(content, Does.Contain("# HELP"))
+            Assert.That(content, Does.Contain("# TYPE"))
         }

--- a/src/Grace.Server.Tests/Owner.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Owner.Server.Tests.fs
@@ -16,6 +16,7 @@ open System.IO
 open System.Text
 open System.Diagnostics
 open Grace.Types.Common
+open Grace.Types
 open System.Net.Http
 
 [<Parallelizable(ParallelScope.All)>]
@@ -26,21 +27,57 @@ type Owner() =
             .Create(fun builder -> builder.AddConsole().AddDebug() |> ignore)
             .CreateLogger("Owner.Server.Tests")
 
+    let createOwnerAsync () =
+        task {
+            let createdOwnerId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Owner.CreateOwnerParameters()
+            parameters.OwnerId <- createdOwnerId
+            parameters.OwnerName <- $"AssertionOwner{Guid.NewGuid():N}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/owner/create", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            return createdOwnerId
+        }
+
+    let getOwnerAsync ownerId =
+        task {
+            let parameters = Parameters.Owner.GetOwnerParameters()
+            parameters.OwnerId <- ownerId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/owner/get", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/json"))
+
+            let returnValue = deserialize<GraceReturnValue<Owner.OwnerDto>> responseText
+            return returnValue.ReturnValue
+        }
+
     member val public TestContext = TestContext.CurrentContext with get, set
 
     [<Test>]
     [<Repeat(1)>]
     member public this.SetDescriptionWithValidValues() =
         task {
+            let! createdOwnerId = createOwnerAsync ()
             let parameters = Parameters.Owner.SetOwnerDescriptionParameters()
+            let expectedDescription = $"Description set at {getCurrentInstantGeneral ()}."
 
-            parameters.Description <- $"Description set at {getCurrentInstantGeneral ()}."
-            parameters.OwnerId <- ownerId
+            parameters.Description <- expectedDescription
+            parameters.OwnerId <- createdOwnerId
+            parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/owner/setDescription", createJsonContent parameters)
-            let! content = response.Content.ReadAsStringAsync()
             response.EnsureSuccessStatusCode() |> ignore
-            Assert.That(content.Length, Is.GreaterThan(0))
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+            Assert.That(returnValue.CorrelationId, Is.Not.Empty)
+
+            let! stored = getOwnerAsync createdOwnerId
+            Assert.That(stored.OwnerId, Is.EqualTo(Guid.Parse(createdOwnerId)))
+            Assert.That(stored.Description, Is.EqualTo(expectedDescription))
         }
 
     [<Test>]
@@ -101,13 +138,29 @@ type Owner() =
     [<Repeat(1)>]
     member public this.SetDescriptionWithInvalidDescription() =
         task {
+            let! createdOwnerId = createOwnerAsync ()
+            let baseline = "Owner description should survive invalid update."
+
+            let validParameters = Parameters.Owner.SetOwnerDescriptionParameters()
+            validParameters.Description <- baseline
+            validParameters.OwnerId <- createdOwnerId
+            validParameters.CorrelationId <- generateCorrelationId ()
+
+            let! validResponse = Client.PostAsync("/owner/setDescription", createJsonContent validParameters)
+            validResponse.EnsureSuccessStatusCode() |> ignore
+
             let parameters = Parameters.Owner.SetOwnerDescriptionParameters()
             parameters.Description <- "a".PadRight(2049, 'a')
-            parameters.OwnerId <- ownerId
+            parameters.OwnerId <- createdOwnerId
+            parameters.CorrelationId <- generateCorrelationId ()
             let! response = Client.PostAsync("/owner/setDescription", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
             let! error = deserializeContent<GraceError> response
             Assert.That(error.Error, Is.EqualTo(getErrorMessage OwnerError.DescriptionIsTooLong))
+            Assert.That(error.CorrelationId, Is.Not.Empty)
+
+            let! stored = getOwnerAsync createdOwnerId
+            Assert.That(stored.Description, Is.EqualTo(baseline))
         }
 
     [<Test>]
@@ -159,14 +212,19 @@ type Owner() =
     [<Repeat(1)>]
     member public this.SetSearchVisibilityToVisible() =
         task {
+            let! createdOwnerId = createOwnerAsync ()
             let parameters = Parameters.Owner.SetOwnerSearchVisibilityParameters()
             parameters.SearchVisibility <- "Visible"
-            parameters.OwnerId <- ownerId
+            parameters.OwnerId <- createdOwnerId
+            parameters.CorrelationId <- generateCorrelationId ()
             let! response = Client.PostAsync("/owner/setSearchVisibility", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<string>> response
             let ownerGuid = Common.requireGuidProperty (nameof OwnerId) returnValue.Properties[nameof OwnerId]
-            Assert.That(ownerGuid, Is.EqualTo(Guid.Parse(ownerId)))
+            Assert.That(ownerGuid, Is.EqualTo(Guid.Parse(createdOwnerId)))
+
+            let! stored = getOwnerAsync createdOwnerId
+            Assert.That(stored.SearchVisibility, Is.EqualTo(SearchVisibility.Visible))
         }
 
     [<Test>]
@@ -240,14 +298,19 @@ type Owner() =
     [<Repeat(1)>]
     member public this.SetNameToValidName() =
         task {
+            let! createdOwnerId = createOwnerAsync ()
             let parameters = Parameters.Owner.SetOwnerNameParameters()
             parameters.NewName <- $"NewOwnerName{rnd.NextInt64()}"
-            parameters.OwnerId <- ownerId
+            parameters.OwnerId <- createdOwnerId
+            parameters.CorrelationId <- generateCorrelationId ()
             let! response = Client.PostAsync("/owner/setName", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<string>> response
             let ownerGuid = Common.requireGuidProperty (nameof OwnerId) returnValue.Properties[nameof OwnerId]
-            Assert.That(ownerGuid, Is.EqualTo(Guid.Parse(ownerId)))
+            Assert.That(ownerGuid, Is.EqualTo(Guid.Parse(createdOwnerId)))
+
+            let! stored = getOwnerAsync createdOwnerId
+            Assert.That(stored.OwnerName, Is.EqualTo(parameters.NewName))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Repository.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Repository.Server.Tests.fs
@@ -16,6 +16,7 @@ open System.IO
 open System.Text
 open System.Diagnostics
 open Grace.Types.Common
+open Grace.Types
 open System.Net.Http
 open Grace.Shared.Validation
 
@@ -44,25 +45,65 @@ type Repository() =
             response.EnsureSuccessStatusCode() |> ignore
         }
 
+    let createRepositoryAsync () =
+        task {
+            let repositoryId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Repository.CreateRepositoryParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.RepositoryName <- $"AssertionRepository{Guid.NewGuid():N}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/repository/create", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            return repositoryId
+        }
+
+    let getRepositoryAsync repositoryId =
+        task {
+            let parameters = Parameters.Repository.GetRepositoryParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/repository/get", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/json"))
+
+            let returnValue = deserialize<GraceReturnValue<Repository.RepositoryDto>> responseText
+            return returnValue.ReturnValue
+        }
+
     member val public TestContext = TestContext.CurrentContext with get, set
 
     [<Test>]
     [<Repeat(1)>]
     member public this.SetDescriptionWithValidValues() =
         task {
+            let! repositoryId = createRepositoryAsync ()
             let parameters = Parameters.Repository.SetRepositoryDescriptionParameters()
+            let expectedDescription = $"Description set at {getCurrentInstantGeneral ()}."
 
-            parameters.Description <- $"Description set at {getCurrentInstantGeneral ()}."
+            parameters.Description <- expectedDescription
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryIds[(rnd.Next(0, numberOfRepositories))]
+            parameters.RepositoryId <- repositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
 
             do! grantRepoAdminAsync parameters.RepositoryId
 
             let! response = Client.PostAsync("/repository/setDescription", createJsonContent parameters)
-            let! content = response.Content.ReadAsStringAsync()
             response.EnsureSuccessStatusCode() |> ignore
-            Assert.That(content.Length, Is.GreaterThan(0))
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+            Assert.That(returnValue.CorrelationId, Is.Not.Empty)
+
+            let! stored = getRepositoryAsync repositoryId
+            Assert.That(stored.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+            Assert.That(stored.Description, Is.EqualTo(expectedDescription))
         }
 
     [<Test>]
@@ -85,35 +126,56 @@ type Repository() =
     [<Repeat(1)>]
     member public this.SetDescriptionWithEmptyDescription() =
         task {
+            let! repositoryId = createRepositoryAsync ()
+            let baseline = "Repository description should survive invalid update."
+
+            let validParameters = Parameters.Repository.SetRepositoryDescriptionParameters()
+            validParameters.OwnerId <- ownerId
+            validParameters.OrganizationId <- organizationId
+            validParameters.RepositoryId <- repositoryId
+            validParameters.Description <- baseline
+            validParameters.CorrelationId <- generateCorrelationId ()
+
+            do! grantRepoAdminAsync repositoryId
+
+            let! validResponse = Client.PostAsync("/repository/setDescription", createJsonContent validParameters)
+            validResponse.EnsureSuccessStatusCode() |> ignore
+
             let parameters = Parameters.Repository.SetRepositoryDescriptionParameters()
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryIds[(rnd.Next(0, numberOfRepositories))]
+            parameters.RepositoryId <- repositoryId
             parameters.Description <- String.Empty
-
-            do! grantRepoAdminAsync parameters.RepositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/repository/setDescription", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
             let! responseStream = response.Content.ReadAsStreamAsync()
             let! error = deserializeAsync<GraceError> responseStream
             Assert.That(error.Error, Is.EqualTo(getErrorMessage RepositoryError.DescriptionIsRequired))
+            Assert.That(error.CorrelationId, Is.Not.Empty)
+
+            let! stored = getRepositoryAsync repositoryId
+            Assert.That(stored.Description, Is.EqualTo(baseline))
         }
 
     [<Test>]
     [<Repeat(1)>]
     member public this.SetSaveDaysWithValidValues() =
         task {
+            let! repositoryId = createRepositoryAsync ()
             let parameters = Parameters.Repository.SetSaveDaysParameters()
             parameters.SaveDays <- 17.5f
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryIds[(rnd.Next(0, numberOfRepositories))]
+            parameters.RepositoryId <- repositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/repository/setSaveDays", createJsonContent parameters)
-            let! content = response.Content.ReadAsStringAsync()
             response.EnsureSuccessStatusCode() |> ignore
-            Assert.That(content.Length, Is.GreaterThan(0))
+
+            let! stored = getRepositoryAsync repositoryId
+            Assert.That(stored.SaveDays, Is.EqualTo(parameters.SaveDays))
         }
 
     [<Test>]
@@ -137,16 +199,19 @@ type Repository() =
     [<Repeat(1)>]
     member public this.SetCheckpointDaysWithValidValues() =
         task {
+            let! repositoryId = createRepositoryAsync ()
             let parameters = Parameters.Repository.SetCheckpointDaysParameters()
             parameters.CheckpointDays <- 17.5f
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryIds[(rnd.Next(0, numberOfRepositories))]
+            parameters.RepositoryId <- repositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/repository/setCheckpointDays", createJsonContent parameters)
-            let! content = response.Content.ReadAsStringAsync()
             response.EnsureSuccessStatusCode() |> ignore
-            Assert.That(content.Length, Is.GreaterThan(0))
+
+            let! stored = getRepositoryAsync repositoryId
+            Assert.That(stored.CheckpointDays, Is.EqualTo(parameters.CheckpointDays))
         }
 
     [<Test>]
@@ -250,18 +315,22 @@ type Repository() =
     [<Repeat(1)>]
     member public this.SetVisibilityWithValidValues() =
         task {
+            let! repositoryId = createRepositoryAsync ()
             let parameters = Parameters.Repository.SetRepositoryVisibilityParameters()
 
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
-            parameters.RepositoryId <- repositoryIds[(rnd.Next(0, numberOfRepositories))]
+            parameters.RepositoryId <- repositoryId
             parameters.Visibility <- "Public"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            do! grantRepoAdminAsync repositoryId
 
             let! response = Client.PostAsync("/repository/setVisibility", createJsonContent parameters)
-            let! content = response.Content.ReadAsStringAsync()
-            //Console.WriteLine($"{content}");
             response.EnsureSuccessStatusCode() |> ignore
-            Assert.That(content.Length, Is.GreaterThan(0))
+
+            let! stored = getRepositoryAsync repositoryId
+            Assert.That(stored.RepositoryType, Is.EqualTo(RepositoryType.Public))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Smoke.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Smoke.Server.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open NUnit.Framework
+open System.Net
 
 [<TestFixture>]
 [<NonParallelizable>]
@@ -10,6 +11,7 @@ type Smoke() =
         task {
             let! response = Services.Client.GetAsync("/healthz")
             let! body = response.Content.ReadAsStringAsync()
-            Assert.That(response.IsSuccessStatusCode, Is.True, "Expected /healthz to return success.")
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), "Expected /healthz to return success.")
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/html"))
             Assert.That(body, Does.Contain("healthy").IgnoreCase, "Expected /healthz body to indicate health.")
         }

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -116,6 +116,16 @@ module private WebhookTestHelpers =
             return! deserializeContent<WebhookRule> createResponse
         }
 
+    let assertRuleMatchesScope (repositoryId: string) (branchId: string) (rule: WebhookRule) =
+        Assert.That(rule.Class, Is.EqualTo(nameof WebhookRule))
+        Assert.That(rule.Scope.OwnerId, Is.EqualTo(Guid.Parse(ownerId)))
+        Assert.That(rule.Scope.OrganizationId, Is.EqualTo(Guid.Parse(organizationId)))
+        Assert.That(rule.Scope.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+        Assert.That(rule.Scope.TargetBranchId, Is.EqualTo(Some(Guid.Parse(branchId))))
+        Assert.That(rule.EventName, Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName))
+        Assert.That(rule.EventVersion, Is.EqualTo(1))
+        Assert.That(rule.SigningSecretVersion, Is.EqualTo("test-secret-v1"))
+
 [<NonParallelizable>]
 type WebhookApiIntegrationTests() =
 
@@ -138,6 +148,8 @@ type WebhookApiIntegrationTests() =
             Assert.That(created.Status, Is.EqualTo(WebhookRuleStatus.Disabled))
             Assert.That(created.Url.Url, Is.EqualTo("https://example.com/grace-webhook"))
             Assert.That(created.Url.Safety, Is.EqualTo(OutboundUrlSafety.PublicHttps))
+            Assert.That(created.CreatedBy, Is.EqualTo(adminUser))
+            WebhookTestHelpers.assertRuleMatchesScope repositoryId branchId created
 
             let showParameters =
                 WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.ShowWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
@@ -147,6 +159,29 @@ type WebhookApiIntegrationTests() =
 
             let! enableResponse = adminClient.PostAsync("/webhook/rule/enable", createJsonContent enableParameters)
             Assert.That(enableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! enabled = deserializeContent<WebhookRule> enableResponse
+            Assert.That(enabled.Status, Is.EqualTo(WebhookRuleStatus.Enabled))
+            WebhookTestHelpers.assertRuleMatchesScope repositoryId branchId enabled
+
+            let! showEnabledResponse = adminClient.PostAsync("/webhook/rule/show", createJsonContent showParameters)
+            Assert.That(showEnabledResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! shownEnabled = deserializeContent<WebhookRule> showEnabledResponse
+            Assert.That(shownEnabled.WebhookRuleId, Is.EqualTo(created.WebhookRuleId))
+            Assert.That(shownEnabled.Status, Is.EqualTo(WebhookRuleStatus.Enabled))
+            WebhookTestHelpers.assertRuleMatchesScope repositoryId branchId shownEnabled
+
+            let! listRulesResponse =
+                adminClient.PostAsync("/webhook/rule/list", createJsonContent (WebhookTestHelpers.listRuleParameters repositoryId branchId))
+
+            Assert.That(listRulesResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! listedRules = deserializeContent<WebhookRule array> listRulesResponse
+
+            let listedRule =
+                listedRules
+                |> Array.find (fun rule -> rule.WebhookRuleId = created.WebhookRuleId)
+
+            Assert.That(listedRule.Status, Is.EqualTo(WebhookRuleStatus.Enabled))
+            WebhookTestHelpers.assertRuleMatchesScope repositoryId branchId listedRule
 
             let testParameters =
                 WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.TestWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
@@ -159,6 +194,9 @@ type WebhookApiIntegrationTests() =
             Assert.That(testDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.Pending))
             Assert.That(testDelivery.WebhookRuleId, Is.EqualTo(created.WebhookRuleId))
             Assert.That(testDelivery.DedupeKey, Is.EqualTo("test-dedupe-key"))
+            Assert.That(testDelivery.EventName, Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName))
+            Assert.That(testDelivery.EventVersion, Is.EqualTo(1))
+            Assert.That(testDelivery.AttemptCount, Is.EqualTo(0))
 
             let! listResponse =
                 adminClient.PostAsync(
@@ -182,6 +220,10 @@ type WebhookApiIntegrationTests() =
                 )
 
             Assert.That(showDeliveryResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! shownDelivery = deserializeContent<WebhookDelivery> showDeliveryResponse
+            Assert.That(shownDelivery.WebhookDeliveryId, Is.EqualTo(testDelivery.WebhookDeliveryId))
+            Assert.That(shownDelivery.WebhookRuleId, Is.EqualTo(created.WebhookRuleId))
+            Assert.That(shownDelivery.DedupeKey, Is.EqualTo(testDelivery.DedupeKey))
 
             let disableParameters =
                 WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.DisableWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
@@ -191,12 +233,19 @@ type WebhookApiIntegrationTests() =
 
             let! showResponse = adminClient.PostAsync("/webhook/rule/show", createJsonContent showParameters)
             Assert.That(showResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! shownBeforeDisable = deserializeContent<WebhookRule> showResponse
+            Assert.That(shownBeforeDisable.Status, Is.EqualTo(WebhookRuleStatus.Enabled))
 
             let! disableResponse = adminClient.PostAsync("/webhook/rule/disable", createJsonContent disableParameters)
             Assert.That(disableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! disabled = deserializeContent<WebhookRule> disableResponse
+            Assert.That(disabled.Status, Is.EqualTo(WebhookRuleStatus.Disabled))
+            Assert.That(disabled.UpdatedAt.IsSome, Is.True)
 
             let! deleteResponse = adminClient.PostAsync("/webhook/rule/delete", createJsonContent deleteParameters)
             Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! deleted = deserializeContent<WebhookRule> deleteResponse
+            Assert.That(deleted.Status, Is.EqualTo(WebhookRuleStatus.Deleted))
         }
 
     [<Test>]


### PR DESCRIPTION
## Summary

- Strengthens existing hosted server tests from status/smoke checks into state, DTO, auth, correlation, and operational contract assertions.
- Adds get-after-set and no-mutate checks for owner/repository updates.
- Deepens approval, webhook, access, auth/login, metrics, root, health, and correlation proof without changing public behavior.

## Issue

Closes #254.
Part of #249.

## Research Trace

- `B-001`, `B-002`: owner and repository get-after-set assertions plus invalid-value no-mutate checks.
- `B-022`, `B-025`: approval policy lifecycle assertions for class, scope, subject, responder, creator, version, status, list inclusion, and evaluate snapshot fields.
- `B-034`: webhook lifecycle and delivery assertions for rule state, signing secret version, delivery identity, dedupe key, attempt count, disabled state, and deletion.
- `B-045`: access grant/list/checkPermission/revoke/list/checkPermission stored-state proof.
- `B-049`: auth/login disabled/unavailable response contract assertions.
- `B-050`: operational metrics/root/health/correlation proof with durable markers only.
- `B-058`: representative correlation and response contract assertions.

## Validation

- `dotnet fantomas --check src/Grace.Server.Tests/Owner.Server.Tests.fs src/Grace.Server.Tests/Repository.Server.Tests.fs src/Grace.Server.Tests/Approval.Server.Tests.fs src/Grace.Server.Tests/Webhook.Server.Tests.fs src/Grace.Server.Tests/Access.Server.Tests.fs src/Grace.Server.Tests/Auth.Server.Tests.fs src/Grace.Server.Tests/Smoke.Server.Tests.fs src/Grace.Server.Tests/General.Server.Tests.fs`: passed before PR.
- `dotnet tool run fantomas --check 'src/Grace.Server.Tests/General.Server.Tests.fs'`: passed after review fix.
- `dotnet test 'src/Grace.Server.Tests/Grace.Server.Tests.fsproj' --configuration Release --filter 'FullyQualifiedName~MetricsRequiresAuthentication'`: passed after review fix.
- `pwsh ./scripts/validate.ps1 -Full`: passed before PR and after review fix; after fix Types 65, Authorization 36, Server.Unit 438, CLI 272 passed / 1 skipped, Server.Tests 141.
- `git diff --check`: passed before PR, after review fix, and during final review.

## Freshness

- `git fetch origin` and `git rev-list --left-right --count HEAD...origin/main`: branch was fresh before final validation (`0 0`).
- After review fix, branch was still not behind `origin/main`; `HEAD...origin/main = 2 0`.

## Review Status

- Implementation worker: Galileo, GPT-5.5 Medium.
- Local review-only sibling: Gibbs, GPT-5.5 High, found one misleading metrics content-length assertion.
- Review report: https://github.com/ScottArbeit/Grace/pull/272#issuecomment-4628265430.
- Fix worker: Ampere, GPT-5.5 Medium, fixed in `e55187f`.
- Review/fix note: https://github.com/ScottArbeit/Grace/pull/272#issuecomment-4628350250.
- Final review-only sibling: Einstein, GPT-5.5 High, completed with no issues.
- Open findings: none.
- Final no-issues review: documented in https://github.com/ScottArbeit/Grace/pull/272#issuecomment-4628388298.

## Docs Impact

No docs update. This is assertion-depth work in existing hosted tests only; no public behavior, command, API, or workflow documentation changed.

## Residual Risk

The strengthened tests add more hosted assertions and may expose future intentional response-contract changes sooner. Assertions avoid unstable Prometheus metric names, generated IDs, and exact timestamps.