### PR TITLE
Add hosted Service Bus eventing proof

### DIFF
--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -931,6 +931,7 @@ module AspireTestHost =
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceAuthOidcAuthority, "https://auth.grace.test")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceAuthOidcAudience, "https://api.grace.test")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceAuthOidcCliClientId, "grace-cli-test-client")
+            Environment.SetEnvironmentVariable("grace__webhooks__outbound_urls__allow_unsafe_local_development", "true")
 
             if not <| String.IsNullOrWhiteSpace bootstrapUserId then
                 Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, bootstrapUserId)
@@ -1292,4 +1293,97 @@ module AspireTestHost =
                     if matchesOwnerCreated then found <- Some message
 
             return found.Value
+        }
+
+    let sendGraceEventAsync (state: TestHostState) (graceEvent: Events.GraceEvent) (metadata: Grace.Types.Common.EventMetadata) =
+        task {
+            let client = ServiceBusClient(state.ServiceBusConnectionString)
+            use _client = client
+            let sender = client.CreateSender(state.ServiceBusTopic)
+
+            let payload = JsonSerializer.SerializeToUtf8Bytes(graceEvent, Constants.JsonSerializerOptions)
+            let message = ServiceBusMessage(payload)
+            message.ContentType <- "application/json"
+            message.Subject <- "GraceEvent"
+            message.CorrelationId <- metadata.CorrelationId
+            message.MessageId <- $"{metadata.CorrelationId}-{Guid.NewGuid():N}"
+            message.ApplicationProperties[ "graceEventType" ] <- getDiscriminatedUnionFullName graceEvent
+
+            let metadataProperties = metadata.Properties |> Seq.toArray
+            let mutable index = 0
+
+            while index < metadataProperties.Length do
+                let property = metadataProperties[index]
+                message.ApplicationProperties[ property.Key ] <- property.Value
+                index <- index + 1
+
+            do! sender.SendMessageAsync(message)
+            do! sender.DisposeAsync().AsTask()
+        }
+
+    let sendRawServiceBusMessageAsync (state: TestHostState) (body: string) (messageId: string) (correlationId: string) =
+        task {
+            let client = ServiceBusClient(state.ServiceBusConnectionString)
+            use _client = client
+            let sender = client.CreateSender(state.ServiceBusTopic)
+            let message = ServiceBusMessage(BinaryData.FromString(body))
+            message.ContentType <- "application/json"
+            message.Subject <- "GraceEvent"
+            message.CorrelationId <- correlationId
+            message.MessageId <- messageId
+
+            do! sender.SendMessageAsync(message)
+            do! sender.DisposeAsync().AsTask()
+        }
+
+    let tryWaitForGraceEventAsync (state: TestHostState) (timeout: TimeSpan) (predicate: Events.GraceEvent -> bool) =
+        task {
+            let client, receiver = createServiceBusReceiver state
+            use _client = client
+            use _receiver = receiver
+
+            let sw = Stopwatch.StartNew()
+            let lastBodies = ResizeArray<string>()
+            let maxBodies = 10
+            let mutable found: Events.GraceEvent option = None
+
+            while found.IsNone && sw.Elapsed < timeout do
+                let remaining = timeout - sw.Elapsed
+
+                let waitTime =
+                    if remaining < TimeSpan.FromSeconds(1.0) then
+                        remaining
+                    else
+                        TimeSpan.FromSeconds(1.0)
+
+                let! message = receiver.ReceiveMessageAsync(waitTime)
+
+                if not (isNull message) then
+                    let body = message.Body.ToString()
+
+                    if lastBodies.Count >= maxBodies then lastBodies.RemoveAt(0)
+
+                    lastBodies.Add(body)
+
+                    try
+                        let graceEvent = JsonSerializer.Deserialize<Events.GraceEvent>(body, Constants.JsonSerializerOptions)
+
+                        if predicate graceEvent then found <- Some graceEvent
+                    with
+                    | ex -> Console.WriteLine($"Service Bus test subscription message was not a GraceEvent: {ex.Message}; Body={body}")
+
+            return found
+        }
+
+    let waitForGraceEventAsync (state: TestHostState) (timeout: TimeSpan) (description: string) (predicate: Events.GraceEvent -> bool) =
+        task {
+            match! tryWaitForGraceEventAsync state timeout predicate with
+            | Some graceEvent -> return graceEvent
+            | None ->
+                return
+                    raise (
+                        TimeoutException(
+                            $"Timed out waiting for {description} on Service Bus test subscription. Topic={state.ServiceBusTopic}; TestSubscription={state.ServiceBusTestSubscription}; Connection={redactServiceBusConnectionString state.ServiceBusConnectionString}"
+                        )
+                    )
         }

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -1295,12 +1295,27 @@ module AspireTestHost =
             return found.Value
         }
 
