### PR TITLE
Close CLI JSON docs and inventory audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,37 @@ Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 grace auth whoami
 ```
 
+### Machine-readable CLI output
+
+Agents, CI jobs, and scripts can request parseable CLI output with `--output Json`. Contracted commands emit exactly
+one JSON document to stdout, using Grace's existing `GraceReturnValue<T>` envelope on success and `GraceError` envelope
+on failure. Use `--schema` and `--examples` to inspect a command's registry-derived contract without executing it.
+
+PowerShell:
+
+```powershell
+grace --output Json maintenance stats
+grace maintenance stats --schema
+grace maintenance stats --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+bash / zsh:
+
+```bash
+grace --output Json maintenance stats
+grace maintenance stats --schema
+grace maintenance stats --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+`--select` is a V1 projection over `ReturnValue` only. Selectors such as `DirectoryCount` or
+`Summary.DirectoryCount` are valid; selectors for envelope metadata, predicates, wildcards, functions, renames,
+computed fields, and streaming output are explicit V2 deferrals.
+
+See [Machine-readable CLI output](./docs/Machine-readable%20CLI%20output.md) for agent recipes, JSON examples, final
+inventory totals, source-only commands, and V2 boundaries.
+
 ### File an issue if anything seems confusing or rough
 
 The intention is for this first-time setup to be as easy as possible. If you run into any problems, please file an issue so we can make it smoother.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -1,0 +1,212 @@
+# Machine-Readable CLI Output
+
+Grace CLI machine-readable output is the public automation contract for commands that opt into JSON mode. Use it when a
+script, agent, CI job, or another tool needs parseable command output instead of human tables or progress text.
+
+The contract version is `cli-json-v1`. The charter is recorded in
+[ADR-0004](./adr/0004-cli-machine-readable-json-contract.md), and the live registry is implemented in
+`src/Grace.CLI/CommandOutputContract.CLI.fs`.
+
+## Quick Reference
+
+- `--output Json` emits one JSON document to stdout for contracted commands.
+- Successful JSON output uses the existing `GraceReturnValue<T>` envelope.
+- Error JSON output uses the existing `GraceError` envelope.
+- Human text, progress, prompts, and diagnostics must not be mixed into JSON stdout.
+- `--schema` and `--examples` are inert introspection options. They do not run the selected command.
+- `--select` projects fields from `ReturnValue` only. It does not read envelope metadata.
+
+PowerShell:
+
+```powershell
+grace --output Json auth logout
+grace auth logout --schema
+grace auth logout --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+bash / zsh:
+
+```bash
+grace --output Json auth logout
+grace auth logout --schema
+grace auth logout --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+## Output Envelopes
+
+A successful command emits a `GraceReturnValue<T>` document:
+
+```json
+{
+  "ReturnValue": "Signed out.",
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": [
+    {
+      "Key": "cli.contractVersion",
+      "Value": "cli-json-v1"
+    }
+  ]
+}
+```
+
+An error emits a `GraceError` document:
+
+```json
+{
+  "Exception": null,
+  "Error": "error message",
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": [
+    {
+      "Key": "cli.contractVersion",
+      "Value": "cli-json-v1"
+    }
+  ]
+}
+```
+
+`--schema` and `--examples` emit registry-derived introspection documents. A schema response starts like this:
+
+```json
+{
+  "Kind": "schema",
+  "ContractVersion": "cli-json-v1",
+  "Command": {
+    "Id": "auth.logout",
+    "Path": [
+      "auth",
+      "logout"
+    ],
+    "GroupPath": [
+      "auth"
+    ],
+    "Name": "logout"
+  },
+  "Registry": {
+    "RouteDisposition": "Routed",
+    "CurrentJsonBehavior": "CommonRenderOutputEnvelope",
+    "Category": "Mutating",
+    "ExecutionScope": "LocalClient",
+    "Mutating": true,
+    "EnvelopeContract": "ExistingGraceResultEnvelope: ReuseExistingApiOrSdkDto",
+    "JsonMode": "ExistingBehavior",
+    "Schema": "FutureInertIntrospection",
+    "Examples": "FutureInertIntrospection",
+    "Select": "ExistingBehavior"
+  }
+}
+```
+
+## Select Projection
+
+`--select` is intentionally small in V1. Selectors are relative to `ReturnValue`; do not prefix them with
+`ReturnValue`.
+
+Accepted examples:
+
+- `--select DirectoryCount`
+- `--select Summary.DirectoryCount`
+- `--select Directories`
+
+Rejected examples:
+
+- `--select ReturnValue.DirectoryCount`
+- `--select EventTime`
+- `--select Properties`
+- `--select Directories[0]`
+- `--select Directories.*.RelativePath`
+- `--select "Directories | length"`
+
+Rejected selectors return a JSON error envelope. They do not produce partial output.
+
+## Final Inventory Evidence
+
+The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
+
+- Total leaf commands: `201`
+- JSON-ready routed commands: `180`
+- Intentionally human-only commands: `1`
+- Deferred routed commands with explicit V2 scope: `11`
+- Source-only/unrouted commands: `9`
+- Deleted commands: `0`
+
+The intentionally human-only command is `watch`. In JSON mode, it short-circuits to a `GraceError` document instead of
+starting the continuous foreground workflow.
+
+The source-only/unrouted commands are defined in source but are not attached to `GraceCommand.rootCommand` in V1:
+
+- `reference.assign`
+- `reference.checkpoint`
+- `reference.commit`
+- `reference.create-external`
+- `reference.delete`
+- `reference.get`
+- `reference.promote`
+- `reference.save`
+- `reference.tag`
+
+The deferred routed commands are not corrupt or unenveloped in current V1 output claims. They have explicit registry
+metadata and V2 scope because their success paths still need migration before Grace can describe stable
+`ReturnValue` schemas, examples, and projections for them. Current deferrals are:
+
+- `diff.checkpoint`
+- `diff.commit`
+- `diff.directoryid`
+- `diff.promotion`
+- `diff.save`
+- `diff.sha`
+- `diff.tag`
+- `history.run`
+- `maintenance.scan`
+- `maintenance.update-index`
+- `repository.init`
+
+The `watch` command is not counted in those V2 routed-success migrations. It is intentionally human-only for success
+behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of
+starting the watcher.
+
+## Agent Recipes
+
+Use `--schema` first when an agent needs to understand a command contract without changing state:
+
+```powershell
+grace workitem show --schema
+```
+
+Then use `--examples` to get representative envelopes:
+
+```powershell
+grace workitem show --examples
+```
+
+For command execution, parse stdout as a single JSON document and treat the process exit code as the success or failure
+signal:
+
+```powershell
+$json = grace --output Json maintenance stats
+$document = $json | ConvertFrom-Json
+$document.ReturnValue.DirectoryCount
+```
+
+When using `--select`, request only the `ReturnValue` field path the automation needs:
+
+```powershell
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+## V2 Deferrals
+
+The following capabilities remain intentionally deferred beyond `cli-json-v1`:
+
+- Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections.
+- JSON Lines progress streams and multi-document streaming JSON.
+- Server-backed schema discovery.
+- Live examples generated from repository or server state.
+- Stable schemas for source-only/unrouted commands until they are routed, deleted, or promoted into a supported
+  contract.
+
+These are explicit V2 boundaries, not hidden V1 promises.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -153,6 +153,9 @@ The deferred routed commands are not corrupt or unenveloped in current V1 output
 metadata and V2 scope because their success paths still need migration before Grace can describe stable
 `ReturnValue` schemas, examples, and projections for them. Current deferrals are:
 
