### PR TITLE
Migrate local CLI JSON outputs to envelopes

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,15 +45,15 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 163
+        |> should equal 175
 
         countBy HumanProgressOnlySuccess
         |> should equal 16
 
-        countBy PartialManualSuccess |> should equal 6
-        countBy ManualJsonUnenveloped |> should equal 5
+        countBy PartialManualSuccess |> should equal 0
+        countBy ManualJsonUnenveloped |> should equal 0
         countBy HumanProcOnly |> should equal 1
-        countBy HumanOnly |> should equal 1
+        countBy HumanOnly |> should equal 0
         countBy UnroutedSourceOnly |> should equal 9
 
     [<Test>]
@@ -124,16 +124,16 @@ module CommandOutputContractRegistryTests =
             |> List.map (fun entry -> entry.CurrentJsonBehavior)
             |> Set.ofList
 
-        behaviors.Contains HumanOnly |> should equal true
+        behaviors.Contains HumanOnly |> should equal false
 
         behaviors.Contains HumanProgressOnlySuccess
         |> should equal true
 
         behaviors.Contains ManualJsonUnenveloped
-        |> should equal true
+        |> should equal false
 
         behaviors.Contains PartialManualSuccess
-        |> should equal true
+        |> should equal false
 
         behaviors.Contains HumanProcOnly
         |> should equal true
@@ -147,13 +147,13 @@ module CommandOutputContractRegistryTests =
             entry.Identity.CommandId |> should equal "connect"
 
             entry.CurrentJsonBehavior
-            |> should equal PartialManualSuccess
+            |> should equal CommonRenderOutputEnvelope
 
             entry.EnvelopeContract
-            |> should equal (MigrationRequiredToGraceResultEnvelope RequiresCliDto)
+            |> should equal (ExistingGraceResultEnvelope RequiresCliDto)
 
             entry.Features.JsonMode
-            |> should equal RequiresMigration
+            |> should equal ExistingBehavior
 
             entry.Features.Schema
             |> should equal FutureInertIntrospection
@@ -162,7 +162,7 @@ module CommandOutputContractRegistryTests =
             |> should equal FutureInertIntrospection
 
             entry.Features.Select
-            |> should equal FutureReturnValueProjection
+            |> should equal ExistingBehavior
         | None -> Assert.Fail("connect should have a registry entry.")
 
     [<Test>]
@@ -171,11 +171,12 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 163
+        commonEntries.Length |> should equal 175
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
-            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
+            | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
+            | RequiresCliDto) -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
             entry.Features.Select
@@ -272,7 +273,7 @@ module CommandOutputContractRegistryTests =
                 schema.Notes
                 |> should
                     contain
-                    "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+                    "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
             | None -> Assert.Fail("Metadata-incomplete schema introspection should include a schema document.")
 
             let examplesDocument = CommandOutputContract.introspectionDocument Examples entry

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -170,6 +170,17 @@ module HelpDoesNotReadConfigTests =
 
         rootElement.Clone()
 
+    let private assertGraceErrorEnvelopeOnCleanStreams (standardOut: string) (standardError: string) =
+        standardError |> should equal String.Empty
+        let error = assertJsonErrorOutput standardOut
+
+        standardOut
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        error
+
     let private withFileBackup (path: string) (action: unit -> unit) =
         let directory = Path.GetDirectoryName(path)
 
@@ -245,6 +256,14 @@ module HelpDoesNotReadConfigTests =
         config.BranchId <- branchId
         let json = serialize config
         File.WriteAllText(Path.Combine(graceDir, "graceconfig.json"), json)
+
+    let private writeValidConfigWithDeterministicIds (root: string) =
+        writeValidConfig
+            root
+            (Guid.Parse("11111111-1111-1111-1111-111111111111"))
+            (Guid.Parse("22222222-2222-2222-2222-222222222222"))
+            (Guid.Parse("33333333-3333-3333-3333-333333333333"))
+            (Guid.Parse("44444444-4444-4444-4444-444444444444"))
 
     let private addLifecycleHeaders
         (response: HttpResponseMessage)
@@ -707,6 +726,172 @@ module HelpDoesNotReadConfigTests =
 
                 deleteExitCode |> should equal 0
                 assertGraceEnvelope deleteOutput |> ignore))
