### PR TITLE
Release CLI machine-readable JSON contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,37 @@ Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 grace auth whoami
 ```
 
+### Machine-readable CLI output
+
+Agents, CI jobs, and scripts can request parseable CLI output with `--output Json`. Contracted commands emit exactly
+one JSON document to stdout, using Grace's existing `GraceReturnValue<T>` envelope on success and `GraceError` envelope
+on failure. Use `--schema` and `--examples` to inspect a command's registry-derived contract without executing it.
+
+PowerShell:
+
+```powershell
+grace --output Json maintenance stats
+grace maintenance stats --schema
+grace maintenance stats --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+bash / zsh:
+
+```bash
+grace --output Json maintenance stats
+grace maintenance stats --schema
+grace maintenance stats --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+`--select` is a V1 projection over `ReturnValue` only. Selectors such as `DirectoryCount` or
+`Summary.DirectoryCount` are valid; selectors for envelope metadata, predicates, wildcards, functions, renames,
+computed fields, and streaming output are explicit V2 deferrals.
+
+See [Machine-readable CLI output](./docs/Machine-readable%20CLI%20output.md) for agent recipes, JSON examples, final
+inventory totals, source-only commands, and V2 boundaries.
+
 ### File an issue if anything seems confusing or rough
 
 The intention is for this first-time setup to be as easy as possible. If you run into any problems, please file an issue so we can make it smoother.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -1,0 +1,212 @@
+# Machine-Readable CLI Output
+
+Grace CLI machine-readable output is the public automation contract for commands that opt into JSON mode. Use it when a
+script, agent, CI job, or another tool needs parseable command output instead of human tables or progress text.
+
+The contract version is `cli-json-v1`. The charter is recorded in
+[ADR-0004](./adr/0004-cli-machine-readable-json-contract.md), and the live registry is implemented in
+`src/Grace.CLI/CommandOutputContract.CLI.fs`.
+
+## Quick Reference
+
+- `--output Json` emits one JSON document to stdout for contracted commands.
+- Successful JSON output uses the existing `GraceReturnValue<T>` envelope.
+- Error JSON output uses the existing `GraceError` envelope.
+- Human text, progress, prompts, and diagnostics must not be mixed into JSON stdout.
+- `--schema` and `--examples` are inert introspection options. They do not run the selected command.
+- `--select` projects fields from `ReturnValue` only. It does not read envelope metadata.
+
+PowerShell:
+
+```powershell
+grace --output Json auth logout
+grace auth logout --schema
+grace auth logout --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+bash / zsh:
+
+```bash
+grace --output Json auth logout
+grace auth logout --schema
+grace auth logout --examples
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+## Output Envelopes
+
+A successful command emits a `GraceReturnValue<T>` document:
+
+```json
+{
+  "ReturnValue": "Signed out.",
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": [
+    {
+      "Key": "cli.contractVersion",
+      "Value": "cli-json-v1"
+    }
+  ]
+}
+```
+
+An error emits a `GraceError` document:
+
+```json
+{
+  "Exception": null,
+  "Error": "error message",
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": [
+    {
+      "Key": "cli.contractVersion",
+      "Value": "cli-json-v1"
+    }
+  ]
+}
+```
+
+`--schema` and `--examples` emit registry-derived introspection documents. A schema response starts like this:
+
+```json
+{
+  "Kind": "schema",
+  "ContractVersion": "cli-json-v1",
+  "Command": {
+    "Id": "auth.logout",
+    "Path": [
+      "auth",
+      "logout"
+    ],
+    "GroupPath": [
+      "auth"
+    ],
+    "Name": "logout"
+  },
+  "Registry": {
+    "RouteDisposition": "Routed",
+    "CurrentJsonBehavior": "CommonRenderOutputEnvelope",
+    "Category": "Mutating",
+    "ExecutionScope": "LocalClient",
+    "Mutating": true,
+    "EnvelopeContract": "ExistingGraceResultEnvelope: ReuseExistingApiOrSdkDto",
+    "JsonMode": "ExistingBehavior",
+    "Schema": "FutureInertIntrospection",
+    "Examples": "FutureInertIntrospection",
+    "Select": "ExistingBehavior"
+  }
+}
+```
+
+## Select Projection
+
+`--select` is intentionally small in V1. Selectors are relative to `ReturnValue`; do not prefix them with
+`ReturnValue`.
+
+Accepted examples:
+
+- `--select DirectoryCount`
+- `--select Summary.DirectoryCount`
+- `--select Directories`
+
+Rejected examples:
+
+- `--select ReturnValue.DirectoryCount`
+- `--select EventTime`
+- `--select Properties`
+- `--select Directories[0]`
+- `--select Directories.*.RelativePath`
+- `--select "Directories | length"`
+
+Rejected selectors return a JSON error envelope. They do not produce partial output.
+
+## Final Inventory Evidence
+
+The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
+
+- Total leaf commands: `201`
+- JSON-ready routed commands: `180`
+- Intentionally human-only commands: `1`
+- Deferred routed commands with explicit V2 scope: `11`
+- Source-only/unrouted commands: `9`
+- Deleted commands: `0`
+
+The intentionally human-only command is `watch`. In JSON mode, it short-circuits to a `GraceError` document instead of
+starting the continuous foreground workflow.
+
+The source-only/unrouted commands are defined in source but are not attached to `GraceCommand.rootCommand` in V1:
+
+- `reference.assign`
+- `reference.checkpoint`
+- `reference.commit`
+- `reference.create-external`
+- `reference.delete`
+- `reference.get`
+- `reference.promote`
+- `reference.save`
+- `reference.tag`
+
+The deferred routed commands are not corrupt or unenveloped in current V1 output claims. They have explicit registry
+metadata and V2 scope because their success paths still need migration before Grace can describe stable
+`ReturnValue` schemas, examples, and projections for them. Current deferrals are:
+
+- `diff.checkpoint`
+- `diff.commit`
+- `diff.directoryid`
+- `diff.promotion`
+- `diff.save`
+- `diff.sha`
+- `diff.tag`
+- `history.run`
+- `maintenance.scan`
+- `maintenance.update-index`
+- `repository.init`
+
+The `watch` command is not counted in those V2 routed-success migrations. It is intentionally human-only for success
+behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of
+starting the watcher.
+
+## Agent Recipes
+
+Use `--schema` first when an agent needs to understand a command contract without changing state:
+
+```powershell
+grace workitem show --schema
+```
+
+Then use `--examples` to get representative envelopes:
+
+```powershell
+grace workitem show --examples
+```
+
+For command execution, parse stdout as a single JSON document and treat the process exit code as the success or failure
+signal:
+
+```powershell
+$json = grace --output Json maintenance stats
+$document = $json | ConvertFrom-Json
+$document.ReturnValue.DirectoryCount
+```
+
+When using `--select`, request only the `ReturnValue` field path the automation needs:
+
+```powershell
+grace --output Json maintenance stats --select DirectoryCount
+```
+
+## V2 Deferrals
+
+The following capabilities remain intentionally deferred beyond `cli-json-v1`:
+
+- Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections.
+- JSON Lines progress streams and multi-document streaming JSON.
+- Server-backed schema discovery.
+- Live examples generated from repository or server state.
+- Stable schemas for source-only/unrouted commands until they are routed, deleted, or promoted into a supported
+  contract.
+
+These are explicit V2 boundaries, not hidden V1 promises.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -153,6 +153,9 @@ The deferred routed commands are not corrupt or unenveloped in current V1 output
 metadata and V2 scope because their success paths still need migration before Grace can describe stable
 `ReturnValue` schemas, examples, and projections for them. Current deferrals are:
 
+- `branch.rebase`
+- `branch.status`
+- `branch.switch`
 - `diff.checkpoint`
 - `diff.commit`
 - `diff.directoryid`
@@ -161,9 +164,6 @@ metadata and V2 scope because their success paths still need migration before Gr
 - `diff.sha`
 - `diff.tag`
 - `history.run`
-- `maintenance.scan`
-- `maintenance.update-index`
-- `repository.init`
 
 The `watch` command is not counted in those V2 routed-success migrations. It is intentionally human-only for success
 behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of

--- a/docs/adr/0004-cli-machine-readable-json-contract.md
+++ b/docs/adr/0004-cli-machine-readable-json-contract.md
@@ -1,0 +1,234 @@
+---
+status: accepted
+date: 2026-06-05
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Charter Grace CLI machine-readable JSON output
+
+Grace will make CLI machine-readable output a first-class public contract. `--output Json` must produce one stdout-clean
+JSON document for every contracted command, keep human output away from stdout, and use the existing Grace result
+envelope instead of creating a CLI-only wrapper.
+
+## Context
+
+Grace already offers JSON output as a CLI mode, but the current behavior is not yet a formal machine-readable contract.
+The CLI has recursive `--output` option plumbing only. There is no accepted `--schema`, `--examples`, or `--select`
+contract, and the current JSON path still needs implementation work before it is stdout-clean for every command.
+
+The durable tracker source for this charter is [#274](https://github.com/ScottArbeit/Grace/issues/274), the parent
+epic for CLI machine-readable JSON output. That issue records the external planning inputs, the accepted boundaries,
+the child-issue DAG, and the inventory evidence used to create this ADR.
+
+This ADR is self-contained for S1 and later implementers. Workers do not need local Downloads files, untracked HTML
+artifacts, or any other non-repository planning artifact to understand the V1 contract or the inventory facts below.
+The original direct inventory SHA-256 recorded in #274 is
+`CA5FC683D2B6A83233808AEB3C492F6D6476CED4BD829EE15EFD41AC4E070996`.
+
+The planning inventory was cross-checked before #274 was created. The direct JSON inventory matched the embedded report
+matrix and was treated as the cleaner source for command-count and backlog detail.
+
+The current inventory found `201` CLI leaf commands:
+
+| Category | Count |
+| -------- | ----: |
+| Routed leaf commands | `192` |
+| Unrouted or source-only leaf commands | `9` |
+| Common `renderOutput` envelope path | `163` |
+| Human/progress-only routed success behavior | `16` |
+| Partial/manual routed success behavior | `6` |
+| Manual non-enveloped JSON success behavior | `5` |
+| Human/proc-only routed success behavior | `1` |
+| Human-only routed success behavior | `1` |
+
+The routed non-common backlog is `29` commands that need explicit DTO, renderer, envelope, or progress handling before
+final all-command JSON audit closure. The `9` unrouted/source-only leaf commands are defined-only `reference` commands
+and remain outside routed V1 coverage until the epic routes them, deletes them, or marks them source-only explicitly.
+
+This ADR charters the accepted contract before implementation begins. Later slices must prove this contract through
+registry coverage, stdout/stderr tests, schema/example generation, projection tests, and a final inventory audit.
+
+## Decision
+
+Grace CLI JSON mode will preserve the existing Grace result model. A successful command serializes the existing
+`GraceReturnValue<'T>` shape. An error serializes the existing `GraceError` shape carried by `GraceResult<'T>`.
+
+The CLI contract tuple is:
+
+```text
+(command, options, output mode, exit code, stdout document, stderr diagnostics)
+```
+
+For every contracted CLI leaf command:
+
+- `--output Json` writes exactly one JSON document to stdout.
+- Human-readable text, progress, tables, prompts, warnings, and diagnostics are written to stderr or suppressed.
+- Stdout has no Spectre markup, banners, progress rows, success lines, trailers, or multiple JSON documents.
+- Exit codes remain the process-level success or failure signal.
+- Success and failure both use the existing Grace result vocabulary rather than a new CLI wrapper.
+
+## Envelope Shape
+
+Successful JSON output is the serialized `GraceReturnValue<'T>` envelope:
+
+```json
+{
+  "ReturnValue": {},
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": {}
+}
+```
+
+Error JSON output is the serialized `GraceError` envelope:
+
+```json
+{
+  "Exception": {},
+  "Error": "error message",
+  "EventTime": "2026-06-05T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": {}
+}
+```
+
+The examples show the contract shape, not literal command output. Implementations must preserve the actual serializer
+policy already used by Grace, including current field names and date/time serialization.
+
+CLI-specific metadata belongs in `Properties`. Examples include output-contract version, command identity, selected
+projection, schema/example provenance, or diagnostics that are safe to expose in machine-readable form. CLI metadata
+must not create a second top-level envelope around `GraceReturnValue<'T>` or `GraceError`.
+
+## Stdout And Stderr
+
+JSON stdout is reserved for the single machine-readable document. This rule applies even when a command performs
+multi-step work, reports progress, prints warnings, or fails after partial execution.
+
+Commands that currently write human/progress output on success must be migrated before they can claim the JSON
+contract. For JSON mode:
+
+- Progress belongs on stderr when useful and safe.
+- Human summaries belong on stderr or are suppressed.
+- Diagnostic messages belong on stderr.
+- Interactive prompts must not corrupt stdout.
+- Commands that cannot run non-interactively must fail with a JSON error document on stdout and explanatory diagnostics
+  on stderr when appropriate.
+
+The final newline after the JSON document is allowed. Additional stdout content is not.
+
+## Option Semantics
+
+`--output Json` selects the machine-readable contract. Other output modes remain human-oriented unless a separate
+contract says otherwise.
+
+`--schema` is an inert introspection option. It must describe the JSON contract for the selected command without running
+the command action, contacting the Grace Server, requiring repository state that the command would normally use, or
+mutating local or remote state. It emits JSON regardless of `--output`.
+
+`--examples` is an inert introspection option. It must print representative JSON examples for the selected command
+without running the command action, contacting the Grace Server, requiring command target state, or mutating state. It
+emits JSON regardless of `--output`.
+
+`--select` applies only to `ReturnValue` in V1. It never projects `EventTime`, `CorrelationId`, `Properties`,
+`Exception`, or `Error`. The V1 grammar is deliberately small:
+
+- Dot-separated property paths over `ReturnValue`.
+- Comma-separated paths when multiple fields are selected.
+- Array/list item projection only when the implementation can keep the result shape deterministic.
+- No predicates.
+- No wildcards.
+- No functions.
+- No renaming.
+- No computed fields.
+- No metadata projection.
+
+`--select` requires JSON mode except when it is used to inspect projected schemas or examples.
+
+When `--select` cannot be applied, the command must fail with the normal JSON error envelope instead of producing an
+ambiguous partial document.
+
+## Schema And Examples Boundaries
+
+Schema and example output exists to make the CLI contract inspectable before a command is executed. These paths are not
+shortcuts for command execution.
+
+Schema and example generation must be derived from the CLI output contract registry and the command's declared DTO
+shape. They must not depend on live server data, remote discovery, local repository contents, command side effects, or
+current user authorization.
+
+Schema and example output can include contract metadata in `Properties`, such as the command identity, schema version,
+or source registry entry. They must make unsupported or source-only commands explicit rather than guessing.
+
+## Compatibility Rules
+
+Grace treats this CLI JSON contract as a public compatibility surface once implemented.
+
+Compatible changes:
+
+- Adding nullable or optional fields to DTOs.
+- Adding new safe keys in `Properties`.
+- Adding new commands with declared contracts.
+- Adding examples for already supported shapes.
+- Expanding schema detail without changing the meaning of existing fields.
+
+Potentially breaking changes:
+
+- Renaming or removing existing envelope fields.
+- Moving CLI metadata out of `Properties` into a new top-level wrapper.
+- Emitting any non-JSON stdout in JSON mode.
+- Changing a command's `ReturnValue` shape without compatibility handling.
+- Changing `--select` behavior so a previously valid path returns a different meaning.
+- Allowing schema or example paths to execute commands, contact the server, or mutate state.
+
+Grace will prefer additive compatibility and explicit deprecation notes over silent contract changes.
+
+## Accepted V2 Deferrals
+
+The V1 contract intentionally defers:
+
+- Predicate, wildcard, function, rename, computed-field, and metadata projection in `--select`.
+- A CLI-only top-level envelope.
+- Server-backed schema discovery.
+- Live examples based on current repository or server state.
+- Multi-document streaming JSON.
+- JSON Lines progress streams.
+- Stable schemas for commands that remain unrouted, source-only, or explicitly unsupported.
+
+These deferrals are accepted boundaries, not accidental omissions.
+
+## Rejected Alternatives
+
+### Create a CLI-only top-level envelope
+
+Grace will not wrap CLI JSON output in a separate top-level object such as `status`, `data`, `metadata`, and `errors`.
+That would duplicate the existing `GraceReturnValue<'T>` / `GraceResult<'T>` model and create another compatibility
+surface for users and SDKs to learn.
+
+### Permit JSON plus human stdout
+
+Grace will not treat stdout as a mixed stream in JSON mode. Tools that parse CLI output need one JSON document, not a
+document plus progress rows, success text, banners, or markup.
+
+### Make `--schema` and `--examples` execute commands
+
+Grace will not make introspection depend on live command execution. Schema and example output must be safe to run in
+automation, documentation, and offline planning contexts.
+
+### Ship a broad V1 projection language
+
+Grace will not begin with a query language for `--select`. V1 projection is limited to deterministic `ReturnValue`
+property paths so implementation and compatibility can stay auditable.
+
+## Consequences
+
+Implementation slices after this charter need a command output contract registry, inert introspection plumbing, a
+stdout-clean JSON writer, schema/example generation, V1 projection, command migrations, and final inventory audit.
+
+Commands in the inventory that currently use manual JSON, human/progress output, partial/manual success behavior, or
+source-only routing must be reconciled before the epic can claim complete CLI JSON contract coverage.
+
+Documentation and pull requests for later slices should trace their evidence back to this ADR, #274, the recorded
+inventory SHA-256, and the final inventory counts recorded when the epic closes.

--- a/docs/adr/0004-cli-machine-readable-json-contract.md
+++ b/docs/adr/0004-cli-machine-readable-json-contract.md
@@ -135,9 +135,9 @@ emits JSON regardless of `--output`.
 `--select` applies only to `ReturnValue` in V1. It never projects `EventTime`, `CorrelationId`, `Properties`,
 `Exception`, or `Error`. The V1 grammar is deliberately small:
 
-- Dot-separated property paths over `ReturnValue`.
-- Comma-separated paths when multiple fields are selected.
-- Array/list item projection only when the implementation can keep the result shape deterministic.
+- Exactly one dot-separated property path over `ReturnValue`.
+- Comma-separated multi-path selectors are rejected in V1.
+- Array/list item projection is rejected in V1.
 - No predicates.
 - No wildcards.
 - No functions.

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,10 +45,10 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 175
+        |> should equal 181
 
         countBy HumanProgressOnlySuccess
-        |> should equal 16
+        |> should equal 10
 
         countBy PartialManualSuccess |> should equal 0
         countBy ManualJsonUnenveloped |> should equal 0
@@ -171,7 +171,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 175
+        commonEntries.Length |> should equal 181
 
         for entry in commonEntries do
             match entry.EnvelopeContract with

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -184,6 +184,31 @@ module CommandOutputContractRegistryTests =
         |> List.filter predicate
         |> List.length
 
