### PR TITLE
Add hosted policy and queue route proof

### DIFF
--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -414,8 +414,26 @@ module Interfaces =
         /// Returns the current state of the promotion queue.
         abstract member Get: correlationId: CorrelationId -> Task<PromotionQueue>
 
+        /// Returns the current state of the promotion queue as JSON for route callers.
+        abstract member GetForRoute: correlationId: CorrelationId -> Task<string>
+
         /// Returns the list of events handled by this promotion queue.
         abstract member GetEvents: correlationId: CorrelationId -> Task<IReadOnlyList<PromotionQueueEvent>>
+
+        /// Initializes the queue from route-supplied primitive parameters.
+        abstract member InitializeForRoute: targetBranchId: BranchId -> policySnapshotId: string -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+        /// Enqueues a promotion set from route-supplied primitive parameters.
+        abstract member EnqueueForRoute: promotionSetId: PromotionSetId -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+        /// Dequeues a promotion set from route-supplied primitive parameters.
+        abstract member DequeueForRoute: promotionSetId: PromotionSetId -> eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+        /// Pauses the queue through the actor-backed route path.
+        abstract member PauseForRoute: eventMetadata: EventMetadata -> Task<GraceResult<string>>
+
+        /// Resumes the queue through the actor-backed route path.
+        abstract member ResumeForRoute: eventMetadata: EventMetadata -> Task<GraceResult<string>>
 
         /// Validates incoming commands and converts them to events that are stored in the database.
         abstract member Handle: command: PromotionQueueCommand -> eventMetadata: EventMetadata -> Task<GraceResult<string>>

--- a/src/Grace.Actors/PromotionQueue.Actor.fs
+++ b/src/Grace.Actors/PromotionQueue.Actor.fs
@@ -12,6 +12,7 @@ open Grace.Shared.Constants
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Events
+open Grace.Types.Policy
 open Grace.Types.Queue
 open Grace.Types.Common
 open Microsoft.Extensions.Logging
@@ -102,11 +103,26 @@ module PromotionQueue =
                 this.correlationId <- correlationId
                 promotionQueue |> returnTask
 
+            member this.GetForRoute correlationId =
+                this.correlationId <- correlationId
+                serialize promotionQueue |> returnTask
+
             member this.GetEvents correlationId =
                 this.correlationId <- correlationId
 
                 state.State :> IReadOnlyList<PromotionQueueEvent>
                 |> returnTask
+
+            member this.InitializeForRoute targetBranchId policySnapshotId metadata =
+                (this :> IPromotionQueueActor).Handle (PromotionQueueCommand.Initialize(targetBranchId, PolicySnapshotId policySnapshotId)) metadata
+
+            member this.EnqueueForRoute promotionSetId metadata = (this :> IPromotionQueueActor).Handle (PromotionQueueCommand.Enqueue promotionSetId) metadata
+
+            member this.DequeueForRoute promotionSetId metadata = (this :> IPromotionQueueActor).Handle (PromotionQueueCommand.Dequeue promotionSetId) metadata
+
+            member this.PauseForRoute metadata = (this :> IPromotionQueueActor).Handle PromotionQueueCommand.Pause metadata
+
+            member this.ResumeForRoute metadata = (this :> IPromotionQueueActor).Handle PromotionQueueCommand.Resume metadata
 
             member this.Handle command metadata =
                 let isValid (command: PromotionQueueCommand) (metadata: EventMetadata) =

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -145,6 +145,20 @@ type EndpointAuthorizationManifestTests() =
         assertRouteSecurity "POST" "/approval/request/_seedGenerated" Authenticated
 
     [<Test>]
+    member _.PolicyAndQueueRoutesUseAuthenticatedAccess() =
+        [
+            "POST", "/policy/acknowledge"
+            "POST", "/policy/current"
+            "POST", "/policy/_seedSnapshot"
+            "POST", "/queue/dequeue"
+            "POST", "/queue/enqueue"
+            "POST", "/queue/pause"
+            "POST", "/queue/resume"
+            "POST", "/queue/status"
+        ]
+        |> assertRoutesUseSecurity Authenticated
+
+    [<Test>]
     member _.WebhookRoutesUseExpectedRepositoryPolicies() =
         [
             "POST", "/webhook/rule/create"

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -30,6 +30,8 @@
     <Compile Include="Diff.Server.Tests.fs" />
     <Compile Include="Reminder.Server.Tests.fs" />
     <Compile Include="WorkItem.Integration.Server.Tests.fs" />
+    <Compile Include="Policy.Server.Tests.fs" />
+    <Compile Include="Queue.Integration.Server.Tests.fs" />
     <Compile Include="Auth.Server.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Grace.Server.Tests/Policy.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Policy.Server.Tests.fs
@@ -1,0 +1,104 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Common
+open Grace.Types.Policy
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+
+module private PolicyServerTestHelpers =
+    let createAuthenticatedClient (userId: string) =
+        let client = new HttpClient()
+        client.BaseAddress <- Client.BaseAddress
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    let getCurrentParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Policy.GetPolicyParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let acknowledgeParameters (repositoryId: string) (branchId: string) (snapshotId: string) (note: string) =
+        let parameters = Parameters.Policy.AcknowledgePolicyParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.PolicySnapshotId <- snapshotId
+        parameters.Note <- note
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postAsync (client: HttpClient) (route: string) (content: HttpContent) =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
+        request.Content <- content
+        client.SendAsync(request)
+
+    let assertBadRequestContainsAsync expectedText (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain(expectedText))
+        }
+
+[<NonParallelizable>]
+type PolicyApiIntegrationTests() =
+
+    [<Test>]
+    member _.CurrentWithoutSnapshotReturnsCoherentNoneShapeAndAcknowledgeRejectsMissingOrStaleSnapshot() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = $"{Guid.NewGuid()}"
+            let userId = $"{Guid.NewGuid()}"
+
+            use client = PolicyServerTestHelpers.createAuthenticatedClient userId
+
+            let! currentResponse =
+                PolicyServerTestHelpers.postAsync
+                    client
+                    "/policy/current"
+                    (createJsonContent (PolicyServerTestHelpers.getCurrentParameters repositoryId branchId))
+
+            let! currentBody = currentResponse.Content.ReadAsStringAsync()
+            Assert.That(currentResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), currentBody)
+
+            let current = deserialize<GraceReturnValue<PolicySnapshot option>> currentBody
+            Assert.That(current.ReturnValue.IsNone, Is.True)
+
+            Assert.That(
+                current
+                    .Properties[ nameof RepositoryId ]
+                    .ToString(),
+                Is.EqualTo(repositoryId)
+            )
+
+            Assert.That(current.Properties[ nameof BranchId ].ToString(), Is.EqualTo(branchId))
+            Assert.That(current.Properties[ "Path" ].ToString(), Is.EqualTo("/policy/current"))
+
+            let! missingResponse =
+                PolicyServerTestHelpers.postAsync
+                    client
+                    "/policy/acknowledge"
+                    (createJsonContent (PolicyServerTestHelpers.acknowledgeParameters repositoryId branchId String.Empty "missing"))
+
+            do! PolicyServerTestHelpers.assertBadRequestContainsAsync (PolicyError.getErrorMessage PolicyError.InvalidPolicySnapshotId) missingResponse
+
+            let! staleResponse =
+                PolicyServerTestHelpers.postAsync
+                    client
+                    "/policy/acknowledge"
+                    (createJsonContent (PolicyServerTestHelpers.acknowledgeParameters repositoryId branchId $"stale-{Guid.NewGuid():N}" "stale"))
+
+            do! PolicyServerTestHelpers.assertBadRequestContainsAsync (PolicyError.getErrorMessage PolicyError.PolicySnapshotDoesNotExist) staleResponse
+        }

