### PR TITLE
W6b: Add hosted directory diff and reminder route proof

### DIFF
--- a/src/Grace.Server.Tests/Diff.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Diff.Server.Tests.fs
@@ -1,0 +1,58 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Net
+
+module DiffServerTestHelpers =
+    let getDiffParameters (repositoryId: string) (directoryVersionId1: DirectoryVersionId) (directoryVersionId2: DirectoryVersionId) =
+        let parameters = Parameters.Diff.GetDiffParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.DirectoryVersionId1 <- directoryVersionId1
+        parameters.DirectoryVersionId2 <- directoryVersionId2
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getDiffBySha256HashParameters (repositoryId: string) (sha256Hash1: Sha256Hash) (sha256Hash2: Sha256Hash) =
+        let parameters = Parameters.Diff.GetDiffBySha256HashParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.Sha256Hash1 <- sha256Hash1
+        parameters.Sha256Hash2 <- sha256Hash2
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+[<NonParallelizable>]
+type DiffServer() =
+
+    [<Test>]
+    member _.DiffRoutesRejectInvalidDirectoryIdsAndShaInputsBeforeReturningSuccessEnvelopes() =
+        task {
+            let repositoryId = repositoryIds[2]
+
+            let invalidDirectoryParameters = DiffServerTestHelpers.getDiffParameters repositoryId Guid.Empty (Guid.NewGuid())
+
+            let! invalidDirectoryResponse = Client.PostAsync("/diff/getDiff", createJsonContent invalidDirectoryParameters)
+            let! invalidDirectoryBody = invalidDirectoryResponse.Content.ReadAsStringAsync()
+            Assert.That(invalidDirectoryResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), invalidDirectoryBody)
+            let invalidDirectoryError = deserialize<GraceError> invalidDirectoryBody
+            Assert.That(invalidDirectoryError.Error, Is.EqualTo(DiffError.getErrorMessage DiffError.InvalidDirectoryVersionId))
+            Assert.That(invalidDirectoryError.CorrelationId, Is.Not.Empty)
+
+            let invalidHashParameters = DiffServerTestHelpers.getDiffBySha256HashParameters repositoryId "not-a-sha" "also-not-a-sha"
+
+            let! invalidHashResponse = Client.PostAsync("/diff/getDiffBySha256Hash", createJsonContent invalidHashParameters)
+            let! invalidHashBody = invalidHashResponse.Content.ReadAsStringAsync()
+            Assert.That(invalidHashResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), invalidHashBody)
+            let invalidHashError = deserialize<GraceError> invalidHashBody
+            Assert.That(invalidHashError.Error, Is.EqualTo(DiffError.getErrorMessage DiffError.InvalidSha256Hash))
+            Assert.That(invalidHashError.CorrelationId, Is.Not.Empty)
+        }

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -209,6 +209,11 @@ type DirectoryVersionServer() =
 
             let! fetchedRoot = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetchedRoot
