### PR TITLE
Make maintenance and watch JSON output safe

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,10 +45,10 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 175
+        |> should equal 181
 
         countBy HumanProgressOnlySuccess
-        |> should equal 16
+        |> should equal 10
 
         countBy PartialManualSuccess |> should equal 0
         countBy ManualJsonUnenveloped |> should equal 0
@@ -171,7 +171,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 175
+        commonEntries.Length |> should equal 181
 
         for entry in commonEntries do
             match entry.EnvelopeContract with

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,7 +45,9 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 181
+        |> should equal 180
+
+        countBy ImmediateJsonErrorOnly |> should equal 1
 
         countBy HumanProgressOnlySuccess
         |> should equal 10
@@ -129,6 +131,9 @@ module CommandOutputContractRegistryTests =
         behaviors.Contains HumanProgressOnlySuccess
         |> should equal true
 
+        behaviors.Contains ImmediateJsonErrorOnly
+        |> should equal true
+
         behaviors.Contains ManualJsonUnenveloped
         |> should equal false
 
@@ -171,7 +176,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 180
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -181,6 +186,41 @@ module CommandOutputContractRegistryTests =
 
             entry.Features.Select
             |> should equal ExistingBehavior
+
+    [<Test>]
+    let ``watch json mode is registered as immediate error only`` () =
+        let identity = CommandOutputContract.commandIdentity [] "watch"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.CurrentJsonBehavior
+            |> should equal ImmediateJsonErrorOnly
+
+            match entry.EnvelopeContract with
+            | JsonModeErrorOnly reason ->
+                reason
+                |> should contain "short-circuited before command execution"
+            | other -> Assert.Fail($"Expected watch to be registered as JsonModeErrorOnly, got {other}.")
+
+            entry.Features.JsonMode
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal RequiresMigration
+
+            entry.ReturnValueContract.Status
+            |> should equal ContractUnsupported
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status |> should equal "unsupported"
+
+                schema.Envelope
+                |> should contain "GraceError only in JSON mode"
+            | None -> Assert.Fail("watch schema introspection should include the explicit unsupported schema document.")
+        | None -> Assert.Fail("watch should have a registry entry.")
 
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
@@ -253,6 +293,50 @@ module CommandOutputContractRegistryTests =
                 |> should equal "string"
             | None -> Assert.Fail("Schema introspection should include a schema document.")
         | None -> Assert.Fail("auth.logout should have a registry entry.")
+
+    [<Test>]
+    let ``maintenance registry entries expose schema ready local dto metadata`` () =
+        let cases =
+            [
+                CommandOutputContract.commandIdentity [ "maintenance" ] "check-ignore-entries", "MaintenanceIgnoreEntriesDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "list-contents", "MaintenanceListContentsDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "scan", "MaintenanceScanDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "stats", "MaintenanceStatsDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "update-index", "MaintenanceStatsDto"
+            ]
+
+        for identity, expectedContract in cases do
+            match CommandOutputContract.tryFind identity with
+            | Some entry ->
+                entry.ReturnValueContract.Status
+                |> should equal SchemaReady
+
+                let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+                match schemaDocument.Schema with
+                | Some schema ->
+                    schema.Status |> should equal "schema-ready"
+
+                    schema.ReturnValueContract
+                    |> should equal expectedContract
+
+                    use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                    let returnValueSchema =
+                        successSchema
+                            .RootElement
+                            .GetProperty("properties")
+                            .GetProperty("ReturnValue")
+
+                    returnValueSchema.GetProperty("title").GetString()
+                    |> should equal expectedContract
+                | None -> Assert.Fail($"Expected schema document for {identity.CommandId}.")
+
+                let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+                examplesDocument.Examples[0].Name
+                |> should equal "success-envelope-shape"
+            | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
 
     [<Test>]
     let ``metadata incomplete registry entries are explicit`` () =

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="WebhookApproval.CLI.Parsing.Tests.fs" />
     <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
+    <Compile Include="Maintenance.CLI.Tests.fs" />
     <Compile Include="CommandOutputContract.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -39,6 +39,7 @@ module MaintenanceCliTests =
         let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
         Directory.CreateDirectory(graceDir) |> ignore
         File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{}")
+        File.WriteAllText(Path.Combine(tempDir, "tracked.txt"), "tracked content")
 
         let originalDir = Environment.CurrentDirectory
 
@@ -57,21 +58,51 @@ module MaintenanceCliTests =
                 | _ -> ()
 
     let private parseJsonOutput (output: string) =
-        output
-            .TrimStart()
-            .StartsWith("{", StringComparison.Ordinal)
+        output.StartsWith("{", StringComparison.Ordinal)
         |> should equal true
 
         JsonDocument.Parse(output)
 
+    let private assertCleanJsonStdout (standardOut: string) =
+        standardOut |> should not' (contain "Elapsed:")
+
+        standardOut
+        |> should not' (contain "Reading Grace index file")
+
+        standardOut
+        |> should not' (contain "Scanning working directory")
+
+        standardOut
+        |> should not' (contain "All values taken from the local Grace status file")
+
+        standardOut
+        |> should not' (contain "Number of differences")
+
+        standardOut
+        |> should not' (contain "Number of directories")
+
+        parseJsonOutput standardOut
+
+    let private runJsonMaintenance args = runWithCapturedStdoutAndStderr (Array.append [| "--output"; "Json"; "maintenance" |] args)
+
+    let private createIndex () =
+        let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+        exitCode |> should equal 0
+        standardError |> should equal String.Empty
+        use document = assertCleanJsonStdout standardOut
+        let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+        returnValue
+            .GetProperty(
+                "DirectoryCount"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Number
+
     [<Test>]
     let ``maintenance check ignore entries json emits one clean envelope`` () =
         withTempRepo (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "maintenance"
-                                                  "check-ignore-entries" |]
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "check-ignore-entries" |]
 
             exitCode |> should equal 0
             standardError |> should equal String.Empty
@@ -79,9 +110,7 @@ module MaintenanceCliTests =
             standardOut
             |> should not' (contain "Directory ignore entries:")
 