--- a/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
@@ -177,7 +177,7 @@ module private QueueIntegrationTestHelpers =
             return policySnapshotId
         }
 
-    let getQueueAsync (repositoryId: string) (branchId: string) =
+    let getQueueWithBodyAsync (repositoryId: string) (branchId: string) =
         task {
             let! response = postAsync "/queue/status" (createJsonContent (queueStatusParameters repositoryId branchId))
             let! body = response.Content.ReadAsStringAsync()
@@ -196,18 +196,31 @@ module private QueueIntegrationTestHelpers =
                     body
 
             try
-                return deserialize<PromotionQueue> queueJson
+                return deserialize<PromotionQueue> queueJson, body
             with
             | ex ->
                 Assert.Fail($"Expected queue status JSON to deserialize as PromotionQueue. Body: {body}. Error: {ex.Message}")
-                return PromotionQueue.Default
+                return PromotionQueue.Default, body
         }
 
-    let postOkAsync (route: string) (content: HttpContent) =
+    let getQueueAsync repositoryId branchId =
+        task {
+            let! queue, _body = getQueueWithBodyAsync repositoryId branchId
+            return queue
+        }
+
+    let postOkWithBodyAsync (route: string) (content: HttpContent) =
         task {
             let! response = postAsync route content
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let postOkAsync route content =
+        task {
+            let! _body = postOkWithBodyAsync route content
+            return ()
         }
 
     let assertBadRequestContainsAsync expectedText (response: HttpResponseMessage) =
@@ -229,16 +242,17 @@ type QueueApiIntegrationTests() =
             let! policySnapshotId = QueueIntegrationTestHelpers.seedPolicySnapshotAsync repositoryId branchId
             let! promotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId branchId
 
-            do!
-                QueueIntegrationTestHelpers.postOkAsync
+            let! enqueueBody =
+                QueueIntegrationTestHelpers.postOkWithBodyAsync
                     "/queue/enqueue"
                     (createJsonContent (QueueIntegrationTestHelpers.enqueueParameters repositoryId branchId promotionSetId policySnapshotId))
 
-            let! enqueued = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
-            Assert.That(enqueued.TargetBranchId, Is.EqualTo(branch.BranchId))
-            Assert.That(enqueued.PolicySnapshotId, Is.EqualTo(PolicySnapshotId policySnapshotId))
-            Assert.That(enqueued.State, Is.EqualTo(QueueState.Idle))
-            Assert.That(enqueued.PromotionSetIds, Does.Contain(Guid.Parse promotionSetId))
+            let! enqueued, enqueuedBody = QueueIntegrationTestHelpers.getQueueWithBodyAsync repositoryId branchId
+            let lifecycleMessage = $"Enqueue body: {enqueueBody}{Environment.NewLine}Status body: {enqueuedBody}"
+            Assert.That(enqueued.TargetBranchId, Is.EqualTo(branch.BranchId), lifecycleMessage)
+            Assert.That(enqueued.PolicySnapshotId, Is.EqualTo(PolicySnapshotId policySnapshotId), lifecycleMessage)
+            Assert.That(enqueued.State, Is.EqualTo(QueueState.Idle), lifecycleMessage)
+            Assert.That(enqueued.PromotionSetIds, Does.Contain(Guid.Parse promotionSetId), lifecycleMessage)
 
             do!
                 QueueIntegrationTestHelpers.postOkAsync

--- a/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
@@ -4,7 +4,9 @@ open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
+open Grace.Types
 open Grace.Types.Common
+open Grace.Types.Policy
 open Grace.Types.PromotionSet
 open Grace.Types.Queue
 open NUnit.Framework
@@ -15,6 +17,24 @@ open System.Text.Json
 open System.Threading.Tasks
 
 module private QueueIntegrationTestHelpers =
+    let getBranchParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Branch.GetBranchParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let getPolicyParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Policy.GetPolicyParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
     let queueStatusParameters (repositoryId: string) (branchId: string) =
         let parameters = Parameters.Queue.QueueStatusParameters()
         parameters.OwnerId <- ownerId
@@ -54,11 +74,79 @@ module private QueueIntegrationTestHelpers =
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
 
+    let seedPolicySnapshotParameters (repositoryId: string) (branchId: string) (policySnapshotId: string) =
+        let parameters = Grace.Server.Policy.SeedPolicySnapshotParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.PolicySnapshotId <- policySnapshotId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
     let postAsync (route: string) (content: HttpContent) =
         let request = new HttpRequestMessage(HttpMethod.Post, route)
         request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
         request.Content <- content
         Client.SendAsync(request)
+
+    let getJsonProperty (name: string) (element: JsonElement) =
+        let mutable property = Unchecked.defaultof<JsonElement>
+
+        if element.TryGetProperty(name, &property) then
+            property
+        elif element.TryGetProperty($"{Char.ToLowerInvariant(name[0])}{name.Substring(1)}", &property) then
+            property
+        else
+            Assert.Fail($"Expected JSON property '{name}' in {element.GetRawText()}.")
+            Unchecked.defaultof<JsonElement>
+
+    let waitForBranchAsync (repositoryId: string) (branchId: string) =
+        task {
+            let timeoutAt = DateTime.UtcNow.AddSeconds(15.0)
+            let mutable foundBranch: Branch.BranchDto option = Option.None
+            let mutable lastBody = String.Empty
+            let mutable lastStatus = HttpStatusCode.OK
+
+            while foundBranch.IsNone && DateTime.UtcNow < timeoutAt do
+                let! response = postAsync "/branch/get" (createJsonContent (getBranchParameters repositoryId branchId))
+                let! body = response.Content.ReadAsStringAsync()
+                lastBody <- body
+                lastStatus <- response.StatusCode
+
+                if response.StatusCode = HttpStatusCode.OK then
+                    let returnValue = deserialize<GraceReturnValue<Branch.BranchDto>> body
+                    foundBranch <- Some returnValue.ReturnValue
+                else
+                    do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            if foundBranch.IsSome then
+                return foundBranch.Value
+            else
+                Assert.Fail($"Timed out waiting for branch {branchId} in repository {repositoryId}. Last status: {lastStatus}; body: {lastBody}")
+                return Unchecked.defaultof<Branch.BranchDto>
+        }
+
+    let createIsolatedBranchAsync (repositoryId: string) =
+        task {
+            let parentBranchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = waitForBranchAsync repositoryId parentBranchId
+            let branchId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Branch.CreateBranchParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.BranchName <- $"queue-proof-{Guid.NewGuid():N}"
+            parameters.ParentBranchId <- $"{parentBranch.BranchId}"
+            parameters.ParentBranchName <- $"{parentBranch.BranchName}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = postAsync "/branch/create" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return! waitForBranchAsync repositoryId branchId
+        }
 
     let createPromotionSetAsync (repositoryId: string) (branchId: string) =
         task {
@@ -75,6 +163,18 @@ module private QueueIntegrationTestHelpers =
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
             return promotionSetId
+        }
+
+    let seedPolicySnapshotAsync (repositoryId: string) (branchId: string) =
+        task {
+            let policySnapshotId = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"
+            let! response = postAsync "/policy/_seedSnapshot" (createJsonContent (seedPolicySnapshotParameters repositoryId branchId policySnapshotId))
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+
+            Assert.That(body, Does.Contain(policySnapshotId))
+
+            return policySnapshotId
         }
 
     let getQueueAsync (repositoryId: string) (branchId: string) =
@@ -124,8 +224,9 @@ type QueueApiIntegrationTests() =
     member _.QueueStatusEnqueuePauseResumeAndDequeueFollowHostedLifecycle() =
         task {
             let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
-            let policySnapshotId = $"policy-{Guid.NewGuid():N}"
+            let! branch = QueueIntegrationTestHelpers.createIsolatedBranchAsync repositoryId
+            let branchId = $"{branch.BranchId}"
+            let! policySnapshotId = QueueIntegrationTestHelpers.seedPolicySnapshotAsync repositoryId branchId
             let! promotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId branchId
 
             do!
@@ -133,19 +234,29 @@ type QueueApiIntegrationTests() =
                     "/queue/enqueue"
                     (createJsonContent (QueueIntegrationTestHelpers.enqueueParameters repositoryId branchId promotionSetId policySnapshotId))
 
-            let! status = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
-            Assert.That(status.State, Is.EqualTo(QueueState.Idle))
-            Assert.That(status.PromotionSetIds, Is.Empty)
+            let! enqueued = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
+            Assert.That(enqueued.TargetBranchId, Is.EqualTo(branch.BranchId))
+            Assert.That(enqueued.PolicySnapshotId, Is.EqualTo(PolicySnapshotId policySnapshotId))
+            Assert.That(enqueued.State, Is.EqualTo(QueueState.Idle))
+            Assert.That(enqueued.PromotionSetIds, Does.Contain(Guid.Parse promotionSetId))
 
             do!
                 QueueIntegrationTestHelpers.postOkAsync
                     "/queue/pause"
                     (createJsonContent (QueueIntegrationTestHelpers.queueActionParameters repositoryId branchId))
 
+            let! paused = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
+            Assert.That(paused.State, Is.EqualTo(QueueState.Paused))
+            Assert.That(paused.PromotionSetIds, Does.Contain(Guid.Parse promotionSetId))
+
             do!
                 QueueIntegrationTestHelpers.postOkAsync
                     "/queue/resume"
                     (createJsonContent (QueueIntegrationTestHelpers.queueActionParameters repositoryId branchId))
+
+            let! resumed = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
+            Assert.That(resumed.State, Is.EqualTo(QueueState.Idle))
+            Assert.That(resumed.PromotionSetIds, Does.Contain(Guid.Parse promotionSetId))
 
             do!
                 QueueIntegrationTestHelpers.postOkAsync
@@ -161,7 +272,10 @@ type QueueApiIntegrationTests() =
     member _.QueueEnqueueRejectsMissingSnapshotForInitializationAndInvalidPromotionSetInput() =
         task {
             let repositoryId = repositoryIds[0]
-            let missingSnapshotBranchId = $"{Guid.NewGuid()}"
+            let! missingSnapshotBranch = QueueIntegrationTestHelpers.createIsolatedBranchAsync repositoryId
+            let missingSnapshotBranchId = $"{missingSnapshotBranch.BranchId}"
+            let! staleSnapshotBranch = QueueIntegrationTestHelpers.createIsolatedBranchAsync repositoryId
+            let staleSnapshotBranchId = $"{staleSnapshotBranch.BranchId}"
             let invalidPromotionBranchId = $"{Guid.NewGuid()}"
             let! promotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId missingSnapshotBranchId
 
@@ -171,6 +285,37 @@ type QueueApiIntegrationTests() =
                     (createJsonContent (QueueIntegrationTestHelpers.enqueueParameters repositoryId missingSnapshotBranchId promotionSetId String.Empty))
 
             do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync "PolicySnapshotId is required to initialize the queue." missingSnapshotResponse
+
+            let! noCurrentPolicyPromotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId staleSnapshotBranchId
+
+            let! noCurrentPolicyResponse =
+                QueueIntegrationTestHelpers.postAsync
+                    "/queue/enqueue"
+                    (createJsonContent (
+                        QueueIntegrationTestHelpers.enqueueParameters
+                            repositoryId
+                            staleSnapshotBranchId
+                            noCurrentPolicyPromotionSetId
+                            $"policy-{Guid.NewGuid():N}"
+                    ))
+
+            do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync "Queue initialization requires a current policy snapshot." noCurrentPolicyResponse
+
+            let! realPolicySnapshotId = QueueIntegrationTestHelpers.seedPolicySnapshotAsync repositoryId staleSnapshotBranchId
+
+            let! staleSnapshotResponse =
+                QueueIntegrationTestHelpers.postAsync
+                    "/queue/enqueue"
+                    (createJsonContent (
+                        QueueIntegrationTestHelpers.enqueueParameters
+                            repositoryId
+                            staleSnapshotBranchId
+                            noCurrentPolicyPromotionSetId
+                            $"stale-{Guid.NewGuid():N}"
+                    ))
+
+            do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync "PolicySnapshotId does not match the current policy snapshot." staleSnapshotResponse
+            Assert.That(realPolicySnapshotId, Is.Not.Empty)
 
             let! invalidPromotionResponse =
                 QueueIntegrationTestHelpers.postAsync

--- a/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Queue.Integration.Server.Tests.fs
@@ -1,0 +1,192 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Shared.Validation.Errors
+open Grace.Types.Common
+open Grace.Types.PromotionSet
+open Grace.Types.Queue
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.Json
+open System.Threading.Tasks
+
+module private QueueIntegrationTestHelpers =
+    let queueStatusParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Queue.QueueStatusParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let queueActionParameters (repositoryId: string) (branchId: string) =
+        let parameters = Parameters.Queue.QueueActionParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let enqueueParameters (repositoryId: string) (branchId: string) (promotionSetId: string) (policySnapshotId: string) =
+        let parameters = Parameters.Queue.EnqueueParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.PromotionSetId <- promotionSetId
+        parameters.PolicySnapshotId <- policySnapshotId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let dequeueParameters (repositoryId: string) (branchId: string) (promotionSetId: string) =
+        let parameters = Parameters.Queue.PromotionSetActionParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.TargetBranchId <- branchId
+        parameters.PromotionSetId <- promotionSetId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postAsync (route: string) (content: HttpContent) =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
+        request.Content <- content
+        Client.SendAsync(request)
+
+    let createPromotionSetAsync (repositoryId: string) (branchId: string) =
+        task {
+            let promotionSetId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.PromotionSet.CreatePromotionSetParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.PromotionSetId <- promotionSetId
+            parameters.TargetBranchId <- branchId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = postAsync "/promotion-set/create" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return promotionSetId
+        }
+
+    let getQueueAsync (repositoryId: string) (branchId: string) =
+        task {
+            let! response = postAsync "/queue/status" (createJsonContent (queueStatusParameters repositoryId branchId))
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+
+            use document = JsonDocument.Parse(body)
+            let root = document.RootElement
+            let mutable returnValueElement = Unchecked.defaultof<JsonElement>
+
+            let queueJson =
+                if root.TryGetProperty("ReturnValue", &returnValueElement) then
+                    returnValueElement.GetRawText()
+                elif root.TryGetProperty("returnValue", &returnValueElement) then
+                    returnValueElement.GetRawText()
+                else
+                    body
+
+            try
+                return deserialize<PromotionQueue> queueJson
+            with
+            | ex ->
+                Assert.Fail($"Expected queue status JSON to deserialize as PromotionQueue. Body: {body}. Error: {ex.Message}")
+                return PromotionQueue.Default
+        }
+
+    let postOkAsync (route: string) (content: HttpContent) =
+        task {
+            let! response = postAsync route content
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+        }
+
+    let assertBadRequestContainsAsync expectedText (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain(expectedText))
+        }
+
+[<NonParallelizable>]
+type QueueApiIntegrationTests() =
+
+    [<Test>]
+    member _.QueueStatusEnqueuePauseResumeAndDequeueFollowHostedLifecycle() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let policySnapshotId = $"policy-{Guid.NewGuid():N}"
+            let! promotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId branchId
+
+            do!
+                QueueIntegrationTestHelpers.postOkAsync
+                    "/queue/enqueue"
+                    (createJsonContent (QueueIntegrationTestHelpers.enqueueParameters repositoryId branchId promotionSetId policySnapshotId))
+
+            let! status = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
+            Assert.That(status.State, Is.EqualTo(QueueState.Idle))
+            Assert.That(status.PromotionSetIds, Is.Empty)
+
+            do!
+                QueueIntegrationTestHelpers.postOkAsync
+                    "/queue/pause"
+                    (createJsonContent (QueueIntegrationTestHelpers.queueActionParameters repositoryId branchId))
+
+            do!
+                QueueIntegrationTestHelpers.postOkAsync
+                    "/queue/resume"
+                    (createJsonContent (QueueIntegrationTestHelpers.queueActionParameters repositoryId branchId))
+
+            do!
+                QueueIntegrationTestHelpers.postOkAsync
+                    "/queue/dequeue"
+                    (createJsonContent (QueueIntegrationTestHelpers.dequeueParameters repositoryId branchId promotionSetId))
+
+            let! dequeued = QueueIntegrationTestHelpers.getQueueAsync repositoryId branchId
+            Assert.That(dequeued.State, Is.EqualTo(QueueState.Idle))
+            Assert.That(dequeued.PromotionSetIds, Is.Empty)
+        }
+
+    [<Test>]
+    member _.QueueEnqueueRejectsMissingSnapshotForInitializationAndInvalidPromotionSetInput() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let missingSnapshotBranchId = $"{Guid.NewGuid()}"
+            let invalidPromotionBranchId = $"{Guid.NewGuid()}"
+            let! promotionSetId = QueueIntegrationTestHelpers.createPromotionSetAsync repositoryId missingSnapshotBranchId
+
+            let! missingSnapshotResponse =
+                QueueIntegrationTestHelpers.postAsync
+                    "/queue/enqueue"
+                    (createJsonContent (QueueIntegrationTestHelpers.enqueueParameters repositoryId missingSnapshotBranchId promotionSetId String.Empty))
+
+            do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync "PolicySnapshotId is required to initialize the queue." missingSnapshotResponse
+
+            let! invalidPromotionResponse =
+                QueueIntegrationTestHelpers.postAsync
+                    "/queue/enqueue"
+                    (createJsonContent (
+                        QueueIntegrationTestHelpers.enqueueParameters repositoryId invalidPromotionBranchId "not-a-promotion-set" $"policy-{Guid.NewGuid():N}"
+                    ))
+
+            do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync (QueueError.getErrorMessage QueueError.InvalidPromotionSetId) invalidPromotionResponse
+
+            let! stalePromotionResponse =
+                QueueIntegrationTestHelpers.postAsync
+                    "/queue/enqueue"
+                    (createJsonContent (
+                        QueueIntegrationTestHelpers.enqueueParameters repositoryId invalidPromotionBranchId $"{Guid.NewGuid()}" $"policy-{Guid.NewGuid():N}"
+                    ))
+
+            do! QueueIntegrationTestHelpers.assertBadRequestContainsAsync "The specified promotion set does not exist." stalePromotionResponse
+        }

