### PR TITLE
Add hosted promotion review validation route proof

### DIFF
--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -32,6 +32,10 @@
     <Compile Include="WorkItem.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />
+    <Compile Include="PromotionSet.Integration.Server.Tests.fs" />
+    <Compile Include="Review.Integration.Server.Tests.fs" />
+    <Compile Include="ValidationSet.Integration.Server.Tests.fs" />
+    <Compile Include="ValidationResult.Integration.Server.Tests.fs" />
     <Compile Include="Auth.Server.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Grace.Server.Tests/PromotionSet.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.Integration.Server.Tests.fs
@@ -54,25 +54,44 @@ module private PromotionSetIntegrationHelpers =
             return body
         }
 
-    let private deserializeRouteValue<'T> (body: string) =
-        use document = JsonDocument.Parse(body)
-        let mutable returnValue = Unchecked.defaultof<JsonElement>
+    let private requireProperty (name: string) (element: JsonElement) =
+        let mutable property = Unchecked.defaultof<JsonElement>
 
-        if (document.RootElement.TryGetProperty("ReturnValue", &returnValue)
-            || document.RootElement.TryGetProperty("returnValue", &returnValue))
-           && returnValue.ValueKind = JsonValueKind.Object then
-            deserialize<GraceReturnValue<'T>> body
-            |> fun value -> value.ReturnValue
-        elif returnValue.ValueKind = JsonValueKind.Null then
-            Assert.Fail($"Route returned null returnValue. Body: {body}")
-            Unchecked.defaultof<'T>
+        if element.TryGetProperty(name, &property) then
+            property
+        elif element.TryGetProperty($"{Char.ToLowerInvariant(name[0])}{name.Substring(1)}", &property) then
+            property
         else
-            try
-                deserialize<'T> body
-            with
-            | ex ->
-                Assert.Fail($"Failed to deserialize direct route value. Body: {body}. Error: {ex.Message}")
-                Unchecked.defaultof<'T>
+            Assert.Fail($"Expected JSON property '{name}' in {element.GetRawText()}.")
+            Unchecked.defaultof<JsonElement>
+
+    let assertEventSequence (body: string) (promotionSetId: string) (expectedNames: string array) =
+        use document = JsonDocument.Parse(body)
+
+        let returnValue =
+            document.RootElement
+            |> requireProperty "ReturnValue"
+
+        let eventNames =
+            returnValue.EnumerateArray()
+            |> Seq.map (fun eventEnvelope ->
+                let eventElement = eventEnvelope |> requireProperty "Event"
+                let eventProperty = eventElement.EnumerateObject() |> Seq.exactlyOne
+                eventProperty.Name)
+            |> Seq.toArray
+
+        let actorIds =
+            returnValue.EnumerateArray()
+            |> Seq.map (fun eventEnvelope ->
+                let metadata = eventEnvelope |> requireProperty "Metadata"
+                let properties = metadata |> requireProperty "Properties"
+
+                (properties |> requireProperty "ActorId")
+                    .GetString())
+            |> Seq.toArray
+
+        Assert.That(eventNames, Is.EqualTo<string array>(expectedNames))
+        Assert.That(actorIds |> Array.forall ((=) promotionSetId), Is.True)
 
     let getPromotionSetAsync repositoryId promotionSetId =
         task {
@@ -99,14 +118,6 @@ module private PromotionSetIntegrationHelpers =
             parameters.TargetBranchId <- targetBranchId
             let! _ = postOkAsync "/promotion-set/create" parameters
             return promotionSetId
-        }
-
-    let unusedAsync () =
-        task {
-            let parameters = scoped (GetPromotionSetParameters()) String.Empty String.Empty
-            let! response = postAsync "/promotion-set/get" (createJsonContent parameters)
-            let! value = deserializeContent<GraceReturnValue<PromotionSetDto>> response
-            return value.ReturnValue
         }
 
     let updateInputPromotionsAsync repositoryId promotionSetId promotionPointers =
@@ -187,9 +198,18 @@ type PromotionSetRouteIntegrationTests() =
             Assert.That(updated, Does.Contain("JsonEnumLikeUnionConverter"))
 
             let! eventsBeforeDelete = PromotionSetIntegrationHelpers.getEventsAsync repositoryId promotionSetId
-            Assert.That(eventsBeforeDelete, Does.Contain("created"))
-            Assert.That(eventsBeforeDelete, Does.Contain("inputPromotionsUpdated"))
-            Assert.That(eventsBeforeDelete, Does.Contain("recomputeFailed"))
+
+            PromotionSetIntegrationHelpers.assertEventSequence
+                eventsBeforeDelete
+                promotionSetId
+                [|
+                    "created"
+                    "recomputeStarted"
+                    "stepsUpdated"
+                    "inputPromotionsUpdated"
+                    "recomputeStarted"
+                    "recomputeFailed"
+                |]
 
             let! _ = PromotionSetIntegrationHelpers.resolveConflictsCurrentFailureAsync repositoryId promotionSetId (Guid.NewGuid().ToString())
 
@@ -200,5 +220,19 @@ type PromotionSetRouteIntegrationTests() =
             Assert.That(deleted, Does.Contain("JsonEnumLikeUnionConverter"))
 
             let! eventsAfterDelete = PromotionSetIntegrationHelpers.getEventsAsync repositoryId promotionSetId
-            Assert.That(eventsAfterDelete, Does.Contain("logicalDeleted"))
+
+            PromotionSetIntegrationHelpers.assertEventSequence
+                eventsAfterDelete
+                promotionSetId
+                [|
+                    "created"
+                    "recomputeStarted"
+                    "stepsUpdated"
+                    "inputPromotionsUpdated"
+                    "recomputeStarted"
+                    "recomputeFailed"
+                    "recomputeStarted"
+                    "recomputeFailed"
+                    "logicalDeleted"
+                |]
         }

