### PR TITLE
Add hosted SignalR and agent session proof

### DIFF
--- a/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
+++ b/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
@@ -1,0 +1,193 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Automation
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+
+module private AgentSessionTestHelpers =
+
+    let private postSessionAsync<'TResponse> (path: string) (parameters: obj) =
+        task {
+            let! response = Client.PostAsync(path, createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return deserialize<GraceReturnValue<'TResponse>> body
+        }
+
+    let private createBaseParameters<'T when 'T :> Parameters.Common.AgentSessionParameters and 'T: (new: unit -> 'T)> repositoryId agentId agentDisplayName =
+        let parameters = new 'T()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.AgentId <- agentId
+        parameters.AgentDisplayName <- agentDisplayName
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    let startParameters repositoryId agentId workItemId operationId =
+        let parameters = createBaseParameters<Parameters.Common.StartAgentSessionParameters> repositoryId agentId $"Agent {agentId}"
+
+        parameters.WorkItemIdOrNumber <- workItemId
+        parameters.PromotionSetId <- $"{Guid.NewGuid()}"
+        parameters.Source <- "server-tests"
+        parameters.OperationId <- operationId
+        parameters
+
+    let stopParameters repositoryId agentId sessionId workItemId operationId =
+        let parameters = createBaseParameters<Parameters.Common.StopAgentSessionParameters> repositoryId agentId $"Agent {agentId}"
+
+        parameters.SessionId <- sessionId
+        parameters.WorkItemIdOrNumber <- workItemId
+        parameters.StopReason <- "test complete"
+        parameters.OperationId <- operationId
+        parameters
+
+    let statusParameters repositoryId agentId sessionId workItemId =
+        let parameters = createBaseParameters<Parameters.Common.GetAgentSessionStatusParameters> repositoryId agentId $"Agent {agentId}"
+
+        parameters.SessionId <- sessionId
+        parameters.WorkItemIdOrNumber <- workItemId
+        parameters
+
+    let activeParameters repositoryId agentId workItemId =
+        let parameters = createBaseParameters<Parameters.Common.GetActiveAgentSessionParameters> repositoryId agentId $"Agent {agentId}"
+
+        parameters.WorkItemIdOrNumber <- workItemId
+        parameters
+
+    let listActiveParameters repositoryId agentId maximumSessionCount =
+        let parameters = createBaseParameters<Parameters.Common.ListActiveAgentSessionsParameters> repositoryId agentId $"Agent {agentId}"
+
+        parameters.MaximumSessionCount <- maximumSessionCount
+        parameters
+
+    let startAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/start" parameters
+
+    let stopAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/stop" parameters
+
+    let statusAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/status" parameters
+
+    let activeAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/active" parameters
+
+    let listActiveAsync parameters = postSessionAsync<AgentSessionListResult> "/agent/session/listActive" parameters
+
+[<NonParallelizable>]
+type AgentSessionServerTests() =
+
+    [<Test>]
+    member _.AgentSessionLifecyclePreservesReplayConflictWrongRepositoryAndStopIdempotency() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let wrongRepositoryId = repositoryIds[1]
+            let agentId = $"agent-{Guid.NewGuid():N}"
+            let firstWorkItem = "262"
+            let secondWorkItem = "263"
+            let firstStartOperationId = $"start-{Guid.NewGuid():N}"
+
+            let! started = AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
+
+            Assert.That(started.ReturnValue.WasIdempotentReplay, Is.False)
+            Assert.That(started.ReturnValue.OperationId, Is.EqualTo(firstStartOperationId))
+            Assert.That(started.ReturnValue.Session.SessionId, Is.EqualTo(firstStartOperationId))
+            Assert.That(started.ReturnValue.Session.AgentId, Is.EqualTo(agentId))
+            Assert.That(started.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(firstWorkItem))
+            Assert.That(started.ReturnValue.Session.Source, Is.EqualTo("server-tests"))
+            Assert.That(started.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+            let! duplicateStart =
+                AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
+
+            Assert.That(duplicateStart.ReturnValue.WasIdempotentReplay, Is.True)
+            Assert.That(duplicateStart.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
+
+            let conflictingStartParameters = AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem $"start-{Guid.NewGuid():N}"
+
+            let! conflictingStart = Client.PostAsync("/agent/session/start", createJsonContent conflictingStartParameters)
+
+            let! conflictingStartBody = conflictingStart.Content.ReadAsStringAsync()
+            Assert.That(conflictingStart.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), conflictingStartBody)
+            Assert.That(conflictingStartBody, Does.Contain(firstWorkItem))
+
+            let! active = AgentSessionTestHelpers.activeAsync (AgentSessionTestHelpers.activeParameters repositoryId agentId firstWorkItem)
+
+            Assert.That(active.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
+            Assert.That(active.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+            let! listed = AgentSessionTestHelpers.listActiveAsync (AgentSessionTestHelpers.listActiveParameters repositoryId agentId 10)
+
+            Assert.That(
+                listed.ReturnValue.Sessions
+                |> List.exists (fun session -> session.SessionId = started.ReturnValue.Session.SessionId),
+                Is.True
+            )
+
+            let! wrongRepositoryStatus =
+                AgentSessionTestHelpers.statusAsync (
+                    AgentSessionTestHelpers.statusParameters wrongRepositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                )
+
+            Assert.That(wrongRepositoryStatus.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+
+            let! wrongRepositoryStop =
+                AgentSessionTestHelpers.stopAsync (
+                    AgentSessionTestHelpers.stopParameters
+                        wrongRepositoryId
+                        agentId
+                        started.ReturnValue.Session.SessionId
+                        firstWorkItem
+                        $"stop-wrong-{Guid.NewGuid():N}"
+                )
+
+            Assert.That(wrongRepositoryStop.ReturnValue.WasIdempotentReplay, Is.True)
+            Assert.That(wrongRepositoryStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+
+            let! stillActive =
+                AgentSessionTestHelpers.statusAsync (
+                    AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                )
+
+            Assert.That(stillActive.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+            let stopOperationId = $"stop-{Guid.NewGuid():N}"
+
+            let! stopped =
+                AgentSessionTestHelpers.stopAsync (
+                    AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
+                )
+
+            Assert.That(stopped.ReturnValue.WasIdempotentReplay, Is.False)
+            Assert.That(stopped.ReturnValue.OperationId, Is.EqualTo(stopOperationId))
+            Assert.That(stopped.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
+
+            let! duplicateStop =
+                AgentSessionTestHelpers.stopAsync (
+                    AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
+                )
+
+            Assert.That(duplicateStop.ReturnValue.WasIdempotentReplay, Is.True)
+            Assert.That(duplicateStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
+
+            let! inactiveAfterStop =
+                AgentSessionTestHelpers.statusAsync (
+                    AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                )
+
+            Assert.That(inactiveAfterStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+
+            let secondStartOperationId = $"start-{Guid.NewGuid():N}"
+
+            let! replacementStart =
+                AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem secondStartOperationId)
+
+            Assert.That(replacementStart.ReturnValue.WasIdempotentReplay, Is.False)
+            Assert.That(replacementStart.ReturnValue.Session.SessionId, Is.EqualTo(secondStartOperationId))
+            Assert.That(replacementStart.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(secondWorkItem))
+            Assert.That(replacementStart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+        }

--- a/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
+++ b/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
@@ -72,6 +72,20 @@ module private AgentSessionTestHelpers =
 
     let stopAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/stop" parameters
 
+    let tryStopAsync repositoryId agentId sessionId workItemId =
+        task {
+            if not <| String.IsNullOrWhiteSpace sessionId then
+                try
+                    let parameters = stopParameters repositoryId agentId sessionId workItemId $"cleanup-stop-{Guid.NewGuid():N}"
+                    let! response = Client.PostAsync("/agent/session/stop", createJsonContent parameters)
+
+                    if not response.IsSuccessStatusCode then
+                        let! body = response.Content.ReadAsStringAsync()
+                        TestContext.Error.WriteLine($"Agent session cleanup failed: {response.StatusCode}; {body}")
+                with
+                | ex -> TestContext.Error.WriteLine($"Agent session cleanup threw: {ex}")
+        }
+
     let statusAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/status" parameters
 
     let activeAsync parameters = postSessionAsync<AgentSessionOperationResult> "/agent/session/active" parameters
@@ -90,104 +104,129 @@ type AgentSessionServerTests() =
             let firstWorkItem = "262"
             let secondWorkItem = "263"
             let firstStartOperationId = $"start-{Guid.NewGuid():N}"
+            let mutable firstSessionId = String.Empty
+            let mutable replacementSessionId = String.Empty
 
-            let! started = AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
+            try
+                let! started =
+                    AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
 
-            Assert.That(started.ReturnValue.WasIdempotentReplay, Is.False)
-            Assert.That(started.ReturnValue.OperationId, Is.EqualTo(firstStartOperationId))
-            Assert.That(started.ReturnValue.Session.SessionId, Is.EqualTo(firstStartOperationId))
-            Assert.That(started.ReturnValue.Session.AgentId, Is.EqualTo(agentId))
-            Assert.That(started.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(firstWorkItem))
-            Assert.That(started.ReturnValue.Session.Source, Is.EqualTo("server-tests"))
-            Assert.That(started.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+                firstSessionId <- started.ReturnValue.Session.SessionId
 
-            let! duplicateStart =
-                AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
+                Assert.That(started.ReturnValue.WasIdempotentReplay, Is.False)
+                Assert.That(started.ReturnValue.OperationId, Is.EqualTo(firstStartOperationId))
+                Assert.That(started.ReturnValue.Session.SessionId, Is.EqualTo(firstStartOperationId))
+                Assert.That(started.ReturnValue.Session.AgentId, Is.EqualTo(agentId))
+                Assert.That(started.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(firstWorkItem))
+                Assert.That(started.ReturnValue.Session.Source, Is.EqualTo("server-tests"))
+                Assert.That(started.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
 
-            Assert.That(duplicateStart.ReturnValue.WasIdempotentReplay, Is.True)
-            Assert.That(duplicateStart.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
+                let! duplicateStart =
+                    AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId firstWorkItem firstStartOperationId)
 
-            let conflictingStartParameters = AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem $"start-{Guid.NewGuid():N}"
+                Assert.That(duplicateStart.ReturnValue.WasIdempotentReplay, Is.True)
+                Assert.That(duplicateStart.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
 
-            let! conflictingStart = Client.PostAsync("/agent/session/start", createJsonContent conflictingStartParameters)
+                let conflictingStartParameters = AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem $"start-{Guid.NewGuid():N}"
 
-            let! conflictingStartBody = conflictingStart.Content.ReadAsStringAsync()
-            Assert.That(conflictingStart.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), conflictingStartBody)
-            Assert.That(conflictingStartBody, Does.Contain(firstWorkItem))
+                let! conflictingStart = Client.PostAsync("/agent/session/start", createJsonContent conflictingStartParameters)
 
-            let! active = AgentSessionTestHelpers.activeAsync (AgentSessionTestHelpers.activeParameters repositoryId agentId firstWorkItem)
+                let! conflictingStartBody = conflictingStart.Content.ReadAsStringAsync()
+                Assert.That(conflictingStart.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), conflictingStartBody)
+                Assert.That(conflictingStartBody, Does.Contain(firstWorkItem))
 
-            Assert.That(active.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
-            Assert.That(active.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+                let! active = AgentSessionTestHelpers.activeAsync (AgentSessionTestHelpers.activeParameters repositoryId agentId firstWorkItem)
 
-            let! listed = AgentSessionTestHelpers.listActiveAsync (AgentSessionTestHelpers.listActiveParameters repositoryId agentId 10)
+                Assert.That(active.ReturnValue.Session.SessionId, Is.EqualTo(started.ReturnValue.Session.SessionId))
+                Assert.That(active.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
 
-            Assert.That(
-                listed.ReturnValue.Sessions
-                |> List.exists (fun session -> session.SessionId = started.ReturnValue.Session.SessionId),
-                Is.True
-            )
+                let! listed = AgentSessionTestHelpers.listActiveAsync (AgentSessionTestHelpers.listActiveParameters repositoryId agentId 10)
 
-            let! wrongRepositoryStatus =
-                AgentSessionTestHelpers.statusAsync (
-                    AgentSessionTestHelpers.statusParameters wrongRepositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                Assert.That(
+                    listed.ReturnValue.Sessions
+                    |> List.exists (fun session -> session.SessionId = started.ReturnValue.Session.SessionId),
+                    Is.True
                 )
 
-            Assert.That(wrongRepositoryStatus.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+                let! wrongRepositoryStatus =
+                    AgentSessionTestHelpers.statusAsync (
+                        AgentSessionTestHelpers.statusParameters wrongRepositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                    )
 
-            let! wrongRepositoryStop =
-                AgentSessionTestHelpers.stopAsync (
-                    AgentSessionTestHelpers.stopParameters
-                        wrongRepositoryId
-                        agentId
-                        started.ReturnValue.Session.SessionId
-                        firstWorkItem
-                        $"stop-wrong-{Guid.NewGuid():N}"
-                )
+                Assert.That(wrongRepositoryStatus.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
 
-            Assert.That(wrongRepositoryStop.ReturnValue.WasIdempotentReplay, Is.True)
-            Assert.That(wrongRepositoryStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+                let! wrongRepositoryStop =
+                    AgentSessionTestHelpers.stopAsync (
+                        AgentSessionTestHelpers.stopParameters
+                            wrongRepositoryId
+                            agentId
+                            started.ReturnValue.Session.SessionId
+                            firstWorkItem
+                            $"stop-wrong-{Guid.NewGuid():N}"
+                    )
 
-            let! stillActive =
-                AgentSessionTestHelpers.statusAsync (
-                    AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
-                )
+                Assert.That(wrongRepositoryStop.ReturnValue.WasIdempotentReplay, Is.True)
+                Assert.That(wrongRepositoryStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
 
-            Assert.That(stillActive.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+                let! stillActive =
+                    AgentSessionTestHelpers.statusAsync (
+                        AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                    )
 
-            let stopOperationId = $"stop-{Guid.NewGuid():N}"
+                Assert.That(stillActive.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
 
-            let! stopped =
-                AgentSessionTestHelpers.stopAsync (
-                    AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
-                )
+                let stopOperationId = $"stop-{Guid.NewGuid():N}"
 
-            Assert.That(stopped.ReturnValue.WasIdempotentReplay, Is.False)
-            Assert.That(stopped.ReturnValue.OperationId, Is.EqualTo(stopOperationId))
-            Assert.That(stopped.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
+                let! stopped =
+                    AgentSessionTestHelpers.stopAsync (
+                        AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
+                    )
 
-            let! duplicateStop =
-                AgentSessionTestHelpers.stopAsync (
-                    AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
-                )
+                Assert.That(stopped.ReturnValue.WasIdempotentReplay, Is.False)
+                Assert.That(stopped.ReturnValue.OperationId, Is.EqualTo(stopOperationId))
+                Assert.That(stopped.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
 
-            Assert.That(duplicateStop.ReturnValue.WasIdempotentReplay, Is.True)
-            Assert.That(duplicateStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
+                let! duplicateStop =
+                    AgentSessionTestHelpers.stopAsync (
+                        AgentSessionTestHelpers.stopParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem stopOperationId
+                    )
 
-            let! inactiveAfterStop =
-                AgentSessionTestHelpers.statusAsync (
-                    AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
-                )
+                Assert.That(duplicateStop.ReturnValue.WasIdempotentReplay, Is.True)
+                Assert.That(duplicateStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
 
-            Assert.That(inactiveAfterStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+                let! inactiveAfterStop =
+                    AgentSessionTestHelpers.statusAsync (
+                        AgentSessionTestHelpers.statusParameters repositoryId agentId started.ReturnValue.Session.SessionId firstWorkItem
+                    )
 
-            let secondStartOperationId = $"start-{Guid.NewGuid():N}"
+                Assert.That(inactiveAfterStop.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
 
-            let! replacementStart =
-                AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem secondStartOperationId)
+                let secondStartOperationId = $"start-{Guid.NewGuid():N}"
 
-            Assert.That(replacementStart.ReturnValue.WasIdempotentReplay, Is.False)
-            Assert.That(replacementStart.ReturnValue.Session.SessionId, Is.EqualTo(secondStartOperationId))
-            Assert.That(replacementStart.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(secondWorkItem))
-            Assert.That(replacementStart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+                let! replacementStart =
+                    AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId secondWorkItem secondStartOperationId)
+
+                replacementSessionId <- replacementStart.ReturnValue.Session.SessionId
+
+                Assert.That(replacementStart.ReturnValue.WasIdempotentReplay, Is.False)
+                Assert.That(replacementStart.ReturnValue.Session.SessionId, Is.EqualTo(secondStartOperationId))
+                Assert.That(replacementStart.ReturnValue.Session.WorkItemIdOrNumber, Is.EqualTo(secondWorkItem))
+                Assert.That(replacementStart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+                let! replacementStopped =
+                    AgentSessionTestHelpers.stopAsync (
+                        AgentSessionTestHelpers.stopParameters
+                            repositoryId
+                            agentId
+                            replacementStart.ReturnValue.Session.SessionId
+                            secondWorkItem
+                            $"stop-{Guid.NewGuid():N}"
+                    )
+
+                Assert.That(replacementStopped.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Stopped))
+            with
+            | ex ->
+                do! AgentSessionTestHelpers.tryStopAsync repositoryId agentId replacementSessionId secondWorkItem
+                do! AgentSessionTestHelpers.tryStopAsync repositoryId agentId firstSessionId firstWorkItem
+                return raise ex
         }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -30,6 +30,8 @@
     <Compile Include="DirectoryVersion.Server.Tests.fs" />
     <Compile Include="Diff.Server.Tests.fs" />
     <Compile Include="Reminder.Server.Tests.fs" />
+    <Compile Include="NotificationHub.Tests.fs" />
+    <Compile Include="AgentSession.Server.Tests.fs" />
     <Compile Include="WorkItem.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />
@@ -48,6 +50,8 @@
     <PackageReference Include="FsCheck" Version="3.3.3" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
     <PackageReference Include="FsUnit" Version="7.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/Grace.Server.Tests/NotificationHub.Tests.fs
+++ b/src/Grace.Server.Tests/NotificationHub.Tests.fs
@@ -1,0 +1,124 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Automation
+open Grace.Types.Common
+open Microsoft.AspNetCore.Http.Connections.Client
+open Microsoft.AspNetCore.SignalR.Client
+open Microsoft.Extensions.DependencyInjection
+open NUnit.Framework
+open System
+open System.Net.Http
+open System.Threading
+open System.Threading.Tasks
+
+module private NotificationHubTestHelpers =
+
+    let createConnection includeAuthentication =
+        let builder = HubConnectionBuilder()
+
+        builder
+            .WithUrl(
+                $"{graceServerBaseAddress}/notifications",
+                fun (options: HttpConnectionOptions) -> if includeAuthentication then options.Headers.Add("x-grace-user-id", testUserId)
+            )
+            .AddJsonProtocol(fun options -> options.PayloadSerializerOptions <- Constants.JsonSerializerOptions)
+            .WithAutomaticReconnect()
+            .Build()
+
+    let startAgentSessionAsync repositoryId agentId workItemId operationId =
+        task {
+            let parameters = Parameters.Common.StartAgentSessionParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.AgentId <- agentId
+            parameters.AgentDisplayName <- $"Agent {agentId}"
+            parameters.WorkItemIdOrNumber <- workItemId
+            parameters.PromotionSetId <- $"{Guid.NewGuid()}"
+            parameters.Source <- "signalr-server-test"
+            parameters.OperationId <- operationId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/agent/session/start", createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            response.EnsureSuccessStatusCode() |> ignore
+            return deserialize<GraceReturnValue<AgentSessionOperationResult>> body
+        }
+
+    let waitForAutomationEventAsync
+        (connection: HubConnection)
+        (repositoryId: string)
+        (agentId: string)
+        (expectedEventType: AutomationEventType)
+        (triggerAsync: unit -> Task)
+        =
+        task {
+            use cts = new CancellationTokenSource(TimeSpan.FromSeconds(30.0))
+
+            let completion = TaskCompletionSource<AutomationEventEnvelope>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            use subscription =
+                connection.On<AutomationEventEnvelope>(
+                    "NotifyAutomationEvent",
+                    Action<AutomationEventEnvelope> (fun envelope ->
+                        if envelope.RepositoryId = Guid.Parse(repositoryId)
+                           && envelope.ActorId.Equals(agentId, StringComparison.OrdinalIgnoreCase)
+                           && envelope.EventType = expectedEventType then
+                            completion.TrySetResult(envelope) |> ignore)
+                )
+
+            use _registration =
+                cts.Token.Register (fun () ->
+                    completion.TrySetException(TimeoutException($"Timed out waiting for {expectedEventType} SignalR automation event."))
+                    |> ignore)
+
+            do! connection.InvokeAsync("RegisterRepository", Guid.Parse(repositoryId), cts.Token)
+            do! triggerAsync ()
+            return! completion.Task
+        }
+
+[<NonParallelizable>]
+type NotificationHubTests() =
+
+    [<Test>]
+    member _.AuthenticatedClientReceivesRepositoryAutomationEvent() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let agentId = $"signalr-agent-{Guid.NewGuid():N}"
+            let workItemId = "262"
+            let operationId = $"signalr-start-{Guid.NewGuid():N}"
+
+            use connection = NotificationHubTestHelpers.createConnection true
+            do! connection.StartAsync()
+
+            let! envelope =
+                NotificationHubTestHelpers.waitForAutomationEventAsync connection repositoryId agentId AutomationEventType.AgentWorkStarted (fun () ->
+                    task {
+                        let! result = NotificationHubTestHelpers.startAgentSessionAsync repositoryId agentId workItemId operationId
+
+                        Assert.That(result.ReturnValue.Session.SessionId, Is.EqualTo(operationId))
+                    }
+                    :> Task)
+
+            Assert.That(envelope.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+            Assert.That(envelope.ActorId, Is.EqualTo(agentId))
+            Assert.That(envelope.EventType, Is.EqualTo(AutomationEventType.AgentWorkStarted))
+            Assert.That(envelope.CorrelationId, Is.Not.Empty)
+            Assert.That(envelope.DataJson, Does.Contain(operationId))
+        }
+
+    [<Test>]
+    member _.UnauthenticatedClientCannotConnectToNotificationsHub() =
+        task {
+            use connection = NotificationHubTestHelpers.createConnection false
+
+            try
+                do! connection.StartAsync()
+                Assert.Fail("Unauthenticated SignalR connection unexpectedly succeeded.")
+            with
+            | :? HttpRequestException as ex -> Assert.That(ex.Message, Does.Contain("401").Or.Contain("Unauthorized"))
+            | :? InvalidOperationException as ex -> Assert.That(ex.Message, Does.Contain("401").Or.Contain("Unauthorized"))
+        }

--- a/src/Grace.Server.Tests/NotificationHub.Tests.fs
+++ b/src/Grace.Server.Tests/NotificationHub.Tests.fs
@@ -48,26 +48,67 @@ module private NotificationHubTestHelpers =
             return deserialize<GraceReturnValue<AgentSessionOperationResult>> body
         }
 
+    let tryStopAgentSessionAsync repositoryId agentId sessionId workItemId =
+        task {
+            if not <| String.IsNullOrWhiteSpace sessionId then
+                try
+                    let parameters = Parameters.Common.StopAgentSessionParameters()
+                    parameters.OwnerId <- ownerId
+                    parameters.OrganizationId <- organizationId
+                    parameters.RepositoryId <- repositoryId
+                    parameters.AgentId <- agentId
+                    parameters.SessionId <- sessionId
+                    parameters.WorkItemIdOrNumber <- workItemId
+                    parameters.StopReason <- "signalr test cleanup"
+                    parameters.OperationId <- $"cleanup-stop-{Guid.NewGuid():N}"
+                    parameters.CorrelationId <- generateCorrelationId ()
+
+                    let! response = Client.PostAsync("/agent/session/stop", createJsonContent parameters)
+
+                    if not response.IsSuccessStatusCode then
+                        let! body = response.Content.ReadAsStringAsync()
+                        TestContext.Error.WriteLine($"SignalR session cleanup failed: {response.StatusCode}; {body}")
+                with
+                | ex -> TestContext.Error.WriteLine($"SignalR session cleanup threw: {ex}")
+        }
+
     let waitForAutomationEventAsync
         (connection: HubConnection)
+        (unexpectedConnection: HubConnection)
         (repositoryId: string)
+        (unexpectedRepositoryId: string)
         (agentId: string)
         (expectedEventType: AutomationEventType)
+        (operationId: string)
         (triggerAsync: unit -> Task)
         =
         task {
             use cts = new CancellationTokenSource(TimeSpan.FromSeconds(30.0))
 
             let completion = TaskCompletionSource<AutomationEventEnvelope>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let unexpectedCompletion = TaskCompletionSource<AutomationEventEnvelope>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let matchesExpectedEvent (envelope: AutomationEventEnvelope) =
+                envelope.ActorId.Equals(agentId, StringComparison.OrdinalIgnoreCase)
+                && envelope.EventType = expectedEventType
+                && envelope.DataJson.Contains(operationId, StringComparison.OrdinalIgnoreCase)
 
             use subscription =
                 connection.On<AutomationEventEnvelope>(
                     "NotifyAutomationEvent",
                     Action<AutomationEventEnvelope> (fun envelope ->
                         if envelope.RepositoryId = Guid.Parse(repositoryId)
-                           && envelope.ActorId.Equals(agentId, StringComparison.OrdinalIgnoreCase)
-                           && envelope.EventType = expectedEventType then
+                           && matchesExpectedEvent envelope then
                             completion.TrySetResult(envelope) |> ignore)
+                )
+
+            use unexpectedSubscription =
+                unexpectedConnection.On<AutomationEventEnvelope>(
+                    "NotifyAutomationEvent",
+                    Action<AutomationEventEnvelope> (fun envelope ->
+                        if matchesExpectedEvent envelope then
+                            unexpectedCompletion.TrySetResult(envelope)
+                            |> ignore)
                 )
 
             use _registration =
@@ -76,8 +117,29 @@ module private NotificationHubTestHelpers =
                     |> ignore)
 
             do! connection.InvokeAsync("RegisterRepository", Guid.Parse(repositoryId), cts.Token)
+            do! unexpectedConnection.InvokeAsync("RegisterRepository", Guid.Parse(unexpectedRepositoryId), cts.Token)
             do! triggerAsync ()
-            return! completion.Task
+
+            let! firstObserved = Task.WhenAny(completion.Task, unexpectedCompletion.Task)
+
+            if obj.ReferenceEquals(firstObserved, unexpectedCompletion.Task) then
+                let! unexpectedEnvelope = unexpectedCompletion.Task
+
+                Assert.Fail(
+                    $"SignalR connection registered to repository {unexpectedRepositoryId} received event {unexpectedEnvelope.EventType} for repository {unexpectedEnvelope.RepositoryId}."
+                )
+
+            let! envelope = completion.Task
+            let! negativeObservation = Task.WhenAny(unexpectedCompletion.Task, Task.Delay(TimeSpan.FromSeconds(1.0), cts.Token))
+
+            if obj.ReferenceEquals(negativeObservation, unexpectedCompletion.Task) then
+                let! unexpectedEnvelope = unexpectedCompletion.Task
+
+                Assert.Fail(
+                    $"SignalR connection registered to repository {unexpectedRepositoryId} received event {unexpectedEnvelope.EventType} for repository {unexpectedEnvelope.RepositoryId}."
+                )
+
+            return envelope
         }
 
 [<NonParallelizable>]
@@ -87,27 +149,47 @@ type NotificationHubTests() =
     member _.AuthenticatedClientReceivesRepositoryAutomationEvent() =
         task {
             let repositoryId = repositoryIds[0]
+            let unexpectedRepositoryId = repositoryIds[1]
             let agentId = $"signalr-agent-{Guid.NewGuid():N}"
             let workItemId = "262"
             let operationId = $"signalr-start-{Guid.NewGuid():N}"
+            let mutable sessionId = String.Empty
 
             use connection = NotificationHubTestHelpers.createConnection true
+            use unexpectedConnection = NotificationHubTestHelpers.createConnection true
             do! connection.StartAsync()
+            do! unexpectedConnection.StartAsync()
 
-            let! envelope =
-                NotificationHubTestHelpers.waitForAutomationEventAsync connection repositoryId agentId AutomationEventType.AgentWorkStarted (fun () ->
-                    task {
-                        let! result = NotificationHubTestHelpers.startAgentSessionAsync repositoryId agentId workItemId operationId
+            try
+                let! envelope =
+                    NotificationHubTestHelpers.waitForAutomationEventAsync
+                        connection
+                        unexpectedConnection
+                        repositoryId
+                        unexpectedRepositoryId
+                        agentId
+                        AutomationEventType.AgentWorkStarted
+                        operationId
+                        (fun () ->
+                            task {
+                                let! result = NotificationHubTestHelpers.startAgentSessionAsync repositoryId agentId workItemId operationId
+                                sessionId <- result.ReturnValue.Session.SessionId
 
-                        Assert.That(result.ReturnValue.Session.SessionId, Is.EqualTo(operationId))
-                    }
-                    :> Task)
+                                Assert.That(result.ReturnValue.Session.SessionId, Is.EqualTo(operationId))
+                            }
+                            :> Task)
 
-            Assert.That(envelope.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
-            Assert.That(envelope.ActorId, Is.EqualTo(agentId))
-            Assert.That(envelope.EventType, Is.EqualTo(AutomationEventType.AgentWorkStarted))
-            Assert.That(envelope.CorrelationId, Is.Not.Empty)
-            Assert.That(envelope.DataJson, Does.Contain(operationId))
+                Assert.That(envelope.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+                Assert.That(envelope.ActorId, Is.EqualTo(agentId))
+                Assert.That(envelope.EventType, Is.EqualTo(AutomationEventType.AgentWorkStarted))
+                Assert.That(envelope.CorrelationId, Is.Not.Empty)
+                Assert.That(envelope.DataJson, Does.Contain(operationId))
+            with
+            | ex ->
+                do! NotificationHubTestHelpers.tryStopAgentSessionAsync repositoryId agentId sessionId workItemId
+                return raise ex
+
+            do! NotificationHubTestHelpers.tryStopAgentSessionAsync repositoryId agentId sessionId workItemId
         }
 
     [<Test>]


### PR DESCRIPTION
## Summary

- Add hosted SignalR `/notifications` proof for authenticated TestAuth clients receiving a repository-scoped `AgentWorkStarted` notification.
- Add negative SignalR repository-scoping proof with a second authenticated client registered to another repository.
- Add unauthorized SignalR connection rejection proof for the current auth contract.
- Add hosted agent-session route proof for start, stop, status, active, and listActive behavior.
- Cover duplicate start replay, same-agent conflict, wrong-repository isolation, stop idempotency, stopped-session replacement, and cleanup of active sessions created by the hosted tests.

## Issue Links

Related to #262.
Part of #249.

## SignalR Package References

This slice adds test-project package references:

- `Microsoft.AspNetCore.SignalR.Client` `10.0.8`
- `Microsoft.AspNetCore.SignalR.Protocols.Json` `10.0.8`

The JSON protocol package is used so the test client can apply Grace's serializer options for `AutomationEventEnvelope`.

## Validation

- `dotnet tool run fantomas src\Grace.Server.Tests\NotificationHub.Tests.fs src\Grace.Server.Tests\AgentSession.Server.Tests.fs`: passed.
- `dotnet test src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~AgentSessionServerTests|FullyQualifiedName~NotificationHubTests"`: passed; 3 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed locally after review-pass-1 fixes.
  - `Grace.Authorization.Tests`: 37 passed.
  - `Grace.Types.Tests`: 65 passed.
  - `Grace.Server.Unit.Tests`: 440 passed.
  - `Grace.CLI.Tests`: 273 passed, 1 skipped.
  - `Grace.Server.Tests`: 163 passed.
- `git diff --check`: passed.

## Review Status

- Review pass 1 by GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 1 open findings were fixed in `7d3865adccc8c8cc67cc29ea5ac1eb0cc5234225`; fix evidence posted in PR comments.
- Review pass 2 by fresh GPT-5.5 High review-only subagent found no issues and was posted in PR comments.
- Ready to merge into `epic/249-validation-coverage` once GitHub checks/mergeability permit.
