### PR TITLE
Add CLI introspection option flow

### DIFF
--- a/src/Grace.CLI.Tests/Program.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Parsing.Tests.fs
@@ -32,6 +32,16 @@ module CommandTokenParsingTests =
         |> should equal (Some "connect")
 
     [<Test>]
+    let ``top level command skips schema option`` () =
+        GraceCommand.tryGetTopLevelCommandFromArgs [| "--schema"; "repository"; "init" |] true
+        |> should equal (Some "repository")
+
+    [<Test>]
+    let ``top level command skips examples option`` () =
+        GraceCommand.tryGetTopLevelCommandFromArgs [| "--examples"; "workitem"; "show" |] true
+        |> should equal (Some "workitem")
+
+    [<Test>]
     let ``top level command honors end of options marker`` () =
         GraceCommand.tryGetTopLevelCommandFromArgs
             [|

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -80,6 +80,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text.Json
 
 [<NonParallelizable>]
 module HelpDoesNotReadConfigTests =
@@ -215,6 +216,116 @@ module HelpDoesNotReadConfigTests =
 
             output
             |> should not' (contain "00000000-0000-0000-0000-0000000000000"))
+
+    [<Test>]
+    let ``schema emits registry-derived json without requiring config`` () =
+        withTempDir (fun root ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = JsonDocument.Parse(output)
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("ContractVersion")
+                .GetString()
+            |> should equal "cli-json-v1"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "repository.init"
+
+            rootElement
+                .GetProperty("Registry")
+                .GetProperty("CurrentJsonBehavior")
+                .GetString()
+            |> should equal "PartialManualSuccess"
+
+            rootElement
+                .GetProperty("Schema")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "registry-placeholder"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``examples emit registry-derived json and ignore output mode`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "workitem"
+                                         "show"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = JsonDocument.Parse(output)
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "workitem.show"
+
+            let examples = rootElement.GetProperty("Examples")
+            examples.GetArrayLength() |> should equal 2
+
+            examples[0].GetProperty("Document").GetProperty(
+                "ReturnValue"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Object)
+
+    [<Test>]
+    let ``unsupported introspection emits json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output = runWithCapturedOutput [| "--schema" |]
+
+            exitCode |> should equal -1
+
+            use document = JsonDocument.Parse(output)
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "does not have CLI output contract metadata"
+
+            rootElement
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should not' (equal String.Empty))
+
+    [<Test>]
+    let ``schema and examples together emit json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema"
+                                         "--examples" |]
+
+            exitCode |> should equal -1
+
+            use document = JsonDocument.Parse(output)
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should equal "--schema and --examples cannot be used together.")
 
     [<Test>]
     let ``verbose parse result shows resolved ids`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -102,6 +102,14 @@ module HelpDoesNotReadConfigTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
     let private captureOutput (action: unit -> unit) =
         use writer = new StringWriter()
         let originalOut = Console.Out
@@ -271,7 +279,7 @@ module HelpDoesNotReadConfigTests =
 
             exitCode |> should equal 0
 
-            use document = JsonDocument.Parse(output)
+            use document = parseJsonOutput output
             let rootElement = document.RootElement
 
             rootElement.GetProperty("Kind").GetString()
@@ -293,17 +301,40 @@ module HelpDoesNotReadConfigTests =
             |> should equal JsonValueKind.Object)
 
     [<Test>]
-    let ``unsupported introspection emits json error envelope`` () =
+    let ``nested command schema resolves full command id`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "attach"
+                                         "summary"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "workitem.attach.summary")
+
+    [<Test>]
+    let ``root schema emits json parse error envelope`` () =
         withTempDir (fun _ ->
             let exitCode, output = runWithCapturedOutput [| "--schema" |]
 
             exitCode |> should equal -1
 
-            use document = JsonDocument.Parse(output)
+            use document = parseJsonOutput output
             let rootElement = document.RootElement
 
             rootElement.GetProperty("Error").GetString()
-            |> should contain "does not have CLI output contract metadata"
+            |> should equal "Required command was not provided."
 
             rootElement
                 .GetProperty("CorrelationId")
@@ -321,11 +352,46 @@ module HelpDoesNotReadConfigTests =
 
             exitCode |> should equal -1
 
-            use document = JsonDocument.Parse(output)
+            use document = parseJsonOutput output
             let rootElement = document.RootElement
 
             rootElement.GetProperty("Error").GetString()
             |> should equal "--schema and --examples cannot be used together.")
+
+    [<Test>]
+    let ``schema with unknown option emits json parse error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema"
+                                         "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``schema with invalid output emits json parse error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Bogus"
+                                         "repository"
+                                         "init"
+                                         "--schema" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Bogus")
 
     [<Test>]
     let ``verbose parse result shows resolved ids`` () =

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -86,6 +86,26 @@ module Common =
             ))
                 .AcceptOnlyFromAmong(listCases<OutputFormat> ())
 
+        let schema =
+            new Option<bool>(
+                OptionName.Schema,
+                Required = false,
+                Description = "Emit the machine-readable JSON contract schema for the selected command.",
+                Arity = ArgumentArity.Zero,
+                Recursive = true,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let examples =
+            new Option<bool>(
+                OptionName.Examples,
+                Required = false,
+                Description = "Emit representative machine-readable JSON examples for the selected command.",
+                Arity = ArgumentArity.Zero,
+                Recursive = true,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
     /// Gets the correlationId value from the command's ParseResult.
     let getCorrelationId (parseResult: ParseResult) = Services.resolveCorrelationId parseResult
 

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -76,6 +76,168 @@ module CommandOutputContract =
             Features: MachineReadableFeatures
         }
 
+    type IntrospectionKind =
+        | Schema
+        | Examples
+
+    type CommandIdentityDocument = { Id: string; Path: string list; GroupPath: string list; Name: string }
+
+    type CommandRegistryDocument =
+        {
+            RouteDisposition: string
+            CurrentJsonBehavior: string
+            Category: string
+            ExecutionScope: string
+            Mutating: bool
+            EnvelopeContract: string
+            JsonMode: string
+            Schema: string
+            Examples: string
+            Select: string
+        }
+
+    type CommandSchemaDocument = { Status: string; Source: string; Envelope: string; ReturnValueDisposition: string; Notes: string list }
+
+    type CommandExampleDocument = { Name: string; Description: string; Document: obj }
+
+    type CommandIntrospectionDocument =
+        {
+            Kind: string
+            ContractVersion: string
+            Command: CommandIdentityDocument
+            Registry: CommandRegistryDocument
+            Schema: CommandSchemaDocument option
+            Examples: CommandExampleDocument list
+        }
+
+    let private unionName value = $"{value}"
+
+    let private routeDispositionText (disposition: RouteDisposition) =
+        match disposition with
+        | Routed -> "Routed"
+        | SourceOnlyUnrouted reason -> $"SourceOnlyUnrouted: {reason}"
+
+    let private outputDtoDispositionText (disposition: OutputDtoDisposition) =
+        match disposition with
+        | ReuseExistingApiOrSdkDto -> "ReuseExistingApiOrSdkDto"
+        | RequiresCliDto -> "RequiresCliDto"
+        | NoServerDto -> "NoServerDto"
+
+    let private envelopeContractText (contract: EnvelopeContract) =
+        match contract with
+        | ExistingGraceResultEnvelope disposition -> $"ExistingGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | MigrationRequiredToGraceResultEnvelope disposition -> $"MigrationRequiredToGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | SourceOnlyUnsupported reason -> $"SourceOnlyUnsupported: {reason}"
+
+    let private returnValueDispositionText (contract: EnvelopeContract) =
+        match contract with
+        | ExistingGraceResultEnvelope disposition
+        | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
+        | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
+
+    let private commandDocument (identity: CommandIdentity) =
+        { Id = identity.CommandId; Path = identity.CommandPath; GroupPath = identity.GroupPath; Name = identity.CommandName }
+
+    let private registryDocument (entry: CommandContractEntry) =
+        {
+            RouteDisposition = routeDispositionText entry.RouteDisposition
+            CurrentJsonBehavior = unionName entry.CurrentJsonBehavior
+            Category = unionName entry.Category
+            ExecutionScope = unionName entry.ExecutionScope
+            Mutating = entry.Mutating
+            EnvelopeContract = envelopeContractText entry.EnvelopeContract
+            JsonMode = unionName entry.Features.JsonMode
+            Schema = unionName entry.Features.Schema
+            Examples = unionName entry.Features.Examples
+            Select = unionName entry.Features.Select
+        }
+
+    let private schemaDocument (entry: CommandContractEntry) =
+        {
+            Status = "registry-placeholder"
+            Source = "CommandOutputContract"
+            Envelope = "GraceReturnValue<T> on success; GraceError on error"
+            ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
+            Notes =
+                [
+                    "S2 emits registry-derived introspection metadata only."
+                    "S4 will replace this placeholder with command DTO-derived schema details."
+                    "This path is inert and does not execute the command action."
+                ]
+        }
+
+    let private successExample (entry: CommandContractEntry) =
+        let returnValue =
+            match entry.EnvelopeContract with
+            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto" |}
+            | ExistingGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto" |}
+            | MigrationRequiredToGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto-requires-migration" |}
+            | MigrationRequiredToGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto-requires-migration" |}
+            | ExistingGraceResultEnvelope NoServerDto
+            | MigrationRequiredToGraceResultEnvelope NoServerDto -> box {| Shape = "no-server-dto" |}
+            | SourceOnlyUnsupported reason -> box {| Unsupported = reason |}
+
+        {
+            Name = "success-envelope-shape"
+            Description = "Representative GraceReturnValue<T> envelope shape; command-specific ReturnValue details are deferred to S4."
+            Document =
+                box
+                    {|
+                        ReturnValue = returnValue
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties =
+                            [|
+                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
+                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
+                            |]
+                    |}
+        }
+
+    let private errorExample (entry: CommandContractEntry) =
+        {
+            Name = "error-envelope-shape"
+            Description = "Representative GraceError envelope shape."
+            Document =
+                box
+                    {|
+                        Exception = null
+                        Error = "error message"
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties =
+                            [|
+                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
+                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
+                            |]
+                    |}
+        }
+
+    let introspectionDocument (kind: IntrospectionKind) (entry: CommandContractEntry) =
+        {
+            Kind =
+                match kind with
+                | Schema -> "schema"
+                | Examples -> "examples"
+            ContractVersion = "cli-json-v1"
+            Command = commandDocument entry.Identity
+            Registry = registryDocument entry
+            Schema =
+                match kind with
+                | Schema -> Some(schemaDocument entry)
+                | Examples -> None
+            Examples =
+                match kind with
+                | Schema -> []
+                | Examples ->
+                    [
+                        successExample entry
+                        errorExample entry
+                    ]
+        }
+
     let private featuresFor behavior =
         match behavior with
         | UnroutedSourceOnly ->

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -44,6 +44,8 @@ module Configuration =
 
 module GraceCommand =
 
+    exception private IntrospectionExit of int
+
     type OptionToUpdate = { optionAlias: string; display: string; displayOnCreate: string; createParentCommand: string }
 
     /// Built-in aliases for Grace commands.
@@ -137,6 +139,53 @@ module GraceCommand =
             gatherAllOptions parentCommand allOptions
         else
             allOptions
+
+    let private commandIdentityFromCommand (command: Command) =
+        let parents =
+            command.Parents.OfType<Command>()
+            |> Seq.toList
+            |> List.rev
+            |> List.filter (fun parent -> not (parent :? RootCommand))
+            |> List.map (fun parent -> parent.Name)
+
+        CommandOutputContract.commandIdentity parents command.Name
+
+    let private tryGetBoolOption (parseResult: ParseResult) (optionName: string) =
+        let result = parseResult.GetResult(optionName)
+
+        if isNull result then false else parseResult.GetValue<bool>(optionName)
+
+    let private introspectionRequest (parseResult: ParseResult) =
+        let schema = tryGetBoolOption parseResult OptionName.Schema
+        let examples = tryGetBoolOption parseResult OptionName.Examples
+
+        match schema, examples with
+        | false, false -> None
+        | true, false -> Some(Ok CommandOutputContract.IntrospectionKind.Schema)
+        | false, true -> Some(Ok CommandOutputContract.IntrospectionKind.Examples)
+        | true, true -> Some(Error "--schema and --examples cannot be used together.")
+
+    let private writeJsonStdout value = Console.Out.WriteLine(serialize value)
+
+    let private writeIntrospectionError parseResult message =
+        let error = GraceError.Create message (getCorrelationId parseResult)
+        writeJsonStdout error
+        -1
+
+    let private handleIntrospectionRequest (parseResult: ParseResult) kind =
+        let command = parseResult.CommandResult.Command
+        let identity = commandIdentityFromCommand command
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            match entry.RouteDisposition with
+            | CommandOutputContract.Routed ->
+                let document = CommandOutputContract.introspectionDocument kind entry
+                writeJsonStdout document
+                0
+            | CommandOutputContract.SourceOnlyUnrouted reason ->
+                writeIntrospectionError parseResult $"Command '{identity.CommandId}' is not routed for CLI introspection. {reason}"
+        | None -> writeIntrospectionError parseResult $"Command '{identity.CommandId}' does not have CLI output contract metadata."
 
     let private replaceDefaultValue (line: string) (defaultValueText: string) =
         let startIndex = line.IndexOf("[default:", StringComparison.OrdinalIgnoreCase)
@@ -566,6 +615,8 @@ module GraceCommand =
         rootCommand.Options.Add(Options.correlationId)
         rootCommand.Options.Add(Options.source)
         rootCommand.Options.Add(Options.output)
+        rootCommand.Options.Add(Options.schema)
+        rootCommand.Options.Add(Options.examples)
 
         // Add subcommands.
         rootCommand.Subcommands.Add(Connect.Build)
@@ -769,6 +820,7 @@ module GraceCommand =
             let mutable parseResult: ParseResult = null
             let mutable returnValue: int = 0
             let mutable parseSucceeded: bool = false
+            let mutable isIntrospection: bool = false
 
             try
                 try
@@ -781,6 +833,17 @@ module GraceCommand =
                     // Write the ParseResult to Services as global context for the CLI.
                     Services.parseResult <- parseResult
                     LocalStateDb.setVerbose (parseResult |> verbose)
+
+                    match introspectionRequest parseResult with
+                    | Some (Ok kind) ->
+                        isIntrospection <- true
+                        returnValue <- handleIntrospectionRequest parseResult kind
+                        raise (IntrospectionExit returnValue)
+                    | Some (Error message) ->
+                        isIntrospection <- true
+                        returnValue <- writeIntrospectionError parseResult message
+                        raise (IntrospectionExit returnValue)
+                    | None -> ()
 
                     let helpAction =
                         match parseResult.Action with
@@ -1054,6 +1117,7 @@ module GraceCommand =
 
                     return returnValue
                 with
+                | IntrospectionExit exitCode -> return exitCode
                 | ex ->
                     AnsiConsole.WriteException ex
                     //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
@@ -1067,17 +1131,18 @@ module GraceCommand =
                     (finishTime - startTime).TotalMilliseconds
                     |> int64
 
-                HistoryStorage.tryRecordInvocation
-                    {
-                        argvOriginal = argvOriginal
-                        argvNormalized = argvNormalized
-                        cwd = Environment.CurrentDirectory
-                        exitCode = returnValue
-                        durationMs = durationMs
-                        parseSucceeded = parseSucceeded
-                        timestampUtc = startTime
-                        source = resolveInvocationSource parseResult
-                    }
+                if not isIntrospection then
+                    HistoryStorage.tryRecordInvocation
+                        {
+                            argvOriginal = argvOriginal
+                            argvNormalized = argvNormalized
+                            cwd = Environment.CurrentDirectory
+                            exitCode = returnValue
+                            durationMs = durationMs
+                            parseSucceeded = parseSucceeded
+                            timestampUtc = startTime
+                            source = resolveInvocationSource parseResult
+                        }
 
                 // If this was grace watch, delete the inter-process communication file.
                 if not <| isNull (parseResult)

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -140,24 +140,45 @@ module GraceCommand =
         else
             allOptions
 
-    let private commandIdentityFromCommand (command: Command) =
-        let parents =
-            command.Parents.OfType<Command>()
-            |> Seq.toList
-            |> List.rev
-            |> List.filter (fun parent -> not (parent :? RootCommand))
-            |> List.map (fun parent -> parent.Name)
+    let private commandIdentityFromCommandResult (commandResult: CommandResult) =
+        let rec loop (current: SymbolResult) (names: string list) =
+            match current with
+            | :? CommandResult as currentCommand ->
+                let nextNames =
+                    if currentCommand.Command :? RootCommand then
+                        names
+                    else
+                        currentCommand.Command.Name :: names
 
-        CommandOutputContract.commandIdentity parents command.Name
+                if isNull currentCommand.Parent then
+                    nextNames
+                else
+                    loop currentCommand.Parent nextNames
+            | _ -> names
 
-    let private tryGetBoolOption (parseResult: ParseResult) (optionName: string) =
-        let result = parseResult.GetResult(optionName)
+        let path = loop commandResult []
 
-        if isNull result then false else parseResult.GetValue<bool>(optionName)
+        match path with
+        | [] -> CommandOutputContract.commandIdentity [] commandResult.Command.Name
+        | _ ->
+            let commandName = path |> List.last
+            let groupPath = path |> List.take (path.Length - 1)
+            CommandOutputContract.commandIdentity groupPath commandName
 
-    let private introspectionRequest (parseResult: ParseResult) =
-        let schema = tryGetBoolOption parseResult OptionName.Schema
-        let examples = tryGetBoolOption parseResult OptionName.Examples
+    let private introspectionRequestFromTokens (args: string array) =
+        let tokens =
+            if isNull args then
+                Array.empty
+            else
+                args
+                |> Array.takeWhile (fun token -> not (token.Equals("--", StringComparison.Ordinal)))
+
+        let containsOption optionName =
+            tokens
+            |> Array.exists (fun token -> token.Equals(optionName, StringComparison.OrdinalIgnoreCase))
+
+        let schema = containsOption OptionName.Schema
+        let examples = containsOption OptionName.Examples
 
         match schema, examples with
         | false, false -> None
@@ -172,9 +193,24 @@ module GraceCommand =
         writeJsonStdout error
         -1
 
+    let private isIgnorableIntrospectionParseError (error: ParseError) =
+        error.Message.StartsWith("Required argument missing for command:", StringComparison.Ordinal)
+
+    let private hasBlockingIntrospectionParseErrors (parseResult: ParseResult) =
+        parseResult.Errors
+        |> Seq.exists (isIgnorableIntrospectionParseError >> not)
+
+    let private writeIntrospectionParseError (parseResult: ParseResult) =
+        let message =
+            parseResult.Errors
+            |> Seq.filter (isIgnorableIntrospectionParseError >> not)
+            |> Seq.map (fun error -> error.Message)
+            |> String.concat Environment.NewLine
+
+        writeIntrospectionError parseResult message
+
     let private handleIntrospectionRequest (parseResult: ParseResult) kind =
-        let command = parseResult.CommandResult.Command
-        let identity = commandIdentityFromCommand command
+        let identity = commandIdentityFromCommandResult parseResult.CommandResult
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -830,20 +866,28 @@ module GraceCommand =
 
                     parseResult <- rootCommand.Parse(argvToParse)
                     parseSucceeded <- parseResult.Errors.Count = 0
-                    // Write the ParseResult to Services as global context for the CLI.
-                    Services.parseResult <- parseResult
-                    LocalStateDb.setVerbose (parseResult |> verbose)
 
-                    match introspectionRequest parseResult with
+                    match introspectionRequestFromTokens argvToParse with
                     | Some (Ok kind) ->
                         isIntrospection <- true
-                        returnValue <- handleIntrospectionRequest parseResult kind
+                        Services.parseResult <- parseResult
+
+                        returnValue <-
+                            if hasBlockingIntrospectionParseErrors parseResult then
+                                writeIntrospectionParseError parseResult
+                            else
+                                handleIntrospectionRequest parseResult kind
+
                         raise (IntrospectionExit returnValue)
                     | Some (Error message) ->
                         isIntrospection <- true
+                        Services.parseResult <- parseResult
                         returnValue <- writeIntrospectionError parseResult message
                         raise (IntrospectionExit returnValue)
-                    | None -> ()
+                    | None ->
+                        // Write the ParseResult to Services as global context for the CLI.
+                        Services.parseResult <- parseResult
+                        LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
                         match parseResult.Action with

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -121,6 +121,12 @@ module Text =
         let Output = "--output"
 
         [<Literal>]
+        let Schema = "--schema"
+
+        [<Literal>]
+        let Examples = "--examples"
+
+        [<Literal>]
         let Overwrite = "--overwrite"
 
         [<Literal>]


### PR DESCRIPTION
## Summary

- Adds recursive global `--schema` and `--examples` option plumbing.
- Adds a pre-handler introspection short-circuit that resolves leaf command registry metadata without executing handlers or contacting services.
- Emits registry-derived placeholder schema/example JSON documents for S2, leaving full schema/example generation to S4.
- Adds CLI parsing and invocation tests for schema/examples, JSON error envelopes, recursive `--output Json` interaction, and side-effect-free `repository init --schema`.

## Introspection Behavior

- `grace repository init --schema` exits `0` and emits one JSON document with `Kind = "schema"`, `ContractVersion = "cli-json-v1"`, `Command.Id = "repository.init"`, registry metadata, placeholder schema status, and no examples.
- `grace --output Json workitem show --examples` exits `0` and emits one JSON document with `Kind = "examples"`, registry metadata, and representative success/error envelope example shapes.
- Unsupported metadata such as root `grace --schema` exits nonzero and emits a `GraceError` JSON envelope.
- `--schema --examples` together exits nonzero and emits a `GraceError` JSON envelope.

## Validation

- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --filter "Name~schema|Name~examples"`
- `dotnet tool run fantomas src/Grace.CLI/Text.CLI.fs src/Grace.CLI/Command/Common.CLI.fs src/Grace.CLI/CommandOutputContract.CLI.fs src/Grace.CLI/Program.CLI.fs src/Grace.CLI.Tests/Program.CLI.Parsing.Tests.fs src/Grace.CLI.Tests/Program.CLI.Tests.fs`
- `pwsh ./scripts/validate.ps1 -Fast`
- `git diff --check`

## Review Status

- Pending fresh review-only sibling subagent pass.

## Issue

Part of #274. Implements #277.