+- `branch.rebase`
+- `branch.status`
+- `branch.switch`
 - `diff.checkpoint`
 - `diff.commit`
 - `diff.directoryid`
@@ -161,9 +164,6 @@ metadata and V2 scope because their success paths still need migration before Gr
 - `diff.sha`
 - `diff.tag`
 - `history.run`
-- `maintenance.scan`
-- `maintenance.update-index`
-- `repository.init`
 
 The `watch` command is not counted in those V2 routed-success migrations. It is intentionally human-only for success
 behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -184,6 +184,31 @@ module CommandOutputContractRegistryTests =
         |> List.filter predicate
         |> List.length
 
+    let private commandIdsFor predicate =
+        CommandOutputContract.entries
+        |> List.filter predicate
+        |> List.map (fun entry -> entry.Identity.CommandId)
+
+    let private markdownBulletIdsAfter (anchor: string) (markdown: string) =
+        let pattern =
+            Regex.Escape(anchor)
+            + @"\r?\n\r?\n(?<items>(?:- `[^`]+`\r?\n)+)"
+
+        let markdownMatch = Regex.Match(markdown, pattern)
+
+        markdownMatch.Success |> should equal true
+
+        markdownMatch
+            .Groups[ "items" ]
+            .Value.Split([| "\r\n"; "\n" |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.map (fun line ->
+            let itemMatch = Regex.Match(line.Trim(), @"^- `(?<id>[^`]+)`$")
+
+            itemMatch.Success |> should equal true
+
+            itemMatch.Groups["id"].Value)
+        |> Array.toList
+
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
@@ -786,38 +811,52 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
+        let jsonReady =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ExistingGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let intentionallyHumanOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, JsonModeErrorOnly _ -> true
+                | _ -> false)
+
+        let deferredV2 =
+            commandIdsFor (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let sourceOnly =
+            commandIdsFor (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
+                | _ -> false)
+
+        let deleted = 0
+
         [
-            "Total leaf commands: `201`"
-            "JSON-ready routed commands: `180`"
-            "Intentionally human-only commands: `1`"
-            "Deferred routed commands with explicit V2 scope: `11`"
-            "Source-only/unrouted commands: `9`"
-            "Deleted commands: `0`"
-            "reference.assign"
-            "reference.checkpoint"
-            "reference.commit"
-            "reference.create-external"
-            "reference.delete"
-            "reference.get"
-            "reference.promote"
-            "reference.save"
-            "reference.tag"
-            "diff.checkpoint"
-            "diff.commit"
-            "diff.directoryid"
-            "diff.promotion"
-            "diff.save"
-            "diff.sha"
-            "diff.tag"
-            "history.run"
-            "maintenance.scan"
-            "maintenance.update-index"
-            "repository.init"
+            $"Total leaf commands: `{CommandOutputContract.entries.Length}`"
+            $"JSON-ready routed commands: `{jsonReady}`"
+            $"Intentionally human-only commands: `{intentionallyHumanOnly}`"
+            $"Deferred routed commands with explicit V2 scope: `{deferredV2.Length}`"
+            $"Source-only/unrouted commands: `{sourceOnly.Length}`"
+            $"Deleted commands: `{deleted}`"
             "Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections"
         ]
         |> List.iter (fun expected ->
             markdown.Contains(expected, StringComparison.Ordinal)
             |> should equal true)
+
+        let sourceOnlyInDocs =
+            markdownBulletIdsAfter "The source-only/unrouted commands are defined in source but are not attached to `GraceCommand.rootCommand` in V1:" markdown
+
+        let deferredV2InDocs = markdownBulletIdsAfter "Current deferrals are:" markdown
+
+        assertSetEqual sourceOnly sourceOnlyInDocs
+        assertSetEqual deferredV2 deferredV2InDocs
 
     [<Test>]
     let ``machine readable cli docs json snippets parse`` () =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -9,6 +9,7 @@ open NUnit.Framework
 open System
 open System.CommandLine
 open System.IO
+open System.Text.RegularExpressions
 open System.Text.Json
 
 [<TestFixture>]
@@ -18,6 +19,10 @@ module CommandOutputContractRegistryTests =
     let private commandId (identity: CommandIdentity) = identity.CommandId
 
     let private placeholderGuid = "11111111-1111-1111-1111-111111111111"
+
+    let private repoRoot = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", ".."))
+
+    let private machineReadableDocPath = Path.Combine(repoRoot, "docs", "Machine-readable CLI output.md")
 
     let private optionPlaceholder optionName =
         match optionName with
@@ -174,6 +179,11 @@ module CommandOutputContractRegistryTests =
         document.RootElement.ValueKind
         |> should equal JsonValueKind.Object
 
+    let private countEntries predicate =
+        CommandOutputContract.entries
+        |> List.filter predicate
+        |> List.length
+
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
@@ -198,6 +208,47 @@ module CommandOutputContractRegistryTests =
         countBy HumanProcOnly |> should equal 1
         countBy HumanOnly |> should equal 0
         countBy UnroutedSourceOnly |> should equal 9
+
+    [<Test>]
+    let ``final inventory dispositions cover every command exactly once`` () =
+        let jsonReady =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ExistingGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let intentionallyHumanOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, JsonModeErrorOnly _ -> true
+                | _ -> false)
+
+        let deferredV2 =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let sourceOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
+                | _ -> false)
+
+        let deleted = 0
+
+        jsonReady |> should equal 180
+        intentionallyHumanOnly |> should equal 1
+        deferredV2 |> should equal 11
+        sourceOnly |> should equal 9
+        deleted |> should equal 0
+
+        jsonReady
+        + intentionallyHumanOnly
+        + deferredV2
+        + sourceOnly
+        + deleted
+        |> should equal CommandOutputContract.entries.Length
 
     [<Test>]
     let ``every live routed leaf command has one registry entry`` () =
