### PR TITLE
W5b: Prove work item artifact and attachment permissions

### DIFF
--- a/src/Grace.Actors/Artifact.Actor.fs
+++ b/src/Grace.Actors/Artifact.Actor.fs
@@ -20,7 +20,7 @@ open System.Threading.Tasks
 
 module Artifact =
 
-    type ArtifactActor([<PersistentState(StateName.Artifact, Constants.GraceActorStorage)>] state: IPersistentState<List<ArtifactEvent>>) =
+    type ArtifactActor([<PersistentState(StateName.Artifact, Constants.GraceActorStorage)>] eventState: IPersistentState<List<ArtifactEvent>>) =
         inherit Grain()
 
         static let actorName = ActorName.Artifact
@@ -34,10 +34,10 @@ module Artifact =
         override this.OnActivateAsync(ct) =
             let activateStartTime = getCurrentInstant ()
 
-            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage eventState.RecordExists)
 
             artifact <-
-                state.State
+                eventState.State
                 |> Seq.fold (fun dto event -> ArtifactMetadata.UpdateDto event dto) artifact
 
             Task.CompletedTask
@@ -47,12 +47,14 @@ module Artifact =
                 let correlationId = artifactEvent.Metadata.CorrelationId
 
                 try
-                    state.State.Add(artifactEvent)
-                    do! state.WriteStateAsync()
-
-                    artifact <-
+                    let updatedArtifact =
                         artifact
                         |> ArtifactMetadata.UpdateDto artifactEvent
+
+                    eventState.State.Add(artifactEvent)
+                    do! eventState.WriteStateAsync()
+
+                    artifact <- updatedArtifact
 
                     let graceEvent = GraceEvent.ArtifactEvent artifactEvent
                     do! publishGraceEvent graceEvent artifactEvent.Metadata
@@ -102,33 +104,41 @@ module Artifact =
             member this.GetEvents correlationId =
                 this.correlationId <- correlationId
 
-                state.State :> IReadOnlyList<ArtifactEvent>
+                eventState.State :> IReadOnlyList<ArtifactEvent>
                 |> returnTask
 
             member this.Handle command metadata =
                 let isValid (artifactCommand: ArtifactCommand) (eventMetadata: EventMetadata) =
                     task {
-                        if state.State.Exists(fun ev -> ev.Metadata.CorrelationId = eventMetadata.CorrelationId) then
+                        if eventState.State.Exists(fun ev -> ev.Metadata.CorrelationId = eventMetadata.CorrelationId) then
                             return Error(GraceError.Create "Duplicate correlation ID for Artifact command." eventMetadata.CorrelationId)
                         else
-                            match artifactCommand with
-                            | ArtifactCommand.Create _ when artifact.ArtifactId <> ArtifactId.Empty ->
+                            match artifactCommand.Command with
+                            | command when not (String.Equals(command, ArtifactCommandNames.Create, StringComparison.OrdinalIgnoreCase)) ->
+                                return
+                                    Error(
+                                        (GraceError.Create "Unsupported Artifact command." eventMetadata.CorrelationId)
+                                            .enhance ("Command", artifactCommand.Command)
+                                    )
+                            | command when
+                                String.Equals(command, ArtifactCommandNames.Create, StringComparison.OrdinalIgnoreCase)
+                                && artifact.ArtifactId <> ArtifactId.Empty
+                                ->
                                 return Error(GraceError.Create "Artifact already exists." eventMetadata.CorrelationId)
                             | _ -> return Ok artifactCommand
                     }
 
                 let processCommand (artifactCommand: ArtifactCommand) (eventMetadata: EventMetadata) =
                     task {
-                        let eventType =
-                            match artifactCommand with
-                            | ArtifactCommand.Create artifactDto -> ArtifactEventType.Created artifactDto
+                        let artifact = artifactCommand.ToCreated()
 
-                        let artifactEvent: ArtifactEvent = { Event = eventType; Metadata = eventMetadata }
+                        let artifactEvent = ArtifactEvent.FromCreated(ArtifactEventNames.Created, artifact, eventMetadata)
+
                         return! this.ApplyEvent artifactEvent
                     }
 
                 task {
-                    currentCommand <- getDiscriminatedUnionCaseName command
+                    currentCommand <- command.Command
                     this.correlationId <- metadata.CorrelationId
 
                     match! isValid command metadata with

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -1457,7 +1457,8 @@ module PromotionSet =
 
                     let artifactActorProxy = Artifact.CreateActorProxy artifactId promotionSetDto.RepositoryId this.correlationId
 
-                    match! artifactActorProxy.Handle (ArtifactCommand.Create artifactMetadata) (this.WithActorMetadata metadata) with
+                    match! artifactActorProxy.Handle (ArtifactCommand.Create(ArtifactCreated.FromMetadata artifactMetadata)) (this.WithActorMetadata metadata)
+                        with
                     | Ok _ ->
                         match! this.UploadArtifactPayload(blobPath, reportJson, metadata) with
                         | Ok () -> return Option.Some artifactId

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -215,22 +215,25 @@ type EndpointAuthorizationManifestTests() =
 
     [<Test>]
     member _.SelectedWorkItemRoutesUseExpectedPolicies() =
-        assertRouteSecurity "POST" "/work/create" (Authorized(Operation.RepoWrite, ResourceKind.Repository))
-
         [
+            "POST", "/work/create"
             "POST", "/work/add-summary"
-            "POST", "/work/get"
             "POST", "/work/link/artifact"
             "POST", "/work/link/promotion-set"
             "POST", "/work/link/reference"
-            "POST", "/work/links/list"
-            "POST", "/work/attachments/list"
-            "POST", "/work/attachments/show"
-            "POST", "/work/attachments/download"
             "POST", "/work/links/remove/artifact"
             "POST", "/work/links/remove/artifact-type"
             "POST", "/work/links/remove/promotion-set"
             "POST", "/work/links/remove/reference"
             "POST", "/work/update"
         ]
-        |> assertRoutesUseSecurity Authenticated
+        |> assertRoutesUseSecurity (Authorized(Operation.RepoWrite, ResourceKind.Repository))
+
+        [
+            "POST", "/work/get"
+            "POST", "/work/links/list"
+            "POST", "/work/attachments/list"
+            "POST", "/work/attachments/show"
+            "POST", "/work/attachments/download"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))

--- a/src/Grace.CLI.Tests/Artifact.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/Artifact.SDK.Tests.fs
@@ -1,0 +1,28 @@
+namespace Grace.CLI.Tests
+
+open Grace.SDK
+open Grace.Shared.Parameters.Artifact
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type ArtifactSdkTests() =
+
+    [<Test>]
+    member _.BuildDownloadUriRouteIncludesOwnerScope() =
+        let parameters =
+            GetArtifactDownloadUriParameters(
+                ArtifactId = " artifact/with spaces ",
+                OwnerId = " owner id ",
+                OrganizationId = " organization id ",
+                RepositoryId = " repository id ",
+                CorrelationId = " correlation id "
+            )
+
+        let route = Artifact.BuildDownloadUriRoute parameters
+
+        Assert.That(
+            route,
+            Is.EqualTo(
+                "artifact/artifact%2Fwith%20spaces/download-uri?ownerId=owner%20id&organizationId=organization%20id&repositoryId=repository%20id&correlationId=correlation%20id"
+            )
+        )

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Connect.CLI.Parsing.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
     <Compile Include="BuildInfo.Tests.fs" />
+    <Compile Include="Artifact.SDK.Tests.fs" />
     <Compile Include="ClientIdentity.SDK.Tests.fs" />
     <Compile Include="Program.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />

