### PR TITLE
Implement CLI schema and examples introspection

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -180,7 +180,7 @@ module CommandOutputContractRegistryTests =
 
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "workitem" ] "show"
+        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -188,42 +188,47 @@ module CommandOutputContractRegistryTests =
 
             document.Kind |> should equal "schema"
 
-            document.Command.Id
-            |> should equal "workitem.show"
+            document.Command.Id |> should equal "auth.logout"
 
             match document.Schema with
             | Some schema ->
                 schema.Status |> should equal "schema-ready"
 
                 schema.ReturnValueContract
-                |> should equal "WorkItemDto"
+                |> should equal "string"
 
                 use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
                 let successRoot = successSchema.RootElement
 
-                successRoot.GetProperty("Title").GetString()
-                |> should equal "GraceReturnValue<WorkItemDto>"
+                successRoot.GetProperty("title").GetString()
+                |> should equal "GraceReturnValue<string>"
 
-                let properties = successRoot.GetProperty("Properties")
+                let properties = successRoot.GetProperty("properties")
+
+                properties
+                    .GetProperty("ReturnValue")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "string"
 
                 properties.GetProperty("ReturnValue").ValueKind
                 |> should equal JsonValueKind.Object
 
                 properties
                     .GetProperty("EventTime")
-                    .GetProperty("Type")
+                    .GetProperty("type")
                     .GetString()
                 |> should equal "string"
 
                 properties
                     .GetProperty("CorrelationId")
-                    .GetProperty("Type")
+                    .GetProperty("type")
                     .GetString()
                 |> should equal "string"
 
                 properties
                     .GetProperty("Properties")
-                    .GetProperty("Type")
+                    .GetProperty("type")
                     .GetString()
                 |> should equal "array"
 
@@ -231,19 +236,19 @@ module CommandOutputContractRegistryTests =
 
                 errorSchema
                     .RootElement
-                    .GetProperty("Title")
+                    .GetProperty("title")
                     .GetString()
                 |> should equal "GraceError"
 
                 errorSchema
                     .RootElement
-                    .GetProperty("Properties")
+                    .GetProperty("properties")
                     .GetProperty("Error")
-                    .GetProperty("Type")
+                    .GetProperty("type")
                     .GetString()
                 |> should equal "string"
             | None -> Assert.Fail("Schema introspection should include a schema document.")
-        | None -> Assert.Fail("workitem.show should have a registry entry.")
+        | None -> Assert.Fail("auth.logout should have a registry entry.")
 
     [<Test>]
     let ``metadata incomplete registry entries are explicit`` () =
@@ -275,8 +280,41 @@ module CommandOutputContractRegistryTests =
         | None -> Assert.Fail("repository.init should have a registry entry.")
 
     [<Test>]
+    let ``dto and union contracts are not schema ready until their full emitted shapes are declared`` () =
+        let cases =
+            [
+                CommandOutputContract.commandIdentity [ "repository" ] "get", "RepositoryDto metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "workitem" ] "show", "WorkItemDto metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "access" ] "check", "PermissionCheckResult metadata is incomplete"
+            ]
+
+        for identity, expectedNote in cases do
+            match CommandOutputContract.tryFind identity with
+            | Some entry ->
+                entry.ReturnValueContract.Status
+                |> should equal MetadataIncomplete
+
+                let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+                match schemaDocument.Schema with
+                | Some schema ->
+                    schema.Status
+                    |> should equal "metadata-incomplete"
+
+                    schema.Notes
+                    |> List.exists (fun note -> note.Contains(expectedNote, StringComparison.Ordinal))
+                    |> should equal true
+                | None -> Assert.Fail($"Expected schema document for {identity.CommandId}.")
+
+                let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+                examplesDocument.Examples[0].Name
+                |> should equal "metadata-incomplete"
+            | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
+
+    [<Test>]
     let ``examples for schema ready commands parse as Grace envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "access" ] "check"
+        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -293,11 +331,8 @@ module CommandOutputContractRegistryTests =
             use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[0].Document)
             let successRoot = success.RootElement
 
-            successRoot
-                .GetProperty("ReturnValue")
-                .GetProperty("Allowed")
-                .GetBoolean()
-            |> should equal true
+            successRoot.GetProperty("ReturnValue").GetString()
+            |> should equal "Signed out."
 
             let successProperties = successRoot.GetProperty("Properties")
 