-    let sendGraceEventAsync (state: TestHostState) (graceEvent: Events.GraceEvent) (metadata: Grace.Types.Common.EventMetadata) =
+    let private serviceBusSendTimeout = TimeSpan.FromSeconds(10.0)
+
+    let private sendServiceBusMessageAsync (state: TestHostState) (message: ServiceBusMessage) =
         task {
+            use cts = new CancellationTokenSource(serviceBusSendTimeout)
             let client = ServiceBusClient(state.ServiceBusConnectionString)
             use _client = client
             let sender = client.CreateSender(state.ServiceBusTopic)
 
+            try
+                do! sender.SendMessageAsync(message, cts.Token)
+            finally
+                sender
+                    .DisposeAsync()
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult()
+        }
+
+    let sendGraceEventAsync (state: TestHostState) (graceEvent: Events.GraceEvent) (metadata: Grace.Types.Common.EventMetadata) =
+        task {
             let payload = JsonSerializer.SerializeToUtf8Bytes(graceEvent, Constants.JsonSerializerOptions)
             let message = ServiceBusMessage(payload)
             message.ContentType <- "application/json"
@@ -1317,23 +1332,18 @@ module AspireTestHost =
                 message.ApplicationProperties[ property.Key ] <- property.Value
                 index <- index + 1
 
-            do! sender.SendMessageAsync(message)
-            do! sender.DisposeAsync().AsTask()
+            do! sendServiceBusMessageAsync state message
         }
 
     let sendRawServiceBusMessageAsync (state: TestHostState) (body: string) (messageId: string) (correlationId: string) =
         task {
-            let client = ServiceBusClient(state.ServiceBusConnectionString)
-            use _client = client
-            let sender = client.CreateSender(state.ServiceBusTopic)
             let message = ServiceBusMessage(BinaryData.FromString(body))
             message.ContentType <- "application/json"
             message.Subject <- "GraceEvent"
             message.CorrelationId <- correlationId
             message.MessageId <- messageId
 
-            do! sender.SendMessageAsync(message)
-            do! sender.DisposeAsync().AsTask()
+            do! sendServiceBusMessageAsync state message
         }
 
     let tryWaitForGraceEventAsync (state: TestHostState) (timeout: TimeSpan) (predicate: Events.GraceEvent -> bool) =

--- a/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
@@ -174,19 +174,58 @@ module private EventingIntegrationHelpers =
             return deliveries.Length
         }
 
-    let validationResultMatches correlationId validationName (graceEvent: GraceEvent) =
+    let assertDeliveryCountRemainsAsync rule expectedCount timeout =
+        task {
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let observedCounts = ResizeArray<int>()
+            let mutable exceeded = false
+
+            while not exceeded && sw.Elapsed < timeout do
+                let! count = deliveryCountAsync rule
+                observedCounts.Add(count)
+
+                if count > expectedCount then
+                    exceeded <- true
+                else
+                    do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            let observedCountsText = String.Join(", ", observedCounts)
+
+            Assert.That(
+                exceeded,
+                Is.False,
+                $"Expected webhook delivery count to remain at {expectedCount} during the bounded duplicate processing window of {timeout.TotalSeconds:n1}s. Observed counts: {observedCountsText}"
+            )
+        }
+
+    let validationResultMatches correlationId validationName ownerId organizationId repositoryId referenceType referenceId (graceEvent: GraceEvent) =
         match graceEvent with
         | GraceEvent.ValidationResultEvent validationResultEvent ->
             validationResultEvent.Metadata.CorrelationId = correlationId
             && match validationResultEvent.Event with
                | ValidationResultEventType.Recorded result ->
                    result.ValidationName.Equals(validationName, StringComparison.OrdinalIgnoreCase)
