### PR TITLE
Update Aspire AppHost SDK and Full validation progress output

### DIFF
--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -249,6 +249,11 @@ function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
 
     Write-Host "Test target: src/Grace.slnx"
     Write-Host ("Test filter: {0}" -f $testFilter)
+    if ($IncludeFullTests) {
+        Write-Host "Progress note: -Full includes Grace.Server.Tests; the Aspire-backed test assembly generally runs for 3-4 minutes after the faster assemblies finish."
+        Write-Host "Progress note: VSTest may buffer test-host progress output; wait for the Grace.Server.Tests summary before treating quiet output as a hang."
+    }
+
     Write-Host ("Running: dotnet test `"src/Grace.slnx`" -c {0} --no-build --filter `"{1}`"" -f $Configuration, $testFilter)
 
     Invoke-External "Grace solution tests" {

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -9,6 +9,7 @@ open Grace.Shared
 open Microsoft.Azure.Cosmos
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
+open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.Diagnostics
@@ -62,6 +63,14 @@ module AspireTestHost =
     let private getTimeout (local: TimeSpan) (ci: TimeSpan) = if isCi then ci else local
 
     let private defaultWaitTimeout = getTimeout (TimeSpan.FromMinutes(5.0)) (TimeSpan.FromMinutes(3.0))
+
+    let private logProgress (message: string) =
+        let progressMessage = $"Grace.Server.Tests progress: {message}"
+
+        TestContext.Progress.WriteLine(progressMessage)
+        TestContext.Progress.Flush()
+        Console.Error.WriteLine(progressMessage)
+        Console.Error.Flush()
 
     let private ensureBootstrapCompatible (bootstrapUserId: string) =
         match sharedBootstrapUserId with
@@ -413,7 +422,9 @@ module AspireTestHost =
         =
         task {
             try
+                logProgress $"waiting for resource '{resourceName}' to become healthy."
                 let! _ = notificationService.WaitForResourceHealthyAsync(resourceName, ct)
+                logProgress $"resource '{resourceName}' is healthy."
                 ()
             with
             | ex ->
@@ -748,6 +759,7 @@ module AspireTestHost =
 
                     let! _ = receiver.PeekMessageAsync()
                     ready <- true
+                    logProgress $"Service Bus emulator ready after {sw.Elapsed.TotalSeconds:n1}s."
                 with
                 | ex ->
                     lastError <- ex.Message
@@ -869,6 +881,7 @@ module AspireTestHost =
                             ()
 
                         ready <- true
+                        logProgress $"Cosmos emulator ready after {sw.Elapsed.TotalSeconds:n1}s."
                     with
                     | ex ->
                         lastError <- formatExceptionChain ex
@@ -924,6 +937,8 @@ module AspireTestHost =
 
     let private startNewHostAsync (bootstrapUserId: string) =
         task {
+            logProgress "Aspire setup starting."
+
             Environment.SetEnvironmentVariable("GRACE_TESTING", "1")
             Environment.SetEnvironmentVariable("GRACE_TEST_CLEANUP", "1")
             Environment.SetEnvironmentVariable("GRACE_TEST_RUN_ID", Guid.NewGuid().ToString("N"))
@@ -939,10 +954,15 @@ module AspireTestHost =
             if shouldSkipServiceBus () then
                 invalidOp FixtureDiagnostics.serviceBusSkipModeMessage
 
+            logProgress "Docker cleanup starting."
             do! cleanupDockerContainersAsync ()
+            logProgress "Docker cleanup complete."
+            logProgress "building Aspire AppHost."
             let! builder = DistributedApplicationTestingBuilder.CreateAsync<Projects.Grace_Aspire_AppHost>()
             let! app = builder.BuildAsync()
+            logProgress "starting Aspire AppHost resources."
             do! app.StartAsync()
+            logProgress "Aspire AppHost started; waiting for resources."
 
             let notificationService = app.Services.GetRequiredService<ResourceNotificationService>()
             let model = app.Services.GetRequiredService<DistributedApplicationModel>()
@@ -992,6 +1012,8 @@ module AspireTestHost =
                 do! waitForResourceHealthyAsync notificationService app serviceBusEmulatorResourceName cts.Token
             else
                 Console.WriteLine("Skipping Service Bus emulator readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
+
+            logProgress "container resources reported healthy; validating service readiness."
 
             let! env = getEnvironmentVariablesAsync app graceServerResourceName
 
@@ -1170,6 +1192,8 @@ module AspireTestHost =
                 do! waitForServiceBusReadyAsync serviceBusEmulatorResourceName serviceBusSqlResourceName state
             else
                 Console.WriteLine("Skipping Service Bus functional readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
+
+            logProgress "containers and service readiness checks complete."
 
             return state
         }

--- a/src/Grace.Server.Tests/General.Server.Tests.fs
+++ b/src/Grace.Server.Tests/General.Server.Tests.fs
@@ -7,6 +7,7 @@ open System
 open System.Net
 open System.Net.Http
 open System.Net.Http.Json
+open System.Reflection
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
@@ -60,7 +61,29 @@ module Services =
     let mutable testUserId = String.Empty
     let mutable testUserClaims: string list = []
 
-    let logToTestConsole (message: string) = Console.WriteLine(message)
+    let logToTestConsole (message: string) =
+        TestContext.Progress.WriteLine(message)
+        TestContext.Progress.Flush()
+        Console.Error.WriteLine(message)
+        Console.Error.Flush()
+
+    let getApproximateTestCount () =
+        Assembly.GetExecutingAssembly().GetTypes()
+        |> Seq.collect (fun testType ->
+            testType.GetMethods(
+                BindingFlags.Instance
+                ||| BindingFlags.Static
+                ||| BindingFlags.Public
+                ||| BindingFlags.NonPublic
+            ))
+        |> Seq.filter (fun methodInfo ->
+            methodInfo
+                .GetCustomAttributes(
+                    typeof<TestAttribute>,
+                    true
+                )
+                .Length > 0)
+        |> Seq.length
 
 open Services
 
@@ -71,10 +94,15 @@ type Setup() =
     [<OneTimeSetUp>]
     member public _.Setup() =
         task {
+            let approximateTestCount = getApproximateTestCount ()
+
+            logToTestConsole "Grace.Server.Tests progress: setup starting."
+            logToTestConsole $"Grace.Server.Tests progress: approximately {approximateTestCount} tests will start after setup."
             logToTestConsole "Starting Aspire test host..."
 
             testUserId <- $"{Guid.NewGuid()}"
             let! hostState = AspireTestHost.startAsync testUserId
+            logToTestConsole "Grace.Server.Tests progress: Aspire setup ready."
 
             App <- Some hostState.App
             Client <- hostState.Client
@@ -87,6 +115,7 @@ type Setup() =
 
             Client.DefaultRequestHeaders.Add("x-grace-user-id", testUserId)
 
+            logToTestConsole "Grace.Server.Tests progress: shared fixture data setup starting."
             logToTestConsole $"Grace.Server base address: {graceServerBaseAddress}"
 
             logToTestConsole
@@ -192,11 +221,15 @@ type Setup() =
                             }
                         ))
                 )
+
+            logToTestConsole $"Grace.Server.Tests progress: shared fixture data ready; approximately {approximateTestCount} tests starting."
         }
 
     [<OneTimeTearDown>]
     member public _.Teardown() =
         task {
+            logToTestConsole "Grace.Server.Tests progress: tests concluded; teardown starting."
+
             let correlationId = generateCorrelationId ()
             let logCleanupFailure (label: string) (detail: string) = logToTestConsole $"Cleanup {label} failed: {detail}"
 
@@ -268,6 +301,8 @@ type Setup() =
                 do! AspireTestHost.stopAsync App
             with
             | ex -> logCleanupFailure "apphost stop" ex.Message
+
+            logToTestConsole "Grace.Server.Tests progress: teardown concluded."
 
         }
 


### PR DESCRIPTION
## Summary  Closes #311.  - Aligns the Aspire AppHost SDK with the current coherent Aspire `13.4.3` package set already used by the AppHost and integration tests. - Adds lightweight progress output for `Grace.Server.Tests` during `validate -Full`, including setup, resource readiness, approximate test count, conclusion, and teardown markers. - Adds a scoped `validate -Full` console note so agents know the Aspire-backed suite can be quiet while VSTest buffers output.  ## Write Set  - `src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj` - `src/Grace.Server.Tests/AspireTestHost.fs` - `src/Grace.Server.Tests/General.Server.Tests.fs` - `scripts/validate.ps1`  `script/validate.ps1` is a write-set expansion from the initial claim. It is limited to Full-mode observability text and does not change validation membership, restore/build/test order, or command semantics.  ## Aspire Construct Evaluation  Made:  - Updated `Aspire.AppHost.Sdk` from `13.3.5` to `13.4.3`. - Preserved the existing Aspire hosting package references at `13.4.3` after live NuGet metadata confirmed that as the latest stable coherent set. - Added progress markers without replacing the existing readiness checks.  Deferred intentionally:  - `RunAsPreviewEmulator` to Cosmos `RunAsEmulator`: 13.4.3 supports stable `RunAsEmulator`, but the current AppHost also uses data explorer behavior tied to the preview emulator path. Changing that is a separate behavior slice. - First-class Service Bus emulator migration: Grace currently owns SQL pairing, generated config, server/test subscriptions, resource names, and readiness checks. - First-class Azurite/Storage and Redis migrations: deferred to avoid changing custom connection strings, resource names, fixed ports, or test isolation behavior. - Broad `.WithReference` / `.WaitFor` rewrites: deferred because Grace relies on explicit custom env vars and resource names.  ## Validation  - Live NuGet metadata check: latest stable `13.4.3` confirmed for `Aspire.AppHost.Sdk`, `Aspire.Hosting`, `Aspire.Hosting.Azure.CosmosDB`, `Aspire.Hosting.Azure.ServiceBus`, `Aspire.Hosting.Azure.Storage`, `Aspire.Hosting.Redis`, and `Aspire.Hosting.Testing`. - `dotnet list src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj package`: passed. - `dotnet list src/Grace.Server.Tests/Grace.Server.Tests.fsproj package`: passed. - `dotnet restore src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj`: passed. - `dotnet tool run fantomas Grace.Server.Tests/General.Server.Tests.fs Grace.Server.Tests/AspireTestHost.fs`: passed. - `pwsh ./scripts/validate.ps1 -Full`: passed in `00:05:12.6777579`.   - `Grace.Authorization.Tests`: 37 passed.   - `Grace.Types.Tests`: 65 passed.   - `Grace.Server.Unit.Tests`: 440 passed.   - `Grace.CLI.Tests`: 380 passed, 1 skipped.   - `Grace.Server.Tests`: 168 passed. - `git diff --check`: passed.  MarkdownLint was skipped because no Markdown files changed.  ## Review Status  - Implementation worker completed and pushed commits `2649a43` and `e5e55ad`. - Awaiting fresh local review-only sibling subagent pass. - Open findings: none recorded yet. - Final no-issues review: pending.  ## Docs Impact  No docs changed. The observable behavior change is limited to validation/test console output.  ## Residual Risk  Low. Runtime/resource behavior should be unchanged, but the progress markers intentionally affect test and validation logs.