@@ -317,4 +352,4 @@ module CommandOutputContractRegistryTests =
 
             errorRoot.GetProperty("CorrelationId").GetString()
             |> should equal "correlation-id"
-        | None -> Assert.Fail("access.check should have a registry entry.")
+        | None -> Assert.Fail("auth.logout should have a registry entry.")

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.CommandOutputContract
 open NUnit.Framework
 open System
+open System.Text.Json
 
 [<TestFixture>]
 [<NonParallelizable>]
@@ -176,3 +177,144 @@ module CommandOutputContractRegistryTests =
             match entry.EnvelopeContract with
             | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
+
+    [<Test>]
+    let ``schema ready registry entries describe success and error envelopes`` () =
+        let identity = CommandOutputContract.commandIdentity [ "workitem" ] "show"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            let document = CommandOutputContract.introspectionDocument Schema entry
+
+            document.Kind |> should equal "schema"
+
+            document.Command.Id
+            |> should equal "workitem.show"
+
+            match document.Schema with
+            | Some schema ->
+                schema.Status |> should equal "schema-ready"
+
+                schema.ReturnValueContract
+                |> should equal "WorkItemDto"
+
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+                let successRoot = successSchema.RootElement
+
+                successRoot.GetProperty("Title").GetString()
+                |> should equal "GraceReturnValue<WorkItemDto>"
+
+                let properties = successRoot.GetProperty("Properties")
+
+                properties.GetProperty("ReturnValue").ValueKind
+                |> should equal JsonValueKind.Object
+
+                properties
+                    .GetProperty("EventTime")
+                    .GetProperty("Type")
+                    .GetString()
+                |> should equal "string"
+
+                properties
+                    .GetProperty("CorrelationId")
+                    .GetProperty("Type")
+                    .GetString()
+                |> should equal "string"
+
+                properties
+                    .GetProperty("Properties")
+                    .GetProperty("Type")
+                    .GetString()
+                |> should equal "array"
+
+                use errorSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.ErrorSchema)
+
+                errorSchema
+                    .RootElement
+                    .GetProperty("Title")
+                    .GetString()
+                |> should equal "GraceError"
+
+                errorSchema
+                    .RootElement
+                    .GetProperty("Properties")
+                    .GetProperty("Error")
+                    .GetProperty("Type")
+                    .GetString()
+                |> should equal "string"
+            | None -> Assert.Fail("Schema introspection should include a schema document.")
+        | None -> Assert.Fail("workitem.show should have a registry entry.")
+
+    [<Test>]
+    let ``metadata incomplete registry entries are explicit`` () =
+        let identity = CommandOutputContract.commandIdentity [ "repository" ] "init"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.ReturnValueContract.Status
+            |> should equal MetadataIncomplete
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status
+                |> should equal "metadata-incomplete"
+
+                schema.Notes
+                |> should
+                    contain
+                    "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+            | None -> Assert.Fail("Metadata-incomplete schema introspection should include a schema document.")
+
+            let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+            examplesDocument.Examples.Length |> should equal 2
+
+            examplesDocument.Examples[0].Name
+            |> should equal "metadata-incomplete"
+        | None -> Assert.Fail("repository.init should have a registry entry.")
+
+    [<Test>]
+    let ``examples for schema ready commands parse as Grace envelopes`` () =
+        let identity = CommandOutputContract.commandIdentity [ "access" ] "check"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            let document = CommandOutputContract.introspectionDocument Examples entry
+
+            document.Examples.Length |> should equal 2
+
+            document.Examples[0].Name
+            |> should equal "success-envelope-shape"
+
+            document.Examples[1].Name
+            |> should equal "error-envelope-shape"
+
+            use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[0].Document)
+            let successRoot = success.RootElement
+
+            successRoot
+                .GetProperty("ReturnValue")
+                .GetProperty("Allowed")
+                .GetBoolean()
+            |> should equal true
+
+            let successProperties = successRoot.GetProperty("Properties")
+
+            successProperties.ValueKind
+            |> should equal JsonValueKind.Array
+
+            successProperties[0]
+                .GetProperty("Key")
+                .GetString()
+            |> should equal "cli.contractVersion"
+
+            use error = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[1].Document)
+            let errorRoot = error.RootElement
+
+            errorRoot.GetProperty("Error").GetString()
+            |> should equal "error message"
+
+            errorRoot.GetProperty("CorrelationId").GetString()
+            |> should equal "correlation-id"
+        | None -> Assert.Fail("access.check should have a registry entry.")

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -306,7 +306,19 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Schema")
                 .GetProperty("Status")
                 .GetString()