--- a/src/Grace.SDK/Artifact.SDK.fs
+++ b/src/Grace.SDK/Artifact.SDK.fs
@@ -10,11 +10,12 @@ type Artifact() =
 
     static member internal BuildDownloadUriRoute(parameters: GetArtifactDownloadUriParameters) =
         let artifactId = Uri.EscapeDataString(parameters.ArtifactId.Trim())
+        let ownerId = Uri.EscapeDataString(parameters.OwnerId.Trim())
         let organizationId = Uri.EscapeDataString(parameters.OrganizationId.Trim())
         let repositoryId = Uri.EscapeDataString(parameters.RepositoryId.Trim())
         let correlationId = Uri.EscapeDataString(parameters.CorrelationId.Trim())
 
-        $"artifact/{artifactId}/download-uri?organizationId={organizationId}&repositoryId={repositoryId}&correlationId={correlationId}"
+        $"artifact/{artifactId}/download-uri?ownerId={ownerId}&organizationId={organizationId}&repositoryId={repositoryId}&correlationId={correlationId}"
 
     /// Creates artifact metadata and returns an upload URI.
     static member public Create(parameters: CreateArtifactParameters) =

--- a/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
@@ -15,6 +15,7 @@ open System
 open System.Net
 open System.Net.Http
 open System.Net.Http.Headers
+open System.Text
 open System.Threading.Tasks
 
 module private WorkItemIntegrationHelpers =
@@ -28,6 +29,24 @@ module private WorkItemIntegrationHelpers =
         let client = new HttpClient()
         client.BaseAddress <- Client.BaseAddress
         client
+
+    let grantRepoRoleAsync (repositoryId: string) (principalId: string) (roleId: string) =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- "repo"
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+        }
 
     let createRepositoryAsync (repositoryNamePrefix: string) =
         task {
@@ -73,7 +92,7 @@ module private WorkItemIntegrationHelpers =
             return repositoryId
         }
 
-    let createWorkItemAsync (repositoryId: string) (title: string) =
+    let createWorkItemWithIdResponseAsync (client: HttpClient) (repositoryId: string) (title: string) =
         task {
             let workItemId = Guid.NewGuid().ToString()
             let parameters = Parameters.WorkItem.CreateWorkItemParameters()
@@ -85,9 +104,33 @@ module private WorkItemIntegrationHelpers =
             parameters.Description <- "integration test work item"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/work/create", createJsonContent parameters)
+            let! response = client.PostAsync("/work/create", createJsonContent parameters)
+            return workItemId, response
+        }
+
+    let createWorkItemResponseAsync (client: HttpClient) (repositoryId: string) (title: string) =
+        task {
+            let! _, response = createWorkItemWithIdResponseAsync client repositoryId title
+            return response
+        }
+
+    let createWorkItemAsync (repositoryId: string) (title: string) =
+        task {
+            let! workItemId, response = createWorkItemWithIdResponseAsync Client repositoryId title
             response.EnsureSuccessStatusCode() |> ignore
             return workItemId
+        }
+
+    let updateWorkItemResponseAsync (client: HttpClient) (repositoryId: string) (workItemIdentifier: string) =
+        task {
+            let parameters = Parameters.WorkItem.UpdateWorkItemParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.WorkItemId <- workItemIdentifier
+            parameters.Title <- $"Updated {Guid.NewGuid():N}"
+            parameters.CorrelationId <- generateCorrelationId ()
+            return! client.PostAsync("/work/update", createJsonContent parameters)
         }
 
     let getWorkItemResponseAsync (client: HttpClient) (repositoryId: string) (workItemIdentifier: string) =
@@ -268,6 +311,16 @@ module private WorkItemIntegrationHelpers =
             return returnValue.ReturnValue.DownloadUri
         }
 
+    let getArtifactDownloadUriResponseAsync (client: HttpClient) (repositoryId: string) (artifactId: Guid) =
+        task {
+            let correlationId = generateCorrelationId ()
+
+            let route =
+                $"/artifact/{artifactId}/download-uri?ownerId={ownerId}&organizationId={organizationId}&repositoryId={repositoryId}&correlationId={correlationId}"
+
+            return! client.GetAsync(route)
+        }
+
     let linkReferenceAsync (repositoryId: string) (workItemIdentifier: string) (referenceId: Guid) =
         task {
             let parameters = Parameters.WorkItem.LinkReferenceParameters()
@@ -296,22 +349,59 @@ module private WorkItemIntegrationHelpers =
             response.EnsureSuccessStatusCode() |> ignore
         }
 
-    let createArtifactAsync (repositoryId: string) (artifactType: string) =
+    let createArtifactResponseAsync
+        (client: HttpClient)
+        (repositoryId: string)
+        (artifactType: string)
+        (mimeType: string)
+        (size: int64)
+        (artifactId: Guid option)
+        =
         task {
             let parameters = Parameters.Artifact.CreateArtifactParameters()
             parameters.OwnerId <- ownerId
             parameters.OrganizationId <- organizationId
             parameters.RepositoryId <- repositoryId
+
+            parameters.ArtifactId <-
+                artifactId
+                |> Option.map string
+                |> Option.defaultValue String.Empty
+
             parameters.ArtifactType <- artifactType
-            parameters.MimeType <- "text/plain"
-            parameters.Size <- 16L
+            parameters.MimeType <- mimeType
+            parameters.Size <- size
             parameters.Sha256 <- ""
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/artifact/create", createJsonContent parameters)
+            return! client.PostAsync("/artifact/create", createJsonContent parameters)
+        }
+
+    let createArtifactAsync (repositoryId: string) (artifactType: string) =
+        task {
+            let! response = createArtifactResponseAsync Client repositoryId artifactType "text/plain" 16L None
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<ArtifactCreateResult>> response
             return returnValue.ReturnValue.ArtifactId
+        }
+
+    let createArtifactResultAsync
+        (client: HttpClient)
+        (repositoryId: string)
+        (artifactType: string)
+        (mimeType: string)
+        (payload: byte array)
+        (artifactId: Guid option)
+        =
+        task {
+            let! response = createArtifactResponseAsync client repositoryId artifactType mimeType (int64 payload.Length) artifactId
+
+            if not response.IsSuccessStatusCode then
+                let! body = response.Content.ReadAsStringAsync()
+                Assert.Fail($"Expected artifact create success but got {response.StatusCode}: {body}")
+
+            let! returnValue = deserializeContent<GraceReturnValue<ArtifactCreateResult>> response
+            return returnValue.ReturnValue
         }
 
     let linkArtifactAsync (repositoryId: string) (workItemIdentifier: string) (artifactId: Guid) =
@@ -326,6 +416,31 @@ module private WorkItemIntegrationHelpers =
 
             let! response = Client.PostAsync("/work/link/artifact", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
+        }
+
+    let linkArtifactResponseAsync (client: HttpClient) (repositoryId: string) (workItemIdentifier: string) (artifactId: Guid) =
+        task {
+            let parameters = Parameters.WorkItem.LinkArtifactParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.WorkItemId <- workItemIdentifier
+            parameters.ArtifactId <- artifactId.ToString()
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/work/link/artifact", createJsonContent parameters)
+        }
+
+    let getLinksResponseAsync (client: HttpClient) (repositoryId: string) (workItemIdentifier: string) =
+        task {
+            let parameters = Parameters.WorkItem.GetWorkItemLinksParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.WorkItemId <- workItemIdentifier
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/work/links/list", createJsonContent parameters)
         }
 
     let removeReferenceLinkAsync (client: HttpClient) (repositoryId: string) (workItemIdentifier: string) (referenceId: Guid) =
