### PR TITLE
Implement CLI ReturnValue select projection

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -178,6 +178,9 @@ module CommandOutputContractRegistryTests =
             | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
         let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="BuildInfo.Tests.fs" />
     <Compile Include="Artifact.SDK.Tests.fs" />
     <Compile Include="ClientIdentity.SDK.Tests.fs" />
+    <Compile Include="SelectProjection.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />
     <Compile Include="HistoryStorage.CLI.Tests.fs" />

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -511,6 +511,148 @@ module HelpDoesNotReadConfigTests =
         standardOut |> should not' (contain "Elapsed:")
 
     [<Test>]
+    let ``select option makes command json-oriented`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "auth"
+                    "logout"
+                    "--select"
+                    "Value"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        Common.json parseResult |> should equal true
+
+        Common.tryGetSelect parseResult
+        |> should equal (Some "Value")
+
+    [<Test>]
+    let ``renderOutput select writes selected scalar json only`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok"; Other = "hidden" |} "corr-select-success"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "\"ok\""
+
+    [<Test>]
+    let ``renderOutput select writes selected object and collection json`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Container.Items" |])
+
+        let returnValue =
+            GraceReturnValue.Create
+                {|
+                    Container =
+                        {|
+                            Items =
+                                [|
+                                    {| Name = "one" |}
+                                    {| Name = "two" |}
+                                |]
+                        |}
+                |}
+                "corr-select-collection"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        use document = JsonDocument.Parse(standardOut)
+        let rootElement = document.RootElement
+
+        rootElement.ValueKind
+        |> should equal JsonValueKind.Array
+
+        rootElement.GetArrayLength() |> should equal 2
+
+        rootElement[ 1 ].GetProperty("Name").GetString()
+        |> should equal "two"
+
+    [<Test>]
+    let ``renderOutput select writes null json`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = (null: string) |} "corr-select-null"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "null"
+
+    [<Test>]
+    let ``renderOutput select missing property emits json error`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Missing" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-missing"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should contain "was not found in ReturnValue"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-select-missing"
+
+    [<Test>]
+    let ``renderOutput select scalar traversal emits json error`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value.Name" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-scalar"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        assertJsonErrorOutput standardOut
+        |> should contain "cannot read 'Name'"
+
+    [<Test>]
+    let ``renderOutput select leaves error envelope unprojected`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let error = GraceError.Create "original failure" "corr-select-error"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Error error)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should equal "original failure"
+
+        let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+        rootElement.TryGetProperty("ReturnValue", &returnValue)
+        |> should equal false
+
+    [<Test>]
     let ``renderOutput json error writes GraceError envelope with shared field names`` () =
         let parseResult = GraceCommand.rootCommand.Parse([| "--output"; "Json" |])
         let error = GraceError.Create "central writer error" "corr-json-error"

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,6 +74,7 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.SDK
 open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
@@ -81,7 +82,10 @@ open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
 open System.IO
+open System.Net
+open System.Net.Http
 open System.Text.Json
 
 [<NonParallelizable>]
@@ -201,6 +205,41 @@ module HelpDoesNotReadConfigTests =
         config.BranchId <- branchId
         let json = serialize config
         File.WriteAllText(Path.Combine(graceDir, "graceconfig.json"), json)
+
+    let private addLifecycleHeaders
+        (response: HttpResponseMessage)
+        (status: string)
+        (unsupportedAfter: string)
+        (minimumVersion: string)
+        (recommendedVersion: string option)
+        (updateUrl: string)
+        =
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleStatusHeaderKey, status)
+        |> ignore
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleUnsupportedAfterHeaderKey, unsupportedAfter)
+        |> ignore
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleMinimumVersionHeaderKey, minimumVersion)
+        |> ignore
+
+        match recommendedVersion with
+        | Some value ->
+            response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleRecommendedVersionHeaderKey, value)
+            |> ignore
+        | None -> ()
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleUpdateUrlHeaderKey, updateUrl)
+        |> ignore
+
+    let private lifecycleProperties status =
+        use response = new HttpResponseMessage(HttpStatusCode.OK)
+
+        addLifecycleHeaders response status "2026-12-01" "0.1.0" (Some "0.2.0") "https://github.com/ScottArbeit/Grace/releases"
+
+        match ClientIdentity.parseLifecycleDiagnostics response with
+        | Some diagnostics -> ClientIdentity.lifecycleDiagnosticsToProperties diagnostics
+        | None -> Dictionary<string, obj>()
 
     [<Test>]
     let ``help works with invalid config`` () =
@@ -543,6 +582,25 @@ module HelpDoesNotReadConfigTests =
         standardOut.Trim() |> should equal "\"ok\""
 
     [<Test>]
+    let ``renderOutput select success suppresses lifecycle warnings`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-lifecycle-success"
+
+        returnValue.enhance (lifecycleProperties "deprecated")
+        |> ignore
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "\"ok\""
+
+        standardOut
+        |> should not' (contain "This Grace client version is deprecated.")
+
+    [<Test>]
     let ``renderOutput select writes selected object and collection json`` () =
         let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Container.Items" |])
 