+    let private commandIdsFor predicate =
+        CommandOutputContract.entries
+        |> List.filter predicate
+        |> List.map (fun entry -> entry.Identity.CommandId)
+
+    let private markdownBulletIdsAfter (anchor: string) (markdown: string) =
+        let pattern =
+            Regex.Escape(anchor)
+            + @"\r?\n\r?\n(?<items>(?:- `[^`]+`\r?\n)+)"
+
+        let markdownMatch = Regex.Match(markdown, pattern)
+
+        markdownMatch.Success |> should equal true
+
+        markdownMatch
+            .Groups[ "items" ]
+            .Value.Split([| "\r\n"; "\n" |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.map (fun line ->
+            let itemMatch = Regex.Match(line.Trim(), @"^- `(?<id>[^`]+)`$")
+
+            itemMatch.Success |> should equal true
+
+            itemMatch.Groups["id"].Value)
+        |> Array.toList
+
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
@@ -786,38 +811,52 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
+        let jsonReady =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ExistingGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let intentionallyHumanOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, JsonModeErrorOnly _ -> true
+                | _ -> false)
+
+        let deferredV2 =
+            commandIdsFor (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let sourceOnly =
+            commandIdsFor (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
+                | _ -> false)
+
+        let deleted = 0
+
         [
-            "Total leaf commands: `201`"
-            "JSON-ready routed commands: `180`"
-            "Intentionally human-only commands: `1`"
-            "Deferred routed commands with explicit V2 scope: `11`"
-            "Source-only/unrouted commands: `9`"
-            "Deleted commands: `0`"
-            "reference.assign"
-            "reference.checkpoint"
-            "reference.commit"
-            "reference.create-external"
-            "reference.delete"
-            "reference.get"
-            "reference.promote"
-            "reference.save"
-            "reference.tag"
-            "diff.checkpoint"
-            "diff.commit"
-            "diff.directoryid"
-            "diff.promotion"
-            "diff.save"
-            "diff.sha"
-            "diff.tag"
-            "history.run"
-            "maintenance.scan"
-            "maintenance.update-index"
-            "repository.init"
+            $"Total leaf commands: `{CommandOutputContract.entries.Length}`"
+            $"JSON-ready routed commands: `{jsonReady}`"
+            $"Intentionally human-only commands: `{intentionallyHumanOnly}`"
+            $"Deferred routed commands with explicit V2 scope: `{deferredV2.Length}`"
+            $"Source-only/unrouted commands: `{sourceOnly.Length}`"
+            $"Deleted commands: `{deleted}`"
             "Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections"
         ]
         |> List.iter (fun expected ->
             markdown.Contains(expected, StringComparison.Ordinal)
             |> should equal true)
+
+        let sourceOnlyInDocs =
+            markdownBulletIdsAfter "The source-only/unrouted commands are defined in source but are not attached to `GraceCommand.rootCommand` in V1:" markdown
+
+        let deferredV2InDocs = markdownBulletIdsAfter "Current deferrals are:" markdown
+
+        assertSetEqual sourceOnly sourceOnlyInDocs
+        assertSetEqual deferredV2 deferredV2InDocs
 
     [<Test>]
     let ``machine readable cli docs json snippets parse`` () =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,7 +45,9 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 181
+        |> should equal 180
+
+        countBy ImmediateJsonErrorOnly |> should equal 1
 
         countBy HumanProgressOnlySuccess
         |> should equal 10
@@ -129,6 +131,9 @@ module CommandOutputContractRegistryTests =
         behaviors.Contains HumanProgressOnlySuccess
         |> should equal true
 
+        behaviors.Contains ImmediateJsonErrorOnly
+        |> should equal true
+
         behaviors.Contains ManualJsonUnenveloped
         |> should equal false
 
@@ -171,7 +176,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 180
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -181,6 +186,41 @@ module CommandOutputContractRegistryTests =
 
             entry.Features.Select
             |> should equal ExistingBehavior
+
+    [<Test>]
+    let ``watch json mode is registered as immediate error only`` () =
+        let identity = CommandOutputContract.commandIdentity [] "watch"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.CurrentJsonBehavior
+            |> should equal ImmediateJsonErrorOnly
+
+            match entry.EnvelopeContract with
+            | JsonModeErrorOnly reason ->
+                reason
+                |> should contain "short-circuited before command execution"
+            | other -> Assert.Fail($"Expected watch to be registered as JsonModeErrorOnly, got {other}.")
+
+            entry.Features.JsonMode
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal RequiresMigration
+
+            entry.ReturnValueContract.Status
+            |> should equal ContractUnsupported
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status |> should equal "unsupported"
+
+                schema.Envelope
+                |> should contain "GraceError only in JSON mode"
+            | None -> Assert.Fail("watch schema introspection should include the explicit unsupported schema document.")
+        | None -> Assert.Fail("watch should have a registry entry.")
 
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
@@ -253,6 +293,50 @@ module CommandOutputContractRegistryTests =
                 |> should equal "string"
             | None -> Assert.Fail("Schema introspection should include a schema document.")
         | None -> Assert.Fail("auth.logout should have a registry entry.")
+
+    [<Test>]
+    let ``maintenance registry entries expose schema ready local dto metadata`` () =
+        let cases =
+            [
+                CommandOutputContract.commandIdentity [ "maintenance" ] "check-ignore-entries", "MaintenanceIgnoreEntriesDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "list-contents", "MaintenanceListContentsDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "scan", "MaintenanceScanDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "stats", "MaintenanceStatsDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "update-index", "MaintenanceStatsDto"
+            ]
+
+        for identity, expectedContract in cases do
+            match CommandOutputContract.tryFind identity with
+            | Some entry ->
+                entry.ReturnValueContract.Status
+                |> should equal SchemaReady
+
+                let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+                match schemaDocument.Schema with
+                | Some schema ->
+                    schema.Status |> should equal "schema-ready"
+
+                    schema.ReturnValueContract
+                    |> should equal expectedContract
+
+                    use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                    let returnValueSchema =
+                        successSchema
+                            .RootElement
+                            .GetProperty("properties")
+                            .GetProperty("ReturnValue")
+
+                    returnValueSchema.GetProperty("title").GetString()
+                    |> should equal expectedContract
+                | None -> Assert.Fail($"Expected schema document for {identity.CommandId}.")
+
+                let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+                examplesDocument.Examples[0].Name
+                |> should equal "success-envelope-shape"
+            | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
 
     [<Test>]
     let ``metadata incomplete registry entries are explicit`` () =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -45,15 +45,15 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 163
+        |> should equal 175
 
         countBy HumanProgressOnlySuccess
         |> should equal 16
 
-        countBy PartialManualSuccess |> should equal 6
-        countBy ManualJsonUnenveloped |> should equal 5
+        countBy PartialManualSuccess |> should equal 0
+        countBy ManualJsonUnenveloped |> should equal 0
         countBy HumanProcOnly |> should equal 1
-        countBy HumanOnly |> should equal 1
+        countBy HumanOnly |> should equal 0
         countBy UnroutedSourceOnly |> should equal 9
 
     [<Test>]
@@ -124,16 +124,16 @@ module CommandOutputContractRegistryTests =
             |> List.map (fun entry -> entry.CurrentJsonBehavior)
             |> Set.ofList
 
-        behaviors.Contains HumanOnly |> should equal true
+        behaviors.Contains HumanOnly |> should equal false
 
         behaviors.Contains HumanProgressOnlySuccess
         |> should equal true
 
         behaviors.Contains ManualJsonUnenveloped
-        |> should equal true
+        |> should equal false
 
         behaviors.Contains PartialManualSuccess
-        |> should equal true
+        |> should equal false
 
         behaviors.Contains HumanProcOnly
         |> should equal true
@@ -147,13 +147,13 @@ module CommandOutputContractRegistryTests =
             entry.Identity.CommandId |> should equal "connect"
 
             entry.CurrentJsonBehavior
-            |> should equal PartialManualSuccess
+            |> should equal CommonRenderOutputEnvelope
 
             entry.EnvelopeContract
-            |> should equal (MigrationRequiredToGraceResultEnvelope RequiresCliDto)
+            |> should equal (ExistingGraceResultEnvelope RequiresCliDto)
 
             entry.Features.JsonMode
-            |> should equal RequiresMigration
+            |> should equal ExistingBehavior
 
             entry.Features.Schema
             |> should equal FutureInertIntrospection
@@ -162,7 +162,7 @@ module CommandOutputContractRegistryTests =
             |> should equal FutureInertIntrospection
 
             entry.Features.Select
-            |> should equal FutureReturnValueProjection
+            |> should equal ExistingBehavior
         | None -> Assert.Fail("connect should have a registry entry.")
 
     [<Test>]
@@ -171,11 +171,12 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 163
+        commonEntries.Length |> should equal 175
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
-            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
+            | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
+            | RequiresCliDto) -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
             entry.Features.Select
@@ -272,7 +273,7 @@ module CommandOutputContractRegistryTests =
                 schema.Notes
                 |> should
                     contain
-                    "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+                    "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
             | None -> Assert.Fail("Metadata-incomplete schema introspection should include a schema document.")
 
             let examplesDocument = CommandOutputContract.introspectionDocument Examples entry

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.CommandOutputContract
 open NUnit.Framework
 open System
+open System.Text.Json
 
 [<TestFixture>]
 [<NonParallelizable>]
@@ -176,3 +177,179 @@ module CommandOutputContractRegistryTests =
             match entry.EnvelopeContract with
             | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
+
+    [<Test>]
+    let ``schema ready registry entries describe success and error envelopes`` () =
+        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            let document = CommandOutputContract.introspectionDocument Schema entry
+
+            document.Kind |> should equal "schema"
+
+            document.Command.Id |> should equal "auth.logout"
+
+            match document.Schema with
+            | Some schema ->
+                schema.Status |> should equal "schema-ready"
+
+                schema.ReturnValueContract
+                |> should equal "string"
+
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+                let successRoot = successSchema.RootElement
+
+                successRoot.GetProperty("title").GetString()
+                |> should equal "GraceReturnValue<string>"
+
+                let properties = successRoot.GetProperty("properties")
+
+                properties
+                    .GetProperty("ReturnValue")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "string"
+
+                properties.GetProperty("ReturnValue").ValueKind
+                |> should equal JsonValueKind.Object
+
+                properties
+                    .GetProperty("EventTime")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "string"
+
+                properties
+                    .GetProperty("CorrelationId")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "string"
+
+                properties
+                    .GetProperty("Properties")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "array"
+
+                use errorSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.ErrorSchema)
+
+                errorSchema
+                    .RootElement
+                    .GetProperty("title")
+                    .GetString()
+                |> should equal "GraceError"
+
+                errorSchema
+                    .RootElement
+                    .GetProperty("properties")
+                    .GetProperty("Error")
+                    .GetProperty("type")
+                    .GetString()
+                |> should equal "string"
+            | None -> Assert.Fail("Schema introspection should include a schema document.")
+        | None -> Assert.Fail("auth.logout should have a registry entry.")
+
+    [<Test>]
+    let ``metadata incomplete registry entries are explicit`` () =
+        let identity = CommandOutputContract.commandIdentity [ "repository" ] "init"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.ReturnValueContract.Status
+            |> should equal MetadataIncomplete
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status
+                |> should equal "metadata-incomplete"
+
+                schema.Notes
+                |> should
+                    contain
+                    "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+            | None -> Assert.Fail("Metadata-incomplete schema introspection should include a schema document.")
+
+            let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+            examplesDocument.Examples.Length |> should equal 2
+
+            examplesDocument.Examples[0].Name
+            |> should equal "metadata-incomplete"
+        | None -> Assert.Fail("repository.init should have a registry entry.")
+
+    [<Test>]
+    let ``dto and union contracts are not schema ready until their full emitted shapes are declared`` () =
+        let cases =
+            [
+                CommandOutputContract.commandIdentity [ "repository" ] "get", "RepositoryDto metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "workitem" ] "show", "WorkItemDto metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "access" ] "check", "PermissionCheckResult metadata is incomplete"
+            ]
+
+        for identity, expectedNote in cases do
+            match CommandOutputContract.tryFind identity with
+            | Some entry ->
+                entry.ReturnValueContract.Status
+                |> should equal MetadataIncomplete
+
+                let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+                match schemaDocument.Schema with
+                | Some schema ->
+                    schema.Status
+                    |> should equal "metadata-incomplete"
+
+                    schema.Notes
+                    |> List.exists (fun note -> note.Contains(expectedNote, StringComparison.Ordinal))
+                    |> should equal true
+                | None -> Assert.Fail($"Expected schema document for {identity.CommandId}.")
+
+                let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+                examplesDocument.Examples[0].Name
+                |> should equal "metadata-incomplete"
+            | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
+
+    [<Test>]
+    let ``examples for schema ready commands parse as Grace envelopes`` () =
+        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            let document = CommandOutputContract.introspectionDocument Examples entry
+
+            document.Examples.Length |> should equal 2
+
+            document.Examples[0].Name
+            |> should equal "success-envelope-shape"
+
+            document.Examples[1].Name
+            |> should equal "error-envelope-shape"
+
+            use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[0].Document)
+            let successRoot = success.RootElement
+
+            successRoot.GetProperty("ReturnValue").GetString()
+            |> should equal "Signed out."
+
+            let successProperties = successRoot.GetProperty("Properties")
+
+            successProperties.ValueKind
+            |> should equal JsonValueKind.Array
+
+            successProperties[0]
+                .GetProperty("Key")
+                .GetString()
+            |> should equal "cli.contractVersion"
+
+            use error = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[1].Document)
+            let errorRoot = error.RootElement
+
+            errorRoot.GetProperty("Error").GetString()
+            |> should equal "error message"
+
+            errorRoot.GetProperty("CorrelationId").GetString()
+            |> should equal "correlation-id"
+        | None -> Assert.Fail("auth.logout should have a registry entry.")

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -1,0 +1,178 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.CommandOutputContract
+open NUnit.Framework
+open System
+
+[<TestFixture>]
+[<NonParallelizable>]
+module CommandOutputContractRegistryTests =
+
+    let private commandId (identity: CommandIdentity) = identity.CommandId
+
+    let private countBy behavior =
+        CommandOutputContract.entries
+        |> List.filter (fun entry -> entry.CurrentJsonBehavior = behavior)
+        |> List.length
+
+    let private assertSetEqual expected actual =
+        let expectedSet = Set.ofSeq expected
+        let actualSet = Set.ofSeq actual
+
+        if expectedSet <> actualSet then
+            let missing =
+                Set.difference expectedSet actualSet
+                |> String.concat ", "
+
+            let extra =
+                Set.difference actualSet expectedSet
+                |> String.concat ", "
+
+            Assert.Fail($"Set mismatch. Missing: {missing}. Extra: {extra}.")
+
+    [<Test>]
+    let ``registry contains accepted inventory totals`` () =
+        CommandOutputContract.entries.Length
+        |> should equal 201
+
+        CommandOutputContract.routedEntries.Length
+        |> should equal 192
+
+        CommandOutputContract.sourceOnlyEntries.Length
+        |> should equal 9
+
+        countBy CommonRenderOutputEnvelope
+        |> should equal 163
+
+        countBy HumanProgressOnlySuccess
+        |> should equal 16
+
+        countBy PartialManualSuccess |> should equal 6
+        countBy ManualJsonUnenveloped |> should equal 5
+        countBy HumanProcOnly |> should equal 1
+        countBy HumanOnly |> should equal 1
+        countBy UnroutedSourceOnly |> should equal 9
+
+    [<Test>]
+    let ``every live routed leaf command has one registry entry`` () =
+        let discovered =
+            CommandOutputContract.discoverLeafCommands GraceCommand.rootCommand
+            |> List.map commandId
+
+        let registered =
+            CommandOutputContract.routedEntries
+            |> List.map (fun entry -> entry.Identity.CommandId)
+
+        discovered.Length |> should equal 192
+
+        discovered.Length
+        |> should equal (discovered |> List.distinct |> List.length)
+
+        registered.Length
+        |> should equal (registered |> List.distinct |> List.length)
+
+        assertSetEqual discovered registered
+
+    [<Test>]
+    let ``source-only entries are explicit and unsupported`` () =
+        let sourceOnlyIds =
+            CommandOutputContract.sourceOnlyEntries
+            |> List.map (fun entry -> entry.Identity.CommandId)
+
+        sourceOnlyIds
+        |> should
+            equal
+            [
+                "reference.assign"
+                "reference.checkpoint"
+                "reference.commit"
+                "reference.create-external"
+                "reference.delete"
+                "reference.get"
+                "reference.promote"
+                "reference.save"
+                "reference.tag"
+            ]
+
+        for entry in CommandOutputContract.sourceOnlyEntries do
+            entry.CurrentJsonBehavior
+            |> should equal UnroutedSourceOnly
+
+            match entry.RouteDisposition, entry.EnvelopeContract with
+            | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> ()
+            | other -> Assert.Fail($"Expected source-only unsupported disposition for {entry.Identity.CommandId}, got {other}.")
+
+            entry.Features.JsonMode
+            |> should equal UnsupportedUntilRouted
+
+            entry.Features.Schema
+            |> should equal UnsupportedUntilRouted
+
+            entry.Features.Examples
+            |> should equal UnsupportedUntilRouted
+
+            entry.Features.Select
+            |> should equal UnsupportedUntilRouted
+
+    [<Test>]
+    let ``routed backlog categories are represented`` () =
+        let behaviors =
+            CommandOutputContract.routedEntries
+            |> List.map (fun entry -> entry.CurrentJsonBehavior)
+            |> Set.ofList
+
+        behaviors.Contains HumanOnly |> should equal true
+
+        behaviors.Contains HumanProgressOnlySuccess
+        |> should equal true
+
+        behaviors.Contains ManualJsonUnenveloped
+        |> should equal true
+
+        behaviors.Contains PartialManualSuccess
+        |> should equal true
+
+        behaviors.Contains HumanProcOnly
+        |> should equal true
+
+    [<Test>]
+    let ``registry metadata is consumable without invoking handlers`` () =
+        let identity = CommandOutputContract.commandIdentity [] "connect"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.Identity.CommandId |> should equal "connect"
+
+            entry.CurrentJsonBehavior
+            |> should equal PartialManualSuccess
+
+            entry.EnvelopeContract
+            |> should equal (MigrationRequiredToGraceResultEnvelope RequiresCliDto)
+
+            entry.Features.JsonMode
+            |> should equal RequiresMigration
+
+            entry.Features.Schema
+            |> should equal FutureInertIntrospection
+
+            entry.Features.Examples
+            |> should equal FutureInertIntrospection
+
+            entry.Features.Select
+            |> should equal FutureReturnValueProjection
+        | None -> Assert.Fail("connect should have a registry entry.")
+
+    [<Test>]
+    let ``current common renderer entries keep the Grace envelope model`` () =
+        let commonEntries =
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
+
+        commonEntries.Length |> should equal 163
+
+        for entry in commonEntries do
+            match entry.EnvelopeContract with
+            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
+            | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -3,8 +3,11 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.CommandOutputContract
+open Grace.Shared
+open Grace.Types.Common
 open NUnit.Framework
 open System
+open System.IO
 open System.Text.Json
 
 [<TestFixture>]
@@ -32,6 +35,41 @@ module CommandOutputContractRegistryTests =
                 |> String.concat ", "
 
             Assert.Fail($"Set mismatch. Missing: {missing}. Extra: {extra}.")