+            Assert.That(fetchedRoot.DirectoryVersion.Directories, Has.Count.EqualTo(1))
+            Assert.That(fetchedRoot.DirectoryVersion.Directories, Does.Contain(childId))
+
+            let! fetchedChild = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId childId
+            DirectoryVersionServerTestHelpers.assertDirectoryVersionDto child fetchedChild
 
             let missingId = Guid.NewGuid()
 

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -1,0 +1,222 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.DirectoryVersion
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Net
+open System.Net.Http
+
+module DirectoryVersionServerTestHelpers =
+    type DirectoryVersionModel = Grace.Types.Common.DirectoryVersion
+
+    let private sha256 (index: int) = Convert.ToString(index, 16).PadLeft(64, '0')
+
+    let createDirectoryVersion
+        (directoryVersionId: DirectoryVersionId)
+        (repositoryId: string)
+        (relativePath: RelativePath)
+        (hashIndex: int)
+        (childDirectoryIds: DirectoryVersionId seq)
+        : DirectoryVersionModel
+        =
+        DirectoryVersionModel.Create
+            directoryVersionId
+            (Guid.Parse ownerId)
+            (Guid.Parse organizationId)
+            (Guid.Parse repositoryId)
+            relativePath
+            (sha256 hashIndex)
+            (List<DirectoryVersionId>(childDirectoryIds))
+            (List<FileVersion>())
+            0L
+
+    let createParameters (directoryVersion: DirectoryVersionModel) =
+        let parameters = Parameters.DirectoryVersion.CreateParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- $"{directoryVersion.RepositoryId}"
+        parameters.DirectoryVersionId <- $"{directoryVersion.DirectoryVersionId}"
+        parameters.DirectoryVersion <- directoryVersion
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getParameters (repositoryId: string) (directoryVersionId: DirectoryVersionId) =
+        let parameters = Parameters.DirectoryVersion.GetParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.DirectoryVersionId <- $"{directoryVersionId}"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getBySha256HashParameters (repositoryId: string) (directoryVersionId: DirectoryVersionId) (sha256Hash: Sha256Hash) =
+        let parameters = Parameters.DirectoryVersion.GetBySha256HashParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.DirectoryVersionId <- $"{directoryVersionId}"
+        parameters.Sha256Hash <- sha256Hash
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let saveParameters (repositoryId: string) (directoryVersions: DirectoryVersionModel seq) =
+        let parameters = Parameters.DirectoryVersion.SaveDirectoryVersionsParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        for directoryVersion in directoryVersions do
+            parameters.DirectoryVersions.Add(directoryVersion)
+
+        parameters
+
+    let assertOk (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/json"))
+        }
+
+    let assertBadRequestGraceError (expectedError: string) (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            let error = deserialize<GraceError> body
+            Assert.That(error.Error, Is.EqualTo(expectedError))
+            Assert.That(error.CorrelationId, Is.Not.Empty)
+        }
+
+    let createDirectoryVersionAsync (directoryVersion: DirectoryVersionModel) =
+        task {
+            let! response = Client.PostAsync("/directory/create", createJsonContent (createParameters directoryVersion))
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+            Assert.That(returnValue.ReturnValue, Is.EqualTo("Directory version command succeeded."))
+            Assert.That(returnValue.Properties.ContainsKey(nameof DirectoryVersionId), Is.True)
+        }
+
+    let getDirectoryVersionAsync (repositoryId: string) (directoryVersionId: DirectoryVersionId) =
+        task {
+            let! response = Client.PostAsync("/directory/get", createJsonContent (getParameters repositoryId directoryVersionId))
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<DirectoryVersionDto>> response
+            return returnValue.ReturnValue
+        }
+
+    let assertDirectoryVersionDto (expected: DirectoryVersionModel) (actual: DirectoryVersionDto) =
+        Assert.That(actual.DirectoryVersion.DirectoryVersionId, Is.EqualTo(expected.DirectoryVersionId))
+        Assert.That(actual.DirectoryVersion.OwnerId, Is.EqualTo(expected.OwnerId))
+        Assert.That(actual.DirectoryVersion.OrganizationId, Is.EqualTo(expected.OrganizationId))
+        Assert.That(actual.DirectoryVersion.RepositoryId, Is.EqualTo(expected.RepositoryId))
+        Assert.That(actual.DirectoryVersion.RelativePath, Is.EqualTo(expected.RelativePath))
+        Assert.That(actual.DirectoryVersion.Sha256Hash, Is.EqualTo(expected.Sha256Hash))
+        Assert.That(actual.DirectoryVersion.HashesValidated, Is.True)
+
+    let assertDirectoryVersion (expected: DirectoryVersionModel) (actual: DirectoryVersionModel) =
+        Assert.That(actual.DirectoryVersionId, Is.EqualTo(expected.DirectoryVersionId))
+        Assert.That(actual.OwnerId, Is.EqualTo(expected.OwnerId))
+        Assert.That(actual.OrganizationId, Is.EqualTo(expected.OrganizationId))
+        Assert.That(actual.RepositoryId, Is.EqualTo(expected.RepositoryId))
+        Assert.That(actual.RelativePath, Is.EqualTo(expected.RelativePath))
+        Assert.That(actual.Sha256Hash, Is.EqualTo(expected.Sha256Hash))
+        Assert.That(actual.HashesValidated, Is.True)
+
+[<NonParallelizable>]
+type DirectoryVersionServer() =
+
+    [<Test>]
+    member _.CreateGetGetByShaAndRecursiveRoutesPreserveDirectoryDtoShapeAndIdentity() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let childId = Guid.NewGuid()
+            let rootId = Guid.NewGuid()
+
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/src/" 0x101 []
+
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" 0x102 [ childId ]
+
+            do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync child
+            do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync root
+
+            let! fetched = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
+            DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetched
+
+            let getByShaParameters = DirectoryVersionServerTestHelpers.getBySha256HashParameters repositoryId rootId root.Sha256Hash
+
+            let! getByShaResponse = Client.PostAsync("/directory/getBySha256Hash", createJsonContent getByShaParameters)
+            do! DirectoryVersionServerTestHelpers.assertOk getByShaResponse
+            let! getBySha = deserializeContent<GraceReturnValue<DirectoryVersionServerTestHelpers.DirectoryVersionModel>> getByShaResponse
+
+            DirectoryVersionServerTestHelpers.assertDirectoryVersion root getBySha.ReturnValue
+
+            let! recursiveResponse =
+                Client.PostAsync(
+                    "/directory/getDirectoryVersionsRecursive",
+                    createJsonContent (DirectoryVersionServerTestHelpers.getParameters repositoryId rootId)
+                )
+
+            do! DirectoryVersionServerTestHelpers.assertOk recursiveResponse
+            let! recursive = deserializeContent<GraceReturnValue<DirectoryVersionDto array>> recursiveResponse
+
+            let recursiveDirectories =
+                recursive.ReturnValue
+                |> Seq.map (fun dto -> dto.DirectoryVersion)
+                |> Seq.toArray
+
+            Assert.That(recursiveDirectories, Has.Length.EqualTo(2))
+
+            Assert.That(
+                recursiveDirectories
+                |> Array.exists (fun directoryVersion -> directoryVersion.DirectoryVersionId = rootId),
+                Is.True
+            )
+
+            Assert.That(
+                recursiveDirectories
+                |> Array.exists (fun directoryVersion -> directoryVersion.DirectoryVersionId = childId),
+                Is.True
+            )
+        }
+
+    [<Test>]
+    member _.SaveDirectoryVersionsCreatesMissingDirectoriesAndKeepsMissingGetAsGraceError() =
+        task {
+            let repositoryId = repositoryIds[1]
+            let childId = Guid.NewGuid()
+            let rootId = Guid.NewGuid()
+
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/docs/" 0x201 []
+
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" 0x202 [ childId ]
+
+            let! saveResponse =
+                Client.PostAsync(
+                    "/directory/saveDirectoryVersions",
+                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ child; root ])
+                )
+
+            do! DirectoryVersionServerTestHelpers.assertOk saveResponse
+            let! saveReturnValue = deserializeContent<GraceReturnValue<string>> saveResponse
+            Assert.That(saveReturnValue.ReturnValue, Is.EqualTo("Uploaded new directory versions."))
+
+            let! fetchedRoot = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
+            DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetchedRoot
+
+            let missingId = Guid.NewGuid()
+
+            let! missingResponse =
+                Client.PostAsync("/directory/get", createJsonContent (DirectoryVersionServerTestHelpers.getParameters repositoryId missingId))
+
+            do!
+                DirectoryVersionServerTestHelpers.assertBadRequestGraceError
+                    (DirectoryVersionError.getErrorMessage DirectoryVersionError.DirectoryDoesNotExist)
+                    missingResponse
+        }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -26,6 +26,9 @@
     <Compile Include="Webhook.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