+
+    [<Test>]
+    let ``connect json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "connect"
+                                                  "owner/repository"
+                                                  "--owner-name"
+                                                  "owner" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "Repository shortcut must be in the form")
+
+    [<Test>]
+    let ``directory version get zip file json validation error emits clean Grace envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "directory-version"
+                                                  "get-zip-file"
+                                                  "--directory-version-id"
+                                                  $"{Guid.Empty}" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "graceconfig.json")
+
+    [<Test>]
+    let ``repository init json invalid directory emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+            let missingDirectory = Path.Combine(root, "missing")
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--directory"
+                                                  missingDirectory |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "directory")
+
+    [<Test>]
+    let ``repository init no output DTO renders absent observability as null`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "--output"
+                    "Json"
+                    "repository"
+                    "init"
+                    "--no-output"
+                |]
+            )
+
+        let output: Common.LocalOutputDto.RepositoryInitDto =
+            { Message = "Initialized repository."; DirectoryCount = None; FileCount = None; TotalFileSize = None; RootSha256Hash = None }
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create output "corr-repository-init"))
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        let rootElement = assertGraceEnvelope standardOut
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Message").GetString()
+        |> should equal "Initialized repository."
+
+        returnValue
+            .GetProperty(
+                "DirectoryCount"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue.GetProperty("FileCount").ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue.GetProperty("TotalFileSize").ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue
+            .GetProperty(
+                "RootSha256Hash"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Null
+
+    [<Test>]
+    let ``review report show json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "review"
+                                                  "report"
+                                                  "show"
+                                                  "--candidate"
+                                                  "not-a-guid" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "CandidateId must be a valid non-empty Guid")
+
+    [<Test>]
+    let ``review report export json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "review"
+                                                  "report"
+                                                  "export"
+                                                  "--candidate"
+                                                  "not-a-guid"
+                                                  "--format"
+                                                  "markdown"
+                                                  "--output-file"
+                                                  "report.md" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "CandidateId must be a valid non-empty Guid")
+
+    [<Test>]
+    let ``workitem attachments download json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "workitem"
+                                                  "attachments"
+                                                  "download"
+                                                  "not-a-work-item"
+                                                  "--artifact-id"
+                                                  $"{Guid.Empty}"
+                                                  "--output-file"
+                                                  "attachment.bin" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "work item ID is invalid")
 
     [<Test>]
     let ``select option makes command json-oriented`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -651,6 +651,25 @@ module HelpDoesNotReadConfigTests =
         |> should be (greaterThanOrEqualTo 0)
 
     [<Test>]
+    let ``history show json select failure returns nonzero error envelope`` () =
+        let exitCode, standardOut, standardError =
+            runWithCapturedStdoutAndStderr [| "--output"
+                                              "Json"
+                                              "history"
+                                              "show"
+                                              "--limit"
+                                              "0"
+                                              "--select"
+                                              "NonExistent" |]
+
+        exitCode |> should equal -1
+
+        let error = assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+
+        error
+        |> should contain "--select path 'NonExistent' was not found"
+
+    [<Test>]
     let ``history search json emits Grace envelope`` () =
         let exitCode, output =
             runWithCapturedOutput [| "--output"
@@ -670,6 +689,26 @@ module HelpDoesNotReadConfigTests =
         )
             .ValueKind
         |> should equal JsonValueKind.Array