+
+    let private captureStdout action =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            let exitCode = action ()
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+
+    let private parseJsonDocument (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    let private assertOneJsonObjectStdout (output: string) =
+        let ansiCsiPrefix = string (char 0x1B) + "["
+
+        output.Contains(ansiCsiPrefix, StringComparison.Ordinal)
+        |> should equal false
+        output |> should not' (contain "[red]")
+        output |> should not' (contain "Elapsed:")
+
+        output
+        |> should not' (contain "Exception in isOutputFormat")
+
+        use document = parseJsonDocument output
+
+        document.RootElement.ValueKind
+        |> should equal JsonValueKind.Object
 
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
@@ -186,6 +224,116 @@ module CommandOutputContractRegistryTests =
 
             entry.Features.Select
             |> should equal ExistingBehavior
+
+    [<Test>]
+    let ``every common renderer entry has recursive json option and central envelope behavior`` () =
+        let commonEntries =
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
+
+        commonEntries.Length |> should equal 180
+
+        for entry in commonEntries do
+            let commandPath = entry.Identity.CommandPath |> List.toArray
+            let parseArgs = Array.append [| "--output"; "Json" |] commandPath
+            let parseResult = GraceCommand.rootCommand.Parse(parseArgs)
+
+            Common.json parseResult |> should equal true
+
+            match entry.EnvelopeContract with
+            | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
+            | RequiresCliDto) -> ()
+            | other -> Assert.Fail($"Expected central Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
+
+            let successValue = GraceReturnValue.Create $"success:{entry.Identity.CommandId}" $"corr-success-{entry.Identity.CommandId}"
+
+            let successExitCode, successOutput = captureStdout (fun () -> Common.renderOutput parseResult (Ok successValue))
+
+            successExitCode |> should equal 0
+            assertOneJsonObjectStdout successOutput
+
+            use successDocument = parseJsonDocument successOutput
+            let successRoot = successDocument.RootElement
+
+            successRoot.GetProperty("ReturnValue").GetString()
+            |> should equal $"success:{entry.Identity.CommandId}"
+
+            successRoot
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should equal $"corr-success-{entry.Identity.CommandId}"
+
+            let error = GraceError.Create $"error:{entry.Identity.CommandId}" $"corr-error-{entry.Identity.CommandId}"
+
+            let errorExitCode, errorOutput = captureStdout (fun () -> Common.renderOutput parseResult (Error error))
+
+            errorExitCode |> should equal -1
+            assertOneJsonObjectStdout errorOutput
+
+            use errorDocument = parseJsonDocument errorOutput
+            let errorRoot = errorDocument.RootElement
+
+            errorRoot.GetProperty("Error").GetString()
+            |> should equal $"error:{entry.Identity.CommandId}"
+
+            errorRoot.GetProperty("CorrelationId").GetString()
+            |> should equal $"corr-error-{entry.Identity.CommandId}"
+
+    [<Test>]
+    let ``representative local dto envelopes use shared serializer contract`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "--output"
+                    "Json"
+                    "maintenance"
+                    "stats"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        let dto: Common.LocalOutputDto.MaintenanceStatsDto =
+            { DirectoryCount = 3; FileCount = 5; TotalFileSize = 89L; RootSha256Hash = Some "0123456789abcdef" }
+
+        let exitCode, output =
+            captureStdout (fun () ->
+                GraceReturnValue.Create dto "corr-local-dto"
+                |> Ok
+                |> Common.renderOutput parseResult)
+
+        exitCode |> should equal 0
+        assertOneJsonObjectStdout output
+
+        use document = parseJsonDocument output
+        let root = document.RootElement
+        let returnValue = root.GetProperty("ReturnValue")
+
+        returnValue
+            .GetProperty("DirectoryCount")
+            .GetInt32()
+        |> should equal 3
+
+        returnValue.GetProperty("FileCount").GetInt32()
+        |> should equal 5
+
+        returnValue
+            .GetProperty("TotalFileSize")
+            .GetInt64()
+        |> should equal 89L
+
+        returnValue
+            .GetProperty("RootSha256Hash")
+            .GetString()
+        |> should equal "0123456789abcdef"
+
+        let mutable camelCaseReturnValue = Unchecked.defaultof<JsonElement>
+
+        root.TryGetProperty("returnValue", &camelCaseReturnValue)
+        |> should equal false
+
+        Constants.JsonSerializerOptions.PropertyNamingPolicy
+        |> should equal null
 
     [<Test>]
     let ``watch json mode is registered as immediate error only`` () =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -178,6 +178,9 @@ module CommandOutputContractRegistryTests =
             | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
         let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Shared
 open Grace.Types.Common
 open NUnit.Framework
 open System
+open System.CommandLine
 open System.IO
 open System.Text.Json
 
@@ -15,6 +16,107 @@ open System.Text.Json
 module CommandOutputContractRegistryTests =
 
     let private commandId (identity: CommandIdentity) = identity.CommandId
+
+    let private placeholderGuid = "11111111-1111-1111-1111-111111111111"
+
+    let private optionPlaceholder optionName =
+        match optionName with
+        | "--after" -> "+15m"
+        | "--allows-large-files"
+        | "--anonymous-access"
+        | "--record-saves" -> "true"
+        | "--branch-name"
+        | "--display-name"
+        | "--name"
+        | "--new-name"
+        | "--organization-name"
+        | "--owner-name"
+        | "--repository-name" -> "example"
+        | "--candidate" -> "candidate-1"
+        | "--checkpoint-days"
+        | "--diff-cache-days"
+        | "--directory-version-cache-days"
+        | "--logical-delete-days"
+        | "--save-days" -> "30"
+        | "--claim" -> "user:user-1"
+        | "--conflict-resolution-policy" -> "NoConflicts"
+        | "--default-server-api-version" -> "Latest"
+        | "--delete-reason"
+        | "--description"
+        | "--message"
+        | "--reason"
+        | "--required-responder"
+        | "--text"
+        | "--title" -> "example text"
+        | "--dir-perm" -> "Read"
+        | "--event" -> "promotion-set.applied"
+        | "--fire-at" -> "2026-01-01T00:00:00Z"
+        | "--format" -> "json"
+        | "--gate" -> "build"
+        | "--operation" -> "RepoRead"
+        | "--organization-type"
+        | "--owner-type"
+        | "--visibility" -> "Public"
+        | "--output-file" -> "output.json"
+        | "--path" -> "src"
+        | "--principal-id" -> "user-1"
+        | "--principal-type" -> "User"
+        | "--promotion-mode" -> "IndividualOnly"
+        | "--resource"
+        | "--scope" -> "repository"
+        | "--search-visibility" -> "Visible"
+        | "--set" -> "Active"
+        | "--status" -> "Active"
+        | "--type" -> "summary"
+        | "--url" -> "https://example.test/webhook"
+        | name when name.EndsWith("-file", StringComparison.OrdinalIgnoreCase) -> "input.txt"
+        | name when name.EndsWith("-id", StringComparison.OrdinalIgnoreCase) -> placeholderGuid
+        | name when name.EndsWith("-type", StringComparison.OrdinalIgnoreCase) -> "Maintenance"
+        | _ -> "example"
+
+    let private argumentPlaceholder argumentName =
+        match argumentName with
+        | "query" -> "example"
+        | name when name.Contains("number", StringComparison.OrdinalIgnoreCase) -> "123"
+        | name when name.Contains("work", StringComparison.OrdinalIgnoreCase) -> "123"
+        | name when name.Contains("file", StringComparison.OrdinalIgnoreCase) -> "input.txt"
+        | name when name.Contains("id", StringComparison.OrdinalIgnoreCase) -> placeholderGuid
+        | _ -> "example"
+
+    let private findCommand (commandPath: string list) =
+        let mutable current: Command = GraceCommand.rootCommand :> Command
+
+        for commandName in commandPath do
+            current <-
+                current.Subcommands
+                |> Seq.find (fun subcommand ->
+                    subcommand.Name.Equals(commandName, StringComparison.Ordinal)
+                    || subcommand.Aliases.Contains(commandName))
+
+        current
+
+    let private auditPlaceholderArgs (entry: CommandContractEntry) =
+        let command = findCommand entry.Identity.CommandPath
+
+        [|
+            for option in command.Options do
+                if option.Required then
+                    yield option.Name
+                    yield optionPlaceholder option.Name
+
+            for argument in command.Arguments do
+                yield argumentPlaceholder argument.Name
+        |]
+
+    let private auditParseArgs (entry: CommandContractEntry) =
+        let commandPath = entry.Identity.CommandPath |> List.toArray
+
+        [|
+            yield "--output"
+            yield "Json"
+            yield! commandPath
+            yield! auditPlaceholderArgs entry
+        |]
 
     let private countBy behavior =
         CommandOutputContract.entries
@@ -60,6 +162,7 @@ module CommandOutputContractRegistryTests =
 
         output.Contains(ansiCsiPrefix, StringComparison.Ordinal)
         |> should equal false
+
         output |> should not' (contain "[red]")
         output |> should not' (contain "Elapsed:")
 
@@ -233,10 +336,30 @@ module CommandOutputContractRegistryTests =
 
         commonEntries.Length |> should equal 180
 
+        let parserInvalidEntries =
+            commonEntries
+            |> List.choose (fun entry ->
+                let parseResult = GraceCommand.rootCommand.Parse(auditParseArgs entry)
+
+                if parseResult.Errors.Count = 0 then
+                    None
+                else
+                    let errors =
+                        parseResult.Errors
+                        |> Seq.map (fun error -> error.Message)
+                        |> String.concat "; "
+
+                    Some $"{entry.Identity.CommandId}: {errors}")
+
+        if not parserInvalidEntries.IsEmpty then
+            parserInvalidEntries
+            |> String.concat Environment.NewLine
+            |> fun errors -> Assert.Fail($"Expected parser-valid audit paths for common renderer entries:{Environment.NewLine}{errors}")
+
         for entry in commonEntries do
-            let commandPath = entry.Identity.CommandPath |> List.toArray
-            let parseArgs = Array.append [| "--output"; "Json" |] commandPath
-            let parseResult = GraceCommand.rootCommand.Parse(parseArgs)
+            let parseResult = GraceCommand.rootCommand.Parse(auditParseArgs entry)
+
+            parseResult.Errors.Count |> should equal 0
 
             Common.json parseResult |> should equal true
 

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -9,6 +9,7 @@ open NUnit.Framework
 open System
 open System.CommandLine
 open System.IO
+open System.Text.RegularExpressions
 open System.Text.Json
 
 [<TestFixture>]
@@ -18,6 +19,10 @@ module CommandOutputContractRegistryTests =
     let private commandId (identity: CommandIdentity) = identity.CommandId
 
     let private placeholderGuid = "11111111-1111-1111-1111-111111111111"
+
+    let private repoRoot = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", ".."))
+
+    let private machineReadableDocPath = Path.Combine(repoRoot, "docs", "Machine-readable CLI output.md")
 
     let private optionPlaceholder optionName =
         match optionName with
@@ -174,6 +179,11 @@ module CommandOutputContractRegistryTests =
         document.RootElement.ValueKind
         |> should equal JsonValueKind.Object
 
+    let private countEntries predicate =
+        CommandOutputContract.entries
+        |> List.filter predicate
+        |> List.length
+
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
@@ -198,6 +208,47 @@ module CommandOutputContractRegistryTests =
         countBy HumanProcOnly |> should equal 1
         countBy HumanOnly |> should equal 0
         countBy UnroutedSourceOnly |> should equal 9
+
+    [<Test>]
+    let ``final inventory dispositions cover every command exactly once`` () =
+        let jsonReady =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ExistingGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let intentionallyHumanOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, JsonModeErrorOnly _ -> true
+                | _ -> false)
+
+        let deferredV2 =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
+                | _ -> false)
+
+        let sourceOnly =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
+                | _ -> false)
+
+        let deleted = 0
+
+        jsonReady |> should equal 180
+        intentionallyHumanOnly |> should equal 1
+        deferredV2 |> should equal 11
+        sourceOnly |> should equal 9
+        deleted |> should equal 0
+
+        jsonReady
+        + intentionallyHumanOnly
+        + deferredV2
+        + sourceOnly
+        + deleted
+        |> should equal CommandOutputContract.entries.Length
 
     [<Test>]
     let ``every live routed leaf command has one registry entry`` () =
@@ -712,3 +763,73 @@ module CommandOutputContractRegistryTests =
             errorRoot.GetProperty("CorrelationId").GetString()
             |> should equal "correlation-id"
         | None -> Assert.Fail("auth.logout should have a registry entry.")
+
+    [<Test>]
+    let ``all registry schema and example documents serialize as json`` () =
+        for entry in CommandOutputContract.entries do
+            for kind in [ Schema; Examples ] do
+                let document = CommandOutputContract.introspectionDocument kind entry
+                let json = Grace.Shared.Utilities.serialize document
+                use parsed = JsonDocument.Parse(json)
+
+                parsed.RootElement.ValueKind
+                |> should equal JsonValueKind.Object
+
+                parsed
+                    .RootElement
+                    .GetProperty("Command")
+                    .GetProperty("Id")
+                    .GetString()
+                |> should equal entry.Identity.CommandId
+
+    [<Test>]
+    let ``machine readable cli docs keep final inventory evidence current`` () =
+        let markdown = File.ReadAllText(machineReadableDocPath)
+
+        [
+            "Total leaf commands: `201`"
+            "JSON-ready routed commands: `180`"
+            "Intentionally human-only commands: `1`"
+            "Deferred routed commands with explicit V2 scope: `11`"
+            "Source-only/unrouted commands: `9`"
+            "Deleted commands: `0`"
+            "reference.assign"
+            "reference.checkpoint"
+            "reference.commit"
+            "reference.create-external"
+            "reference.delete"
+            "reference.get"
+            "reference.promote"
+            "reference.save"
+            "reference.tag"
+            "diff.checkpoint"
+            "diff.commit"
+            "diff.directoryid"
+            "diff.promotion"
+            "diff.save"
+            "diff.sha"
+            "diff.tag"
+            "history.run"
+            "maintenance.scan"
+            "maintenance.update-index"
+            "repository.init"
+            "Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections"
+        ]
+        |> List.iter (fun expected ->
+            markdown.Contains(expected, StringComparison.Ordinal)
+            |> should equal true)
+
+    [<Test>]
+    let ``machine readable cli docs json snippets parse`` () =
+        let markdown = File.ReadAllText(machineReadableDocPath)
+        let matches = Regex.Matches(markdown, "```json\r?\n(?<json>.*?)\r?\n```", RegexOptions.Singleline)
+
+        matches.Count
+        |> should be (greaterThanOrEqualTo 3)
+
+        for markdownMatch in matches |> Seq.cast<Match> do
+            let json = markdownMatch.Groups["json"].Value
+            use parsed = JsonDocument.Parse(json)
+
+            parsed.RootElement.ValueKind
+            |> should not' (equal JsonValueKind.Undefined)

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="BuildInfo.Tests.fs" />
     <Compile Include="Artifact.SDK.Tests.fs" />
     <Compile Include="ClientIdentity.SDK.Tests.fs" />
+    <Compile Include="SelectProjection.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />
     <Compile Include="HistoryStorage.CLI.Tests.fs" />

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="WebhookApproval.CLI.Parsing.Tests.fs" />
     <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
+    <Compile Include="CommandOutputContract.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />
     <Compile Include="ManifestUpload.SDK.Tests.fs" />

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="WebhookApproval.CLI.Parsing.Tests.fs" />
     <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
+    <Compile Include="Maintenance.CLI.Tests.fs" />
     <Compile Include="CommandOutputContract.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -39,6 +39,7 @@ module MaintenanceCliTests =
         let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
         Directory.CreateDirectory(graceDir) |> ignore
         File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{}")
+        File.WriteAllText(Path.Combine(tempDir, "tracked.txt"), "tracked content")
 
         let originalDir = Environment.CurrentDirectory
 
@@ -57,21 +58,51 @@ module MaintenanceCliTests =
                 | _ -> ()
 
     let private parseJsonOutput (output: string) =
-        output
-            .TrimStart()
-            .StartsWith("{", StringComparison.Ordinal)
+        output.StartsWith("{", StringComparison.Ordinal)
         |> should equal true
 
         JsonDocument.Parse(output)
 
+    let private assertCleanJsonStdout (standardOut: string) =
+        standardOut |> should not' (contain "Elapsed:")
+
+        standardOut
+        |> should not' (contain "Reading Grace index file")
+
+        standardOut
+        |> should not' (contain "Scanning working directory")
+
+        standardOut
+        |> should not' (contain "All values taken from the local Grace status file")
+
+        standardOut
+        |> should not' (contain "Number of differences")
+
+        standardOut
+        |> should not' (contain "Number of directories")
+
+        parseJsonOutput standardOut
+
+    let private runJsonMaintenance args = runWithCapturedStdoutAndStderr (Array.append [| "--output"; "Json"; "maintenance" |] args)
+
+    let private createIndex () =
+        let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+        exitCode |> should equal 0
+        standardError |> should equal String.Empty
+        use document = assertCleanJsonStdout standardOut
+        let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+        returnValue
+            .GetProperty(
+                "DirectoryCount"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Number
+
     [<Test>]
     let ``maintenance check ignore entries json emits one clean envelope`` () =
         withTempRepo (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "maintenance"
-                                                  "check-ignore-entries" |]
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "check-ignore-entries" |]
 
             exitCode |> should equal 0
             standardError |> should equal String.Empty
@@ -79,9 +110,7 @@ module MaintenanceCliTests =
             standardOut
             |> should not' (contain "Directory ignore entries:")
 
-            standardOut |> should not' (contain "Elapsed:")
-
-            use document = parseJsonOutput standardOut
+            use document = assertCleanJsonStdout standardOut
             let root = document.RootElement
 
             root.GetProperty("ReturnValue").GetProperty(
@@ -97,4 +126,117 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Array
 
             root.GetProperty("Properties").ValueKind
+            |> should equal JsonValueKind.Array)
+
+    [<Test>]
+    let ``maintenance update-index json emits stats envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DirectoryCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("FileCount").ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("TotalFileSize").ValueKind
+            |> should equal JsonValueKind.Number)
+
+    [<Test>]
+    let ``maintenance scan json emits scan envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "scan" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DifferenceCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("Differences").ValueKind
+            |> should equal JsonValueKind.Array
+
+            returnValue
+                .GetProperty(
+                    "NewDirectoryVersionCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue
+                .GetProperty(
+                    "NewDirectoryVersions"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Array)
+
+    [<Test>]
+    let ``maintenance stats json emits stats envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "stats" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty(
+                    "DirectoryCount"
+                )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("FileCount").ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue
+                .GetProperty(
+                    "RootSha256Hash"
+                )
+                .ValueKind
+            |> should not' (equal JsonValueKind.Undefined))
+
+    [<Test>]
+    let ``maintenance list contents json emits contents envelope with clean stdout`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "list-contents" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue.GetProperty("Summary").GetProperty(
+                "DirectoryCount"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Number
+
+            returnValue.GetProperty("Directories").ValueKind
             |> should equal JsonValueKind.Array)

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -1,0 +1,100 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.Shared
+open Grace.Shared.Client.Configuration
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+
+[<NonParallelizable>]
+module MaintenanceCliTests =
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
+    let private withTempRepo (action: string -> unit) =
+        let tempDir = Path.Combine(Path.GetTempPath(), $"grace-maintenance-cli-tests-{Guid.NewGuid():N}")
+        let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
+        Directory.CreateDirectory(graceDir) |> ignore
+        File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{}")
+
+        let originalDir = Environment.CurrentDirectory
+
+        try
+            Environment.CurrentDirectory <- tempDir
+            resetConfiguration ()
+            action tempDir
+        finally
+            resetConfiguration ()
+            Environment.CurrentDirectory <- originalDir
+
+            if Directory.Exists(tempDir) then
+                try
+                    Directory.Delete(tempDir, true)
+                with
+                | _ -> ()
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    [<Test>]
+    let ``maintenance check ignore entries json emits one clean envelope`` () =
+        withTempRepo (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "maintenance"
+                                                  "check-ignore-entries" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            standardOut
+            |> should not' (contain "Directory ignore entries:")
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement
+
+            root.GetProperty("ReturnValue").GetProperty(
+                "DirectoryEntries"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Array
+
+            root.GetProperty("ReturnValue").GetProperty(
+                "FileEntries"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Array
+
+            root.GetProperty("Properties").ValueKind
+            |> should equal JsonValueKind.Array)

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -153,6 +153,44 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Number)
 
     [<Test>]
+    let ``maintenance update-index json exception emits one clean error envelope`` () =
+        withTempRepo (fun root ->
+            let localStateDbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+            Directory.CreateDirectory(localStateDbPath)
+            |> ignore
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "update-index" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            standardOut
+            |> should not' (contain "Reading existing Grace index file")
+
+            standardOut
+            |> should not' (contain "Computing new Grace index file")
+
+            standardOut
+            |> should not' (contain "Writing new Grace index file")
+
+            standardOut
+            |> should not' (contain "Number of directories scanned")
+
+            use document = assertCleanJsonStdout standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Exception in UpdateIndex:"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
     let ``maintenance scan json emits scan envelope with clean stdout`` () =
         withTempRepo (fun _ ->
             createIndex ()

--- a/src/Grace.CLI.Tests/Program.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Parsing.Tests.fs
@@ -32,6 +32,16 @@ module CommandTokenParsingTests =
         |> should equal (Some "connect")
 
     [<Test>]
+    let ``top level command skips schema option`` () =
+        GraceCommand.tryGetTopLevelCommandFromArgs [| "--schema"; "repository"; "init" |] true
+        |> should equal (Some "repository")
+
+    [<Test>]
+    let ``top level command skips examples option`` () =
+        GraceCommand.tryGetTopLevelCommandFromArgs [| "--examples"; "workitem"; "show" |] true
+        |> should equal (Some "workitem")
+
+    [<Test>]
     let ``top level command honors end of options marker`` () =
         GraceCommand.tryGetTopLevelCommandFromArgs
             [|

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,6 +74,7 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.SDK
 open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
@@ -81,7 +82,10 @@ open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
 open System.IO
+open System.Net
+open System.Net.Http
 open System.Text.Json
 
 [<NonParallelizable>]
@@ -201,6 +205,41 @@ module HelpDoesNotReadConfigTests =
         config.BranchId <- branchId
         let json = serialize config
         File.WriteAllText(Path.Combine(graceDir, "graceconfig.json"), json)
+
+    let private addLifecycleHeaders
+        (response: HttpResponseMessage)
+        (status: string)
+        (unsupportedAfter: string)
+        (minimumVersion: string)
+        (recommendedVersion: string option)
+        (updateUrl: string)
+        =
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleStatusHeaderKey, status)
+        |> ignore
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleUnsupportedAfterHeaderKey, unsupportedAfter)
+        |> ignore
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleMinimumVersionHeaderKey, minimumVersion)
+        |> ignore
+
+        match recommendedVersion with
+        | Some value ->
+            response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleRecommendedVersionHeaderKey, value)
+            |> ignore
+        | None -> ()
+
+        response.Headers.TryAddWithoutValidation(Constants.SdkLifecycleUpdateUrlHeaderKey, updateUrl)
+        |> ignore
+
+    let private lifecycleProperties status =
+        use response = new HttpResponseMessage(HttpStatusCode.OK)
+
+        addLifecycleHeaders response status "2026-12-01" "0.1.0" (Some "0.2.0") "https://github.com/ScottArbeit/Grace/releases"
+
+        match ClientIdentity.parseLifecycleDiagnostics response with
+        | Some diagnostics -> ClientIdentity.lifecycleDiagnosticsToProperties diagnostics
+        | None -> Dictionary<string, obj>()
 
     [<Test>]
     let ``help works with invalid config`` () =
@@ -509,6 +548,207 @@ module HelpDoesNotReadConfigTests =
         |> should equal "corr-json-success"
 
         standardOut |> should not' (contain "Elapsed:")
+
+    [<Test>]
+    let ``select option makes command json-oriented`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "auth"
+                    "logout"
+                    "--select"
+                    "Value"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        Common.json parseResult |> should equal true
+
+        Common.tryGetSelect parseResult
+        |> should equal (Some "Value")
+
+    [<Test>]
+    let ``renderOutput select writes selected scalar json only`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok"; Other = "hidden" |} "corr-select-success"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "\"ok\""
+
+    [<Test>]
+    let ``renderOutput select success suppresses lifecycle warnings`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-lifecycle-success"
+
+        returnValue.enhance (lifecycleProperties "deprecated")
+        |> ignore
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "\"ok\""
+
+        standardOut
+        |> should not' (contain "This Grace client version is deprecated.")
+
+    [<Test>]
+    let ``renderOutput select writes selected object and collection json`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Container.Items" |])
+
+        let returnValue =
+            GraceReturnValue.Create
+                {|
+                    Container =
+                        {|
+                            Items =
+                                [|
+                                    {| Name = "one" |}
+                                    {| Name = "two" |}
+                                |]
+                        |}
+                |}
+                "corr-select-collection"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        use document = JsonDocument.Parse(standardOut)
+        let rootElement = document.RootElement
+
+        rootElement.ValueKind
+        |> should equal JsonValueKind.Array
+
+        rootElement.GetArrayLength() |> should equal 2
+
+        rootElement[ 1 ].GetProperty("Name").GetString()
+        |> should equal "two"
+
+    [<Test>]
+    let ``renderOutput select writes null json`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let returnValue = GraceReturnValue.Create {| Value = (null: string) |} "corr-select-null"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+        standardOut.Trim() |> should equal "null"
+
+    [<Test>]
+    let ``renderOutput select missing property emits json error`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Missing" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-missing"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should contain "was not found in ReturnValue"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-select-missing"
+
+    [<Test>]
+    let ``renderOutput select scalar traversal emits json error`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value.Name" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-select-scalar"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        assertJsonErrorOutput standardOut
+        |> should contain "cannot read 'Name'"
+
+    [<Test>]
+    let ``renderOutput select leaves error envelope unprojected`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--select"; "Value" |])
+        let error = GraceError.Create "original failure" "corr-select-error"
+
+        error.enhance (lifecycleProperties "unsupported")
+        |> ignore
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Error error)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should equal "original failure"
+
+        standardOut
+        |> should not' (contain "This Grace client version is no longer supported.")
+
+        let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+        rootElement.TryGetProperty("ReturnValue", &returnValue)
+        |> should equal false
+
+    [<Test>]
+    let ``invalid select grammar does not invoke command`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "connect"
+                                                  "--select"
+                                                  "Value[0]" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "predicates, wildcards, functions, and expressions are not supported"
+
+            File.Exists(Path.Combine(root, ".grace", "graceconfig.json"))
+            |> should equal false)
+
+    [<Test>]
+    let ``valid select on unsupported command is json error without invoking command`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "connect"
+                                                  "--select"
+                                                  "Value" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "does not support --select in this release"
+
+            File.Exists(Path.Combine(root, ".grace", "graceconfig.json"))
+            |> should equal false)
 
     [<Test>]
     let ``renderOutput json error writes GraceError envelope with shared field names`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -511,6 +511,30 @@ module HelpDoesNotReadConfigTests =
             |> should equal "workitem.attach.summary")
 
     [<Test>]
+    let ``root output json is honored for nested commands before config errors`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "agent"
+                                                  "work"
+                                                  "status" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "graceconfig.json"
+
+            standardOut |> should not' (contain "Elapsed:")
+
+            standardOut
+            |> should not' (contain "Grace Version Control System"))
+
+    [<Test>]
     let ``root schema emits json parse error envelope`` () =
         withTempDir (fun _ ->
             let exitCode, output = runWithCapturedOutput [| "--schema" |]
@@ -1339,6 +1363,9 @@ module HelpDoesNotReadConfigTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should not' (equal String.Empty)
+
+            rootElement.GetProperty("Exception").ValueKind
+            |> should equal JsonValueKind.Object
 
             rootElement
                 .GetProperty("CorrelationId")

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,8 +74,10 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Command
 open Grace.SDK
 open Grace.Shared
+open Grace.Shared.Client
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
 open Grace.Types.Common
@@ -150,6 +152,55 @@ module HelpDoesNotReadConfigTests =
 
         error
 
+    let private assertGraceEnvelope (output: string) =
+        use document = parseJsonOutput output
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("ReturnValue").ValueKind
+        |> should equal JsonValueKind.Object
+
+        rootElement.GetProperty("EventTime").ValueKind
+        |> should equal JsonValueKind.String
+
+        rootElement.GetProperty("CorrelationId").ValueKind
+        |> should equal JsonValueKind.String
+
+        rootElement.GetProperty("Properties").ValueKind
+        |> should equal JsonValueKind.Array
+
+        rootElement.Clone()
+
+    let private assertGraceErrorEnvelopeOnCleanStreams (standardOut: string) (standardError: string) =
+        standardError |> should equal String.Empty
+        let error = assertJsonErrorOutput standardOut
+
+        standardOut
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        error
+
+    let private withFileBackup (path: string) (action: unit -> unit) =
+        let directory = Path.GetDirectoryName(path)
+
+        if not (String.IsNullOrWhiteSpace(directory)) then
+            Directory.CreateDirectory(directory) |> ignore
+
+        let backupPath = Path.Combine(Path.GetTempPath(), $"grace-cli-test-backup-{Guid.NewGuid():N}")
+        let existed = File.Exists(path)
+
+        if existed then File.Copy(path, backupPath, true)
+
+        try
+            action ()
+        finally
+            if existed then
+                File.Copy(backupPath, path, true)
+                File.Delete(backupPath)
+            elif File.Exists(path) then
+                File.Delete(path)
+
     let private captureStdoutAndStderr (action: unit -> unit) =
         use standardOutWriter = new StringWriter()
         use standardErrorWriter = new StringWriter()
@@ -205,6 +256,14 @@ module HelpDoesNotReadConfigTests =
         config.BranchId <- branchId
         let json = serialize config
         File.WriteAllText(Path.Combine(graceDir, "graceconfig.json"), json)
+
+    let private writeValidConfigWithDeterministicIds (root: string) =
+        writeValidConfig
+            root
+            (Guid.Parse("11111111-1111-1111-1111-111111111111"))
+            (Guid.Parse("22222222-2222-2222-2222-222222222222"))
+            (Guid.Parse("33333333-3333-3333-3333-333333333333"))
+            (Guid.Parse("44444444-4444-4444-4444-444444444444"))
 
     let private addLifecycleHeaders
         (response: HttpResponseMessage)
@@ -339,7 +398,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Registry")
                 .GetProperty("CurrentJsonBehavior")
                 .GetString()
-            |> should equal "PartialManualSuccess"
+            |> should equal "CommonRenderOutputEnvelope"
 
             rootElement
                 .GetProperty("Schema")
@@ -550,6 +609,330 @@ module HelpDoesNotReadConfigTests =
         standardOut |> should not' (contain "Elapsed:")
 
     [<Test>]
+    let ``alias list json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "alias"
+                                     "list" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Count").GetInt32()
+        |> should be (greaterThan 0)
+
+        returnValue.GetProperty("Aliases").ValueKind
+        |> should equal JsonValueKind.Array
+
+        output |> should not' (contain "Grace command")
+
+    [<Test>]
+    let ``history show json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "show"
+                                     "--limit"
+                                     "0" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Entries").ValueKind
+        |> should equal JsonValueKind.Array
+
+        returnValue.GetProperty("Count").GetInt32()
+        |> should be (greaterThanOrEqualTo 0)
+
+    [<Test>]
+    let ``history show json select failure returns nonzero error envelope`` () =
+        let exitCode, standardOut, standardError =
+            runWithCapturedStdoutAndStderr [| "--output"
+                                              "Json"
+                                              "history"
+                                              "show"
+                                              "--limit"
+                                              "0"
+                                              "--select"
+                                              "NonExistent" |]
+
+        exitCode |> should equal -1
+
+        let error = assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+
+        error
+        |> should contain "--select path 'NonExistent' was not found"
+
+    [<Test>]
+    let ``history search json emits Grace envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "search"
+                                     "workitem"
+                                     "--limit"
+                                     "0" |]
+
+        exitCode |> should equal 0
+
+        let rootElement = assertGraceEnvelope output
+
+        rootElement.GetProperty("ReturnValue").GetProperty(
+            "Entries"
+        )
+            .ValueKind
+        |> should equal JsonValueKind.Array
+
+    [<Test>]
+    let ``history search json select failure returns nonzero error envelope`` () =
+        let exitCode, standardOut, standardError =
+            runWithCapturedStdoutAndStderr [| "--output"
+                                              "Json"
+                                              "history"
+                                              "search"
+                                              "workitem"
+                                              "--limit"
+                                              "0"
+                                              "--select"
+                                              "NonExistent" |]
+
+        exitCode |> should equal -1
+
+        let error = assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+
+        error
+        |> should contain "--select path 'NonExistent' was not found"
+
+    [<Test>]
+    let ``history validation error json emits Grace error envelope`` () =
+        let exitCode, output =
+            runWithCapturedOutput [| "--output"
+                                     "Json"
+                                     "history"
+                                     "show"
+                                     "--limit"
+                                     "-1" |]
+
+        exitCode |> should equal -1
+
+        use document = parseJsonOutput output
+
+        document
+            .RootElement
+            .GetProperty("Error")
+            .GetString()
+        |> should equal "Limit must be positive."
+
+    [<Test>]
+    let ``history on off and delete json emit Grace envelopes`` () =
+        let userConfigPath = UserConfiguration.getUserConfigurationPath ()
+        let historyPath = HistoryStorage.getHistoryFilePath ()
+
+        withFileBackup userConfigPath (fun () ->
+            withFileBackup historyPath (fun () ->
+                let onExitCode, onOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "on" |]
+
+                onExitCode |> should equal 0
+                assertGraceEnvelope onOutput |> ignore
+
+                let offExitCode, offOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "off" |]
+
+                offExitCode |> should equal 0
+                assertGraceEnvelope offOutput |> ignore
+
+                File.WriteAllText(historyPath, String.Empty)
+
+                let deleteExitCode, deleteOutput =
+                    runWithCapturedOutput [| "--output"
+                                             "Json"
+                                             "history"
+                                             "delete" |]
+
+                deleteExitCode |> should equal 0
+                assertGraceEnvelope deleteOutput |> ignore))
+
+    [<Test>]
+    let ``connect json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "connect"
+                                                  "owner/repository"
+                                                  "--owner-name"
+                                                  "owner" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "Repository shortcut must be in the form")
+
+    [<Test>]
+    let ``directory version get zip file json validation error emits clean Grace envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "directory-version"
+                                                  "get-zip-file"
+                                                  "--directory-version-id"
+                                                  $"{Guid.Empty}" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "graceconfig.json")
+
+    [<Test>]
+    let ``repository init json invalid directory emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+            let missingDirectory = Path.Combine(root, "missing")
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--directory"
+                                                  missingDirectory |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "directory")
+
+    [<Test>]
+    let ``repository init no output DTO renders absent observability as null`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "--output"
+                    "Json"
+                    "repository"
+                    "init"
+                    "--no-output"
+                |]
+            )
+
+        let output: Common.LocalOutputDto.RepositoryInitDto =
+            { Message = "Initialized repository."; DirectoryCount = None; FileCount = None; TotalFileSize = None; RootSha256Hash = None }
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok(GraceReturnValue.Create output "corr-repository-init"))
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        let rootElement = assertGraceEnvelope standardOut
+        let returnValue = rootElement.GetProperty("ReturnValue")
+
+        returnValue.GetProperty("Message").GetString()
+        |> should equal "Initialized repository."
+
+        returnValue
+            .GetProperty(
+                "DirectoryCount"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue.GetProperty("FileCount").ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue.GetProperty("TotalFileSize").ValueKind
+        |> should equal JsonValueKind.Null
+
+        returnValue
+            .GetProperty(
+                "RootSha256Hash"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Null
+
+    [<Test>]
+    let ``review report show json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "review"
+                                                  "report"
+                                                  "show"
+                                                  "--candidate"
+                                                  "not-a-guid" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "CandidateId must be a valid non-empty Guid")
+
+    [<Test>]
+    let ``review report export json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "review"
+                                                  "report"
+                                                  "export"
+                                                  "--candidate"
+                                                  "not-a-guid"
+                                                  "--format"
+                                                  "markdown"
+                                                  "--output-file"
+                                                  "report.md" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "CandidateId must be a valid non-empty Guid")
+
+    [<Test>]
+    let ``workitem attachments download json validation error emits clean Grace envelope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "workitem"
+                                                  "attachments"
+                                                  "download"
+                                                  "not-a-work-item"
+                                                  "--artifact-id"
+                                                  $"{Guid.Empty}"
+                                                  "--output-file"
+                                                  "attachment.bin" |]
+
+            exitCode |> should equal -1
+
+            assertGraceErrorEnvelopeOnCleanStreams standardOut standardError
+            |> should contain "work item ID is invalid")
+
+    [<Test>]
     let ``select option makes command json-oriented`` () =
         let parseResult =
             GraceCommand.rootCommand.Parse(
@@ -737,7 +1120,8 @@ module HelpDoesNotReadConfigTests =
     let ``valid select on unsupported command is json error without invoking command`` () =
         withTempDir (fun root ->
             let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "connect"
+                runWithCapturedStdoutAndStderr [| "history"
+                                                  "run"
                                                   "--select"
                                                   "Value" |]
 

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -512,27 +512,45 @@ module HelpDoesNotReadConfigTests =
 
     [<Test>]
     let ``root output json is honored for nested commands before config errors`` () =
-        withTempDir (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "agent"
-                                                  "work"
-                                                  "status" |]
+        let cases =
+            [
+                [| "agent"; "work"; "status" |]
+                [| "approval"; "policy"; "list" |]
+                [|
+                    "webhook"
+                    "delivery"
+                    "show"
+                    "--delivery"
+                    "11111111-1111-1111-1111-111111111111"
+                |]
+                [|
+                    "workitem"
+                    "attach"
+                    "summary"
+                    "123"
+                    "--text"
+                    "summary text"
+                |]
+            ]
 
-            exitCode |> should equal -1
-            standardError |> should equal String.Empty
+        for commandArgs in cases do
+            withTempDir (fun _ ->
+                let args = Array.append [| "--output"; "Json" |] commandArgs
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
 
-            use document = parseJsonOutput standardOut
-            let rootElement = document.RootElement
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
 
-            rootElement.GetProperty("Error").GetString()
-            |> should contain "graceconfig.json"
+                use document = parseJsonOutput standardOut
+                let rootElement = document.RootElement
 
-            standardOut |> should not' (contain "Elapsed:")
+                rootElement.GetProperty("Error").GetString()
+                |> should contain "graceconfig.json"
 
-            standardOut
-            |> should not' (contain "Grace Version Control System"))
+                standardOut |> should not' (contain "Elapsed:")
+
+                standardOut
+                |> should not' (contain "Grace Version Control System"))
 
     [<Test>]
     let ``root schema emits json parse error envelope`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -74,8 +74,10 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
+open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -102,6 +104,23 @@ module HelpDoesNotReadConfigTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
     let private parseJsonOutput (output: string) =
         output
             .TrimStart()
@@ -110,18 +129,43 @@ module HelpDoesNotReadConfigTests =
 
         JsonDocument.Parse(output)
 
-    let private captureOutput (action: unit -> unit) =
-        use writer = new StringWriter()
+    let private assertJsonErrorOutput (standardOut: string) =
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+        let error = rootElement.GetProperty("Error").GetString()
+
+        error |> should not' (equal String.Empty)
+
+        standardOut
+        |> should not' (contain "Exception in isOutputFormat")
+
+        standardOut
+        |> should not' (contain "graceconfig.json is not found")
+
+        standardOut |> should not' (contain "Elapsed:")
+
+        error
+
+    let private captureStdoutAndStderr (action: unit -> unit) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
         let originalOut = Console.Out
+        let originalError = Console.Error
 
         try
-            Console.SetOut(writer)
-            setAnsiConsoleOutput writer
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
             action ()
-            writer.ToString()
+            standardOutWriter.ToString(), standardErrorWriter.ToString()
         finally
             Console.SetOut(originalOut)
+            Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
+
+    let private captureOutput (action: unit -> unit) =
+        let standardOut, _ = captureStdoutAndStderr action
+        standardOut
 
 
     let private withTempDir (action: string -> unit) =