-            |> should equal "registry-placeholder"
+            |> should equal "metadata-incomplete"
+
+            rootElement.GetProperty("Schema").GetProperty(
+                "SuccessSchema"
+            )
+                .GetProperty(
+                "Properties"
+            )
+                .GetProperty(
+                "ReturnValue"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Object
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
@@ -343,6 +355,39 @@ module HelpDoesNotReadConfigTests =
             )
                 .ValueKind
             |> should equal JsonValueKind.Object)
+
+    [<Test>]
+    let ``examples for missing dto metadata emit explicit unsupported document`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            let examples = rootElement.GetProperty("Examples")
+
+            examples[ 0 ].GetProperty("Name").GetString()
+            |> should equal "metadata-incomplete"
+
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "metadata-incomplete"
+
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("CommandId")
+                .GetString()
+            |> should equal "repository.init")
 
     [<Test>]
     let ``nested command schema resolves full command id`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -312,7 +312,7 @@ module HelpDoesNotReadConfigTests =
                 "SuccessSchema"
             )
                 .GetProperty(
-                "Properties"
+                "properties"
             )
                 .GetProperty(
                 "ReturnValue"
@@ -329,8 +329,8 @@ module HelpDoesNotReadConfigTests =
             let exitCode, output =
                 runWithCapturedOutput [| "--output"
                                          "Json"
-                                         "workitem"
-                                         "show"
+                                         "auth"
+                                         "logout"
                                          "--examples" |]
 
             exitCode |> should equal 0
@@ -345,23 +345,23 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Command")
                 .GetProperty("Id")
                 .GetString()
-            |> should equal "workitem.show"
+            |> should equal "auth.logout"
 
             let examples = rootElement.GetProperty("Examples")
             examples.GetArrayLength() |> should equal 2
 
-            examples[0].GetProperty("Document").GetProperty(
-                "ReturnValue"
-            )
-                .ValueKind
-            |> should equal JsonValueKind.Object)
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("ReturnValue")
+                .GetString()
+            |> should equal "Signed out.")
 
     [<Test>]
     let ``examples for missing dto metadata emit explicit unsupported document`` () =
         withTempDir (fun _ ->
             let exitCode, output =
-                runWithCapturedOutput [| "repository"
-                                         "init"
+                runWithCapturedOutput [| "workitem"
+                                         "show"
                                          "--examples" |]
 
             exitCode |> should equal 0
@@ -387,7 +387,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Document")
                 .GetProperty("CommandId")
                 .GetString()
-            |> should equal "repository.init")
+            |> should equal "workitem.show")
 
     [<Test>]
     let ``nested command schema resolves full command id`` () =

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -1,6 +1,7 @@
 namespace Grace.CLI
 
 open System
+open System.Collections.Generic
 open System.CommandLine
 
 module CommandOutputContract =
@@ -64,6 +65,13 @@ module CommandOutputContract =
 
     type MachineReadableFeatures = { JsonMode: FeatureState; Schema: FeatureState; Examples: FeatureState; Select: FeatureState }
 
+    type ReturnValueMetadataStatus =
+        | SchemaReady
+        | MetadataIncomplete
+        | ContractUnsupported
+
+    type ReturnValueContract = { Name: string; Provenance: string; Status: ReturnValueMetadataStatus; Schema: obj; Example: obj; Notes: string list }
+
     type CommandContractEntry =
         {
             Identity: CommandIdentity
@@ -74,6 +82,7 @@ module CommandOutputContract =
             Mutating: bool
             EnvelopeContract: EnvelopeContract
             Features: MachineReadableFeatures
+            ReturnValueContract: ReturnValueContract
         }
 
     type IntrospectionKind =
@@ -96,7 +105,17 @@ module CommandOutputContract =
             Select: string
         }
 