--- a/src/Grace.Server.Tests/PromotionSet.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/PromotionSet.Integration.Server.Tests.fs
@@ -1,0 +1,204 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Parameters.PromotionSet
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.PromotionSet
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.Json
+open System.Threading.Tasks
+
+module private PromotionSetIntegrationHelpers =
+    let private scoped<'T when 'T :> PromotionSetParameters> (parameters: 'T) repositoryId promotionSetId : 'T =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.PromotionSetId <- promotionSetId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postAsync (route: string) (content: HttpContent) =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
+        request.Content <- content
+        Client.SendAsync(request)
+
+    let postOkAsync route parameters =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let postBadRequestContainsAsync route parameters expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
+    let postStatusContainsAsync route parameters (expectedStatus: HttpStatusCode) expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(expectedStatus), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
+    let private deserializeRouteValue<'T> (body: string) =
+        use document = JsonDocument.Parse(body)
+        let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+        if (document.RootElement.TryGetProperty("ReturnValue", &returnValue)
+            || document.RootElement.TryGetProperty("returnValue", &returnValue))
+           && returnValue.ValueKind = JsonValueKind.Object then
+            deserialize<GraceReturnValue<'T>> body
+            |> fun value -> value.ReturnValue
+        elif returnValue.ValueKind = JsonValueKind.Null then
+            Assert.Fail($"Route returned null returnValue. Body: {body}")
+            Unchecked.defaultof<'T>
+        else
+            try
+                deserialize<'T> body
+            with
+            | ex ->
+                Assert.Fail($"Failed to deserialize direct route value. Body: {body}. Error: {ex.Message}")
+                Unchecked.defaultof<'T>
+
+    let getPromotionSetAsync repositoryId promotionSetId =
+        task {
+            let parameters = scoped (GetPromotionSetParameters()) repositoryId promotionSetId
+            let! response = postAsync "/promotion-set/get" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let getEventsAsync repositoryId promotionSetId =
+        task {
+            let parameters = scoped (GetPromotionSetEventsParameters()) repositoryId promotionSetId
+            let! response = postAsync "/promotion-set/get-events" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let createAsync repositoryId targetBranchId =
+        task {
+            let promotionSetId = Guid.NewGuid().ToString()
+            let parameters = scoped (CreatePromotionSetParameters()) repositoryId promotionSetId
+            parameters.TargetBranchId <- targetBranchId
+            let! _ = postOkAsync "/promotion-set/create" parameters
+            return promotionSetId
+        }
+
+    let unusedAsync () =
+        task {
+            let parameters = scoped (GetPromotionSetParameters()) String.Empty String.Empty
+            let! response = postAsync "/promotion-set/get" (createJsonContent parameters)
+            let! value = deserializeContent<GraceReturnValue<PromotionSetDto>> response
+            return value.ReturnValue
+        }
+
+    let updateInputPromotionsAsync repositoryId promotionSetId promotionPointers =
+        task {
+            let parameters = scoped (UpdatePromotionSetInputPromotionsParameters()) repositoryId promotionSetId
+            parameters.PromotionPointers <- promotionPointers
+
+            let! _ =
+                postBadRequestContainsAsync
+                    "/promotion-set/update-input-promotions"
+                    parameters
+                    "DirectoryVersion was not found while recomputing PromotionSet step."
+
+            return ()
+        }
+
+    let recomputeAsync repositoryId promotionSetId reason =
+        let parameters = scoped (RecomputePromotionSetParameters()) repositoryId promotionSetId
+        parameters.Reason <- reason
+        postOkAsync "/promotion-set/recompute" parameters
+
+    let applyBadRequestAsync repositoryId promotionSetId expectedText =
+        let parameters = scoped (ApplyPromotionSetParameters()) repositoryId promotionSetId
+        postBadRequestContainsAsync "/promotion-set/apply" parameters expectedText
+
+    let resolveConflictsCurrentFailureAsync repositoryId promotionSetId stepId =
+        let parameters = scoped (ResolvePromotionSetConflictsParameters()) repositoryId promotionSetId
+        parameters.StepId <- stepId
+        parameters.StepsComputationAttempt <- 1
+
+        parameters.Decisions <-
+            [
+                { FilePath = "src/app.fs"; Accepted = true; OverrideContentArtifactId = Option.None }
+            ]
+
+        postStatusContainsAsync $"/promotion-set/{promotionSetId}/resolve-conflicts" parameters HttpStatusCode.InternalServerError "ValidateIdsMiddleware"
+
+    let deleteAsync repositoryId promotionSetId =
+        task {
+            let parameters = scoped (DeletePromotionSetParameters()) repositoryId promotionSetId
+            parameters.Force <- true
+            parameters.DeleteReason <- "integration lifecycle cleanup"
+            let! _ = postOkAsync "/promotion-set/delete" parameters
+            return ()
+        }
+
+[<NonParallelizable>]
+type PromotionSetRouteIntegrationTests() =
+
+    [<Test>]
+    member _.PromotionSetLifecyclePreservesStateEventsProjectionOrderAndGuardedMutations() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let targetBranchId = repositoryDefaultBranchIds[0]
+            let! promotionSetId = PromotionSetIntegrationHelpers.createAsync repositoryId targetBranchId
+
+            let! created = PromotionSetIntegrationHelpers.getPromotionSetAsync repositoryId promotionSetId
+            Assert.That(created, Does.Contain("JsonEnumLikeUnionConverter"))
+            Assert.That(created, Does.Contain("Object reference not set"))
+
+            let! recomputeBody = PromotionSetIntegrationHelpers.recomputeAsync repositoryId promotionSetId "hosted proof empty set"
+
+            Assert.That(
+                recomputeBody,
+                Does
+                    .Contain("PromotionSet steps are already computed")
+                    .Or.Contain("PromotionSet command processed")
+                    .Or.Contain("Promotion set command succeeded")
+            )
+
+            let firstPointer = { BranchId = Guid.NewGuid(); ReferenceId = Guid.NewGuid(); DirectoryVersionId = Guid.NewGuid() }
+
+            let secondPointer = { BranchId = Guid.NewGuid(); ReferenceId = Guid.NewGuid(); DirectoryVersionId = Guid.NewGuid() }
+
+            do! PromotionSetIntegrationHelpers.updateInputPromotionsAsync repositoryId promotionSetId [ firstPointer; secondPointer ]
+
+            let! updated = PromotionSetIntegrationHelpers.getPromotionSetAsync repositoryId promotionSetId
+            Assert.That(updated, Does.Contain("JsonEnumLikeUnionConverter"))
+
+            let! eventsBeforeDelete = PromotionSetIntegrationHelpers.getEventsAsync repositoryId promotionSetId
+            Assert.That(eventsBeforeDelete, Does.Contain("created"))
+            Assert.That(eventsBeforeDelete, Does.Contain("inputPromotionsUpdated"))
+            Assert.That(eventsBeforeDelete, Does.Contain("recomputeFailed"))
+
+            let! _ = PromotionSetIntegrationHelpers.resolveConflictsCurrentFailureAsync repositoryId promotionSetId (Guid.NewGuid().ToString())
+
+            let! _ = PromotionSetIntegrationHelpers.applyBadRequestAsync repositoryId promotionSetId "DirectoryVersion was not found"
+
+            do! PromotionSetIntegrationHelpers.deleteAsync repositoryId promotionSetId
+            let! deleted = PromotionSetIntegrationHelpers.getPromotionSetAsync repositoryId promotionSetId
+            Assert.That(deleted, Does.Contain("JsonEnumLikeUnionConverter"))
+
+            let! eventsAfterDelete = PromotionSetIntegrationHelpers.getEventsAsync repositoryId promotionSetId
+            Assert.That(eventsAfterDelete, Does.Contain("logicalDeleted"))
+        }

--- a/src/Grace.Server.Tests/Review.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Review.Integration.Server.Tests.fs
@@ -1,0 +1,214 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Server
+open Grace.Shared
+open Grace.Shared.Parameters.Review
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.Policy
+open Grace.Types.PromotionSet
+open Grace.Types.Review
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.Json
+open System.Threading.Tasks
+
+module private ReviewIntegrationHelpers =
+    let private postAsync (route: string) (content: HttpContent) =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
+        request.Content <- content
+        Client.SendAsync(request)
+
+    let private reviewScoped<'T when 'T :> ReviewParameters> (parameters: 'T) repositoryId promotionSetId : 'T =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.PromotionSetId <- promotionSetId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let private candidateScoped<'T when 'T :> CandidateProjectionParameters> (parameters: 'T) repositoryId candidateId : 'T =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CandidateId <- candidateId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postOkReturnAsync<'T, 'P> route (parameters: 'P) =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            use document = JsonDocument.Parse(body)
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            if (document.RootElement.TryGetProperty("ReturnValue", &returnValue)
+                || document.RootElement.TryGetProperty("returnValue", &returnValue))
+               && returnValue.ValueKind = JsonValueKind.Object then
+                return
+                    deserialize<GraceReturnValue<'T>> body
+                    |> fun value -> value.ReturnValue
+            else
+                return deserialize<'T> body
+        }
+
+    let postBadRequestContainsAsync<'P> route (parameters: 'P) expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
+    let postStatusContainsAsync<'P> route (parameters: 'P) (expectedStatus: HttpStatusCode) expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(expectedStatus), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
+    let createPromotionSetAsync repositoryId targetBranchId =
+        task {
+            let promotionSetId = Guid.NewGuid().ToString()
+            let parameters = Grace.Shared.Parameters.PromotionSet.CreatePromotionSetParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.PromotionSetId <- promotionSetId
+            parameters.TargetBranchId <- targetBranchId
+            parameters.CorrelationId <- generateCorrelationId ()
+            let! response = postAsync "/promotion-set/create" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return promotionSetId
+        }
+
+    let seedPolicySnapshotAsync repositoryId branchId =
+        task {
+            let policySnapshotId = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"
+            let parameters = Grace.Server.Policy.SeedPolicySnapshotParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.TargetBranchId <- branchId
+            parameters.PolicySnapshotId <- policySnapshotId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = postAsync "/policy/_seedSnapshot" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return policySnapshotId
+        }
+
+    let checkpointAsync repositoryId promotionSetId reviewedUpToReferenceId policySnapshotId =
+        task {
+            let parameters = reviewScoped (ReviewCheckpointParameters()) repositoryId promotionSetId
+            parameters.ReviewedUpToReferenceId <- reviewedUpToReferenceId
+            parameters.PolicySnapshotId <- policySnapshotId
+            let! response = postAsync "/review/checkpoint" (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+
+            Assert.That(
+                body,
+                Does
+                    .Contain("ReturnValue")
+                    .Or.Contain("returnValue")
+            )
+
+            return ()
+        }
+
+    let getNotesAsync repositoryId promotionSetId =
+        let parameters = reviewScoped (GetReviewNotesParameters()) repositoryId promotionSetId
+        postOkReturnAsync<ReviewNotes option, GetReviewNotesParameters> "/review/notes" parameters
+
+    let resolveMissingFindingAsync repositoryId promotionSetId findingId =
+        let parameters = reviewScoped (ResolveFindingParameters()) repositoryId promotionSetId
+        parameters.FindingId <- findingId
+        parameters.ResolutionState <- "Approved"
+        parameters.Note <- "hosted route proof"
+        postBadRequestContainsAsync<ResolveFindingParameters> "/review/resolve" parameters "Review notes do not exist"
+
+    let candidateIdentityAsync repositoryId candidateId =
+        candidateScoped (ResolveCandidateIdentityParameters()) repositoryId candidateId
+        |> postOkReturnAsync<CandidateIdentityProjectionResult, ResolveCandidateIdentityParameters> "/review/candidate/resolve"
+
+    let candidateGetAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> postOkReturnAsync<CandidateProjectionSnapshotResult, CandidateProjectionParameters> "/review/candidate/get"
+
+    let candidateGetCurrentFailureAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> fun parameters -> postStatusContainsAsync "/review/candidate/get" parameters HttpStatusCode.InternalServerError "deriveCandidateRequiredActions"
+
+    let candidateRequiredActionsAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> postOkReturnAsync<CandidateRequiredActionsResult, CandidateProjectionParameters> "/review/candidate/required-actions"
+
+    let candidateAttestationsAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> postOkReturnAsync<CandidateAttestationsResult, CandidateProjectionParameters> "/review/candidate/attestations"
+
+    let reviewReportAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> postOkReturnAsync<ReviewModels.ReviewReportResult, CandidateProjectionParameters> "/review/report/get"
+
+    let retryAsync repositoryId candidateId =
+        let parameters = candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        postBadRequestContainsAsync<CandidateProjectionParameters> "/review/candidate/retry" parameters "DirectoryVersion was not found"
+
+    let cancelAsync repositoryId candidateId =
+        let parameters = candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        postBadRequestContainsAsync<CandidateProjectionParameters> "/review/candidate/cancel" parameters "target branch queue is not initialized"
+
+    let gateRerunAsync repositoryId candidateId =
+        let parameters = candidateScoped (CandidateGateRerunParameters()) repositoryId candidateId
+        parameters.Gate <- "required-validation"
+        postBadRequestContainsAsync<CandidateGateRerunParameters> "/review/candidate/gate-rerun" parameters "DirectoryVersion was not found"
+
+    let deepenStubAsync repositoryId promotionSetId =
+        let parameters = reviewScoped (DeepenReviewParameters()) repositoryId promotionSetId
+        parameters.ChapterId <- "chapter-proof"
+        postBadRequestContainsAsync<DeepenReviewParameters> "/review/deepen" parameters "Deepen is not implemented yet."
+
+[<NonParallelizable>]
+type ReviewRouteIntegrationTests() =
+
+    [<Test>]
+    member _.ReviewCandidateRoutesPreserveProjectionOrderCheckpointAndCurrentStubContract() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let targetBranchId = repositoryDefaultBranchIds[0]
+            let! promotionSetId = ReviewIntegrationHelpers.createPromotionSetAsync repositoryId targetBranchId
+            let! policySnapshotId = ReviewIntegrationHelpers.seedPolicySnapshotAsync repositoryId targetBranchId
+            let reviewedUpToReferenceId = Guid.NewGuid().ToString()
+
+            let! identity = ReviewIntegrationHelpers.candidateIdentityAsync repositoryId promotionSetId
+            Assert.That(identity.Identity.CandidateId, Is.EqualTo(promotionSetId))
+            Assert.That(identity.Identity.PromotionSetId, Is.EqualTo(Guid.Empty.ToString()))
+            Assert.That(identity.Identity.IdentityMode, Is.EqualTo(CandidateIdentityModes.DirectPromotionSetProjection))
+
+            let identitySourceSections =
+                identity.SourceStates
+                |> List.map (fun state -> state.Section)
+                |> List.toArray
+
+            Assert.That(identitySourceSections, Does.Contain("identity"))
+
+            let! _ = ReviewIntegrationHelpers.candidateGetCurrentFailureAsync repositoryId promotionSetId
+
+            do! ReviewIntegrationHelpers.checkpointAsync repositoryId promotionSetId reviewedUpToReferenceId policySnapshotId
+
+            let! _ = ReviewIntegrationHelpers.deepenStubAsync repositoryId promotionSetId
+
+            return ()
+        }

--- a/src/Grace.Server.Tests/Review.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Review.Integration.Server.Tests.fs
@@ -75,6 +75,15 @@ module private ReviewIntegrationHelpers =
             return body
         }
 
+    let postOkBodyContainsAsync<'P> route (parameters: 'P) expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
     let createPromotionSetAsync repositoryId targetBranchId =
         task {
             let promotionSetId = Guid.NewGuid().ToString()
@@ -131,12 +140,16 @@ module private ReviewIntegrationHelpers =
         let parameters = reviewScoped (GetReviewNotesParameters()) repositoryId promotionSetId
         postOkReturnAsync<ReviewNotes option, GetReviewNotesParameters> "/review/notes" parameters
 
+    let getNotesCurrentNoNotesAsync repositoryId promotionSetId =
+        let parameters = reviewScoped (GetReviewNotesParameters()) repositoryId promotionSetId
+        postOkBodyContainsAsync "/review/notes" parameters "ReturnValue"
+
     let resolveMissingFindingAsync repositoryId promotionSetId findingId =
         let parameters = reviewScoped (ResolveFindingParameters()) repositoryId promotionSetId
         parameters.FindingId <- findingId
         parameters.ResolutionState <- "Approved"
         parameters.Note <- "hosted route proof"
-        postBadRequestContainsAsync<ResolveFindingParameters> "/review/resolve" parameters "Review notes do not exist"
+        postBadRequestContainsAsync<ResolveFindingParameters> "/review/resolve" parameters "The review notes do not exist."
 
     let candidateIdentityAsync repositoryId candidateId =
         candidateScoped (ResolveCandidateIdentityParameters()) repositoryId candidateId
@@ -154,6 +167,11 @@ module private ReviewIntegrationHelpers =
         candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
         |> postOkReturnAsync<CandidateRequiredActionsResult, CandidateProjectionParameters> "/review/candidate/required-actions"
 
+    let candidateRequiredActionsCurrentFailureAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> fun parameters ->
+            postStatusContainsAsync "/review/candidate/required-actions" parameters HttpStatusCode.InternalServerError "deriveCandidateRequiredActions"
+
     let candidateAttestationsAsync repositoryId candidateId =
         candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
         |> postOkReturnAsync<CandidateAttestationsResult, CandidateProjectionParameters> "/review/candidate/attestations"
@@ -162,9 +180,13 @@ module private ReviewIntegrationHelpers =
         candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
         |> postOkReturnAsync<ReviewModels.ReviewReportResult, CandidateProjectionParameters> "/review/report/get"
 
+    let reviewReportCurrentFailureAsync repositoryId candidateId =
+        candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
+        |> fun parameters -> postStatusContainsAsync "/review/report/get" parameters HttpStatusCode.InternalServerError "deriveCandidateRequiredActions"
+
     let retryAsync repositoryId candidateId =
         let parameters = candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
-        postBadRequestContainsAsync<CandidateProjectionParameters> "/review/candidate/retry" parameters "DirectoryVersion was not found"
+        postBadRequestContainsAsync<CandidateProjectionParameters> "/review/candidate/retry" parameters "PromotionSet does not exist."
 
     let cancelAsync repositoryId candidateId =
         let parameters = candidateScoped (CandidateProjectionParameters()) repositoryId candidateId
@@ -173,7 +195,7 @@ module private ReviewIntegrationHelpers =
     let gateRerunAsync repositoryId candidateId =
         let parameters = candidateScoped (CandidateGateRerunParameters()) repositoryId candidateId
         parameters.Gate <- "required-validation"
-        postBadRequestContainsAsync<CandidateGateRerunParameters> "/review/candidate/gate-rerun" parameters "DirectoryVersion was not found"
+        postBadRequestContainsAsync<CandidateGateRerunParameters> "/review/candidate/gate-rerun" parameters "PromotionSet does not exist."
 
     let deepenStubAsync repositoryId promotionSetId =
         let parameters = reviewScoped (DeepenReviewParameters()) repositoryId promotionSetId
@@ -208,6 +230,44 @@ type ReviewRouteIntegrationTests() =
 
             do! ReviewIntegrationHelpers.checkpointAsync repositoryId promotionSetId reviewedUpToReferenceId policySnapshotId
 
+            let! notesBody = ReviewIntegrationHelpers.getNotesCurrentNoNotesAsync repositoryId promotionSetId
+            Assert.That(notesBody, Does.Contain("ReturnValue"))
+            Assert.That(notesBody, Does.Contain("null"))
+
+            let! _ = ReviewIntegrationHelpers.resolveMissingFindingAsync repositoryId promotionSetId (Guid.NewGuid().ToString())
+
+            let! _ = ReviewIntegrationHelpers.candidateRequiredActionsCurrentFailureAsync repositoryId promotionSetId
+
+            let! attestations = ReviewIntegrationHelpers.candidateAttestationsAsync repositoryId promotionSetId
+            Assert.That(attestations.Identity.CandidateId, Is.EqualTo(promotionSetId))
+            Assert.That(attestations.Identity.PromotionSetId, Is.EqualTo(Guid.Empty.ToString()))
+
+            let attestationNames =
+                attestations.Attestations
+                |> List.map (fun attestation -> attestation.Name)
+                |> List.toArray
+
+            Assert.That(attestationNames.Length, Is.EqualTo(2))
+            Assert.That(attestationNames[0], Is.EqualTo("PolicySnapshot"))
+            Assert.That(attestationNames[1], Is.EqualTo("ReviewCheckpoint"))
+
+            Assert.That(attestations.Attestations[0].Status, Is.EqualTo(ProjectionSourceStates.NotAvailable))
+            Assert.That(attestations.Attestations[1].Status, Is.EqualTo(ProjectionSourceStates.NotAvailable))
+
+            let attestationSourceSections =
+                attestations.SourceStates
+                |> List.map (fun sourceState -> sourceState.Section)
+                |> List.toArray
+
+            Assert.That(attestationSourceSections.Length, Is.EqualTo(3))
+            Assert.That(attestationSourceSections[0], Is.EqualTo("identity"))
+            Assert.That(attestationSourceSections[1], Is.EqualTo("policy"))
+            Assert.That(attestationSourceSections[2], Is.EqualTo("checkpoint"))
+
+            let! _ = ReviewIntegrationHelpers.reviewReportCurrentFailureAsync repositoryId promotionSetId
+            let! _ = ReviewIntegrationHelpers.retryAsync repositoryId promotionSetId
+            let! _ = ReviewIntegrationHelpers.cancelAsync repositoryId promotionSetId
+            let! _ = ReviewIntegrationHelpers.gateRerunAsync repositoryId promotionSetId
             let! _ = ReviewIntegrationHelpers.deepenStubAsync repositoryId promotionSetId
 
             return ()

--- a/src/Grace.Server.Tests/ValidationResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ValidationResult.Integration.Server.Tests.fs
@@ -14,18 +14,7 @@ open System.Text.Json
 open System.Threading.Tasks
 
 module private ValidationResultIntegrationHelpers =
-    type RecordedValidationResult =
-        {
-            ValidationResultId: Guid
-            RepositoryId: Guid
-            ValidationSetId: Guid option
-            PromotionSetId: Guid option
-            PromotionSetStepId: Guid option
-            StepsComputationAttempt: int option
-            Status: string
-            Summary: string
-            ArtifactIds: Guid list
-        }
+    type RecordedValidationResult = { OutputKind: JsonValueKind; PropertiesRaw: string }
 
     let recordParameters repositoryId validationResultId validationSetId promotionSetId promotionSetStepId stepsComputationAttempt artifactIds =
         let parameters = RecordValidationResultParameters()
@@ -62,28 +51,7 @@ module private ValidationResultIntegrationHelpers =
             Assert.Fail($"Expected JSON property '{name}' in {element.GetRawText()}.")
             Unchecked.defaultof<JsonElement>
 
-    let private getOptionalGuid (name: string) (element: JsonElement) =
-        let property = tryGetProperty name element
-
-        if property.ValueKind = JsonValueKind.Null then
-            Option.None
-        else
-            let value = property.GetString()
-
-            if String.IsNullOrWhiteSpace(value) then
-                Option.None
-            else
-                Option.Some(Guid.Parse value)
-
-    let private getOptionalInt (name: string) (element: JsonElement) =
-        let property = tryGetProperty name element
-
-        if property.ValueKind = JsonValueKind.Null then
-            Option.None
-        else
-            Option.Some(property.GetInt32())
-
-    let private parseRecordedValidationResult (body: string) =
+    let parseRecordedValidationResult (body: string) =
         use document = JsonDocument.Parse(body)
 
         let envelopeReturnValue =
@@ -100,32 +68,12 @@ module private ValidationResultIntegrationHelpers =
                 document.RootElement
 
         let output = returnValue |> tryGetProperty "Output"
-        let artifactIds = output |> tryGetProperty "ArtifactIds"
 
-        let artifacts =
-            artifactIds.EnumerateArray()
-            |> Seq.map (fun value -> Guid.Parse(value.GetString()))
-            |> Seq.toList
+        let properties =
+            document.RootElement
+            |> tryGetProperty "Properties"
 
-        {
-            ValidationResultId =
-                Guid.Parse(
-                    (returnValue |> tryGetProperty "ValidationResultId")
-                        .GetString()
-                )
-            RepositoryId =
-                Guid.Parse(
-                    (returnValue |> tryGetProperty "RepositoryId")
-                        .GetString()
-                )
-            ValidationSetId = getOptionalGuid "ValidationSetId" returnValue
-            PromotionSetId = getOptionalGuid "PromotionSetId" returnValue
-            PromotionSetStepId = getOptionalGuid "PromotionSetStepId" returnValue
-            StepsComputationAttempt = getOptionalInt "StepsComputationAttempt" returnValue
-            Status = (output |> tryGetProperty "Status").GetString()
-            Summary = (output |> tryGetProperty "Summary").GetString()
-            ArtifactIds = artifacts
-        }
+        { OutputKind = output.ValueKind; PropertiesRaw = properties.GetRawText() }
 
     let recordBodyAsync correlationId parameters =
         task {
@@ -147,7 +95,7 @@ module private ValidationResultIntegrationHelpers =
 type ValidationResultRouteIntegrationTests() =
 
     [<Test>]
-    member _.ValidationResultRecordPersistsArtifactLinksAndRejectsDuplicateCorrelationReplay() =
+    member _.ValidationResultRecordPinsCurrentNullOutputDriftAndRejectsDuplicateCorrelationReplay() =
         task {
             let repositoryId = repositoryIds[0]
             let validationResultId = Guid.NewGuid().ToString()
@@ -172,17 +120,12 @@ type ValidationResultRouteIntegrationTests() =
                     |]
 
             let! recorded = ValidationResultIntegrationHelpers.recordBodyAsync correlationId parameters
-            Assert.That(recorded, Does.Contain("ValidationResultId"))
-            Assert.That(recorded, Does.Contain(validationResultId))
-            Assert.That(recorded, Does.Contain(firstArtifactId.ToString()))
-            Assert.That(recorded, Does.Contain(secondArtifactId.ToString()))
+            let parsed = ValidationResultIntegrationHelpers.parseRecordedValidationResult recorded
 
-            Assert.That(
-                recorded,
-                Does
-                    .Contain("Output\": null")
-                    .Or.Contain("output\": null")
-            )
+            Assert.That(parsed.OutputKind, Is.EqualTo(JsonValueKind.Null), "Current hosted response does not expose persisted ValidationOutput.")
+            Assert.That(parsed.PropertiesRaw, Does.Contain(validationResultId))
+            Assert.That(parsed.PropertiesRaw, Does.Contain(firstArtifactId.ToString()))
+            Assert.That(parsed.PropertiesRaw, Does.Contain(secondArtifactId.ToString()))
 
             do!
                 ValidationResultIntegrationHelpers.recordBadRequestContainsAsync
@@ -192,7 +135,15 @@ type ValidationResultRouteIntegrationTests() =
 
             let newCorrelationId = generateCorrelationId ()
             let! replayedWithNewCorrelation = ValidationResultIntegrationHelpers.recordBodyAsync newCorrelationId parameters
-            Assert.That(replayedWithNewCorrelation, Does.Contain(validationResultId))
-            Assert.That(replayedWithNewCorrelation, Does.Contain(firstArtifactId.ToString()))
-            Assert.That(replayedWithNewCorrelation, Does.Contain(secondArtifactId.ToString()))
+            let parsedReplay = ValidationResultIntegrationHelpers.parseRecordedValidationResult replayedWithNewCorrelation
+
+            Assert.That(
+                parsedReplay.OutputKind,
+                Is.EqualTo(JsonValueKind.Null),
+                "Current hosted replay response still does not expose persisted ValidationOutput."
+            )
+
+            Assert.That(parsedReplay.PropertiesRaw, Does.Contain(validationResultId))
+            Assert.That(parsedReplay.PropertiesRaw, Does.Contain(firstArtifactId.ToString()))
+            Assert.That(parsedReplay.PropertiesRaw, Does.Contain(secondArtifactId.ToString()))
         }

--- a/src/Grace.Server.Tests/ValidationResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ValidationResult.Integration.Server.Tests.fs
@@ -1,0 +1,198 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Parameters.Validation
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.Validation
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.Json
+open System.Threading.Tasks
+
+module private ValidationResultIntegrationHelpers =
+    type RecordedValidationResult =
+        {
+            ValidationResultId: Guid
+            RepositoryId: Guid
+            ValidationSetId: Guid option
+            PromotionSetId: Guid option
+            PromotionSetStepId: Guid option
+            StepsComputationAttempt: int option
+            Status: string
+            Summary: string
+            ArtifactIds: Guid list
+        }
+
+    let recordParameters repositoryId validationResultId validationSetId promotionSetId promotionSetStepId stepsComputationAttempt artifactIds =
+        let parameters = RecordValidationResultParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.ValidationResultId <- validationResultId
+        parameters.ValidationSetId <- validationSetId
+        parameters.PromotionSetId <- promotionSetId
+        parameters.PromotionSetStepId <- promotionSetStepId
+        parameters.StepsComputationAttempt <- stepsComputationAttempt
+        parameters.ValidationName <- "hosted-proof"
+        parameters.ValidationVersion <- "1.0"
+        parameters.Status <- "Pass"
+        parameters.Summary <- "Hosted validation result route proof."
+        parameters.ArtifactIds <- artifactIds
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postWithCorrelationAsync (route: string) (correlationId: string) parameters =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, correlationId)
+        request.Content <- createJsonContent parameters
+        Client.SendAsync(request)
+
+    let private tryGetProperty (name: string) (element: JsonElement) =
+        let mutable property = Unchecked.defaultof<JsonElement>
+
+        if element.TryGetProperty(name, &property) then
+            property
+        elif element.TryGetProperty($"{Char.ToLowerInvariant(name[0])}{name.Substring(1)}", &property) then
+            property
+        else
+            Assert.Fail($"Expected JSON property '{name}' in {element.GetRawText()}.")
+            Unchecked.defaultof<JsonElement>
+
+    let private getOptionalGuid (name: string) (element: JsonElement) =
+        let property = tryGetProperty name element
+
+        if property.ValueKind = JsonValueKind.Null then
+            Option.None
+        else
+            let value = property.GetString()
+
+            if String.IsNullOrWhiteSpace(value) then
+                Option.None
+            else
+                Option.Some(Guid.Parse value)
+
+    let private getOptionalInt (name: string) (element: JsonElement) =
+        let property = tryGetProperty name element
+
+        if property.ValueKind = JsonValueKind.Null then
+            Option.None
+        else
+            Option.Some(property.GetInt32())
+
+    let private parseRecordedValidationResult (body: string) =
+        use document = JsonDocument.Parse(body)
+
+        let envelopeReturnValue =
+            document.RootElement
+            |> tryGetProperty "ReturnValue"
+
+        let returnValue =
+            if envelopeReturnValue.ValueKind = JsonValueKind.Object then
+                envelopeReturnValue
+            elif envelopeReturnValue.ValueKind = JsonValueKind.Null then
+                Assert.Fail($"Route returned null returnValue. Body: {body}")
+                Unchecked.defaultof<JsonElement>
+            else
+                document.RootElement
+
+        let output = returnValue |> tryGetProperty "Output"
+        let artifactIds = output |> tryGetProperty "ArtifactIds"
+
+        let artifacts =
+            artifactIds.EnumerateArray()
+            |> Seq.map (fun value -> Guid.Parse(value.GetString()))
+            |> Seq.toList
+
+        {
+            ValidationResultId =
+                Guid.Parse(
+                    (returnValue |> tryGetProperty "ValidationResultId")
+                        .GetString()
+                )
+            RepositoryId =
+                Guid.Parse(
+                    (returnValue |> tryGetProperty "RepositoryId")
+                        .GetString()
+                )
+            ValidationSetId = getOptionalGuid "ValidationSetId" returnValue
+            PromotionSetId = getOptionalGuid "PromotionSetId" returnValue
+            PromotionSetStepId = getOptionalGuid "PromotionSetStepId" returnValue
+            StepsComputationAttempt = getOptionalInt "StepsComputationAttempt" returnValue
+            Status = (output |> tryGetProperty "Status").GetString()
+            Summary = (output |> tryGetProperty "Summary").GetString()
+            ArtifactIds = artifacts
+        }
+
+    let recordBodyAsync correlationId parameters =
+        task {
+            let! response = postWithCorrelationAsync "/validation-result/record" correlationId parameters
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let recordBadRequestContainsAsync correlationId parameters expectedText =
+        task {
+            let! response = postWithCorrelationAsync "/validation-result/record" correlationId parameters
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain(expectedText))
+        }
+
+[<NonParallelizable>]
+type ValidationResultRouteIntegrationTests() =
+
+    [<Test>]
+    member _.ValidationResultRecordPersistsArtifactLinksAndRejectsDuplicateCorrelationReplay() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let validationResultId = Guid.NewGuid().ToString()
+            let validationSetId = Guid.NewGuid().ToString()
+            let promotionSetId = Guid.NewGuid().ToString()
+            let promotionSetStepId = Guid.NewGuid().ToString()
+            let firstArtifactId = Guid.NewGuid()
+            let secondArtifactId = Guid.NewGuid()
+            let correlationId = generateCorrelationId ()
+
+            let parameters =
+                ValidationResultIntegrationHelpers.recordParameters
+                    repositoryId
+                    validationResultId
+                    validationSetId
+                    promotionSetId
+                    promotionSetStepId
+                    1
+                    [|
+                        firstArtifactId.ToString()
+                        secondArtifactId.ToString()
+                    |]
+
+            let! recorded = ValidationResultIntegrationHelpers.recordBodyAsync correlationId parameters
+            Assert.That(recorded, Does.Contain("ValidationResultId"))
+            Assert.That(recorded, Does.Contain(validationResultId))
+            Assert.That(recorded, Does.Contain(firstArtifactId.ToString()))
+            Assert.That(recorded, Does.Contain(secondArtifactId.ToString()))
+
+            Assert.That(
+                recorded,
+                Does
+                    .Contain("Output\": null")
+                    .Or.Contain("output\": null")
+            )
+
+            do!
+                ValidationResultIntegrationHelpers.recordBadRequestContainsAsync
+                    correlationId
+                    parameters
+                    "Duplicate correlation ID for ValidationResult command."
+
+            let newCorrelationId = generateCorrelationId ()
+            let! replayedWithNewCorrelation = ValidationResultIntegrationHelpers.recordBodyAsync newCorrelationId parameters
+            Assert.That(replayedWithNewCorrelation, Does.Contain(validationResultId))
+            Assert.That(replayedWithNewCorrelation, Does.Contain(firstArtifactId.ToString()))
+            Assert.That(replayedWithNewCorrelation, Does.Contain(secondArtifactId.ToString()))
+        }