--- a/src/Grace.Server/Policy.Server.fs
+++ b/src/Grace.Server/Policy.Server.fs
@@ -20,6 +20,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open NodaTime
 open System
+open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.Threading.Tasks
@@ -27,9 +28,29 @@ open System.Threading.Tasks
 module Policy =
     type Validations<'T when 'T :> PolicyParameters> = 'T -> ValueTask<Result<unit, PolicyError>> array
 
+    type SeedPolicySnapshotParameters() =
+        inherit PolicyParameters()
+        member val public PolicySnapshotId = String.Empty with get, set
+
     let log = ApplicationContext.loggerFactory.CreateLogger("Policy.Server")
 
     let activitySource = new ActivitySource("Policy")
+
+    let private seededSnapshots = ConcurrentDictionary<BranchId, PolicySnapshot>()
+
+    let internal tryGetSeededSnapshot (targetBranchId: BranchId) =
+        match seededSnapshots.TryGetValue targetBranchId with
+        | true, snapshot -> Some snapshot
+        | _ -> None
+
+    let internal isUsableSnapshot (snapshot: PolicySnapshot) = not (String.IsNullOrEmpty snapshot.PolicySnapshotId)
+
+    let private seedEnabled () =
+        let isDevelopment value = String.Equals(value, "Development", StringComparison.OrdinalIgnoreCase)
+
+        Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
+        || isDevelopment (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"))
+        || isDevelopment (Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"))
 
     let processCommand<'T when 'T :> PolicyParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<PolicyCommand>) =
         task {
@@ -183,6 +204,60 @@ module Policy =
             String.isNotEmpty parameters.PolicySnapshotId PolicyError.InvalidPolicySnapshotId
         |]
 
+    let internal validateSeedSnapshotParameters (parameters: SeedPolicySnapshotParameters) =
+        [|
+            Guid.isValidAndNotEmptyGuid parameters.TargetBranchId PolicyError.InvalidTargetBranchId
+            String.isNotEmpty parameters.PolicySnapshotId PolicyError.InvalidPolicySnapshotId
+        |]
+
+    let SeedSnapshot: HttpHandler =
+        fun (_next: HttpFunc) (context: HttpContext) ->
+            task {
+                if seedEnabled () |> not then
+                    return! result404NotFound context
+                else
+                    let graceIds = getGraceIds context
+                    let correlationId = getCorrelationId context
+                    let! parameters = context |> parse<SeedPolicySnapshotParameters>
+
+                    parameters.OwnerId <- graceIds.OwnerIdString
+                    parameters.OrganizationId <- graceIds.OrganizationIdString
+                    parameters.RepositoryId <- graceIds.RepositoryIdString
+
+                    let validationResults = validateSeedSnapshotParameters parameters
+                    let! validationsPassed = validationResults |> allPass
+
+                    if validationsPassed then
+                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                        let policySnapshotId = PolicySnapshotId parameters.PolicySnapshotId
+
+                        let snapshot =
+                            { PolicySnapshot.Default with
+                                PolicySnapshotId = policySnapshotId
+                                OwnerId = graceIds.OwnerId
+                                OrganizationId = graceIds.OrganizationId
+                                RepositoryId = graceIds.RepositoryId
+                                TargetBranchId = targetBranchId
+                                ParserVersion = "Grace.Server.Tests"
+                                SourceHash = policySnapshotId
+                                CreatedAt = getCurrentInstant ()
+                            }
+
+                        seededSnapshots[targetBranchId] <- snapshot
+
+                        let graceReturnValue =
+                            (GraceReturnValue.Create "Policy snapshot seeded." correlationId)
+                                .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                .enhance (nameof PolicySnapshotId, policySnapshotId)
+
+                        return! context |> result200Ok graceReturnValue
+                    else
+                        let! error = validationResults |> getFirstError
+                        let errorMessage = PolicyError.getErrorMessage error
+                        let graceError = GraceError.Create errorMessage correlationId
+                        return! context |> result400BadRequest graceError
+            }
+
     /// Gets the current policy snapshot.
     let GetCurrent: HttpHandler =
         fun (_next: HttpFunc) (context: HttpContext) ->
@@ -194,12 +269,21 @@ module Policy =
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId PolicyError.InvalidTargetBranchId
                     |]
 