-    type CommandSchemaDocument = { Status: string; Source: string; Envelope: string; ReturnValueDisposition: string; Notes: string list }
+    type CommandSchemaDocument =
+        {
+            Status: string
+            Source: string
+            Envelope: string
+            ReturnValueDisposition: string
+            ReturnValueContract: string
+            SuccessSchema: obj
+            ErrorSchema: obj
+            Notes: string list
+        }
 
     type CommandExampleDocument = { Name: string; Description: string; Document: obj }
 
@@ -111,6 +130,154 @@ module CommandOutputContract =
         }
 
     let private unionName value = $"{value}"
+
+    let private schemaObject (title: string) (properties: (string * obj) list) (required: string array) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["$schema"] <- "https://json-schema.org/draft/2020-12/schema"
+        schema["Title"] <- title
+        schema["Type"] <- "object"
+        schema["Required"] <- required
+        schema["Properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
+        box schema
+
+    let private scalarSchema (typeName: string) = box {| Type = typeName |}
+
+    let private anySchema description = box {| Description = description |}
+
+    let private nullableObjectSchema description = box {| Type = [| "object"; "null" |]; Description = description |}
+
+    let private propertyBagSchema =
+        let propertyEntry =
+            schemaObject
+                "Grace CLI property entry"
+                [
+                    "Key", scalarSchema "string"
+                    "Value", anySchema "Safe machine-readable metadata value."
+                ]
+                [| "Key"; "Value" |]
+
+        box {| Type = "array"; Items = propertyEntry; Description = "CLI stdout representation of Grace Properties metadata." |}
+
+    let private cliProperties commandId provenance =
+        [|
+            {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+            {| Key = "cli.commandId"; Value = commandId |}
+            {| Key = "cli.introspectionSource"; Value = provenance |}
+        |]
+
+    let private unsupportedReturnValueSchema reason =
+        schemaObject
+            "Unsupported command output contract"
+            [
+                "Status", scalarSchema "string"
+                "Reason", scalarSchema "string"
+            ]
+            [| "Status"; "Reason" |]
+
+    let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
+
+    let private stringReturnValueSchema = scalarSchema "string"
+
+    let private repositoryDtoSchema =
+        schemaObject
+            "RepositoryDto"
+            [
+                "RepositoryId", scalarSchema "string"
+                "RepositoryName", scalarSchema "string"
+                "OwnerId", scalarSchema "string"
+                "OrganizationId", scalarSchema "string"
+                "DefaultBranchId", scalarSchema "string"
+                "RepositoryType", scalarSchema "string"
+                "AnonymousAccess", scalarSchema "boolean"
+            ]
+            [|
+                "RepositoryId"
+                "RepositoryName"
+                "OwnerId"
+                "OrganizationId"
+            |]
+
+    let private workItemDtoSchema =
+        schemaObject
+            "WorkItemDto"
+            [
+                "WorkItemId", scalarSchema "string"
+                "OwnerId", scalarSchema "string"
+                "OrganizationId", scalarSchema "string"
+                "RepositoryId", scalarSchema "string"
+                "Title", scalarSchema "string"
+                "Status", scalarSchema "string"
+                "CreatedAt", scalarSchema "string"
+                "UpdatedAt", scalarSchema "string"
+            ]
+            [|
+                "WorkItemId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "Title"
+                "Status"
+            |]
+
+    let private permissionCheckResultSchema =
+        schemaObject
+            "PermissionCheckResult"
+            [
+                "Allowed", scalarSchema "boolean"
+                "Reason", scalarSchema "string"
+                "MatchedAssignments", box {| Type = "array"; Items = anySchema "Matched role or path assignment." |}
+            ]
+            [| "Allowed"; "Reason" |]
+
+    let private repositoryDtoExample =
+        box
+            {|
+                RepositoryId = "00000000-0000-0000-0000-000000000001"
+                RepositoryName = "example-repository"
+                OwnerId = "00000000-0000-0000-0000-000000000002"
+                OrganizationId = "00000000-0000-0000-0000-000000000003"
+                DefaultBranchId = "00000000-0000-0000-0000-000000000004"
+                RepositoryType = "Public"
+                AnonymousAccess = false
+            |}
+
+    let private workItemDtoExample =
+        box
+            {|
+                WorkItemId = "00000000-0000-0000-0000-000000000010"
+                OwnerId = "00000000-0000-0000-0000-000000000002"
+                OrganizationId = "00000000-0000-0000-0000-000000000003"
+                RepositoryId = "00000000-0000-0000-0000-000000000001"
+                Title = "Example work item"
+                Status = "Open"
+                CreatedAt = "2026-06-05T00:00:00Z"
+                UpdatedAt = "2026-06-05T00:00:00Z"
+            |}
+
+    let private permissionCheckResultExample = box {| Allowed = true; Reason = "Matched an example role assignment."; MatchedAssignments = Array.empty<obj> |}
+
+    let private supportedReturnValueContract name provenance schema example notes =
+        { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
+
+    let private incompleteReturnValueContract name reason =
+        {
+            Name = name
+            Provenance = "CommandOutputContract"
+            Status = MetadataIncomplete
+            Schema = unsupportedReturnValueSchema reason
+            Example = unsupportedReturnValueExample reason
+            Notes = [ reason ]
+        }
+
+    let private unsupportedReturnValueContract name reason =
+        {
+            Name = name
+            Provenance = "CommandOutputContract"
+            Status = ContractUnsupported
+            Schema = unsupportedReturnValueSchema reason
+            Example = unsupportedReturnValueExample reason
+            Notes = [ reason ]
+        }
 
     let private routeDispositionText (disposition: RouteDisposition) =
         match disposition with
@@ -135,6 +302,54 @@ module CommandOutputContract =
         | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
 
+    let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
+        match identity.CommandId, envelopeContract with
+        | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            supportedReturnValueContract
+                "RepositoryDto"
+                "Grace.Types.Repository.RepositoryDto"
+                repositoryDtoSchema
+                repositoryDtoExample
+                [
+                    "Representative API/SDK DTO schema for a common Grace result envelope command."
+                ]
+        | "workitem.show", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            supportedReturnValueContract
+                "WorkItemDto"
+                "Grace.Types.WorkItem.WorkItemDto"
+                workItemDtoSchema
+                workItemDtoExample
+                [
+                    "Representative API/SDK DTO schema for a common Grace result envelope command."
+                ]
+        | "access.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            supportedReturnValueContract
+                "PermissionCheckResult"
+                "Grace.Types.Authorization.PermissionCheckResult"
+                permissionCheckResultSchema
+                permissionCheckResultExample
+                [
+                    "Representative command result DTO schema for a common Grace result envelope command."
+                ]
+        | "auth.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            supportedReturnValueContract
+                "string"
+                "GraceReturnValue<string>"
+                stringReturnValueSchema
+                (box "Signed out.")
+                [
+                    "Representative scalar ReturnValue schema for a common Grace result envelope command."
+                ]
+        | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
+        | _, MigrationRequiredToGraceResultEnvelope disposition ->
+            incompleteReturnValueContract
+                (outputDtoDispositionText disposition)
+                "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+        | _, ExistingGraceResultEnvelope disposition ->
+            incompleteReturnValueContract
+                (outputDtoDispositionText disposition)
+                "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
+
     let private commandDocument (identity: CommandIdentity) =
         { Id = identity.CommandId; Path = identity.CommandPath; GroupPath = identity.GroupPath; Name = identity.CommandName }
 
@@ -152,46 +367,94 @@ module CommandOutputContract =
             Select = unionName entry.Features.Select
         }
 
+    let private successEnvelopeSchema (entry: CommandContractEntry) =
+        schemaObject
+            $"GraceReturnValue<{entry.ReturnValueContract.Name}>"
+            [
+                "ReturnValue", entry.ReturnValueContract.Schema
+                "EventTime", scalarSchema "string"
+                "CorrelationId", scalarSchema "string"
+                "Properties", propertyBagSchema
+            ]
+            [|
+                "ReturnValue"
+                "EventTime"
+                "CorrelationId"
+                "Properties"
+            |]
+
+    let private errorEnvelopeSchema =
+        schemaObject
+            "GraceError"
+            [
+                "Exception", nullableObjectSchema "Serialized Grace exception details, or null/default when no exception object is available."
+                "Error", scalarSchema "string"
+                "EventTime", scalarSchema "string"
+                "CorrelationId", scalarSchema "string"
+                "Properties", anySchema "GraceError serializes Properties with the shared serializer policy."
+            ]
+            [|
+                "Exception"
+                "Error"
+                "EventTime"
+                "CorrelationId"
+                "Properties"
+            |]
+
     let private schemaDocument (entry: CommandContractEntry) =
+        let status =
+            match entry.ReturnValueContract.Status with
+            | SchemaReady -> "schema-ready"
+            | MetadataIncomplete -> "metadata-incomplete"
+            | ContractUnsupported -> "unsupported"
+
         {
-            Status = "registry-placeholder"
+            Status = status
             Source = "CommandOutputContract"
-            Envelope = "GraceReturnValue<T> on success; GraceError on error"
+            Envelope = "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
+            ReturnValueContract = entry.ReturnValueContract.Name
+            SuccessSchema = successEnvelopeSchema entry
+            ErrorSchema = errorEnvelopeSchema
             Notes =
                 [
-                    "S2 emits registry-derived introspection metadata only."
-                    "S4 will replace this placeholder with command DTO-derived schema details."
+                    "Schema is derived from CommandOutputContract registry metadata."
                     "This path is inert and does not execute the command action."
+                    yield! entry.ReturnValueContract.Notes
                 ]
         }
 
     let private successExample (entry: CommandContractEntry) =
-        let returnValue =
-            match entry.EnvelopeContract with
-            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto" |}
-            | ExistingGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto" |}
-            | MigrationRequiredToGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto-requires-migration" |}
-            | MigrationRequiredToGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto-requires-migration" |}
-            | ExistingGraceResultEnvelope NoServerDto
-            | MigrationRequiredToGraceResultEnvelope NoServerDto -> box {| Shape = "no-server-dto" |}
-            | SourceOnlyUnsupported reason -> box {| Unsupported = reason |}
-
         {
             Name = "success-envelope-shape"
-            Description = "Representative GraceReturnValue<T> envelope shape; command-specific ReturnValue details are deferred to S4."
+            Description = $"Representative GraceReturnValue<{entry.ReturnValueContract.Name}> envelope shape from registry metadata."
             Document =
                 box
                     {|
-                        ReturnValue = returnValue
+                        ReturnValue = entry.ReturnValueContract.Example
                         EventTime = "2026-06-05T00:00:00Z"
                         CorrelationId = "correlation-id"
-                        Properties =
-                            [|
-                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
-                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
-                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
-                            |]
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
+                    |}
+        }
+
+    let private incompleteMetadataExample (entry: CommandContractEntry) =
+        {
+            Name = "metadata-incomplete"
+            Description = "Explicit machine-readable metadata gap for a command that is not schema-ready."
+            Document =
+                box
+                    {|
+                        Status =
+                            match entry.ReturnValueContract.Status with
+                            | ContractUnsupported -> "unsupported"
+                            | _ -> "metadata-incomplete"
+                        CommandId = entry.Identity.CommandId
+                        ReturnValueContract = entry.ReturnValueContract.Name
+                        Reason =
+                            entry.ReturnValueContract.Notes
+                            |> String.concat " "
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
                     |}
         }
 
@@ -206,12 +469,7 @@ module CommandOutputContract =
                         Error = "error message"
                         EventTime = "2026-06-05T00:00:00Z"
                         CorrelationId = "correlation-id"
-                        Properties =
-                            [|
-                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
-                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
-                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
-                            |]
+                        Properties = cliProperties entry.Identity.CommandId "CommandOutputContract"
                     |}
         }
 
