### PR TITLE
Add process-local restart contract tests

### DIFF
--- a/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
+++ b/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
@@ -13,6 +13,25 @@ open System.Threading.Tasks
 
 module private AgentSessionTestHelpers =
 
+    let restartGraceServerAsync () =
+        let state =
+            match App with
+            | Some app ->
+                {
+                    App = app
+                    Client = Client
+                    GraceServerBaseAddress = graceServerBaseAddress
+                    ServiceBusConnectionString = serviceBusConnectionString
+                    ServiceBusTopic = serviceBusTopic
+                    ServiceBusServerSubscription = serviceBusServerSubscription
+                    ServiceBusTestSubscription = serviceBusTestSubscription
+                }
+            | None ->
+                Assert.Fail("Aspire test host was not started by the shared setup fixture.")
+                Unchecked.defaultof<TestHostState>
+
+        AspireTestHost.restartGraceServerAsync state
+
     let private postSessionAsync<'TResponse> (path: string) (parameters: obj) =
         task {
             let! response = Client.PostAsync(path, createJsonContent parameters)
@@ -229,4 +248,43 @@ type AgentSessionServerTests() =
                 do! AgentSessionTestHelpers.tryStopAsync repositoryId agentId replacementSessionId secondWorkItem
                 do! AgentSessionTestHelpers.tryStopAsync repositoryId agentId firstSessionId firstWorkItem
                 return raise ex
+        }
+
+    [<Test>]
+    [<NonParallelizable>]
+    member _.ActiveAgentSessionsAreProcessLocalAcrossRestart() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let agentId = $"agent-{Guid.NewGuid():N}"
+            let workItemId = "264"
+            let startOperationId = $"start-{Guid.NewGuid():N}"
+
+            let! started = AgentSessionTestHelpers.startAsync (AgentSessionTestHelpers.startParameters repositoryId agentId workItemId startOperationId)
+
+            Assert.That(started.ReturnValue.Session.SessionId, Is.EqualTo(startOperationId))
+            Assert.That(started.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+            let! activeBeforeRestart = AgentSessionTestHelpers.activeAsync (AgentSessionTestHelpers.activeParameters repositoryId agentId workItemId)
+            Assert.That(activeBeforeRestart.ReturnValue.Session.SessionId, Is.EqualTo(startOperationId))
+            Assert.That(activeBeforeRestart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
+
+            do! AgentSessionTestHelpers.restartGraceServerAsync ()
+
+            // Contract: active agent sessions are process-local coordination state and are intentionally lost on restart.
+            let! statusAfterRestart =
+                AgentSessionTestHelpers.statusAsync (AgentSessionTestHelpers.statusParameters repositoryId agentId startOperationId workItemId)
+
+            Assert.That(statusAfterRestart.ReturnValue.Session.SessionId, Is.EqualTo(startOperationId))
+            Assert.That(statusAfterRestart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+
+            let! activeAfterRestart = AgentSessionTestHelpers.activeAsync (AgentSessionTestHelpers.activeParameters repositoryId agentId workItemId)
+            Assert.That(activeAfterRestart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Inactive))
+
+            let! listedAfterRestart = AgentSessionTestHelpers.listActiveAsync (AgentSessionTestHelpers.listActiveParameters repositoryId agentId 10)
+
+            Assert.That(
+                listedAfterRestart.ReturnValue.Sessions
+                |> List.exists (fun session -> session.SessionId = startOperationId),
+                Is.False
+            )
         }

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -15,6 +15,25 @@ open System.Threading.Tasks
 
 module private ApprovalTestHelpers =
 
+    let restartGraceServerAsync () =
+        let state =
+            match App with
+            | Some app ->
+                {
+                    App = app
+                    Client = Client
+                    GraceServerBaseAddress = graceServerBaseAddress
+                    ServiceBusConnectionString = serviceBusConnectionString
+                    ServiceBusTopic = serviceBusTopic
+                    ServiceBusServerSubscription = serviceBusServerSubscription
+                    ServiceBusTestSubscription = serviceBusTestSubscription
+                }
+            | None ->
+                Assert.Fail("Aspire test host was not started by the shared setup fixture.")
+                Unchecked.defaultof<TestHostState>
+
+        AspireTestHost.restartGraceServerAsync state
+
     let createAuthenticatedClient (userId: string) =
         let client = new HttpClient()
         client.BaseAddress <- Client.BaseAddress
@@ -253,6 +272,90 @@ type ApprovalApiIntegrationTests() =
             Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
             let! deleted = deserializeContent<ApprovalPolicy> deleteResponse
             Assert.That(deleted.Status, Is.EqualTo(ApprovalPolicyStatus.Deleted))
+        }
+
+    [<Test>]
+    [<NonParallelizable>]
+    member _.ApprovalPolicyStoreIsProcessLocalWhileGeneratedRequestsRemainActorBackedAcrossRestart() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "ApprovalResponder"
+
+            Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
+            let! created = ApprovalTestHelpers.createPolicyAsync adminClient repositoryId branchId
+            let showParameters = ApprovalTestHelpers.showPolicyParameters repositoryId branchId (created.ApprovalPolicyId.ToString())
+            let! enableResponse = adminClient.PostAsync("/approval/policy/enable", createJsonContent showParameters)
+            Assert.That(enableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            let seedParameters =
+                ApprovalTestHelpers.seedGeneratedParameters repositoryId branchId (Some(Guid.NewGuid())) created.ApprovalPolicyId $"user:{adminUser}" (Some 264)
+
+            let! seedResponse = Client.PostAsync("/approval/request/_seedGenerated", createJsonContent seedParameters)
+            let! seedText = seedResponse.Content.ReadAsStringAsync()
+            Assert.That(seedResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), seedText)
+            let seededRequest = deserialize<ApprovalRequest> seedText
+
+            let! beforeRestartPolicies =
+                adminClient.PostAsync("/approval/policy/evaluate", createJsonContent (ApprovalTestHelpers.createPolicyParameters repositoryId branchId))
+
+            Assert.That(beforeRestartPolicies.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! policiesBeforeRestart = deserializeContent<ApprovalPolicy array> beforeRestartPolicies
+
+            Assert.That(
+                policiesBeforeRestart
+                |> Array.map (fun policy -> policy.ApprovalPolicyId),
+                Does.Contain(created.ApprovalPolicyId)
+            )
+
+            do! ApprovalTestHelpers.restartGraceServerAsync ()
+
+            // Contract: approval policies are process-local configuration and are intentionally lost on Grace.Server restart.
+            let! listPoliciesAfterRestart =
+                adminClient.PostAsync("/approval/policy/list", createJsonContent (ApprovalTestHelpers.listPolicyParameters repositoryId branchId))
+
+            let! listPoliciesAfterRestartText = listPoliciesAfterRestart.Content.ReadAsStringAsync()
+            Assert.That(listPoliciesAfterRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK), listPoliciesAfterRestartText)
+            let policiesAfterRestart = deserialize<ApprovalPolicy array> listPoliciesAfterRestartText
+
+            Assert.That(
+                policiesAfterRestart
+                |> Array.exists (fun policy -> policy.ApprovalPolicyId = created.ApprovalPolicyId),
+                Is.False
+            )
+
+            let! evaluateAfterRestart =
+                adminClient.PostAsync("/approval/policy/evaluate", createJsonContent (ApprovalTestHelpers.createPolicyParameters repositoryId branchId))
+
+            let! evaluateAfterRestartText = evaluateAfterRestart.Content.ReadAsStringAsync()
+            Assert.That(evaluateAfterRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK), evaluateAfterRestartText)
+            let evaluatedAfterRestart = deserialize<ApprovalPolicy array> evaluateAfterRestartText
+
+            Assert.That(
+                evaluatedAfterRestart
+                |> Array.exists (fun policy -> policy.ApprovalPolicyId = created.ApprovalPolicyId),
+                Is.False
+            )
+
+            let! listRequestsAfterRestart =
+                adminClient.PostAsync("/approval/request/list", createJsonContent (ApprovalTestHelpers.listRequestParameters repositoryId branchId))
+
+            let! listRequestsAfterRestartText = listRequestsAfterRestart.Content.ReadAsStringAsync()
+            Assert.That(listRequestsAfterRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK), listRequestsAfterRestartText)
+            let requestsAfterRestart = deserialize<ApprovalRequest array> listRequestsAfterRestartText
+
+            Assert.That(
+                requestsAfterRestart
+                |> Array.map (fun request -> request.ApprovalRequestId),
+                Does.Contain(seededRequest.ApprovalRequestId)
+            )
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -13,6 +13,25 @@ open System.Net.Http
 
 module private WebhookTestHelpers =
 