@@ -392,6 +436,263 @@ module HelpDoesNotReadConfigTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should contain "Bogus")
+
+    [<Test>]
+    let ``renderOutput json success writes one stdout document and no stderr`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--output"; "Json" |])
+        let returnValue = GraceReturnValue.Create {| Value = "ok" |} "corr-json-success"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Ok returnValue)
+                |> should equal 0)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement
+            .GetProperty("ReturnValue")
+            .GetProperty("Value")
+            .GetString()
+        |> should equal "ok"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-json-success"
+
+        standardOut |> should not' (contain "Elapsed:")
+
+    [<Test>]
+    let ``renderOutput json error writes GraceError envelope with shared field names`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "--output"; "Json" |])
+        let error = GraceError.Create "central writer error" "corr-json-error"
+
+        let standardOut, standardError =
+            captureStdoutAndStderr (fun () ->
+                Common.renderOutput parseResult (Error error)
+                |> should equal -1)
+
+        standardError |> should equal String.Empty
+
+        use document = parseJsonOutput standardOut
+        let rootElement = document.RootElement
+
+        rootElement.GetProperty("Error").GetString()
+        |> should equal "central writer error"
+
+        rootElement
+            .GetProperty("CorrelationId")
+            .GetString()
+        |> should equal "corr-json-error"
+
+        let mutable camelCaseCorrelationId = Unchecked.defaultof<JsonElement>
+
+        rootElement.TryGetProperty("correlationId", &camelCaseCorrelationId)
+        |> should equal false
+
+        Constants.JsonSerializerOptions.PropertyNamingPolicy
+        |> should equal null
+
+    [<Test>]
+    let ``missing config in json mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "graceconfig.json"
+
+            standardOut |> should not' (contain "Elapsed:"))
+
+    [<Test>]
+    let ``missing config in json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "graceconfig.json")
+
+    [<Test>]
+    let ``missing config in mixed-case json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--OUTPUT=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "graceconfig.json")
+
+    [<Test>]
+    let ``earlier non-json output token does not mask later json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Normal"
+                                                  "--output=Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``malformed split output option does not mask later long json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "--output"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``malformed split output option does not mask later short json intent`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "-o"
+                                                  "-o"
+                                                  "Json"
+                                                  "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``parse error in json mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``parse error in json equals mode emits one error document on stdout`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``short equals json output spelling emits json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "-o=Json"
+                                                  "repository"
+                                                  "init"
+                                                  "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut |> ignore)
+
+    [<Test>]
+    let ``lowercase json value is rejected with json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output=json"
+                                                  "repository"
+                                                  "init" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            assertJsonErrorOutput standardOut
+            |> should contain "json")
+
+    [<Test>]
+    let ``catch all exception in json mode emits one error document on stdout`` () =
+        withTempDir (fun root ->
+            writeInvalidConfig root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "access"
+                                                  "list-roles" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should not' (equal String.Empty)
+
+            rootElement
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should not' (equal String.Empty)
+
+            standardOut |> should not' (contain "Exception:"))
+
+    [<Test>]
+    let ``missing config in human mode remains human oriented`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, _ =
+                runWithCapturedStdoutAndStderr [| "branch"
+                                                  "get" |]
+
+            exitCode |> should equal -1
+
+            standardOut
+                .TrimStart()
+                .StartsWith("{", StringComparison.Ordinal)
+            |> should equal false
+
+            standardOut |> should contain "graceconfig.json")
 
     [<Test>]
     let ``verbose parse result shows resolved ids`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -80,6 +80,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text.Json
 
 [<NonParallelizable>]
 module HelpDoesNotReadConfigTests =
@@ -100,6 +101,14 @@ module HelpDoesNotReadConfigTests =
         finally
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
 
     let private captureOutput (action: unit -> unit) =
         use writer = new StringWriter()
@@ -215,6 +224,174 @@ module HelpDoesNotReadConfigTests =
 
             output
             |> should not' (contain "00000000-0000-0000-0000-0000000000000"))
+
+    [<Test>]
+    let ``schema emits registry-derived json without requiring config`` () =
+        withTempDir (fun root ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = JsonDocument.Parse(output)
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("ContractVersion")
+                .GetString()
+            |> should equal "cli-json-v1"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "repository.init"
+
+            rootElement
+                .GetProperty("Registry")
+                .GetProperty("CurrentJsonBehavior")
+                .GetString()
+            |> should equal "PartialManualSuccess"
+
+            rootElement
+                .GetProperty("Schema")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "registry-placeholder"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``examples emit registry-derived json and ignore output mode`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "workitem"
+                                         "show"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "workitem.show"
+
+            let examples = rootElement.GetProperty("Examples")
+            examples.GetArrayLength() |> should equal 2
+
+            examples[0].GetProperty("Document").GetProperty(
+                "ReturnValue"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Object)
+
+    [<Test>]
+    let ``nested command schema resolves full command id`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "attach"
+                                         "summary"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "workitem.attach.summary")
+
+    [<Test>]
+    let ``root schema emits json parse error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output = runWithCapturedOutput [| "--schema" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should equal "Required command was not provided."
+
+            rootElement
+                .GetProperty("CorrelationId")
+                .GetString()
+            |> should not' (equal String.Empty))
+
+    [<Test>]
+    let ``schema and examples together emit json error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema"
+                                         "--examples" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should equal "--schema and --examples cannot be used together.")
+
+    [<Test>]
+    let ``schema with unknown option emits json parse error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "repository"
+                                         "init"
+                                         "--schema"
+                                         "--definitely-not-an-option" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unrecognized command or argument")
+
+    [<Test>]
+    let ``schema with invalid output emits json parse error envelope`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Bogus"
+                                         "repository"
+                                         "init"
+                                         "--schema" |]
+
+            exitCode |> should equal -1
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Bogus")
 
     [<Test>]
     let ``verbose parse result shows resolved ids`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -306,7 +306,19 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Schema")
                 .GetProperty("Status")
                 .GetString()
-            |> should equal "registry-placeholder"
+            |> should equal "metadata-incomplete"
+
+            rootElement.GetProperty("Schema").GetProperty(
+                "SuccessSchema"
+            )
+                .GetProperty(
+                "properties"
+            )
+                .GetProperty(
+                "ReturnValue"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Object
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
@@ -317,8 +329,8 @@ module HelpDoesNotReadConfigTests =
             let exitCode, output =
                 runWithCapturedOutput [| "--output"
                                          "Json"
-                                         "workitem"
-                                         "show"
+                                         "auth"
+                                         "logout"
                                          "--examples" |]
 
             exitCode |> should equal 0
@@ -333,16 +345,49 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Command")
                 .GetProperty("Id")
                 .GetString()
-            |> should equal "workitem.show"
+            |> should equal "auth.logout"
 
             let examples = rootElement.GetProperty("Examples")
             examples.GetArrayLength() |> should equal 2
 
-            examples[0].GetProperty("Document").GetProperty(
-                "ReturnValue"
-            )
-                .ValueKind
-            |> should equal JsonValueKind.Object)
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("ReturnValue")
+                .GetString()
+            |> should equal "Signed out.")
+
+    [<Test>]
+    let ``examples for missing dto metadata emit explicit unsupported document`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "show"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            let examples = rootElement.GetProperty("Examples")
+
+            examples[ 0 ].GetProperty("Name").GetString()
+            |> should equal "metadata-incomplete"
+
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "metadata-incomplete"
+
+            examples[0]
+                .GetProperty("Document")
+                .GetProperty("CommandId")
+                .GetString()
+            |> should equal "workitem.show")
 
     [<Test>]
     let ``nested command schema resolves full command id`` () =

--- a/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
@@ -1,0 +1,63 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+open System.Text.Json
+
+[<TestFixture>]
+module SelectProjectionParsingTests =
+
+    let private parse selector = SelectProjection.tryParse "corr-select-parse" selector
+
+    [<TestCase("Value")>]
+    [<TestCase("Owner.Name")>]
+    [<TestCase("_links.Self")>]
+    [<TestCase("Items.Item1")>]
+    let ``accepted simple property paths parse`` selector =
+        match parse selector with
+        | Ok _ -> ()
+        | Error error -> Assert.Fail(error.Error)
+
+    [<TestCase("Properties.CorrelationId")>]
+    [<TestCase("properties.CorrelationId")>]
+    [<TestCase("CorrelationId")>]
+    [<TestCase("EventTime")>]
+    [<TestCase("ReturnValue.Value")>]
+    let ``metadata paths are rejected`` selector =
+        match parse selector with
+        | Ok _ -> Assert.Fail($"Expected selector '{selector}' to be rejected.")
+        | Error error ->
+            error.Error
+            |> should contain "cannot read envelope metadata"
+
+    [<TestCase("")>]
+    [<TestCase(" ")>]
+    [<TestCase("Value ")>]
+    [<TestCase(".Value")>]
+    [<TestCase("Value.")>]
+    [<TestCase("Value..Name")>]
+    [<TestCase("Value[0]")>]
+    [<TestCase("Items[*]")>]
+    [<TestCase("Items?(@.Name)")>]
+    [<TestCase("Name()")>]
+    [<TestCase("Name | length")>]
+    let ``malformed expression selectors are rejected`` selector =
+        match parse selector with
+        | Ok _ -> Assert.Fail($"Expected selector '{selector}' to be rejected.")
+        | Error error ->
+            error.CorrelationId
+            |> should equal "corr-select-parse"
+
+    [<Test>]
+    let ``project returns selected nested property`` () =
+        match parse "Container.Value" with
+        | Error error -> Assert.Fail(error.Error)
+        | Ok selector ->
+            match SelectProjection.project "corr-project" selector (box {| Container = {| Value = 42 |} |}) with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok selected ->
+                selected.ValueKind
+                |> should equal JsonValueKind.Number
+
+                selected.GetInt32() |> should equal 42

--- a/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
@@ -50,6 +50,14 @@ module SelectProjectionParsingTests =
             |> should equal "corr-select-parse"
 
     [<Test>]
+    let ``comma-separated multi-path selectors are rejected in V1`` () =
+        match parse "Value,Name" with
+        | Ok _ -> Assert.Fail("Expected comma-separated selector to be rejected.")
+        | Error error ->
+            error.Error
+            |> should contain "supports only dot-separated ReturnValue property names"
+
+    [<Test>]
     let ``project returns selected nested property`` () =
         match parse "Container.Value" with
         | Error error -> Assert.Fail(error.Error)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -9,6 +9,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text.Json
 
 [<NonParallelizable>]
 module WatchTests =
@@ -29,6 +30,23 @@ module WatchTests =
             exitCode, writer.ToString()
         finally
             Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
 
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
@@ -67,6 +85,14 @@ module WatchTests =
                 Constants.EnvironmentVariables.GraceServerUri
             ]
             action
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
 
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
@@ -137,3 +163,31 @@ module WatchTests =
 
                 output
                 |> should contain "Authentication is not configured."))
+
+    [<Test>]
+    let ``watch json auth failure emits one clean error envelope`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "watch" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                standardOut
+                |> should not' (contain "SignalR Hub connection state")
+
+                standardOut |> should not' (contain "Elapsed:")
+
+                use document = parseJsonOutput standardOut
+                let root = document.RootElement
+
+                root.GetProperty("Error").GetString()
+                |> should contain "watch is a continuous foreground workflow"
+
+                let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+                root.TryGetProperty("ReturnValue", &returnValue)
+                |> should equal false))

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -257,7 +257,7 @@ module WatchTests =
 
                 let exitCode, standardOut, standardError = runGraceProcessWithCapturedStdoutAndStderr root [| "--output"; "Json"; "watch" |]
 
-                exitCode |> should equal -1
+                Assert.That(exitCode, Is.EqualTo(-1).Or.EqualTo(255))
                 standardError |> should equal String.Empty
 
                 use document = parseJsonOutput standardOut

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5,9 +5,14 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
+open System.Diagnostics
 open System.IO
 open System.Text.Json
 
@@ -48,6 +53,41 @@ module WatchTests =
             Console.SetOut(originalOut)
             Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
+
+    let private runGraceProcessWithCapturedStdoutAndStderr workingDirectory (args: string array) =
+        let cliDllPath = Path.Combine(AppContext.BaseDirectory, "grace.dll")
+
+        File.Exists(cliDllPath) |> should equal true
+
+        let startInfo = ProcessStartInfo()
+        startInfo.FileName <- "dotnet"
+        startInfo.WorkingDirectory <- workingDirectory
+        startInfo.RedirectStandardOutput <- true
+        startInfo.RedirectStandardError <- true
+        startInfo.UseShellExecute <- false
+        startInfo.CreateNoWindow <- true
+        startInfo.ArgumentList.Add(cliDllPath)
+
+        for arg in args do
+            startInfo.ArgumentList.Add(arg)
+
+        use proc = new Process()
+        proc.StartInfo <- startInfo
+
+        if not (proc.Start()) then failwith "Failed to start grace process."
+
+        let standardOut = proc.StandardOutput.ReadToEnd()
+        let standardError = proc.StandardError.ReadToEnd()
+
+        if not (proc.WaitForExit(30000)) then
+            try
+                proc.Kill(true)
+            with
+            | _ -> ()
+
+            Assert.Fail("Timed out waiting for grace process to exit.")
+
+        proc.ExitCode, standardOut, standardError
 
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
         let original = Environment.GetEnvironmentVariable(name)
@@ -91,6 +131,25 @@ module WatchTests =
         |> should equal true
 
         JsonDocument.Parse(output)
+
+    let private writeLiveWatchStatusFile () =
+        let status: Services.GraceWatchStatus =
+            {
+                UpdatedAt = getCurrentInstant ()
+                RootDirectoryId = Guid.NewGuid()
+                RootDirectorySha256Hash = Sha256Hash "live-watch-root"
+                LastFileUploadInstant = Instant.MinValue
+                LastDirectoryVersionInstant = Instant.MinValue
+                DirectoryIds = HashSet<DirectoryVersionId>()
+            }
+
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, serialize status)
+        ipcFileName
 
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
@@ -189,3 +248,24 @@ module WatchTests =
 
                 root.TryGetProperty("ReturnValue", &returnValue)
                 |> should equal false))
+
+    [<Test>]
+    let ``watch json error in separate process does not delete live watch ipc file`` () =
+        withTempRepo (fun root ->
+            clearWatchAuthEnv (fun () ->
+                let ipcFileName = writeLiveWatchStatusFile ()
+
+                let exitCode, standardOut, standardError = runGraceProcessWithCapturedStdoutAndStderr root [| "--output"; "Json"; "watch" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+
+                document
+                    .RootElement
+                    .GetProperty("Error")
+                    .GetString()
+                |> should contain "watch is a continuous foreground workflow"
+
+                File.Exists(ipcFileName) |> should equal true))

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -87,9 +87,7 @@ module WatchTests =
             action
 
     let private parseJsonOutput (output: string) =
-        output
-            .TrimStart()
-            .StartsWith("{", StringComparison.Ordinal)
+        output.StartsWith("{", StringComparison.Ordinal)
         |> should equal true
 
         JsonDocument.Parse(output)

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -106,6 +106,15 @@ module Common =
                 DefaultValueFactory = (fun _ -> false)
             )
 
+        let select =
+            new Option<string>(
+                OptionName.Select,
+                Required = false,
+                Description = "Emit only the selected dot-separated ReturnValue property path as JSON.",
+                Arity = ArgumentArity.ExactlyOne,
+                Recursive = true
+            )
+
     /// Gets the correlationId value from the command's ParseResult.
     let getCorrelationId (parseResult: ParseResult) = Services.resolveCorrelationId parseResult
 
@@ -294,7 +303,27 @@ module Common =
             false
 
     /// Checks if the output format from the command line is Json.
-    let json parseResult = parseResult |> isOutputFormat Json
+    let tryGetSelect (parseResult: ParseResult) =
+        if isNull parseResult then
+            None
+        else
+            let result = parseResult.GetResult(OptionName.Select)
+
+            if isNull result then
+                None
+            else
+                try
+                    parseResult.GetValue<string>(Options.select)
+                    |> Option.ofObj
+                with
+                | :? InvalidOperationException -> None
+
+    let hasSelect parseResult = tryGetSelect parseResult |> Option.isSome
+
+    /// Checks if the command should emit machine-readable JSON.
+    let json parseResult =
+        (parseResult |> isOutputFormat Json)
+        || (parseResult |> hasSelect)
 
     /// Checks if the output format from the command line is Minimal.
     let minimal parseResult = parseResult |> isOutputFormat Minimal
@@ -474,6 +503,21 @@ module Common =
 
     let writeJsonReturnValueStdout (graceReturnValue: GraceReturnValue<'T>) = Console.Out.WriteLine(renderJsonReturnValue graceReturnValue)
 
+    let private tryRenderJsonSelection (parseResult: ParseResult) (graceReturnValue: GraceReturnValue<'T>) =
+        match tryGetSelect parseResult with
+        | None -> None
+        | Some selectorText ->
+            let correlationId = graceReturnValue.CorrelationId
+
+            match SelectProjection.tryParse correlationId selectorText with
+            | Error error -> Some(Error error)
+            | Ok selector ->
+                let returnValue = redactJsonReturnValue graceReturnValue.ReturnValue
+
+                match SelectProjection.project correlationId selector returnValue with
+                | Error error -> Some(Error error)
+                | Ok selected -> Some(Ok(SelectProjection.renderSelectedJson selected))
+
     let private tryGetProperty (properties: Dictionary<string, obj>) key =
         if isNull properties then
             None
@@ -557,10 +601,11 @@ module Common =
 
             Some(normalizedStatus, String.Join(Environment.NewLine, lines))
 
-    let private renderLifecycleWarningOnce outputFormat properties =
+    let private renderLifecycleWarningOnce parseResult outputFormat properties =
         match outputFormat with
         | Json
         | Silent -> ()
+        | _ when parseResult |> hasSelect -> ()
         | _ ->
             match tryBuildLifecycleWarning properties with
             | Some (status, warningText) ->
@@ -580,29 +625,37 @@ module Common =
 
         match result with
         | Ok graceReturnValue ->
-            renderLifecycleWarningOnce outputFormat graceReturnValue.Properties
+            renderLifecycleWarningOnce parseResult outputFormat graceReturnValue.Properties
 
-            match outputFormat with
-            | Json -> writeJsonReturnValueStdout graceReturnValue
-            | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
-            | Silent -> ()
-            | Verbose ->
-                AnsiConsole.WriteLine()
+            match tryRenderJsonSelection parseResult graceReturnValue with
+            | Some (Ok json) ->
+                Console.Out.WriteLine(json)
+                0
+            | Some (Error error) ->
+                writeJsonErrorStdout error
+                -1
+            | None ->
+                match outputFormat with
+                | Json -> writeJsonReturnValueStdout graceReturnValue
+                | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
+                | Silent -> ()
+                | Verbose ->
+                    AnsiConsole.WriteLine()
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]EventTime: {formatInstantExtended graceReturnValue.EventTime}[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]EventTime: {formatInstantExtended graceReturnValue.EventTime}[/]""")
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]CorrelationId: "{graceReturnValue.CorrelationId}"[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]CorrelationId: "{graceReturnValue.CorrelationId}"[/]""")
 
-                let properties = sanitizeLifecyclePropertiesForHumanOutput graceReturnValue.Properties
+                    let properties = sanitizeLifecyclePropertiesForHumanOutput graceReturnValue.Properties
 
-                AnsiConsole.MarkupLine($"""[{Colors.Verbose}]Properties: {Markup.Escape(serialize properties)}[/]""")
+                    AnsiConsole.MarkupLine($"""[{Colors.Verbose}]Properties: {Markup.Escape(serialize properties)}[/]""")
 
-                AnsiConsole.WriteLine()
-            | Normal -> () // Return unit because in the Normal case, we expect to print output within each command.
+                    AnsiConsole.WriteLine()
+                | Normal -> () // Return unit because in the Normal case, we expect to print output within each command.
 
-            0
+                0
         | Error error ->
-            renderLifecycleWarningOnce outputFormat error.Properties
+            renderLifecycleWarningOnce parseResult outputFormat error.Properties
 
             let json =
                 if error.Error.Contains("Stack trace") then
@@ -621,6 +674,7 @@ module Common =
                     Uri.UnescapeDataString(error.Error)
 
             match outputFormat with
+            | _ when parseResult |> hasSelect -> writeJsonErrorStdout error
             | Json -> writeJsonErrorStdout error
             | Minimal -> AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(errorText)}[/]")
             | Silent -> ()

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -86,6 +86,26 @@ module Common =
             ))
                 .AcceptOnlyFromAmong(listCases<OutputFormat> ())
 
+        let schema =
+            new Option<bool>(
+                OptionName.Schema,
+                Required = false,
+                Description = "Emit the machine-readable JSON contract schema for the selected command.",
+                Arity = ArgumentArity.Zero,
+                Recursive = true,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let examples =
+            new Option<bool>(
+                OptionName.Examples,
+                Required = false,
+                Description = "Emit representative machine-readable JSON examples for the selected command.",
+                Arity = ArgumentArity.Zero,
+                Recursive = true,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
     /// Gets the correlationId value from the command's ParseResult.
     let getCorrelationId (parseResult: ParseResult) = Services.resolveCorrelationId parseResult
 

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -88,6 +88,38 @@ module Common =
 
         type ReviewReportExportDto = { CandidateId: string; Format: string; OutputFile: string; BytesWritten: int64 }
 
+        type MaintenanceStatsDto = { DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string option }
+
+        type MaintenanceListContentsFileDto = { RelativePath: string; FileName: string; Sha256Hash: string; Size: int64; LastWriteTimeUtc: DateTime }
+
+        type MaintenanceListContentsDirectoryDto =
+            {
+                RelativePath: string
+                DirectoryVersionId: Guid
+                Sha256Hash: string
+                Size: int64
+                LastWriteTimeUtc: DateTime
+                Files: MaintenanceListContentsFileDto array
+            }
+
+        type MaintenanceListContentsDto = { Summary: MaintenanceStatsDto; Directories: MaintenanceListContentsDirectoryDto array }
+
+        type MaintenanceIgnoreEntriesDto = { DirectoryEntries: string array; FileEntries: string array }
+
+        type MaintenanceScanDifferenceDto = { DifferenceType: string; FileSystemEntryType: string; RelativePath: string }
+
+        type MaintenanceScanDirectoryVersionDto = { DirectoryVersionId: Guid; RelativePath: string; Sha256Hash: string }
+
+        type MaintenanceScanDto =
+            {
+                DifferenceCount: int
+                Differences: MaintenanceScanDifferenceDto array
+                NewDirectoryVersionCount: int
+                NewDirectoryVersions: MaintenanceScanDirectoryVersionDto array
+            }
+
+        type WatchResultDto = { Started: bool; Completed: bool; Message: string; RootDirectory: string; ServerUri: string; RepositoryId: Guid; BranchId: Guid }
+
     /// The output format for the command.
     type OutputFormat =
         | Normal

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -457,6 +457,10 @@ module Common =
             )
         | _ -> box returnValue
 
+    let writeJsonStdout value = Console.Out.WriteLine(serialize value)
+
+    let writeJsonErrorStdout (error: GraceError) = writeJsonStdout error
+
     let private renderJsonReturnValue (graceReturnValue: GraceReturnValue<'T>) =
         let output =
             {|
@@ -467,6 +471,8 @@ module Common =
             |}
 
         serialize output
+
+    let writeJsonReturnValueStdout (graceReturnValue: GraceReturnValue<'T>) = Console.Out.WriteLine(renderJsonReturnValue graceReturnValue)
 
     let private tryGetProperty (properties: Dictionary<string, obj>) key =
         if isNull properties then
@@ -577,7 +583,7 @@ module Common =
             renderLifecycleWarningOnce outputFormat graceReturnValue.Properties
 
             match outputFormat with
-            | Json -> AnsiConsole.WriteLine(Markup.Escape(renderJsonReturnValue graceReturnValue))
+            | Json -> writeJsonReturnValueStdout graceReturnValue
             | Minimal -> () //AnsiConsole.MarkupLine($"""[{Colors.Highlighted}]{Markup.Escape($"{graceReturnValue.ReturnValue}")}[/]""")
             | Silent -> ()
             | Verbose ->
@@ -615,7 +621,7 @@ module Common =
                     Uri.UnescapeDataString(error.Error)
 
             match outputFormat with
-            | Json -> AnsiConsole.WriteLine($"{Markup.Escape(json)}")
+            | Json -> writeJsonErrorStdout error
             | Minimal -> AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(errorText)}[/]")
             | Silent -> ()
             | Verbose ->

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -35,6 +35,59 @@ module Common =
         member val public Json: bool = false with get, set
         member val public OutputFormat: string = String.Empty with get, set
 
+    module LocalOutputDto =
+        type AliasListItemDto = { Alias: string; CommandPath: string array; Command: string }
+
+        type AliasListDto = { Aliases: AliasListItemDto array; Count: int }
+
+        type HistoryEntryDto =
+            {
+                Id: Guid
+                TimestampUtc: NodaTime.Instant
+                CommandLine: string
+                Cwd: string
+                RepoRoot: string option
+                RepoName: string option
+                RepoBranch: string option
+                GraceVersion: string
+                ExitCode: int
+                DurationMs: int64
+                ParseSucceeded: bool
+                Source: string option
+                RedactionCount: int
+            }
+
+        type HistoryEntriesDto = { Entries: HistoryEntryDto array; Count: int; CorruptCount: int }
+
+        type HistoryRecordingDto = { Enabled: bool }
+
+        type HistoryDeleteDto = { Deleted: bool; Removed: int }
+
+        type RepositoryInitDto =
+            {
+                Message: string
+                DirectoryCount: int option
+                FileCount: int option
+                TotalFileSize: int64 option
+                RootSha256Hash: string option
+            }
+
+        type ConnectDto =
+            {
+                OwnerId: Guid
+                OwnerName: string
+                OrganizationId: Guid
+                OrganizationName: string
+                RepositoryId: Guid
+                RepositoryName: string
+                BranchId: Guid
+                BranchName: string
+                DefaultBranchName: string
+                RetrievedDefaultBranch: bool
+            }
+
+        type ReviewReportExportDto = { CandidateId: string; Format: string; OutputFile: string; BytesWritten: int64 }
+
     /// The output format for the command.
     type OutputFormat =
         | Normal

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -579,6 +579,34 @@ module Connect =
 
         lookup
 
+    let private writeHumanLine (parseResult: ParseResult) text =
+        if
+            not (parseResult |> json)
+            && not (parseResult |> silent)
+        then
+            AnsiConsole.MarkupLine text
+
+    let private toConnectDto
+        (ownerDto: OwnerDto)
+        (organizationDto: OrganizationDto)
+        (repositoryDto: RepositoryDto)
+        (branchDto: BranchDto)
+        (retrievedDefaultBranch: bool)
+        : LocalOutputDto.ConnectDto
+        =
+        {
+            OwnerId = ownerDto.OwnerId
+            OwnerName = ownerDto.OwnerName
+            OrganizationId = organizationDto.OrganizationId
+            OrganizationName = organizationDto.OrganizationName
+            RepositoryId = repositoryDto.RepositoryId
+            RepositoryName = repositoryDto.RepositoryName
+            BranchId = branchDto.BranchId
+            BranchName = branchDto.BranchName
+            DefaultBranchName = repositoryDto.DefaultBranchName
+            RetrievedDefaultBranch = retrievedDefaultBranch
+        }
+
     let private extractZipEntries
         (parseResult: ParseResult)
         (fileVersionsByRelativePath: Dictionary<RelativePath, FileVersion>)
@@ -588,8 +616,8 @@ module Connect =
         use zipFile = zipFile
         use zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Read)
 
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Streaming contents from .zip file.[/]"
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Starting to write files to disk.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Streaming contents from .zip file.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Starting to write files to disk.[/]"
 
         let additionalEntries = ResizeArray<string>()
 
@@ -636,14 +664,14 @@ module Connect =
                         if writeObjectFile then uncompressAndWriteToFile entry objectFileInfo
 
                     if parseResult |> verbose then
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Wrote {fileVersion.RelativePath}.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Wrote {fileVersion.RelativePath}.[/]"
                 | false, _ -> additionalEntries.Add(entry.FullName))
 
         if additionalEntries.Count > 0
            && (parseResult |> verbose) then
-            AnsiConsole.MarkupLine $"[{Colors.Deemphasized}]Zip contained {additionalEntries.Count} additional entry(ies). Ignored.[/]"
+            writeHumanLine parseResult $"[{Colors.Deemphasized}]Zip contained {additionalEntries.Count} additional entry(ies). Ignored.[/]"
 
-        AnsiConsole.MarkupLine $"[{Colors.Important}]Finished writing files to disk.[/]"
+        writeHumanLine parseResult $"[{Colors.Important}]Finished writing files to disk.[/]"
 
     let private retrieveDefaultBranchAndWrite
         (parseResult: ParseResult)
@@ -668,7 +696,7 @@ module Connect =
                         CorrelationId = graceIds.CorrelationId
                     )
 
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieving all DirectoryVersions.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Retrieving all DirectoryVersions.[/]"
 
                 let! directoryVersionsResult = DirectoryVersion.GetDirectoryVersionsRecursive(getDirectoryContentsParameters)
 
@@ -681,13 +709,13 @@ module Connect =
                         CorrelationId = graceIds.CorrelationId
                     )
 
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieving zip file download uri.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Retrieving zip file download uri.[/]"
                 let! getZipFileResult = DirectoryVersion.GetZipFile(getZipFileParameters)
-                AnsiConsole.MarkupLine $"[{Colors.Important}]Finished getting zip file download uri.[/]"
+                writeHumanLine parseResult $"[{Colors.Important}]Finished getting zip file download uri.[/]"
 
                 match (directoryVersionsResult, getZipFileResult) with
                 | (Ok directoryVerionsReturnValue, Ok getZipFileReturnValue) ->
-                    AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieved all DirectoryVersions.[/]"
+                    writeHumanLine parseResult $"[{Colors.Important}]Retrieved all DirectoryVersions.[/]"
 
                     let directoryVersionDtos = directoryVerionsReturnValue.ReturnValue
 