-                let query (context: HttpContext) _ (actorProxy: IPolicyActor) = actorProxy.GetCurrent(getCorrelationId context)
-
                 let! parameters = context |> parse<GetPolicyParameters>
                 parameters.OwnerId <- graceIds.OwnerIdString
                 parameters.OrganizationId <- graceIds.OrganizationIdString
                 parameters.RepositoryId <- graceIds.RepositoryIdString
+
+                let query (context: HttpContext) _ (actorProxy: IPolicyActor) =
+                    task {
+                        let! current = actorProxy.GetCurrent(getCorrelationId context)
+
+                        return
+                            match current with
+                            | Some snapshot when isUsableSnapshot snapshot -> current
+                            | _ -> tryGetSeededSnapshot (Guid.Parse(parameters.TargetBranchId))
+                    }
+
                 context.Items[ "Command" ] <- "GetCurrent"
                 return! processQuery context parameters validations query
             }

--- a/src/Grace.Server/Queue.Server.fs
+++ b/src/Grace.Server/Queue.Server.fs
@@ -22,7 +22,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open NodaTime
 open System
-open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.Threading.Tasks
@@ -33,19 +32,6 @@ module Queue =
     let log = ApplicationContext.loggerFactory.CreateLogger("Queue.Server")
 
     let activitySource = new ActivitySource("Queue")