--- a/src/Grace.Server.Tests/ValidationSet.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ValidationSet.Integration.Server.Tests.fs
@@ -1,0 +1,165 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Parameters.Validation
+open Grace.Shared.Utilities
+open Grace.Types.Automation
+open Grace.Types.Common
+open Grace.Types.Validation
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Text.Json
+open System.Threading.Tasks
+
+module private ValidationSetIntegrationHelpers =
+    let private scoped<'T when 'T :> ValidationParameters> (parameters: 'T) repositoryId : 'T =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postAsync (route: string) (content: HttpContent) =
+        let request = new HttpRequestMessage(HttpMethod.Post, route)
+        request.Headers.Add(Constants.CorrelationIdHeaderKey, generateCorrelationId ())
+        request.Content <- content
+        Client.SendAsync(request)
+
+    let postOkReturnAsync<'T, 'P> route (parameters: 'P) =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            use document = JsonDocument.Parse(body)
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            if (document.RootElement.TryGetProperty("ReturnValue", &returnValue)
+                || document.RootElement.TryGetProperty("returnValue", &returnValue))
+               && returnValue.ValueKind = JsonValueKind.Object then
+                return
+                    deserialize<GraceReturnValue<'T>> body
+                    |> fun value -> value.ReturnValue
+            else
+                return deserialize<'T> body
+        }
+
+    let postOkBodyAsync route parameters =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return body
+        }
+
+    let postStatusBodyAsync route parameters (expectedStatus: HttpStatusCode) expectedText =
+        task {
+            let! response = postAsync route (createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(expectedStatus), body)
+            Assert.That(body, Does.Contain(expectedText))
+            return body
+        }
+
+    let createParameters repositoryId validationSetId targetBranchId validationName =
+        let parameters = scoped (CreateValidationSetParameters()) repositoryId
+        parameters.ValidationSetId <- validationSetId
+        parameters.TargetBranchId <- targetBranchId
+
+        parameters.Rules <-
+            [
+                {
+                    EventTypes =
+                        [
+                            AutomationEventType.PromotionSetCreated
+                        ]
+                    BranchNameGlob = "main"
+                }
+            ]
+
+        parameters.Validations <-
+            [
+                { Name = validationName; Version = "1.0"; ExecutionMode = ValidationExecutionMode.Synchronous; RequiredForApply = true }
+            ]
+
+        parameters
+
+    let updateParameters repositoryId validationSetId targetBranchId validationName =
+        let parameters = scoped (UpdateValidationSetParameters()) repositoryId
+        parameters.ValidationSetId <- validationSetId
+        parameters.TargetBranchId <- targetBranchId
+
+        parameters.Rules <-
+            [
+                {
+                    EventTypes =
+                        [
+                            AutomationEventType.ValidationRequested
+                        ]
+                    BranchNameGlob = "release/*"
+                }
+            ]
+
+        parameters.Validations <-
+            [
+                { Name = validationName; Version = "2.0"; ExecutionMode = ValidationExecutionMode.AsyncCallback; RequiredForApply = false }
+            ]
+
+        parameters
+
+    let getAsync repositoryId validationSetId =
+        let parameters = scoped (GetValidationSetParameters()) repositoryId
+        parameters.ValidationSetId <- validationSetId
+        postOkBodyAsync "/validation-set/get" parameters
+
+    let deleteAsync repositoryId validationSetId =
+        task {
+            let parameters = scoped (DeleteValidationSetParameters()) repositoryId
+            parameters.ValidationSetId <- validationSetId
+            parameters.Force <- true
+            parameters.DeleteReason <- "validation-set hosted proof cleanup"
+            let! _ = postOkBodyAsync "/validation-set/delete" parameters
+            return ()
+        }
+
+[<NonParallelizable>]
+type ValidationSetRouteIntegrationTests() =
+
+    [<Test>]
+    member _.ValidationSetCrudPreservesIdentityRulesValidationDefinitionsAndDeleteState() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let targetBranchId = repositoryDefaultBranchIds[0]
+            let validationSetId = Guid.NewGuid().ToString()
+
+            let! createBody =
+                ValidationSetIntegrationHelpers.postOkBodyAsync
+                    "/validation-set/create"
+                    (ValidationSetIntegrationHelpers.createParameters repositoryId validationSetId targetBranchId "hosted-proof")
+
+            Assert.That(createBody, Does.Contain("Validation set command succeeded."))
+
+            let! created = ValidationSetIntegrationHelpers.getAsync repositoryId validationSetId
+            Assert.That(created, Does.Contain(validationSetId))
+            Assert.That(created, Does.Contain("ValidationSetId"))
+
+            Assert.That(
+                created,
+                Does
+                    .Contain("Rules\": null")
+                    .Or.Contain("rules\": null")
+            )
+
+            let! updateBody =
+                ValidationSetIntegrationHelpers.postStatusBodyAsync
+                    "/validation-set/update"
+                    (ValidationSetIntegrationHelpers.updateParameters repositoryId validationSetId targetBranchId "hosted-proof-updated")
+                    HttpStatusCode.InternalServerError
+                    "ValidateIdsMiddleware"
+
+            Assert.That(updateBody, Does.Contain("ValidateIdsMiddleware"))
+
+            ()
+        }

