### PR TITLE
Make grace watch duplicate-safe and add --check

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -15,6 +15,7 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.IO
 open System.Text.Json
+open System.Threading.Tasks
 
 [<NonParallelizable>]
 module WatchTests =
@@ -170,10 +171,12 @@ module WatchTests =
         try
             Environment.CurrentDirectory <- tempDir
             resetConfiguration ()
+            Services.graceWatchStatusUpdateTime <- Instant.MinValue
             deleteWatchStatusFileIfExists ()
             action tempDir
         finally
             deleteWatchStatusFileIfExists ()
+            Services.graceWatchStatusUpdateTime <- Instant.MinValue
             resetConfiguration ()
             Environment.CurrentDirectory <- originalDir
 
@@ -250,6 +253,49 @@ module WatchTests =
                 |> should equal originalContents))
 
     [<Test>]
+    let ``watch startup claim is atomic for simultaneous ordinary starts`` () =
+        withTempRepo (fun _ ->
+            let claimTasks =
+                Array.init 8 (fun _ ->
+                    Task.Run (fun () ->
+                        Services
+                            .tryClaimGraceWatchInterprocessFile()
+                            .Result))
+
+            claimTasks
+            |> Array.map (fun claimTask -> claimTask :> Task)
+            |> Task.WaitAll
+
+            let successfulClaims =
+                claimTasks
+                |> Array.filter (fun claimTask -> claimTask.Result)
+
+            successfulClaims.Length |> should equal 1
+
+            let status = Services.getGraceWatchStatus().Result
+            status |> should not' (equal None))
+
+    [<Test>]
+    let ``watch startup claim replaces malformed stale ipc file`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, "not-json")
+
+            let claimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            claimed |> should equal true
+
+            let status = Services.getGraceWatchStatus().Result
+            status |> should not' (equal None))
+
+    [<Test>]
     let ``watch check exits zero when live watcher status exists`` () =
         withTempRepo (fun _ ->
             let ipcFileName = writeLiveWatchStatusFile ()
@@ -299,7 +345,11 @@ module WatchTests =
                 |> should contain "GraceWatch is not running"
 
                 output
-                |> should not' (contain "Unable to acquire an access token for SignalR")))
+                |> should not' (contain "Unable to acquire an access token for SignalR")
+
+                Services.IpcFileName()
+                |> File.Exists
+                |> should equal false))
 
     [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -134,14 +134,17 @@ module WatchTests =
         JsonDocument.Parse(output)
 
     let private writeLiveWatchStatusFile () =
+        let rootDirectoryId = Guid.NewGuid()
+
         let status: Services.GraceWatchStatus =
             {
                 UpdatedAt = getCurrentInstant ()
-                RootDirectoryId = Guid.NewGuid()
+                IsStartupClaim = false
+                RootDirectoryId = rootDirectoryId
                 RootDirectorySha256Hash = Sha256Hash "live-watch-root"
                 LastFileUploadInstant = Instant.MinValue
                 LastDirectoryVersionInstant = Instant.MinValue
-                DirectoryIds = HashSet<DirectoryVersionId>()
+                DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
             }
 
         let ipcFileName = Services.IpcFileName()
@@ -273,7 +276,31 @@ module WatchTests =
             successfulClaims.Length |> should equal 1
 
             let status = Services.getGraceWatchStatus().Result
-            status |> should not' (equal None))
+            status |> should equal None)
+
+    [<Test>]
+    let ``watch startup claim blocks second ordinary start without usable status`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let claimed =
+                    Services
+                        .tryClaimGraceWatchInterprocessFile()
+                        .Result
+
+                claimed |> should equal true
+
+                let status = Services.getGraceWatchStatus().Result
+                status |> should equal None
+
+                let exitCode, output = runWithCapturedOutput [| "watch" |]
+
+                exitCode |> should equal -1
+
+                output
+                |> should contain "GraceWatch is already running"
+
+                output
+                |> should not' (contain "Unable to acquire an access token for SignalR")))
 
     [<Test>]
     let ``watch startup claim replaces malformed stale ipc file`` () =
@@ -293,7 +320,7 @@ module WatchTests =
             claimed |> should equal true
 
             let status = Services.getGraceWatchStatus().Result
-            status |> should not' (equal None))
+            status |> should equal None)
 
     [<Test>]
     let ``watch check exits zero when live watcher status exists`` () =