+
+    [<Test>]
+    let ``history search json select failure returns nonzero error envelope`` () =
+        let exitCode, standardOut, standardError =
+            runWithCapturedStdoutAndStderr [| "--output"
+                                              "Json"
+                                              "history"
+                                              "search"
+                                              "workitem"
+                                              "--limit"
+                                              "0"
+                                              "--select"
+                                              "NonExistent" |]
+
+        exitCode |> should equal -1
+
+        let error = assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+
+        error
+        |> should contain "--select path 'NonExistent' was not found"
 
     [<Test>]
     let ``history validation error json emits Grace error envelope`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,8 +74,10 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Command
 open Grace.SDK
 open Grace.Shared
+open Grace.Shared.Client
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
 open Grace.Types.Common
@@ -149,6 +151,44 @@ module HelpDoesNotReadConfigTests =
         standardOut |> should not' (contain "Elapsed:")
 
         error
+
+    let private assertGraceEnvelope (output: string) =
+        use document = parseJsonOutput output
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("ReturnValue").ValueKind
+        |> should equal JsonValueKind.Object
+
+        rootElement.GetProperty("EventTime").ValueKind
+        |> should equal JsonValueKind.String
+
+        rootElement.GetProperty("CorrelationId").ValueKind
+        |> should equal JsonValueKind.String
+
+        rootElement.GetProperty("Properties").ValueKind
+        |> should equal JsonValueKind.Array
+
+        rootElement.Clone()
+
+    let private withFileBackup (path: string) (action: unit -> unit) =
+        let directory = Path.GetDirectoryName(path)
+
+        if not (String.IsNullOrWhiteSpace(directory)) then
+            Directory.CreateDirectory(directory) |> ignore
+
+        let backupPath = Path.Combine(Path.GetTempPath(), $"grace-cli-test-backup-{Guid.NewGuid():N}")
+        let existed = File.Exists(path)
+
+        if existed then File.Copy(path, backupPath, true)
+
+        try
+            action ()
+        finally
+            if existed then
+                File.Copy(backupPath, path, true)
+                File.Delete(backupPath)
+            elif File.Exists(path) then
+                File.Delete(path)
 
     let private captureStdoutAndStderr (action: unit -> unit) =
         use standardOutWriter = new StringWriter()
@@ -339,7 +379,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Registry")
                 .GetProperty("CurrentJsonBehavior")
                 .GetString()
-            |> should equal "PartialManualSuccess"
+            |> should equal "CommonRenderOutputEnvelope"
 
             rootElement
                 .GetProperty("Schema")
@@ -550,6 +590,125 @@ module HelpDoesNotReadConfigTests =
         standardOut |> should not' (contain "Elapsed:")
 
     [<Test>]
+    let ``alias list json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "alias"
+                                     "list" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Count").GetInt32()
+        |> should be (greaterThan 0)
+
+        returnValue.GetProperty("Aliases").ValueKind
+        |> should equal JsonValueKind.Array
+
+        output |> should not' (contain "Grace command")
+
+    [<Test>]
+    let ``history show json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "show"
+                                     "--limit"
+                                     "0" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Entries").ValueKind
+        |> should equal JsonValueKind.Array
+
+        returnValue.GetProperty("Count").GetInt32()
+        |> should be (greaterThanOrEqualTo 0)
+
+    [<Test>]
+    let ``history search json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "search"
+                                     "workitem"
+                                     "--limit"
+                                     "0" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+
+        rootElement.GetProperty("ReturnValue").GetProperty(
+            "Entries"
+        )
+            .ValueKind
+        |> should equal JsonValueKind.Array
+
+    [<Test>]
+    let ``history validation error json emits Grace error envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "show"
+                                     "--limit"
+                                     "-1" |]
+
+        exitCode |> should equal -1
+
+        use document = parseJsonOutput output
+
+        document
+            .RootElement
+            .GetProperty("Error")
+            .GetString()
+        |> should equal "Limit must be positive."
+
+    [<Test>]
+    let ``history on off and delete json emit Grace envelopes`` () =
+        let userConfigPath = UserConfiguration.getUserConfigurationPath ()
+        let historyPath = HistoryStorage.getHistoryFilePath ()
+
+        withFileBackup userConfigPath (fun () ->
+            withFileBackup historyPath (fun () ->
+                let onExitCode, onOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "on" |]
+
+                onExitCode |> should equal 0
+                assertGraceEnvelope onOutput |> ignore
+
+                let offExitCode, offOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "off" |]
+
+                offExitCode |> should equal 0
+                assertGraceEnvelope offOutput |> ignore
+
+                File.WriteAllText(historyPath, String.Empty)
+
+                let deleteExitCode, deleteOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "delete" |]
+
+                deleteExitCode |> should equal 0
+                assertGraceEnvelope deleteOutput |> ignore))
+
+    [<Test>]
     let ``select option makes command json-oriented`` () =
         let parseResult =
             GraceCommand.rootCommand.Parse(
@@ -737,7 +896,8 @@ module HelpDoesNotReadConfigTests =
     let ``valid select on unsupported command is json error without invoking command`` () =
         withTempDir (fun root ->
             let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "connect"
+                runWithCapturedStdoutAndStderr [| "history"
+                                                  "run"
                                                   "--select"
                                                   "Value" |]
 

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -35,6 +35,52 @@ module Common =
         member val public Json: bool = false with get, set
         member val public OutputFormat: string = String.Empty with get, set
 
+    module LocalOutputDto =
+        type AliasListItemDto = { Alias: string; CommandPath: string array; Command: string }
+
+        type AliasListDto = { Aliases: AliasListItemDto array; Count: int }
+
+        type HistoryEntryDto =
+            {
+                Id: Guid
+                TimestampUtc: NodaTime.Instant
+                CommandLine: string
+                Cwd: string
+                RepoRoot: string option
+                RepoName: string option
+                RepoBranch: string option
+                GraceVersion: string
+                ExitCode: int
+                DurationMs: int64
+                ParseSucceeded: bool
+                Source: string option
+                RedactionCount: int
+            }
+
+        type HistoryEntriesDto = { Entries: HistoryEntryDto array; Count: int; CorruptCount: int }
+
+        type HistoryRecordingDto = { Enabled: bool }
+
+        type HistoryDeleteDto = { Deleted: bool; Removed: int }
+
+        type RepositoryInitDto = { Message: string; DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string }
+
+        type ConnectDto =
+            {
+                OwnerId: Guid
+                OwnerName: string
+                OrganizationId: Guid
+                OrganizationName: string
+                RepositoryId: Guid
+                RepositoryName: string
+                BranchId: Guid
+                BranchName: string
+                DefaultBranchName: string
+                RetrievedDefaultBranch: bool
+            }
+
+        type ReviewReportExportDto = { CandidateId: string; Format: string; OutputFile: string; BytesWritten: int64 }
+
     /// The output format for the command.
     type OutputFormat =
         | Normal

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -63,7 +63,14 @@ module Common =
 
         type HistoryDeleteDto = { Deleted: bool; Removed: int }
 
-        type RepositoryInitDto = { Message: string; DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string }
+        type RepositoryInitDto =
+            {
+                Message: string
+                DirectoryCount: int option
+                FileCount: int option
+                TotalFileSize: int64 option
+                RootSha256Hash: string option
+            }
 
         type ConnectDto =
             {

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -579,6 +579,34 @@ module Connect =
 
         lookup
 
+    let private writeHumanLine (parseResult: ParseResult) text =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            AnsiConsole.MarkupLine text
+
+    let private toConnectDto
+        (ownerDto: OwnerDto)
+        (organizationDto: OrganizationDto)
+        (repositoryDto: RepositoryDto)
+        (branchDto: BranchDto)
+        (retrievedDefaultBranch: bool)
+        : LocalOutputDto.ConnectDto
+        =
+        {
+            OwnerId = ownerDto.OwnerId
+            OwnerName = ownerDto.OwnerName
+            OrganizationId = organizationDto.OrganizationId
+            OrganizationName = organizationDto.OrganizationName
+            RepositoryId = repositoryDto.RepositoryId
+            RepositoryName = repositoryDto.RepositoryName
+            BranchId = branchDto.BranchId
+            BranchName = branchDto.BranchName
+            DefaultBranchName = repositoryDto.DefaultBranchName
+            RetrievedDefaultBranch = retrievedDefaultBranch
+        }
+
     let private extractZipEntries
         (parseResult: ParseResult)
         (fileVersionsByRelativePath: Dictionary<RelativePath, FileVersion>)
@@ -588,8 +616,8 @@ module Connect =
         use zipFile = zipFile
         use zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Read)
 
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Streaming contents from .zip file.[/]"
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Starting to write files to disk.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Streaming contents from .zip file.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Starting to write files to disk.[/]"
 
         let additionalEntries = ResizeArray<string>()
 
@@ -636,14 +664,14 @@ module Connect =
                         if writeObjectFile then uncompressAndWriteToFile entry objectFileInfo
 
                     if parseResult |> verbose then
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Wrote {fileVersion.RelativePath}.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Wrote {fileVersion.RelativePath}.[/]"
                 | false, _ -> additionalEntries.Add(entry.FullName))
 
         if additionalEntries.Count > 0
            && (parseResult |> verbose) then
-            AnsiConsole.MarkupLine $"[{Colors.Deemphasized}]Zip contained {additionalEntries.Count} additional entry(ies). Ignored.[/]"
+            writeHumanLine parseResult $"[{Colors.Deemphasized}]Zip contained {additionalEntries.Count} additional entry(ies). Ignored.[/]"
 
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Finished writing files to disk.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Finished writing files to disk.[/]"
 
     let private retrieveDefaultBranchAndWrite
         (parseResult: ParseResult)
@@ -668,7 +696,7 @@ module Connect =
                         CorrelationId = graceIds.CorrelationId
                     )
 
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieving all DirectoryVersions.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Retrieving all DirectoryVersions.[/]"
 
                 let! directoryVersionsResult = DirectoryVersion.GetDirectoryVersionsRecursive(getDirectoryContentsParameters)
 
@@ -681,13 +709,13 @@ module Connect =
                         CorrelationId = graceIds.CorrelationId
                     )
 
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieving zip file download uri.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Retrieving zip file download uri.[/]"
                 let! getZipFileResult = DirectoryVersion.GetZipFile(getZipFileParameters)
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Finished getting zip file download uri.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Finished getting zip file download uri.[/]"
 
                 match (directoryVersionsResult, getZipFileResult) with
                 | (Ok directoryVerionsReturnValue, Ok getZipFileReturnValue) ->
-                    AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieved all DirectoryVersions.[/]"
+                    writeHumanLine parseResult $"[{Colors.Important}]Retrieved all DirectoryVersions.[/]"
 
                     let directoryVersionDtos = directoryVerionsReturnValue.ReturnValue
 
@@ -702,12 +730,12 @@ module Connect =
                     let! conflicts, filesToSkip = collectFileConflicts fileVersions force
 
                     if conflicts.Count > 0 then
-                        AnsiConsole.MarkupLine $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
+                        writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
 
                         if parseResult |> verbose then
                             conflicts
                             |> Seq.sort
-                            |> Seq.iter (fun conflict -> AnsiConsole.MarkupLine $"[{Colors.Error}]{conflict}[/]")
+                            |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
 
                         return
                             (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
@@ -723,12 +751,12 @@ module Connect =
                         let! zipFile = blobClient.OpenReadAsync(bufferSize = 64 * 1024)
                         extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
 
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Creating Grace Index file.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
                         let! previousGraceStatus = readGraceStatusFile ()
                         let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
                         do! writeGraceStatusFile graceStatus
 
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
                         do! upsertObjectCache graceStatus.Index.Values
                         return 0
                 | (Error error, _) -> return (Error error |> renderOutput parseResult)
@@ -760,13 +788,13 @@ module Connect =
 
                         match ownerOrgRepoResult with
                         | Ok (ownerDto, organizationDto, repositoryDto) ->
-                            AnsiConsole.MarkupLine $"[{Colors.Important}]Found owner, organization, and repository.[/]"
+                            writeHumanLine parseResult $"[{Colors.Important}]Found owner, organization, and repository.[/]"
 
                             let! branchResult = getBranchForConnect parseResult graceIds ownerDto organizationDto repositoryDto
 
                             match branchResult with
                             | Ok branchDto ->
-                                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieved branch {branchDto.BranchName}.[/]"
+                                writeHumanLine parseResult $"[{Colors.Important}]Retrieved branch {branchDto.BranchName}.[/]"
                                 // Write the new configuration to the config file.
                                 let newConfig = Current()
                                 newConfig.OwnerId <- ownerDto.OwnerId
@@ -781,14 +809,29 @@ module Connect =
                                 newConfig.ObjectStorageProvider <- repositoryDto.ObjectStorageProvider
                                 updateConfiguration newConfig
                                 reloadConfiguration ()
-                                AnsiConsole.MarkupLine $"[{Colors.Important}]Wrote new Grace configuration file.[/]"
+                                writeHumanLine parseResult $"[{Colors.Important}]Wrote new Grace configuration file.[/]"
 
                                 let retrieveDefaultBranch = parseResult.GetValue(Options.retrieveDefaultBranch)
 
                                 if retrieveDefaultBranch then
-                                    return! retrieveDefaultBranchAndWrite parseResult graceIds ownerDto organizationDto repositoryDto branchDto
+                                    let! retrieveExitCode = retrieveDefaultBranchAndWrite parseResult graceIds ownerDto organizationDto repositoryDto branchDto
+
+                                    if retrieveExitCode = 0 then
+                                        let output = toConnectDto ownerDto organizationDto repositoryDto branchDto true
+
+                                        return
+                                            GraceReturnValue.Create output (getCorrelationId parseResult)
+                                            |> Ok
+                                            |> renderOutput parseResult
+                                    else
+                                        return retrieveExitCode
                                 else
-                                    return 0
+                                    let output = toConnectDto ownerDto organizationDto repositoryDto branchDto false
+
+                                    return
+                                        GraceReturnValue.Create output (getCorrelationId parseResult)
+                                        |> Ok
+                                        |> renderOutput parseResult
                             | Error error -> return (Error error |> renderOutput parseResult)
                         | Error error -> return (Error error |> renderOutput parseResult)
         }

--- a/src/Grace.CLI/Command/History.CLI.fs
+++ b/src/Grace.CLI/Command/History.CLI.fs
@@ -6,6 +6,7 @@ open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Client
 open Grace.Shared.Utilities
+open Grace.Types.Common
 open NodaTime
 open Spectre.Console
 open System
@@ -309,10 +310,39 @@ module History =
 
         AnsiConsole.Write(table)
 
+    let private toHistoryEntryDto (entry: HistoryStorage.HistoryEntry) : LocalOutputDto.HistoryEntryDto =
+        {
+            Id = entry.id
+            TimestampUtc = entry.timestampUtc
+            CommandLine = entry.commandLine
+            Cwd = entry.cwd
+            RepoRoot = entry.repoRoot
+            RepoName = entry.repoName
+            RepoBranch = entry.repoBranch
+            GraceVersion = entry.graceVersion
+            ExitCode = entry.exitCode
+            DurationMs = entry.durationMs
+            ParseSucceeded = entry.parseSucceeded
+            Source = entry.source
+            RedactionCount = entry.redactions.Length
+        }
+
     let private outputEntries (parseResult: ParseResult) (entries: HistoryStorage.HistoryEntry list) (showId: bool) (corruptCount: int) =
         if parseResult |> json then
-            let payload = serialize entries
-            AnsiConsole.WriteLine(Markup.Escape(payload))
+            let dto: LocalOutputDto.HistoryEntriesDto =
+                {
+                    Entries =
+                        entries
+                        |> List.map toHistoryEntryDto
+                        |> List.toArray
+                    Count = entries.Length
+                    CorruptCount = corruptCount
+                }
+
+            GraceReturnValue.Create dto (getCorrelationId parseResult)
+            |> Ok
+            |> renderOutput parseResult
+            |> ignore
         elif parseResult |> silent then
             ()
         else
@@ -341,18 +371,22 @@ module History =
                 match UserConfiguration.saveUserConfiguration configuration with
                 | Ok _ ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| enabled = true |}))
+                        let dto: LocalOutputDto.HistoryRecordingDto = { Enabled = true }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History recording enabled.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     type HistoryOff() =
@@ -374,18 +408,22 @@ module History =
                 match UserConfiguration.saveUserConfiguration configuration with
                 | Ok _ ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| enabled = false |}))
+                        let dto: LocalOutputDto.HistoryRecordingDto = { Enabled = false }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History recording disabled.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     type HistoryShow() =
@@ -403,8 +441,10 @@ module History =
                 let showId = parseResult.GetValue(Options.showId)
 
                 if limit < 0 then
-                    AnsiConsole.MarkupLine("[red]Limit must be positive.[/]")
-                    return -1
+                    return
+                        GraceError.Create "Limit must be positive." (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
                 else
                     let sinceDuration =
                         if String.IsNullOrWhiteSpace(sinceText) then
@@ -416,8 +456,10 @@ module History =
 
                     match sinceDuration with
                     | Error error ->
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-                        return -1
+                        return
+                            GraceError.Create error (getCorrelationId parseResult)
+                            |> Error
+                            |> renderOutput parseResult
                     | Ok since ->
                         let readResult = HistoryStorage.readHistoryEntries ()
 
@@ -451,8 +493,10 @@ module History =
                 let showId = parseResult.GetValue(Options.showId)
 
                 if limit < 0 then
-                    AnsiConsole.MarkupLine("[red]Limit must be positive.[/]")
-                    return -1
+                    return
+                        GraceError.Create "Limit must be positive." (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
                 else
                     let sinceDuration =
                         if String.IsNullOrWhiteSpace(sinceText) then
@@ -464,8 +508,10 @@ module History =
 
                     match sinceDuration with
                     | Error error ->
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-                        return -1
+                        return
+                            GraceError.Create error (getCorrelationId parseResult)
+                            |> Error
+                            |> renderOutput parseResult
                     | Ok since ->
                         let readResult = HistoryStorage.readHistoryEntries ()
 
@@ -718,18 +764,22 @@ module History =
                 match HistoryStorage.clearHistory () with
                 | Ok removed ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| deleted = true; removed = removed |}))
+                        let dto: LocalOutputDto.HistoryDeleteDto = { Deleted = true; Removed = removed }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History cleared.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     let Build =

--- a/src/Grace.CLI/Command/History.CLI.fs
+++ b/src/Grace.CLI/Command/History.CLI.fs
@@ -342,15 +342,15 @@ module History =
             GraceReturnValue.Create dto (getCorrelationId parseResult)
             |> Ok
             |> renderOutput parseResult
-            |> ignore
         elif parseResult |> silent then
-            ()
+            0
         else
             if corruptCount > 0 then
                 AnsiConsole.MarkupLine($"[yellow]Skipped {corruptCount} corrupt history entries.[/]")
 
             renderTable entries showId
             AnsiConsole.WriteLine()
+            0
 
     type HistoryOn() =
         inherit AsynchronousCommandLineAction()
@@ -474,8 +474,7 @@ module History =
                                 (if String.IsNullOrWhiteSpace(containsText) then None else Some containsText)
                                 (if String.IsNullOrWhiteSpace(sourceText) then None else Some sourceText)
 
-                        outputEntries parseResult filtered showId readResult.CorruptCount
-                        return 0
+                        return outputEntries parseResult filtered showId readResult.CorruptCount
             }
 
     type HistorySearch() =
@@ -526,8 +525,7 @@ module History =
                                 (if String.IsNullOrWhiteSpace(searchText) then None else Some searchText)
                                 (if String.IsNullOrWhiteSpace(sourceText) then None else Some sourceText)
 
-                        outputEntries parseResult filtered showId readResult.CorruptCount
-                        return 0
+                        return outputEntries parseResult filtered showId readResult.CorruptCount
             }
 
     let private parseReplacements (values: string array) =

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -711,10 +711,28 @@ module Repository =
 
                                     AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(0, 8)}[/]"
 
-                                    return Ok(GraceReturnValue.Create "Initialized repository." (parseResult |> getCorrelationId))
+                                    let output: LocalOutputDto.RepositoryInitDto =
+                                        {
+                                            Message = "Initialized repository."
+                                            DirectoryCount = graceStatus.Index.Count
+                                            FileCount = fileCount
+                                            TotalFileSize = totalFileSize
+                                            RootSha256Hash = rootDirectoryVersion.Sha256Hash
+                                        }
+
+                                    return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
                                 else
                                     // Do the whole thing with no output
-                                    return Ok(GraceReturnValue.Create "Initialized repository." (parseResult |> getCorrelationId))
+                                    let output: LocalOutputDto.RepositoryInitDto =
+                                        {
+                                            Message = "Initialized repository."
+                                            DirectoryCount = 0
+                                            FileCount = 0
+                                            TotalFileSize = 0L
+                                            RootSha256Hash = String.Empty
+                                        }
+
+                                    return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
                             else
                                 return
                                     Error(GraceError.Create (RepositoryError.getErrorMessage RepositoryIsAlreadyInitialized) (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -714,10 +714,10 @@ module Repository =
                                     let output: LocalOutputDto.RepositoryInitDto =
                                         {
                                             Message = "Initialized repository."
-                                            DirectoryCount = graceStatus.Index.Count
-                                            FileCount = fileCount
-                                            TotalFileSize = totalFileSize
-                                            RootSha256Hash = rootDirectoryVersion.Sha256Hash
+                                            DirectoryCount = Some graceStatus.Index.Count
+                                            FileCount = Some fileCount
+                                            TotalFileSize = Some totalFileSize
+                                            RootSha256Hash = Some rootDirectoryVersion.Sha256Hash
                                         }
 
                                     return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
@@ -726,10 +726,10 @@ module Repository =
                                     let output: LocalOutputDto.RepositoryInitDto =
                                         {
                                             Message = "Initialized repository."
-                                            DirectoryCount = 0
-                                            FileCount = 0
-                                            TotalFileSize = 0L
-                                            RootSha256Hash = String.Empty
+                                            DirectoryCount = None
+                                            FileCount = None
+                                            TotalFileSize = None
+                                            RootSha256Hash = None
                                         }
 
                                     return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Review.CLI.fs
+++ b/src/Grace.CLI/Command/Review.CLI.fs
@@ -692,7 +692,20 @@ module ReviewCommand =
 
                                     AnsiConsole.MarkupLine($"[green]Review report exported ({formatText}) to[/] {Markup.Escape(outputFile)}")
 
-                                return Ok returnValue
+                                let formatText =
+                                    match reportFormat with
+                                    | Markdown -> "markdown"
+                                    | Json -> "json"
+
+                                let output: LocalOutputDto.ReviewReportExportDto =
+                                    {
+                                        CandidateId = candidateId
+                                        Format = formatText
+                                        OutputFile = outputFile
+                                        BytesWritten = int64 (Encoding.UTF8.GetByteCount(content))
+                                    }
+
+                                return Ok(GraceReturnValue.Create output (getCorrelationId parseResult))
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -528,7 +528,7 @@ module CommandOutputContract =
             row [ "agent"; "work" ] "start" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
             row [ "agent"; "work" ] "status" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
             row [ "agent"; "work" ] "stop" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
-            row [ "alias" ] "list" true false human_only help_introspection local_client RequiresCliDto
+            row [ "alias" ] "list" true false common_renderOutput_envelope help_introspection local_client RequiresCliDto
             row [ "approval"; "policy" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "policy" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "policy" ] "disable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
@@ -593,7 +593,7 @@ module CommandOutputContract =
             row [ "candidate" ] "required-actions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "retry" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "config" ] "write" true false common_renderOutput_envelope read_or_mutating_verify local_client ReuseExistingApiOrSdkDto
-            row [] "connect" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [] "connect" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "checkpoint" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "commit" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "directoryid" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
@@ -601,13 +601,13 @@ module CommandOutputContract =
             row [ "diff" ] "save" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "sha" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "tag" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
-            row [ "directory-version" ] "get-zip-file" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
-            row [ "history" ] "delete" true true manual_json_unenveloped mutating local_client RequiresCliDto
-            row [ "history" ] "off" true true manual_json_unenveloped mutating local_client RequiresCliDto
-            row [ "history" ] "on" true true manual_json_unenveloped mutating local_client RequiresCliDto
+            row [ "directory-version" ] "get-zip-file" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
+            row [ "history" ] "delete" true true common_renderOutput_envelope mutating local_client RequiresCliDto
+            row [ "history" ] "off" true true common_renderOutput_envelope mutating local_client RequiresCliDto
+            row [ "history" ] "on" true true common_renderOutput_envelope mutating local_client RequiresCliDto
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
-            row [ "history" ] "search" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
-            row [ "history" ] "show" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
+            row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "check-ignore-entries" true false human_progress_only_success read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "list-contents" true false human_progress_only_success read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "scan" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
@@ -691,7 +691,7 @@ module CommandOutputContract =
             row [ "repository" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "repository" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "repository" ] "get-branches" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "repository" ] "init" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "repository" ] "init" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row
                 [ "repository" ]
                 "set-allows-large-files"
@@ -751,8 +751,8 @@ module CommandOutputContract =
             row [ "review" ] "deepen" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
             row [ "review" ] "inbox" true false common_renderOutput_envelope read_list_search verify ReuseExistingApiOrSdkDto
             row [ "review" ] "open" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [ "review"; "report" ] "export" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
-            row [ "review"; "report" ] "show" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
+            row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
+            row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
             row [] "watch" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
@@ -768,7 +768,7 @@ module CommandOutputContract =
             row [ "workitem"; "attach" ] "notes" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attach" ] "prompt" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attach" ] "summary" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem"; "attachments" ] "download" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "workitem"; "attachments" ] "download" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "workitem"; "attachments" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attachments" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -75,6 +75,22 @@ module GraceCommand =
         //aliases.Add("", [""; ""])
         aliases
 
+    let private getAliasListDto () =
+        let items: LocalOutputDto.AliasListItemDto array =
+            aliases
+            |> Seq.map (fun alias ->
+                let commandPath = alias.Value |> Seq.toArray
+                let command = String.Join(" ", commandPath)
+
+                let item: LocalOutputDto.AliasListItemDto = { Alias = $"grace {alias.Key}"; CommandPath = commandPath; Command = $"grace {command}" }
+
+                item)
+            |> Seq.sortBy (fun item -> item.Alias)
+            |> Seq.toArray
+
+        let dto: LocalOutputDto.AliasListDto = { Aliases = items; Count = items.Length }
+        dto
+
     /// The character sequences that Grace will recognize as a request for help.
     let helpOptions = [| "-h"; "/h"; "--help"; "-?"; "/?" |]
 
@@ -96,6 +112,19 @@ module GraceCommand =
             |> ignore)
 
         AnsiConsole.Write(table)
+
+    let private renderAliases (parseResult: ParseResult) =
+        if parseResult |> json then
+            let result =
+                GraceReturnValue.Create (getAliasListDto ()) (getCorrelationId parseResult)
+                |> Ok
+
+            renderOutput parseResult result
+        elif parseResult |> silent then
+            0
+        else
+            printAliases ()
+            0
 
     let internal tryGetTopLevelCommandFromArgs (args: string array) (isCaseInsensitive: bool) =
         if isNull args || args.Length = 0 then
@@ -799,7 +828,7 @@ module GraceCommand =
 
         let Alias = Command("alias", "Display aliases for Grace commands.")
         let ListAliases = Command("list", "Display aliases for Grace commands.")
-        ListAliases.SetAction(fun _ -> printAliases ())
+        ListAliases.SetAction(fun parseResult -> renderAliases parseResult)
         Alias.Subcommands.Add(ListAliases)
         rootCommand.Subcommands.Add(Alias)
         rootCommand
@@ -1289,6 +1318,7 @@ module GraceCommand =
                                 "history"
                                 "auth"
                                 "connect"
+                                "alias"
                             ]
 
                         let isAllowed =


### PR DESCRIPTION
## Summary

- Migrates local/ad hoc CLI JSON output backlog commands toward envelope-backed JSON contracts.
- Replaces manual raw JSON for history commands with typed DTOs through `renderOutput`.
- Adds explicit DTO output for alias, connect, repository init, and review report export behavior.
- Updates command output registry metadata and invocation tests for migrated local/ad hoc command families.

## Related Issue

Part of #274. Addresses #281.

Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for #281.

## Validation

Worker evidence:

- Targeted Fantomas ran on touched F# files before validation.
- Focused CLI build passed: `dotnet build --configuration Release C:\Source\Grace-gh-281\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`.
- Focused CLI tests passed `351/351`: `dotnet test --no-build --configuration Release C:\Source\Grace-gh-281\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`.
- Review-fix focused CLI tests passed `52/52`: `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --no-build --filter FullyQualifiedName~HelpDoesNotReadConfigTests`.
- `pwsh ./scripts/validate.ps1 -Fast` passed after the latest fix: CLI `353`, Server.Unit `440`, Types `65`, Authorization `37`.
- Hosted PR check: `full` passed.
- `git diff --check` passed.

## Review Status

- First fresh GPT-5.3-Codex High review-only pass recorded in https://github.com/ScottArbeit/Grace/pull/302#issuecomment-4637635912.
- First review found two issues: `repository init --no-output` placeholder JSON values and incomplete invocation-level JSON/stdout-cleanliness coverage.
- Fresh worker fix recorded in https://github.com/ScottArbeit/Grace/pull/302#issuecomment-4637678976 at commit `69001711eb09c38b2bfda04bd311a9bec57278f0`.
- Second fresh GPT-5.3-Codex High review-only pass recorded in https://github.com/ScottArbeit/Grace/pull/302#issuecomment-4637706047.
- Second review found one high issue: `history show` / `history search` did not propagate `renderOutput` exit code in JSON mode when `--select` projection failed.
- Fresh worker fix recorded in https://github.com/ScottArbeit/Grace/pull/302#issuecomment-4637745731 at commit `ac1bea23a4344a853082639ea31e359ba274e56c`.
- Final fresh GPT-5.3-Codex High review-only pass recorded in https://github.com/ScottArbeit/Grace/pull/302#issuecomment-4637777231.
- Final review found no blocking defects and recommended merge.
- Reviewed And OK: history select error exit-code propagation, alias/history/connect/review/workitem envelope routing, sensitive output constraints, `repository init --no-output` null observability behavior, and registry consistency.