+    let restartGraceServerAsync () =
+        let state =
+            match App with
+            | Some app ->
+                {
+                    App = app
+                    Client = Client
+                    GraceServerBaseAddress = graceServerBaseAddress
+                    ServiceBusConnectionString = serviceBusConnectionString
+                    ServiceBusTopic = serviceBusTopic
+                    ServiceBusServerSubscription = serviceBusServerSubscription
+                    ServiceBusTestSubscription = serviceBusTestSubscription
+                }
+            | None ->
+                Assert.Fail("Aspire test host was not started by the shared setup fixture.")
+                Unchecked.defaultof<TestHostState>
+
+        AspireTestHost.restartGraceServerAsync state
+
     let createAuthenticatedClient (userId: string) =
         let client = new HttpClient()
         client.BaseAddress <- Client.BaseAddress
@@ -246,6 +265,84 @@ type WebhookApiIntegrationTests() =
             Assert.That(deleteResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
             let! deleted = deserializeContent<WebhookRule> deleteResponse
             Assert.That(deleted.Status, Is.EqualTo(WebhookRuleStatus.Deleted))
+        }
+
+    [<Test>]
+    [<NonParallelizable>]
+    member _.WebhookRuleAndDeliveryStoresAreProcessLocalAcrossRestart() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let adminUser = $"{Guid.NewGuid()}"
+
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
+            let! created = WebhookTestHelpers.createRuleAsync adminClient repositoryId branchId
+
+            let enableParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.EnableWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            let! enableResponse = adminClient.PostAsync("/webhook/rule/enable", createJsonContent enableParameters)
+            let! enableText = enableResponse.Content.ReadAsStringAsync()
+            Assert.That(enableResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), enableText)
+
+            let testParameters =
+                WebhookTestHelpers.ruleIdParameters<Parameters.Webhook.TestWebhookRuleParameters> repositoryId branchId (created.WebhookRuleId.ToString())
+
+            testParameters.DedupeKey <- $"restart-contract-{Guid.NewGuid():N}"
+            let! testResponse = adminClient.PostAsync("/webhook/rule/test", createJsonContent testParameters)
+            let! testText = testResponse.Content.ReadAsStringAsync()
+            Assert.That(testResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), testText)
+            let createdDelivery = deserialize<WebhookDelivery> testText
+
+            let! deliveriesBeforeRestart =
+                adminClient.PostAsync(
+                    "/webhook/delivery/list",
+                    createJsonContent (WebhookTestHelpers.listDeliveryParameters repositoryId branchId (created.WebhookRuleId.ToString()))
+                )
+
+            Assert.That(deliveriesBeforeRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! listedBeforeRestart = deserializeContent<WebhookDelivery array> deliveriesBeforeRestart
+
+            Assert.That(
+                listedBeforeRestart
+                |> Array.map (fun delivery -> delivery.WebhookDeliveryId),
+                Does.Contain(createdDelivery.WebhookDeliveryId)
+            )
+
+            do! WebhookTestHelpers.restartGraceServerAsync ()
+
+            // Contract: webhook rules and their pending or retry-scheduled deliveries are process-local and intentionally lost on restart.
+            let! rulesAfterRestart =
+                adminClient.PostAsync("/webhook/rule/list", createJsonContent (WebhookTestHelpers.listRuleParameters repositoryId branchId))
+
+            let! rulesAfterRestartText = rulesAfterRestart.Content.ReadAsStringAsync()
+            Assert.That(rulesAfterRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK), rulesAfterRestartText)
+            let listedRulesAfterRestart = deserialize<WebhookRule array> rulesAfterRestartText
+
+            Assert.That(
+                listedRulesAfterRestart
+                |> Array.exists (fun rule -> rule.WebhookRuleId = created.WebhookRuleId),
+                Is.False
+            )
+
+            let! deliveriesAfterRestart =
+                adminClient.PostAsync(
+                    "/webhook/delivery/list",
+                    createJsonContent (WebhookTestHelpers.listDeliveryParameters repositoryId branchId (created.WebhookRuleId.ToString()))
+                )
+
+            let! deliveriesAfterRestartText = deliveriesAfterRestart.Content.ReadAsStringAsync()
+            Assert.That(deliveriesAfterRestart.StatusCode, Is.EqualTo(HttpStatusCode.OK), deliveriesAfterRestartText)
+            let listedDeliveriesAfterRestart = deserialize<WebhookDelivery array> deliveriesAfterRestartText
+
+            Assert.That(
+                listedDeliveriesAfterRestart
+                |> Array.exists (fun delivery -> delivery.WebhookDeliveryId = createdDelivery.WebhookDeliveryId),
+                Is.False
+            )
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -269,7 +269,7 @@ type WebhookApiIntegrationTests() =
 
     [<Test>]
     [<NonParallelizable>]
