### PR TITLE
W6a: Add hosted branch lifecycle route proof

### DIFF
--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -1,0 +1,248 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation
+open Grace.Shared.Validation.Errors
+open Grace.Types
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+
+module BranchServerTestHelpers =
+    let private assertOk (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+        }
+
+    let private assertBadRequestGraceError (expectedError: string) (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            let error = deserialize<GraceError> body
+            Assert.That(error.Error, Is.EqualTo(expectedError))
+            Assert.That(error.CorrelationId, Is.Not.Empty)
+        }
+
+    let getBranchParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Branch.GetBranchParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getBranchAsync (repositoryId: string) (branchId: string) =
+        task {
+            let! response = Client.PostAsync("/branch/get", createJsonContent (getBranchParameters repositoryId branchId))
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> response
+            return returnValue.ReturnValue
+        }
+
+    let waitForBranchAsync (repositoryId: string) (branchId: string) =
+        task {
+            let timeoutAt = DateTime.UtcNow.AddSeconds(15.0)
+            let mutable branch = None
+            let mutable lastBody = String.Empty
+            let mutable lastStatus = HttpStatusCode.OK
+
+            while branch.IsNone && DateTime.UtcNow < timeoutAt do
+                let! response = Client.PostAsync("/branch/get", createJsonContent (getBranchParameters repositoryId branchId))
+                let! body = response.Content.ReadAsStringAsync()
+                lastBody <- body
+                lastStatus <- response.StatusCode
+
+                if response.StatusCode = HttpStatusCode.OK then
+                    let returnValue = deserialize<GraceReturnValue<Branch.BranchDto>> body
+                    branch <- Some returnValue.ReturnValue
+                else
+                    do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            match branch with
+            | Some branch -> return branch
+            | None ->
+                Assert.Fail($"Timed out waiting for branch {branchId} in repository {repositoryId}. Last status: {lastStatus}; body: {lastBody}")
+                return Unchecked.defaultof<Branch.BranchDto>
+        }
+
+    let createBranchAsync (repositoryId: string) (parentBranch: Branch.BranchDto) (branchName: string) =
+        task {
+            let branchId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Branch.CreateBranchParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.BranchName <- branchName
+            parameters.ParentBranchId <- $"{parentBranch.BranchId}"
+            parameters.ParentBranchName <- $"{parentBranch.BranchName}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/branch/create", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+
+            Assert.That(returnValue.Properties.ContainsKey(nameof BranchId), Is.True)
+
+            let returnedBranchProperty = returnValue.Properties[nameof BranchId]
+
+            let returnedBranchId = Grace.Server.Tests.Common.requireGuidProperty (nameof BranchId) returnedBranchProperty
+
+            Assert.That(returnedBranchId, Is.EqualTo(Guid.Parse(branchId)))
+
+            return! waitForBranchAsync repositoryId branchId
+        }
+
+    let getRepositoryBranchesAsync (repositoryId: string) =
+        task {
+            let parameters = Parameters.Repository.GetBranchesParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.MaxCount <- 100
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/repository/getBranches", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto array>> response
+            return returnValue.ReturnValue
+        }
+
+    let saveBranchAsync (repositoryId: string) (branch: Branch.BranchDto) =
+        task {
+            let parameters = Parameters.Branch.CreateReferenceParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.DirectoryVersionId <- branch.BasedOn.DirectoryId
+            parameters.Sha256Hash <- $"{branch.BasedOn.Sha256Hash}"
+            parameters.Message <- "Hosted branch lifecycle route proof save"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/branch/save", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+
+            Assert.That(returnValue.Properties.ContainsKey(nameof BranchId), Is.True)
+            Assert.That(returnValue.Properties.ContainsKey(nameof RepositoryId), Is.True)
+
+            return returnValue
+        }
+
+    let getBranchReferencesAsync (repositoryId: string) (branchId: string) =
+        task {
+            let parameters = Parameters.Branch.GetReferencesParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.MaxCount <- 10
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/branch/getReferences", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Reference.ReferenceDto array>> response
+            return returnValue.ReturnValue
+        }
+
+    let getBranchVersionAsync (repositoryId: string) (branchId: string) =
+        task {
+            let parameters = Parameters.Branch.GetBranchVersionParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/branch/getVersion", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Guid array>> response
+            return returnValue.ReturnValue
+        }
+
+    let assertBranchMatches (expectedRepositoryId: string) (expectedBranchId: string) (expectedBranchName: string) (branch: Branch.BranchDto) =
+        Assert.That(branch.RepositoryId, Is.EqualTo(Guid.Parse(expectedRepositoryId)))
+        Assert.That(branch.BranchId, Is.EqualTo(Guid.Parse(expectedBranchId)))
+        Assert.That($"{branch.BranchName}", Is.EqualTo(expectedBranchName))
+        Assert.That(branch.OwnerId, Is.EqualTo(Guid.Parse(ownerId)))
+        Assert.That(branch.OrganizationId, Is.EqualTo(Guid.Parse(organizationId)))
+        Assert.That(branch.BasedOn.ReferenceId, Is.Not.EqualTo(Guid.Empty))
+
+    let assertBranchReferenceShape (expectedRepositoryId: string) (expectedBranchId: string) (reference: Reference.ReferenceDto) =
+        Assert.That(reference.RepositoryId, Is.EqualTo(Guid.Parse(expectedRepositoryId)))
+        Assert.That(reference.BranchId, Is.EqualTo(Guid.Parse(expectedBranchId)))
+        Assert.That(reference.ReferenceId, Is.Not.EqualTo(Guid.Empty))
+        Assert.That(reference.DirectoryId, Is.Not.EqualTo(Guid.Empty))
+        Assert.That($"{reference.Sha256Hash}", Is.Not.Empty)
+
+    let assertMissingRepositoryAsync () =
+        task {
+            let parameters = getBranchParameters $"{Guid.NewGuid()}" repositoryDefaultBranchIds[0]
+            let! response = Client.PostAsync("/branch/get", createJsonContent parameters)
+            let expected = RepositoryError.getErrorMessage RepositoryError.RepositoryIdDoesNotExist
+            do! assertBadRequestGraceError expected response
+        }
+
+    let assertMissingBranchAsync (repositoryId: string) =
+        task {
+            let parameters = getBranchParameters repositoryId $"{Guid.NewGuid()}"
+            let! response = Client.PostAsync("/branch/get", createJsonContent parameters)
+            let expected = BranchError.getErrorMessage BranchError.BranchIdDoesNotExist
+            do! assertBadRequestGraceError expected response
+        }
+
+[<Parallelizable(ParallelScope.All)>]
+type BranchServer() =
+
+    [<Test>]
+    member _.CreateGetListReferenceAndVersionRoutesRoundTripBranchIdentity() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let parentBranchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId parentBranchId
+            let branchName = $"Branch{Guid.NewGuid():N}"
+
+            let! createdBranch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch branchName
+            BranchServerTestHelpers.assertBranchMatches repositoryId $"{createdBranch.BranchId}" branchName createdBranch
+            Assert.That(createdBranch.ParentBranchId, Is.EqualTo(parentBranch.BranchId))
+            Assert.That(createdBranch.BasedOn.ReferenceId, Is.EqualTo(parentBranch.BasedOn.ReferenceId))
+
+            let! fetchedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{createdBranch.BranchId}"
+            BranchServerTestHelpers.assertBranchMatches repositoryId $"{createdBranch.BranchId}" branchName fetchedBranch
+
+            let! listedBranches = BranchServerTestHelpers.getRepositoryBranchesAsync repositoryId
+
+            Assert.That(
+                listedBranches
+                |> Array.exists (fun branch -> branch.BranchId = createdBranch.BranchId),
+                Is.True
+            )
+
+            let! _saveResult = BranchServerTestHelpers.saveBranchAsync repositoryId createdBranch
+            let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{createdBranch.BranchId}"
+            Assert.That(savedBranch.LatestSave.ReferenceId, Is.Not.EqualTo(Guid.Empty))
+            Assert.That(savedBranch.LatestSave.BranchId, Is.EqualTo(createdBranch.BranchId))
+
+            let! references = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{createdBranch.BranchId}"
+            Assert.That(references, Is.Not.Empty)
+
+            references
+            |> Array.iter (BranchServerTestHelpers.assertBranchReferenceShape repositoryId $"{createdBranch.BranchId}")
+
+            let! versionDirectoryIds = BranchServerTestHelpers.getBranchVersionAsync repositoryId $"{createdBranch.BranchId}"
+            Assert.That(versionDirectoryIds, Is.Not.Empty)
+
+            versionDirectoryIds
+            |> Array.iter (fun directoryId -> Assert.That(directoryId, Is.Not.EqualTo(Guid.Empty)))
+
+            do! BranchServerTestHelpers.assertMissingRepositoryAsync ()
+            do! BranchServerTestHelpers.assertMissingBranchAsync repositoryId
+        }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Slop.Server.Tests.fs" />
     <Compile Include="Owner.Server.Tests.fs" />
     <Compile Include="Repository.Server.Tests.fs" />