+    <Compile Include="DirectoryVersion.Server.Tests.fs" />
+    <Compile Include="Diff.Server.Tests.fs" />
+    <Compile Include="Reminder.Server.Tests.fs" />
     <Compile Include="WorkItem.Integration.Server.Tests.fs" />
     <Compile Include="Auth.Server.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Server.Tests/Reminder.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Reminder.Server.Tests.fs
@@ -1,0 +1,219 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.Reminder
+open NodaTime
+open NodaTime.Text
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.RegularExpressions
+
+module ReminderServerTestHelpers =
+    let formatInstant (instant: Instant) = InstantPattern.ExtendedIso.Format instant
+
+    let createParameters (actorName: string) (actorId: string) (reminderType: string) (fireAt: Instant) =
+        let parameters = Parameters.Reminder.CreateReminderParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ActorName <- actorName
+        parameters.ActorId <- actorId
+        parameters.ReminderType <- reminderType
+        parameters.FireAt <- formatInstant fireAt
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let listParameters (actorName: string) (reminderType: string) =
+        let parameters = Parameters.Reminder.ListRemindersParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ActorName <- actorName
+        parameters.ReminderType <- reminderType
+        parameters.MaxCount <- 100
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getParameters (reminderId: string) =
+        let parameters = Parameters.Reminder.GetReminderParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ReminderId <- $"{reminderId}"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let updateTimeParameters (reminderId: ReminderId) (fireAt: Instant) =
+        let parameters = Parameters.Reminder.UpdateReminderTimeParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ReminderId <- $"{reminderId}"
+        parameters.FireAt <- formatInstant fireAt
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let rescheduleParameters (reminderId: ReminderId) (after: string) =
+        let parameters = Parameters.Reminder.RescheduleReminderParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ReminderId <- $"{reminderId}"
+        parameters.After <- after
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let deleteParameters (reminderId: ReminderId) =
+        let parameters = Parameters.Reminder.DeleteReminderParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryIds[0]
+        parameters.ReminderId <- $"{reminderId}"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let assertOk (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/json"))
+        }
+
+    let extractReminderId (message: string) : ReminderId =
+        let matchResult = Regex.Match(message, "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+
+        if matchResult.Success then
+            Guid.Parse(matchResult.Value)
+        else
+            Assert.Fail($"Could not find a reminder id in message: {message}")
+            Guid.Empty
+
+    let createReminderAsync (actorName: string) (actorId: string) (reminderType: string) (fireAt: Instant) =
+        task {
+            let! response = Client.PostAsync("/reminder/create", createJsonContent (createParameters actorName actorId reminderType fireAt))
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+            return extractReminderId returnValue.ReturnValue
+        }
+
+    let getReminderAsync (reminderId: ReminderId) =
+        task {
+            let! response = Client.PostAsync("/reminder/get", createJsonContent (getParameters $"{reminderId}"))
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<ReminderDto>> response
+            return returnValue.ReturnValue
+        }
+
+    let assertReminder
+        (expectedReminderId: ReminderId)
+        (expectedActorName: string)
+        (expectedActorId: string)
+        (expectedReminderType: ReminderTypes)
+        (expectedTime: Instant)
+        (reminder: ReminderDto)
+        =
+        Assert.That(reminder.ReminderId, Is.EqualTo(expectedReminderId))
+        Assert.That(reminder.ActorName, Is.EqualTo(expectedActorName))
+        Assert.That(reminder.ActorId, Is.EqualTo(expectedActorId))
+        Assert.That(reminder.OwnerId, Is.EqualTo(Guid.Parse(ownerId)))
+        Assert.That(reminder.OrganizationId, Is.EqualTo(Guid.Parse(organizationId)))
+        Assert.That(reminder.RepositoryId, Is.EqualTo(Guid.Parse(repositoryIds[0])))
+        Assert.That(reminder.ReminderType, Is.EqualTo(expectedReminderType))
+        Assert.That(reminder.ReminderTime, Is.EqualTo(expectedTime))
+        Assert.That(reminder.State, Is.EqualTo(ReminderState.EmptyReminderState))
+
+[<NonParallelizable>]
+type ReminderServer() =
+
+    [<Test>]
+    member _.CreateListGetUpdateRescheduleAndDeletePreserveExplicitSchedulingState() =
+        task {
+            let actorName = $"DirectoryVersionActor"
+            let actorId = $"{Guid.NewGuid()}"
+            let initialFireAt = Instant.FromUtc(2035, 1, 2, 3, 4, 5)
+            let updatedFireAt = Instant.FromUtc(2035, 2, 3, 4, 5, 6)
+
+            let! reminderId = ReminderServerTestHelpers.createReminderAsync actorName actorId "Maintenance" initialFireAt
+
+            let! createdReminder = ReminderServerTestHelpers.getReminderAsync reminderId
+            ReminderServerTestHelpers.assertReminder reminderId actorName actorId ReminderTypes.Maintenance initialFireAt createdReminder
+
+            let! listResponse = Client.PostAsync("/reminder/list", createJsonContent (ReminderServerTestHelpers.listParameters actorName "Maintenance"))
+
+            do! ReminderServerTestHelpers.assertOk listResponse
+            let! listed = deserializeContent<GraceReturnValue<ReminderDto seq>> listResponse
+
+            Assert.That(
+                listed.ReturnValue
+                |> Seq.exists (fun reminder ->
+                    reminder.ReminderId = reminderId
+                    && reminder.ReminderTime = initialFireAt),
+                Is.True
+            )
+
+            let! updateResponse =
+                Client.PostAsync("/reminder/updateTime", createJsonContent (ReminderServerTestHelpers.updateTimeParameters reminderId updatedFireAt))
+
+            do! ReminderServerTestHelpers.assertOk updateResponse
+            let! updateReturnValue = deserializeContent<GraceReturnValue<string>> updateResponse
+            Assert.That(updateReturnValue.ReturnValue, Is.EqualTo("Reminder time updated successfully."))
+
+            let! updatedReminder = ReminderServerTestHelpers.getReminderAsync reminderId
+            ReminderServerTestHelpers.assertReminder reminderId actorName actorId ReminderTypes.Maintenance updatedFireAt updatedReminder
+
+            let lowerBound = getCurrentInstant () + Duration.FromHours(2.0)
+
+            let! rescheduleResponse =
+                Client.PostAsync("/reminder/reschedule", createJsonContent (ReminderServerTestHelpers.rescheduleParameters reminderId "+2h"))
+
+            let upperBound =
+                getCurrentInstant ()
+                + Duration.FromHours(2.0)
+                + Duration.FromSeconds(5.0)
+
+            do! ReminderServerTestHelpers.assertOk rescheduleResponse
+            let! rescheduleReturnValue = deserializeContent<GraceReturnValue<string>> rescheduleResponse
+            Assert.That(rescheduleReturnValue.ReturnValue, Does.Contain("Reminder rescheduled to"))
+
+            let! rescheduledReminder = ReminderServerTestHelpers.getReminderAsync reminderId
+            Assert.That(rescheduledReminder.ReminderId, Is.EqualTo(reminderId))
+            Assert.That(rescheduledReminder.ReminderTime >= lowerBound, Is.True)
+            Assert.That(rescheduledReminder.ReminderTime <= upperBound, Is.True)
+
+            let! deleteResponse = Client.PostAsync("/reminder/delete", createJsonContent (ReminderServerTestHelpers.deleteParameters reminderId))
+
+            do! ReminderServerTestHelpers.assertOk deleteResponse
+            let! deleteReturnValue = deserializeContent<GraceReturnValue<string>> deleteResponse
+            Assert.That(deleteReturnValue.ReturnValue, Is.EqualTo("Reminder deleted successfully."))
+
+            let! deletedReminder = ReminderServerTestHelpers.getReminderAsync reminderId
+            Assert.That(deletedReminder.ReminderId, Is.EqualTo(Guid.Empty))
+        }
+
+    [<Test>]
+    member _.ReminderRoutesRejectInvalidCreateAndMissingGetInputsAsGraceErrors() =
+        task {
+            let invalidCreate = ReminderServerTestHelpers.createParameters String.Empty $"{Guid.NewGuid()}" "Maintenance" (Instant.FromUtc(2035, 1, 1, 0, 0))
+
+            let! invalidCreateResponse = Client.PostAsync("/reminder/create", createJsonContent invalidCreate)
+            let! invalidCreateBody = invalidCreateResponse.Content.ReadAsStringAsync()
+            Assert.That(invalidCreateResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), invalidCreateBody)
+            let invalidCreateError = deserialize<GraceError> invalidCreateBody
+            Assert.That(invalidCreateError.Error, Is.EqualTo(ReminderError.getErrorMessage ReminderError.ReminderActorNameIsRequired))
+            Assert.That(invalidCreateError.CorrelationId, Is.Not.Empty)
+
+            let missingGet = ReminderServerTestHelpers.getParameters String.Empty
+            let! missingGetResponse = Client.PostAsync("/reminder/get", createJsonContent missingGet)
+            let! missingGetBody = missingGetResponse.Content.ReadAsStringAsync()
+            Assert.That(missingGetResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), missingGetBody)
+            let missingGetError = deserialize<GraceError> missingGetBody
+            Assert.That(missingGetError.Error, Is.EqualTo(ReminderError.getErrorMessage ReminderError.ReminderIdIsRequired))
+            Assert.That(missingGetError.CorrelationId, Is.Not.Empty)
+        }