-    member _.WebhookRuleAndDeliveryStoresAreProcessLocalAcrossRestart() =
+    member _.WebhookRuleAndHttpObservableDeliveriesAreProcessLocalAcrossRestart() =
         task {
             let repositoryId = repositoryIds[0]
             let branchId = repositoryDefaultBranchIds[0]
@@ -314,7 +314,9 @@ type WebhookApiIntegrationTests() =
 
             do! WebhookTestHelpers.restartGraceServerAsync ()
 
-            // Contract: webhook rules and their pending or retry-scheduled deliveries are process-local and intentionally lost on restart.
+            // Contract: webhook rules are process-local. HTTP-observable pending deliveries are intentionally
+            // unavailable after restart; retry-scheduled deliveries share the same process-local store by
+            // implementation contract, but this public route remains rule-dependent.
             let! rulesAfterRestart =
                 adminClient.PostAsync("/webhook/rule/list", createJsonContent (WebhookTestHelpers.listRuleParameters repositoryId branchId))
 


### PR DESCRIPTION
## Summary

- Add process-local restart/loss contract coverage for approval policies, webhook rules/deliveries, and active agent sessions.
- Prove approval policies are intentionally process-local/lost across Grace.Server project-resource restart while generated approval requests remain actor-backed/durable.
- Prove webhook rules and HTTP-observable deliveries are intentionally process-local/lost across restart.
- Prove active agent sessions intentionally become inactive/unlisted across restart.

## Issue Links

Related to #264.
Part of #249.

## Contract Notes

- No durable-store redesign is included in this PR.
- The tests encode the product disposition directly in test names and contract comments beside restart assertions.
- Webhook retry-scheduled deliveries use the same process-local `WebhookStore` delivery collection; this PR proves HTTP-observable pending-delivery unavailability through the public route after restart and records that `/webhook/delivery/list` is rule-dependent, so it does not independently prove deletion of hidden dangling delivery records.
- No docs were changed; contract wording is encoded in the hosted tests.

## Validation

- `dotnet tool run fantomas src/Grace.Server.Tests/Approval.Server.Tests.fs src/Grace.Server.Tests/Webhook.Server.Tests.fs src/Grace.Server.Tests/AgentSession.Server.Tests.fs`: passed.
- `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~ApprovalPolicyStoreIsProcessLocalWhileGeneratedRequestsRemainActorBackedAcrossRestart|FullyQualifiedName~WebhookRuleAndHttpObservableDeliveriesAreProcessLocalAcrossRestart|FullyQualifiedName~ActiveAgentSessionsAreProcessLocalAcrossRestart"`: passed; 3 passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed after isolation patch and again after the webhook wording fix.
  - `Grace.Types.Tests`: 65 passed.
  - `Grace.Authorization.Tests`: 37 passed.
  - `Grace.Server.Unit.Tests`: 440 passed.
  - `Grace.CLI.Tests`: 273 passed, 1 skipped.
  - `Grace.Server.Tests`: 168 passed.
- `git diff --check`: passed.

## Review Status

- Review pass 1 by GPT-5.5 High review-only subagent posted in PR comments.
- Review pass 1 finding fixed/narrowed in `1e36c7e7e32bb42d6bb2d9b5e9ea98b4e21fbd1c`; worker fix evidence posted in PR comments.
- Review pass 2 by GPT-5.5 High review-only subagent posted in PR comments; no findings, including confirmation that the prior webhook overclaim is resolved.
- Ready to merge after GitHub `full` passes.