@@ -374,6 +489,22 @@ module private WorkItemIntegrationHelpers =
             parameters.ArtifactType <- artifactType
             parameters.CorrelationId <- generateCorrelationId ()
             return! client.PostAsync("/work/links/remove/artifact-type", createJsonContent parameters)
+        }
+
+    let uploadBytesWithSasAsync (uploadUri: Uri) (payload: byte array) =
+        task {
+            let blobClient = Azure.Storage.Blobs.Specialized.BlockBlobClient(uploadUri)
+            use stream = new System.IO.MemoryStream(payload, writable = false)
+            let options = Azure.Storage.Blobs.Models.BlobUploadOptions()
+            let! _ = blobClient.UploadAsync(stream, options)
+            ()
+        }
+
+    let downloadBytesWithSasAsync (downloadUri: string) =
+        task {
+            let blobClient = BlobClient(Uri downloadUri)
+            let! response = blobClient.DownloadContentAsync()
+            return response.Value.Content.ToArray()
         }
 
     let createPersonalAccessTokenAsync () =
@@ -762,9 +893,10 @@ type WorkItemAttachmentEndpointsIntegrationTests() =
         task {
             let! repositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "wi-attachments-download"
             let! workItemId = WorkItemIntegrationHelpers.createWorkItemAsync repositoryId "attachments download"
+            let summaryContent = "download summary content"
 
             let! addSummaryResult =
-                WorkItemIntegrationHelpers.addSummaryAsync Client repositoryId workItemId "download summary content" None None (generateCorrelationId ())
+                WorkItemIntegrationHelpers.addSummaryAsync Client repositoryId workItemId summaryContent None None (generateCorrelationId ())
 
             let! linkedOtherArtifactId = WorkItemIntegrationHelpers.createArtifactAsync repositoryId "Other"
             do! WorkItemIntegrationHelpers.linkArtifactAsync repositoryId workItemId linkedOtherArtifactId
@@ -774,7 +906,14 @@ type WorkItemAttachmentEndpointsIntegrationTests() =
 
             Assert.That(downloadResult.ArtifactId, Is.EqualTo(summaryArtifactId.ToString()))
             Assert.That(downloadResult.AttachmentType, Is.EqualTo("summary"))
+            Assert.That(downloadResult.MimeType, Is.EqualTo("text/markdown"))
+            Assert.That(downloadResult.Size, Is.EqualTo(Encoding.UTF8.GetByteCount(summaryContent)))
             Assert.That(String.IsNullOrWhiteSpace(downloadResult.DownloadUri), Is.False)
+
+            let! downloadedBytes = WorkItemIntegrationHelpers.downloadBytesWithSasAsync downloadResult.DownloadUri
+            let downloadedContent = Encoding.UTF8.GetString(downloadedBytes)
+
+            Assert.That(downloadedContent, Is.EqualTo(summaryContent))
 
             let! notLinkedResponse = WorkItemIntegrationHelpers.downloadWorkItemAttachmentResponseAsync Client repositoryId workItemId (Guid.NewGuid())
 
@@ -787,121 +926,242 @@ type WorkItemAttachmentEndpointsIntegrationTests() =
 type WorkItemLinksAuthorizationIntegrationTests() =
 
     [<Test>]
-    member _.WorkItemLinkEndpointsRequireAuthenticationAndAllowAuthenticatedUsers() =
+    member _.WorkItemAndAttachmentRoutesEnforceRepositoryPermissionsByRoleAndRepositoryScope() =
         task {
-            let! repositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "wi-links-auth"
-            let! workItemId = WorkItemIntegrationHelpers.createWorkItemAsync repositoryId "auth matrix"
+            let! repositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "wi-permission-target"
+            let! otherRepositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "wi-permission-other"
+            let repoReader = $"{Guid.NewGuid()}"
+            let repoWriter = $"{Guid.NewGuid()}"
+            let repoAdmin = $"{Guid.NewGuid()}"
+            let crossRepoPrincipal = $"{Guid.NewGuid()}"
 
-            let summaryArtifactId = Guid.NewGuid()
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoAdmin "RepoAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+
             use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
-            use authenticatedClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
+            use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
+            use readerClient = WorkItemIntegrationHelpers.createAuthenticatedClient repoReader
+            use writerClient = WorkItemIntegrationHelpers.createAuthenticatedClient repoWriter
+            use adminClient = WorkItemIntegrationHelpers.createAuthenticatedClient repoAdmin
+            use crossRepoClient = WorkItemIntegrationHelpers.createAuthenticatedClient crossRepoPrincipal
 
-            let calls: (string * (unit -> Task<HttpResponseMessage>)) list =
-                [
-                    "/work/links/list",
-                    (fun () ->
-                        task {
-                            let parameters = Parameters.WorkItem.GetWorkItemLinksParameters()
-                            parameters.OwnerId <- ownerId
-                            parameters.OrganizationId <- organizationId
-                            parameters.RepositoryId <- repositoryId
-                            parameters.WorkItemId <- workItemId
-                            parameters.CorrelationId <- generateCorrelationId ()
-                            return! unauthenticatedClient.PostAsync("/work/links/list", createJsonContent parameters)
-                        })
-                    "/work/attachments/list",
-                    (fun () ->
-                        task {
-                            let parameters = Parameters.WorkItem.ListWorkItemAttachmentsParameters()
-                            parameters.OwnerId <- ownerId
-                            parameters.OrganizationId <- organizationId
-                            parameters.RepositoryId <- repositoryId
-                            parameters.WorkItemId <- workItemId
-                            parameters.CorrelationId <- generateCorrelationId ()
-                            return! unauthenticatedClient.PostAsync("/work/attachments/list", createJsonContent parameters)
-                        })
-                    "/work/attachments/show",
-                    (fun () ->
-                        task {
-                            let parameters = Parameters.WorkItem.ShowWorkItemAttachmentParameters()
-                            parameters.OwnerId <- ownerId
-                            parameters.OrganizationId <- organizationId
-                            parameters.RepositoryId <- repositoryId
-                            parameters.WorkItemId <- workItemId
-                            parameters.AttachmentType <- "summary"
-                            parameters.Latest <- true
-                            parameters.CorrelationId <- generateCorrelationId ()
-                            return! unauthenticatedClient.PostAsync("/work/attachments/show", createJsonContent parameters)
-                        })
-                    "/work/attachments/download",
-                    (fun () ->
-                        task {
-                            let parameters = Parameters.WorkItem.DownloadWorkItemAttachmentParameters()
-                            parameters.OwnerId <- ownerId
-                            parameters.OrganizationId <- organizationId
-                            parameters.RepositoryId <- repositoryId
-                            parameters.WorkItemId <- workItemId
-                            parameters.ArtifactId <- summaryArtifactId.ToString()
-                            parameters.CorrelationId <- generateCorrelationId ()
-                            return! unauthenticatedClient.PostAsync("/work/attachments/download", createJsonContent parameters)
-                        })
-                    "/work/links/remove/reference",
-                    (fun () -> WorkItemIntegrationHelpers.removeReferenceLinkAsync unauthenticatedClient repositoryId workItemId (Guid.NewGuid()))
-                    "/work/links/remove/promotion-set",
-                    (fun () -> WorkItemIntegrationHelpers.removePromotionSetLinkAsync unauthenticatedClient repositoryId workItemId (Guid.NewGuid()))
-                    "/work/links/remove/artifact",
-                    (fun () -> WorkItemIntegrationHelpers.removeArtifactLinkAsync unauthenticatedClient repositoryId workItemId (Guid.NewGuid()))
-                    "/work/links/remove/artifact-type",
-                    (fun () -> WorkItemIntegrationHelpers.removeArtifactTypeLinksAsync unauthenticatedClient repositoryId workItemId "summary")
-                ]
+            let! unauthenticatedCreate = WorkItemIntegrationHelpers.createWorkItemResponseAsync unauthenticatedClient repositoryId "unauth create"
+            Assert.That(unauthenticatedCreate.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
 
-            for (path, invokeUnauthenticated) in calls do
-                let! response = invokeUnauthenticated ()
-                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), $"Expected 401 for {path}.")
+            let! noRoleCreate = WorkItemIntegrationHelpers.createWorkItemResponseAsync noRoleClient repositoryId "no role create"
+            Assert.That(noRoleCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! listAuthenticated =
-                task {
-                    let parameters = Parameters.WorkItem.GetWorkItemLinksParameters()
-                    parameters.OwnerId <- ownerId
-                    parameters.OrganizationId <- organizationId
-                    parameters.RepositoryId <- repositoryId
-                    parameters.WorkItemId <- workItemId
-                    parameters.CorrelationId <- generateCorrelationId ()
-                    return! authenticatedClient.PostAsync("/work/links/list", createJsonContent parameters)
-                }
+            let! readerCreate = WorkItemIntegrationHelpers.createWorkItemResponseAsync readerClient repositoryId "reader create"
+            Assert.That(readerCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            Assert.That(listAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! crossRepoCreate = WorkItemIntegrationHelpers.createWorkItemResponseAsync crossRepoClient repositoryId "cross repo create"
+            Assert.That(crossRepoCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! listAttachmentsAuthenticated = WorkItemIntegrationHelpers.listWorkItemAttachmentsResponseAsync authenticatedClient repositoryId workItemId
+            let! workItemId, writerCreate = WorkItemIntegrationHelpers.createWorkItemWithIdResponseAsync writerClient repositoryId "writer create"
+            Assert.That(writerCreate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            Assert.That(listAttachmentsAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! createdWorkItem = WorkItemIntegrationHelpers.getWorkItemDtoAsync writerClient repositoryId workItemId
+            let workItemNumber = createdWorkItem.WorkItemNumber.ToString()
 
-            let! showAttachmentAuthenticated =
-                WorkItemIntegrationHelpers.showWorkItemAttachmentResponseAsync authenticatedClient repositoryId workItemId "summary" true
+            let! adminCreate = WorkItemIntegrationHelpers.createWorkItemResponseAsync adminClient repositoryId "admin create"
+            Assert.That(adminCreate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            Assert.That(showAttachmentAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+            let! noRoleGet = WorkItemIntegrationHelpers.getWorkItemResponseAsync noRoleClient repositoryId workItemId
+            Assert.That(noRoleGet.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! downloadAttachmentAuthenticated =
-                WorkItemIntegrationHelpers.downloadWorkItemAttachmentResponseAsync authenticatedClient repositoryId workItemId summaryArtifactId
+            let! crossRepoGet = WorkItemIntegrationHelpers.getWorkItemResponseAsync crossRepoClient repositoryId workItemId
+            Assert.That(crossRepoGet.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            Assert.That(downloadAttachmentAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+            let! readerGet = WorkItemIntegrationHelpers.getWorkItemResponseAsync readerClient repositoryId workItemNumber
+            Assert.That(readerGet.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! removeReferenceAuthenticated = WorkItemIntegrationHelpers.removeReferenceLinkAsync authenticatedClient repositoryId workItemId (Guid.NewGuid())
+            let! writerGet = WorkItemIntegrationHelpers.getWorkItemResponseAsync writerClient repositoryId workItemId
+            Assert.That(writerGet.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            Assert.That(removeReferenceAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! adminGet = WorkItemIntegrationHelpers.getWorkItemResponseAsync adminClient repositoryId workItemId
+            Assert.That(adminGet.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! removePromotionAuthenticated =
-                WorkItemIntegrationHelpers.removePromotionSetLinkAsync authenticatedClient repositoryId workItemId (Guid.NewGuid())
+            let! readerUpdate = WorkItemIntegrationHelpers.updateWorkItemResponseAsync readerClient repositoryId workItemId
+            Assert.That(readerUpdate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            Assert.That(removePromotionAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! crossRepoUpdate = WorkItemIntegrationHelpers.updateWorkItemResponseAsync crossRepoClient repositoryId workItemId
+            Assert.That(crossRepoUpdate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! removeArtifactAuthenticated = WorkItemIntegrationHelpers.removeArtifactLinkAsync authenticatedClient repositoryId workItemId (Guid.NewGuid())
+            let! writerUpdate = WorkItemIntegrationHelpers.updateWorkItemResponseAsync writerClient repositoryId workItemId
+            Assert.That(writerUpdate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            Assert.That(removeArtifactAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! adminUpdate = WorkItemIntegrationHelpers.updateWorkItemResponseAsync adminClient repositoryId workItemId
+            Assert.That(adminUpdate.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! removeArtifactTypeAuthenticated = WorkItemIntegrationHelpers.removeArtifactTypeLinksAsync authenticatedClient repositoryId workItemId "summary"
+            let linkedArtifactId = Guid.NewGuid()
+            let! readerLink = WorkItemIntegrationHelpers.linkArtifactResponseAsync readerClient repositoryId workItemId linkedArtifactId
+            Assert.That(readerLink.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            Assert.That(removeArtifactTypeAuthenticated.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! crossRepoLink = WorkItemIntegrationHelpers.linkArtifactResponseAsync crossRepoClient repositoryId workItemId linkedArtifactId
+            Assert.That(crossRepoLink.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! writerLink = WorkItemIntegrationHelpers.linkArtifactResponseAsync writerClient repositoryId workItemId linkedArtifactId
+            Assert.That(writerLink.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! linksForReader = WorkItemIntegrationHelpers.getLinksResponseAsync readerClient repositoryId workItemId
+            Assert.That(linksForReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! linksForNoRole = WorkItemIntegrationHelpers.getLinksResponseAsync noRoleClient repositoryId workItemId
+            Assert.That(linksForNoRole.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! linksForCrossRepo = WorkItemIntegrationHelpers.getLinksResponseAsync crossRepoClient repositoryId workItemId
+            Assert.That(linksForCrossRepo.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let summaryContent = "permission matrix summary"
+
+            let! readerAddSummary =
+                WorkItemIntegrationHelpers.addSummaryResponseAsync readerClient repositoryId workItemId summaryContent None None None (generateCorrelationId ())
+
+            Assert.That(readerAddSummary.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! crossRepoAddSummary =
+                WorkItemIntegrationHelpers.addSummaryResponseAsync
+                    crossRepoClient
+                    repositoryId
+                    workItemId
+                    summaryContent
+                    None
+                    None
+                    None
+                    (generateCorrelationId ())
+
+            Assert.That(crossRepoAddSummary.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! addedSummary =
+                WorkItemIntegrationHelpers.addSummaryAsync writerClient repositoryId workItemId summaryContent None None (generateCorrelationId ())
+
+            let summaryArtifactId = Guid.Parse(addedSummary.SummaryArtifactId)
+
+            let! readerAttachments = WorkItemIntegrationHelpers.listWorkItemAttachmentsResponseAsync readerClient repositoryId workItemNumber
+            Assert.That(readerAttachments.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! noRoleAttachments = WorkItemIntegrationHelpers.listWorkItemAttachmentsResponseAsync noRoleClient repositoryId workItemId
+            Assert.That(noRoleAttachments.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! crossRepoAttachments = WorkItemIntegrationHelpers.listWorkItemAttachmentsResponseAsync crossRepoClient repositoryId workItemId
+            Assert.That(crossRepoAttachments.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! readerShow = WorkItemIntegrationHelpers.showWorkItemAttachmentResponseAsync readerClient repositoryId workItemNumber "summary" true
+            Assert.That(readerShow.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! noRoleShow = WorkItemIntegrationHelpers.showWorkItemAttachmentResponseAsync noRoleClient repositoryId workItemId "summary" true
+            Assert.That(noRoleShow.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! readerDownload = WorkItemIntegrationHelpers.downloadWorkItemAttachmentResponseAsync readerClient repositoryId workItemId summaryArtifactId
+            Assert.That(readerDownload.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! noRoleDownload = WorkItemIntegrationHelpers.downloadWorkItemAttachmentResponseAsync noRoleClient repositoryId workItemId summaryArtifactId
+            Assert.That(noRoleDownload.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! readerRemoveReference = WorkItemIntegrationHelpers.removeReferenceLinkAsync readerClient repositoryId workItemId (Guid.NewGuid())
+            Assert.That(readerRemoveReference.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! writerRemoveReference = WorkItemIntegrationHelpers.removeReferenceLinkAsync writerClient repositoryId workItemId (Guid.NewGuid())
+            Assert.That(writerRemoveReference.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! adminRemoveArtifact = WorkItemIntegrationHelpers.removeArtifactLinkAsync adminClient repositoryId workItemId linkedArtifactId
+            Assert.That(adminRemoveArtifact.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+        }
+
+    [<Test>]
+    member _.ArtifactRoutesEnforceRepositoryPermissionsAndPreserveDownloadIdentityPathAndBytes() =
+        task {
+            let! repositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "artifact-permission-target"
+            let! otherRepositoryId = WorkItemIntegrationHelpers.createRepositoryAsync "artifact-permission-other"
+            let repoReader = $"{Guid.NewGuid()}"
+            let repoWriter = $"{Guid.NewGuid()}"
+            let crossRepoPrincipal = $"{Guid.NewGuid()}"
+
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+
+            use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
+            use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
+            use readerClient = WorkItemIntegrationHelpers.createAuthenticatedClient repoReader
+            use writerClient = WorkItemIntegrationHelpers.createAuthenticatedClient repoWriter
+            use crossRepoClient = WorkItemIntegrationHelpers.createAuthenticatedClient crossRepoPrincipal
+
+            let payload = Encoding.UTF8.GetBytes("artifact permission payload")
+            let artifactId = Guid.NewGuid()
+
+            let! unauthenticatedCreate =
+                WorkItemIntegrationHelpers.createArtifactResponseAsync
+                    unauthenticatedClient
+                    repositoryId
+                    "ValidationOutput"
+                    "text/plain"
+                    (int64 payload.Length)
+                    (Some artifactId)
+
+            Assert.That(unauthenticatedCreate.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
+
+            let! noRoleCreate =
+                WorkItemIntegrationHelpers.createArtifactResponseAsync
+                    noRoleClient
+                    repositoryId
+                    "ValidationOutput"
+                    "text/plain"
+                    (int64 payload.Length)
+                    (Some artifactId)
+
+            Assert.That(noRoleCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! readerCreate =
+                WorkItemIntegrationHelpers.createArtifactResponseAsync
+                    readerClient
+                    repositoryId
+                    "ValidationOutput"
+                    "text/plain"
+                    (int64 payload.Length)
+                    (Some artifactId)
+
+            Assert.That(readerCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! crossRepoCreate =
+                WorkItemIntegrationHelpers.createArtifactResponseAsync
+                    crossRepoClient
+                    repositoryId
+                    "ValidationOutput"
+                    "text/plain"
+                    (int64 payload.Length)
+                    (Some artifactId)
+
+            Assert.That(crossRepoCreate.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! createResult =
+                WorkItemIntegrationHelpers.createArtifactResultAsync writerClient repositoryId "ValidationOutput" "text/plain" payload (Some artifactId)
+
+            Assert.That(createResult.ArtifactId, Is.EqualTo(artifactId))
+            Assert.That(createResult.BlobPath, Does.Contain(artifactId.ToString()))
+            Assert.That(createResult.BlobPath, Does.StartWith("grace-artifacts/"))
+
+            do! WorkItemIntegrationHelpers.uploadBytesWithSasAsync createResult.UploadUri payload
+
+            let! noRoleDownload = WorkItemIntegrationHelpers.getArtifactDownloadUriResponseAsync noRoleClient repositoryId artifactId
+            Assert.That(noRoleDownload.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! crossRepoDownload = WorkItemIntegrationHelpers.getArtifactDownloadUriResponseAsync crossRepoClient repositoryId artifactId
+            Assert.That(crossRepoDownload.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+
+            let! readerDownloadResponse = WorkItemIntegrationHelpers.getArtifactDownloadUriResponseAsync readerClient repositoryId artifactId
+            Assert.That(readerDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! readerDownloadReturnValue = deserializeContent<GraceReturnValue<ArtifactDownloadUriResult>> readerDownloadResponse
+            Assert.That(readerDownloadReturnValue.ReturnValue.ArtifactId, Is.EqualTo(artifactId))
+
+            let downloadUri = readerDownloadReturnValue.ReturnValue.DownloadUri
+            Assert.That(String.IsNullOrWhiteSpace(downloadUri.AbsoluteUri), Is.False)
+
+            let! downloadedBytes = WorkItemIntegrationHelpers.downloadBytesWithSasAsync downloadUri.AbsoluteUri
+            Assert.That(Convert.ToHexString(downloadedBytes), Is.EqualTo(Convert.ToHexString(payload)))
         }
 
 [<NonParallelizable>]

--- a/src/Grace.Server/Artifact.Server.fs
+++ b/src/Grace.Server/Artifact.Server.fs
@@ -149,7 +149,7 @@ module Artifact =
                     let metadata = createMetadata context
                     let artifactActorProxy = Artifact.CreateActorProxy artifactId graceIds.RepositoryId correlationId
 
-                    match! artifactActorProxy.Handle (ArtifactCommand.Create artifactDto) metadata with
+                    match! artifactActorProxy.Handle (ArtifactCommand.Create(ArtifactCreated.FromMetadata artifactDto)) metadata with
                     | Error graceError -> return! context |> result400BadRequest graceError
                     | Ok _ ->
                         let response: ArtifactCreateResult = { ArtifactId = artifactId; UploadUri = uploadUri; BlobPath = blobPath }

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -119,8 +119,8 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/validation-set/update" Authenticated
             endpoint "POST" "/validation-set/delete" Authenticated
             endpoint "POST" "/validation-result/record" Authenticated
-            endpoint "POST" "/artifact/create" Authenticated
-            endpoint "GET" "/artifact/%O/download-uri" Authenticated
+            endpoint "POST" "/artifact/create" (Authorized(RepoWrite, Repository))
+            endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepoRead, Repository))
             endpoint "POST" "/diff/getDiff" Authenticated
             endpoint "POST" "/diff/getDiffBySha256Hash" Authenticated
             endpoint "POST" "/diff/populate" Authenticated
@@ -211,20 +211,20 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
             endpoint "POST" "/work/create" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/add-summary" Authenticated
-            endpoint "POST" "/work/get" Authenticated
-            endpoint "POST" "/work/link/artifact" Authenticated
-            endpoint "POST" "/work/link/promotion-set" Authenticated
-            endpoint "POST" "/work/link/reference" Authenticated
-            endpoint "POST" "/work/links/list" Authenticated
-            endpoint "POST" "/work/attachments/list" Authenticated
-            endpoint "POST" "/work/attachments/show" Authenticated
-            endpoint "POST" "/work/attachments/download" Authenticated
-            endpoint "POST" "/work/links/remove/artifact" Authenticated
-            endpoint "POST" "/work/links/remove/artifact-type" Authenticated
-            endpoint "POST" "/work/links/remove/promotion-set" Authenticated
-            endpoint "POST" "/work/links/remove/reference" Authenticated
-            endpoint "POST" "/work/update" Authenticated
+            endpoint "POST" "/work/add-summary" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/get" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/work/link/artifact" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/link/promotion-set" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/link/reference" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/links/list" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/work/attachments/list" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/work/attachments/show" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/work/attachments/download" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/work/links/remove/artifact" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/links/remove/artifact-type" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/links/remove/promotion-set" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/links/remove/reference" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/update" (Authorized(RepoWrite, Repository))
             endpoint "GET" "/metrics" (Authorized(SystemAdmin, System))
             endpoint "GET" "/notifications" Authenticated
         ]

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -125,6 +125,34 @@ module Application =
                 return Resource.Repository(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId)
             }
 
+        let artifactRepositoryPermissionFromQuery (context: HttpContext) =
+            task {
+                let correlationId = Services.getCorrelationId context
+
+                let tryGetQueryGuid queryParameterName =
+                    match context.Request.Query.TryGetValue queryParameterName with
+                    | true, values when
+                        values.Count > 0
+                        && not (String.IsNullOrWhiteSpace values[0])
+                        ->
+                        let mutable parsed = Guid.Empty
+
+                        if
+                            Guid.TryParse(values[0], &parsed)
+                            && parsed <> Guid.Empty
+                        then
+                            Ok parsed
+                        else
+                            Error(GraceError.Create $"{queryParameterName} must be a non-empty GUID." correlationId)
+                    | _ -> Error(GraceError.Create $"{queryParameterName} is required." correlationId)
+
+                match tryGetQueryGuid "ownerId", tryGetQueryGuid "organizationId", tryGetQueryGuid "repositoryId" with
+                | Ok ownerId, Ok organizationId, Ok repositoryId -> return Ok(Operation.RepoRead, Resource.Repository(ownerId, organizationId, repositoryId))
+                | Error error, _, _
+                | _, Error error, _
+                | _, _, Error error -> return Error error
+            }
+
         let ownerResourceFromContext (context: HttpContext) =
             task {
                 let graceIds = Services.getGraceIds context
@@ -238,6 +266,8 @@ module Application =
         let requireRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoRead repositoryResourceFromContext
 
         let requireRepoWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoWrite repositoryResourceFromContext
+
+        let requireArtifactRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
 
         let requireBranchAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchAdmin branchResourceFromContext
 
@@ -1201,46 +1231,46 @@ module Application =
                         POST [ route "/create" (composeHandlers requireRepoWrite WorkItem.Create)
                                |> addMetadata typeof<WorkItem.CreateWorkItemParameters>
 
-                               route "/get" WorkItem.Get
+                               route "/get" (composeHandlers requireRepoRead WorkItem.Get)
                                |> addMetadata typeof<WorkItem.GetWorkItemParameters>
 
-                               route "/update" WorkItem.Update
+                               route "/update" (composeHandlers requireRepoWrite WorkItem.Update)
                                |> addMetadata typeof<WorkItem.UpdateWorkItemParameters>
 
-                               route "/add-summary" WorkItem.AddSummary
+                               route "/add-summary" (composeHandlers requireRepoWrite WorkItem.AddSummary)
                                |> addMetadata typeof<WorkItem.AddSummaryParameters>
 
-                               route "/link/reference" WorkItem.LinkReference
+                               route "/link/reference" (composeHandlers requireRepoWrite WorkItem.LinkReference)
                                |> addMetadata typeof<WorkItem.LinkReferenceParameters>
 
-                               route "/link/artifact" WorkItem.LinkArtifact
+                               route "/link/artifact" (composeHandlers requireRepoWrite WorkItem.LinkArtifact)
                                |> addMetadata typeof<WorkItem.LinkArtifactParameters>
 
-                               route "/link/promotion-set" WorkItem.LinkPromotionSet
+                               route "/link/promotion-set" (composeHandlers requireRepoWrite WorkItem.LinkPromotionSet)
                                |> addMetadata typeof<WorkItem.LinkPromotionSetParameters>
 
-                               route "/links/list" WorkItem.GetLinks
+                               route "/links/list" (composeHandlers requireRepoRead WorkItem.GetLinks)
                                |> addMetadata typeof<WorkItem.GetWorkItemLinksParameters>
 
-                               route "/attachments/list" WorkItem.ListAttachments
+                               route "/attachments/list" (composeHandlers requireRepoRead WorkItem.ListAttachments)
                                |> addMetadata typeof<WorkItem.ListWorkItemAttachmentsParameters>
 
-                               route "/attachments/show" WorkItem.ShowAttachment
+                               route "/attachments/show" (composeHandlers requireRepoRead WorkItem.ShowAttachment)
                                |> addMetadata typeof<WorkItem.ShowWorkItemAttachmentParameters>
 
-                               route "/attachments/download" WorkItem.DownloadAttachment
+                               route "/attachments/download" (composeHandlers requireRepoRead WorkItem.DownloadAttachment)
                                |> addMetadata typeof<WorkItem.DownloadWorkItemAttachmentParameters>
 
-                               route "/links/remove/reference" WorkItem.RemoveReferenceLink
+                               route "/links/remove/reference" (composeHandlers requireRepoWrite WorkItem.RemoveReferenceLink)
                                |> addMetadata typeof<WorkItem.RemoveReferenceLinkParameters>
 
-                               route "/links/remove/promotion-set" WorkItem.RemovePromotionSetLink
+                               route "/links/remove/promotion-set" (composeHandlers requireRepoWrite WorkItem.RemovePromotionSetLink)
                                |> addMetadata typeof<WorkItem.RemovePromotionSetLinkParameters>
 
-                               route "/links/remove/artifact" WorkItem.RemoveArtifactLink
+                               route "/links/remove/artifact" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactLink)
                                |> addMetadata typeof<WorkItem.RemoveArtifactLinkParameters>
 
-                               route "/links/remove/artifact-type" WorkItem.RemoveArtifactTypeLinks
+                               route "/links/remove/artifact-type" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactTypeLinks)
                                |> addMetadata typeof<WorkItem.RemoveArtifactTypeLinksParameters> ]
                     ]
                 subRoute
@@ -1360,10 +1390,10 @@ module Application =
                 subRoute
                     "/artifact"
                     [
-                        POST [ route "/create" Artifact.Create
+                        POST [ route "/create" (composeHandlers requireRepoWrite Artifact.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Artifact.CreateArtifactParameters> ]
 
-                        GET [ routef "/%O/download-uri" Artifact.GetDownloadUri ]
+                        GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepoRead (Artifact.GetDownloadUri artifactId)) ]
                     ]
                 subRoute
                     "/repository"

--- a/src/Grace.Server/WorkItem.Server.fs
+++ b/src/Grace.Server/WorkItem.Server.fs
@@ -583,7 +583,7 @@ module WorkItem =
 
             let! persistedArtifactMetadataResult =
                 task {
-                    match! artifactActorProxy.Handle (ArtifactCommand.Create artifactMetadata) metadata with
+                    match! artifactActorProxy.Handle (ArtifactCommand.Create(ArtifactCreated.FromMetadata artifactMetadata)) metadata with
                     | Ok _ -> return Ok artifactMetadata
                     | Error graceError when isRecoverableArtifactCreateError graceError ->
                         match! artifactActorProxy.Get metadata.CorrelationId with

--- a/src/Grace.Types/Artifact.Types.fs
+++ b/src/Grace.Types/Artifact.Types.fs
@@ -24,17 +24,29 @@ module Artifact =
     [<GenerateSerializer>]
     type ArtifactMetadata =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             ArtifactId: ArtifactId
+            [<Id(2u)>]
             OwnerId: OwnerId
+            [<Id(3u)>]
             OrganizationId: OrganizationId
+            [<Id(4u)>]
             RepositoryId: RepositoryId
+            [<Id(5u)>]
             ArtifactType: ArtifactType
+            [<Id(6u)>]
             MimeType: string
+            [<Id(7u)>]
             Size: int64
+            [<Id(8u)>]
             Sha256: Sha256Hash option
+            [<Id(9u)>]
             BlobPath: string
+            [<Id(10u)>]
             CreatedAt: Instant
+            [<Id(11u)>]
             CreatedBy: UserId
         }
 
@@ -60,21 +72,233 @@ module Artifact =
     [<GenerateSerializer>]
     type ArtifactDownloadUriResult = { ArtifactId: ArtifactId; DownloadUri: UriWithSharedAccessSignature }
 
-    [<KnownType("GetKnownTypes")>]
+    [<CLIMutable; GenerateSerializer>]
+    type ArtifactCreated =
+        {
+            [<Id(0u)>]
+            ArtifactId: ArtifactId
+            [<Id(1u)>]
+            OwnerId: OwnerId
+            [<Id(2u)>]
+            OrganizationId: OrganizationId
+            [<Id(3u)>]
+            RepositoryId: RepositoryId
+            [<Id(4u)>]
+            ArtifactType: string
+            [<Id(5u)>]
+            OtherArtifactType: string
+            [<Id(6u)>]
+            MimeType: string
+            [<Id(7u)>]
+            Size: int64
+            [<Id(8u)>]
+            Sha256: string
+            [<Id(9u)>]
+            BlobPath: string
+            [<Id(10u)>]
+            CreatedAtUnixTimeTicks: int64
+            [<Id(11u)>]
+            CreatedBy: string
+        }
+
+        static member FromMetadata(artifact: ArtifactMetadata) =
+            let artifactType, otherArtifactType =
+                match artifact.ArtifactType with
+                | ArtifactType.AgentSummary -> "AgentSummary", String.Empty
+                | ArtifactType.ConflictReport -> "ConflictReport", String.Empty
+                | ArtifactType.Prompt -> "Prompt", String.Empty
+                | ArtifactType.ValidationOutput -> "ValidationOutput", String.Empty
+                | ArtifactType.ReviewNotes -> "ReviewNotes", String.Empty
+                | ArtifactType.Other kind -> "Other", kind
+
+            {
+                ArtifactId = artifact.ArtifactId
+                OwnerId = artifact.OwnerId
+                OrganizationId = artifact.OrganizationId
+                RepositoryId = artifact.RepositoryId
+                ArtifactType = artifactType
+                OtherArtifactType = otherArtifactType
+                MimeType = artifact.MimeType
+                Size = artifact.Size
+                Sha256 =
+                    artifact.Sha256
+                    |> Option.map string
+                    |> Option.defaultValue String.Empty
+                BlobPath = artifact.BlobPath
+                CreatedAtUnixTimeTicks = artifact.CreatedAt.ToUnixTimeTicks()
+                CreatedBy = artifact.CreatedBy
+            }
+
+        member this.ToMetadata() =
+            let artifactType =
+                match this.ArtifactType with
+                | value when String.Equals(value, "AgentSummary", StringComparison.OrdinalIgnoreCase) -> ArtifactType.AgentSummary
+                | value when String.Equals(value, "ConflictReport", StringComparison.OrdinalIgnoreCase) -> ArtifactType.ConflictReport
+                | value when String.Equals(value, "Prompt", StringComparison.OrdinalIgnoreCase) -> ArtifactType.Prompt
+                | value when String.Equals(value, "ValidationOutput", StringComparison.OrdinalIgnoreCase) -> ArtifactType.ValidationOutput
+                | value when String.Equals(value, "ReviewNotes", StringComparison.OrdinalIgnoreCase) -> ArtifactType.ReviewNotes
+                | value when String.Equals(value, "Other", StringComparison.OrdinalIgnoreCase) -> ArtifactType.Other this.OtherArtifactType
+                | value -> ArtifactType.Other value
+
+            { ArtifactMetadata.Default with
+                ArtifactId = this.ArtifactId
+                OwnerId = this.OwnerId
+                OrganizationId = this.OrganizationId
+                RepositoryId = this.RepositoryId
+                ArtifactType = artifactType
+                MimeType = this.MimeType
+                Size = this.Size
+                Sha256 =
+                    if String.IsNullOrWhiteSpace this.Sha256 then
+                        None
+                    else
+                        Some(Sha256Hash this.Sha256)
+                BlobPath = this.BlobPath
+                CreatedAt = Instant.FromUnixTimeTicks this.CreatedAtUnixTimeTicks
+                CreatedBy = UserId this.CreatedBy
+            }
+
+    [<CLIMutable; GenerateSerializer>]
     type ArtifactCommand =
-        | Create of artifact: ArtifactMetadata
+        {
+            [<Id(0u)>]
+            Command: string
+            [<Id(1u)>]
+            ArtifactId: ArtifactId
+            [<Id(2u)>]
+            OwnerId: OwnerId
+            [<Id(3u)>]
+            OrganizationId: OrganizationId
+            [<Id(4u)>]
+            RepositoryId: RepositoryId
+            [<Id(5u)>]
+            ArtifactType: string
+            [<Id(6u)>]
+            OtherArtifactType: string
+            [<Id(7u)>]
+            MimeType: string
+            [<Id(8u)>]
+            Size: int64
+            [<Id(9u)>]
+            Sha256: string
+            [<Id(10u)>]
+            BlobPath: string
+            [<Id(11u)>]
+            CreatedAtUnixTimeTicks: int64
+            [<Id(12u)>]
+            CreatedBy: string
+        }
 
-        static member GetKnownTypes() = GetKnownTypes<ArtifactCommand>()
+        static member Create(artifact: ArtifactCreated) =
+            {
+                Command = "Create"
+                ArtifactId = artifact.ArtifactId
+                OwnerId = artifact.OwnerId
+                OrganizationId = artifact.OrganizationId
+                RepositoryId = artifact.RepositoryId
+                ArtifactType = artifact.ArtifactType
+                OtherArtifactType = artifact.OtherArtifactType
+                MimeType = artifact.MimeType
+                Size = artifact.Size
+                Sha256 = artifact.Sha256
+                BlobPath = artifact.BlobPath
+                CreatedAtUnixTimeTicks = artifact.CreatedAtUnixTimeTicks
+                CreatedBy = artifact.CreatedBy
+            }
 
-    [<KnownType("GetKnownTypes")>]
-    type ArtifactEventType =
-        | Created of artifact: ArtifactMetadata
+        member this.ToCreated() =
+            {
+                ArtifactId = this.ArtifactId
+                OwnerId = this.OwnerId
+                OrganizationId = this.OrganizationId
+                RepositoryId = this.RepositoryId
+                ArtifactType = this.ArtifactType
+                OtherArtifactType = this.OtherArtifactType
+                MimeType = this.MimeType
+                Size = this.Size
+                Sha256 = this.Sha256
+                BlobPath = this.BlobPath
+                CreatedAtUnixTimeTicks = this.CreatedAtUnixTimeTicks
+                CreatedBy = this.CreatedBy
+            }
 
-        static member GetKnownTypes() = GetKnownTypes<ArtifactEventType>()
+    module ArtifactCommandNames =
+        let Create = "Create"
 
-    type ArtifactEvent = { Event: ArtifactEventType; Metadata: EventMetadata }
+    [<CLIMutable; GenerateSerializer>]
+    type ArtifactEvent =
+        {
+            [<Id(0u)>]
+            Event: string
+            [<Id(1u)>]
+            ArtifactId: ArtifactId
+            [<Id(2u)>]
+            OwnerId: OwnerId
+            [<Id(3u)>]
+            OrganizationId: OrganizationId
+            [<Id(4u)>]
+            RepositoryId: RepositoryId
+            [<Id(5u)>]
+            ArtifactType: string
+            [<Id(6u)>]
+            OtherArtifactType: string
+            [<Id(7u)>]
+            MimeType: string
+            [<Id(8u)>]
+            Size: int64
+            [<Id(9u)>]
+            Sha256: string
+            [<Id(10u)>]
+            BlobPath: string
+            [<Id(11u)>]
+            CreatedAtUnixTimeTicks: int64
+            [<Id(12u)>]
+            CreatedBy: string
+            [<Id(13u)>]
+            Metadata: EventMetadata
+        }
+
+        static member FromCreated(eventName: string, artifact: ArtifactCreated, metadata: EventMetadata) =
+            {
+                Event = eventName
+                ArtifactId = artifact.ArtifactId
+                OwnerId = artifact.OwnerId
+                OrganizationId = artifact.OrganizationId
+                RepositoryId = artifact.RepositoryId
+                ArtifactType = artifact.ArtifactType
+                OtherArtifactType = artifact.OtherArtifactType
+                MimeType = artifact.MimeType
+                Size = artifact.Size
+                Sha256 = artifact.Sha256
+                BlobPath = artifact.BlobPath
+                CreatedAtUnixTimeTicks = artifact.CreatedAtUnixTimeTicks
+                CreatedBy = artifact.CreatedBy
+                Metadata = metadata
+            }
+
+        member this.ToMetadata() =
+            {
+                ArtifactId = this.ArtifactId
+                OwnerId = this.OwnerId
+                OrganizationId = this.OrganizationId
+                RepositoryId = this.RepositoryId
+                ArtifactType = this.ArtifactType
+                OtherArtifactType = this.OtherArtifactType
+                MimeType = this.MimeType
+                Size = this.Size
+                Sha256 = this.Sha256
+                BlobPath = this.BlobPath
+                CreatedAtUnixTimeTicks = this.CreatedAtUnixTimeTicks
+                CreatedBy = this.CreatedBy
+            }
+                .ToMetadata()
+
+    module ArtifactEventNames =
+        let Created = "Created"
 
     module ArtifactMetadata =
-        let UpdateDto (artifactEvent: ArtifactEvent) (_current: ArtifactMetadata) =
-            match artifactEvent.Event with
-            | ArtifactEventType.Created artifact -> artifact
+        let UpdateDto (artifactEvent: ArtifactEvent) (current: ArtifactMetadata) =
+            if String.Equals(artifactEvent.Event, ArtifactEventNames.Created, StringComparison.OrdinalIgnoreCase) then
+                artifactEvent.ToMetadata()
+            else
+                current


### PR DESCRIPTION
## Summary

- Adds hosted work-item, artifact, attachment, and repository-permission proofs for `B-013`, `B-014`, and `B-016`.
- Proves attachment download URIs resolve to expected blob bytes and persisted content metadata.
- Proves artifact create/download identity, blob path, and metadata round-trip through actor-backed reads.
- Tightens work-item/artifact route authorization wiring and endpoint manifest expectations.
- Fixes artifact metadata Orleans serialization by assigning stable field IDs to `ArtifactMetadata`.
- Fixes the SDK artifact download route so it includes the owner scope required by server authorization.

## Implementation Notes

`ArtifactMetadata` had `[<GenerateSerializer>]` without Orleans `[<Id>]` fields, so actor `Get` calls could return default
metadata over Orleans. The fix assigns stable IDs to metadata fields and keeps the flattened artifact command/event shape
from the issue pass. `ArtifactActor.Handle` now rejects unsupported command strings instead of letting them create default
artifact state.

`Artifact.BuildDownloadUriRoute` now includes `ownerId` alongside organization and repository scope, matching
`requireArtifactRepoRead` for SDK and CLI callers.

## Validation

- `dotnet fantomas src\Grace.Actors\Artifact.Actor.fs src\Grace.Actors\PromotionSet.Actor.fs src\Grace.Server.Tests\WorkItem.Integration.Server.Tests.fs src\Grace.Server\Artifact.Server.fs src\Grace.Server\Security\EndpointAuthorizationManifest.Server.fs src\Grace.Server\Startup.Server.fs src\Grace.Server\WorkItem.Server.fs src\Grace.Types\Artifact.Types.fs`
- `dotnet fantomas src\Grace.Authorization.Tests\EndpointAuthorizationManifest.Tests.fs`
- `dotnet build src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release`
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~WorkItemLinksAuthorizationIntegrationTests|FullyQualifiedName~WorkItemAttachmentEndpointsIntegrationTests"`
  - Passed: 5/5.
- `dotnet test src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --configuration Release --filter "FullyQualifiedName~EndpointAuthorizationManifestTests"`
  - Passed: 9/9.
- `pwsh ./scripts/validate.ps1 -Full`
  - Passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Test counts: Types 65; Authorization 36; Server.Unit 440; CLI 272 passed and 1 skipped; Server.Tests 144.
- Fix validation for `1e7d06d789b875a3d118afb8c767e9734c51fe46`:
  - `dotnet fantomas 'src\Grace.SDK\Artifact.SDK.fs' 'src\Grace.CLI.Tests\Artifact.SDK.Tests.fs'` passed.
  - `dotnet test --configuration Release 'src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj' --filter 'FullyQualifiedName~BuildDownloadUriRouteIncludesOwnerScope'` passed, 1/1.
  - `pwsh ./scripts/validate.ps1 -Full` passed: Types 65; Authorization 36; Server.Unit 440; CLI 274; Server.Tests 144.
  - `git diff --check` passed.

## Review Status

- Implementation by worker Euler completed in `07eeec5c12bc54fbafa5fc8674273e6478f74942`.
- Planck review-only pass posted findings and OK notes: https://github.com/ScottArbeit/Grace/pull/289#issuecomment-4631450466
- Planck P1 finding was fixed by worker Maxwell in `1e7d06d789b875a3d118afb8c767e9734c51fe46`.
- Fix evidence was posted here: https://github.com/ScottArbeit/Grace/pull/289#issuecomment-4631534001
- Turing final review-only pass found no issues and posted OK notes: https://github.com/ScottArbeit/Grace/pull/289#issuecomment-4631595523
- No open review findings remain.

## Notes

- PR target is the epic integration branch `epic/249-validation-coverage`, per the updated epic workflow.
- No OpenAPI/generated artifacts changed.
- No docs changed.
- `validate.ps1 -Full` reports its repo format phase as skipped because repo formatting is temporarily disabled;
  targeted Fantomas was run on touched F# files before validation.

Closes #256