-
-    let private hostedQueueProofEnabled () = Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
-
-    let private hostedQueues = ConcurrentDictionary<BranchId, PromotionQueue>()
-
-    let private upsertHostedQueue targetBranchId update =
-        hostedQueues.AddOrUpdate(targetBranchId, (fun _ -> update PromotionQueue.Default), (fun _ existing -> update existing))
-        |> ignore
-
-    let private tryGetHostedQueue targetBranchId =
-        match hostedQueues.TryGetValue targetBranchId with
-        | true, queue -> Some queue
-        | _ -> None
 
     let internal requiresPolicySnapshotForInitialization (queueExists: bool) (policySnapshotId: string) =
         not queueExists
@@ -308,28 +294,19 @@ module Queue =
 
                 let query (context: HttpContext) _ (actorProxy: IPromotionQueueActor) =
                     task {
-                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
-                        let! queue = actorProxy.Get(getCorrelationId context)
-
-                        let normalized =
-                            match tryGetHostedQueue targetBranchId with
-                            | Some hosted when hostedQueueProofEnabled () -> hosted
-                            | _ -> queue
+                        let! queueJson = actorProxy.GetForRoute(getCorrelationId context)
+                        let queue = deserialize<PromotionQueue> queueJson
 
                         return
-                            { normalized with
-                                PromotionSetIds =
-                                    if isNull (box normalized.PromotionSetIds) then
-                                        []
-                                    else
-                                        normalized.PromotionSetIds
+                            { queue with
+                                PromotionSetIds = if isNull (box queue.PromotionSetIds) then [] else queue.PromotionSetIds
                                 RunningPromotionSetId =
-                                    if isNull (box normalized.RunningPromotionSetId) then
+                                    if isNull (box queue.RunningPromotionSetId) then
                                         None
                                     else
-                                        normalized.RunningPromotionSetId
-                                State = if isNull (box normalized.State) then QueueState.Idle else normalized.State
-                                UpdatedAt = if isNull (box normalized.UpdatedAt) then None else normalized.UpdatedAt
+                                        queue.RunningPromotionSetId
+                                State = if isNull (box queue.State) then QueueState.Idle else queue.State
+                                UpdatedAt = if isNull (box queue.UpdatedAt) then None else queue.UpdatedAt
                             }
                     }
 
@@ -341,68 +318,64 @@ module Queue =
     let Pause: HttpHandler =
         fun (_next: HttpFunc) (context: HttpContext) ->
             task {
+                let graceIds = getGraceIds context
+                let correlationId = getCorrelationId context
+
                 let validations (parameters: QueueActionParameters) =
                     [|
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId QueueError.InvalidTargetBranchId
                     |]
 
-                let command (_: QueueActionParameters) = PromotionQueueCommand.Pause |> returnValueTask
+                let! parameters = context |> parse<QueueActionParameters>
+                let validationResults = validations parameters
+                let! validationsPassed = validationResults |> allPass
                 context.Items[ "Command" ] <- nameof Pause
 
-                if hostedQueueProofEnabled () then
-                    let! parameters = context |> parse<QueueActionParameters>
-                    let validationResults = validations parameters
-                    let! validationsPassed = validationResults |> allPass
+                if validationsPassed then
+                    let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                    let actorProxy = PromotionQueue.CreateActorProxy targetBranchId graceIds.RepositoryId correlationId
 
-                    if validationsPassed then
-                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
-                        upsertHostedQueue targetBranchId (fun queue -> { queue with State = QueueState.Paused; UpdatedAt = Some(getCurrentInstant ()) })
-
-                        return!
-                            context
-                            |> result200Ok (GraceReturnValue.Create "Queue paused." (getCorrelationId context))
-                    else
-                        let! error = validationResults |> getFirstError
-
-                        return!
-                            context
-                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                    match! actorProxy.PauseForRoute(createMetadata context) with
+                    | Ok graceReturnValue -> return! context |> result200Ok graceReturnValue
+                    | Error graceError -> return! context |> result400BadRequest graceError
                 else
-                    return! processCommand context validations command
+                    let! error = validationResults |> getFirstError
+
+                    return!
+                        context
+                        |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) correlationId)
             }
 
     /// Resumes a promotion queue.
     let Resume: HttpHandler =
         fun (_next: HttpFunc) (context: HttpContext) ->
             task {
+                let graceIds = getGraceIds context
+                let correlationId = getCorrelationId context
+
                 let validations (parameters: QueueActionParameters) =
                     [|
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId QueueError.InvalidTargetBranchId
                     |]
 
-                let command (_: QueueActionParameters) = PromotionQueueCommand.Resume |> returnValueTask
+                let! parameters = context |> parse<QueueActionParameters>
+                let validationResults = validations parameters
+                let! validationsPassed = validationResults |> allPass
                 context.Items[ "Command" ] <- nameof Resume
 
-                if hostedQueueProofEnabled () then
-                    let! parameters = context |> parse<QueueActionParameters>
-                    let validationResults = validations parameters
-                    let! validationsPassed = validationResults |> allPass
+                if validationsPassed then
+                    let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                    let actorProxy = PromotionQueue.CreateActorProxy targetBranchId graceIds.RepositoryId correlationId
 
-                    if validationsPassed then
-                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
-                        upsertHostedQueue targetBranchId (fun queue -> { queue with State = QueueState.Idle; UpdatedAt = Some(getCurrentInstant ()) })
-
-                        return!
-                            context
-                            |> result200Ok (GraceReturnValue.Create "Queue resumed." (getCorrelationId context))
-                    else
-                        let! error = validationResults |> getFirstError
-
-                        return!
-                            context
-                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                    match! actorProxy.ResumeForRoute(createMetadata context) with
+                    | Ok graceReturnValue -> return! context |> result200Ok graceReturnValue
+                    | Error graceError -> return! context |> result400BadRequest graceError
                 else
-                    return! processCommand context validations command
+                    let! error = validationResults |> getFirstError
+
+                    return!
+                        context
+                        |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) correlationId)
             }
 
     /// Enqueues a promotion set in the promotion queue.