+    <Compile Include="Branch.Server.Tests.fs" />
     <Compile Include="Approval.Server.Tests.fs" />
     <Compile Include="Webhook.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds focused hosted HTTP proof for the core branch lifecycle route family for `B-003`.
- Proves branch create/get/list behavior under an existing repository and default parent branch.
- Proves a representative branch state transition through `/branch/save`.
- Proves reference and version DTO shape after the save.
- Proves missing repository and missing branch inputs return the current `GraceError`/`400 BadRequest` contract.

## Validation

- `dotnet tool restore`
- `fantomas src\Grace.Server.Tests\Branch.Server.Tests.fs`
- `dotnet build --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj`
- `dotnet test --configuration Release --no-build src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~BranchServer"`
  - Passed: 1/1.
- `pwsh ./scripts/validate.ps1 -Full`
  - Passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Test counts: Types 65; Authorization 36; Server.Unit 440; CLI 273 passed and 1 skipped; Server.Tests 145.
- `git diff --check`
  - Passed.

## Review Status

- Implementation by worker Gauss completed in `21fc726156f531484f213f8e749d506066cb94b9`.
- Wegener review-only pass found no issues and posted OK notes: https://github.com/ScottArbeit/Grace/pull/290#issuecomment-4631806548
- No open review findings remain.

## Notes

- PR target is the epic integration branch `epic/249-validation-coverage`, per the updated epic workflow.
- No OpenAPI or generated artifacts changed.
- No branch actor/server semantics changed.
- `/repository/getBranchesByBranchId` is intentionally not asserted in this PR. The focused worker run found it returns an
  empty collection for a newly created branch; that looks like existing query-shape/casing behavior and should be handled
  as follow-up evidence rather than smuggled into this proof-only slice.
- `validate.ps1 -Full` reports its repo format phase as skipped because repo formatting is temporarily disabled;
  targeted Fantomas was run on the touched F# file before validation.

Closes #257