### PR DESCRIPTION
## Summary

- Adds hosted directory route proof for `B-004`: create, get, get-by-SHA, recursive get, save, model shape,
  persistence, and missing-directory error behavior.
- Adds hosted diff invalid-input rejection proof for `B-005`, ensuring bad directory IDs and bad SHA inputs do not return
  success envelopes.
- Adds hosted reminder CRUD/scheduling proof for `B-006`: create, list, get, update time, reschedule, and delete with
  deterministic or bounded no-sleep assertions.
- Explicitly defers directory zip proof for `B-007` because `/directory/getZipFile` is currently classified as an
  internal workflow route pending public-contract decision and the issue asked not to add zip proof until storage helper
  setup is stable.

## Deferred / Blocked Notes

- Diff happy-path populate/get proof is deferred. Focused hosted testing found `/diff/populate` currently returns
  `500 InternalServerError` under Azurite-backed `AzureBlobGrainStorage.Diff` because the Diff actor key is built as
  `<directoryVersionId1>*<directoryVersionId2>`, and `*` becomes an invalid Azure Blob state resource name. This PR does
  not broaden into Diff actor state-name repair.
- Directory zip proof is deferred until `/directory/getZipFile` is accepted as public contract and storage helper setup
  is stable.
- Directory unknown-hash missing behavior is not asserted as an error contract in this slice.