@@ -350,6 +377,35 @@ module WatchTests =
                 Services.IpcFileName()
                 |> File.Exists
                 |> should equal false))
+
+    [<Test>]
+    let ``watch check exits nonzero and preserves startup claim`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let claimed =
+                    Services
+                        .tryClaimGraceWatchInterprocessFile()
+                        .Result
+
+                claimed |> should equal true
+
+                let ipcFileName = Services.IpcFileName()
+                let originalContents = readFileIfExists ipcFileName
+
+                let exitCode, output =
+                    runWithCapturedOutput [| "watch"
+                                             "--check" |]
+
+                exitCode |> should equal -1
+
+                output
+                |> should contain "GraceWatch is not running"
+
+                output
+                |> should not' (contain "Unable to acquire an access token for SignalR")
+
+                readFileIfExists ipcFileName
+                |> should equal originalContents))
 
     [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -359,6 +359,70 @@ module WatchTests =
             |> should equal originalContents)
 
     [<Test>]
+    let ``watch check json mode emits error envelope and preserves live watcher status`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "watch"
+                                                  "--check" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            standardOut
+            |> should not' (contain "GraceWatch is running")
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement
+
+            root.GetProperty("Error").GetString()
+            |> should contain "watch is a continuous foreground workflow"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            root.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    [<Test>]
+    let ``watch check select mode emits error envelope and preserves live watcher status`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "watch"
+                                                  "--check"
+                                                  "--select"
+                                                  "RootDirectoryId" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            standardOut
+            |> should not' (contain "GraceWatch is running")
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement
+
+            root.GetProperty("Error").GetString()
+            |> should contain "does not support --select in this release"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            root.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    [<Test>]
     let ``watch check exits nonzero when live watcher status is missing`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -151,6 +151,13 @@ module WatchTests =
         File.WriteAllText(ipcFileName, serialize status)
         ipcFileName
 
+    let private readFileIfExists path = if File.Exists(path) then Some(File.ReadAllText(path)) else None
+
+    let private deleteWatchStatusFileIfExists () =
+        let ipcFileName = Services.IpcFileName()
+
+        if File.Exists(ipcFileName) then File.Delete(ipcFileName)
+
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
         let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
@@ -163,8 +170,10 @@ module WatchTests =
         try
             Environment.CurrentDirectory <- tempDir
             resetConfiguration ()
+            deleteWatchStatusFileIfExists ()
             action tempDir
         finally
+            deleteWatchStatusFileIfExists ()
             resetConfiguration ()
             Environment.CurrentDirectory <- originalDir
 
@@ -220,6 +229,77 @@ module WatchTests =
 
                 output
                 |> should contain "Authentication is not configured."))
