### PR TITLE
Centralize CLI JSON stdout writer

### DIFF
--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -523,13 +523,14 @@ module HelpDoesNotReadConfigTests =
         withTempDir (fun root ->
             writeInvalidConfig root
 
-            let exitCode, standardOut, _ =
+            let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
                                                   "Json"
                                                   "access"
                                                   "list-roles" |]
 
             exitCode |> should equal -1
+            standardError |> should equal String.Empty
 
             use document = parseJsonOutput standardOut
             let rootElement = document.RootElement

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -545,6 +545,21 @@ module HelpDoesNotReadConfigTests =
             |> should contain "graceconfig.json")
 
     [<Test>]
+    let ``earlier non-json output token does not mask later json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Normal"
+                                                  "--output=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
     let ``parse error in json mode emits one error document on stdout`` () =
         withTempDir (fun _ ->
             let exitCode, standardOut, standardError =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -560,6 +560,36 @@ module HelpDoesNotReadConfigTests =
             assertJsonErrorOutput standardOut |> ignore)
 
     [<Test>]
+    let ``malformed split output option does not mask later long json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "--output"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``malformed split output option does not mask later short json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "-o"
+                                                  "-o"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
     let ``parse error in json mode emits one error document on stdout`` () =
         withTempDir (fun _ ->
             let exitCode, standardOut, standardError =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -129,6 +129,23 @@ module HelpDoesNotReadConfigTests =
 
         JsonDocument.Parse(output)
 
+    let private assertJsonErrorOutput (standardOut: string) =
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+        let error = rootElement.GetProperty("Error").GetString()
+
+        error |> should not' (equal String.Empty)
+
+        standardOut
+        |> should not' (contain "Exception in isOutputFormat")
+
+        standardOut
+        |> should not' (contain "graceconfig.json is not found")
+
+        standardOut |> should not' (contain "Elapsed:")
+
+        error
+
     let private captureStdoutAndStderr (action: unit -> unit) =
         use standardOutWriter = new StringWriter()
         use standardErrorWriter = new StringWriter()
@@ -500,6 +517,34 @@ module HelpDoesNotReadConfigTests =
             standardOut |> should not' (contain "Elapsed:"))
 
     [<Test>]
+    let ``missing config in json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "graceconfig.json")
+
+    [<Test>]
+    let ``missing config in mixed-case json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--OUTPUT=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "graceconfig.json")
+
+    [<Test>]
     let ``parse error in json mode emits one error document on stdout`` () =
         withTempDir (fun _ ->
             let exitCode, standardOut, standardError =
@@ -517,6 +562,49 @@ module HelpDoesNotReadConfigTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``parse error in json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``short equals json output spelling emits json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "-o=Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``lowercase json value is rejected with json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=json"
+                                                  "repository"
+                                                  "init" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "json")
 
     [<Test>]
     let ``catch all exception in json mode emits one error document on stdout`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,8 +74,10 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
+open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -102,6 +104,23 @@ module HelpDoesNotReadConfigTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
     let private parseJsonOutput (output: string) =
         output
             .TrimStart()
@@ -110,18 +129,26 @@ module HelpDoesNotReadConfigTests =
 
         JsonDocument.Parse(output)
 
-    let private captureOutput (action: unit -> unit) =
-        use writer = new StringWriter()
+    let private captureStdoutAndStderr (action: unit -> unit) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
         let originalOut = Console.Out
+        let originalError = Console.Error
 
         try
-            Console.SetOut(writer)
-            setAnsiConsoleOutput writer
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
             action ()
-            writer.ToString()
+            standardOutWriter.ToString(), standardErrorWriter.ToString()
         finally
             Console.SetOut(originalOut)
+            Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
+
+    let private captureOutput (action: unit -> unit) =
+        let standardOut, _ = captureStdoutAndStderr action
+        standardOut
 
 
     let private withTempDir (action: string -> unit) =
@@ -392,6 +419,146 @@ module HelpDoesNotReadConfigTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should contain "Bogus")
+
+    [<Test>]
+    let ``renderOutput json success writes one stdout document and no stderr`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--output"; "Json" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-json-success"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement
+            .GetProperty("ReturnValue")
+            .GetProperty("Value")
+            .GetString()
+        |> should equal "ok"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-json-success"
+
+        standardOut |> should not' (contain "Elapsed:")
+
+    [<Test>]
+    let ``renderOutput json error writes GraceError envelope with shared field names`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--output"; "Json" |])
+        let error = GraceError.Create "central writer error" "corr-json-error"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Error error)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should equal "central writer error"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-json-error"
+
+        let mutable camelCaseCorrelationId = Unchecked.defaultof<JsonElement>
+
+        rootElement.TryGetProperty("correlationId", &camelCaseCorrelationId)
+        |> should equal false
+
+        Constants.JsonSerializerOptions.PropertyNamingPolicy
+        |> should equal null
+
+    [<Test>]
+    let ``missing config in json mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "graceconfig.json"
+
+            standardOut |> should not' (contain "Elapsed:"))
+
+    [<Test>]
+    let ``parse error in json mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``catch all exception in json mode emits one error document on stdout`` () =
+        withTempDir (fun root ->
+            writeInvalidConfig root
+
+            let exitCode, standardOut, _ =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "access"
+                                                  "list-roles" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should not' (equal String.Empty)
+
+            rootElement
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should not' (equal String.Empty)
+
+            standardOut |> should not' (contain "Exception:"))
+
+    [<Test>]
+    let ``missing config in human mode remains human oriented`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, _ =
+                runWithCapturedStdoutAndStderr [| "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+
+            standardOut
+                .TrimStart()
+                .StartsWith("{", StringComparison.Ordinal)
+            |> should equal false
+
+            standardOut |> should contain "graceconfig.json")
 
     [<Test>]
     let ``verbose parse result shows resolved ids`` () =

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -457,6 +457,10 @@ module Common =
             )
         | _ -> box returnValue
 