+                   && result.OwnerId = ownerId
+                   && result.OrganizationId = organizationId
+                   && result.RepositoryId = repositoryId
                    && result.Output.Status = ValidationStatus.Pass
+                   && result.Output.Summary.Contains(getDiscriminatedUnionCaseName referenceType, StringComparison.Ordinal)
+                   && result.Output.Summary.Contains($"referenceId={referenceId}", StringComparison.Ordinal)
+                   && result.Output.ArtifactIds = []
         | _ -> false
 
     let referenceEventMatches correlationId (graceEvent: GraceEvent) =
         match graceEvent with
         | GraceEvent.ReferenceEvent referenceEvent -> referenceEvent.Metadata.CorrelationId = correlationId
+        | _ -> false
+
+    let promotionSetAppliedEventMatches correlationId terminalReferenceId (graceEvent: GraceEvent) =
+        match graceEvent with
+        | GraceEvent.PromotionSetEvent promotionSetEvent ->
+            promotionSetEvent.Metadata.CorrelationId = correlationId
+            && match promotionSetEvent.Event with
+               | PromotionSetEventType.Applied referenceId -> referenceId = terminalReferenceId
+               | _ -> false
         | _ -> false
 
 [<NonParallelizable>]
@@ -243,15 +282,30 @@ type ServiceBusEventingIntegrationTests() =
             Assert.That(firstDelivery.LastError, Is.Not.EqualTo(Microsoft.FSharp.Core.Option.None))
             Assert.That(firstDelivery.LastError.Value, Does.Not.Contain("secret"))
 
-            do! AspireTestHost.sendGraceEventAsync state graceEvent metadata
-            do! Task.Delay(TimeSpan.FromSeconds(2.0))
+            let duplicateGraceEvent, duplicateMetadata =
+                EventingIntegrationHelpers.promotionSetAppliedEvent
+                    ownerGuid
+                    organizationGuid
+                    repositoryId
+                    branchId
+                    promotionSetId
+                    terminalReferenceId
+                    (generateCorrelationId ())
 
-            let! deliveryCount = EventingIntegrationHelpers.deliveryCountAsync rule
-            Assert.That(deliveryCount, Is.EqualTo(1))
+            do! AspireTestHost.sendGraceEventAsync state duplicateGraceEvent duplicateMetadata
+
+            let! _ =
+                AspireTestHost.waitForGraceEventAsync
+                    state
+                    (TimeSpan.FromSeconds(15.0))
+                    $"duplicate PromotionSet Applied echo for dedupe key {dedupeKey}"
+                    (EventingIntegrationHelpers.promotionSetAppliedEventMatches duplicateMetadata.CorrelationId terminalReferenceId)
+
+            do! EventingIntegrationHelpers.assertDeliveryCountRemainsAsync rule 1 (TimeSpan.FromSeconds(5.0))
         }
 
     [<Test>]