@@ -634,6 +692,9 @@ module HelpDoesNotReadConfigTests =
         let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
         let error = GraceError.Create "original failure" "corr-select-error"
 
+        error.enhance (lifecycleProperties "unsupported")
+        |> ignore
+
         let standardOut, standardError =
             captureStdoutAndStderr (fun () ->
                 Common.renderOutput parseResult (Error error)
@@ -647,10 +708,47 @@ module HelpDoesNotReadConfigTests =
         rootElement.GetProperty("Error").GetString()
         |> should equal "original failure"
 
+        standardOut
+        |> should not' (contain "This Grace client version is no longer supported.")
+
         let mutable returnValue = Unchecked.defaultof<JsonElement>
 
         rootElement.TryGetProperty("ReturnValue", &returnValue)
         |> should equal false
+
+    [<Test>]
+    let ``invalid select grammar does not invoke command`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "connect"
+                                                  "--select"
+                                                  "Value[0]" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "predicates, wildcards, functions, and expressions are not supported"
+
+            File.Exists(Path.Combine(root, ".grace", "graceconfig.json"))
+            |> should equal false)
+
+    [<Test>]
+    let ``valid select on unsupported command is json error without invoking command`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "connect"
+                                                  "--select"
+                                                  "Value" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "does not support --select in this release"
+
+            File.Exists(Path.Combine(root, ".grace", "graceconfig.json"))
+            |> should equal false)
 
     [<Test>]
     let ``renderOutput json error writes GraceError envelope with shared field names`` () =

--- a/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
@@ -1,0 +1,63 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+open System.Text.Json
+
+[<TestFixture>]
+module SelectProjectionParsingTests =
+
+    let private parse selector = SelectProjection.tryParse "corr-select-parse" selector
+
+    [<TestCase("Value")>]
+    [<TestCase("Owner.Name")>]
+    [<TestCase("_links.Self")>]
+    [<TestCase("Items.Item1")>]
+    let ``accepted simple property paths parse`` selector =
+        match parse selector with
+        | Ok _ -> ()
+        | Error error -> Assert.Fail(error.Error)
+
+    [<TestCase("Properties.CorrelationId")>]
+    [<TestCase("properties.CorrelationId")>]
+    [<TestCase("CorrelationId")>]
+    [<TestCase("EventTime")>]
+    [<TestCase("ReturnValue.Value")>]
+    let ``metadata paths are rejected`` selector =
+        match parse selector with
+        | Ok _ -> Assert.Fail($"Expected selector '{selector}' to be rejected.")
+        | Error error ->
+            error.Error
+            |> should contain "cannot read envelope metadata"
+
+    [<TestCase("")>]
+    [<TestCase(" ")>]
+    [<TestCase("Value ")>]
+    [<TestCase(".Value")>]
+    [<TestCase("Value.")>]
+    [<TestCase("Value..Name")>]
+    [<TestCase("Value[0]")>]
+    [<TestCase("Items[*]")>]
+    [<TestCase("Items?(@.Name)")>]
+    [<TestCase("Name()")>]
+    [<TestCase("Name | length")>]
+    let ``malformed expression selectors are rejected`` selector =
+        match parse selector with
+        | Ok _ -> Assert.Fail($"Expected selector '{selector}' to be rejected.")
+        | Error error ->
+            error.CorrelationId
+            |> should equal "corr-select-parse"
+
+    [<Test>]
+    let ``project returns selected nested property`` () =
+        match parse "Container.Value" with
+        | Error error -> Assert.Fail(error.Error)
+        | Ok selector ->
+            match SelectProjection.project "corr-project" selector (box {| Container = {| Value = 42 |} |}) with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok selected ->
+                selected.ValueKind
+                |> should equal JsonValueKind.Number
+
+                selected.GetInt32() |> should equal 42

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -601,10 +601,11 @@ module Common =
 
             Some(normalizedStatus, String.Join(Environment.NewLine, lines))
 