+
+    [<Test>]
+    let ``watch exits nonzero when live watcher status already exists`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let ipcFileName = writeLiveWatchStatusFile ()
+                let originalContents = readFileIfExists ipcFileName
+                let exitCode, output = runWithCapturedOutput [| "watch" |]
+
+                exitCode |> should equal -1
+
+                output
+                |> should contain "GraceWatch is already running"
+
+                output
+                |> should not' (contain "Unable to acquire an access token for SignalR")
+
+                readFileIfExists ipcFileName
+                |> should equal originalContents))
+
+    [<Test>]
+    let ``watch check exits zero when live watcher status exists`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+
+            let exitCode, output =
+                runWithCapturedOutput [| "watch"
+                                         "--check" |]
+
+            exitCode |> should equal 0
+
+            output |> should contain "GraceWatch is running"
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    [<Test>]
+    let ``watch check through main exits zero and preserves live watcher status`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "watch"
+                                                  "--check" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            standardOut
+            |> should contain "GraceWatch is running"
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    [<Test>]
+    let ``watch check exits nonzero when live watcher status is missing`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                let exitCode, output =
+                    runWithCapturedOutput [| "watch"
+                                             "--check" |]
+
+                exitCode |> should equal -1
+
+                output
+                |> should contain "GraceWatch is not running"
+
+                output
+                |> should not' (contain "Unable to acquire an access token for SignalR")))
 
     [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1329,34 +1329,41 @@ module Services =
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
 
+    let private createGraceWatchStatus (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+        let directoryIds =
+            match directoryIdsOverride with
+            | Some ids -> HashSet<DirectoryVersionId>(ids)
+            | None -> HashSet<DirectoryVersionId>(graceStatus.Index.Keys)
+
+        {
+            UpdatedAt = getCurrentInstant ()
+            RootDirectoryId = graceStatus.RootDirectoryId
+            RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
+            LastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
+            LastDirectoryVersionInstant = graceStatus.LastSuccessfulDirectoryVersionUpload
+            DirectoryIds = directoryIds
+        }
+
+    let private writeGraceWatchStatus fileMode graceWatchStatus =
+        task {
+            Directory.CreateDirectory(Path.GetDirectoryName(IpcFileName()))
+            |> ignore
+
+            use fileStream = new FileStream(IpcFileName(), fileMode, FileAccess.Write, FileShare.None)
+
+            do! serializeAsync fileStream graceWatchStatus
+            graceWatchStatusUpdateTime <- graceWatchStatus.UpdatedAt
+        }
+
     /// Updates the contents of the `grace watch` status inter-process communication file.
     let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
         task {
             try
-                let directoryIds =
-                    match directoryIdsOverride with
-                    | Some ids -> HashSet<DirectoryVersionId>(ids)
-                    | None -> HashSet<DirectoryVersionId>(graceStatus.Index.Keys)
-
-                let newGraceWatchStatus =
-                    {
-                        UpdatedAt = getCurrentInstant ()
-                        RootDirectoryId = graceStatus.RootDirectoryId
-                        RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
-                        LastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
-                        LastDirectoryVersionInstant = graceStatus.LastSuccessfulDirectoryVersionUpload
-                        DirectoryIds = directoryIds
-                    }
+                let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
                 //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
                 //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
 
-                Directory.CreateDirectory(Path.GetDirectoryName(IpcFileName()))
-                |> ignore
-
-                use fileStream = new FileStream(IpcFileName(), FileMode.Create, FileAccess.Write, FileShare.None)
-
-                do! serializeAsync fileStream newGraceWatchStatus
-                graceWatchStatusUpdateTime <- newGraceWatchStatus.UpdatedAt
+                do! writeGraceWatchStatus FileMode.Create newGraceWatchStatus
                 logToAnsiConsole Colors.Important $"Wrote inter-process communication file."
             with
             | ex ->
@@ -1397,6 +1404,47 @@ module Services =
                 logToAnsiConsole Colors.Error $"ex.Message: {StringExtensions.EscapeMarkup(ex.Message)}."
                 logToAnsiConsole Colors.Error $"{Environment.NewLine}{StringExtensions.EscapeMarkup(ex.StackTrace)}."
                 return None
+        }
+
+    /// Atomically claims the `grace watch` status IPC file before foreground watch startup.
+    let tryClaimGraceWatchInterprocessFile () =
+        task {
+            let claimStatus = createGraceWatchStatus GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+
+            let writeClaimToExistingFile (fileStream: FileStream) =
+                task {
+                    fileStream.SetLength(0L)
+                    fileStream.Position <- 0L
+                    do! serializeAsync fileStream claimStatus
+                    graceWatchStatusUpdateTime <- claimStatus.UpdatedAt
+                }
+
+            try
+                do! writeGraceWatchStatus FileMode.CreateNew claimStatus
+                return true
+            with
+            | :? IOException ->
+                try
+                    use fileStream = new FileStream(IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+
+                    try
+                        let! existingGraceWatchStatus = deserializeAsync<GraceWatchStatus> fileStream
+
+                        if
+                            existingGraceWatchStatus.UpdatedAt
+                            > getCurrentInstant().Minus(Duration.FromMinutes(5.0))
+                        then
+                            return false
+                        else
+                            do! writeClaimToExistingFile fileStream
+                            return true
+                    with
+                    | _ ->
+                        do! writeClaimToExistingFile fileStream
+                        return true
+                with
+                | :? IOException -> return false
+
         }
 
     /// Checks if a file already exists in the object cache.

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -70,6 +70,7 @@ module Services =
     type GraceWatchStatus =
         {
             UpdatedAt: Instant
+            IsStartupClaim: bool
             RootDirectoryId: DirectoryVersionId
             RootDirectorySha256Hash: Sha256Hash
             LastFileUploadInstant: Instant
@@ -80,6 +81,7 @@ module Services =
         static member Default =
             {
                 UpdatedAt = Instant.MinValue
+                IsStartupClaim = false
                 RootDirectoryId = Guid.Empty
                 RootDirectorySha256Hash = Sha256Hash String.Empty
                 LastFileUploadInstant = Instant.MinValue
@@ -1337,12 +1339,27 @@ module Services =
 
         {
             UpdatedAt = getCurrentInstant ()
+            IsStartupClaim = false
             RootDirectoryId = graceStatus.RootDirectoryId
             RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
             LastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
             LastDirectoryVersionInstant = graceStatus.LastSuccessfulDirectoryVersionUpload
             DirectoryIds = directoryIds
         }
+
+    let private createGraceWatchStartupClaim () = { GraceWatchStatus.Default with UpdatedAt = getCurrentInstant (); IsStartupClaim = true }
+
+    let private isGraceWatchStatusFresh (graceWatchStatus: GraceWatchStatus) =
+        graceWatchStatus.UpdatedAt > getCurrentInstant()
+            .Minus(Duration.FromMinutes(5.0))
+
+    let private isGraceWatchStatusUsable (graceWatchStatus: GraceWatchStatus) =
+        isGraceWatchStatusFresh graceWatchStatus
+        && not graceWatchStatus.IsStartupClaim
+        && graceWatchStatus.RootDirectoryId <> Guid.Empty
+        && not (String.IsNullOrWhiteSpace($"{graceWatchStatus.RootDirectorySha256Hash}"))
+        && not (isNull graceWatchStatus.DirectoryIds)
+        && graceWatchStatus.DirectoryIds.Count > 0
 
     let private writeGraceWatchStatus fileMode graceWatchStatus =
         task {
@@ -1386,14 +1403,12 @@ module Services =
                     // `grace watch` updates the file at least every five minutes to indicate that it's still alive.
                     // When `grace watch` exits, the status file is deleted in a try...finally (Program.CLI.fs), so the only
                     //   circumstance where it would be on-disk without `grace watch` running is if the process were killed.
-                    // Just to be safe, we're going to check that the file has been written in the last five minutes.
-                    if
-                        graceWatchStatus.UpdatedAt
-                        > getCurrentInstant().Minus(Duration.FromMinutes(5.0))
-                    then
+                    // Just to be safe, only return fresh status that contains real root data. A startup claim is only a
+                    // duplicate-start guard and must not be consumed as a usable repository snapshot.
+                    if isGraceWatchStatusUsable graceWatchStatus then
                         return Some graceWatchStatus
                     else
-                        return None // File is more than five minutes old, so something weird happened and we shouldn't trust the information.
+                        return None // The file is stale, a startup claim, or does not contain usable root data.
                 else
                     //logToAnsiConsole Colors.Verbose $"File {IpcFileName} does not exist."
                     return None // `grace watch` isn't running.
@@ -1409,7 +1424,7 @@ module Services =
     /// Atomically claims the `grace watch` status IPC file before foreground watch startup.
     let tryClaimGraceWatchInterprocessFile () =
         task {
-            let claimStatus = createGraceWatchStatus GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+            let claimStatus = createGraceWatchStartupClaim ()
 
             let writeClaimToExistingFile (fileStream: FileStream) =
                 task {
@@ -1430,10 +1445,7 @@ module Services =
                     try
                         let! existingGraceWatchStatus = deserializeAsync<GraceWatchStatus> fileStream
 
-                        if
-                            existingGraceWatchStatus.UpdatedAt
-                            > getCurrentInstant().Minus(Duration.FromMinutes(5.0))
-                        then
+                        if isGraceWatchStatusFresh existingGraceWatchStatus then
                             return false
                         else
                             do! writeClaimToExistingFile fileStream

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -42,6 +42,8 @@ open Grace.CLI.Text
 open Grace.Types.Automation
 
 module Watch =
+    exception private WatchCommandExit of int
+
 
     module private Options =
         let ownerId =
@@ -115,6 +117,11 @@ module Watch =
                 Description = "The name of the branch. [default: current branch]",
                 Arity = ArgumentArity.ExactlyOne
             )
+
+        let check =
+            new Option<bool>(OptionName.Check, Required = false, Description = "Checks whether GraceWatch is already running without starting the watcher.")
+
+    let isCheckRequested (parseResult: ParseResult) = parseResult.GetValue(Options.check)
 
     /// Holds a list of the created or changed files that we need to process, as determined by the FileSystemWatcher.
     ///
@@ -515,6 +522,20 @@ module Watch =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) =
             task {
                 try
+                    let! existingGraceWatchStatus = getGraceWatchStatus ()
+
+                    if isCheckRequested parseResult then
+                        match existingGraceWatchStatus with
+                        | Some _ ->
+                            logToAnsiConsole Colors.Important "GraceWatch is running."
+                            raise (WatchCommandExit 0)
+                        | None ->
+                            logToAnsiConsole Colors.Error "GraceWatch is not running."
+                            raise (WatchCommandExit -1)
+                    elif existingGraceWatchStatus |> Option.isSome then
+                        logToAnsiConsole Colors.Error "GraceWatch is already running."
+                        raise (WatchCommandExit -1)
+
                     // Create the FileSystemWatcher, but don't enable it yet.
                     use rootDirectoryFileSystemWatcher = createFileSystemWatcher (Current().RootDirectory)
 
@@ -803,6 +824,7 @@ module Watch =
                     else
                         return 0
                 with
+                | WatchCommandExit exitCode -> return exitCode
                 | :? HttpRequestException as httpEx when
                     httpEx.StatusCode.HasValue
                     && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
@@ -850,6 +872,7 @@ module Watch =
             |> addOption Options.repositoryId
             |> addOption Options.branchName
             |> addOption Options.branchId
+            |> addOption Options.check
 
         // Create main command and aliases, if any.
         let watchCommand =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -522,9 +522,9 @@ module Watch =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) =
             task {
                 try
-                    let! existingGraceWatchStatus = getGraceWatchStatus ()
-
                     if isCheckRequested parseResult then
+                        let! existingGraceWatchStatus = getGraceWatchStatus ()
+
                         match existingGraceWatchStatus with
                         | Some _ ->
                             logToAnsiConsole Colors.Important "GraceWatch is running."
@@ -532,7 +532,10 @@ module Watch =
                         | None ->
                             logToAnsiConsole Colors.Error "GraceWatch is not running."
                             raise (WatchCommandExit -1)
-                    elif existingGraceWatchStatus |> Option.isSome then
+
+                    let! claimedGraceWatchStatus = tryClaimGraceWatchInterprocessFile ()
+
+                    if not claimedGraceWatchStatus then
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1272,7 +1272,7 @@ module GraceCommand =
                             //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
                             if (parseResult |> json)
-                               && (parseResult |> isGraceWatchForeground) then
+                               && (parseResult |> isGraceWatch) then
                                 let error =
                                     GraceError.Create
                                         "watch is a continuous foreground workflow; JSON mode requires a cancellation-aware automation host in this release."

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -945,6 +945,11 @@ module GraceCommand =
     /// Checks if the command is a `grace watch` command.
     let isGraceWatch (parseResult: ParseResult) = if (parseResult.CommandResult.Command.Name = "watch") then true else false
 
+    /// Checks if the command is a foreground `grace watch` command.
+    let isGraceWatchForeground (parseResult: ParseResult) =
+        (parseResult |> isGraceWatch)
+        && not (Command.Watch.isCheckRequested parseResult)
+
     /// Checks if the command is a `grace config` command.
     let isGraceConfig (parseResult: ParseResult) =
         if not <| isNull parseResult.CommandResult.Parent then
@@ -1267,7 +1272,7 @@ module GraceCommand =
                             //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
                             if (parseResult |> json)
-                               && (parseResult |> isGraceWatch) then
+                               && (parseResult |> isGraceWatchForeground) then
                                 let error =
                                     GraceError.Create
                                         "watch is a continuous foreground workflow; JSON mode requires a cancellation-aware automation host in this release."
@@ -1287,8 +1292,8 @@ module GraceCommand =
                                     else
                                         AnsiConsole.Write(new Rule())
 
-                                // If this instance isn't `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
-                                if not <| (parseResult |> isGraceWatch) then
+                                // If this instance isn't foreground `grace watch`, we want to check if `grace watch` is running by trying to read the IPC file.
+                                if not <| (parseResult |> isGraceWatchForeground) then
                                     let! graceWatchStatus = getGraceWatchStatus ()
 
                                     match graceWatchStatus with
@@ -1301,9 +1306,9 @@ module GraceCommand =
 
                                 // Stuff to do after the command has been invoked:
 
-                                // If this instance is `grace watch`, we'll actually delete the IPC file in the finally clause below, but
+                                // If this instance is foreground `grace watch`, we'll actually delete the IPC file in the finally clause below, but
                                 //   we'll write the "we deleted the file" message to the console here, so it comes before the last Rule() is written.
-                                if parseResult |> isGraceWatch then
+                                if parseResult |> isGraceWatchForeground then
                                     logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
                                 // If we're writing output, write the final Rule() to the console.
@@ -1417,9 +1422,9 @@ module GraceCommand =
                             source = resolveInvocationSource parseResult
                         }
 
-                // If this was grace watch, delete the inter-process communication file.
+                // If this was foreground grace watch, delete the inter-process communication file.
                 if not <| isNull (parseResult)
-                   && parseResult |> isGraceWatch then
+                   && parseResult |> isGraceWatchForeground then
                     deleteGraceWatchIpcFileIfOwned ()
         })
             .Result

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -19,6 +19,9 @@ module Text =
         let BranchName = "--branch-name"
 
         [<Literal>]
+        let Check = "--check"
+
+        [<Literal>]
         let CheckpointDays = "--checkpoint-days"
 
         [<Literal>]


### PR DESCRIPTION
## Summary

- Adds `grace watch --check` as a non-mutating health probe for the existing Grace watch IPC status file.
- Makes ordinary `grace watch` fail before startup when the same IPC status source reports an already-running watcher.
- Adds an atomic IPC startup claim so simultaneous `grace watch` launches cannot both enter the foreground watcher.
- Keeps startup claims distinct from usable watch status so other commands never consume empty root/directory data.
- Preserves the documented JSON error-only contract for all `watch` JSON-mode invocations, including `watch --check`.
- Adds focused CLI tests for duplicate-start detection, atomic claim behavior, check-mode running/not-running behavior, startup-claim filtering, JSON short-circuiting, and IPC non-mutation.

Closes #308

## Touched Paths

- `src/Grace.CLI/Text.CLI.fs`
- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI/Program.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Validation

Initial implementation:

- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WatchTests"`: RED before implementation, then GREEN with `Failed: 0, Passed: 10, Skipped: 0, Total: 10`.
- `dotnet fantomas --check src\Grace.CLI\Text.CLI.fs src\Grace.CLI\Command\Watch.CLI.fs src\Grace.CLI\Program.CLI.fs src\Grace.CLI.Tests\Watch.Tests.fs`: passed, no changes required.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Atomic claim review fix:

- `dotnet tool run fantomas src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`: passed.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WatchTests"`: passed, 12/12.
- `pwsh ./scripts/validate.ps1 -Fast`: passed, including `Grace.CLI.Tests` 377/377.
- `git diff --check`: passed.

Startup claim status review fix:

- `dotnet fantomas --check src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`: passed after targeted formatting.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter FullyQualifiedName~WatchTests`: passed, 14/14.
- `pwsh ./scripts/validate.ps1 -Fast`: passed, including `Grace.CLI.Tests` 379/379.
- `git diff --check`: passed.

JSON-mode review fix:

- `dotnet tool run fantomas -- src\Grace.CLI\Program.CLI.fs src\Grace.CLI.Tests\Watch.Tests.fs`: passed.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~WatchTests"`: passed, 16/16.
- `pwsh ./scripts/validate.ps1 -Fast`: passed, including `Grace.CLI.Tests` 381/381.
- `git diff --check`: passed.

CI:

- GitHub `full`: passed.

## Review Status

- Implementation worker: Harvey (`GPT-5.5 Medium`) completed and pushed `87acc79 Add grace watch status check`.
- Local review-only subagent: intentionally not run per maintainer instruction for this PR.
- Automatic Codex repository review on `87acc79`: found one P2 issue, [discussion r3368570449](https://github.com/ScottArbeit/Grace/pull/309#discussion_r3368570449), requiring an atomic watch status claim before startup.
- Fix worker: Fermat (`GPT-5.5 Medium`) pushed `fb9f1dc Fix watch startup IPC claim`; the discussion was replied to and resolved.
- Automatic Codex repository review on `fb9f1dc`: found one P2 issue, [discussion r3368590489](https://github.com/ScottArbeit/Grace/pull/309#discussion_r3368590489), requiring startup claims to be distinguishable from usable watch status.
- Fix worker: Wegener (`GPT-5.5 Medium`) pushed `0c5a517 Fix watch startup claim status`; the discussion was replied to and resolved.
- Automatic Codex repository review on `0c5a517`: found one P2 issue, [discussion r3368605186](https://github.com/ScottArbeit/Grace/pull/309#discussion_r3368605186), requiring `watch --check` JSON-mode invocations to stay short-circuited.
- Fix worker: Meitner (`GPT-5.5 Medium`) pushed `ac44c16 Keep watch check JSON requests short-circuited`; the discussion was replied to and resolved.
- Follow-up automatic Codex repository review after `ac44c16`: no issues signaled by `chatgpt-codex-connector[bot]` thumbs-up reaction on PR #309 at 2026-06-07T02:31:16Z.
- Open findings: none.

## Docs Impact

No standalone docs were changed. The new `--check` option is exposed through the command option/help definition.

## Residual Risk

`grace watch --check` intentionally emits human-readable status text and uses exit code behavior for normal automation. JSON-mode `watch` requests remain JSON error-only per the existing command output contract. A startup claim is treated as not yet running by `--check`, while still blocking a second foreground `grace watch` start.