@@ -702,12 +730,12 @@ module Connect =
                     let! conflicts, filesToSkip = collectFileConflicts fileVersions force
 
                     if conflicts.Count > 0 then
-                        AnsiConsole.MarkupLine $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
+                        writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
 
                         if parseResult |> verbose then
                             conflicts
                             |> Seq.sort
-                            |> Seq.iter (fun conflict -> AnsiConsole.MarkupLine $"[{Colors.Error}]{conflict}[/]")
+                            |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
 
                         return
                             (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
@@ -723,12 +751,12 @@ module Connect =
                         let! zipFile = blobClient.OpenReadAsync(bufferSize = 64 * 1024)
                         extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
 
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Creating Grace Index file.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
                         let! previousGraceStatus = readGraceStatusFile ()
                         let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
                         do! writeGraceStatusFile graceStatus
 
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
                         do! upsertObjectCache graceStatus.Index.Values
                         return 0
                 | (Error error, _) -> return (Error error |> renderOutput parseResult)
@@ -760,13 +788,13 @@ module Connect =
 
                         match ownerOrgRepoResult with
                         | Ok (ownerDto, organizationDto, repositoryDto) ->
-                            AnsiConsole.MarkupLine $"[{Colors.Important}]Found owner, organization, and repository.[/]"
+                            writeHumanLine parseResult $"[{Colors.Important}]Found owner, organization, and repository.[/]"
 
                             let! branchResult = getBranchForConnect parseResult graceIds ownerDto organizationDto repositoryDto
 
                             match branchResult with
                             | Ok branchDto ->
-                                AnsiConsole.MarkupLine $"[{Colors.Important}]Retrieved branch {branchDto.BranchName}.[/]"
+                                writeHumanLine parseResult $"[{Colors.Important}]Retrieved branch {branchDto.BranchName}.[/]"
                                 // Write the new configuration to the config file.
                                 let newConfig = Current()
                                 newConfig.OwnerId <- ownerDto.OwnerId
@@ -781,14 +809,29 @@ module Connect =
                                 newConfig.ObjectStorageProvider <- repositoryDto.ObjectStorageProvider
                                 updateConfiguration newConfig
                                 reloadConfiguration ()
-                                AnsiConsole.MarkupLine $"[{Colors.Important}]Wrote new Grace configuration file.[/]"
+                                writeHumanLine parseResult $"[{Colors.Important}]Wrote new Grace configuration file.[/]"
 
                                 let retrieveDefaultBranch = parseResult.GetValue(Options.retrieveDefaultBranch)
 
                                 if retrieveDefaultBranch then
-                                    return! retrieveDefaultBranchAndWrite parseResult graceIds ownerDto organizationDto repositoryDto branchDto
+                                    let! retrieveExitCode = retrieveDefaultBranchAndWrite parseResult graceIds ownerDto organizationDto repositoryDto branchDto
+
+                                    if retrieveExitCode = 0 then
+                                        let output = toConnectDto ownerDto organizationDto repositoryDto branchDto true
+
+                                        return
+                                            GraceReturnValue.Create output (getCorrelationId parseResult)
+                                            |> Ok
+                                            |> renderOutput parseResult
+                                    else
+                                        return retrieveExitCode
                                 else
-                                    return 0
+                                    let output = toConnectDto ownerDto organizationDto repositoryDto branchDto false
+
+                                    return
+                                        GraceReturnValue.Create output (getCorrelationId parseResult)
+                                        |> Ok
+                                        |> renderOutput parseResult
                             | Error error -> return (Error error |> renderOutput parseResult)
                         | Error error -> return (Error error |> renderOutput parseResult)
         }

--- a/src/Grace.CLI/Command/History.CLI.fs
+++ b/src/Grace.CLI/Command/History.CLI.fs
@@ -6,6 +6,7 @@ open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Client
 open Grace.Shared.Utilities
+open Grace.Types.Common
 open NodaTime
 open Spectre.Console
 open System
@@ -309,18 +310,47 @@ module History =
 
         AnsiConsole.Write(table)
 
+    let private toHistoryEntryDto (entry: HistoryStorage.HistoryEntry) : LocalOutputDto.HistoryEntryDto =
+        {
+            Id = entry.id
+            TimestampUtc = entry.timestampUtc
+            CommandLine = entry.commandLine
+            Cwd = entry.cwd
+            RepoRoot = entry.repoRoot
+            RepoName = entry.repoName
+            RepoBranch = entry.repoBranch
+            GraceVersion = entry.graceVersion
+            ExitCode = entry.exitCode
+            DurationMs = entry.durationMs
+            ParseSucceeded = entry.parseSucceeded
+            Source = entry.source
+            RedactionCount = entry.redactions.Length
+        }
+
     let private outputEntries (parseResult: ParseResult) (entries: HistoryStorage.HistoryEntry list) (showId: bool) (corruptCount: int) =
         if parseResult |> json then
-            let payload = serialize entries
-            AnsiConsole.WriteLine(Markup.Escape(payload))
+            let dto: LocalOutputDto.HistoryEntriesDto =
+                {
+                    Entries =
+                        entries
+                        |> List.map toHistoryEntryDto
+                        |> List.toArray
+                    Count = entries.Length
+                    CorruptCount = corruptCount
+                }
+
+            GraceReturnValue.Create dto (getCorrelationId parseResult)
+            |> Ok
+            |> renderOutput parseResult
         elif parseResult |> silent then
-            ()
+            0
         else
             if corruptCount > 0 then
                 AnsiConsole.MarkupLine($"[yellow]Skipped {corruptCount} corrupt history entries.[/]")
 
             renderTable entries showId
             AnsiConsole.WriteLine()
+            0
 
     type HistoryOn() =
         inherit AsynchronousCommandLineAction()
@@ -341,18 +371,22 @@ module History =
                 match UserConfiguration.saveUserConfiguration configuration with
                 | Ok _ ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| enabled = true |}))
+                        let dto: LocalOutputDto.HistoryRecordingDto = { Enabled = true }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History recording enabled.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     type HistoryOff() =
@@ -374,18 +408,22 @@ module History =
                 match UserConfiguration.saveUserConfiguration configuration with
                 | Ok _ ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| enabled = false |}))
+                        let dto: LocalOutputDto.HistoryRecordingDto = { Enabled = false }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History recording disabled.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     type HistoryShow() =
@@ -403,8 +441,10 @@ module History =
                 let showId = parseResult.GetValue(Options.showId)
 
                 if limit < 0 then
-                    AnsiConsole.MarkupLine("[red]Limit must be positive.[/]")
-                    return -1
+                    return
+                        GraceError.Create "Limit must be positive." (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
                 else
                     let sinceDuration =
                         if String.IsNullOrWhiteSpace(sinceText) then
@@ -416,8 +456,10 @@ module History =
 
                     match sinceDuration with
                     | Error error ->
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-                        return -1
+                        return
+                            GraceError.Create error (getCorrelationId parseResult)
+                            |> Error
+                            |> renderOutput parseResult
                     | Ok since ->
                         let readResult = HistoryStorage.readHistoryEntries ()
 
@@ -432,8 +474,7 @@ module History =
                                 (if String.IsNullOrWhiteSpace(containsText) then None else Some containsText)
                                 (if String.IsNullOrWhiteSpace(sourceText) then None else Some sourceText)
 
-                        outputEntries parseResult filtered showId readResult.CorruptCount
-                        return 0
+                        return outputEntries parseResult filtered showId readResult.CorruptCount
             }
 
     type HistorySearch() =
@@ -451,8 +492,10 @@ module History =
                 let showId = parseResult.GetValue(Options.showId)
 
                 if limit < 0 then
-                    AnsiConsole.MarkupLine("[red]Limit must be positive.[/]")
-                    return -1
+                    return
+                        GraceError.Create "Limit must be positive." (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
                 else
                     let sinceDuration =
                         if String.IsNullOrWhiteSpace(sinceText) then
@@ -464,8 +507,10 @@ module History =
 
                     match sinceDuration with
                     | Error error ->
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-                        return -1
+                        return
+                            GraceError.Create error (getCorrelationId parseResult)
+                            |> Error
+                            |> renderOutput parseResult
                     | Ok since ->
                         let readResult = HistoryStorage.readHistoryEntries ()
 
@@ -480,8 +525,7 @@ module History =
                                 (if String.IsNullOrWhiteSpace(searchText) then None else Some searchText)
                                 (if String.IsNullOrWhiteSpace(sourceText) then None else Some sourceText)
 
-                        outputEntries parseResult filtered showId readResult.CorruptCount
-                        return 0
+                        return outputEntries parseResult filtered showId readResult.CorruptCount
             }
 
     let private parseReplacements (values: string array) =
@@ -718,18 +762,22 @@ module History =
                 match HistoryStorage.clearHistory () with
                 | Ok removed ->
                     if parseResult |> json then
-                        AnsiConsole.WriteLine(Markup.Escape(serialize {| deleted = true; removed = removed |}))
+                        let dto: LocalOutputDto.HistoryDeleteDto = { Deleted = true; Removed = removed }
+
+                        return
+                            GraceReturnValue.Create dto (getCorrelationId parseResult)
+                            |> Ok
+                            |> renderOutput parseResult
                     elif parseResult |> silent then
-                        ()
+                        return 0
                     else
                         AnsiConsole.MarkupLine("[green]History cleared.[/]")
-
-                    return 0
+                        return 0
                 | Error error ->
-                    if not (parseResult |> silent) then
-                        AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]")
-
-                    return -1
+                    return
+                        GraceError.Create error (getCorrelationId parseResult)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
     let Build =

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -627,7 +627,14 @@ module Maintenance =
 
             with
             | ex ->
-                logToAnsiConsole Colors.Error $"Exception in UpdateIndex: {ExceptionResponse.Create ex}"
+                let message = $"Exception in UpdateIndex: {ExceptionResponse.Create ex}"
+
+                if parseResult |> json then
+                    GraceError.Create message (getCorrelationId parseResult)
+                    |> writeJsonErrorStdout
+                else
+                    logToAnsiConsole Colors.Error message
+
                 return -1
         }
 

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -135,13 +135,104 @@ module Maintenance =
         | Some rootSha256Hash -> AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Root SHA-256 hash: {getShortHash rootSha256Hash}[/]")
         | None -> AnsiConsole.MarkupLine($"[{Colors.Error}]Root SHA-256 hash: unavailable (root directory entry missing).[/]")
 
+    let private toStatsDto (graceStatus: GraceStatus) : LocalOutputDto.MaintenanceStatsDto =
+        let directoryCount = graceStatus.Index.Count
+
+        let fileCount =
+            graceStatus
+                .Index
+                .Values
+                .Select(fun directoryVersion -> directoryVersion.Files.Count)
+                .Sum()
+
+        let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+
+        {
+            DirectoryCount = directoryCount
+            FileCount = fileCount
+            TotalFileSize = totalFileSize
+            RootSha256Hash =
+                tryGetRootSha256Hash graceStatus
+                |> Option.map string
+        }
+
+    let private toListContentsDto listDirectories listFiles (graceStatus: GraceStatus) : LocalOutputDto.MaintenanceListContentsDto =
+        let directories =
+            if listDirectories then
+                graceStatus.Index.Values
+                |> Seq.sortBy (fun directoryVersion -> directoryVersion.RelativePath)
+                |> Seq.map (fun directoryVersion ->
+                    let files =
+                        if listFiles then
+                            directoryVersion.Files
+                            |> Seq.sortBy (fun file -> file.RelativePath)
+                            |> Seq.map (fun file ->
+                                {
+                                    LocalOutputDto.MaintenanceListContentsFileDto.RelativePath = string file.RelativePath
+                                    FileName = file.FileInfo.Name
+                                    Sha256Hash = string file.Sha256Hash
+                                    Size = int64 file.Size
+                                    LastWriteTimeUtc = file.LastWriteTimeUtc
+                                }: LocalOutputDto.MaintenanceListContentsFileDto)
+                            |> Seq.toArray
+                        else
+                            Array.empty
+
+                    ({
+                         LocalOutputDto.MaintenanceListContentsDirectoryDto.RelativePath = string directoryVersion.RelativePath
+                         DirectoryVersionId = directoryVersion.DirectoryVersionId
+                         Sha256Hash = string directoryVersion.Sha256Hash
+                         Size = int64 directoryVersion.Size
+                         LastWriteTimeUtc = directoryVersion.LastWriteTimeUtc
+                         Files = files
+                     }: LocalOutputDto.MaintenanceListContentsDirectoryDto))
+                |> Seq.toArray
+            else
+                Array.empty
+
+        { Summary = toStatsDto graceStatus; Directories = directories }
+
+    let private toScanDto (differences: List<FileSystemDifference>) (newDirectoryVersions: List<LocalDirectoryVersion>) : LocalOutputDto.MaintenanceScanDto =
+        {
+            DifferenceCount = differences.Count
+            Differences =
+                differences
+                |> Seq.map (fun difference ->
+                    ({
+                         LocalOutputDto.MaintenanceScanDifferenceDto.DifferenceType = getDiscriminatedUnionCaseName difference.DifferenceType
+                         FileSystemEntryType = getDiscriminatedUnionCaseName difference.FileSystemEntryType
+                         RelativePath = string difference.RelativePath
+                     }: LocalOutputDto.MaintenanceScanDifferenceDto))
+                |> Seq.toArray
+            NewDirectoryVersionCount = newDirectoryVersions.Count
+            NewDirectoryVersions =
+                newDirectoryVersions
+                |> Seq.map (fun directoryVersion ->
+                    ({
+                         LocalOutputDto.MaintenanceScanDirectoryVersionDto.DirectoryVersionId = directoryVersion.DirectoryVersionId
+                         RelativePath = string directoryVersion.RelativePath
+                         Sha256Hash = string directoryVersion.Sha256Hash
+                     }: LocalOutputDto.MaintenanceScanDirectoryVersionDto))
+                |> Seq.toArray
+        }
+
+    let private renderLocalJson parseResult dto =
+        Ok(GraceReturnValue.Create dto (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
     let private updateIndexHandler (parseResult: ParseResult) =
         task {
             try
                 if parseResult |> verbose then printParseResult parseResult
                 let graceIds = parseResult |> getNormalizedIdsAndNames
 
-                if parseResult |> hasOutput then
+                if parseResult |> json then
+                    let! previousGraceStatus = readGraceStatusFile ()
+                    let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                    do! writeGraceStatusFile graceStatus
+                    do! upsertObjectCache graceStatus.Index.Values
+                    return renderLocalJson parseResult (toStatsDto graceStatus)
+                elif parseResult |> hasOutput then
                     let! graceStatus =
                         progress
                             .Columns(progressColumns)
@@ -581,17 +672,22 @@ module Maintenance =
                                     return (differences, newDirectoryVersions)
                                 })
 
-                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
+                    if parseResult |> json then
+                        return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
+                    else
+                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
 
-                    for difference in differences do
-                        let x = sprintf "%A" difference
-                        AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
+                        for difference in differences do
+                            let x = sprintf "%A" difference
+                            AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
 
-                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
+                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
 
-                    for ldv in newDirectoryVersions do
-                        AnsiConsole.MarkupLine
-                            $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+                        for ldv in newDirectoryVersions do
+                            AnsiConsole.MarkupLine
+                                $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+
+                        return 0
                 //AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(8)}[/]"
                 else
                     let! previousGraceStatus = readGraceStatusFile ()
@@ -611,7 +707,7 @@ module Maintenance =
                         AnsiConsole.MarkupLine
                             $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
 
-                return 0
+                    return 0
             }
 
     type Stats() =
@@ -622,25 +718,19 @@ module Maintenance =
                 if parseResult |> verbose then printParseResult parseResult
 
                 let! graceStatus = readGraceStatusFile ()
-                let directoryCount = graceStatus.Index.Count
+                let dto = toStatsDto graceStatus
 
-                let fileCount =
-                    graceStatus
-                        .Index
-                        .Values
-                        .Select(fun directoryVersion -> directoryVersion.Files.Count)
-                        .Sum()
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {dto.DirectoryCount}.[/]")
 
-                let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {dto.FileCount}; total file size: {dto.TotalFileSize:N0}.[/]")
 
-                AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
+                    writeRootShaSummary graceStatus
 
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
-
-                writeRootShaSummary graceStatus
-
-                return 0
+                    return 0
             }
 
     type ListContents() =
@@ -654,68 +744,66 @@ module Maintenance =
                 let listFiles = parseResult.GetValue(Options.listFiles)
 
                 let! graceStatus = readGraceStatusFile ()
-                let directoryCount = graceStatus.Index.Count
+                let dto = toListContentsDto listDirectories listFiles graceStatus
 
-                let fileCount =
-                    graceStatus
-                        .Index
-                        .Values
-                        .Select(fun directoryVersion -> directoryVersion.Files.Count)
-                        .Sum()
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    let directoryCount = dto.Summary.DirectoryCount
 
-                let totalFileSize = graceStatus.Index.Values.Sum(fun directoryVersion -> directoryVersion.Files.Sum(fun f -> int64 f.Size))
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
+                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
 
-                AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the local Grace status file.[/]")
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
+                    AnsiConsole.MarkupLine(
+                        $"[{Colors.Highlighted}]Number of files: {dto.Summary.FileCount}; total file size: {dto.Summary.TotalFileSize:N0}.[/]"
+                    )
 
-                AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
+                    writeRootShaSummary graceStatus
 
-                writeRootShaSummary graceStatus
+                    if listDirectories then
+                        if directoryCount = 0 then
+                            AnsiConsole.MarkupLine($"[{Colors.Verbose}]No directory entries found in the local Grace status file.[/]")
+                        else
+                            let longestRelativePath = getLongestRelativePath graceStatus.Index.Values
+                            let additionalSpaces = String.replicate (longestRelativePath - 2) " "
+                            let additionalImportantDashes = String.replicate (longestRelativePath + 3) "-"
+                            let additionalDeemphasizedDashes = String.replicate 38 "-"
 
-                if listDirectories then
-                    if directoryCount = 0 then
-                        AnsiConsole.MarkupLine($"[{Colors.Verbose}]No directory entries found in the local Grace status file.[/]")
-                    else
-                        let longestRelativePath = getLongestRelativePath graceStatus.Index.Values
-                        let additionalSpaces = String.replicate (longestRelativePath - 2) " "
-                        let additionalImportantDashes = String.replicate (longestRelativePath + 3) "-"
-                        let additionalDeemphasizedDashes = String.replicate 38 "-"
+                            let sortedDirectoryVersions = graceStatus.Index.Values.OrderBy(fun dv -> dv.RelativePath)
 
-                        let sortedDirectoryVersions = graceStatus.Index.Values.OrderBy(fun dv -> dv.RelativePath)
+                            sortedDirectoryVersions
+                            |> Seq.iteri (fun i directoryVersion ->
+                                AnsiConsole.WriteLine()
 
-                        sortedDirectoryVersions
-                        |> Seq.iteri (fun i directoryVersion ->
-                            AnsiConsole.WriteLine()
-
-                            if i = 0 then
-                                AnsiConsole.MarkupLine(
-                                    $"[{Colors.Important}]Last Write Time (UTC)        SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
-                                )
-
-                                AnsiConsole.MarkupLine(
-                                    $"[{Colors.Important}]-----------------------------------------------------{additionalImportantDashes}[/][{Colors.Deemphasized}] {additionalDeemphasizedDashes}[/]"
-                                )
-
-                            let rightAlignedDirectoryVersionId =
-                                (String.replicate
-                                    (longestRelativePath
-                                     - directoryVersion.RelativePath.Length)
-                                    " ")
-                                + $"({directoryVersion.DirectoryVersionId})"
-
-                            AnsiConsole.MarkupLine(
-                                $"[{Colors.Highlighted}]{formatDateTimeAligned directoryVersion.LastWriteTimeUtc}   {getShortSha256Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
-                            )
-
-                            if listFiles then
-                                let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
-
-                                for file in sortedFiles do
+                                if i = 0 then
                                     AnsiConsole.MarkupLine(
-                                        $"[{Colors.Verbose}]{formatDateTimeAligned file.LastWriteTimeUtc}   {getShortSha256Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.FileInfo.Name}[/]"
-                                    ))
+                                        $"[{Colors.Important}]Last Write Time (UTC)        SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
+                                    )
 
-                return 0
+                                    AnsiConsole.MarkupLine(
+                                        $"[{Colors.Important}]-----------------------------------------------------{additionalImportantDashes}[/][{Colors.Deemphasized}] {additionalDeemphasizedDashes}[/]"
+                                    )
+
+                                let rightAlignedDirectoryVersionId =
+                                    (String.replicate
+                                        (longestRelativePath
+                                         - directoryVersion.RelativePath.Length)
+                                        " ")
+                                    + $"({directoryVersion.DirectoryVersionId})"
+
+                                AnsiConsole.MarkupLine(
+                                    $"[{Colors.Highlighted}]{formatDateTimeAligned directoryVersion.LastWriteTimeUtc}   {getShortSha256Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
+                                )
+
+                                if listFiles then
+                                    let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
+
+                                    for file in sortedFiles do
+                                        AnsiConsole.MarkupLine(
+                                            $"[{Colors.Verbose}]{formatDateTimeAligned file.LastWriteTimeUtc}   {getShortSha256Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.FileInfo.Name}[/]"
+                                        ))
+
+                    return 0
             }
 
     type CheckIgnoreEntries() =
@@ -724,18 +812,30 @@ module Maintenance =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 if parseResult |> verbose then printParseResult parseResult
-                AnsiConsole.MarkupLine($"[{Colors.Important}]Directory ignore entries:[/]")
 
-                for dir in Current().GraceDirectoryIgnoreEntries do
-                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {dir}[/]")
+                let dto =
+                    ({
+                         LocalOutputDto.MaintenanceIgnoreEntriesDto.DirectoryEntries =
+                             Current().GraceDirectoryIgnoreEntries
+                             |> Seq.toArray
+                         FileEntries = Current().GraceFileIgnoreEntries |> Seq.toArray
+                     }: LocalOutputDto.MaintenanceIgnoreEntriesDto)
 
-                AnsiConsole.WriteLine()
-                AnsiConsole.MarkupLine($"[{Colors.Important}]File ignore entries:[/]")
+                if parseResult |> json then
+                    return renderLocalJson parseResult dto
+                else
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]Directory ignore entries:[/]")
 
-                for file in Current().GraceFileIgnoreEntries do
-                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {file}[/]")
+                    for dir in dto.DirectoryEntries do
+                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {dir}[/]")
 
-                return 0
+                    AnsiConsole.WriteLine()
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]File ignore entries:[/]")
+
+                    for file in dto.FileEntries do
+                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]  {file}[/]")
+
+                    return 0
             }
 
     let Build =

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -644,7 +644,12 @@ module Maintenance =
             task {
                 if parseResult |> verbose then printParseResult parseResult
 
-                if parseResult |> hasOutput then
+                if parseResult |> json then
+                    let! previousGraceStatus = readGraceStatusFile ()
+                    let! differences = scanForDifferences previousGraceStatus
+                    let! (_, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
+                    return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
+                elif parseResult |> hasOutput then
                     let! (differences, newDirectoryVersions) =
                         progress
                             .Columns(progressColumns)
@@ -672,22 +677,19 @@ module Maintenance =
                                     return (differences, newDirectoryVersions)
                                 })
 
-                    if parseResult |> json then
-                        return renderLocalJson parseResult (toScanDto differences newDirectoryVersions)
-                    else
-                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
+                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of differences: {differences.Count}[/]"
 
-                        for difference in differences do
-                            let x = sprintf "%A" difference
-                            AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
+                    for difference in differences do
+                        let x = sprintf "%A" difference
+                        AnsiConsole.MarkupLine $"[{Colors.Important}]{x}[/]"
 
-                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
+                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Number of new DirectoryVersions: {newDirectoryVersions.Count}[/]"
 
-                        for ldv in newDirectoryVersions do
-                            AnsiConsole.MarkupLine
-                                $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
+                    for ldv in newDirectoryVersions do
+                        AnsiConsole.MarkupLine
+                            $"[{Colors.Important}]SHA-256: {ldv.Sha256Hash.Substring(0, 8)}; DirectoryId: {ldv.DirectoryVersionId}; RelativePath: {ldv.RelativePath}[/]"
 
-                        return 0
+                    return 0
                 //AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(8)}[/]"
                 else
                     let! previousGraceStatus = readGraceStatusFile ()

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -711,10 +711,28 @@ module Repository =
 
                                     AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(0, 8)}[/]"
 
-                                    return Ok(GraceReturnValue.Create "Initialized repository." (parseResult |> getCorrelationId))
+                                    let output: LocalOutputDto.RepositoryInitDto =
+                                        {
+                                            Message = "Initialized repository."
+                                            DirectoryCount = Some graceStatus.Index.Count
+                                            FileCount = Some fileCount
+                                            TotalFileSize = Some totalFileSize
+                                            RootSha256Hash = Some rootDirectoryVersion.Sha256Hash
+                                        }
+
+                                    return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
                                 else
                                     // Do the whole thing with no output