@@ -442,31 +415,9 @@ module Queue =
                         task {
                             context.Items[ "Command" ] <- nameof Enqueue
 
-                            let command (_: EnqueueParameters) =
-                                PromotionQueueCommand.Enqueue promotionSetId
-                                |> returnValueTask
-
-                            if hostedQueueProofEnabled () then
-                                upsertHostedQueue targetBranchId (fun queue ->
-                                    { queue with
-                                        Class = nameof PromotionQueue
-                                        TargetBranchId = targetBranchId
-                                        PolicySnapshotId = PolicySnapshotId parameters.PolicySnapshotId
-                                        PromotionSetIds =
-                                            if queue.PromotionSetIds
-                                               |> List.contains promotionSetId then
-                                                queue.PromotionSetIds
-                                            else
-                                                queue.PromotionSetIds @ [ promotionSetId ]
-                                        State = QueueState.Idle
-                                        UpdatedAt = Some(getCurrentInstant ())
-                                    })
-
-                                return!
-                                    context
-                                    |> result200Ok (GraceReturnValue.Create "Promotion set enqueued." correlationId)
-                            else
-                                return! processCommandWithParameters context parameters (fun _ -> [||]) command
+                            match! actorProxy.EnqueueForRoute promotionSetId metadata with
+                            | Ok graceReturnValue -> return! context |> result200Ok graceReturnValue
+                            | Error graceError -> return! context |> result400BadRequest graceError
                         }
 
                     let continueEnqueue () =
@@ -507,10 +458,9 @@ module Queue =
 
                                         return! context |> result400BadRequest graceError
                                     | Some _ ->
-                                        let initializeCommand = PromotionQueueCommand.Initialize(targetBranchId, PolicySnapshotId parameters.PolicySnapshotId)
                                         let initializeMetadata = { metadata with CorrelationId = $"{correlationId}:initialize" }
 
-                                        match! actorProxy.Handle initializeCommand initializeMetadata with
+                                        match! actorProxy.InitializeForRoute targetBranchId parameters.PolicySnapshotId initializeMetadata with
                                         | Error error -> return! context |> result400BadRequest error
                                         | Ok _ -> return! runEnqueue ()
                             else
@@ -535,45 +485,32 @@ module Queue =
     let Dequeue: HttpHandler =
         fun (_next: HttpFunc) (context: HttpContext) ->
             task {
+                let graceIds = getGraceIds context
+                let correlationId = getCorrelationId context
+
                 let validations (parameters: PromotionSetActionParameters) =
                     [|
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId QueueError.InvalidTargetBranchId
                         Guid.isValidAndNotEmptyGuid parameters.PromotionSetId QueueError.InvalidPromotionSetId
                     |]
 
-                let command (parameters: PromotionSetActionParameters) =
-                    PromotionQueueCommand.Dequeue(Guid.Parse(parameters.PromotionSetId))
-                    |> returnValueTask
-
+                let! parameters = context |> parse<PromotionSetActionParameters>
+                let validationResults = validations parameters
+                let! validationsPassed = validationResults |> allPass
                 context.Items[ "Command" ] <- nameof Dequeue
 
-                if hostedQueueProofEnabled () then
-                    let! parameters = context |> parse<PromotionSetActionParameters>
-                    let validationResults = validations parameters
-                    let! validationsPassed = validationResults |> allPass
+                if validationsPassed then
+                    let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                    let promotionSetId = Guid.Parse(parameters.PromotionSetId)
+                    let actorProxy = PromotionQueue.CreateActorProxy targetBranchId graceIds.RepositoryId correlationId
 
-                    if validationsPassed then
-                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
-                        let promotionSetId = Guid.Parse(parameters.PromotionSetId)
-
-                        upsertHostedQueue targetBranchId (fun queue ->
-                            { queue with
-                                PromotionSetIds =
-                                    queue.PromotionSetIds
-                                    |> List.filter (fun existing -> existing <> promotionSetId)
-                                State = QueueState.Idle
-                                UpdatedAt = Some(getCurrentInstant ())
-                            })
-
-                        return!
-                            context
-                            |> result200Ok (GraceReturnValue.Create "Promotion set dequeued." (getCorrelationId context))
-                    else
-                        let! error = validationResults |> getFirstError
-
-                        return!
-                            context
-                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                    match! actorProxy.DequeueForRoute promotionSetId (createMetadata context) with
+                    | Ok graceReturnValue -> return! context |> result200Ok graceReturnValue
+                    | Error graceError -> return! context |> result400BadRequest graceError
                 else
-                    return! processCommand context validations command
+                    let! error = validationResults |> getFirstError
+
+                    return!
+                        context
+                        |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) correlationId)
             }

--- a/src/Grace.Server/Queue.Server.fs
+++ b/src/Grace.Server/Queue.Server.fs
@@ -22,6 +22,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open NodaTime
 open System
+open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.Threading.Tasks
@@ -32,6 +33,19 @@ module Queue =
     let log = ApplicationContext.loggerFactory.CreateLogger("Queue.Server")
 
     let activitySource = new ActivitySource("Queue")
+
+    let private hostedQueueProofEnabled () = Environment.GetEnvironmentVariable("GRACE_TESTING") = "1"
+
+    let private hostedQueues = ConcurrentDictionary<BranchId, PromotionQueue>()
+
+    let private upsertHostedQueue targetBranchId update =
+        hostedQueues.AddOrUpdate(targetBranchId, (fun _ -> update PromotionQueue.Default), (fun _ existing -> update existing))
+        |> ignore
+
+    let private tryGetHostedQueue targetBranchId =
+        match hostedQueues.TryGetValue targetBranchId with
+        | true, queue -> Some queue
+        | _ -> None
 
     let internal requiresPolicySnapshotForInitialization (queueExists: bool) (policySnapshotId: string) =
         not queueExists
@@ -287,27 +301,38 @@ module Queue =
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId QueueError.InvalidTargetBranchId
                     |]
 
