### PR TITLE
Align ADR select V1 contract with parser

### DIFF
--- a/docs/adr/0004-cli-machine-readable-json-contract.md
+++ b/docs/adr/0004-cli-machine-readable-json-contract.md
@@ -135,9 +135,9 @@ emits JSON regardless of `--output`.
 `--select` applies only to `ReturnValue` in V1. It never projects `EventTime`, `CorrelationId`, `Properties`,
 `Exception`, or `Error`. The V1 grammar is deliberately small:
 
-- Dot-separated property paths over `ReturnValue`.
-- Comma-separated paths when multiple fields are selected.
-- Array/list item projection only when the implementation can keep the result shape deterministic.
+- Exactly one dot-separated property path over `ReturnValue`.
+- Comma-separated multi-path selectors are rejected in V1.
+- Array/list item projection is rejected in V1.
 - No predicates.
 - No wildcards.
 - No functions.

--- a/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/SelectProjection.CLI.Parsing.Tests.fs
@@ -50,6 +50,14 @@ module SelectProjectionParsingTests =
             |> should equal "corr-select-parse"
 
     [<Test>]
+    let ``comma-separated multi-path selectors are rejected in V1`` () =
+        match parse "Value,Name" with
+        | Ok _ -> Assert.Fail("Expected comma-separated selector to be rejected.")
+        | Error error ->
+            error.Error
+            |> should contain "supports only dot-separated ReturnValue property names"
+
+    [<Test>]
     let ``project returns selected nested property`` () =
         match parse "Container.Value" with
         | Error error -> Assert.Fail(error.Error)


### PR DESCRIPTION
## Summary  - Corrects ADR `0004` so the V1 `--select` contract matches implementation: exactly one dot-separated   `ReturnValue` path is supported. - Documents comma-separated multi-path selectors and array/list projections as rejected in V1. - Adds a focused parser regression asserting comma-separated selectors are rejected with the V1 dot-separated-only   contract message.  ## Related Issue  Follow-up release-candidate fix for #274 and PR #306 review feedback.  Because this PR targets the epic integration branch, it intentionally does not use a default-branch closing keyword.  ## Validation  Worker evidence from commit `cd29d6d`:  - Targeted Fantomas ran for `SelectProjection.CLI.Parsing.Tests.fs` and passed with no changes. - MarkdownLint passed for `docs/adr/0004-cli-machine-readable-json-contract.md`. - Focused CLI test project build passed with 0 warnings and 0 errors. - Focused `SelectProjectionParsingTests` passed: `22/22`. - `git diff --check` passed.  ## Review Status  - Awaiting fresh GPT-5.3-Codex High review-only pass.  ## Scope Notes  - This PR preserves the implemented V1 scope. - It does not implement comma-separated multi-path projection. - It is intended to unblock final release-candidate PR #306 by resolving the ADR/runtime contract mismatch. 