@@ -232,10 +490,18 @@ module CommandOutputContract =
                 match kind with
                 | Schema -> []
                 | Examples ->
-                    [
-                        successExample entry
-                        errorExample entry
-                    ]
+                    match entry.ReturnValueContract.Status with
+                    | SchemaReady ->
+                        [
+                            successExample entry
+                            errorExample entry
+                        ]
+                    | MetadataIncomplete
+                    | ContractUnsupported ->
+                        [
+                            incompleteMetadataExample entry
+                            errorExample entry
+                        ]
         }
 
     let private featuresFor behavior =
@@ -275,21 +541,26 @@ module CommandOutputContract =
         |> List.collect (loop [])
 
     let private row groupPath commandName routed mutating behavior category executionScope dtoDisposition =
+        let identity = commandIdentity groupPath commandName
+
         let routeDisposition =
             if routed then
                 Routed
             else
                 SourceOnlyUnrouted "Defined-only reference command; not attached to GraceCommand.rootCommand."
 
+        let envelopeContract = envelopeFor routed behavior dtoDisposition
+
         {
-            Identity = commandIdentity groupPath commandName
+            Identity = identity
             RouteDisposition = routeDisposition
             CurrentJsonBehavior = behavior
             Category = category
             ExecutionScope = executionScope
             Mutating = mutating
-            EnvelopeContract = envelopeFor routed behavior dtoDisposition
+            EnvelopeContract = envelopeContract
             Features = featuresFor behavior
+            ReturnValueContract = returnValueContractFor identity envelopeContract
         }
 
     let private common_renderOutput_envelope = CommonRenderOutputEnvelope

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -134,17 +134,27 @@ module CommandOutputContract =
     let private schemaObject (title: string) (properties: (string * obj) list) (required: string array) =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
         schema["$schema"] <- "https://json-schema.org/draft/2020-12/schema"