--- a/src/Grace.Server.Tests/ValidationSet.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ValidationSet.Integration.Server.Tests.fs
@@ -15,12 +15,69 @@ open System.Text.Json
 open System.Threading.Tasks
 
 module private ValidationSetIntegrationHelpers =
+    type ValidationSetRouteSnapshot =
+        {
+            ValidationSetId: Guid
+            TargetBranchId: Guid
+            RulesKind: JsonValueKind
+            ValidationsKind: JsonValueKind
+            DeletedAtKind: JsonValueKind
+            DeleteReason: string
+            PropertiesRaw: string
+        }
+
     let private scoped<'T when 'T :> ValidationParameters> (parameters: 'T) repositoryId : 'T =
         parameters.OwnerId <- ownerId
         parameters.OrganizationId <- organizationId
         parameters.RepositoryId <- repositoryId
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
+
+    let private requireProperty (name: string) (element: JsonElement) =
+        let mutable property = Unchecked.defaultof<JsonElement>
+
+        if element.TryGetProperty(name, &property) then
+            property
+        elif element.TryGetProperty($"{Char.ToLowerInvariant(name[0])}{name.Substring(1)}", &property) then
+            property
+        else
+            Assert.Fail($"Expected JSON property '{name}' in {element.GetRawText()}.")
+            Unchecked.defaultof<JsonElement>
+
+    let parseValidationSetSnapshot (body: string) =
+        use document = JsonDocument.Parse(body)
+
+        let returnValue =
+            document.RootElement
+            |> requireProperty "ReturnValue"
+
+        let properties =
+            document.RootElement
+            |> requireProperty "Properties"
+
+        {
+            ValidationSetId =
+                Guid.Parse(
+                    (returnValue |> requireProperty "ValidationSetId")
+                        .GetString()
+                )
+            TargetBranchId =
+                Guid.Parse(
+                    (returnValue |> requireProperty "TargetBranchId")
+                        .GetString()
+                )
+            RulesKind = (returnValue |> requireProperty "Rules").ValueKind
+            ValidationsKind =
+                (returnValue |> requireProperty "Validations")
+                    .ValueKind
+            DeletedAtKind =
+                (returnValue |> requireProperty "DeletedAt")
+                    .ValueKind
+            DeleteReason =
+                (returnValue |> requireProperty "DeleteReason")
+                    .GetString()
+            PropertiesRaw = properties.GetRawText()
+        }
 
     let postAsync (route: string) (content: HttpContent) =
         let request = new HttpRequestMessage(HttpMethod.Post, route)
@@ -120,15 +177,14 @@ module private ValidationSetIntegrationHelpers =
             parameters.ValidationSetId <- validationSetId
             parameters.Force <- true
             parameters.DeleteReason <- "validation-set hosted proof cleanup"
-            let! _ = postOkBodyAsync "/validation-set/delete" parameters
-            return ()
+            return! postOkBodyAsync "/validation-set/delete" parameters
         }
 
 [<NonParallelizable>]
 type ValidationSetRouteIntegrationTests() =
 
     [<Test>]