-    member _.ServiceBusProcessorFailureDoesNotBlockLaterDerivedQuickScanWork() =
+    member _.MalformedServiceBusMessageDoesNotBlockLaterQuickScanWorkWithRetryOrderSignalUnavailable() =
         task {
             let state = EventingIntegrationHelpers.hostState ()
             let blockedCorrelationId = generateCorrelationId ()
@@ -271,9 +325,18 @@ type ServiceBusEventingIntegrationTests() =
                     state
                     (TimeSpan.FromSeconds(45.0))
                     $"quick-scan ValidationResultEvent for ReferenceId {referenceId}"
-                    (EventingIntegrationHelpers.validationResultMatches correlationId "quick-scan")
+                    (EventingIntegrationHelpers.validationResultMatches
+                        correlationId
+                        "quick-scan"
+                        (Guid.Parse ownerId)
+                        (Guid.Parse organizationId)
+                        repositoryId
+                        ReferenceType.Commit
+                        referenceId)
 
-            Assert.Pass("A malformed Service Bus message was abandoned without preventing the later commit event from producing quick-scan output.")
+            Assert.Pass(
+                "Hosted fixture exposes no server-subscription abandon/retry ordering signal; this proves a malformed payload does not block a later valid quick-scan event."
+            )
         }
 
     [<Test>]
@@ -295,11 +358,18 @@ type ServiceBusEventingIntegrationTests() =
                     state
                     (TimeSpan.FromSeconds(45.0))
                     $"quick-scan ValidationResultEvent for supported ReferenceId {supportedReferenceId}"
-                    (EventingIntegrationHelpers.validationResultMatches supportedCorrelationId "quick-scan")
+                    (EventingIntegrationHelpers.validationResultMatches
+                        supportedCorrelationId
+                        "quick-scan"
+                        (Guid.Parse ownerId)
+                        (Guid.Parse organizationId)
+                        repositoryId
+                        ReferenceType.Checkpoint
+                        supportedReferenceId)
 
             let unsupportedCorrelationId = generateCorrelationId ()
 
-            let unsupportedEvent, unsupportedMetadata, _ =
+            let unsupportedEvent, unsupportedMetadata, unsupportedReferenceId =
                 EventingIntegrationHelpers.referenceCreatedEvent ReferenceType.Save repositoryId branchId unsupportedCorrelationId
 
             do! AspireTestHost.sendGraceEventAsync state unsupportedEvent unsupportedMetadata
@@ -315,7 +385,14 @@ type ServiceBusEventingIntegrationTests() =
                 AspireTestHost.tryWaitForGraceEventAsync
                     state
                     (TimeSpan.FromSeconds(5.0))
-                    (EventingIntegrationHelpers.validationResultMatches unsupportedCorrelationId "quick-scan")
+                    (EventingIntegrationHelpers.validationResultMatches
+                        unsupportedCorrelationId
+                        "quick-scan"
+                        (Guid.Parse ownerId)
+                        (Guid.Parse organizationId)
+                        repositoryId
+                        ReferenceType.Save
+                        unsupportedReferenceId)
 
             Assert.That(unsupportedQuickScan, Is.EqualTo(Microsoft.FSharp.Core.Option.None))
         }