-                                    return Ok(GraceReturnValue.Create "Initialized repository." (parseResult |> getCorrelationId))
+                                    let output: LocalOutputDto.RepositoryInitDto =
+                                        {
+                                            Message = "Initialized repository."
+                                            DirectoryCount = None
+                                            FileCount = None
+                                            TotalFileSize = None
+                                            RootSha256Hash = None
+                                        }
+
+                                    return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
                             else
                                 return
                                     Error(GraceError.Create (RepositoryError.getErrorMessage RepositoryIsAlreadyInitialized) (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Review.CLI.fs
+++ b/src/Grace.CLI/Command/Review.CLI.fs
@@ -692,7 +692,20 @@ module ReviewCommand =
 
                                     AnsiConsole.MarkupLine($"[green]Review report exported ({formatText}) to[/] {Markup.Escape(outputFile)}")
 
-                                return Ok returnValue
+                                let formatText =
+                                    match reportFormat with
+                                    | Markdown -> "markdown"
+                                    | Json -> "json"
+
+                                let output: LocalOutputDto.ReviewReportExportDto =
+                                    {
+                                        CandidateId = candidateId
+                                        Format = formatText
+                                        OutputFile = outputFile
+                                        BytesWritten = int64 (Encoding.UTF8.GetByteCount(content))
+                                    }
+
+                                return Ok(GraceReturnValue.Create output (getCorrelationId parseResult))
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -154,6 +154,27 @@ module Watch =
             return resolveSignalRAccessTokenResult tokenResult
         }
 
+    let private renderJsonResult parseResult started completed message =
+        let configuration = Current()
+
+        let dto: LocalOutputDto.WatchResultDto =
+            {
+                Started = started
+                Completed = completed
+                Message = message
+                RootDirectory = configuration.RootDirectory
+                ServerUri = configuration.ServerUri
+                RepositoryId = configuration.RepositoryId
+                BranchId = configuration.BranchId
+            }
+
+        Ok(GraceReturnValue.Create dto (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
+    let private renderJsonError parseResult message =
+        Error(GraceError.Create message (getCorrelationId parseResult))
+        |> renderOutput parseResult
+
     let private createSignalRConnection (signalRUrl: Uri) =
         HubConnectionBuilder()
             .WithAutomaticReconnect()
@@ -777,17 +798,23 @@ module Watch =
                             //logToAnsiConsole Colors.Verbose $"Memory before GC: {memoryBeforeGC:N0}; after: {Process.GetCurrentProcess().WorkingSet64:N0}."
                             previousGC <- getCurrentInstant ()
 
-                    return 0
+                    if parseResult |> json then
+                        return renderJsonResult parseResult true true "Watch completed because cancellation was requested or the timer stopped."
+                    else
+                        return 0
                 with
                 | :? HttpRequestException as httpEx when
                     httpEx.StatusCode.HasValue
                     && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
                     ->
-                    logToAnsiConsole
-                        Colors.Error
+                    let message =
                         $"SignalR negotiation failed with 401 Unauthorized. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
 
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult message
+                    else
+                        logToAnsiConsole Colors.Error message
+                        return -1
                 | :? InvalidOperationException as invalidOperationException when
                     invalidOperationException.Message.Contains
                         (
@@ -795,15 +822,21 @@ module Watch =
                             StringComparison.OrdinalIgnoreCase
                         )
                     ->
-                    logToAnsiConsole Colors.Error $"{Markup.Escape(invalidOperationException.Message)}"
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult invalidOperationException.Message
+                    else
+                        logToAnsiConsole Colors.Error $"{Markup.Escape(invalidOperationException.Message)}"
+                        return -1
                 | ex ->
                     //let exceptionMarkup = Markup.Escape($"{ExceptionResponse.Create ex}").Replace("\\\\", @"\").Replace("\r\n", Environment.NewLine)
                     //logToAnsiConsole Colors.Error $"{exceptionMarkup}"
-                    let exceptionSettings = ExceptionSettings(Format = ExceptionFormats.Default)
-                    // Need to fill in some exception styles here.
-                    AnsiConsole.WriteException(ex, exceptionSettings)
-                    return -1
+                    if parseResult |> json then
+                        return renderJsonError parseResult $"{ExceptionResponse.Create ex}"
+                    else
+                        let exceptionSettings = ExceptionSettings(Format = ExceptionFormats.Default)
+                        // Need to fill in some exception styles here.
+                        AnsiConsole.WriteException(ex, exceptionSettings)
+                        return -1
             }
 
     let Build =

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -22,6 +22,7 @@ module CommandOutputContract =
 
     type CurrentJsonBehavior =
         | CommonRenderOutputEnvelope
+        | ImmediateJsonErrorOnly
         | HumanProgressOnlySuccess
         | PartialManualSuccess
         | ManualJsonUnenveloped
@@ -54,6 +55,7 @@ module CommandOutputContract =
     type EnvelopeContract =
         | ExistingGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
         | MigrationRequiredToGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
+        | JsonModeErrorOnly of reason: string
         | SourceOnlyUnsupported of disposition: string
 
     type FeatureState =
@@ -156,6 +158,25 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
+    let private nullableStringSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- [| "string"; "null" |]
+        schema["description"] <- description
+        box schema
+
+    let private arraySchema itemSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "array"
+        schema["items"] <- itemSchema
+        schema["description"] <- description
+        box schema
+
+    let private stringDateTimeSchema =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["format"] <- "date-time"
+        box schema
+
     let private propertyBagSchema =
         let propertyEntry =
             schemaObject
@@ -191,6 +212,167 @@ module CommandOutputContract =
     let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
 
     let private stringReturnValueSchema = scalarSchema "string"
+
+    let private maintenanceStatsSchema =
+        schemaObject
+            "MaintenanceStatsDto"
+            [
+                "DirectoryCount", scalarSchema "integer"
+                "FileCount", scalarSchema "integer"
+                "TotalFileSize", scalarSchema "integer"
+                "RootSha256Hash", nullableStringSchema "Root directory SHA-256 hash when the local index contains or records it."
+            ]
+            [|
+                "DirectoryCount"
+                "FileCount"
+                "TotalFileSize"
+                "RootSha256Hash"
+            |]
+
+    let private maintenanceStatsExample = box {| DirectoryCount = 1; FileCount = 2; TotalFileSize = 42L; RootSha256Hash = "0123456789abcdef" |}
+
+    let private maintenanceListContentsFileSchema =
+        schemaObject
+            "MaintenanceListContentsFileDto"
+            [
+                "RelativePath", scalarSchema "string"
+                "FileName", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+                "Size", scalarSchema "integer"
+                "LastWriteTimeUtc", stringDateTimeSchema
+            ]
+            [|
+                "RelativePath"
+                "FileName"
+                "Sha256Hash"
+                "Size"
+                "LastWriteTimeUtc"
+            |]
+
+    let private maintenanceListContentsDirectorySchema =
+        schemaObject
+            "MaintenanceListContentsDirectoryDto"
+            [
+                "RelativePath", scalarSchema "string"
+                "DirectoryVersionId", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+                "Size", scalarSchema "integer"
+                "LastWriteTimeUtc", stringDateTimeSchema
+                "Files", arraySchema maintenanceListContentsFileSchema "Files in the indexed directory when file listing is enabled."
+            ]
+            [|
+                "RelativePath"
+                "DirectoryVersionId"
+                "Sha256Hash"
+                "Size"
+                "LastWriteTimeUtc"
+                "Files"
+            |]
+
+    let private maintenanceListContentsSchema =
+        schemaObject
+            "MaintenanceListContentsDto"
+            [
+                "Summary", maintenanceStatsSchema
+                "Directories", arraySchema maintenanceListContentsDirectorySchema "Indexed directories returned by maintenance list-contents."
+            ]
+            [| "Summary"; "Directories" |]
+
+    let private maintenanceListContentsExample =
+        box
+            {|
+                Summary = {| DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = "0123456789abcdef" |}
+                Directories =
+                    [|
+                        {|
+                            RelativePath = "."
+                            DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
+                            Sha256Hash = "0123456789abcdef"
+                            Size = 12L
+                            LastWriteTimeUtc = "2026-06-05T00:00:00Z"
+                            Files =
+                                [|
+                                    {|
+                                        RelativePath = "README.md"
+                                        FileName = "README.md"
+                                        Sha256Hash = "abcdef0123456789"
+                                        Size = 12L
+                                        LastWriteTimeUtc = "2026-06-05T00:00:00Z"
+                                    |}
+                                |]
+                        |}
+                    |]
+            |}
+
+    let private maintenanceIgnoreEntriesSchema =
+        schemaObject
+            "MaintenanceIgnoreEntriesDto"
+            [
+                "DirectoryEntries", arraySchema (scalarSchema "string") "Configured Grace directory ignore entries."
+                "FileEntries", arraySchema (scalarSchema "string") "Configured Grace file ignore entries."
+            ]
+            [| "DirectoryEntries"; "FileEntries" |]
+
+    let private maintenanceIgnoreEntriesExample = box {| DirectoryEntries = [| ".git"; ".grace" |]; FileEntries = [| "*.tmp" |] |}
+
+    let private maintenanceScanDifferenceSchema =
+        schemaObject
+            "MaintenanceScanDifferenceDto"
+            [
+                "DifferenceType", scalarSchema "string"
+                "FileSystemEntryType", scalarSchema "string"
+                "RelativePath", scalarSchema "string"
+            ]
+            [|
+                "DifferenceType"
+                "FileSystemEntryType"
+                "RelativePath"
+            |]
+
+    let private maintenanceScanDirectoryVersionSchema =
+        schemaObject
+            "MaintenanceScanDirectoryVersionDto"
+            [
+                "DirectoryVersionId", scalarSchema "string"
+                "RelativePath", scalarSchema "string"
+                "Sha256Hash", scalarSchema "string"
+            ]
+            [|
+                "DirectoryVersionId"
+                "RelativePath"
+                "Sha256Hash"
+            |]
+
+    let private maintenanceScanSchema =
+        schemaObject
+            "MaintenanceScanDto"
+            [
+                "DifferenceCount", scalarSchema "integer"
+                "Differences", arraySchema maintenanceScanDifferenceSchema "Detected filesystem differences compared with the local Grace index."
+                "NewDirectoryVersionCount", scalarSchema "integer"
+                "NewDirectoryVersions", arraySchema maintenanceScanDirectoryVersionSchema "Computed directory versions for detected differences."
+            ]
+            [|
+                "DifferenceCount"
+                "Differences"
+                "NewDirectoryVersionCount"
+                "NewDirectoryVersions"
+            |]
+
+    let private maintenanceScanExample =
+        box
+            {|
+                DifferenceCount = 1
+                Differences =
+                    [|
+                        {| DifferenceType = "Added"; FileSystemEntryType = "File"; RelativePath = "README.md" |}
+                    |]
+                NewDirectoryVersionCount = 1
+                NewDirectoryVersions =
+                    [|
+                        {| DirectoryVersionId = "11111111-1111-1111-1111-111111111111"; RelativePath = "."; Sha256Hash = "0123456789abcdef" |}
+                    |]
+            |}
 
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
@@ -230,16 +412,63 @@ module CommandOutputContract =
         match contract with
         | ExistingGraceResultEnvelope disposition -> $"ExistingGraceResultEnvelope: {outputDtoDispositionText disposition}"
         | MigrationRequiredToGraceResultEnvelope disposition -> $"MigrationRequiredToGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | JsonModeErrorOnly reason -> $"JsonModeErrorOnly: {reason}"
         | SourceOnlyUnsupported reason -> $"SourceOnlyUnsupported: {reason}"
 
     let private returnValueDispositionText (contract: EnvelopeContract) =
         match contract with
         | ExistingGraceResultEnvelope disposition
         | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
+        | JsonModeErrorOnly reason -> $"Unsupported: {reason}"
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
 
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
+        | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceIgnoreEntriesDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceIgnoreEntriesSchema
+                maintenanceIgnoreEntriesExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance check-ignore-entries in the common Grace result envelope."
+                ]
+        | "maintenance.list-contents", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceListContentsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceListContentsSchema
+                maintenanceListContentsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance list-contents in the common Grace result envelope."
+                ]
+        | "maintenance.scan", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceScanDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceScanSchema
+                maintenanceScanExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance scan in the common Grace result envelope."
+                ]
+        | "maintenance.stats", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceStatsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceStatsSchema
+                maintenanceStatsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance stats in the common Grace result envelope."
+                ]
+        | "maintenance.update-index", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceStatsDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceStatsSchema
+                maintenanceStatsExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance update-index in the common Grace result envelope after the local index is updated."
+                ]
         | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "RepositoryDto"
@@ -261,7 +490,9 @@ module CommandOutputContract =
                 [
                     "Representative scalar ReturnValue schema for a common Grace result envelope command."
                 ]
+        | "watch", JsonModeErrorOnly reason -> unsupportedReturnValueContract "WatchResultDto" reason
         | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
+        | _, JsonModeErrorOnly reason -> unsupportedReturnValueContract "unsupported" reason
         | _, MigrationRequiredToGraceResultEnvelope disposition ->
             incompleteReturnValueContract
                 (outputDtoDispositionText disposition)
@@ -332,7 +563,10 @@ module CommandOutputContract =
         {
             Status = status
             Source = "CommandOutputContract"
-            Envelope = "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
+            Envelope =
+                match entry.EnvelopeContract with
+                | JsonModeErrorOnly reason -> $"GraceError only in JSON mode for this release; no success ReturnValue envelope is emitted. {reason}"
+                | _ -> "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
             ReturnValueContract = entry.ReturnValueContract.Name
             SuccessSchema = successEnvelopeSchema entry
@@ -429,6 +663,8 @@ module CommandOutputContract =
         match behavior with
         | UnroutedSourceOnly ->
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
+        | ImmediateJsonErrorOnly ->
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = RequiresMigration }
         | CommonRenderOutputEnvelope ->
             { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
@@ -437,6 +673,9 @@ module CommandOutputContract =
         match routed, behavior with
         | false, _ -> SourceOnlyUnsupported "Defined in source but not root-routed for V1."
         | true, CommonRenderOutputEnvelope -> ExistingGraceResultEnvelope dtoDisposition
+        | true, ImmediateJsonErrorOnly ->
+            JsonModeErrorOnly
+                "The command is routed, but --output Json is intentionally short-circuited before command execution because watch is a continuous foreground workflow."
         | true, _ -> MigrationRequiredToGraceResultEnvelope dtoDisposition
 
     let internal commandIdentity groupPath commandName = { GroupPath = groupPath; CommandName = commandName }
@@ -485,6 +724,7 @@ module CommandOutputContract =
         }
 
     let private common_renderOutput_envelope = CommonRenderOutputEnvelope
+    let private immediate_json_error_only = ImmediateJsonErrorOnly
     let private human_progress_only_success = HumanProgressOnlySuccess
     let private partial_manual_success = PartialManualSuccess
     let private manual_json_unenveloped = ManualJsonUnenveloped
@@ -754,7 +994,7 @@ module CommandOutputContract =
             row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [] "watch" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
+            row [] "watch" true true immediate_json_error_only progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -608,11 +608,11 @@ module CommandOutputContract =
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
             row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "check-ignore-entries" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "list-contents" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "scan" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
-            row [ "maintenance" ] "stats" true false human_progress_only_success read_list_search local_client RequiresCliDto
-            row [ "maintenance" ] "update-index" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "check-ignore-entries" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "list-contents" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "scan" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "stats" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "update-index" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
             row [ "organization" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "organization" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "organization" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -754,7 +754,7 @@ module CommandOutputContract =
             row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [] "watch" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [] "watch" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -1,0 +1,481 @@
+namespace Grace.CLI
+
+open System
+open System.CommandLine
+
+module CommandOutputContract =
+
+    type CommandIdentity =
+        {
+            GroupPath: string list
+            CommandName: string
+        }
+
+        member this.CommandPath = this.GroupPath @ [ this.CommandName ]
+        member this.CommandId = String.Join(".", this.CommandPath)
+        override this.ToString() = String.Join(" ", this.CommandPath)
+
+    type RouteDisposition =
+        | Routed
+        | SourceOnlyUnrouted of disposition: string
+
+    type CurrentJsonBehavior =
+        | CommonRenderOutputEnvelope
+        | HumanProgressOnlySuccess
+        | PartialManualSuccess
+        | ManualJsonUnenveloped
+        | HumanProcOnly
+        | HumanOnly
+        | UnroutedSourceOnly
+
+    type CommandCategory =
+        | ProgressLocalWorkflow
+        | MutatingStateTransition
+        | ReadOrMutatingVerify
+        | ReadListSearch
+        | Mutating
+        | FireAndForgetProgress
+        | WorkflowAcceptedOperation
+        | HelpIntrospection
+
+    type ExecutionScope =
+        | CompositeLocalAndServer
+        | LocalClient
+        | ServerViaSdk
+        | Verify
+        | ServerViaSdkDefinedButNotRootRouted
+
+    type OutputDtoDisposition =
+        | ReuseExistingApiOrSdkDto
+        | RequiresCliDto
+        | NoServerDto
+
+    type EnvelopeContract =
+        | ExistingGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
+        | MigrationRequiredToGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
+        | SourceOnlyUnsupported of disposition: string
+
+    type FeatureState =
+        | ExistingBehavior
+        | FutureInertIntrospection
+        | FutureReturnValueProjection
+        | UnsupportedUntilRouted
+        | RequiresMigration
+
+    type MachineReadableFeatures = { JsonMode: FeatureState; Schema: FeatureState; Examples: FeatureState; Select: FeatureState }
+
+    type CommandContractEntry =
+        {
+            Identity: CommandIdentity
+            RouteDisposition: RouteDisposition
+            CurrentJsonBehavior: CurrentJsonBehavior
+            Category: CommandCategory
+            ExecutionScope: ExecutionScope
+            Mutating: bool
+            EnvelopeContract: EnvelopeContract
+            Features: MachineReadableFeatures
+        }
+
+    let private featuresFor behavior =
+        match behavior with
+        | UnroutedSourceOnly ->
+            { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
+        | CommonRenderOutputEnvelope ->
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
+        | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
+
+    let private envelopeFor routed behavior dtoDisposition =
+        match routed, behavior with
+        | false, _ -> SourceOnlyUnsupported "Defined in source but not root-routed for V1."
+        | true, CommonRenderOutputEnvelope -> ExistingGraceResultEnvelope dtoDisposition
+        | true, _ -> MigrationRequiredToGraceResultEnvelope dtoDisposition
+
+    let internal commandIdentity groupPath commandName = { GroupPath = groupPath; CommandName = commandName }
+
+    let discoverLeafCommands (rootCommand: Command) =
+        let rec loop path (command: Command) =
+            let subcommands =
+                command.Subcommands
+                |> Seq.cast<Command>
+                |> Seq.toList
+
+            if subcommands.IsEmpty then
+                [
+                    { GroupPath = path; CommandName = command.Name }
+                ]
+            else
+                subcommands
+                |> List.collect (fun child -> loop (path @ [ command.Name ]) child)
+
+        rootCommand.Subcommands
+        |> Seq.cast<Command>
+        |> Seq.toList
+        |> List.collect (loop [])
+
+    let private row groupPath commandName routed mutating behavior category executionScope dtoDisposition =
+        let routeDisposition =
+            if routed then
+                Routed
+            else
+                SourceOnlyUnrouted "Defined-only reference command; not attached to GraceCommand.rootCommand."
+
+        {
+            Identity = commandIdentity groupPath commandName
+            RouteDisposition = routeDisposition
+            CurrentJsonBehavior = behavior
+            Category = category
+            ExecutionScope = executionScope
+            Mutating = mutating
+            EnvelopeContract = envelopeFor routed behavior dtoDisposition
+            Features = featuresFor behavior
+        }
+
+    let private common_renderOutput_envelope = CommonRenderOutputEnvelope
+    let private human_progress_only_success = HumanProgressOnlySuccess
+    let private partial_manual_success = PartialManualSuccess
+    let private manual_json_unenveloped = ManualJsonUnenveloped
+    let private human_proc_only = HumanProcOnly
+    let private human_only = HumanOnly
+    let private unrouted_source_only = UnroutedSourceOnly
+
+    let private progress_local_workflow = ProgressLocalWorkflow
+    let private mutating_state_transition = MutatingStateTransition
+    let private read_or_mutating_verify = ReadOrMutatingVerify
+    let private read_list_search = ReadListSearch
+    let private mutating = Mutating
+    let private fire_and_forget_progress = FireAndForgetProgress
+    let private workflow_accepted_operation = WorkflowAcceptedOperation
+    let private help_introspection = HelpIntrospection
+
+    let private composite_local_server = CompositeLocalAndServer
+    let private local_client = LocalClient
+    let private server_via_sdk = ServerViaSdk
+    let private verify = Verify
+    let private server_via_sdk_defined_but_not_root_routed = ServerViaSdkDefinedButNotRootRouted
+
+    let entries =
+        [
+            row [ "access" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "list-role-assignments" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "list-roles" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "remove-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "access" ] "upsert-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "reschedule" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "admin"; "reminder" ] "update-time" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "agent" ] "add-summary" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
+            row [ "agent" ] "bootstrap" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
+            row [ "agent"; "work" ] "start" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
+            row [ "agent"; "work" ] "status" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
+            row [ "agent"; "work" ] "stop" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
+            row [ "alias" ] "list" true false human_only help_introspection local_client RequiresCliDto
+            row [ "approval"; "policy" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "disable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "enable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "evaluate" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "policy" ] "update" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "approve" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "history" true true common_renderOutput_envelope workflow_accepted_operation server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "reject" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "approval"; "request" ] "wait" true true common_renderOutput_envelope workflow_accepted_operation server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth" ] "login" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth" ] "logout" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "clear" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "revoke" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "auth" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "assign" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "commit" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "create-external" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-assign" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-auto-rebase" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-checkpoints" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-commit" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-external" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-promotion" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-save" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "enable-tag" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-checkpoints" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-commits" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-externals" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-promotions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-recursive-size" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-references" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-saves" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "get-tags" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "list-contents" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
+            row [ "branch" ] "promote" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "rebase" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "branch" ] "save" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "set-name" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "set-promotion-mode" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "status" true false human_progress_only_success read_list_search composite_local_server RequiresCliDto
+            row [ "branch" ] "switch" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "branch" ] "tag" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "update-parent-branch" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate" ] "attestations" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate" ] "cancel" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate"; "gate" ] "rerun" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate" ] "required-actions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "candidate" ] "retry" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "config" ] "write" true false common_renderOutput_envelope read_or_mutating_verify local_client ReuseExistingApiOrSdkDto
+            row [] "connect" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "checkpoint" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "commit" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "directoryid" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "promotion" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "save" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "sha" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "diff" ] "tag" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "directory-version" ] "get-zip-file" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "history" ] "delete" true true manual_json_unenveloped mutating local_client RequiresCliDto
+            row [ "history" ] "off" true true manual_json_unenveloped mutating local_client RequiresCliDto
+            row [ "history" ] "on" true true manual_json_unenveloped mutating local_client RequiresCliDto
+            row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
+            row [ "history" ] "search" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
+            row [ "history" ] "show" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "check-ignore-entries" true false human_progress_only_success read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "list-contents" true false human_progress_only_success read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "scan" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "stats" true false human_progress_only_success read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "update-index" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [ "organization" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "organization" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "organization" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "organization" ] "set-description" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "organization" ] "set-name" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "organization" ]
+                "set-search-visibility"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "organization" ] "set-type" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "organization" ] "undelete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "set-description" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "set-name" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "set-search-visibility" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "set-type" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "owner" ] "undelete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "apply" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "promotion-set"; "conflicts" ]
+                "resolve"
+                true
+                true
+                common_renderOutput_envelope
+                mutating_state_transition
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "promotion-set"; "conflicts" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "get-events" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "recompute" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "request-approval" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "promotion-set" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "promotion-set" ]
+                "update-input-promotions"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "queue" ] "dequeue" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "queue" ] "enqueue" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "queue" ] "pause" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "queue" ] "resume" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "queue" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "reference" ] "assign" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "checkpoint" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "commit" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row
+                [ "reference" ]
+                "create-external"
+                false
+                true
+                unrouted_source_only
+                mutating_state_transition
+                server_via_sdk_defined_but_not_root_routed
+                NoServerDto
+            row [ "reference" ] "delete" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "get" false false unrouted_source_only read_list_search server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "promote" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "save" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "reference" ] "tag" false true unrouted_source_only mutating_state_transition server_via_sdk_defined_but_not_root_routed NoServerDto
+            row [ "repository" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "get-branches" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "init" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row
+                [ "repository" ]
+                "set-allows-large-files"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-anonymous-access" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-checkpoint-days" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "repository" ]
+                "set-conflict-resolution-policy"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row
+                [ "repository" ]
+                "set-default-server-api-version"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-description" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-diff-cache-days" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "repository" ]
+                "set-directory-version-cache-days"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row
+                [ "repository" ]
+                "set-logical-delete-days"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-name" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-record-saves" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-save-days" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-status" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "set-visibility" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "repository" ] "undelete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "review" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
+            row [ "review" ] "deepen" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
+            row [ "review" ] "inbox" true false common_renderOutput_envelope read_list_search verify ReuseExistingApiOrSdkDto
+            row [ "review" ] "open" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
+            row [ "review"; "report" ] "export" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
+            row [ "review"; "report" ] "show" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
+            row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
+            row [] "watch" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
+            row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook"; "delivery" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "disable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "enable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "test" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "webhook" ] "update" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attach" ] "notes" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attach" ] "prompt" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attach" ] "summary" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attachments" ] "download" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "workitem"; "attachments" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attachments" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "link" ] "prset" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "link" ] "ref" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "links" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "workitem"; "links"; "remove" ]
+                "notes"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row
+                [ "workitem"; "links"; "remove" ]
+                "prompt"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row
+                [ "workitem"; "links"; "remove" ]
+                "prset"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "workitem"; "links"; "remove" ] "ref" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "workitem"; "links"; "remove" ]
+                "summary"
+                true
+                false
+                common_renderOutput_envelope
+                read_or_mutating_verify
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "workitem" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+        ]
+
+    let tryFind identity =
+        entries
+        |> List.tryFind (fun entry -> entry.Identity = identity)
+
+    let routedEntries =
+        entries
+        |> List.filter (fun entry ->
+            match entry.RouteDisposition with
+            | Routed -> true
+            | SourceOnlyUnrouted _ -> false)
+
+    let sourceOnlyEntries =
+        entries
+        |> List.filter (fun entry ->
+            match entry.RouteDisposition with
+            | Routed -> false
+            | SourceOnlyUnrouted _ -> true)

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -430,7 +430,7 @@ module CommandOutputContract =
         | UnroutedSourceOnly ->
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
         | CommonRenderOutputEnvelope ->
-            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
 
     let private envelopeFor routed behavior dtoDisposition =

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -528,7 +528,7 @@ module CommandOutputContract =
             row [ "agent"; "work" ] "start" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
             row [ "agent"; "work" ] "status" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
             row [ "agent"; "work" ] "stop" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
-            row [ "alias" ] "list" true false human_only help_introspection local_client RequiresCliDto
+            row [ "alias" ] "list" true false common_renderOutput_envelope help_introspection local_client RequiresCliDto
             row [ "approval"; "policy" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "policy" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "policy" ] "disable" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
@@ -593,7 +593,7 @@ module CommandOutputContract =
             row [ "candidate" ] "required-actions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "retry" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "config" ] "write" true false common_renderOutput_envelope read_or_mutating_verify local_client ReuseExistingApiOrSdkDto
-            row [] "connect" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [] "connect" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "checkpoint" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "commit" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "directoryid" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
@@ -601,13 +601,13 @@ module CommandOutputContract =
             row [ "diff" ] "save" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "sha" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "diff" ] "tag" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
-            row [ "directory-version" ] "get-zip-file" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
-            row [ "history" ] "delete" true true manual_json_unenveloped mutating local_client RequiresCliDto
-            row [ "history" ] "off" true true manual_json_unenveloped mutating local_client RequiresCliDto
-            row [ "history" ] "on" true true manual_json_unenveloped mutating local_client RequiresCliDto
+            row [ "directory-version" ] "get-zip-file" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
+            row [ "history" ] "delete" true true common_renderOutput_envelope mutating local_client RequiresCliDto
+            row [ "history" ] "off" true true common_renderOutput_envelope mutating local_client RequiresCliDto
+            row [ "history" ] "on" true true common_renderOutput_envelope mutating local_client RequiresCliDto
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
-            row [ "history" ] "search" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
-            row [ "history" ] "show" true false manual_json_unenveloped read_list_search local_client RequiresCliDto
+            row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "check-ignore-entries" true false human_progress_only_success read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "list-contents" true false human_progress_only_success read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "scan" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
@@ -691,7 +691,7 @@ module CommandOutputContract =
             row [ "repository" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "repository" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "repository" ] "get-branches" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "repository" ] "init" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "repository" ] "init" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row
                 [ "repository" ]
                 "set-allows-large-files"
@@ -751,8 +751,8 @@ module CommandOutputContract =
             row [ "review" ] "deepen" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
             row [ "review" ] "inbox" true false common_renderOutput_envelope read_list_search verify ReuseExistingApiOrSdkDto
             row [ "review" ] "open" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [ "review"; "report" ] "export" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