+    let writeJsonStdout value = Console.Out.WriteLine(serialize value)
+
+    let writeJsonErrorStdout (error: GraceError) = writeJsonStdout error
+
     let private renderJsonReturnValue (graceReturnValue: GraceReturnValue<'T>) =
         let output =
             {|
@@ -467,6 +471,8 @@ module Common =
             |}
 
         serialize output
+
+    let writeJsonReturnValueStdout (graceReturnValue: GraceReturnValue<'T>) = Console.Out.WriteLine(renderJsonReturnValue graceReturnValue)
 
     let private tryGetProperty (properties: Dictionary<string, obj>) key =
         if isNull properties then
@@ -577,7 +583,7 @@ module Common =
             renderLifecycleWarningOnce outputFormat graceReturnValue.Properties
 
             match outputFormat with
-            | Json -> AnsiConsole.WriteLine(Markup.Escape(renderJsonReturnValue graceReturnValue))
+            | Json -> writeJsonReturnValueStdout graceReturnValue
             | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
             | Silent -> ()
             | Verbose ->
@@ -615,7 +621,7 @@ module Common =
                     Uri.UnescapeDataString(error.Error)
 
             match outputFormat with
-            | Json -> AnsiConsole.WriteLine($"{Markup.Escape(json)}")
+            | Json -> writeJsonErrorStdout error
             | Minimal -> AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(errorText)}[/]")
             | Silent -> ()
             | Verbose ->

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -235,6 +235,7 @@ module GraceCommand =
                 false
             else
                 let token = tokens[index]
+                let outputEqualsPrefix = $"{OptionName.Output}="
 
                 if
                     token.Equals(OptionName.Output, StringComparison.OrdinalIgnoreCase)
@@ -242,6 +243,14 @@ module GraceCommand =
                 then
                     index + 1 < tokens.Length
                     && tokens[index + 1]
+                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                elif token.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then
+                    token
+                        .Substring(outputEqualsPrefix.Length)
+                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                elif token.StartsWith("-o=", StringComparison.OrdinalIgnoreCase) then
+                    token
+                        .Substring("-o=".Length)
                         .Equals("Json", StringComparison.OrdinalIgnoreCase)
                 else
                     loop (index + 1)
@@ -903,7 +912,14 @@ module GraceCommand =
                     args
                     |> Array.map (fun arg ->
                         if isCaseInsensitive && arg.StartsWith("--") then
-                            arg.ToLowerInvariant()
+                            let equalsIndex = arg.IndexOf("=", StringComparison.Ordinal)
+
+                            if equalsIndex > 0 then
+                                let optionName = arg.Substring(0, equalsIndex).ToLowerInvariant()
+                                let optionValue = arg.Substring(equalsIndex)
+                                $"{optionName}{optionValue}"
+                            else
+                                arg.ToLowerInvariant()
                         else
                             arg)
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -921,20 +921,37 @@ module GraceCommand =
             else
                 let firstToken = if isCaseInsensitive then args[ 0 ].ToLowerInvariant() else args[0]
 
+                let normalizeOutputEqualsToken (arg: string) =
+                    let outputEqualsPrefix = $"{OptionName.Output}="
+
+                    if arg.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then
+                        $"{OptionName.Output}={arg.Substring(outputEqualsPrefix.Length)}"
+                    else
+                        arg
+
                 let properCasedArgs =
                     args
                     |> Array.map (fun arg ->
-                        if isCaseInsensitive && arg.StartsWith("--") then
-                            let equalsIndex = arg.IndexOf("=", StringComparison.Ordinal)
+                        let normalizedArg = normalizeOutputEqualsToken arg
+
+                        if
+                            isCaseInsensitive
+                            && normalizedArg.StartsWith("--")
+                        then
+                            let equalsIndex = normalizedArg.IndexOf("=", StringComparison.Ordinal)
 
                             if equalsIndex > 0 then
-                                let optionName = arg.Substring(0, equalsIndex).ToLowerInvariant()
-                                let optionValue = arg.Substring(equalsIndex)
+                                let optionName =
+                                    normalizedArg
+                                        .Substring(0, equalsIndex)
+                                        .ToLowerInvariant()
+
+                                let optionValue = normalizedArg.Substring(equalsIndex)
                                 $"{optionName}{optionValue}"
                             else
-                                arg.ToLowerInvariant()
+                                normalizedArg.ToLowerInvariant()
                         else
-                            arg)
+                            normalizedArg)
 
                 if aliases.ContainsKey(firstToken) then
                     let newArgs = List<string>()

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -26,6 +26,7 @@ open System.Diagnostics
 open System.Globalization
 open System.IO
 open System.Linq