@@ -712,3 +763,73 @@ module CommandOutputContractRegistryTests =
             errorRoot.GetProperty("CorrelationId").GetString()
             |> should equal "correlation-id"
         | None -> Assert.Fail("auth.logout should have a registry entry.")
+
+    [<Test>]
+    let ``all registry schema and example documents serialize as json`` () =
+        for entry in CommandOutputContract.entries do
+            for kind in [ Schema; Examples ] do
+                let document = CommandOutputContract.introspectionDocument kind entry
+                let json = Grace.Shared.Utilities.serialize document
+                use parsed = JsonDocument.Parse(json)
+
+                parsed.RootElement.ValueKind
+                |> should equal JsonValueKind.Object
+
+                parsed
+                    .RootElement
+                    .GetProperty("Command")
+                    .GetProperty("Id")
+                    .GetString()
+                |> should equal entry.Identity.CommandId
+
+    [<Test>]
+    let ``machine readable cli docs keep final inventory evidence current`` () =
+        let markdown = File.ReadAllText(machineReadableDocPath)
+
+        [
+            "Total leaf commands: `201`"
+            "JSON-ready routed commands: `180`"
+            "Intentionally human-only commands: `1`"
+            "Deferred routed commands with explicit V2 scope: `11`"
+            "Source-only/unrouted commands: `9`"
+            "Deleted commands: `0`"
+            "reference.assign"
+            "reference.checkpoint"
+            "reference.commit"
+            "reference.create-external"
+            "reference.delete"
+            "reference.get"
+            "reference.promote"
+            "reference.save"
+            "reference.tag"
+            "diff.checkpoint"
+            "diff.commit"
+            "diff.directoryid"
+            "diff.promotion"
+            "diff.save"
+            "diff.sha"
+            "diff.tag"
+            "history.run"
+            "maintenance.scan"
+            "maintenance.update-index"
+            "repository.init"
+            "Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections"
+        ]
+        |> List.iter (fun expected ->
+            markdown.Contains(expected, StringComparison.Ordinal)
+            |> should equal true)
+
+    [<Test>]
+    let ``machine readable cli docs json snippets parse`` () =
+        let markdown = File.ReadAllText(machineReadableDocPath)
+        let matches = Regex.Matches(markdown, "```json\r?\n(?<json>.*?)\r?\n```", RegexOptions.Singleline)
+
+        matches.Count
+        |> should be (greaterThanOrEqualTo 3)
+
+        for markdownMatch in matches |> Seq.cast<Match> do
+            let json = markdownMatch.Groups["json"].Value
+            use parsed = JsonDocument.Parse(json)
+
+            parsed.RootElement.ValueKind
+            |> should not' (equal JsonValueKind.Undefined)