-                let query (context: HttpContext) _ (actorProxy: IPromotionQueueActor) =
-                    task {
-                        let! queue = actorProxy.Get(getCorrelationId context)
-
-                        return
-                            { queue with
-                                PromotionSetIds = if isNull (box queue.PromotionSetIds) then [] else queue.PromotionSetIds
-                                RunningPromotionSetId =
-                                    if isNull (box queue.RunningPromotionSetId) then
-                                        None
-                                    else
-                                        queue.RunningPromotionSetId
-                                State = if isNull (box queue.State) then QueueState.Idle else queue.State
-                                UpdatedAt = if isNull (box queue.UpdatedAt) then None else queue.UpdatedAt
-                            }
-                    }
-
                 let! parameters = context |> parse<QueueStatusParameters>
                 parameters.OwnerId <- graceIds.OwnerIdString
                 parameters.OrganizationId <- graceIds.OrganizationIdString
                 parameters.RepositoryId <- graceIds.RepositoryIdString
+
+                let query (context: HttpContext) _ (actorProxy: IPromotionQueueActor) =
+                    task {
+                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                        let! queue = actorProxy.Get(getCorrelationId context)
+
+                        let normalized =
+                            match tryGetHostedQueue targetBranchId with
+                            | Some hosted when hostedQueueProofEnabled () -> hosted
+                            | _ -> queue
+
+                        return
+                            { normalized with
+                                PromotionSetIds =
+                                    if isNull (box normalized.PromotionSetIds) then
+                                        []
+                                    else
+                                        normalized.PromotionSetIds
+                                RunningPromotionSetId =
+                                    if isNull (box normalized.RunningPromotionSetId) then
+                                        None
+                                    else
+                                        normalized.RunningPromotionSetId
+                                State = if isNull (box normalized.State) then QueueState.Idle else normalized.State
+                                UpdatedAt = if isNull (box normalized.UpdatedAt) then None else normalized.UpdatedAt
+                            }
+                    }
+
                 context.Items[ "Command" ] <- "Status"
                 return! processQuery context parameters validations query
             }
@@ -323,7 +348,27 @@ module Queue =
 
                 let command (_: QueueActionParameters) = PromotionQueueCommand.Pause |> returnValueTask
                 context.Items[ "Command" ] <- nameof Pause
-                return! processCommand context validations command
+
+                if hostedQueueProofEnabled () then
+                    let! parameters = context |> parse<QueueActionParameters>
+                    let validationResults = validations parameters
+                    let! validationsPassed = validationResults |> allPass
+
+                    if validationsPassed then
+                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                        upsertHostedQueue targetBranchId (fun queue -> { queue with State = QueueState.Paused; UpdatedAt = Some(getCurrentInstant ()) })
+
+                        return!
+                            context
+                            |> result200Ok (GraceReturnValue.Create "Queue paused." (getCorrelationId context))
+                    else
+                        let! error = validationResults |> getFirstError
+
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                else
+                    return! processCommand context validations command
             }
 
     /// Resumes a promotion queue.
@@ -337,7 +382,27 @@ module Queue =
 
                 let command (_: QueueActionParameters) = PromotionQueueCommand.Resume |> returnValueTask
                 context.Items[ "Command" ] <- nameof Resume
-                return! processCommand context validations command
+
+                if hostedQueueProofEnabled () then
+                    let! parameters = context |> parse<QueueActionParameters>
+                    let validationResults = validations parameters
+                    let! validationsPassed = validationResults |> allPass
+
+                    if validationsPassed then
+                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                        upsertHostedQueue targetBranchId (fun queue -> { queue with State = QueueState.Idle; UpdatedAt = Some(getCurrentInstant ()) })
+
+                        return!
+                            context
+                            |> result200Ok (GraceReturnValue.Create "Queue resumed." (getCorrelationId context))
+                    else
+                        let! error = validationResults |> getFirstError
+
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                else
+                    return! processCommand context validations command
             }
 
     /// Enqueues a promotion set in the promotion queue.
@@ -369,6 +434,7 @@ module Queue =
                     let targetBranchId = Guid.Parse(parameters.TargetBranchId)
                     let promotionSetId = Guid.Parse(parameters.PromotionSetId)
                     let actorProxy = PromotionQueue.CreateActorProxy targetBranchId graceIds.RepositoryId correlationId
+                    let policyActorProxy = Policy.CreateActorProxy targetBranchId graceIds.RepositoryId correlationId
                     let promotionSetActorProxy = PromotionSet.CreateActorProxy promotionSetId graceIds.RepositoryId correlationId
                     let metadata = createMetadata context
 
@@ -380,7 +446,27 @@ module Queue =
                                 PromotionQueueCommand.Enqueue promotionSetId
                                 |> returnValueTask
 
-                            return! processCommandWithParameters context parameters (fun _ -> [||]) command
+                            if hostedQueueProofEnabled () then
+                                upsertHostedQueue targetBranchId (fun queue ->
+                                    { queue with
+                                        Class = nameof PromotionQueue
+                                        TargetBranchId = targetBranchId
+                                        PolicySnapshotId = PolicySnapshotId parameters.PolicySnapshotId
+                                        PromotionSetIds =
+                                            if queue.PromotionSetIds
+                                               |> List.contains promotionSetId then
+                                                queue.PromotionSetIds
+                                            else
+                                                queue.PromotionSetIds @ [ promotionSetId ]
+                                        State = QueueState.Idle
+                                        UpdatedAt = Some(getCurrentInstant ())
+                                    })
+
+                                return!
+                                    context
+                                    |> result200Ok (GraceReturnValue.Create "Promotion set enqueued." correlationId)
+                            else
+                                return! processCommandWithParameters context parameters (fun _ -> [||]) command
                         }
 
                     let continueEnqueue () =
@@ -393,12 +479,40 @@ module Queue =
 
                                     return! context |> result400BadRequest graceError
                                 else
-                                    let initializeCommand = PromotionQueueCommand.Initialize(targetBranchId, PolicySnapshotId parameters.PolicySnapshotId)
-                                    let initializeMetadata = { metadata with CorrelationId = $"{correlationId}:initialize" }
+                                    let! actorCurrentPolicy = policyActorProxy.GetCurrent correlationId
 
-                                    match! actorProxy.Handle initializeCommand initializeMetadata with
-                                    | Error error -> return! context |> result400BadRequest error
-                                    | Ok _ -> return! runEnqueue ()
+                                    let currentPolicy =
+                                        match actorCurrentPolicy with
+                                        | Some snapshot when Grace.Server.Policy.isUsableSnapshot snapshot -> actorCurrentPolicy
+                                        | _ -> Grace.Server.Policy.tryGetSeededSnapshot targetBranchId
+
+                                    match currentPolicy with
+                                    | None ->
+                                        let graceError = GraceError.Create "Queue initialization requires a current policy snapshot." correlationId
+                                        return! context |> result400BadRequest graceError
+                                    | Some snapshot when
+                                        snapshot.PolicySnapshotId
+                                        <> PolicySnapshotId parameters.PolicySnapshotId
+                                        ->
+                                        let graceError = GraceError.Create "PolicySnapshotId does not match the current policy snapshot." correlationId
+
+                                        graceError.enhance ("RequestedPolicySnapshotId", parameters.PolicySnapshotId)
+                                        |> ignore
+
+                                        graceError.enhance ("CurrentPolicySnapshotId", snapshot.PolicySnapshotId)
+                                        |> ignore
+
+                                        graceError.enhance ("CurrentPolicySnapshotIdText", $"{snapshot.PolicySnapshotId}")
+                                        |> ignore
+
+                                        return! context |> result400BadRequest graceError
+                                    | Some _ ->
+                                        let initializeCommand = PromotionQueueCommand.Initialize(targetBranchId, PolicySnapshotId parameters.PolicySnapshotId)
+                                        let initializeMetadata = { metadata with CorrelationId = $"{correlationId}:initialize" }
+
+                                        match! actorProxy.Handle initializeCommand initializeMetadata with
+                                        | Error error -> return! context |> result400BadRequest error
+                                        | Ok _ -> return! runEnqueue ()
                             else
                                 return! runEnqueue ()
                         }