-    let private renderLifecycleWarningOnce outputFormat properties =
+    let private renderLifecycleWarningOnce parseResult outputFormat properties =
         match outputFormat with
         | Json
         | Silent -> ()
+        | _ when parseResult |> hasSelect -> ()
         | _ ->
             match tryBuildLifecycleWarning properties with
             | Some (status, warningText) ->
@@ -624,7 +625,7 @@ module Common =
 
         match result with
         | Ok graceReturnValue ->
-            renderLifecycleWarningOnce outputFormat graceReturnValue.Properties
+            renderLifecycleWarningOnce parseResult outputFormat graceReturnValue.Properties
 
             match tryRenderJsonSelection parseResult graceReturnValue with
             | Some (Ok json) ->
@@ -654,7 +655,7 @@ module Common =
 
                 0
         | Error error ->
-            renderLifecycleWarningOnce outputFormat error.Properties
+            renderLifecycleWarningOnce parseResult outputFormat error.Properties
 
             let json =
                 if error.Error.Contains("Stack trace") then

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -106,6 +106,15 @@ module Common =
                 DefaultValueFactory = (fun _ -> false)
             )
 
+        let select =
+            new Option<string>(
+                OptionName.Select,
+                Required = false,
+                Description = "Emit only the selected dot-separated ReturnValue property path as JSON.",
+                Arity = ArgumentArity.ExactlyOne,
+                Recursive = true
+            )
+
     /// Gets the correlationId value from the command's ParseResult.
     let getCorrelationId (parseResult: ParseResult) = Services.resolveCorrelationId parseResult
 
@@ -294,7 +303,27 @@ module Common =
             false
 
     /// Checks if the output format from the command line is Json.
-    let json parseResult = parseResult |> isOutputFormat Json
+    let tryGetSelect (parseResult: ParseResult) =
+        if isNull parseResult then
+            None
+        else
+            let result = parseResult.GetResult(OptionName.Select)
+
+            if isNull result then
+                None
+            else
+                try
+                    parseResult.GetValue<string>(Options.select)
+                    |> Option.ofObj
+                with
+                | :? InvalidOperationException -> None
+
+    let hasSelect parseResult = tryGetSelect parseResult |> Option.isSome
+
+    /// Checks if the command should emit machine-readable JSON.
+    let json parseResult =
+        (parseResult |> isOutputFormat Json)
+        || (parseResult |> hasSelect)
 
     /// Checks if the output format from the command line is Minimal.
     let minimal parseResult = parseResult |> isOutputFormat Minimal