+open System.Text.Json
 open System.Text.RegularExpressions
 open System.Threading.Tasks
 open Microsoft.Extensions.Caching.Memory
@@ -186,11 +187,9 @@ module GraceCommand =
         | false, true -> Some(Ok CommandOutputContract.IntrospectionKind.Examples)
         | true, true -> Some(Error "--schema and --examples cannot be used together.")
 
-    let private writeJsonStdout value = Console.Out.WriteLine(serialize value)
-
     let private writeIntrospectionError parseResult message =
         let error = GraceError.Create message (getCorrelationId parseResult)
-        writeJsonStdout error
+        Common.writeJsonErrorStdout error
         -1
 
     let private isIgnorableIntrospectionParseError (error: ParseError) =
@@ -217,11 +216,86 @@ module GraceCommand =
             match entry.RouteDisposition with
             | CommandOutputContract.Routed ->
                 let document = CommandOutputContract.introspectionDocument kind entry
-                writeJsonStdout document
+                Common.writeJsonStdout document
                 0
             | CommandOutputContract.SourceOnlyUnrouted reason ->
                 writeIntrospectionError parseResult $"Command '{identity.CommandId}' is not routed for CLI introspection. {reason}"
         | None -> writeIntrospectionError parseResult $"Command '{identity.CommandId}' does not have CLI output contract metadata."