## Validation

- `dotnet tool restore`
- `dotnet ...\fantomas-tool.dll src\Grace.Server.Tests\DirectoryVersion.Server.Tests.fs src\Grace.Server.Tests\Diff.Server.Tests.fs src\Grace.Server.Tests\Reminder.Server.Tests.fs`
- `dotnet build --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj`
- `dotnet test --configuration Release --no-build src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter 'FullyQualifiedName~DirectoryVersionServer|FullyQualifiedName~DiffServer|FullyQualifiedName~ReminderServer'`
  - Passed: 5/5.
- `pwsh ./scripts/validate.ps1 -Full`
  - Passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Test counts: Authorization 36; Types 65; Server.Unit 440; CLI 273 passed and 1 skipped; Server.Tests 150.
- Fix validation for `d560a4451a236f21f5b9eda4fd3771152d099e48`:
  - Targeted Fantomas on `DirectoryVersion.Server.Tests.fs` passed.
  - Focused save-directory test passed: 1/1.
  - `pwsh ./scripts/validate.ps1 -Full` passed: Types 65; Authorization 36; Server.Unit 440; CLI 273 passed and 1 skipped; Server.Tests 150.
  - `git diff --check` passed.

## Review Status

- Implementation by worker Socrates completed in `b86097293b3bc64c88e5555431a0b9100bfe704c`.
- Goodall review-only pass posted findings and OK notes: https://github.com/ScottArbeit/Grace/pull/291#issuecomment-4632214306
- Goodall's medium save-directory proof-depth finding was fixed by worker Hume in `d560a4451a236f21f5b9eda4fd3771152d099e48`.
- Fix evidence was posted here: https://github.com/ScottArbeit/Grace/pull/291#issuecomment-4632398267
- Tesla final review-only pass found no issues and posted OK notes: https://github.com/ScottArbeit/Grace/pull/291#issuecomment-4632463767
- No open review findings remain.

## Notes

- PR target is the epic integration branch `epic/249-validation-coverage`, per the updated epic workflow.
- No OpenAPI or generated artifacts changed.
- No server behavior changes were made.
- No docs changed.
- `validate.ps1 -Full` reports its repo format phase as skipped because repo formatting is temporarily disabled;
  targeted Fantomas was run on touched F# files before validation.

Closes #258