-    member _.ValidationSetCrudPreservesIdentityRulesValidationDefinitionsAndDeleteState() =
+    member _.ValidationSetCrudPinsCurrentRuleProjectionDriftAndDeleteState() =
         task {
             let repositoryId = repositoryIds[0]
             let targetBranchId = repositoryDefaultBranchIds[0]
@@ -141,16 +197,16 @@ type ValidationSetRouteIntegrationTests() =
 
             Assert.That(createBody, Does.Contain("Validation set command succeeded."))
 
-            let! created = ValidationSetIntegrationHelpers.getAsync repositoryId validationSetId
-            Assert.That(created, Does.Contain(validationSetId))
-            Assert.That(created, Does.Contain("ValidationSetId"))
+            let! createdBody = ValidationSetIntegrationHelpers.getAsync repositoryId validationSetId
+            let created = ValidationSetIntegrationHelpers.parseValidationSetSnapshot createdBody
 
-            Assert.That(
-                created,
-                Does
-                    .Contain("Rules\": null")
-                    .Or.Contain("rules\": null")
-            )
+            Assert.That(created.ValidationSetId, Is.EqualTo(Guid.Empty), "Current hosted ReturnValue uses the default ValidationSetId.")
+            Assert.That(created.TargetBranchId, Is.EqualTo(Guid.Empty), "Current hosted ReturnValue uses the default TargetBranchId.")
+            Assert.That(created.PropertiesRaw, Does.Contain(validationSetId))
+            Assert.That(created.RulesKind, Is.EqualTo(JsonValueKind.Null), "Current hosted projection drops created Rules.")
+            Assert.That(created.ValidationsKind, Is.EqualTo(JsonValueKind.Null), "Current hosted projection drops created Validations.")
+            Assert.That(created.DeletedAtKind, Is.EqualTo(JsonValueKind.Null))
+            Assert.That(created.DeleteReason, Is.Null)
 
             let! updateBody =
                 ValidationSetIntegrationHelpers.postStatusBodyAsync
@@ -161,5 +217,18 @@ type ValidationSetRouteIntegrationTests() =
 
             Assert.That(updateBody, Does.Contain("ValidateIdsMiddleware"))
 
-            ()
+            let! deleteBody = ValidationSetIntegrationHelpers.deleteAsync repositoryId validationSetId
+            Assert.That(deleteBody, Does.Contain("Validation set command succeeded."))
+            Assert.That(deleteBody, Does.Contain(validationSetId))
+
+            let! deletedBody = ValidationSetIntegrationHelpers.getAsync repositoryId validationSetId
+            let deleted = ValidationSetIntegrationHelpers.parseValidationSetSnapshot deletedBody
+
+            Assert.That(deleted.ValidationSetId, Is.EqualTo(created.ValidationSetId))
+            Assert.That(deleted.TargetBranchId, Is.EqualTo(created.TargetBranchId))
+            Assert.That(deleted.PropertiesRaw, Does.Contain(validationSetId))
+            Assert.That(deleted.RulesKind, Is.EqualTo(JsonValueKind.Null), "Current hosted projection still drops Rules after delete.")
+            Assert.That(deleted.ValidationsKind, Is.EqualTo(JsonValueKind.Null), "Current hosted projection still drops Validations after delete.")
+            Assert.That(deleted.DeletedAtKind, Is.EqualTo(JsonValueKind.Null), "Current hosted get does not expose delete state.")
+            Assert.That(deleted.DeleteReason, Is.Null, "Current hosted get does not expose delete reason.")
         }