+
+    let private isJsonOutputRequestedFromTokens (args: string array) =
+        let tokens =
+            if isNull args then
+                Array.empty
+            else
+                args
+                |> Array.takeWhile (fun token -> not (token.Equals("--", StringComparison.Ordinal)))
+
+        let rec loop index =
+            if index >= tokens.Length then
+                false
+            else
+                let token = tokens[index]
+
+                if
+                    token.Equals(OptionName.Output, StringComparison.OrdinalIgnoreCase)
+                    || token.Equals("-o", StringComparison.OrdinalIgnoreCase)
+                then
+                    index + 1 < tokens.Length
+                    && tokens[index + 1]
+                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                else
+                    loop (index + 1)
+
+        loop 0
+
+    let private writeJsonParseError (parseResult: ParseResult) =
+        let message =
+            parseResult.Errors
+            |> Seq.map (fun error -> error.Message)
+            |> String.concat Environment.NewLine
+
+        let error = GraceError.Create message (getCorrelationId parseResult)
+        Common.writeJsonErrorStdout error
+        -1
+
+    let private writeJsonException (parseResult: ParseResult) (ex: exn) =
+        let correlationId =
+            if isNull parseResult then
+                generateCorrelationId ()
+            else
+                getCorrelationId parseResult
+
+        let error = GraceError.CreateWithException ex ex.Message correlationId
+        Common.writeJsonErrorStdout error
+        -1
+
+    let private tryFindGraceConfigurationFileForJsonMode () =
+        let rec loop (directory: DirectoryInfo) =
+            if isNull directory then
+                None
+            else
+                let candidate = Path.Combine(directory.FullName, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
+
+                if File.Exists candidate then Some candidate else loop directory.Parent
+
+        loop (DirectoryInfo(Environment.CurrentDirectory))
+
+    let private tryGetJsonConfigurationError (parseResult: ParseResult) =
+        if parseResult |> json then
+            match tryFindGraceConfigurationFileForJsonMode () with
+            | Some graceConfigurationFilePath ->
+                try
+                    use fileStream = new FileStream(graceConfigurationFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
+
+                    JsonSerializer.Deserialize<GraceConfiguration>(fileStream, Constants.JsonSerializerOptions)
+                    |> ignore
+
+                    None
+                with
+                | ex -> Some(GraceError.CreateWithException ex ex.Message (getCorrelationId parseResult))
+            | None -> None
+        else
+            None
 
     let private replaceDefaultValue (line: string) (defaultValueText: string) =
         let startIndex = line.IndexOf("[default:", StringComparison.OrdinalIgnoreCase)
@@ -810,10 +884,6 @@ module GraceCommand =
     [<EntryPoint>]
     let main args =
         let startTime = getCurrentInstant ()
-        Auth.configureSdkAuth ()
-        Services.configureSdkClientIdentity ()
-        Services.resetInvocationCorrelationId ()
-        Common.resetLifecycleWarningSuppression ()
 
         // Create a MemoryCache instance.
         //let memoryCacheOptions = MemoryCacheOptions(TrackStatistics = false, TrackLinkedCacheEntries = false)
@@ -860,6 +930,11 @@ module GraceCommand =
 
             try
                 try
+                    Auth.configureSdkAuth ()
+                    Services.configureSdkClientIdentity ()
+                    Services.resetInvocationCorrelationId ()
+                    Common.resetLifecycleWarningSuppression ()
+
                     //let commandLineConfiguration = ParserConfiguration rootCommand
 
                     let argvToParse = if args.Length = 0 then [| helpOptions[0] |] else argvNormalized
@@ -887,6 +962,12 @@ module GraceCommand =
                     | None ->
                         // Write the ParseResult to Services as global context for the CLI.
                         Services.parseResult <- parseResult
+
+                        if parseResult.Errors.Count > 0
+                           && isJsonOutputRequestedFromTokens argvToParse then
+                            returnValue <- writeJsonParseError parseResult
+                            raise (IntrospectionExit returnValue)
+
                         LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
@@ -1058,63 +1139,67 @@ module GraceCommand =
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
                     else if configurationFileExists () then
-                        //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
+                        match tryGetJsonConfigurationError parseResult with
+                        | Some error ->
+                            Common.writeJsonErrorStdout error
+                            returnValue <- -1
+                        | None ->
+                            //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
-                        if parseResult |> hasOutput then
-                            if parseResult |> verbose then
-                                AnsiConsole.Write(
-                                    (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
-                                        .RightJustified()
-                                )
+                            if parseResult |> hasOutput then
+                                if parseResult |> verbose then
+                                    AnsiConsole.Write(
+                                        (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
+                                            .RightJustified()
+                                    )
 
-                            //printParseResult parseResult
-                            else
-                                AnsiConsole.Write(new Rule())
+                                //printParseResult parseResult
+                                else
+                                    AnsiConsole.Write(new Rule())
 
-                        // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
-                        if not <| (parseResult |> isGraceWatch) then
-                            let! graceWatchStatus = getGraceWatchStatus ()
+                            // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
+                            if not <| (parseResult |> isGraceWatch) then
+                                let! graceWatchStatus = getGraceWatchStatus ()
 
-                            match graceWatchStatus with
-                            | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
-                            | None -> ()
+                                match graceWatchStatus with
+                                | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
+                                | None -> ()
 
-                        // Now we can invoke the command!
-                        let! returnValue = parseResult.InvokeAsync()
+                            // Now we can invoke the command!
+                            let! invokedReturnValue = parseResult.InvokeAsync()
+                            returnValue <- invokedReturnValue
 
-                        // Stuff to do after the command has been invoked:
+                            // Stuff to do after the command has been invoked:
 
-                        // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
-                        //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
-                        if parseResult |> isGraceWatch then
-                            logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
+                            // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
+                            //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
+                            if parseResult |> isGraceWatch then
+                                logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
-                        // If we're writing output, write the final Rule() to the console.
-                        if parseResult |> hasOutput then
-                            let finishTime = getCurrentInstant ()
+                            // If we're writing output, write the final Rule() to the console.
+                            if parseResult |> hasOutput then
+                                let finishTime = getCurrentInstant ()
 
-                            let elapsed =
-                                (finishTime - startTime)
-                                    .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                let elapsed =
+                                    (finishTime - startTime)
+                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
 
-                            if parseResult |> verbose then
-                                AnsiConsole.Write(
-                                    (new Rule(
-                                        $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
-                                    ))
-                                        .RightJustified()
-                                )
-                            else
-                                AnsiConsole.Write(
-                                    (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                        .RightJustified()
-                                )
+                                if parseResult |> verbose then
+                                    AnsiConsole.Write(
+                                        (new Rule(
+                                            $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
+                                        ))
+                                            .RightJustified()
+                                    )
+                                else
+                                    AnsiConsole.Write(
+                                        (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
+                                            .RightJustified()
+                                    )
 
-                            AnsiConsole.WriteLine()
+                                AnsiConsole.WriteLine()
                     else
                         // We don't have a config file, so write an error message and exit.
-                        AnsiConsole.Write(new Rule())
-
                         let comparison =
                             if isCaseInsensitive then
                                 StringComparison.InvariantCultureIgnoreCase
@@ -1146,28 +1231,41 @@ module GraceCommand =
                             returnValue <- invokedReturnValue
                             ()
                         else
-                            AnsiConsole.MarkupLine($"[{Colors.Important}]{getLocalizedString StringResourceName.GraceConfigFileNotFound}[/]")
+                            let message = getLocalizedString StringResourceName.GraceConfigFileNotFound
 
-                        let finishTime = getCurrentInstant ()
+                            if parseResult |> json then
+                                let error = GraceError.Create message (getCorrelationId parseResult)
+                                Common.writeJsonErrorStdout error
+                            else
+                                AnsiConsole.Write(new Rule())
+                                AnsiConsole.MarkupLine($"[{Colors.Important}]{message}[/]")
 
-                        let elapsed =
-                            (finishTime - startTime)
-                                .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                let finishTime = getCurrentInstant ()
 
-                        AnsiConsole.Write(
-                            (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                .RightJustified()
-                        )
+                                let elapsed =
+                                    (finishTime - startTime)
+                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+
+                                AnsiConsole.Write(
+                                    (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: -1.[/]"))
+                                        .RightJustified()
+                                )
+
+                            returnValue <- -1
 
                     return returnValue
                 with
                 | IntrospectionExit exitCode -> return exitCode
                 | ex ->
-                    AnsiConsole.WriteException ex
-                    //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
-                    //logToAnsiConsole Colors.Error $"{ex.StackTrace}"
-                    returnValue <- -1
-                    return -1
+                    if isJsonOutputRequestedFromTokens argvNormalized then
+                        returnValue <- writeJsonException parseResult ex
+                    else
+                        AnsiConsole.WriteException ex
+                        //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
+                        //logToAnsiConsole Colors.Error $"{ex.StackTrace}"
+                        returnValue <- -1
+
+                    return returnValue
             finally
                 let finishTime = getCurrentInstant ()
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -245,6 +245,10 @@ module GraceCommand =
                        && tokens[index + 1]
                            .Equals("Json", StringComparison.OrdinalIgnoreCase) then
                         true
+                    elif index + 1 < tokens.Length
+                         && tokens[index + 1]
+                             .StartsWith("-", StringComparison.Ordinal) then
+                        loop (index + 1)
                     else
                         loop (index + 2)
                 elif token.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -241,17 +241,26 @@ module GraceCommand =
                     token.Equals(OptionName.Output, StringComparison.OrdinalIgnoreCase)
                     || token.Equals("-o", StringComparison.OrdinalIgnoreCase)
                 then
-                    index + 1 < tokens.Length
-                    && tokens[index + 1]
-                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                    if index + 1 < tokens.Length
+                       && tokens[index + 1]
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    else
+                        loop (index + 2)
                 elif token.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then
-                    token
+                    if token
                         .Substring(outputEqualsPrefix.Length)
-                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    else
+                        loop (index + 1)
                 elif token.StartsWith("-o=", StringComparison.OrdinalIgnoreCase) then
-                    token
+                    if token
                         .Substring("-o=".Length)
-                        .Equals("Json", StringComparison.OrdinalIgnoreCase)
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    else
+                        loop (index + 1)
                 else
                     loop (index + 1)
 


### PR DESCRIPTION
## Summary

- Adds a central CLI JSON stdout writer for common JSON success/error output.
- Routes `Common.renderOutput` JSON success/error and S2 introspection documents through the central writer.
- Adds JSON-mode parse, missing-config, and invalid-config preflight handling so stdout remains a single `GraceError` document.
- Preserves human-mode missing-config behavior and avoids broad command migrations.

## Stdout/Stderr Evidence

Worker tests prove:

- JSON success via `Common.renderOutput`: stdout is one parseable JSON document with `ReturnValue` and `CorrelationId`; stderr is empty; no `Elapsed:` trailer.
- JSON error via `Common.renderOutput`: stdout is one parseable `GraceError` envelope with `Error` and `CorrelationId`; stderr is empty; PascalCase envelope fields preserved.
- Missing config under `--output Json`: exit `-1`; stdout is one parseable `GraceError` document; stderr is empty; no human elapsed/rule text.
- Parse error under `--output Json`: exit `-1`; stdout is one parseable `GraceError` document; stderr is empty.
- Invalid config / catch-all style JSON path: exit `-1`; stdout is one parseable `GraceError` document with non-empty `Error` and `CorrelationId`; stderr is empty; no human `Exception:` prefix.
- Human missing-config regression remains human-oriented and does not start with JSON.

## Validation

- `dotnet tool run fantomas -- src/Grace.CLI/Command/Common.CLI.fs src/Grace.CLI/Program.CLI.fs src/Grace.CLI.Tests/Program.CLI.Tests.fs`
- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~HelpDoesNotReadConfigTests"`
- `pwsh ./scripts/validate.ps1 -Fast`
- `git diff --check`

## Review Status

- Pending fresh review-only sibling subagent pass.

## Issue

Part of #274. Implements #278.