@@ -474,6 +503,21 @@ module Common =
 
     let writeJsonReturnValueStdout (graceReturnValue: GraceReturnValue<'T>) = Console.Out.WriteLine(renderJsonReturnValue graceReturnValue)
 
+    let private tryRenderJsonSelection (parseResult: ParseResult) (graceReturnValue: GraceReturnValue<'T>) =
+        match tryGetSelect parseResult with
+        | None -> None
+        | Some selectorText ->
+            let correlationId = graceReturnValue.CorrelationId
+
+            match SelectProjection.tryParse correlationId selectorText with
+            | Error error -> Some(Error error)
+            | Ok selector ->
+                let returnValue = redactJsonReturnValue graceReturnValue.ReturnValue
+
+                match SelectProjection.project correlationId selector returnValue with
+                | Error error -> Some(Error error)
+                | Ok selected -> Some(Ok(SelectProjection.renderSelectedJson selected))
+
     let private tryGetProperty (properties: Dictionary<string, obj>) key =
         if isNull properties then
             None
@@ -582,25 +626,33 @@ module Common =
         | Ok graceReturnValue ->
             renderLifecycleWarningOnce outputFormat graceReturnValue.Properties
 
-            match outputFormat with
-            | Json -> writeJsonReturnValueStdout graceReturnValue
-            | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
-            | Silent -> ()
-            | Verbose ->
-                AnsiConsole.WriteLine()
+            match tryRenderJsonSelection parseResult graceReturnValue with
+            | Some (Ok json) ->
+                Console.Out.WriteLine(json)
+                0
+            | Some (Error error) ->
+                writeJsonErrorStdout error
+                -1
+            | None ->
+                match outputFormat with
+                | Json -> writeJsonReturnValueStdout graceReturnValue
+                | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
+                | Silent -> ()
+                | Verbose ->
+                    AnsiConsole.WriteLine()
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]EventTime: {formatInstantExtended graceReturnValue.EventTime}[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]EventTime: {formatInstantExtended graceReturnValue.EventTime}[/]""")
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]CorrelationId: "{graceReturnValue.CorrelationId}"[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]CorrelationId: "{graceReturnValue.CorrelationId}"[/]""")
 