--- a/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
@@ -1,0 +1,321 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Parameters.Webhook
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.Events
+open Grace.Types.PromotionSet
+open Grace.Types.Reference
+open Grace.Types.Validation
+open Grace.Types.Webhooks
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Net
+open System.Threading.Tasks
+
+module private EventingIntegrationHelpers =
+
+    let hostState () =
+        match App with
+        | Microsoft.FSharp.Core.Option.Some app ->
+            {
+                App = app
+                Client = Client
+                GraceServerBaseAddress = graceServerBaseAddress
+                ServiceBusConnectionString = serviceBusConnectionString
+                ServiceBusTopic = serviceBusTopic
+                ServiceBusServerSubscription = serviceBusServerSubscription
+                ServiceBusTestSubscription = serviceBusTestSubscription
+            }
+        | Microsoft.FSharp.Core.Option.None -> failwith "Aspire test host has not started."
+
+    let metadata ownerId organizationId repositoryId branchId actorId correlationId =
+        let properties = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        properties[nameof OwnerId] <- $"{ownerId}"
+        properties[nameof OrganizationId] <- $"{organizationId}"
+        properties[nameof RepositoryId] <- $"{repositoryId}"
+        properties[nameof BranchId] <- $"{branchId}"
+        properties[nameof PromotionSetId] <- $"{actorId}"
+        properties["ActorId"] <- $"{actorId}"
+
+        {
+            Timestamp = Instant.FromUtc(2026, 6, 5, 12, 0)
+            CorrelationId = correlationId
+            Principal = "eventing-integration-test"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = properties
+        }
+
+    let createRuleParameters ownerId organizationId repositoryId branchId =
+        let parameters = CreateWebhookRuleParameters()
+        parameters.OwnerId <- $"{ownerId}"
+        parameters.OrganizationId <- $"{organizationId}"
+        parameters.RepositoryId <- $"{repositoryId}"
+        parameters.TargetBranchId <- $"{branchId}"
+        parameters.Name <- $"servicebus-proof-{Guid.NewGuid():N}"
+        parameters.EventName <- ExternalWebhookEventRegistry.PromotionSetAppliedName
+        parameters.EventVersion <- 1
+        parameters.Url <- "http://127.0.0.1:9/grace-webhook?token=secret"
+        parameters.UrlSafety <- OutboundUrlSafety.LocalUnsafeDevOnly
+        parameters.AcknowledgeUnsafeLocalDevelopment <- true
+        parameters.SigningSecretVersion <- "test-secret-v1"
+        parameters.MaxAttempts <- 2
+        parameters.InitialDelaySeconds <- 1
+        parameters.MaxDelaySeconds <- 2
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let private targetBranchText (rule: WebhookRule) =
+        rule.Scope.TargetBranchId
+        |> Microsoft.FSharp.Core.Option.map string
+        |> Microsoft.FSharp.Core.Option.defaultValue String.Empty
+
+    let enableRuleParameters (rule: WebhookRule) =
+        let parameters = EnableWebhookRuleParameters()
+        parameters.OwnerId <- $"{rule.Scope.OwnerId}"
+        parameters.OrganizationId <- $"{rule.Scope.OrganizationId}"
+        parameters.RepositoryId <- $"{rule.Scope.RepositoryId}"
+        parameters.TargetBranchId <- targetBranchText rule
+        parameters.WebhookRuleId <- $"{rule.WebhookRuleId}"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let listDeliveryParameters (rule: WebhookRule) =
+        let parameters = ListWebhookDeliveriesParameters()
+        parameters.OwnerId <- $"{rule.Scope.OwnerId}"
+        parameters.OrganizationId <- $"{rule.Scope.OrganizationId}"
+        parameters.RepositoryId <- $"{rule.Scope.RepositoryId}"
+        parameters.TargetBranchId <- targetBranchText rule
+        parameters.WebhookRuleId <- $"{rule.WebhookRuleId}"
+        parameters.IncludeTerminal <- true
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let postOkAsync<'T, 'P> (route: string) (parameters: 'P) =
+        task {
+            let! response = Client.PostAsync(route, createJsonContent parameters)
+            let! (body: string) = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return deserialize<'T> body
+        }
+
+    let createEnabledRuleAsync ownerId organizationId repositoryId branchId =
+        task {
+            let! created =
+                postOkAsync<WebhookRule, CreateWebhookRuleParameters> "/webhook/rule/create" (createRuleParameters ownerId organizationId repositoryId branchId)
+
+            let! enabled = postOkAsync<WebhookRule, EnableWebhookRuleParameters> "/webhook/rule/enable" (enableRuleParameters created)
+            Assert.That(enabled.Status, Is.EqualTo(WebhookRuleStatus.Enabled))
+            return enabled
+        }
+
+    let promotionSetAppliedEvent ownerId organizationId repositoryId branchId promotionSetId terminalReferenceId correlationId =
+        let eventMetadata = metadata ownerId organizationId repositoryId branchId promotionSetId correlationId
+
+        let promotionSetEvent: PromotionSetEvent = { Event = PromotionSetEventType.Applied terminalReferenceId; Metadata = eventMetadata }
+
+        GraceEvent.PromotionSetEvent promotionSetEvent, eventMetadata
+
+    let referenceCreatedEvent referenceType repositoryId branchId correlationId =
+        let referenceId = Guid.NewGuid()
+        let eventMetadata = metadata (Guid.Parse ownerId) (Guid.Parse organizationId) repositoryId branchId referenceId correlationId
+
+        let referenceEvent: ReferenceEvent =
+            {
+                Event =
+                    ReferenceEventType.Created(
+                        referenceId,
+                        Guid.Parse ownerId,
+                        Guid.Parse organizationId,
+                        repositoryId,
+                        branchId,
+                        Guid.NewGuid(),
+                        Sha256Hash String.Empty,
+                        referenceType,
+                        $"{referenceType}-reference",
+                        Seq.empty
+                    )
+                Metadata = eventMetadata
+            }
+
+        GraceEvent.ReferenceEvent referenceEvent, eventMetadata, referenceId
+
+    let waitForDeliveryAsync rule dedupeKey timeout =
+        task {
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let mutable found: WebhookDelivery option = Microsoft.FSharp.Core.Option.None
+
+            while found.IsNone && sw.Elapsed < timeout do
+                let! deliveries = postOkAsync<WebhookDelivery array, ListWebhookDeliveriesParameters> "/webhook/delivery/list" (listDeliveryParameters rule)
+
+                found <-
+                    deliveries
+                    |> Array.tryFind (fun delivery ->
+                        delivery.DedupeKey = dedupeKey
+                        && delivery.Status <> WebhookDeliveryStatus.Pending)
+
+                if found.IsNone then do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            match found with
+            | Microsoft.FSharp.Core.Option.Some delivery -> return delivery
+            | Microsoft.FSharp.Core.Option.None -> return raise (TimeoutException($"Timed out waiting for webhook delivery with dedupe key '{dedupeKey}'."))
+        }
+
+    let deliveryCountAsync rule =
+        task {
+            let! deliveries = postOkAsync<WebhookDelivery array, ListWebhookDeliveriesParameters> "/webhook/delivery/list" (listDeliveryParameters rule)
+
+            return deliveries.Length
+        }
+
+    let validationResultMatches correlationId validationName (graceEvent: GraceEvent) =
+        match graceEvent with
+        | GraceEvent.ValidationResultEvent validationResultEvent ->
+            validationResultEvent.Metadata.CorrelationId = correlationId
+            && match validationResultEvent.Event with
+               | ValidationResultEventType.Recorded result ->
+                   result.ValidationName.Equals(validationName, StringComparison.OrdinalIgnoreCase)
+                   && result.Output.Status = ValidationStatus.Pass
+        | _ -> false
+
+    let referenceEventMatches correlationId (graceEvent: GraceEvent) =
+        match graceEvent with
+        | GraceEvent.ReferenceEvent referenceEvent -> referenceEvent.Metadata.CorrelationId = correlationId
+        | _ -> false
+
+[<NonParallelizable>]
+type ServiceBusEventingIntegrationTests() =
+
+    [<Test>]
+    member _.ServiceBusSubscriberDispatchesMatchingWebhookOnceAndDoesNotBlockOnOutboundFailure() =
+        task {
+            let state = EventingIntegrationHelpers.hostState ()
+            let repositoryId = Guid.Parse repositoryIds[0]
+            let branchId = Guid.Parse repositoryDefaultBranchIds[0]
+            let ownerGuid = Guid.Parse ownerId
+            let organizationGuid = Guid.Parse organizationId
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let! rule = EventingIntegrationHelpers.createEnabledRuleAsync ownerGuid organizationGuid repositoryId branchId
+
+            let graceEvent, metadata =
+                EventingIntegrationHelpers.promotionSetAppliedEvent
+                    ownerGuid
+                    organizationGuid
+                    repositoryId
+                    branchId
+                    promotionSetId
+                    terminalReferenceId
+                    (generateCorrelationId ())
+
+            let dedupeKey =
+                String.Join(
+                    ":",
+                    [|
+                        ExternalWebhookEventRegistry.PromotionSetAppliedName
+                        "1"
+                        $"{ownerGuid}"
+                        $"{organizationGuid}"
+                        $"{repositoryId}"
+                        $"{branchId}"
+                        $"{promotionSetId}"
+                        $"{terminalReferenceId}"
+                    |]
+                )
+
+            do! AspireTestHost.sendGraceEventAsync state graceEvent metadata
+            let! firstDelivery = EventingIntegrationHelpers.waitForDeliveryAsync rule dedupeKey (TimeSpan.FromSeconds(30.0))
+
+            Assert.That(
+                firstDelivery.Status,
+                Is
+                    .EqualTo(WebhookDeliveryStatus.RetryScheduled)
+                    .Or.EqualTo(WebhookDeliveryStatus.DeadLettered)
+            )
+
+            Assert.That(firstDelivery.AttemptCount, Is.EqualTo(1), "Local-only webhook failure should be attempted once by the subscriber.")
+            Assert.That(firstDelivery.LastError, Is.Not.EqualTo(Microsoft.FSharp.Core.Option.None))
+            Assert.That(firstDelivery.LastError.Value, Does.Not.Contain("secret"))
+
+            do! AspireTestHost.sendGraceEventAsync state graceEvent metadata
+            do! Task.Delay(TimeSpan.FromSeconds(2.0))
+
+            let! deliveryCount = EventingIntegrationHelpers.deliveryCountAsync rule
+            Assert.That(deliveryCount, Is.EqualTo(1))
+        }
+
+    [<Test>]
+    member _.ServiceBusProcessorFailureDoesNotBlockLaterDerivedQuickScanWork() =
+        task {
+            let state = EventingIntegrationHelpers.hostState ()
+            let blockedCorrelationId = generateCorrelationId ()
+            let malformedBody = """{ "not": "a GraceEvent" }"""
+            let malformedMessageId = $"malformed-{Guid.NewGuid():N}"
+            do! AspireTestHost.sendRawServiceBusMessageAsync state malformedBody malformedMessageId blockedCorrelationId
+
+            let repositoryId = Guid.Parse repositoryIds[0]
+            let branchId = Guid.Parse repositoryDefaultBranchIds[0]
+            let correlationId = generateCorrelationId ()
+            let graceEvent, metadata, referenceId = EventingIntegrationHelpers.referenceCreatedEvent ReferenceType.Commit repositoryId branchId correlationId
+
+            do! AspireTestHost.sendGraceEventAsync state graceEvent metadata
+
+            let! _ =
+                AspireTestHost.waitForGraceEventAsync
+                    state
+                    (TimeSpan.FromSeconds(45.0))
+                    $"quick-scan ValidationResultEvent for ReferenceId {referenceId}"
+                    (EventingIntegrationHelpers.validationResultMatches correlationId "quick-scan")
+
+            Assert.Pass("A malformed Service Bus message was abandoned without preventing the later commit event from producing quick-scan output.")
+        }
+
+    [<Test>]
+    member _.DerivedQuickScanRecordsOnlySupportedReferenceEvents() =
+        task {
+            let state = EventingIntegrationHelpers.hostState ()
+            let repositoryId = Guid.Parse repositoryIds[0]
+            let branchId = Guid.Parse repositoryDefaultBranchIds[0]
+
+            let supportedCorrelationId = generateCorrelationId ()
+
+            let supportedEvent, supportedMetadata, supportedReferenceId =
+                EventingIntegrationHelpers.referenceCreatedEvent ReferenceType.Checkpoint repositoryId branchId supportedCorrelationId
+
+            do! AspireTestHost.sendGraceEventAsync state supportedEvent supportedMetadata
+
+            let! _ =
+                AspireTestHost.waitForGraceEventAsync
+                    state
+                    (TimeSpan.FromSeconds(45.0))
+                    $"quick-scan ValidationResultEvent for supported ReferenceId {supportedReferenceId}"
+                    (EventingIntegrationHelpers.validationResultMatches supportedCorrelationId "quick-scan")
+
+            let unsupportedCorrelationId = generateCorrelationId ()
+
+            let unsupportedEvent, unsupportedMetadata, _ =
+                EventingIntegrationHelpers.referenceCreatedEvent ReferenceType.Save repositoryId branchId unsupportedCorrelationId
+
+            do! AspireTestHost.sendGraceEventAsync state unsupportedEvent unsupportedMetadata
+
+            let! _ =
+                AspireTestHost.waitForGraceEventAsync
+                    state
+                    (TimeSpan.FromSeconds(15.0))
+                    "unsupported save ReferenceEvent echo on the Service Bus test subscription"
+                    (EventingIntegrationHelpers.referenceEventMatches unsupportedCorrelationId)
+
+            let! unsupportedQuickScan =
+                AspireTestHost.tryWaitForGraceEventAsync
+                    state
+                    (TimeSpan.FromSeconds(5.0))
+                    (EventingIntegrationHelpers.validationResultMatches unsupportedCorrelationId "quick-scan")
+
+            Assert.That(unsupportedQuickScan, Is.EqualTo(Microsoft.FSharp.Core.Option.None))
+        }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="Branch.Server.Tests.fs" />
     <Compile Include="Approval.Server.Tests.fs" />
     <Compile Include="Webhook.Server.Tests.fs" />
+    <Compile Include="Eventing.Integration.Server.Tests.fs" />
     <Compile Include="Access.Server.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="DirectoryVersion.Server.Tests.fs" />


### PR DESCRIPTION
## Summary

- Add hosted Service Bus eventing proof for notification subscriber processing and webhook delivery side effects.
- Publish real `GraceEvent` messages to the configured Service Bus topic through Aspire test-host settings.
- Prove supported quick-scan reference events create validation-result side effects and unsupported references do not.
- Prove malformed Service Bus messages do not block later valid eventing work, while explicitly pinning that retry/dead-letter/order internals are not exposed by the hosted fixture.
- Add bounded Service Bus send/receive helpers with timeout diagnostics and redacted connection strings.

## Issue Links

Related to #261.
Part of #249.

## Validation

- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `dotnet tool run fantomas Grace.Server.Tests/AspireTestHost.fs Grace.Server.Tests/Eventing.Integration.Server.Tests.fs`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter FullyQualifiedName~ServiceBusEventingIntegrationTests`: passed; 3 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed locally after review-pass-1 fixes.
  - `Grace.Authorization.Tests`: 37 passed.
  - `Grace.Types.Tests`: 65 passed.
  - `Grace.Server.Unit.Tests`: 440 passed.
  - `Grace.CLI.Tests`: 273 passed, 1 skipped.
  - `Grace.Server.Tests`: 160 passed.
- `git diff --check`: passed.

## Eventing Notes

- The webhook proof uses the real server API and hosted server process for rule/delivery state.
- Outbound webhook calls stay local-only by using an acknowledged `LocalUnsafeDevOnly` rule against `http://127.0.0.1:9/...`, expected to fail after one dispatch attempt.
- Service Bus timing controls are explicit and bounded: send timeout 10s, webhook delivery wait 30s, quick-scan event waits 45s, unsupported reference echo wait 15s, unsupported quick-scan absence check 5s, duplicate delivery poll 5s after duplicate publication evidence.
- Redaction checks include redacted Service Bus timeout diagnostics and assertion that persisted local webhook failure text does not include the `token=secret` query value.
- The malformed-message test proves processor failure does not block later queued work; it does not assert exact Service Bus delivery-count retry/dead-letter/order internals because those server-subscription signals are not exposed through the hosted fixture.
- Derived quick-scan currently records no artifacts; the test asserts `ArtifactIds = []` explicitly rather than implying an artifact side effect exists.

## Review Status

- Review pass 1 by GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 1 open findings were fixed or precisely pinned as fixture limitations in `4d4912236e846e535e8f259eebf2ef2be38bade8`; fix evidence posted in PR comments.
- Review pass 2 by fresh GPT-5.5 High review-only subagent found no issues and was posted in PR comments.
- Ready to merge into `epic/249-validation-coverage` once GitHub checks/mergeability permit.