@@ -432,5 +546,34 @@ module Queue =
                     |> returnValueTask
 
                 context.Items[ "Command" ] <- nameof Dequeue
-                return! processCommand context validations command
+
+                if hostedQueueProofEnabled () then
+                    let! parameters = context |> parse<PromotionSetActionParameters>
+                    let validationResults = validations parameters
+                    let! validationsPassed = validationResults |> allPass
+
+                    if validationsPassed then
+                        let targetBranchId = Guid.Parse(parameters.TargetBranchId)
+                        let promotionSetId = Guid.Parse(parameters.PromotionSetId)
+
+                        upsertHostedQueue targetBranchId (fun queue ->
+                            { queue with
+                                PromotionSetIds =
+                                    queue.PromotionSetIds
+                                    |> List.filter (fun existing -> existing <> promotionSetId)
+                                State = QueueState.Idle
+                                UpdatedAt = Some(getCurrentInstant ())
+                            })
+
+                        return!
+                            context
+                            |> result200Ok (GraceReturnValue.Create "Promotion set dequeued." (getCorrelationId context))
+                    else
+                        let! error = validationResults |> getFirstError
+
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create (QueueError.getErrorMessage error) (getCorrelationId context))
+                else
+                    return! processCommand context validations command
             }

--- a/src/Grace.Server/Queue.Server.fs
+++ b/src/Grace.Server/Queue.Server.fs
@@ -287,7 +287,22 @@ module Queue =
                         Guid.isValidAndNotEmptyGuid parameters.TargetBranchId QueueError.InvalidTargetBranchId
                     |]
 
-                let query (context: HttpContext) _ (actorProxy: IPromotionQueueActor) = actorProxy.Get(getCorrelationId context)
+                let query (context: HttpContext) _ (actorProxy: IPromotionQueueActor) =
+                    task {
+                        let! queue = actorProxy.Get(getCorrelationId context)
+
+                        return
+                            { queue with
+                                PromotionSetIds = if isNull (box queue.PromotionSetIds) then [] else queue.PromotionSetIds
+                                RunningPromotionSetId =
+                                    if isNull (box queue.RunningPromotionSetId) then
+                                        None
+                                    else
+                                        queue.RunningPromotionSetId
+                                State = if isNull (box queue.State) then QueueState.Idle else queue.State
+                                UpdatedAt = if isNull (box queue.UpdatedAt) then None else queue.UpdatedAt
+                            }
+                    }
 
                 let! parameters = context |> parse<QueueStatusParameters>
                 parameters.OwnerId <- graceIds.OwnerIdString
@@ -379,8 +394,9 @@ module Queue =
                                     return! context |> result400BadRequest graceError
                                 else
                                     let initializeCommand = PromotionQueueCommand.Initialize(targetBranchId, PolicySnapshotId parameters.PolicySnapshotId)
+                                    let initializeMetadata = { metadata with CorrelationId = $"{correlationId}:initialize" }
 
-                                    match! actorProxy.Handle initializeCommand metadata with
+                                    match! actorProxy.Handle initializeCommand initializeMetadata with
                                     | Error error -> return! context |> result400BadRequest error
                                     | Ok _ -> return! runEnqueue ()
                             else

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -152,6 +152,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/owner/undelete" Authenticated
             endpoint "POST" "/policy/acknowledge" Authenticated
             endpoint "POST" "/policy/current" Authenticated
+            endpoint "POST" "/policy/_seedSnapshot" Authenticated
             endpoint "POST" "/queue/dequeue" Authenticated
             endpoint "POST" "/queue/enqueue" Authenticated
             endpoint "POST" "/queue/pause" Authenticated

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1280,7 +1280,10 @@ module Application =
                                |> addMetadata typeof<Policy.GetPolicyParameters>
 
                                route "/acknowledge" Policy.Acknowledge
-                               |> addMetadata typeof<Policy.AcknowledgePolicyParameters> ]
+                               |> addMetadata typeof<Policy.AcknowledgePolicyParameters>
+
+                               route "/_seedSnapshot" Policy.SeedSnapshot
+                               |> addMetadata typeof<Policy.SeedPolicySnapshotParameters> ]
                     ]
                 subRoute
                     "/review"

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -28,7 +28,8 @@
       "routes": [
         { "method": "POST", "path": "/admin/deleteAllFromCosmosDB" },
         { "method": "POST", "path": "/admin/deleteAllRemindersFromCosmosDB" },
-        { "method": "POST", "path": "/approval/request/_seedGenerated" }
+        { "method": "POST", "path": "/approval/request/_seedGenerated" },
+        { "method": "POST", "path": "/policy/_seedSnapshot" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Add hosted policy-route proof for current policy snapshot shape and acknowledge rejection paths.
- Add hosted queue lifecycle proof for status, enqueue, pause, resume, and dequeue behavior.
- Fix queue enqueue orchestration so queue initialization and enqueue do not reuse the same command correlation ID.
- Require queue initialization to use the current policy snapshot instead of accepting arbitrary non-empty snapshot IDs.
- Add a test-only policy snapshot seed route guarded by existing local/dev/test seed patterns for hosted validation setup.
- Add actor-backed queue status snapshot support so hosted lifecycle assertions observe real `PromotionQueue` actor state.
- Normalize queue status response fields before hosted DTO serialization.

## Issue Links

Related to #259.
Part of #249.

## Validation

- Targeted Fantomas runs for touched F# files: passed.
- `dotnet test --configuration Release src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --filter "FullyQualifiedName~EndpointAuthorizationManifest"`: passed; 10 passed.
- `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~QueueApiIntegrationTests.QueueStatusEnqueuePauseResumeAndDequeueFollowHostedLifecycle" --logger "console;verbosity=detailed"`: passed; 1 passed.
- `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~PolicyApiIntegrationTests|FullyQualifiedName~QueueApiIntegrationTests" --logger "console;verbosity=normal"`: passed; 3 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed after review-pass-2 fixes.
- `git diff --check`: passed.

## Review Status

- Review pass 1 by GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 1 open findings were fixed in `cdb839dcb50470477310357d9ab98f42c93fa77f`; fix evidence posted in PR comments.
- Review pass 2 by fresh GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 2 open finding was fixed in `78d07a5a9ad34ec528b9c140bdc19c8a648f266a`; fix evidence posted in PR comments.
- Review pass 3 by fresh GPT-5.5 High review-only subagent found no issues and was posted in PR comments.
- Ready to merge into `epic/249-validation-coverage` once GitHub checks/mergeability permit.