-                let properties = sanitizeLifecyclePropertiesForHumanOutput graceReturnValue.Properties
+                    let properties = sanitizeLifecyclePropertiesForHumanOutput graceReturnValue.Properties
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]Properties: {Markup.Escape(serialize properties)}[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]Properties: {Markup.Escape(serialize properties)}[/]""")
 
-                AnsiConsole.WriteLine()
-            | Normal -> () // Return unit because in the Normal case, we expect to print output within each command.
+                    AnsiConsole.WriteLine()
+                | Normal -> () // Return unit because in the Normal case, we expect to print output within each command.
 
-            0
+                0
         | Error error ->
             renderLifecycleWarningOnce outputFormat error.Properties
 
@@ -621,6 +673,7 @@ module Common =
                     Uri.UnescapeDataString(error.Error)
 
             match outputFormat with
+            | _ when parseResult |> hasSelect -> writeJsonErrorStdout error
             | Json -> writeJsonErrorStdout error
             | Minimal -> AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(errorText)}[/]")
             | Silent -> ()

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -430,7 +430,7 @@ module CommandOutputContract =
         | UnroutedSourceOnly ->
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
         | CommonRenderOutputEnvelope ->
-            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
 
     let private envelopeFor routed behavior dtoDisposition =

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -26,6 +26,7 @@
 		<Compile Include="Log.CLI.fs" />
 		<Compile Include="Text.CLI.fs" />
 		<Compile Include="LocalStateDb.CLI.fs" />
+		<Compile Include="SelectProjection.CLI.fs" />
 		<Compile Include="Command\Services.CLI.fs" />
 		<Compile Include="Command\Common.CLI.fs" />
 		<Compile Include="Command\Auth.CLI.fs" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -113,6 +113,7 @@ module GraceCommand =
                 || token.Equals(OptionName.CorrelationId, comparison)
                 || token.Equals("-c", comparison)
                 || token.Equals(OptionName.Source, comparison)
+                || token.Equals(OptionName.Select, comparison)
 
             let rec loop index =
                 if index >= args.Length then
@@ -265,6 +266,11 @@ module GraceCommand =
                         true
                     else
                         loop (index + 1)
+                elif
+                    token.Equals(OptionName.Select, StringComparison.OrdinalIgnoreCase)
+                    || token.StartsWith($"{OptionName.Select}=", StringComparison.OrdinalIgnoreCase)
+                then
+                    true
                 else
                     loop (index + 1)
 
@@ -749,6 +755,7 @@ module GraceCommand =
         rootCommand.Options.Add(Options.output)
         rootCommand.Options.Add(Options.schema)
         rootCommand.Options.Add(Options.examples)
+        rootCommand.Options.Add(Options.select)
 
         // Add subcommands.
         rootCommand.Subcommands.Add(Connect.Build)

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -297,6 +297,22 @@ module GraceCommand =
         Common.writeJsonErrorStdout error
         -1
 
+    let private tryValidateSelectRequest (parseResult: ParseResult) =
+        match Common.tryGetSelect parseResult with
+        | None -> None
+        | Some selectorText ->
+            let correlationId = getCorrelationId parseResult
+
+            match SelectProjection.tryParse correlationId selectorText with
+            | Error error -> Some error
+            | Ok _ ->
+                let identity = commandIdentityFromCommandResult parseResult.CommandResult
+
+                match CommandOutputContract.tryFind identity with
+                | Some entry when entry.Features.Select = CommandOutputContract.ExistingBehavior -> None
+                | Some _ -> Some(GraceError.Create $"Command '{identity.CommandId}' does not support --select in this release." correlationId)
+                | None -> Some(GraceError.Create $"Command '{identity.CommandId}' does not have CLI output contract metadata for --select." correlationId)
+
     let private tryFindGraceConfigurationFileForJsonMode () =
         let rec loop (directory: DirectoryInfo) =
             if isNull directory then
@@ -1020,6 +1036,14 @@ module GraceCommand =
                            && isJsonOutputRequestedFromTokens argvToParse then
                             returnValue <- writeJsonParseError parseResult
                             raise (IntrospectionExit returnValue)
+
+                        if parseResult.Errors.Count = 0 then
+                            match tryValidateSelectRequest parseResult with
+                            | Some error ->
+                                Common.writeJsonErrorStdout error
+                                returnValue <- -1
+                                raise (IntrospectionExit returnValue)
+                            | None -> ()
 
                         LocalStateDb.setVerbose (parseResult |> verbose)
 

--- a/src/Grace.CLI/SelectProjection.CLI.fs
+++ b/src/Grace.CLI/SelectProjection.CLI.fs
@@ -1,0 +1,112 @@
+namespace Grace.CLI
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open System
+open System.Collections.Generic
+open System.Text.Json
+open System.Text.RegularExpressions
+
+module SelectProjection =
+
+    type SelectorPath = private { Segments: string list }
+
+    let private identifier = Regex("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)
+
+    let private forbiddenSegments =
+        HashSet<string>(
+            [
+                "CorrelationId"
+                "EventTime"
+                "Error"
+                "Properties"
+                "ReturnValue"
+            ],
+            StringComparer.OrdinalIgnoreCase
+        )
+
+    let private formatPath (segments: string list) = String.Join(".", segments)
+
+    let private error correlationId message = Error(GraceError.Create message correlationId)
+
+    let tryParse correlationId (selector: string) =
+        if String.IsNullOrWhiteSpace selector then
+            error correlationId "--select requires a non-empty ReturnValue property path."
+        else
+            let trimmed = selector.Trim()
+
+            if trimmed <> selector then
+                error correlationId "--select paths cannot include leading or trailing whitespace."
+            elif
+                trimmed.IndexOfAny
+                    (
+                        [|
+                            '['
+                            ']'
+                            '('
+                            ')'
+                            '*'
+                            '''
+                            '"'
+                            '$'
+                            '@'
+                            '?'
+                            ':'
+                            ','
+                            ' '
+                            '\t'
+                            '\r'
+                            '\n'
+                        |]
+                    )
+                >= 0
+            then
+                error
+                    correlationId
+                    "--select supports only dot-separated ReturnValue property names; predicates, wildcards, functions, and expressions are not supported."
+            else
+                let segments =
+                    trimmed.Split('.', StringSplitOptions.None)
+                    |> Array.toList
+
+                match segments with
+                | [] -> error correlationId "--select requires a ReturnValue property path."
+                | _ when segments |> List.exists String.IsNullOrWhiteSpace -> error correlationId "--select paths must not contain empty property segments."
+                | _ ->
+                    match
+                        segments
+                        |> List.tryFind (identifier.IsMatch >> not)
+                        with
+                    | Some segment -> error correlationId $"--select property segment '{segment}' is not valid."
+                    | None ->
+                        match segments
+                              |> List.tryFind forbiddenSegments.Contains
+                            with
+                        | Some segment ->
+                            error correlationId $"--select cannot project '{segment}'. Selectors are relative to ReturnValue and cannot read envelope metadata."
+                        | None -> Ok { Segments = segments }
+
+    let project correlationId (selector: SelectorPath) (returnValue: obj) =
+        let json = serialize returnValue
+        use document = JsonDocument.Parse(json)
+
+        let rec loop (current: JsonElement) remaining =
+            match remaining with
+            | [] -> Ok(current.Clone())
+            | (segment: string) :: rest ->
+                if current.ValueKind <> JsonValueKind.Object then
+                    error
+                        correlationId
+                        $"--select path '{formatPath selector.Segments}' cannot read '{segment}' because the current ReturnValue value is {current.ValueKind}."
+                else
+                    let mutable value = Unchecked.defaultof<JsonElement>
+
+                    if current.TryGetProperty(segment, &value) then
+                        loop value rest
+                    else
+                        error correlationId $"--select path '{formatPath selector.Segments}' was not found in ReturnValue."
+
+        loop document.RootElement selector.Segments
+
+    let renderSelectedJson (selected: JsonElement) = selected.GetRawText()

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -127,6 +127,9 @@ module Text =
         let Examples = "--examples"
 
         [<Literal>]
+        let Select = "--select"
+
+        [<Literal>]
         let Overwrite = "--overwrite"
 
         [<Literal>]


### PR DESCRIPTION
## Summary

- Adds strict V1 `--select` parsing and evaluation for successful `ReturnValue` projection only.
- Wires `--select` as a recursive root option and integrates it with the central JSON writer.
- Adds parser, runtime, composition, and registry tests for projection success and error behavior.

## Related Issue

Part of #274. Addresses #280.

Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for #280.

## Validation

Worker evidence:

- Targeted Fantomas ran on touched F# files before validation.
- `dotnet test C:\Source\Grace-gh-280\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~HelpDoesNotReadConfigTests|FullyQualifiedName~SelectProjectionParsingTests|FullyQualifiedName~ClientIdentitySdkTests"` passed `71` tests.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed: Authorization `37`, Types `65`, Server.Unit `440`, CLI `339`.
- Hosted PR check: `full` passed after rebase on updated `main`.

## Review Status

- First review-only subagent pass recorded in https://github.com/ScottArbeit/Grace/pull/301#issuecomment-4637393409.
- First review found two P1 issues: lifecycle warning stdout contamination under `--select`, and malformed selector grammar rejected only after handler execution.
- Worker fix recorded in https://github.com/ScottArbeit/Grace/pull/301#issuecomment-4637422203 at commit `2e9b41a459685d384ae066034ae1559a21abfc08`.
- Fix summary: `--select` suppresses lifecycle warnings like JSON output; malformed selector grammar is prevalidated before invocation; future-only select commands return explicit JSON unsupported errors before invocation.
- Final review-only subagent pass recorded in https://github.com/ScottArbeit/Grace/pull/301#issuecomment-4637469235.
- Final review found no issues and recommended merge.
- Reviewed And OK: lifecycle-warning suppression, pre-invocation selector validation, future-only unsupported preflight, narrow grammar, ReturnValue-only projection, JSON error behavior, unprojected command errors, and CLI/test-only diff scope.