### PR DESCRIPTION
## Summary

- Add hosted HTTP proof tests for promotion-set, review, validation-set, and validation-result route surfaces.
- Pin current hosted contracts for promotion/review/validation drift and stub behavior instead of silently treating them as desired product behavior.
- Prove `/review/deepen` remains the current not-implemented stub and does not start provider/model work.
- Cover validation-result duplicate-correlation rejection while explicitly pinning the current `Output = null` persistence drift.
- Cover validation-set create/delete route success while explicitly pinning current default/null projection drift.

## Issue Links

Related to #260.
Part of #249.

## Validation

- `dotnet tool run fantomas src/Grace.Server.Tests/PromotionSet.Integration.Server.Tests.fs src/Grace.Server.Tests/Review.Integration.Server.Tests.fs src/Grace.Server.Tests/ValidationSet.Integration.Server.Tests.fs src/Grace.Server.Tests/ValidationResult.Integration.Server.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~PromotionSetRouteIntegrationTests|FullyQualifiedName~ReviewRouteIntegrationTests|FullyQualifiedName~ValidationSetRouteIntegrationTests|FullyQualifiedName~ValidationResultRouteIntegrationTests"`: passed; 4 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed after review-pass-1 fixes.
  - `Grace.Authorization.Tests`: 37 passed.
  - `Grace.Types.Tests`: 65 passed.
  - `Grace.Server.Unit.Tests`: 440 passed.
  - `Grace.CLI.Tests`: 273 passed, 1 skipped.
  - `Grace.Server.Tests`: 157 passed.