-            standardOut |> should not' (contain "Elapsed:")
-
-            use document = parseJsonOutput standardOut
+            use document = assertCleanJsonStdout standardOut
             let root = document.RootElement
 
             root.GetProperty("ReturnValue").GetProperty(
@@ -97,4 +126,117 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Array
 
             root.GetProperty("Properties").ValueKind
+            |> should equal JsonValueKind.Array)
+
+    [<Test>]
+    let ``maintenance update-index json emits stats envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DirectoryCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("FileCount").ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("TotalFileSize").ValueKind
+            |> should equal JsonValueKind.Number)
+
+    [<Test>]
+    let ``maintenance scan json emits scan envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "scan" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DifferenceCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("Differences").ValueKind
+            |> should equal JsonValueKind.Array
+
+            returnValue
+                .GetProperty(
+                    "NewDirectoryVersionCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue
+                .GetProperty(
+                    "NewDirectoryVersions"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Array)
+
+    [<Test>]
+    let ``maintenance stats json emits stats envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "stats" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DirectoryCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("FileCount").ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue
+                .GetProperty(
+                    "RootSha256Hash"
+                )
+                .ValueKind
+            |> should not' (equal JsonValueKind.Undefined))
+
+    [<Test>]
+    let ``maintenance list contents json emits contents envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "list-contents" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue.GetProperty("Summary").GetProperty(
+                "DirectoryCount"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("Directories").ValueKind
             |> should equal JsonValueKind.Array)

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -1,0 +1,100 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.Shared
+open Grace.Shared.Client.Configuration
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+
+[<NonParallelizable>]
+module MaintenanceCliTests =
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
+    let private withTempRepo (action: string -> unit) =
+        let tempDir = Path.Combine(Path.GetTempPath(), $"grace-maintenance-cli-tests-{Guid.NewGuid():N}")
+        let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
+        Directory.CreateDirectory(graceDir) |> ignore
+        File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{}")
+
+        let originalDir = Environment.CurrentDirectory
+
+        try
+            Environment.CurrentDirectory <- tempDir
+            resetConfiguration ()
+            action tempDir
+        finally
+            resetConfiguration ()
+            Environment.CurrentDirectory <- originalDir
+
+            if Directory.Exists(tempDir) then
+                try
+                    Directory.Delete(tempDir, true)
+                with
+                | _ -> ()
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    [<Test>]
+    let ``maintenance check ignore entries json emits one clean envelope`` () =
+        withTempRepo (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "maintenance"
+                                                  "check-ignore-entries" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            standardOut
+            |> should not' (contain "Directory ignore entries:")
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement
+
+            root.GetProperty("ReturnValue").GetProperty(
+                "DirectoryEntries"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Array
+
+            root.GetProperty("ReturnValue").GetProperty(
+                "FileEntries"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Array
+
+            root.GetProperty("Properties").ValueKind
+            |> should equal JsonValueKind.Array)

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -153,6 +153,44 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Number)
 
     [<Test>]
+    let ``maintenance update-index json exception emits one clean error envelope`` () =
+        withTempRepo (fun root ->
+            let localStateDbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+            Directory.CreateDirectory(localStateDbPath)
+            |> ignore
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            standardOut
+            |> should not' (contain "Reading existing Grace index file")
+
+            standardOut
+            |> should not' (contain "Computing new Grace index file")
+
+            standardOut
+            |> should not' (contain "Writing new Grace index file")
+
+            standardOut
+            |> should not' (contain "Number of directories scanned")
+
+            use document = assertCleanJsonStdout standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Exception in UpdateIndex:"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
     let ``maintenance scan json emits scan envelope with clean stdout`` () =
         withTempRepo (fun _ ->
             createIndex ()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -9,6 +9,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text.Json
 
 [<NonParallelizable>]
 module WatchTests =
@@ -29,6 +30,23 @@ module WatchTests =
             exitCode, writer.ToString()
         finally
             Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
 
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
@@ -67,6 +85,14 @@ module WatchTests =
                 Constants.EnvironmentVariables.GraceServerUri
             ]
             action
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
 
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
@@ -137,3 +163,31 @@ module WatchTests =
 
                 output
                 |> should contain "Authentication is not configured."))
+
+    [<Test>]
+    let ``watch json auth failure emits one clean error envelope`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "watch" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                standardOut
+                |> should not' (contain "SignalR Hub connection state")
+
+                standardOut |> should not' (contain "Elapsed:")
+
+                use document = parseJsonOutput standardOut
+                let root = document.RootElement
+
+                root.GetProperty("Error").GetString()
+                |> should contain "watch is a continuous foreground workflow"
+
+                let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+                root.TryGetProperty("ReturnValue", &returnValue)
+                |> should equal false))

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -257,7 +257,7 @@ module WatchTests =
 
                 let exitCode, standardOut, standardError = runGraceProcessWithCapturedStdoutAndStderr root [| "--output"; "Json"; "watch" |]
 
-                exitCode |> should equal -1
+                Assert.That(exitCode, Is.EqualTo(-1).Or.EqualTo(255))
                 standardError |> should equal String.Empty
 
                 use document = parseJsonOutput standardOut

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5,9 +5,14 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
+open System.Diagnostics
 open System.IO
 open System.Text.Json
 
@@ -48,6 +53,41 @@ module WatchTests =
             Console.SetOut(originalOut)
             Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
+
+    let private runGraceProcessWithCapturedStdoutAndStderr workingDirectory (args: string array) =
+        let cliDllPath = Path.Combine(AppContext.BaseDirectory, "grace.dll")
+
+        File.Exists(cliDllPath) |> should equal true
+
+        let startInfo = ProcessStartInfo()
+        startInfo.FileName <- "dotnet"
+        startInfo.WorkingDirectory <- workingDirectory
+        startInfo.RedirectStandardOutput <- true
+        startInfo.RedirectStandardError <- true
+        startInfo.UseShellExecute <- false
+        startInfo.CreateNoWindow <- true
+        startInfo.ArgumentList.Add(cliDllPath)
+
+        for arg in args do
+            startInfo.ArgumentList.Add(arg)
+
+        use proc = new Process()
+        proc.StartInfo <- startInfo
+
+        if not (proc.Start()) then failwith "Failed to start grace process."
+
+        let standardOut = proc.StandardOutput.ReadToEnd()
+        let standardError = proc.StandardError.ReadToEnd()
+
+        if not (proc.WaitForExit(30000)) then
+            try
+                proc.Kill(true)
+            with
+            | _ -> ()
+
+            Assert.Fail("Timed out waiting for grace process to exit.")
+
+        proc.ExitCode, standardOut, standardError
 
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
         let original = Environment.GetEnvironmentVariable(name)
@@ -91,6 +131,25 @@ module WatchTests =
         |> should equal true
 
         JsonDocument.Parse(output)
+
+    let private writeLiveWatchStatusFile () =
+        let status: Services.GraceWatchStatus =
+            {
+                UpdatedAt = getCurrentInstant ()
+                RootDirectoryId = Guid.NewGuid()
+                RootDirectorySha256Hash = Sha256Hash "live-watch-root"
+                LastFileUploadInstant = Instant.MinValue
+                LastDirectoryVersionInstant = Instant.MinValue
+                DirectoryIds = HashSet<DirectoryVersionId>()
+            }
+
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, serialize status)
+        ipcFileName
 
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
@@ -189,3 +248,24 @@ module WatchTests =
 
                 root.TryGetProperty("ReturnValue", &returnValue)
                 |> should equal false))
+
+    [<Test>]
+    let ``watch json error in separate process does not delete live watch ipc file`` () =
+        withTempRepo (fun root ->
+            clearWatchAuthEnv (fun () ->
+                let ipcFileName = writeLiveWatchStatusFile ()
+
+                let exitCode, standardOut, standardError = runGraceProcessWithCapturedStdoutAndStderr root [| "--output"; "Json"; "watch" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+
+                document
+                    .RootElement
+                    .GetProperty("Error")
+                    .GetString()
+                |> should contain "watch is a continuous foreground workflow"
+
+                File.Exists(ipcFileName) |> should equal true))

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -87,9 +87,7 @@ module WatchTests =
             action
 
     let private parseJsonOutput (output: string) =
-        output
-            .TrimStart()
-            .StartsWith("{", StringComparison.Ordinal)
+        output.StartsWith("{", StringComparison.Ordinal)
         |> should equal true
 
         JsonDocument.Parse(output)

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -88,6 +88,38 @@ module Common =
 
         type ReviewReportExportDto = { CandidateId: string; Format: string; OutputFile: string; BytesWritten: int64 }
 
+        type MaintenanceStatsDto = { DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string option }
+
+        type MaintenanceListContentsFileDto = { RelativePath: string; FileName: string; Sha256Hash: string; Size: int64; LastWriteTimeUtc: DateTime }
+
+        type MaintenanceListContentsDirectoryDto =
+            {
+                RelativePath: string
+                DirectoryVersionId: Guid
+                Sha256Hash: string
+                Size: int64
+                LastWriteTimeUtc: DateTime
+                Files: MaintenanceListContentsFileDto array
+            }
+
+        type MaintenanceListContentsDto = { Summary: MaintenanceStatsDto; Directories: MaintenanceListContentsDirectoryDto array }
+
+        type MaintenanceIgnoreEntriesDto = { DirectoryEntries: string array; FileEntries: string array }
+
+        type MaintenanceScanDifferenceDto = { DifferenceType: string; FileSystemEntryType: string; RelativePath: string }
+
+        type MaintenanceScanDirectoryVersionDto = { DirectoryVersionId: Guid; RelativePath: string; Sha256Hash: string }
+
+        type MaintenanceScanDto =
+            {
+                DifferenceCount: int
+                Differences: MaintenanceScanDifferenceDto array
+                NewDirectoryVersionCount: int
+                NewDirectoryVersions: MaintenanceScanDirectoryVersionDto array
+            }
+
+        type WatchResultDto = { Started: bool; Completed: bool; Message: string; RootDirectory: string; ServerUri: string; RepositoryId: Guid; BranchId: Guid }
+
     /// The output format for the command.
     type OutputFormat =
         | Normal

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -627,7 +627,14 @@ module Maintenance =
 
             with
             | ex ->
-                logToAnsiConsole Colors.Error $"Exception in UpdateIndex: {ExceptionResponse.Create ex}"
+                let message = $"Exception in UpdateIndex: {ExceptionResponse.Create ex}"
+
+                if parseResult |> json then
+                    GraceError.Create message (getCorrelationId parseResult)
+                    |> writeJsonErrorStdout
+                else
+                    logToAnsiConsole Colors.Error message
+
                 return -1
         }
 

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -135,13 +135,104 @@ module Maintenance =
         | Some rootSha256Hash -> AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Root SHA-256 hash: {getShortHash rootSha256Hash}[/]")
         | None -> AnsiConsole.MarkupLine($"[{Colors.Error}]Root SHA-256 hash: unavailable (root directory entry missing).[/]")
 
+    let private toStatsDto (graceStatus: GraceStatus) : LocalOutputDto.MaintenanceStatsDto =
+        let directoryCount = graceStatus.Index.Count
+
+        let fileCount =
+            graceStatus
+                .Index
+                .Values
+                .Select(fun directoryVersion -> directoryVersion.Files.Count)
+                .Sum()
+
+        let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+
+        {
+            DirectoryCount = directoryCount
+            FileCount = fileCount
+            TotalFileSize = totalFileSize
+            RootSha256Hash =
+                tryGetRootSha256Hash graceStatus
+                |> Option.map string
+        }
+
+    let private toListContentsDto listDirectories listFiles (graceStatus: GraceStatus) : LocalOutputDto.MaintenanceListContentsDto =
+        let directories =
+            if listDirectories then
+                graceStatus.Index.Values
+                |> Seq.sortBy (fun directoryVersion -> directoryVersion.RelativePath)
+                |> Seq.map (fun directoryVersion ->
+                    let files =
+                        if listFiles then
+                            directoryVersion.Files
+                            |> Seq.sortBy (fun file -> file.RelativePath)
+                            |> Seq.map (fun file ->
+                                {
+                                    LocalOutputDto.MaintenanceListContentsFileDto.RelativePath = string file.RelativePath
+                                    FileName = file.FileInfo.Name
+                                    Sha256Hash = string file.Sha256Hash
+                                    Size = int64 file.Size
+                                    LastWriteTimeUtc = file.LastWriteTimeUtc
+                                }: LocalOutputDto.MaintenanceListContentsFileDto)
+                            |> Seq.toArray
+                        else
+                            Array.empty
+
+                    ({
+                         LocalOutputDto.MaintenanceListContentsDirectoryDto.RelativePath = string directoryVersion.RelativePath
+                         DirectoryVersionId = directoryVersion.DirectoryVersionId
+                         Sha256Hash = string directoryVersion.Sha256Hash
+                         Size = int64 directoryVersion.Size
+                         LastWriteTimeUtc = directoryVersion.LastWriteTimeUtc
+                         Files = files
+                     }: LocalOutputDto.MaintenanceListContentsDirectoryDto))
+                |> Seq.toArray
+            else
+                Array.empty
+
+        { Summary = toStatsDto graceStatus; Directories = directories }
+
+    let private toScanDto (differences: List<FileSystemDifference>) (newDirectoryVersions: List<LocalDirectoryVersion>) : LocalOutputDto.MaintenanceScanDto =
+        {
+            DifferenceCount = differences.Count
+            Differences =
+                differences
+                |> Seq.map (fun difference ->
+                    ({
+                         LocalOutputDto.MaintenanceScanDifferenceDto.DifferenceType = getDiscriminatedUnionCaseName difference.DifferenceType
+                         FileSystemEntryType = getDiscriminatedUnionCaseName difference.FileSystemEntryType
+                         RelativePath = string difference.RelativePath
+                     }: LocalOutputDto.MaintenanceScanDifferenceDto))
+                |> Seq.toArray
+            NewDirectoryVersionCount = newDirectoryVersions.Count
+            NewDirectoryVersions =
+                newDirectoryVersions
+                |> Seq.map (fun directoryVersion ->
+                    ({
+                         LocalOutputDto.MaintenanceScanDirectoryVersionDto.DirectoryVersionId = directoryVersion.DirectoryVersionId
+                         RelativePath = string directoryVersion.RelativePath
+                         Sha256Hash = string directoryVersion.Sha256Hash
+                     }: LocalOutputDto.MaintenanceScanDirectoryVersionDto))
+                |> Seq.toArray
+        }
+
+    let private renderLocalJson parseResult dto =
+        Ok(GraceReturnValue.Create dto (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
     let private updateIndexHandler (parseResult: ParseResult) =
         task {
             try
                 if parseResult |> verbose then printParseResult parseResult
                 let graceIds = parseResult |> getNormalizedIdsAndNames
 
-                if parseResult |> hasOutput then
+                if parseResult |> json then
+                    let! previousGraceStatus = readGraceStatusFile ()
+                    let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                    do! writeGraceStatusFile graceStatus
+                    do! upsertObjectCache graceStatus.Index.Values
+                    return renderLocalJson parseResult (toStatsDto graceStatus)
+                elif parseResult |> hasOutput then
                     let! graceStatus =
                         progress
                             .Columns(progressColumns)
@@ -581,17 +672,22 @@ module Maintenance =
                                     return (differences, newDirectoryVersions)
                                 })
 
-                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
+                    if parseResult |> json then
+                        return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
+                    else
+                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
 
-                    for difference in differences do
-                        let x = sprintf "%A" difference
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
+                        for difference in differences do
+                            let x = sprintf "%A" difference
+                            AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
 
-                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
+                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
 
-                    for ldv in newDirectoryVersions do
-                        AnsiConsole.MarkupLine
-                            $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+                        for ldv in newDirectoryVersions do
+                            AnsiConsole.MarkupLine
+                                $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+
+                        return 0
                 //AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(8)}[/]"
                 else
                     let! previousGraceStatus = readGraceStatusFile ()
@@ -611,7 +707,7 @@ module Maintenance =
                         AnsiConsole.MarkupLine
                             $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
 
-                return 0
+                    return 0
             }
 
     type Stats() =
@@ -622,25 +718,19 @@ module Maintenance =
                 if parseResult |> verbose then printParseResult parseResult
 
                 let! graceStatus = readGraceStatusFile ()
-                let directoryCount = graceStatus.Index.Count
+                let dto = toStatsDto graceStatus
 
-                let fileCount =
-                    graceStatus
-                        .Index
-                        .Values
-                        .Select(fun directoryVersion -> directoryVersion.Files.Count)
-                        .Sum()
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {dto.DirectoryCount}.[/]")
 
-                let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {dto.FileCount}; total file size: {dto.TotalFileSize:N0}.[/]")
 
-                AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
+                    writeRootShaSummary graceStatus
 
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
-
-                writeRootShaSummary graceStatus
-
-                return 0
+                    return 0
             }
 
     type ListContents() =
@@ -654,68 +744,66 @@ module Maintenance =
                 let listFiles = parseResult.GetValue(Options.listFiles)
 
                 let! graceStatus = readGraceStatusFile ()
-                let directoryCount = graceStatus.Index.Count
+                let dto = toListContentsDto listDirectories listFiles graceStatus
 
-                let fileCount =
-                    graceStatus
-                        .Index
-                        .Values
-                        .Select(fun directoryVersion -> directoryVersion.Files.Count)
-                        .Sum()
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    let directoryCount = dto.Summary.DirectoryCount
 
-                let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
 
-                AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
+                    AnsiConsole.MarkupLine(
+                        $"[{Colors.Highlighted}]Number of files: {dto.Summary.FileCount}; total file size: {dto.Summary.TotalFileSize:N0}.[/]"
+                    )
 
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
+                    writeRootShaSummary graceStatus
 
-                writeRootShaSummary graceStatus
+                    if listDirectories then
+                        if directoryCount = 0 then
+                            AnsiConsole.MarkupLine($"[{Colors.Verbose}]No directory entries found in the local Grace status file.[/]")
+                        else
+                            let longestRelativePath = getLongestRelativePath graceStatus.Index.Values
+                            let additionalSpaces = String.replicate (longestRelativePath - 2) " "
+                            let additionalImportantDashes = String.replicate (longestRelativePath + 3) "-"
+                            let additionalDeemphasizedDashes = String.replicate 38 "-"
 
-                if listDirectories then
-                    if directoryCount = 0 then
-                        AnsiConsole.MarkupLine($"[{Colors.Verbose}]No directory entries found in the local Grace status file.[/]")
-                    else
-                        let longestRelativePath = getLongestRelativePath graceStatus.Index.Values
-                        let additionalSpaces = String.replicate (longestRelativePath - 2) " "
-                        let additionalImportantDashes = String.replicate (longestRelativePath + 3) "-"
-                        let additionalDeemphasizedDashes = String.replicate 38 "-"
+                            let sortedDirectoryVersions = graceStatus.Index.Values.OrderBy(fun dv -> dv.RelativePath)
 
-                        let sortedDirectoryVersions = graceStatus.Index.Values.OrderBy(fun dv -> dv.RelativePath)
+                            sortedDirectoryVersions
+                            |> Seq.iteri (fun i directoryVersion ->
+                                AnsiConsole.WriteLine()
 
-                        sortedDirectoryVersions
-                        |> Seq.iteri (fun i directoryVersion ->
-                            AnsiConsole.WriteLine()
-
-                            if i = 0 then
-                                AnsiConsole.MarkupLine(
-                                    $"[{Colors.Important}]Last Write Time (UTC)        SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
-                                )
-
-                                AnsiConsole.MarkupLine(
-                                    $"[{Colors.Important}]-----------------------------------------------------{additionalImportantDashes}[/][{Colors.Deemphasized}] {additionalDeemphasizedDashes}[/]"
-                                )
-
-                            let rightAlignedDirectoryVersionId =
-                                (String.replicate
-                                    (longestRelativePath
-                                     - directoryVersion.RelativePath.Length)
-                                    " ")
-                                + $"({directoryVersion.DirectoryVersionId})"
-
-                            AnsiConsole.MarkupLine(
-                                $"[{Colors.Highlighted}]{formatDateTimeAligned directoryVersion.LastWriteTimeUtc}   {getShortSha256Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
-                            )
-
-                            if listFiles then
-                                let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
-
-                                for file in sortedFiles do
+                                if i = 0 then
                                     AnsiConsole.MarkupLine(
-                                        $"[{Colors.Verbose}]{formatDateTimeAligned file.LastWriteTimeUtc}   {getShortSha256Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.FileInfo.Name}[/]"
-                                    ))
+                                        $"[{Colors.Important}]Last Write Time (UTC)        SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
+                                    )
 
-                return 0
+                                    AnsiConsole.MarkupLine(
+                                        $"[{Colors.Important}]-----------------------------------------------------{additionalImportantDashes}[/][{Colors.Deemphasized}] {additionalDeemphasizedDashes}[/]"
+                                    )
+
+                                let rightAlignedDirectoryVersionId =
+                                    (String.replicate
+                                        (longestRelativePath
+                                         - directoryVersion.RelativePath.Length)
+                                        " ")
+                                    + $"({directoryVersion.DirectoryVersionId})"
+
+                                AnsiConsole.MarkupLine(
+                                    $"[{Colors.Highlighted}]{formatDateTimeAligned directoryVersion.LastWriteTimeUtc}   {getShortSha256Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
+                                )
+
+                                if listFiles then
+                                    let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
+
+                                    for file in sortedFiles do
+                                        AnsiConsole.MarkupLine(
+                                            $"[{Colors.Verbose}]{formatDateTimeAligned file.LastWriteTimeUtc}   {getShortSha256Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.FileInfo.Name}[/]"
+                                        ))
+
+                    return 0
             }
 
     type CheckIgnoreEntries() =
@@ -724,18 +812,30 @@ module Maintenance =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 if parseResult |> verbose then printParseResult parseResult
-                AnsiConsole.MarkupLine($"[{Colors.Important}]Directory ignore entries:[/]")
 
-                for dir in Current().GraceDirectoryIgnoreEntries do
-                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {dir}[/]")
+                let dto =
+                    ({
+                         LocalOutputDto.MaintenanceIgnoreEntriesDto.DirectoryEntries =
+                             Current().GraceDirectoryIgnoreEntries
+                             |> Seq.toArray
+                         FileEntries = Current().GraceFileIgnoreEntries |> Seq.toArray
+                     }: LocalOutputDto.MaintenanceIgnoreEntriesDto)
 
-                AnsiConsole.WriteLine()
-                AnsiConsole.MarkupLine($"[{Colors.Important}]File ignore entries:[/]")
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]Directory ignore entries:[/]")
 
-                for file in Current().GraceFileIgnoreEntries do
-                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {file}[/]")
+                    for dir in dto.DirectoryEntries do
+                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {dir}[/]")
 
-                return 0
+                    AnsiConsole.WriteLine()
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]File ignore entries:[/]")
+
+                    for file in dto.FileEntries do
+                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {file}[/]")
+
+                    return 0
             }
 
     let Build =

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -644,7 +644,12 @@ module Maintenance =
             task {
                 if parseResult |> verbose then printParseResult parseResult
 
-                if parseResult |> hasOutput then
+                if parseResult |> json then
+                    let! previousGraceStatus = readGraceStatusFile ()
+                    let! differences = scanForDifferences previousGraceStatus
+                    let! (_, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
+                    return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
+                elif parseResult |> hasOutput then
                     let! (differences, newDirectoryVersions) =
                         progress
                             .Columns(progressColumns)
@@ -672,22 +677,19 @@ module Maintenance =
                                     return (differences, newDirectoryVersions)
                                 })
 
-                    if parseResult |> json then
-                        return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
-                    else
-                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
+                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
 
-                        for difference in differences do
-                            let x = sprintf "%A" difference
-                            AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
+                    for difference in differences do
+                        let x = sprintf "%A" difference
+                        AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
 
-                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
+                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
 
-                        for ldv in newDirectoryVersions do
-                            AnsiConsole.MarkupLine
-                                $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+                    for ldv in newDirectoryVersions do
+                        AnsiConsole.MarkupLine
+                            $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
 
-                        return 0
+                    return 0
                 //AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(8)}[/]"
                 else
                     let! previousGraceStatus = readGraceStatusFile ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -154,6 +154,27 @@ module Watch =
             return resolveSignalRAccessTokenResult tokenResult
         }
 
+    let private renderJsonResult parseResult started completed message =
+        let configuration = Current()
+
+        let dto: LocalOutputDto.WatchResultDto =
+            {
+                Started = started
+                Completed = completed
+                Message = message
+                RootDirectory = configuration.RootDirectory
+                ServerUri = configuration.ServerUri
+                RepositoryId = configuration.RepositoryId
+                BranchId = configuration.BranchId
+            }
+
+        Ok(GraceReturnValue.Create dto (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
+    let private renderJsonError parseResult message =
+        Error(GraceError.Create message (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
     let private createSignalRConnection (signalRUrl: Uri) =
         HubConnectionBuilder()
             .WithAutomaticReconnect()
@@ -777,17 +798,23 @@ module Watch =
                             //logToAnsiConsole Colors.Verbose $"Memory before GC: {memoryBeforeGC:N0}; after: {Process.GetCurrentProcess().WorkingSet64:N0}."
                             previousGC <- getCurrentInstant ()
 
-                    return 0
+                    if parseResult |> json then
+                        return renderJsonResult parseResult true true "Watch completed because cancellation was requested or the timer stopped."
+                    else
+                        return 0
                 with
                 | :? HttpRequestException as httpEx when
                     httpEx.StatusCode.HasValue
                     && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
                     ->
-                    logToAnsiConsole
-                        Colors.Error
+                    let message =
                         $"SignalR negotiation failed with 401 Unauthorized. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
 
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult message
+                    else
+                        logToAnsiConsole Colors.Error message
+                        return -1
                 | :? InvalidOperationException as invalidOperationException when
                     invalidOperationException.Message.Contains
                         (
@@ -795,15 +822,21 @@ module Watch =
                             StringComparison.OrdinalIgnoreCase
                         )
                     ->
-                    logToAnsiConsole Colors.Error $"{Markup.Escape(invalidOperationException.Message)}"
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult invalidOperationException.Message
+                    else
+                        logToAnsiConsole Colors.Error $"{Markup.Escape(invalidOperationException.Message)}"
+                        return -1
                 | ex ->
                     //let exceptionMarkup = Markup.Escape($"{ExceptionResponse.Create ex}").Replace("\\\\", @"\").Replace("\r\n", Environment.NewLine)
                     //logToAnsiConsole Colors.Error $"{exceptionMarkup}"
-                    let exceptionSettings = ExceptionSettings(Format = ExceptionFormats.Default)
-                    // Need to fill in some exception styles here.
-                    AnsiConsole.WriteException(ex, exceptionSettings)
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult $"{ExceptionResponse.Create ex}"
+                    else
+                        let exceptionSettings = ExceptionSettings(Format = ExceptionFormats.Default)
+                        // Need to fill in some exception styles here.
+                        AnsiConsole.WriteException(ex, exceptionSettings)
+                        return -1
             }
 
     let Build =

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -22,6 +22,7 @@ module CommandOutputContract =
 
     type CurrentJsonBehavior =
         | CommonRenderOutputEnvelope
+        | ImmediateJsonErrorOnly
         | HumanProgressOnlySuccess
         | PartialManualSuccess
         | ManualJsonUnenveloped
@@ -54,6 +55,7 @@ module CommandOutputContract =
     type EnvelopeContract =
         | ExistingGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
         | MigrationRequiredToGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
+        | JsonModeErrorOnly of reason: string
         | SourceOnlyUnsupported of disposition: string
 
     type FeatureState =
@@ -156,6 +158,25 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
+    let private nullableStringSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- [| "string"; "null" |]
+        schema["description"] <- description
+        box schema
+
+    let private arraySchema itemSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "array"
+        schema["items"] <- itemSchema
+        schema["description"] <- description
+        box schema
+
+    let private stringDateTimeSchema =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["format"] <- "date-time"
+        box schema
+
     let private propertyBagSchema =
         let propertyEntry =
             schemaObject
@@ -191,6 +212,167 @@ module CommandOutputContract =
     let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
 
     let private stringReturnValueSchema = scalarSchema "string"
+
+    let private maintenanceStatsSchema =
+        schemaObject
+            "MaintenanceStatsDto"
+            [
+                "DirectoryCount", scalarSchema "integer"
+                "FileCount", scalarSchema "integer"
+                "TotalFileSize", scalarSchema "integer"
+                "RootSha256Hash", nullableStringSchema "Root directory SHA-256 hash when the local index contains or records it."
+            ]
+            [|
+                "DirectoryCount"
+                "FileCount"
+                "TotalFileSize"
+                "RootSha256Hash"
+            |]
+
+    let private maintenanceStatsExample = box {| DirectoryCount = 1; FileCount = 2; TotalFileSize = 42L; RootSha256Hash = "0123456789abcdef" |}
+
+    let private maintenanceListContentsFileSchema =
+        schemaObject
+            "MaintenanceListContentsFileDto"
+            [
+                "RelativePath", scalarSchema "string"
+                "FileName", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+                "Size", scalarSchema "integer"
+                "LastWriteTimeUtc", stringDateTimeSchema
+            ]
+            [|
+                "RelativePath"
+                "FileName"
+                "Sha256Hash"
+                "Size"
+                "LastWriteTimeUtc"
+            |]
+
+    let private maintenanceListContentsDirectorySchema =
+        schemaObject
+            "MaintenanceListContentsDirectoryDto"
+            [
+                "RelativePath", scalarSchema "string"
+                "DirectoryVersionId", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+                "Size", scalarSchema "integer"
+                "LastWriteTimeUtc", stringDateTimeSchema
+                "Files", arraySchema maintenanceListContentsFileSchema "Files in the indexed directory when file listing is enabled."
+            ]
+            [|
+                "RelativePath"
+                "DirectoryVersionId"
+                "Sha256Hash"
+                "Size"
+                "LastWriteTimeUtc"
+                "Files"
+            |]
+
+    let private maintenanceListContentsSchema =
+        schemaObject
+            "MaintenanceListContentsDto"
+            [
+                "Summary", maintenanceStatsSchema
+                "Directories", arraySchema maintenanceListContentsDirectorySchema "Indexed directories returned by maintenance list-contents."
+            ]
+            [| "Summary"; "Directories" |]
+
+    let private maintenanceListContentsExample =
+        box
+            {|
+                Summary = {| DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = "0123456789abcdef" |}
+                Directories =
+                    [|
+                        {|
+                            RelativePath = "."
+                            DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
+                            Sha256Hash = "0123456789abcdef"
+                            Size = 12L
+                            LastWriteTimeUtc = "2026-06-05T00:00:00Z"
+                            Files =
+                                [|
+                                    {|
+                                        RelativePath = "README.md"
+                                        FileName = "README.md"
+                                        Sha256Hash = "abcdef0123456789"
+                                        Size = 12L
+                                        LastWriteTimeUtc = "2026-06-05T00:00:00Z"
+                                    |}
+                                |]
+                        |}
+                    |]
+            |}
+
+    let private maintenanceIgnoreEntriesSchema =
+        schemaObject
+            "MaintenanceIgnoreEntriesDto"
+            [
+                "DirectoryEntries", arraySchema (scalarSchema "string") "Configured Grace directory ignore entries."
+                "FileEntries", arraySchema (scalarSchema "string") "Configured Grace file ignore entries."
+            ]
+            [| "DirectoryEntries"; "FileEntries" |]
+
+    let private maintenanceIgnoreEntriesExample = box {| DirectoryEntries = [| ".git"; ".grace" |]; FileEntries = [| "*.tmp" |] |}
+
+    let private maintenanceScanDifferenceSchema =
+        schemaObject
+            "MaintenanceScanDifferenceDto"
+            [
+                "DifferenceType", scalarSchema "string"
+                "FileSystemEntryType", scalarSchema "string"
+                "RelativePath", scalarSchema "string"
+            ]
+            [|
+                "DifferenceType"
+                "FileSystemEntryType"
+                "RelativePath"
+            |]
+
+    let private maintenanceScanDirectoryVersionSchema =
+        schemaObject
+            "MaintenanceScanDirectoryVersionDto"
+            [
+                "DirectoryVersionId", scalarSchema "string"
+                "RelativePath", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+            ]
+            [|
+                "DirectoryVersionId"
+                "RelativePath"
+                "Sha256Hash"
+            |]
+
+    let private maintenanceScanSchema =
+        schemaObject
+            "MaintenanceScanDto"
+            [
+                "DifferenceCount", scalarSchema "integer"
+                "Differences", arraySchema maintenanceScanDifferenceSchema "Detected filesystem differences compared with the local Grace index."
+                "NewDirectoryVersionCount", scalarSchema "integer"
+                "NewDirectoryVersions", arraySchema maintenanceScanDirectoryVersionSchema "Computed directory versions for detected differences."
+            ]
+            [|
+                "DifferenceCount"
+                "Differences"
+                "NewDirectoryVersionCount"
+                "NewDirectoryVersions"
+            |]
+
+    let private maintenanceScanExample =
+        box
+            {|
+                DifferenceCount = 1
+                Differences =
+                    [|
+                        {| DifferenceType = "Added"; FileSystemEntryType = "File"; RelativePath = "README.md" |}
+                    |]
+                NewDirectoryVersionCount = 1
+                NewDirectoryVersions =
+                    [|
+                        {| DirectoryVersionId = "11111111-1111-1111-1111-111111111111"; RelativePath = "."; Sha256Hash = "0123456789abcdef" |}
+                    |]
+            |}
 
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
@@ -230,16 +412,63 @@ module CommandOutputContract =
         match contract with
         | ExistingGraceResultEnvelope disposition -> $"ExistingGraceResultEnvelope: {outputDtoDispositionText disposition}"
         | MigrationRequiredToGraceResultEnvelope disposition -> $"MigrationRequiredToGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | JsonModeErrorOnly reason -> $"JsonModeErrorOnly: {reason}"
         | SourceOnlyUnsupported reason -> $"SourceOnlyUnsupported: {reason}"
 
     let private returnValueDispositionText (contract: EnvelopeContract) =
         match contract with
         | ExistingGraceResultEnvelope disposition
         | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
+        | JsonModeErrorOnly reason -> $"Unsupported: {reason}"
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
 
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
+        | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceIgnoreEntriesDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceIgnoreEntriesSchema
+                maintenanceIgnoreEntriesExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance check-ignore-entries in the common Grace result envelope."
+                ]
+        | "maintenance.list-contents", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceListContentsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceListContentsSchema
+                maintenanceListContentsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance list-contents in the common Grace result envelope."
+                ]
+        | "maintenance.scan", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceScanDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceScanSchema
+                maintenanceScanExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance scan in the common Grace result envelope."
+                ]
+        | "maintenance.stats", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceStatsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceStatsSchema
+                maintenanceStatsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance stats in the common Grace result envelope."
+                ]
+        | "maintenance.update-index", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceStatsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceStatsSchema
+                maintenanceStatsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance update-index in the common Grace result envelope after the local index is updated."
+                ]
         | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "RepositoryDto"
@@ -261,7 +490,9 @@ module CommandOutputContract =
                 [
                     "Representative scalar ReturnValue schema for a common Grace result envelope command."
                 ]
+        | "watch", JsonModeErrorOnly reason -> unsupportedReturnValueContract "WatchResultDto" reason
         | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
+        | _, JsonModeErrorOnly reason -> unsupportedReturnValueContract "unsupported" reason
         | _, MigrationRequiredToGraceResultEnvelope disposition ->
             incompleteReturnValueContract
                 (outputDtoDispositionText disposition)
@@ -332,7 +563,10 @@ module CommandOutputContract =
         {
             Status = status
             Source = "CommandOutputContract"
-            Envelope = "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
+            Envelope =
+                match entry.EnvelopeContract with
+                | JsonModeErrorOnly reason -> $"GraceError only in JSON mode for this release; no success ReturnValue envelope is emitted. {reason}"
+                | _ -> "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
             ReturnValueContract = entry.ReturnValueContract.Name
             SuccessSchema = successEnvelopeSchema entry
@@ -429,6 +663,8 @@ module CommandOutputContract =
         match behavior with
         | UnroutedSourceOnly ->
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
+        | ImmediateJsonErrorOnly ->
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = RequiresMigration }
         | CommonRenderOutputEnvelope ->
             { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
@@ -437,6 +673,9 @@ module CommandOutputContract =
         match routed, behavior with
         | false, _ -> SourceOnlyUnsupported "Defined in source but not root-routed for V1."
         | true, CommonRenderOutputEnvelope -> ExistingGraceResultEnvelope dtoDisposition
+        | true, ImmediateJsonErrorOnly ->
+            JsonModeErrorOnly
+                "The command is routed, but --output Json is intentionally short-circuited before command execution because watch is a continuous foreground workflow."
         | true, _ -> MigrationRequiredToGraceResultEnvelope dtoDisposition
 
     let internal commandIdentity groupPath commandName = { GroupPath = groupPath; CommandName = commandName }
@@ -485,6 +724,7 @@ module CommandOutputContract =
         }
 
     let private common_renderOutput_envelope = CommonRenderOutputEnvelope
+    let private immediate_json_error_only = ImmediateJsonErrorOnly
     let private human_progress_only_success = HumanProgressOnlySuccess
     let private partial_manual_success = PartialManualSuccess
     let private manual_json_unenveloped = ManualJsonUnenveloped
@@ -754,7 +994,7 @@ module CommandOutputContract =
             row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [] "watch" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
+            row [] "watch" true true immediate_json_error_only progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -608,11 +608,11 @@ module CommandOutputContract =
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
             row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "check-ignore-entries" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "list-contents" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "scan" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
-            row [ "maintenance" ] "stats" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "update-index" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "check-ignore-entries" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "list-contents" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "scan" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "stats" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "update-index" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
             row [ "organization" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "organization" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "organization" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -754,7 +754,7 @@ module CommandOutputContract =
             row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [] "watch" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [] "watch" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -49,6 +49,20 @@ module GraceCommand =
 
     type OptionToUpdate = { optionAlias: string; display: string; displayOnCreate: string; createParentCommand: string }
 
+    let private deleteGraceWatchIpcFileIfOwned () =
+        if graceWatchStatusUpdateTime <> Instant.MinValue then
+            try
+                let ipcFileName = IpcFileName()
+
+                if File.Exists(ipcFileName) then
+                    let status =
+                        File.ReadAllText(ipcFileName)
+                        |> deserialize<GraceWatchStatus>
+
+                    if status.UpdatedAt = graceWatchStatusUpdateTime then File.Delete(ipcFileName)
+            with
+            | _ -> ()
+
     /// Built-in aliases for Grace commands.
     let private aliases =
         let aliases = Dictionary<string, string seq>()
@@ -1406,6 +1420,6 @@ module GraceCommand =
                 // If this was grace watch, delete the inter-process communication file.
                 if not <| isNull (parseResult)
                    && parseResult |> isGraceWatch then
-                    File.Delete(IpcFileName())
+                    deleteGraceWatchIpcFileIfOwned ()
         })
             .Result

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1252,58 +1252,68 @@ module GraceCommand =
                         | None ->
                             //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
-                            if parseResult |> hasOutput then
-                                if parseResult |> verbose then
-                                    AnsiConsole.Write(
-                                        (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
-                                            .RightJustified()
-                                    )
+                            if (parseResult |> json)
+                               && (parseResult |> isGraceWatch) then
+                                let error =
+                                    GraceError.Create
+                                        "watch is a continuous foreground workflow; JSON mode requires a cancellation-aware automation host in this release."
+                                        (getCorrelationId parseResult)
 
-                                //printParseResult parseResult
-                                else
-                                    AnsiConsole.Write(new Rule())
+                                Common.writeJsonErrorStdout error
+                                returnValue <- -1
+                            else
+                                if parseResult |> hasOutput then
+                                    if parseResult |> verbose then
+                                        AnsiConsole.Write(
+                                            (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
+                                                .RightJustified()
+                                        )
 
-                            // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
-                            if not <| (parseResult |> isGraceWatch) then
-                                let! graceWatchStatus = getGraceWatchStatus ()
+                                    //printParseResult parseResult
+                                    else
+                                        AnsiConsole.Write(new Rule())
 
-                                match graceWatchStatus with
-                                | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
-                                | None -> ()
+                                // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
+                                if not <| (parseResult |> isGraceWatch) then
+                                    let! graceWatchStatus = getGraceWatchStatus ()
 
-                            // Now we can invoke the command!
-                            let! invokedReturnValue = parseResult.InvokeAsync()
-                            returnValue <- invokedReturnValue
+                                    match graceWatchStatus with
+                                    | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
+                                    | None -> ()
 
-                            // Stuff to do after the command has been invoked:
+                                // Now we can invoke the command!
+                                let! invokedReturnValue = parseResult.InvokeAsync()
+                                returnValue <- invokedReturnValue
 
-                            // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
-                            //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
-                            if parseResult |> isGraceWatch then
-                                logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
+                                // Stuff to do after the command has been invoked:
 
-                            // If we're writing output, write the final Rule() to the console.
-                            if parseResult |> hasOutput then
-                                let finishTime = getCurrentInstant ()
+                                // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
+                                //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
+                                if parseResult |> isGraceWatch then
+                                    logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
-                                let elapsed =
-                                    (finishTime - startTime)
-                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                // If we're writing output, write the final Rule() to the console.
+                                if parseResult |> hasOutput then
+                                    let finishTime = getCurrentInstant ()
 
-                                if parseResult |> verbose then
-                                    AnsiConsole.Write(
-                                        (new Rule(
-                                            $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
-                                        ))
-                                            .RightJustified()
-                                    )
-                                else
-                                    AnsiConsole.Write(
-                                        (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                            .RightJustified()
-                                    )
+                                    let elapsed =
+                                        (finishTime - startTime)
+                                            .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
 
-                                AnsiConsole.WriteLine()
+                                    if parseResult |> verbose then
+                                        AnsiConsole.Write(
+                                            (new Rule(
+                                                $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
+                                            ))
+                                                .RightJustified()
+                                        )
+                                    else
+                                        AnsiConsole.Write(
+                                            (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
+                                                .RightJustified()
+                                        )
+
+                                    AnsiConsole.WriteLine()
                     else
                         // We don't have a config file, so write an error message and exit.
                         let comparison =


### PR DESCRIPTION
## Summary  - Migrates maintenance progress-heavy JSON paths to envelope-backed DTO output. - Adds JSON safety handling for `watch --output Json` so it returns one clean JSON error envelope instead of starting the continuous foreground watcher. - Updates output contract registry metadata and focused output-capture tests for maintenance/watch behavior.  ## Related Issue  Part of #274. Addresses #282.  Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for #282.  ## Validation  Worker evidence:  - Targeted Fantomas ran on touched F# and test files. - Focused CLI build passed: `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`. - Focused CLI tests passed `16/16`: `MaintenanceCliTests`, `WatchTests`, and `CommandOutputContractRegistryTests`. - `pwsh ./scripts/validate.ps1 -Fast` passed, including `Grace.CLI.Tests` `355/355`. - `git diff --check` passed.  Review-fix evidence from commit `0ea4f17`:  - Targeted Fantomas ran on `CommandOutputContract.CLI.fs`, `Maintenance.CLI.fs`, `CommandOutputContract.CLI.Tests.fs`, `Maintenance.CLI.Tests.fs`, and `Watch.Tests.fs`. - Focused CLI tests passed `22/22`: `CommandOutputContractRegistryTests`, `MaintenanceCliTests`, and `WatchTests`. - `pwsh ./scripts/validate.ps1 -Fast` passed after the final file change: build succeeded with 0 warnings/errors; tests passed `Grace.Types.Tests` `65/65`, `Grace.Authorization.Tests` `37/37`, `Grace.Server.Unit.Tests` `440/440`, and `Grace.CLI.Tests` `361/361`. - `git diff --check` passed. Follow-up review-fix evidence from commit `d1d352f`: - Targeted Fantomas ran on `Program.CLI.fs`, `Maintenance.CLI.fs`, `Watch.Tests.fs`, and `Maintenance.CLI.Tests.fs`, with focused reruns after test edits. - Focused CLI build passed with 0 warnings/errors: `dotnet build --configuration Release C:\Source\Grace-gh-282\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`. - Focused CLI tests passed `12/12`: `dotnet test --configuration Release --no-build C:\Source\Grace-gh-282\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~WatchTests|FullyQualifiedName~MaintenanceCliTests"`. - `git diff --check` passed. Hosted CI follow-up fix evidence from commit `a8ab553`: - Targeted Fantomas ran on `Watch.Tests.fs`; the file was unchanged. - Focused CLI build passed with 0 warnings/errors: `dotnet build C:\Source\Grace-gh-282\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release`. - Focused watch tests passed `6/6`: `dotnet test C:\Source\Grace-gh-282\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~Grace.CLI.Tests.WatchTests"`. - `git diff --check` passed.  Skipped validation: did not rerun `pwsh ./scripts/validate.ps1 -Fast` or `-Full`; this CI follow-up changes only the portable assertion in the already-focused separate-process watch regression, and the focused Release build plus filtered watch test slice passed after targeted Fantomas.  ## Review Status - First fresh GPT-5.3-Codex High review-only pass recorded in https://github.com/ScottArbeit/Grace/pull/303#issuecomment-4637898576. - Review-fix commit `0ea4f17` pushed to address the first three findings:   - `watch` no longer advertises a common JSON success envelope; registry metadata marks it as JSON error-only before command execution.   - Migrated maintenance DTOs now have command-specific schema-ready metadata for `maintenance update-index`, `maintenance scan`, `maintenance stats`, `maintenance list-contents`, and `maintenance check-ignore-entries`.   - Output-capture tests now parse stdout as-is for the migrated maintenance/watch JSON flows and assert no progress/human lines leak into JSON stdout. - Second fresh review pass recorded in https://github.com/ScottArbeit/Grace/pull/303#issuecomment-4637994454 found two follow-up issues. - Follow-up review-fix commit `d1d352f` pushed to address both open findings:   - `watch --output Json` no longer deletes another live watch process's IPC heartbeat because cleanup only deletes an IPC file whose heartbeat timestamp was written by the current invocation.   - `maintenance update-index --output Json` exception paths now emit a strict JSON `GraceError` envelope without `logToAnsiConsole` human/progress-like output. - Detailed follow-up fix evidence and skipped-validation notes are recorded in https://github.com/ScottArbeit/Grace/pull/303#issuecomment-4638014791. - Reviewed And OK preserved: changed maintenance/watch JSON branches suppress human/progress output, `watch --output Json` returns one clean JSON error instead of starting the watcher, and branch/diff/history-run are still not overclaimed as common JSON. - Hosted CI follow-up commit `a8ab553` pushed to fix the Ubuntu `full` check failure in run `27057856542`, job `79865384011`:   - The separate-process watch JSON regression now accepts both the intended process return `-1` and Unix's portable child-process exit-code mapping `255` while continuing to assert clean stdout JSON, empty stderr, and preserved live watch IPC file.   - Focused fix evidence and skipped-validation notes are recorded in the latest CI-fix PR comment. ## Residual Risk  The worker explicitly scoped this commit to maintenance commands and `watch` JSON safety. Branch, diff, and history-run remain tracked backlog work rather than schema-ready common JSON success-envelope commands in this PR. `watch --output Json` remains intentionally limited to a clean immediate `GraceError` until a cancellation-aware automation host owns a real JSON success path.     