-            row [ "review"; "report" ] "show" true false partial_manual_success read_list_search composite_local_server RequiresCliDto
+            row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
+            row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
             row [] "watch" true true human_progress_only_success progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
@@ -768,7 +768,7 @@ module CommandOutputContract =
             row [ "workitem"; "attach" ] "notes" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attach" ] "prompt" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attach" ] "summary" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem"; "attachments" ] "download" true true partial_manual_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "workitem"; "attachments" ] "download" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "workitem"; "attachments" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attachments" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -1,6 +1,7 @@
 namespace Grace.CLI
 
 open System
+open System.Collections.Generic
 open System.CommandLine
 
 module CommandOutputContract =
@@ -64,6 +65,13 @@ module CommandOutputContract =
 
     type MachineReadableFeatures = { JsonMode: FeatureState; Schema: FeatureState; Examples: FeatureState; Select: FeatureState }
 
+    type ReturnValueMetadataStatus =
+        | SchemaReady
+        | MetadataIncomplete
+        | ContractUnsupported
+
+    type ReturnValueContract = { Name: string; Provenance: string; Status: ReturnValueMetadataStatus; Schema: obj; Example: obj; Notes: string list }
+
     type CommandContractEntry =
         {
             Identity: CommandIdentity
@@ -74,6 +82,7 @@ module CommandOutputContract =
             Mutating: bool
             EnvelopeContract: EnvelopeContract
             Features: MachineReadableFeatures
+            ReturnValueContract: ReturnValueContract
         }
 
     type IntrospectionKind =
@@ -96,7 +105,17 @@ module CommandOutputContract =
             Select: string
         }
 
-    type CommandSchemaDocument = { Status: string; Source: string; Envelope: string; ReturnValueDisposition: string; Notes: string list }
+    type CommandSchemaDocument =
+        {
+            Status: string
+            Source: string
+            Envelope: string
+            ReturnValueDisposition: string
+            ReturnValueContract: string
+            SuccessSchema: obj
+            ErrorSchema: obj
+            Notes: string list
+        }
 
     type CommandExampleDocument = { Name: string; Description: string; Document: obj }
 
@@ -111,6 +130,90 @@ module CommandOutputContract =
         }
 
     let private unionName value = $"{value}"
+
+    let private schemaObject (title: string) (properties: (string * obj) list) (required: string array) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["$schema"] <- "https://json-schema.org/draft/2020-12/schema"
+        schema["title"] <- title
+        schema["type"] <- "object"
+        schema["required"] <- required
+        schema["properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
+        box schema
+
+    let private scalarSchema (typeName: string) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- typeName
+        box schema
+
+    let private anySchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["description"] <- description
+        box schema
+
+    let private nullableObjectSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- [| "object"; "null" |]
+        schema["description"] <- description
+        box schema
+
+    let private propertyBagSchema =
+        let propertyEntry =
+            schemaObject
+                "Grace CLI property entry"
+                [
+                    "Key", scalarSchema "string"
+                    "Value", anySchema "Safe machine-readable metadata value."
+                ]
+                [| "Key"; "Value" |]
+
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "array"
+        schema["items"] <- propertyEntry
+        schema["description"] <- "CLI stdout representation of Grace Properties metadata."
+        box schema
+
+    let private cliProperties commandId provenance =
+        [|
+            {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+            {| Key = "cli.commandId"; Value = commandId |}
+            {| Key = "cli.introspectionSource"; Value = provenance |}
+        |]
+
+    let private unsupportedReturnValueSchema reason =
+        schemaObject
+            "Unsupported command output contract"
+            [
+                "Status", scalarSchema "string"
+                "Reason", scalarSchema "string"
+            ]
+            [| "Status"; "Reason" |]
+
+    let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
+
+    let private stringReturnValueSchema = scalarSchema "string"
+
+    let private supportedReturnValueContract name provenance schema example notes =
+        { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
+
+    let private incompleteReturnValueContract name reason =
+        {
+            Name = name
+            Provenance = "CommandOutputContract"
+            Status = MetadataIncomplete
+            Schema = unsupportedReturnValueSchema reason
+            Example = unsupportedReturnValueExample reason
+            Notes = [ reason ]
+        }
+
+    let private unsupportedReturnValueContract name reason =
+        {
+            Name = name
+            Provenance = "CommandOutputContract"
+            Status = ContractUnsupported
+            Schema = unsupportedReturnValueSchema reason
+            Example = unsupportedReturnValueExample reason
+            Notes = [ reason ]
+        }
 
     let private routeDispositionText (disposition: RouteDisposition) =
         match disposition with
@@ -135,6 +238,39 @@ module CommandOutputContract =
         | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
 
+    let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
+        match identity.CommandId, envelopeContract with
+        | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            incompleteReturnValueContract
+                "RepositoryDto"
+                "RepositoryDto metadata is incomplete: src/Grace.Types/Repository.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
+        | "workitem.show", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            incompleteReturnValueContract
+                "WorkItemDto"
+                "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
+        | "access.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            incompleteReturnValueContract
+                "PermissionCheckResult"
+                "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
+        | "auth.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+            supportedReturnValueContract
+                "string"
+                "GraceReturnValue<string>"
+                stringReturnValueSchema
+                (box "Signed out.")
+                [
+                    "Representative scalar ReturnValue schema for a common Grace result envelope command."
+                ]
+        | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
+        | _, MigrationRequiredToGraceResultEnvelope disposition ->
+            incompleteReturnValueContract
+                (outputDtoDispositionText disposition)
+                "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+        | _, ExistingGraceResultEnvelope disposition ->
+            incompleteReturnValueContract
+                (outputDtoDispositionText disposition)
+                "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
+
     let private commandDocument (identity: CommandIdentity) =
         { Id = identity.CommandId; Path = identity.CommandPath; GroupPath = identity.GroupPath; Name = identity.CommandName }
 
@@ -152,46 +288,94 @@ module CommandOutputContract =
             Select = unionName entry.Features.Select
         }
 
+    let private successEnvelopeSchema (entry: CommandContractEntry) =
+        schemaObject
+            $"GraceReturnValue<{entry.ReturnValueContract.Name}>"
+            [
+                "ReturnValue", entry.ReturnValueContract.Schema
+                "EventTime", scalarSchema "string"
+                "CorrelationId", scalarSchema "string"
+                "Properties", propertyBagSchema
+            ]
+            [|
+                "ReturnValue"
+                "EventTime"
+                "CorrelationId"
+                "Properties"
+            |]
+
+    let private errorEnvelopeSchema =
+        schemaObject
+            "GraceError"
+            [
+                "Exception", nullableObjectSchema "Serialized Grace exception details, or null/default when no exception object is available."
+                "Error", scalarSchema "string"
+                "EventTime", scalarSchema "string"
+                "CorrelationId", scalarSchema "string"
+                "Properties", anySchema "GraceError serializes Properties with the shared serializer policy."
+            ]
+            [|
+                "Exception"
+                "Error"
+                "EventTime"
+                "CorrelationId"
+                "Properties"
+            |]
+
     let private schemaDocument (entry: CommandContractEntry) =
+        let status =
+            match entry.ReturnValueContract.Status with
+            | SchemaReady -> "schema-ready"
+            | MetadataIncomplete -> "metadata-incomplete"
+            | ContractUnsupported -> "unsupported"
+
         {
-            Status = "registry-placeholder"
+            Status = status
             Source = "CommandOutputContract"
-            Envelope = "GraceReturnValue<T> on success; GraceError on error"
+            Envelope = "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
+            ReturnValueContract = entry.ReturnValueContract.Name
+            SuccessSchema = successEnvelopeSchema entry
+            ErrorSchema = errorEnvelopeSchema
             Notes =
                 [
-                    "S2 emits registry-derived introspection metadata only."
-                    "S4 will replace this placeholder with command DTO-derived schema details."
+                    "Schema is derived from CommandOutputContract registry metadata."
                     "This path is inert and does not execute the command action."
+                    yield! entry.ReturnValueContract.Notes
                 ]
         }
 
     let private successExample (entry: CommandContractEntry) =
-        let returnValue =
-            match entry.EnvelopeContract with
-            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto" |}
-            | ExistingGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto" |}
-            | MigrationRequiredToGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto-requires-migration" |}
-            | MigrationRequiredToGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto-requires-migration" |}
-            | ExistingGraceResultEnvelope NoServerDto
-            | MigrationRequiredToGraceResultEnvelope NoServerDto -> box {| Shape = "no-server-dto" |}
-            | SourceOnlyUnsupported reason -> box {| Unsupported = reason |}
-
         {
             Name = "success-envelope-shape"
-            Description = "Representative GraceReturnValue<T> envelope shape; command-specific ReturnValue details are deferred to S4."
+            Description = $"Representative GraceReturnValue<{entry.ReturnValueContract.Name}> envelope shape from registry metadata."
             Document =
                 box
                     {|
-                        ReturnValue = returnValue
+                        ReturnValue = entry.ReturnValueContract.Example
                         EventTime = "2026-06-05T00:00:00Z"
                         CorrelationId = "correlation-id"
-                        Properties =
-                            [|
-                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
-                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
-                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
-                            |]
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
+                    |}
+        }
+
+    let private incompleteMetadataExample (entry: CommandContractEntry) =
+        {
+            Name = "metadata-incomplete"
+            Description = "Explicit machine-readable metadata gap for a command that is not schema-ready."
+            Document =
+                box
+                    {|
+                        Status =
+                            match entry.ReturnValueContract.Status with
+                            | ContractUnsupported -> "unsupported"
+                            | _ -> "metadata-incomplete"
+                        CommandId = entry.Identity.CommandId
+                        ReturnValueContract = entry.ReturnValueContract.Name
+                        Reason =
+                            entry.ReturnValueContract.Notes
+                            |> String.concat " "
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
                     |}
         }
 
@@ -206,12 +390,7 @@ module CommandOutputContract =
                         Error = "error message"
                         EventTime = "2026-06-05T00:00:00Z"
                         CorrelationId = "correlation-id"
-                        Properties =
-                            [|
-                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
-                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
-                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
-                            |]
+                        Properties = cliProperties entry.Identity.CommandId "CommandOutputContract"
                     |}
         }
 
@@ -232,10 +411,18 @@ module CommandOutputContract =
                 match kind with
                 | Schema -> []
                 | Examples ->
-                    [
-                        successExample entry
-                        errorExample entry
-                    ]
+                    match entry.ReturnValueContract.Status with
+                    | SchemaReady ->
+                        [
+                            successExample entry
+                            errorExample entry
+                        ]
+                    | MetadataIncomplete
+                    | ContractUnsupported ->
+                        [
+                            incompleteMetadataExample entry
+                            errorExample entry
+                        ]
         }
 
     let private featuresFor behavior =
@@ -275,21 +462,26 @@ module CommandOutputContract =
         |> List.collect (loop [])
 
     let private row groupPath commandName routed mutating behavior category executionScope dtoDisposition =
+        let identity = commandIdentity groupPath commandName
+
         let routeDisposition =
             if routed then
                 Routed
             else
                 SourceOnlyUnrouted "Defined-only reference command; not attached to GraceCommand.rootCommand."
 
+        let envelopeContract = envelopeFor routed behavior dtoDisposition
+
         {
-            Identity = commandIdentity groupPath commandName
+            Identity = identity
             RouteDisposition = routeDisposition
             CurrentJsonBehavior = behavior
             Category = category
             ExecutionScope = executionScope
             Mutating = mutating
-            EnvelopeContract = envelopeFor routed behavior dtoDisposition
+            EnvelopeContract = envelopeContract
             Features = featuresFor behavior
+            ReturnValueContract = returnValueContractFor identity envelopeContract
         }
 
     let private common_renderOutput_envelope = CommonRenderOutputEnvelope

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -76,6 +76,168 @@ module CommandOutputContract =
             Features: MachineReadableFeatures
         }
 
+    type IntrospectionKind =
+        | Schema
+        | Examples
+
+    type CommandIdentityDocument = { Id: string; Path: string list; GroupPath: string list; Name: string }
+
+    type CommandRegistryDocument =
+        {
+            RouteDisposition: string
+            CurrentJsonBehavior: string
+            Category: string
+            ExecutionScope: string
+            Mutating: bool
+            EnvelopeContract: string
+            JsonMode: string
+            Schema: string
+            Examples: string
+            Select: string
+        }
+
+    type CommandSchemaDocument = { Status: string; Source: string; Envelope: string; ReturnValueDisposition: string; Notes: string list }
+
+    type CommandExampleDocument = { Name: string; Description: string; Document: obj }
+
+    type CommandIntrospectionDocument =
+        {
+            Kind: string
+            ContractVersion: string
+            Command: CommandIdentityDocument
+            Registry: CommandRegistryDocument
+            Schema: CommandSchemaDocument option
+            Examples: CommandExampleDocument list
+        }
+
+    let private unionName value = $"{value}"
+
+    let private routeDispositionText (disposition: RouteDisposition) =
+        match disposition with
+        | Routed -> "Routed"
+        | SourceOnlyUnrouted reason -> $"SourceOnlyUnrouted: {reason}"
+
+    let private outputDtoDispositionText (disposition: OutputDtoDisposition) =
+        match disposition with
+        | ReuseExistingApiOrSdkDto -> "ReuseExistingApiOrSdkDto"
+        | RequiresCliDto -> "RequiresCliDto"
+        | NoServerDto -> "NoServerDto"
+
+    let private envelopeContractText (contract: EnvelopeContract) =
+        match contract with
+        | ExistingGraceResultEnvelope disposition -> $"ExistingGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | MigrationRequiredToGraceResultEnvelope disposition -> $"MigrationRequiredToGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | SourceOnlyUnsupported reason -> $"SourceOnlyUnsupported: {reason}"
+
+    let private returnValueDispositionText (contract: EnvelopeContract) =
+        match contract with
+        | ExistingGraceResultEnvelope disposition
+        | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
+        | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
+
+    let private commandDocument (identity: CommandIdentity) =
+        { Id = identity.CommandId; Path = identity.CommandPath; GroupPath = identity.GroupPath; Name = identity.CommandName }
+
+    let private registryDocument (entry: CommandContractEntry) =
+        {
+            RouteDisposition = routeDispositionText entry.RouteDisposition
+            CurrentJsonBehavior = unionName entry.CurrentJsonBehavior
+            Category = unionName entry.Category
+            ExecutionScope = unionName entry.ExecutionScope
+            Mutating = entry.Mutating
+            EnvelopeContract = envelopeContractText entry.EnvelopeContract
+            JsonMode = unionName entry.Features.JsonMode
+            Schema = unionName entry.Features.Schema
+            Examples = unionName entry.Features.Examples
+            Select = unionName entry.Features.Select
+        }
+
+    let private schemaDocument (entry: CommandContractEntry) =
+        {
+            Status = "registry-placeholder"
+            Source = "CommandOutputContract"
+            Envelope = "GraceReturnValue<T> on success; GraceError on error"
+            ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
+            Notes =
+                [
+                    "S2 emits registry-derived introspection metadata only."
+                    "S4 will replace this placeholder with command DTO-derived schema details."
+                    "This path is inert and does not execute the command action."
+                ]
+        }
+
+    let private successExample (entry: CommandContractEntry) =
+        let returnValue =
+            match entry.EnvelopeContract with
+            | ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto" |}
+            | ExistingGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto" |}
+            | MigrationRequiredToGraceResultEnvelope ReuseExistingApiOrSdkDto -> box {| Shape = "existing-api-or-sdk-dto-requires-migration" |}
+            | MigrationRequiredToGraceResultEnvelope RequiresCliDto -> box {| Shape = "cli-dto-requires-migration" |}
+            | ExistingGraceResultEnvelope NoServerDto
+            | MigrationRequiredToGraceResultEnvelope NoServerDto -> box {| Shape = "no-server-dto" |}
+            | SourceOnlyUnsupported reason -> box {| Unsupported = reason |}
+
+        {
+            Name = "success-envelope-shape"
+            Description = "Representative GraceReturnValue<T> envelope shape; command-specific ReturnValue details are deferred to S4."
+            Document =
+                box
+                    {|
+                        ReturnValue = returnValue
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties =
+                            [|
+                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
+                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
+                            |]
+                    |}
+        }
+
+    let private errorExample (entry: CommandContractEntry) =
+        {
+            Name = "error-envelope-shape"
+            Description = "Representative GraceError envelope shape."
+            Document =
+                box
+                    {|
+                        Exception = null
+                        Error = "error message"
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties =
+                            [|
+                                {| Key = "cli.contractVersion"; Value = "cli-json-v1" |}
+                                {| Key = "cli.commandId"; Value = entry.Identity.CommandId |}
+                                {| Key = "cli.introspectionSource"; Value = "CommandOutputContract" |}
+                            |]
+                    |}
+        }
+
+    let introspectionDocument (kind: IntrospectionKind) (entry: CommandContractEntry) =
+        {
+            Kind =
+                match kind with
+                | Schema -> "schema"
+                | Examples -> "examples"
+            ContractVersion = "cli-json-v1"
+            Command = commandDocument entry.Identity
+            Registry = registryDocument entry
+            Schema =
+                match kind with
+                | Schema -> Some(schemaDocument entry)
+                | Examples -> None
+            Examples =
+                match kind with
+                | Schema -> []
+                | Examples ->
+                    [
+                        successExample entry
+                        errorExample entry
+                    ]
+        }
+
     let private featuresFor behavior =
         match behavior with
         | UnroutedSourceOnly ->

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -53,6 +53,7 @@
 		<Compile Include="Command\Admin.CLI.fs" />
 		<Compile Include="HistoryStorage.CLI.fs" />
 		<Compile Include="Command\History.CLI.fs" />
+		<Compile Include="CommandOutputContract.CLI.fs" />
 		<Compile Include="Program.CLI.fs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -26,6 +26,7 @@
 		<Compile Include="Log.CLI.fs" />
 		<Compile Include="Text.CLI.fs" />
 		<Compile Include="LocalStateDb.CLI.fs" />
+		<Compile Include="SelectProjection.CLI.fs" />
 		<Compile Include="Command\Services.CLI.fs" />
 		<Compile Include="Command\Common.CLI.fs" />
 		<Compile Include="Command\Auth.CLI.fs" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -49,6 +49,20 @@ module GraceCommand =
 
     type OptionToUpdate = { optionAlias: string; display: string; displayOnCreate: string; createParentCommand: string }
 
+    let private deleteGraceWatchIpcFileIfOwned () =
+        if graceWatchStatusUpdateTime <> Instant.MinValue then
+            try
+                let ipcFileName = IpcFileName()
+
+                if File.Exists(ipcFileName) then
+                    let status =
+                        File.ReadAllText(ipcFileName)
+                        |> deserialize<GraceWatchStatus>
+
+                    if status.UpdatedAt = graceWatchStatusUpdateTime then File.Delete(ipcFileName)
+            with
+            | _ -> ()
+
     /// Built-in aliases for Grace commands.
     let private aliases =
         let aliases = Dictionary<string, string seq>()
@@ -1406,6 +1420,6 @@ module GraceCommand =
                 // If this was grace watch, delete the inter-process communication file.
                 if not <| isNull (parseResult)
                    && parseResult |> isGraceWatch then
-                    File.Delete(IpcFileName())
+                    deleteGraceWatchIpcFileIfOwned ()
         })
             .Result

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -44,6 +44,8 @@ module Configuration =
 
 module GraceCommand =
 
+    exception private IntrospectionExit of int
+
     type OptionToUpdate = { optionAlias: string; display: string; displayOnCreate: string; createParentCommand: string }
 
     /// Built-in aliases for Grace commands.
@@ -137,6 +139,89 @@ module GraceCommand =
             gatherAllOptions parentCommand allOptions
         else
             allOptions
+
+    let private commandIdentityFromCommandResult (commandResult: CommandResult) =
+        let rec loop (current: SymbolResult) (names: string list) =
+            match current with
+            | :? CommandResult as currentCommand ->
+                let nextNames =
+                    if currentCommand.Command :? RootCommand then
+                        names
+                    else
+                        currentCommand.Command.Name :: names
+
+                if isNull currentCommand.Parent then
+                    nextNames
+                else
+                    loop currentCommand.Parent nextNames
+            | _ -> names
+
+        let path = loop commandResult []
+
+        match path with
+        | [] -> CommandOutputContract.commandIdentity [] commandResult.Command.Name
+        | _ ->
+            let commandName = path |> List.last
+            let groupPath = path |> List.take (path.Length - 1)
+            CommandOutputContract.commandIdentity groupPath commandName
+
+    let private introspectionRequestFromTokens (args: string array) =
+        let tokens =
+            if isNull args then
+                Array.empty
+            else
+                args
+                |> Array.takeWhile (fun token -> not (token.Equals("--", StringComparison.Ordinal)))
+
+        let containsOption optionName =
+            tokens
+            |> Array.exists (fun token -> token.Equals(optionName, StringComparison.OrdinalIgnoreCase))
+
+        let schema = containsOption OptionName.Schema
+        let examples = containsOption OptionName.Examples
+
+        match schema, examples with
+        | false, false -> None
+        | true, false -> Some(Ok CommandOutputContract.IntrospectionKind.Schema)
+        | false, true -> Some(Ok CommandOutputContract.IntrospectionKind.Examples)
+        | true, true -> Some(Error "--schema and --examples cannot be used together.")
+
+    let private writeJsonStdout value = Console.Out.WriteLine(serialize value)
+
+    let private writeIntrospectionError parseResult message =
+        let error = GraceError.Create message (getCorrelationId parseResult)
+        writeJsonStdout error
+        -1
+
+    let private isIgnorableIntrospectionParseError (error: ParseError) =
+        error.Message.StartsWith("Required argument missing for command:", StringComparison.Ordinal)
+
+    let private hasBlockingIntrospectionParseErrors (parseResult: ParseResult) =
+        parseResult.Errors
+        |> Seq.exists (isIgnorableIntrospectionParseError >> not)
+
+    let private writeIntrospectionParseError (parseResult: ParseResult) =
+        let message =
+            parseResult.Errors
+            |> Seq.filter (isIgnorableIntrospectionParseError >> not)
+            |> Seq.map (fun error -> error.Message)
+            |> String.concat Environment.NewLine
+
+        writeIntrospectionError parseResult message
+
+    let private handleIntrospectionRequest (parseResult: ParseResult) kind =
+        let identity = commandIdentityFromCommandResult parseResult.CommandResult
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            match entry.RouteDisposition with
+            | CommandOutputContract.Routed ->
+                let document = CommandOutputContract.introspectionDocument kind entry
+                writeJsonStdout document
+                0
+            | CommandOutputContract.SourceOnlyUnrouted reason ->
+                writeIntrospectionError parseResult $"Command '{identity.CommandId}' is not routed for CLI introspection. {reason}"
+        | None -> writeIntrospectionError parseResult $"Command '{identity.CommandId}' does not have CLI output contract metadata."
 
     let private replaceDefaultValue (line: string) (defaultValueText: string) =
         let startIndex = line.IndexOf("[default:", StringComparison.OrdinalIgnoreCase)
@@ -566,6 +651,8 @@ module GraceCommand =
         rootCommand.Options.Add(Options.correlationId)
         rootCommand.Options.Add(Options.source)
         rootCommand.Options.Add(Options.output)
+        rootCommand.Options.Add(Options.schema)
+        rootCommand.Options.Add(Options.examples)
 
         // Add subcommands.
         rootCommand.Subcommands.Add(Connect.Build)
@@ -769,6 +856,7 @@ module GraceCommand =
             let mutable parseResult: ParseResult = null
             let mutable returnValue: int = 0
             let mutable parseSucceeded: bool = false
+            let mutable isIntrospection: bool = false
 
             try
                 try
@@ -778,9 +866,28 @@ module GraceCommand =
 
                     parseResult <- rootCommand.Parse(argvToParse)
                     parseSucceeded <- parseResult.Errors.Count = 0
-                    // Write the ParseResult to Services as global context for the CLI.
-                    Services.parseResult <- parseResult
-                    LocalStateDb.setVerbose (parseResult |> verbose)
+
+                    match introspectionRequestFromTokens argvToParse with
+                    | Some (Ok kind) ->
+                        isIntrospection <- true
+                        Services.parseResult <- parseResult
+
+                        returnValue <-
+                            if hasBlockingIntrospectionParseErrors parseResult then
+                                writeIntrospectionParseError parseResult
+                            else
+                                handleIntrospectionRequest parseResult kind
+
+                        raise (IntrospectionExit returnValue)
+                    | Some (Error message) ->
+                        isIntrospection <- true
+                        Services.parseResult <- parseResult
+                        returnValue <- writeIntrospectionError parseResult message
+                        raise (IntrospectionExit returnValue)
+                    | None ->
+                        // Write the ParseResult to Services as global context for the CLI.
+                        Services.parseResult <- parseResult
+                        LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
                         match parseResult.Action with
@@ -1054,6 +1161,7 @@ module GraceCommand =
 
                     return returnValue
                 with
+                | IntrospectionExit exitCode -> return exitCode
                 | ex ->
                     AnsiConsole.WriteException ex
                     //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
@@ -1067,17 +1175,18 @@ module GraceCommand =
                     (finishTime - startTime).TotalMilliseconds
                     |> int64
 
-                HistoryStorage.tryRecordInvocation
-                    {
-                        argvOriginal = argvOriginal
-                        argvNormalized = argvNormalized
-                        cwd = Environment.CurrentDirectory
-                        exitCode = returnValue
-                        durationMs = durationMs
-                        parseSucceeded = parseSucceeded
-                        timestampUtc = startTime
-                        source = resolveInvocationSource parseResult
-                    }
+                if not isIntrospection then
+                    HistoryStorage.tryRecordInvocation
+                        {
+                            argvOriginal = argvOriginal
+                            argvNormalized = argvNormalized
+                            cwd = Environment.CurrentDirectory
+                            exitCode = returnValue
+                            durationMs = durationMs
+                            parseSucceeded = parseSucceeded
+                            timestampUtc = startTime
+                            source = resolveInvocationSource parseResult
+                        }
 
                 // If this was grace watch, delete the inter-process communication file.
                 if not <| isNull (parseResult)

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -75,6 +75,22 @@ module GraceCommand =
         //aliases.Add("", [""; ""])
         aliases
 
+    let private getAliasListDto () =
+        let items: LocalOutputDto.AliasListItemDto array =
+            aliases
+            |> Seq.map (fun alias ->
+                let commandPath = alias.Value |> Seq.toArray
+                let command = String.Join(" ", commandPath)
+
+                let item: LocalOutputDto.AliasListItemDto = { Alias = $"grace {alias.Key}"; CommandPath = commandPath; Command = $"grace {command}" }
+
+                item)
+            |> Seq.sortBy (fun item -> item.Alias)
+            |> Seq.toArray
+
+        let dto: LocalOutputDto.AliasListDto = { Aliases = items; Count = items.Length }
+        dto
+
     /// The character sequences that Grace will recognize as a request for help.
     let helpOptions = [| "-h"; "/h"; "--help"; "-?"; "/?" |]
 
@@ -96,6 +112,19 @@ module GraceCommand =
             |> ignore)
 
         AnsiConsole.Write(table)