-        schema["Title"] <- title
-        schema["Type"] <- "object"
-        schema["Required"] <- required
-        schema["Properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
+        schema["title"] <- title
+        schema["type"] <- "object"
+        schema["required"] <- required
+        schema["properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
         box schema
 
-    let private scalarSchema (typeName: string) = box {| Type = typeName |}
+    let private scalarSchema (typeName: string) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- typeName
+        box schema
 
-    let private anySchema description = box {| Description = description |}
+    let private anySchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["description"] <- description
+        box schema
 
-    let private nullableObjectSchema description = box {| Type = [| "object"; "null" |]; Description = description |}
+    let private nullableObjectSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- [| "object"; "null" |]
+        schema["description"] <- description
+        box schema
 
     let private propertyBagSchema =
         let propertyEntry =
@@ -156,7 +166,11 @@ module CommandOutputContract =
                 ]
                 [| "Key"; "Value" |]
 
-        box {| Type = "array"; Items = propertyEntry; Description = "CLI stdout representation of Grace Properties metadata." |}
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "array"
+        schema["items"] <- propertyEntry
+        schema["description"] <- "CLI stdout representation of Grace Properties metadata."
+        box schema
 
     let private cliProperties commandId provenance =
         [|
@@ -177,84 +191,6 @@ module CommandOutputContract =
     let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
 
     let private stringReturnValueSchema = scalarSchema "string"
-
-    let private repositoryDtoSchema =
-        schemaObject
-            "RepositoryDto"
-            [
-                "RepositoryId", scalarSchema "string"
-                "RepositoryName", scalarSchema "string"
-                "OwnerId", scalarSchema "string"
-                "OrganizationId", scalarSchema "string"
-                "DefaultBranchId", scalarSchema "string"
-                "RepositoryType", scalarSchema "string"
-                "AnonymousAccess", scalarSchema "boolean"
-            ]
-            [|
-                "RepositoryId"
-                "RepositoryName"
-                "OwnerId"
-                "OrganizationId"
-            |]
-
-    let private workItemDtoSchema =
-        schemaObject
-            "WorkItemDto"
-            [
-                "WorkItemId", scalarSchema "string"
-                "OwnerId", scalarSchema "string"
-                "OrganizationId", scalarSchema "string"
-                "RepositoryId", scalarSchema "string"
-                "Title", scalarSchema "string"
-                "Status", scalarSchema "string"
-                "CreatedAt", scalarSchema "string"
-                "UpdatedAt", scalarSchema "string"
-            ]
-            [|
-                "WorkItemId"
-                "OwnerId"
-                "OrganizationId"
-                "RepositoryId"
-                "Title"
-                "Status"
-            |]
-
-    let private permissionCheckResultSchema =
-        schemaObject
-            "PermissionCheckResult"
-            [
-                "Allowed", scalarSchema "boolean"
-                "Reason", scalarSchema "string"
-                "MatchedAssignments", box {| Type = "array"; Items = anySchema "Matched role or path assignment." |}
-            ]
-            [| "Allowed"; "Reason" |]
-
-    let private repositoryDtoExample =
-        box
-            {|
-                RepositoryId = "00000000-0000-0000-0000-000000000001"
-                RepositoryName = "example-repository"
-                OwnerId = "00000000-0000-0000-0000-000000000002"
-                OrganizationId = "00000000-0000-0000-0000-000000000003"
-                DefaultBranchId = "00000000-0000-0000-0000-000000000004"
-                RepositoryType = "Public"
-                AnonymousAccess = false
-            |}
-
-    let private workItemDtoExample =
-        box
-            {|
-                WorkItemId = "00000000-0000-0000-0000-000000000010"
-                OwnerId = "00000000-0000-0000-0000-000000000002"
-                OrganizationId = "00000000-0000-0000-0000-000000000003"
-                RepositoryId = "00000000-0000-0000-0000-000000000001"
-                Title = "Example work item"
-                Status = "Open"
-                CreatedAt = "2026-06-05T00:00:00Z"
-                UpdatedAt = "2026-06-05T00:00:00Z"
-            |}
-
-    let private permissionCheckResultExample = box {| Allowed = true; Reason = "Matched an example role assignment."; MatchedAssignments = Array.empty<obj> |}
 
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
@@ -305,32 +241,17 @@ module CommandOutputContract =
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
         | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            supportedReturnValueContract
+            incompleteReturnValueContract
                 "RepositoryDto"
-                "Grace.Types.Repository.RepositoryDto"
-                repositoryDtoSchema
-                repositoryDtoExample
-                [
-                    "Representative API/SDK DTO schema for a common Grace result envelope command."
-                ]
+                "RepositoryDto metadata is incomplete: src/Grace.Types/Repository.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
         | "workitem.show", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            supportedReturnValueContract
+            incompleteReturnValueContract
                 "WorkItemDto"
-                "Grace.Types.WorkItem.WorkItemDto"
-                workItemDtoSchema
-                workItemDtoExample
-                [
-                    "Representative API/SDK DTO schema for a common Grace result envelope command."
-                ]
+                "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
         | "access.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            supportedReturnValueContract
+            incompleteReturnValueContract
                 "PermissionCheckResult"
-                "Grace.Types.Authorization.PermissionCheckResult"
-                permissionCheckResultSchema
-                permissionCheckResultExample
-                [
-                    "Representative command result DTO schema for a common Grace result envelope command."
-                ]
+                "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
         | "auth.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             supportedReturnValueContract
                 "string"


### PR DESCRIPTION
## Summary

- Implements registry-backed `--schema` and `--examples` outputs for representative CLI output contracts.
- Adds explicit metadata-incomplete/unsupported introspection states instead of silently claiming unavailable schema success.
- Adds registry and CLI invocation coverage for schema/example output shape.

## Related Issue

Part of #274. Addresses #279.

Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for #279.

## Validation

Worker evidence:

- `dotnet tool run fantomas -- src\Grace.CLI\CommandOutputContract.CLI.fs src\Grace.CLI.Tests\CommandOutputContract.CLI.Tests.fs src\Grace.CLI.Tests\Program.CLI.Tests.fs`
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`
- `dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` passed `308/308`
- `pwsh ./scripts/validate.ps1 -Fast` passed: Authorization `37`, Types `65`, Server.Unit `440`, CLI `308`
- `git diff --check`

## Review Status

- First review-only subagent pass recorded in https://github.com/ScottArbeit/Grace/pull/300#issuecomment-4637293927.
- First review found two issues: inaccurate schema-ready DTO contracts and PascalCase JSON Schema vocabulary.
- Worker fix recorded in https://github.com/ScottArbeit/Grace/pull/300#issuecomment-4637318848 at commit `8b035233906bbc9d7d1a496360635566798fe600`.
- Final review-only subagent pass recorded in https://github.com/ScottArbeit/Grace/pull/300#issuecomment-4637333026.
- Final review found no issues and recommended merge.
- Reviewed And OK: risky DTO/DU entries are now `metadata-incomplete`, schema-ready `auth.logout` matches runtime, JSON Schema keywords are lowercase, introspection remains inert, option/error behavior remains machine-readable, envelope concepts remain represented, and touched files remain limited to CLI contract/test files.