- `git diff --check`: passed.

## Route Contract Notes

- Promotion-set `get` currently surfaces a serialization drift body, while `get-events` proves the actual lifecycle event stream once events exist.
- Promotion-set `resolve-conflicts` currently fails through `ValidateIdsMiddleware`; this is recorded as current route-contract drift.
- Review candidate get, required-actions, and report currently fail in `deriveCandidateRequiredActions`; retry/gate-rerun currently stop at promotion-set drift, while cancel reaches queue-not-initialized behavior.
- Review attestations currently report both policy and checkpoint as `NotAvailable` even after seeded policy/checkpoint setup.
- Validation-result route currently does not expose persisted `ValidationOutput` in `ReturnValue`; the test pins `Output = null` and avoids claiming artifact persistence from envelope/request properties.
- Validation-set get currently returns default/null `ReturnValue` projection for identity, target branch, rules, validations, and delete state; create/delete route success is covered, but rule/definition persistence remains a follow-up.
- `/review/deepen` remains explicitly proven as a stub; no provider/model work was added.

## Review Status

- Review pass 1 by GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 1 open findings were fixed or explicitly pinned as drift in `cbcf9b2a577d801f62c8b1b5d716a412aa6b8c1b`; fix evidence posted in PR comments.
- Review pass 2 by fresh GPT-5.5 High review-only subagent found no issues and was posted in PR comments.
- Ready to merge into `epic/249-validation-coverage` once GitHub checks/mergeability permit.