+
+    let private renderAliases (parseResult: ParseResult) =
+        if parseResult |> json then
+            let result =
+                GraceReturnValue.Create (getAliasListDto ()) (getCorrelationId parseResult)
+                |> Ok
+
+            renderOutput parseResult result
+        elif parseResult |> silent then
+            0
+        else
+            printAliases ()
+            0
 
     let internal tryGetTopLevelCommandFromArgs (args: string array) (isCaseInsensitive: bool) =
         if isNull args || args.Length = 0 then
@@ -799,7 +828,7 @@ module GraceCommand =
 
         let Alias = Command("alias", "Display aliases for Grace commands.")
         let ListAliases = Command("list", "Display aliases for Grace commands.")
-        ListAliases.SetAction(fun _ -> printAliases ())
+        ListAliases.SetAction(fun parseResult -> renderAliases parseResult)
         Alias.Subcommands.Add(ListAliases)
         rootCommand.Subcommands.Add(Alias)
         rootCommand
@@ -1289,6 +1318,7 @@ module GraceCommand =
                                 "history"
                                 "auth"
                                 "connect"
+                                "alias"
                             ]
 
                         let isAllowed =

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -113,6 +113,7 @@ module GraceCommand =
                 || token.Equals(OptionName.CorrelationId, comparison)
                 || token.Equals("-c", comparison)
                 || token.Equals(OptionName.Source, comparison)
+                || token.Equals(OptionName.Select, comparison)
 
             let rec loop index =
                 if index >= args.Length then
@@ -265,6 +266,11 @@ module GraceCommand =
                         true
                     else
                         loop (index + 1)
+                elif
+                    token.Equals(OptionName.Select, StringComparison.OrdinalIgnoreCase)
+                    || token.StartsWith($"{OptionName.Select}=", StringComparison.OrdinalIgnoreCase)
+                then
+                    true
                 else
                     loop (index + 1)
 
@@ -290,6 +296,22 @@ module GraceCommand =
         let error = GraceError.CreateWithException ex ex.Message correlationId
         Common.writeJsonErrorStdout error
         -1
+
+    let private tryValidateSelectRequest (parseResult: ParseResult) =
+        match Common.tryGetSelect parseResult with
+        | None -> None
+        | Some selectorText ->
+            let correlationId = getCorrelationId parseResult
+
+            match SelectProjection.tryParse correlationId selectorText with
+            | Error error -> Some error
+            | Ok _ ->
+                let identity = commandIdentityFromCommandResult parseResult.CommandResult
+
+                match CommandOutputContract.tryFind identity with
+                | Some entry when entry.Features.Select = CommandOutputContract.ExistingBehavior -> None
+                | Some _ -> Some(GraceError.Create $"Command '{identity.CommandId}' does not support --select in this release." correlationId)
+                | None -> Some(GraceError.Create $"Command '{identity.CommandId}' does not have CLI output contract metadata for --select." correlationId)
 
     let private tryFindGraceConfigurationFileForJsonMode () =
         let rec loop (directory: DirectoryInfo) =
@@ -749,6 +771,7 @@ module GraceCommand =
         rootCommand.Options.Add(Options.output)
         rootCommand.Options.Add(Options.schema)
         rootCommand.Options.Add(Options.examples)
+        rootCommand.Options.Add(Options.select)
 
         // Add subcommands.
         rootCommand.Subcommands.Add(Connect.Build)
@@ -1013,6 +1036,14 @@ module GraceCommand =
                            && isJsonOutputRequestedFromTokens argvToParse then
                             returnValue <- writeJsonParseError parseResult
                             raise (IntrospectionExit returnValue)
+
+                        if parseResult.Errors.Count = 0 then
+                            match tryValidateSelectRequest parseResult with
+                            | Some error ->
+                                Common.writeJsonErrorStdout error
+                                returnValue <- -1
+                                raise (IntrospectionExit returnValue)
+                            | None -> ()
 
                         LocalStateDb.setVerbose (parseResult |> verbose)
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -26,6 +26,7 @@ open System.Diagnostics
 open System.Globalization
 open System.IO
 open System.Linq
+open System.Text.Json
 open System.Text.RegularExpressions
 open System.Threading.Tasks
 open Microsoft.Extensions.Caching.Memory
@@ -186,11 +187,9 @@ module GraceCommand =
         | false, true -> Some(Ok CommandOutputContract.IntrospectionKind.Examples)
         | true, true -> Some(Error "--schema and --examples cannot be used together.")
 
-    let private writeJsonStdout value = Console.Out.WriteLine(serialize value)
-
     let private writeIntrospectionError parseResult message =
         let error = GraceError.Create message (getCorrelationId parseResult)
-        writeJsonStdout error
+        Common.writeJsonErrorStdout error
         -1
 
     let private isIgnorableIntrospectionParseError (error: ParseError) =
@@ -217,11 +216,108 @@ module GraceCommand =
             match entry.RouteDisposition with
             | CommandOutputContract.Routed ->
                 let document = CommandOutputContract.introspectionDocument kind entry
-                writeJsonStdout document
+                Common.writeJsonStdout document
                 0
             | CommandOutputContract.SourceOnlyUnrouted reason ->
                 writeIntrospectionError parseResult $"Command '{identity.CommandId}' is not routed for CLI introspection. {reason}"
         | None -> writeIntrospectionError parseResult $"Command '{identity.CommandId}' does not have CLI output contract metadata."
+
+    let private isJsonOutputRequestedFromTokens (args: string array) =
+        let tokens =
+            if isNull args then
+                Array.empty
+            else
+                args
+                |> Array.takeWhile (fun token -> not (token.Equals("--", StringComparison.Ordinal)))
+
+        let rec loop index =
+            if index >= tokens.Length then
+                false
+            else
+                let token = tokens[index]
+                let outputEqualsPrefix = $"{OptionName.Output}="
+
+                if
+                    token.Equals(OptionName.Output, StringComparison.OrdinalIgnoreCase)
+                    || token.Equals("-o", StringComparison.OrdinalIgnoreCase)
+                then
+                    if index + 1 < tokens.Length
+                       && tokens[index + 1]
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    elif index + 1 < tokens.Length
+                         && tokens[index + 1]
+                             .StartsWith("-", StringComparison.Ordinal) then
+                        loop (index + 1)
+                    else
+                        loop (index + 2)
+                elif token.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then
+                    if token
+                        .Substring(outputEqualsPrefix.Length)
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    else
+                        loop (index + 1)
+                elif token.StartsWith("-o=", StringComparison.OrdinalIgnoreCase) then
+                    if token
+                        .Substring("-o=".Length)
+                           .Equals("Json", StringComparison.OrdinalIgnoreCase) then
+                        true
+                    else
+                        loop (index + 1)
+                else
+                    loop (index + 1)
+
+        loop 0
+
+    let private writeJsonParseError (parseResult: ParseResult) =
+        let message =
+            parseResult.Errors
+            |> Seq.map (fun error -> error.Message)
+            |> String.concat Environment.NewLine
+
+        let error = GraceError.Create message (getCorrelationId parseResult)
+        Common.writeJsonErrorStdout error
+        -1
+
+    let private writeJsonException (parseResult: ParseResult) (ex: exn) =
+        let correlationId =
+            if isNull parseResult then
+                generateCorrelationId ()
+            else
+                getCorrelationId parseResult
+
+        let error = GraceError.CreateWithException ex ex.Message correlationId
+        Common.writeJsonErrorStdout error
+        -1
+
+    let private tryFindGraceConfigurationFileForJsonMode () =
+        let rec loop (directory: DirectoryInfo) =
+            if isNull directory then
+                None
+            else
+                let candidate = Path.Combine(directory.FullName, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
+
+                if File.Exists candidate then Some candidate else loop directory.Parent
+
+        loop (DirectoryInfo(Environment.CurrentDirectory))
+
+    let private tryGetJsonConfigurationError (parseResult: ParseResult) =
+        if parseResult |> json then
+            match tryFindGraceConfigurationFileForJsonMode () with
+            | Some graceConfigurationFilePath ->
+                try
+                    use fileStream = new FileStream(graceConfigurationFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
+
+                    JsonSerializer.Deserialize<GraceConfiguration>(fileStream, Constants.JsonSerializerOptions)
+                    |> ignore
+
+                    None
+                with
+                | ex -> Some(GraceError.CreateWithException ex ex.Message (getCorrelationId parseResult))
+            | None -> None
+        else
+            None
 
     let private replaceDefaultValue (line: string) (defaultValueText: string) =
         let startIndex = line.IndexOf("[default:", StringComparison.OrdinalIgnoreCase)
@@ -810,10 +906,6 @@ module GraceCommand =
     [<EntryPoint>]
     let main args =
         let startTime = getCurrentInstant ()
-        Auth.configureSdkAuth ()
-        Services.configureSdkClientIdentity ()
-        Services.resetInvocationCorrelationId ()
-        Common.resetLifecycleWarningSuppression ()
 
         // Create a MemoryCache instance.
         //let memoryCacheOptions = MemoryCacheOptions(TrackStatistics = false, TrackLinkedCacheEntries = false)
@@ -829,13 +921,37 @@ module GraceCommand =
             else
                 let firstToken = if isCaseInsensitive then args[ 0 ].ToLowerInvariant() else args[0]
 
+                let normalizeOutputEqualsToken (arg: string) =
+                    let outputEqualsPrefix = $"{OptionName.Output}="
+
+                    if arg.StartsWith(outputEqualsPrefix, StringComparison.OrdinalIgnoreCase) then
+                        $"{OptionName.Output}={arg.Substring(outputEqualsPrefix.Length)}"
+                    else
+                        arg
+
                 let properCasedArgs =
                     args
                     |> Array.map (fun arg ->
-                        if isCaseInsensitive && arg.StartsWith("--") then
-                            arg.ToLowerInvariant()
+                        let normalizedArg = normalizeOutputEqualsToken arg
+
+                        if
+                            isCaseInsensitive
+                            && normalizedArg.StartsWith("--")
+                        then
+                            let equalsIndex = normalizedArg.IndexOf("=", StringComparison.Ordinal)
+
+                            if equalsIndex > 0 then
+                                let optionName =
+                                    normalizedArg
+                                        .Substring(0, equalsIndex)
+                                        .ToLowerInvariant()
+
+                                let optionValue = normalizedArg.Substring(equalsIndex)
+                                $"{optionName}{optionValue}"
+                            else
+                                normalizedArg.ToLowerInvariant()
                         else
-                            arg)
+                            normalizedArg)
 
                 if aliases.ContainsKey(firstToken) then
                     let newArgs = List<string>()
@@ -860,6 +976,11 @@ module GraceCommand =
 
             try
                 try
+                    Auth.configureSdkAuth ()
+                    Services.configureSdkClientIdentity ()
+                    Services.resetInvocationCorrelationId ()
+                    Common.resetLifecycleWarningSuppression ()
+
                     //let commandLineConfiguration = ParserConfiguration rootCommand
 
                     let argvToParse = if args.Length = 0 then [| helpOptions[0] |] else argvNormalized
@@ -887,6 +1008,12 @@ module GraceCommand =
                     | None ->
                         // Write the ParseResult to Services as global context for the CLI.
                         Services.parseResult <- parseResult
+
+                        if parseResult.Errors.Count > 0
+                           && isJsonOutputRequestedFromTokens argvToParse then
+                            returnValue <- writeJsonParseError parseResult
+                            raise (IntrospectionExit returnValue)
+
                         LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
@@ -1058,63 +1185,67 @@ module GraceCommand =
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
                     else if configurationFileExists () then
-                        //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
+                        match tryGetJsonConfigurationError parseResult with
+                        | Some error ->
+                            Common.writeJsonErrorStdout error
+                            returnValue <- -1
+                        | None ->
+                            //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
-                        if parseResult |> hasOutput then
-                            if parseResult |> verbose then
-                                AnsiConsole.Write(
-                                    (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
-                                        .RightJustified()
-                                )
+                            if parseResult |> hasOutput then
+                                if parseResult |> verbose then
+                                    AnsiConsole.Write(
+                                        (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
+                                            .RightJustified()
+                                    )
 
-                            //printParseResult parseResult
-                            else
-                                AnsiConsole.Write(new Rule())
+                                //printParseResult parseResult
+                                else
+                                    AnsiConsole.Write(new Rule())
 
-                        // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
-                        if not <| (parseResult |> isGraceWatch) then
-                            let! graceWatchStatus = getGraceWatchStatus ()
+                            // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
+                            if not <| (parseResult |> isGraceWatch) then
+                                let! graceWatchStatus = getGraceWatchStatus ()
 
-                            match graceWatchStatus with
-                            | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
-                            | None -> ()
+                                match graceWatchStatus with
+                                | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
+                                | None -> ()
 
-                        // Now we can invoke the command!
-                        let! returnValue = parseResult.InvokeAsync()
+                            // Now we can invoke the command!
+                            let! invokedReturnValue = parseResult.InvokeAsync()
+                            returnValue <- invokedReturnValue
 
-                        // Stuff to do after the command has been invoked:
+                            // Stuff to do after the command has been invoked:
 
-                        // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
-                        //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
-                        if parseResult |> isGraceWatch then
-                            logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
+                            // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
+                            //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
+                            if parseResult |> isGraceWatch then
+                                logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
-                        // If we're writing output, write the final Rule() to the console.
-                        if parseResult |> hasOutput then
-                            let finishTime = getCurrentInstant ()
+                            // If we're writing output, write the final Rule() to the console.
+                            if parseResult |> hasOutput then
+                                let finishTime = getCurrentInstant ()
 
-                            let elapsed =
-                                (finishTime - startTime)
-                                    .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                let elapsed =
+                                    (finishTime - startTime)
+                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
 
-                            if parseResult |> verbose then
-                                AnsiConsole.Write(
-                                    (new Rule(
-                                        $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
-                                    ))
-                                        .RightJustified()
-                                )
-                            else
-                                AnsiConsole.Write(
-                                    (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                        .RightJustified()
-                                )
+                                if parseResult |> verbose then
+                                    AnsiConsole.Write(
+                                        (new Rule(
+                                            $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
+                                        ))
+                                            .RightJustified()
+                                    )
+                                else
+                                    AnsiConsole.Write(
+                                        (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
+                                            .RightJustified()
+                                    )
 
-                            AnsiConsole.WriteLine()
+                                AnsiConsole.WriteLine()
                     else
                         // We don't have a config file, so write an error message and exit.
-                        AnsiConsole.Write(new Rule())
-
                         let comparison =
                             if isCaseInsensitive then
                                 StringComparison.InvariantCultureIgnoreCase
@@ -1146,28 +1277,41 @@ module GraceCommand =
                             returnValue <- invokedReturnValue
                             ()
                         else
-                            AnsiConsole.MarkupLine($"[{Colors.Important}]{getLocalizedString StringResourceName.GraceConfigFileNotFound}[/]")
+                            let message = getLocalizedString StringResourceName.GraceConfigFileNotFound
 
-                        let finishTime = getCurrentInstant ()
+                            if parseResult |> json then
+                                let error = GraceError.Create message (getCorrelationId parseResult)
+                                Common.writeJsonErrorStdout error
+                            else
+                                AnsiConsole.Write(new Rule())
+                                AnsiConsole.MarkupLine($"[{Colors.Important}]{message}[/]")
 
-                        let elapsed =
-                            (finishTime - startTime)
-                                .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                let finishTime = getCurrentInstant ()
 
-                        AnsiConsole.Write(
-                            (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                .RightJustified()
-                        )
+                                let elapsed =
+                                    (finishTime - startTime)
+                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+
+                                AnsiConsole.Write(
+                                    (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: -1.[/]"))
+                                        .RightJustified()
+                                )
+
+                            returnValue <- -1
 
                     return returnValue
                 with
                 | IntrospectionExit exitCode -> return exitCode
                 | ex ->
-                    AnsiConsole.WriteException ex
-                    //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
-                    //logToAnsiConsole Colors.Error $"{ex.StackTrace}"
-                    returnValue <- -1
-                    return -1
+                    if isJsonOutputRequestedFromTokens argvNormalized then
+                        returnValue <- writeJsonException parseResult ex
+                    else
+                        AnsiConsole.WriteException ex
+                        //logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}"
+                        //logToAnsiConsole Colors.Error $"{ex.StackTrace}"
+                        returnValue <- -1
+
+                    return returnValue
             finally
                 let finishTime = getCurrentInstant ()
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1252,58 +1252,68 @@ module GraceCommand =
                         | None ->
                             //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
-                            if parseResult |> hasOutput then
-                                if parseResult |> verbose then
-                                    AnsiConsole.Write(
-                                        (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
-                                            .RightJustified()
-                                    )
+                            if (parseResult |> json)
+                               && (parseResult |> isGraceWatch) then
+                                let error =
+                                    GraceError.Create
+                                        "watch is a continuous foreground workflow; JSON mode requires a cancellation-aware automation host in this release."
+                                        (getCorrelationId parseResult)
 
-                                //printParseResult parseResult
-                                else
-                                    AnsiConsole.Write(new Rule())
+                                Common.writeJsonErrorStdout error
+                                returnValue <- -1
+                            else
+                                if parseResult |> hasOutput then
+                                    if parseResult |> verbose then
+                                        AnsiConsole.Write(
+                                            (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
+                                                .RightJustified()
+                                        )
 
-                            // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
-                            if not <| (parseResult |> isGraceWatch) then
-                                let! graceWatchStatus = getGraceWatchStatus ()
+                                    //printParseResult parseResult
+                                    else
+                                        AnsiConsole.Write(new Rule())
 
-                                match graceWatchStatus with
-                                | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
-                                | None -> ()
+                                // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
+                                if not <| (parseResult |> isGraceWatch) then
+                                    let! graceWatchStatus = getGraceWatchStatus ()
 
-                            // Now we can invoke the command!
-                            let! invokedReturnValue = parseResult.InvokeAsync()
-                            returnValue <- invokedReturnValue
+                                    match graceWatchStatus with
+                                    | Some status -> Configuration.updateConfiguration { GraceWatchStatus = status }
+                                    | None -> ()
 
-                            // Stuff to do after the command has been invoked:
+                                // Now we can invoke the command!
+                                let! invokedReturnValue = parseResult.InvokeAsync()
+                                returnValue <- invokedReturnValue
 
-                            // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
-                            //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
-                            if parseResult |> isGraceWatch then
-                                logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
+                                // Stuff to do after the command has been invoked:
 
-                            // If we're writing output, write the final Rule() to the console.
-                            if parseResult |> hasOutput then
-                                let finishTime = getCurrentInstant ()
+                                // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
+                                //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
+                                if parseResult |> isGraceWatch then
+                                    logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
-                                let elapsed =
-                                    (finishTime - startTime)
-                                        .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
+                                // If we're writing output, write the final Rule() to the console.
+                                if parseResult |> hasOutput then
+                                    let finishTime = getCurrentInstant ()
 
-                                if parseResult |> verbose then
-                                    AnsiConsole.Write(
-                                        (new Rule(
-                                            $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
-                                        ))
-                                            .RightJustified()
-                                    )
-                                else
-                                    AnsiConsole.Write(
-                                        (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
-                                            .RightJustified()
-                                    )
+                                    let elapsed =
+                                        (finishTime - startTime)
+                                            .Plus(Duration.FromMilliseconds(110.0)) // Adding 110ms for .NET Runtime startup time.
 
-                                AnsiConsole.WriteLine()
+                                    if parseResult |> verbose then
+                                        AnsiConsole.Write(
+                                            (new Rule(
+                                                $"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}. Finished: {formatInstantExtended finishTime}[/]"
+                                            ))
+                                                .RightJustified()
+                                        )
+                                    else
+                                        AnsiConsole.Write(
+                                            (new Rule($"[{Colors.Important}]Elapsed: {elapsed.TotalSeconds:F3}s. Exit code: {returnValue}.[/]"))
+                                                .RightJustified()
+                                        )
+
+                                    AnsiConsole.WriteLine()
                     else
                         // We don't have a config file, so write an error message and exit.
                         let comparison =

--- a/src/Grace.CLI/SelectProjection.CLI.fs
+++ b/src/Grace.CLI/SelectProjection.CLI.fs
@@ -1,0 +1,112 @@
+namespace Grace.CLI
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open System
+open System.Collections.Generic
+open System.Text.Json
+open System.Text.RegularExpressions
+
+module SelectProjection =
+
+    type SelectorPath = private { Segments: string list }
+
+    let private identifier = Regex("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)
+
+    let private forbiddenSegments =
+        HashSet<string>(
+            [
+                "CorrelationId"
+                "EventTime"
+                "Error"
+                "Properties"
+                "ReturnValue"
+            ],
+            StringComparer.OrdinalIgnoreCase
+        )
+
+    let private formatPath (segments: string list) = String.Join(".", segments)
+
+    let private error correlationId message = Error(GraceError.Create message correlationId)
+
+    let tryParse correlationId (selector: string) =
+        if String.IsNullOrWhiteSpace selector then
+            error correlationId "--select requires a non-empty ReturnValue property path."
+        else
+            let trimmed = selector.Trim()
+
+            if trimmed <> selector then
+                error correlationId "--select paths cannot include leading or trailing whitespace."
+            elif
+                trimmed.IndexOfAny
+                    (
+                        [|
+                            '['
+                            ']'
+                            '('
+                            ')'
+                            '*'
+                            '''
+                            '"'
+                            '$'
+                            '@'
+                            '?'
+                            ':'
+                            ','
+                            ' '
+                            '\t'
+                            '\r'
+                            '\n'
+                        |]
+                    )
+                >= 0
+            then
+                error
+                    correlationId
+                    "--select supports only dot-separated ReturnValue property names; predicates, wildcards, functions, and expressions are not supported."
+            else
+                let segments =
+                    trimmed.Split('.', StringSplitOptions.None)
+                    |> Array.toList
+
+                match segments with
+                | [] -> error correlationId "--select requires a ReturnValue property path."
+                | _ when segments |> List.exists String.IsNullOrWhiteSpace -> error correlationId "--select paths must not contain empty property segments."
+                | _ ->
+                    match
+                        segments
+                        |> List.tryFind (identifier.IsMatch >> not)
+                        with
+                    | Some segment -> error correlationId $"--select property segment '{segment}' is not valid."
+                    | None ->
+                        match segments
+                              |> List.tryFind forbiddenSegments.Contains
+                            with
+                        | Some segment ->
+                            error correlationId $"--select cannot project '{segment}'. Selectors are relative to ReturnValue and cannot read envelope metadata."
+                        | None -> Ok { Segments = segments }
+
+    let project correlationId (selector: SelectorPath) (returnValue: obj) =
+        let json = serialize returnValue
+        use document = JsonDocument.Parse(json)
+
+        let rec loop (current: JsonElement) remaining =
+            match remaining with
+            | [] -> Ok(current.Clone())
+            | (segment: string) :: rest ->
+                if current.ValueKind <> JsonValueKind.Object then
+                    error
+                        correlationId
+                        $"--select path '{formatPath selector.Segments}' cannot read '{segment}' because the current ReturnValue value is {current.ValueKind}."
+                else
+                    let mutable value = Unchecked.defaultof<JsonElement>
+
+                    if current.TryGetProperty(segment, &value) then
+                        loop value rest
+                    else
+                        error correlationId $"--select path '{formatPath selector.Segments}' was not found in ReturnValue."
+
+        loop document.RootElement selector.Segments
+
+    let renderSelectedJson (selected: JsonElement) = selected.GetRawText()

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -121,6 +121,12 @@ module Text =
         let Output = "--output"
 
         [<Literal>]
+        let Schema = "--schema"
+
+        [<Literal>]
+        let Examples = "--examples"
+
+        [<Literal>]
         let Overwrite = "--overwrite"
 
         [<Literal>]

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -127,6 +127,9 @@ module Text =
         let Examples = "--examples"
 
         [<Literal>]
+        let Select = "--select"
+
+        [<Literal>]
         let Overwrite = "--overwrite"
 
         [<Literal>]


### PR DESCRIPTION
## Summary  - Makes Grace CLI machine-readable JSON output a first-class contract for supported routed commands. - Adds the CLI output contract registry, schema/examples introspection, central stdout-clean JSON writer, and V1   `ReturnValue`-only `--select` projection. - Migrates supported local, ad hoc, maintenance, and watch-safe paths into explicit JSON dispositions. - Adds final inventory, docs, freshness tests, and user/agent guidance for current support and V2 deferrals.  ## Related Issue  Closes #274.  ## Epic Traceability  Completed child issues:  - #275 S0: Charter Grace CLI machine-readable JSON contract. - #276 S1: Add CLI output contract registry spine. - #277 S2: Add CLI introspection option parsing and short-circuit flow. - #278 S3: Make CLI JSON output stdout-clean through a central writer. - #279 S4: Generate CLI JSON schemas and examples from the registry. - #280 S5: Implement V1 ReturnValue-only `--select` projection. - #281 S6: Migrate local and ad hoc CLI commands to envelope contracts. - #282 S7: Migrate composite and progress CLI flows to JSON-safe output. - #283 S8: Audit common-renderOutput commands and JSON error behavior. - #284 S9: Close CLI JSON epic with docs and inventory audit.  ## Final Inventory  - Total leaf commands: `201`. - JSON-ready routed commands: `180`. - Intentionally human-only commands: `1`. - Deferred routed commands with explicit V2 scope: `11`. - Source-only/unrouted commands: `9`. - Deleted commands: `0`.  ## Validation  Release-candidate validation on `epic/274-cli-machine-readable-json` after all child PRs merged:  - Branch freshness: `0` behind and `20` ahead of `origin/main`. - Scoped diff checked against `origin/main`; no unexpected deletions were present. - `pwsh ./scripts/validate.ps1 -Fast` passed.   - Build succeeded with 0 warnings and 0 errors.   - Tests passed: Authorization `37/37`, Types `65/65`, Server.Unit `440/440`, CLI `370/371` with one existing skip.   - `Grace.Server.Tests` had no matching fast-filter tests and the script exited `0`. - `git diff --check origin/main...HEAD` passed.  ## Review Status  - Awaiting final fresh GPT-5.3-Codex High review-only pass on this release-candidate PR. - Awaiting hosted PR checks for the final epic-to-main branch.  ## V2 Deferrals  - Routed success migrations: `branch.rebase`, `branch.status`, `branch.switch`, `diff.checkpoint`, `diff.commit`,   `diff.directoryid`, `diff.promotion`, `diff.save`, `diff.sha`, `diff.tag`, and `history.run`. - Predicate, wildcard, function, rename, computed-field, metadata, and streaming projections. - JSON Lines progress streams and multi-document streaming JSON. - Server-backed schema discovery. - Live examples generated from repository or server state. - Stable schemas for source-only/unrouted commands until they are routed, deleted, or promoted into a supported   contract.  ## Scope Notes  - The release uses the existing `GraceReturnValue<'T>` / `GraceResult<'T>` envelope shape. - CLI-specific metadata stays in `Properties`. - JSON mode emits one stdout-clean JSON document for supported command paths. - Human, progress, and diagnostics output are suppressed or kept off stdout according to the command contract. - `watch --output Json` intentionally returns an immediate JSON error instead of starting the continuous workflow.  
