### PR TITLE
Audit common CLI JSON envelope behavior

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -3,8 +3,11 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.CommandOutputContract
+open Grace.Shared
+open Grace.Types.Common
 open NUnit.Framework
 open System
+open System.IO
 open System.Text.Json
 
 [<TestFixture>]
@@ -32,6 +35,41 @@ module CommandOutputContractRegistryTests =
                 |> String.concat ", "
 
             Assert.Fail($"Set mismatch. Missing: {missing}. Extra: {extra}.")
+
+    let private captureStdout action =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            let exitCode = action ()
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+
+    let private parseJsonDocument (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    let private assertOneJsonObjectStdout (output: string) =
+        let ansiCsiPrefix = string (char 0x1B) + "["
+
+        output.Contains(ansiCsiPrefix, StringComparison.Ordinal)
+        |> should equal false
+        output |> should not' (contain "[red]")
+        output |> should not' (contain "Elapsed:")
+
+        output
+        |> should not' (contain "Exception in isOutputFormat")
+
+        use document = parseJsonDocument output
+
+        document.RootElement.ValueKind
+        |> should equal JsonValueKind.Object
 
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
@@ -186,6 +224,116 @@ module CommandOutputContractRegistryTests =
 
             entry.Features.Select
             |> should equal ExistingBehavior
+
+    [<Test>]
+    let ``every common renderer entry has recursive json option and central envelope behavior`` () =
+        let commonEntries =
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
+
+        commonEntries.Length |> should equal 180
+
+        for entry in commonEntries do
+            let commandPath = entry.Identity.CommandPath |> List.toArray
+            let parseArgs = Array.append [| "--output"; "Json" |] commandPath
+            let parseResult = GraceCommand.rootCommand.Parse(parseArgs)
+
+            Common.json parseResult |> should equal true
+
+            match entry.EnvelopeContract with
+            | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
+            | RequiresCliDto) -> ()
+            | other -> Assert.Fail($"Expected central Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
+
+            let successValue = GraceReturnValue.Create $"success:{entry.Identity.CommandId}" $"corr-success-{entry.Identity.CommandId}"
+
+            let successExitCode, successOutput = captureStdout (fun () -> Common.renderOutput parseResult (Ok successValue))
+
+            successExitCode |> should equal 0
+            assertOneJsonObjectStdout successOutput
+
+            use successDocument = parseJsonDocument successOutput
+            let successRoot = successDocument.RootElement
+
+            successRoot.GetProperty("ReturnValue").GetString()
+            |> should equal $"success:{entry.Identity.CommandId}"
+
+            successRoot
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should equal $"corr-success-{entry.Identity.CommandId}"
+
+            let error = GraceError.Create $"error:{entry.Identity.CommandId}" $"corr-error-{entry.Identity.CommandId}"
+
+            let errorExitCode, errorOutput = captureStdout (fun () -> Common.renderOutput parseResult (Error error))
+
+            errorExitCode |> should equal -1
+            assertOneJsonObjectStdout errorOutput
+
+            use errorDocument = parseJsonDocument errorOutput
+            let errorRoot = errorDocument.RootElement
+
+            errorRoot.GetProperty("Error").GetString()
+            |> should equal $"error:{entry.Identity.CommandId}"
+
+            errorRoot.GetProperty("CorrelationId").GetString()
+            |> should equal $"corr-error-{entry.Identity.CommandId}"
+
+    [<Test>]
+    let ``representative local dto envelopes use shared serializer contract`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "--output"
+                    "Json"
+                    "maintenance"
+                    "stats"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        let dto: Common.LocalOutputDto.MaintenanceStatsDto =
+            { DirectoryCount = 3; FileCount = 5; TotalFileSize = 89L; RootSha256Hash = Some "0123456789abcdef" }
+
+        let exitCode, output =
+            captureStdout (fun () ->
+                GraceReturnValue.Create dto "corr-local-dto"
+                |> Ok
+                |> Common.renderOutput parseResult)
+
+        exitCode |> should equal 0
+        assertOneJsonObjectStdout output
+
+        use document = parseJsonDocument output
+        let root = document.RootElement
+        let returnValue = root.GetProperty("ReturnValue")
+
+        returnValue
+            .GetProperty("DirectoryCount")
+            .GetInt32()
+        |> should equal 3
+
+        returnValue.GetProperty("FileCount").GetInt32()
+        |> should equal 5
+
+        returnValue
+            .GetProperty("TotalFileSize")
+            .GetInt64()
+        |> should equal 89L
+
+        returnValue
+            .GetProperty("RootSha256Hash")
+            .GetString()
+        |> should equal "0123456789abcdef"
+
+        let mutable camelCaseReturnValue = Unchecked.defaultof<JsonElement>
+
+        root.TryGetProperty("returnValue", &camelCaseReturnValue)
+        |> should equal false
+
+        Constants.JsonSerializerOptions.PropertyNamingPolicy
+        |> should equal null
 
     [<Test>]
     let ``watch json mode is registered as immediate error only`` () =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Shared
 open Grace.Types.Common
 open NUnit.Framework
 open System
+open System.CommandLine
 open System.IO
 open System.Text.Json
 
@@ -15,6 +16,107 @@ open System.Text.Json
 module CommandOutputContractRegistryTests =
 
     let private commandId (identity: CommandIdentity) = identity.CommandId
+
+    let private placeholderGuid = "11111111-1111-1111-1111-111111111111"
+
+    let private optionPlaceholder optionName =
+        match optionName with
+        | "--after" -> "+15m"
+        | "--allows-large-files"
+        | "--anonymous-access"
+        | "--record-saves" -> "true"
+        | "--branch-name"
+        | "--display-name"
+        | "--name"
+        | "--new-name"
+        | "--organization-name"
+        | "--owner-name"
+        | "--repository-name" -> "example"
+        | "--candidate" -> "candidate-1"
+        | "--checkpoint-days"
+        | "--diff-cache-days"
+        | "--directory-version-cache-days"
+        | "--logical-delete-days"
+        | "--save-days" -> "30"
+        | "--claim" -> "user:user-1"
+        | "--conflict-resolution-policy" -> "NoConflicts"
+        | "--default-server-api-version" -> "Latest"
+        | "--delete-reason"
+        | "--description"
+        | "--message"
+        | "--reason"
+        | "--required-responder"
+        | "--text"
+        | "--title" -> "example text"
+        | "--dir-perm" -> "Read"
+        | "--event" -> "promotion-set.applied"
+        | "--fire-at" -> "2026-01-01T00:00:00Z"
+        | "--format" -> "json"
+        | "--gate" -> "build"
+        | "--operation" -> "RepoRead"
+        | "--organization-type"
+        | "--owner-type"
+        | "--visibility" -> "Public"
+        | "--output-file" -> "output.json"
+        | "--path" -> "src"
+        | "--principal-id" -> "user-1"
+        | "--principal-type" -> "User"
+        | "--promotion-mode" -> "IndividualOnly"
+        | "--resource"
+        | "--scope" -> "repository"
+        | "--search-visibility" -> "Visible"
+        | "--set" -> "Active"
+        | "--status" -> "Active"
+        | "--type" -> "summary"
+        | "--url" -> "https://example.test/webhook"
+        | name when name.EndsWith("-file", StringComparison.OrdinalIgnoreCase) -> "input.txt"
+        | name when name.EndsWith("-id", StringComparison.OrdinalIgnoreCase) -> placeholderGuid
+        | name when name.EndsWith("-type", StringComparison.OrdinalIgnoreCase) -> "Maintenance"
+        | _ -> "example"
+
+    let private argumentPlaceholder argumentName =
+        match argumentName with
+        | "query" -> "example"
+        | name when name.Contains("number", StringComparison.OrdinalIgnoreCase) -> "123"
+        | name when name.Contains("work", StringComparison.OrdinalIgnoreCase) -> "123"
+        | name when name.Contains("file", StringComparison.OrdinalIgnoreCase) -> "input.txt"
+        | name when name.Contains("id", StringComparison.OrdinalIgnoreCase) -> placeholderGuid
+        | _ -> "example"
+
+    let private findCommand (commandPath: string list) =
+        let mutable current: Command = GraceCommand.rootCommand :> Command
+
+        for commandName in commandPath do
+            current <-
+                current.Subcommands
+                |> Seq.find (fun subcommand ->
+                    subcommand.Name.Equals(commandName, StringComparison.Ordinal)
+                    || subcommand.Aliases.Contains(commandName))
+
+        current
+
+    let private auditPlaceholderArgs (entry: CommandContractEntry) =
+        let command = findCommand entry.Identity.CommandPath
+
+        [|
+            for option in command.Options do
+                if option.Required then
+                    yield option.Name
+                    yield optionPlaceholder option.Name
+
+            for argument in command.Arguments do
+                yield argumentPlaceholder argument.Name
+        |]
+
+    let private auditParseArgs (entry: CommandContractEntry) =
+        let commandPath = entry.Identity.CommandPath |> List.toArray
+
+        [|
+            yield "--output"
+            yield "Json"
+            yield! commandPath
+            yield! auditPlaceholderArgs entry
+        |]
 
     let private countBy behavior =
         CommandOutputContract.entries
@@ -60,6 +162,7 @@ module CommandOutputContractRegistryTests =
 
         output.Contains(ansiCsiPrefix, StringComparison.Ordinal)
         |> should equal false
+
         output |> should not' (contain "[red]")
         output |> should not' (contain "Elapsed:")
 
@@ -233,10 +336,30 @@ module CommandOutputContractRegistryTests =
 
         commonEntries.Length |> should equal 180
 
+        let parserInvalidEntries =
+            commonEntries
+            |> List.choose (fun entry ->
+                let parseResult = GraceCommand.rootCommand.Parse(auditParseArgs entry)
+
+                if parseResult.Errors.Count = 0 then
+                    None
+                else
+                    let errors =
+                        parseResult.Errors
+                        |> Seq.map (fun error -> error.Message)
+                        |> String.concat "; "
+
+                    Some $"{entry.Identity.CommandId}: {errors}")
+
+        if not parserInvalidEntries.IsEmpty then
+            parserInvalidEntries
+            |> String.concat Environment.NewLine
+            |> fun errors -> Assert.Fail($"Expected parser-valid audit paths for common renderer entries:{Environment.NewLine}{errors}")
+
         for entry in commonEntries do
-            let commandPath = entry.Identity.CommandPath |> List.toArray
-            let parseArgs = Array.append [| "--output"; "Json" |] commandPath
-            let parseResult = GraceCommand.rootCommand.Parse(parseArgs)
+            let parseResult = GraceCommand.rootCommand.Parse(auditParseArgs entry)
+
+            parseResult.Errors.Count |> should equal 0
 
             Common.json parseResult |> should equal true
 

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -511,6 +511,30 @@ module HelpDoesNotReadConfigTests =
             |> should equal "workitem.attach.summary")
 
     [<Test>]
+    let ``root output json is honored for nested commands before config errors`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "agent"
+                                                  "work"
+                                                  "status" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "graceconfig.json"
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            standardOut
+            |> should not' (contain "Grace Version Control System"))
+
+    [<Test>]
     let ``root schema emits json parse error envelope`` () =
         withTempDir (fun _ ->
             let exitCode, output = runWithCapturedOutput [| "--schema" |]
@@ -1339,6 +1363,9 @@ module HelpDoesNotReadConfigTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should not' (equal String.Empty)
+
+            rootElement.GetProperty("Exception").ValueKind
+            |> should equal JsonValueKind.Object
 
             rootElement
                 .GetProperty("CorrelationId")

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -512,27 +512,45 @@ module HelpDoesNotReadConfigTests =
 
     [<Test>]
     let ``root output json is honored for nested commands before config errors`` () =
-        withTempDir (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "agent"
-                                                  "work"
-                                                  "status" |]
+        let cases =
+            [
+                [| "agent"; "work"; "status" |]
+                [| "approval"; "policy"; "list" |]
+                [|
+                    "webhook"
+                    "delivery"
+                    "show"
+                    "--delivery"
+                    "11111111-1111-1111-1111-111111111111"
+                |]
+                [|
+                    "workitem"
+                    "attach"
+                    "summary"
+                    "123"
+                    "--text"
+                    "summary text"
+                |]
+            ]
 
-            exitCode |> should equal -1
-            standardError |> should equal String.Empty
+        for commandArgs in cases do
+            withTempDir (fun _ ->
+                let args = Array.append [| "--output"; "Json" |] commandArgs
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
 
-            use document = parseJsonOutput standardOut
-            let rootElement = document.RootElement
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
 
-            rootElement.GetProperty("Error").GetString()
-            |> should contain "graceconfig.json"
+                use document = parseJsonOutput standardOut
+                let rootElement = document.RootElement
 
-            standardOut |> should not' (contain "Elapsed:")
+                rootElement.GetProperty("Error").GetString()
+                |> should contain "graceconfig.json"
 
-            standardOut
-            |> should not' (contain "Grace Version Control System"))
+                standardOut |> should not' (contain "Elapsed:")
+
+                standardOut
+                |> should not' (contain "Grace Version Control System"))
 
     [<Test>]
     let ``root schema emits json parse error envelope`` () =


### PR DESCRIPTION
## Summary  - Adds an inventory-driven audit over every `CommonRenderOutputEnvelope` registry entry. - Verifies root-recursive `--output Json`, central success/failure JSON envelopes, and exit-code behavior. - Parses JSON stdout as-is, without stripping ANSI, markup, progress text, or other human output. - Adds representative DTO serializer coverage and strengthens root/common JSON error tests.  ## Related Issue  Part of #274. Addresses #283.  Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for issue #283.  ## Validation  Worker evidence from commit `2a565d0`:  - Targeted Fantomas check passed for the touched CLI test files. - Focused CLI test project build passed with 0 warnings and 0 errors. - Focused CLI tests passed: `366/366`. - `pwsh ./scripts/validate.ps1 -Fast` passed. - `git diff --check` passed.  Review-fix evidence from commit `06edaa8`:  - Targeted Fantomas check passed for the touched CLI test files. - Focused CLI test project build passed with 0 warnings and 0 errors. - Focused review-scope tests passed: `67/67`. - `git diff --check` passed. - `pwsh ./scripts/validate.ps1 -Fast` was not rerun for this test-only review-fix commit; the first PR commit already   recorded a passing fast gate for this branch.  ## Review Status  - Fresh GPT-5.3-Codex High review-only pass recorded in   [PR comment #4638197851](https://github.com/ScottArbeit/Grace/pull/304#issuecomment-4638197851). - Review-fix commit `06edaa8` resolved both low findings from that review:   - The common renderer inventory now generates parser-valid placeholder args for required options and arguments.   - The audit aggregates parser-invalid paths and asserts `parseResult.Errors.Count = 0` before central render checks.   - The nested root `--output Json` regression now covers multiple nested command families, including required-option     and conditional-argument shapes. - Awaiting fresh GPT-5.3-Codex High review-only pass on commit `06edaa8`. - Reviewed And OK preserved:   - The audit loops over all 180 `CommonRenderOutputEnvelope` entries.   - JSON is parsed without cleanup or sanitization.   - Central success/failure envelope fields and exit codes are validated.   - The invalid-config `Exception` object assertion matches the shared error contract.  ## Scope Notes  - No command business logic was reworked. - No server, OpenAPI, or SDK artifacts were edited. - Commands outside `CommonRenderOutputEnvelope` remain under their existing registry dispositions. - The inventory audit uses synthetic `GraceReturnValue<string>` rendering to prove central writer behavior without   invoking command-specific live server or local side effects.  ## Residual Risk  The audit proves central renderer behavior and recursive JSON option recognition for every common-envelope-ready registry entry, but it does not execute every handler with live DTOs. Handler-specific DTO/schema completeness remains governed by registry metadata and later command-specific migration slices. 