### PR DESCRIPTION
## Summary  - Adds user-facing and agent-facing documentation for Grace CLI machine-readable JSON output. - Documents `--schema`, `--examples`, and V1 `--select` behavior with accepted and rejected examples. - Adds registry-backed final inventory/freshness tests for command dispositions, source-only commands, V2 deferrals,   and docs JSON snippets. - Records final #274 inventory totals and closure evidence for the release-candidate path.  ## Related Issue  Part of #274. Addresses #284.  Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword for issue #284.  ## Validation  Worker evidence from commit `d12179e`:  - Targeted Fantomas ran and passed for the touched CLI test file. - MarkdownLint passed for `README.md` and `docs/Machine-readable CLI output.md`. - Focused registry/documentation tests passed: `18` tests. - `git diff --check` passed. - `pwsh ./scripts/validate.ps1 -Fast` passed with 0 build warnings/errors and selected fast tests passing:   Authorization 37, Types 65, Server.Unit 440, CLI 370.  Review-fix evidence from commit `1d38e0b`:  - Targeted Fantomas ran and passed for `src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs`. - MarkdownLint passed for `docs/Machine-readable CLI output.md`. - Focused registry/documentation tests passed: `18` tests. - `git diff --check` passed. - `pwsh ./scripts/validate.ps1 -Fast` was not rerun for this narrow review fix because the prior commit already passed   the fast gate and this follow-up only corrected the docs inventory plus the registry-derived freshness assertion.  ## Final Inventory  - Total leaf commands: `201`. - JSON-ready routed commands: `180`. - Intentionally human-only commands: `1`. - Deferred routed commands with explicit V2 scope: `11`. - Source-only/unrouted commands: `9`. - Deleted commands: `0`.  ## Explicit V2 Deferrals  - Routed success migrations: `branch.rebase`, `branch.status`, `branch.switch`, `diff.checkpoint`, `diff.commit`,   `diff.directoryid`, `diff.promotion`, `diff.save`, `diff.sha`, `diff.tag`, and `history.run`. - Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections. - JSON Lines progress streams and multi-document streaming JSON. - Server-backed schema discovery. - Live examples generated from repository or server state. - Stable schemas for source-only/unrouted commands until they are routed, deleted, or promoted into a supported   contract.  ## Review Status  - Review comment https://github.com/ScottArbeit/Grace/pull/305#issuecomment-4638358355 fixed by commit `1d38e0b`:   docs now list the registry-derived deferred routed set, and the docs freshness test now compares the Markdown   source-only and deferred command lists against computed registry sets. - No open review findings remain from that comment after this worker fix.  ## Scope Notes  - This closure slice documents and tests the current contract. - It does not migrate the 11 V2 routed-success commands. - It does not route the 9 source-only `reference.*` commands. - No server, OpenAPI, or SDK artifacts were changed.  ## Residual Risk  The orchestrator still owns PR review, hosted check monitoring, merge to the epic branch, the final epic-to-main release PR, and final epic closure.
