### PR TITLE
[Branch annotate V1 S1] Add Reference creator identity

### DIFF
--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="EventMetadata.Types.Tests.fs" />
     <Compile Include="Automation.Types.Tests.fs" />
+    <Compile Include="Reference.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />
     <Compile Include="Webhooks.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/Reference.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Reference.Types.Tests.fs
@@ -1,0 +1,101 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.Reference
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+[<Parallelizable(ParallelScope.All)>]
+type ReferenceDtoTests() =
+
+    let timestamp = Instant.FromUtc(2026, 6, 9, 10, 0)
+    let referenceId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+    let ownerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+    let organizationId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+    let repositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+    let branchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+    let directoryId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+    let promotionSetId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+
+    let createMetadata principal timestamp =
+        {
+            Timestamp = timestamp
+            CorrelationId = "reference-created-by-tests"
+            Principal = principal
+            ClientType = Option.None
+            Properties = Dictionary<string, string>()
+        }
+
+    let createdEvent principal =
+        {
+            Event =
+                ReferenceEventType.Created(
+                    referenceId,
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    branchId,
+                    directoryId,
+                    Sha256Hash "abc123",
+                    ReferenceType.Commit,
+                    ReferenceText "commit reference",
+                    Seq.empty
+                )
+            Metadata = createMetadata principal timestamp
+        }
+
+    [<Test>]
+    member _.CreatedEventWithPrincipalPopulatesCreatedBy() =
+        let updated = ReferenceDto.UpdateDto (createdEvent "alice@example.test") ReferenceDto.Default
+
+        Assert.That(updated.CreatedBy, Is.EqualTo(Some "alice@example.test"))
+        Assert.That(updated.CreatedAt, Is.EqualTo(timestamp))
+
+    [<Test>]
+    member _.DefaultAndBlankCreatedPrincipalKeepCreatedByMissing() =
+        let updated = ReferenceDto.UpdateDto (createdEvent " ") ReferenceDto.Default
+
+        Assert.That(ReferenceDto.Default.CreatedBy, Is.EqualTo(Option.None))
+        Assert.That(updated.CreatedBy, Is.EqualTo(Option.None))
+
+    [<Test>]
+    member _.JsonSerializationWritesNullableCreatedBy() =
+        let withCreator = ReferenceDto.UpdateDto (createdEvent "alice@example.test") ReferenceDto.Default
+        let withoutCreator = { withCreator with CreatedBy = Option.None }
+
+        let withCreatorJson = serialize withCreator
+        let withoutCreatorJson = serialize withoutCreator
+
+        Assert.That(withCreatorJson, Does.Contain("\"CreatedBy\": \"alice@example.test\""))
+        Assert.That(withoutCreatorJson, Does.Contain("\"CreatedBy\": null"))
+
+        let roundTripWithoutCreator = deserialize<ReferenceDto> withoutCreatorJson
+        Assert.That(roundTripWithoutCreator.CreatedBy, Is.EqualTo(Option.None))
+
+    [<Test>]
+    member _.UpdateEventsDoNotOverwriteCreatedBy() =
+        let created = ReferenceDto.UpdateDto (createdEvent "alice@example.test") ReferenceDto.Default
+
+        let linkAddedEvent =
+            {
+                Event = ReferenceEventType.LinkAdded(ReferenceLinkType.PromotionSetTerminal promotionSetId)
+                Metadata = createMetadata "bob@example.test" (timestamp + Duration.FromMinutes(1.0))
+            }
+
+        let deletedEvent =
+            {
+                Event = ReferenceEventType.LogicalDeleted(false, "cleanup")
+                Metadata = createMetadata "carol@example.test" (timestamp + Duration.FromMinutes(2.0))
+            }
+
+        let linked = ReferenceDto.UpdateDto linkAddedEvent created
+        let deleted = ReferenceDto.UpdateDto deletedEvent linked
+
+        Assert.That(linked.CreatedBy, Is.EqualTo(Some "alice@example.test"))
+        Assert.That(deleted.CreatedBy, Is.EqualTo(Some "alice@example.test"))
+        Assert.That(linked.UpdatedAt, Is.EqualTo(Some(timestamp + Duration.FromMinutes(1.0))))
+        Assert.That(deleted.UpdatedAt, Is.EqualTo(Some(timestamp + Duration.FromMinutes(2.0))))

--- a/src/Grace.Types/Reference.Types.fs
+++ b/src/Grace.Types/Reference.Types.fs
@@ -88,6 +88,7 @@ module Reference =
             ReferenceType: ReferenceType
             ReferenceText: ReferenceText
             Links: ReferenceLinkType seq
+            CreatedBy: string option
             CreatedAt: Instant
             UpdatedAt: Instant option
             DeletedAt: Instant option
@@ -107,6 +108,7 @@ module Reference =
                 ReferenceType = Save
                 ReferenceText = ReferenceText String.Empty
                 Links = Seq.empty
+                CreatedBy = None
                 CreatedAt = Constants.DefaultTimestamp
                 UpdatedAt = None
                 DeletedAt = None
@@ -129,6 +131,11 @@ module Reference =
                         ReferenceType = referenceType
                         ReferenceText = referenceText
                         Links = links
+                        CreatedBy =
+                            if String.IsNullOrWhiteSpace referenceEvent.Metadata.Principal then
+                                None
+                            else
+                                Some referenceEvent.Metadata.Principal
                         CreatedAt = referenceEvent.Metadata.Timestamp
                     }
                 | LinkAdded link ->

--- a/src/OpenAPI/Dto.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Dto.Components.OpenAPI.yaml
@@ -154,6 +154,9 @@
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType
         ReferenceText:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceText
+        CreatedBy:
+          type: string
+          nullable: true
         CreatedAt:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Instant
 

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -3783,6 +3783,9 @@ components:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
           $ref: '#/components/schemas/ReferenceText'
+        CreatedBy:
+          type: string
+          nullable: true
         CreatedAt:
           $ref: '#/components/schemas/Instant'
     RepositoryDto:

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -3783,6 +3783,9 @@ components:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
           $ref: '#/components/schemas/ReferenceText'
+        CreatedBy:
+          type: string
+          nullable: true
         CreatedAt:
           $ref: '#/components/schemas/Instant'
     RepositoryDto:

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -37,7 +37,7 @@
     },
     {
       "path": "Dto.Components.OpenAPI.yaml",
-      "sha256": "886f072e857098fa93c038e681d506b243a102f4fc81bfdd339653cfe61f7ac3"
+      "sha256": "72acc5bea675e60a851d6631738cdfe558b903a66ff2976be413f51ec5cda7fd"
     },
     {
       "path": "Main.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
+      "sourceDigest": "fff94f29f265cd8e9e954a68bdbeff52c41fa959ce5b11bfb0ed920c76547bf0",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "eecad416391e6bc462dcfa032f39c9da7c57717403eac37a5fe6ca890c4a3e57"
+      "sha256": "b036d135d9f0aa6eb6402d1034f365389e416e804670f18c5a53bb9c6984ba22"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
+      "sourceDigest": "fff94f29f265cd8e9e954a68bdbeff52c41fa959ce5b11bfb0ed920c76547bf0",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "e2be4a02d2f63a3b9f4cdabe7f615ba0a5c98673618c132d063b9bbf4273f590"
+      "sha256": "8d567fc230e4611a3852a63454749133a9fa174f28397da47de18131e7b489c1"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "44ecf1253f5f605be16387ef293c144cd43aa3d508041021e09048a218039917",
+      "sourceDigest": "fff94f29f265cd8e9e954a68bdbeff52c41fa959ce5b11bfb0ed920c76547bf0",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",


### PR DESCRIPTION
## Summary

- Adds optional Reference creator identity to `ReferenceDto`.
- Populates `CreatedBy` from nonblank `ReferenceEvent.Metadata.Principal` on Created events only.
- Preserves compatibility for old/default References and update/delete event replay.

## Issue Links

Part of #313
Related to #314

## Touched Paths

- `src/Grace.Types/Reference.Types.fs`
- `src/Grace.Types.Tests/Reference.Types.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

Initial worker validation on `c691b27ace5bcb993a329034c72df419205d7404`:

- `dotnet tool run fantomas Grace.Types\Reference.Types.fs Grace.Types.Tests\Reference.Types.Tests.fs`: passed.
- `dotnet build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed, `0` warnings, `0` errors.
- `dotnet test --no-build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed, `69` passed, `0` failed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness -AllowPending`: passed, no pending gates; no OpenAPI/generated files changed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Build succeeded with `0` warnings and `0` errors. Selected tests passed: Types `69`, Authorization `37`, Server.Unit `440`, CLI `380` with `1` skipped.
- `git diff --check`: passed.

Fix worker validation on `fc995b1fe7a10b520c7cf7818abf7697c835d12d`:

- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness`: passed; proof manifest covers 25 canonical source files and no pending gates.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Build succeeded with `0` warnings and `0` errors. Selected tests passed: Types `69`, Authorization `37`, Server.Unit `440`, CLI `380` with `1` skipped.
- `git diff --check`: passed.

`pwsh ./scripts/validate.ps1 -Full` was skipped because this is a `Grace.Types` contract/OpenAPI schema slice with no Aspire, emulator, storage, Service Bus, Redis, or cross-service runtime behavior touched.


## Review Status

- Implementation worker: Locke, fresh GPT-5.5 Medium worker.
- Fix worker: Planck, fresh GPT-5.5 Medium worker.
- Final head commit before merge: `fc995b1fe7a10b520c7cf7818abf7697c835d12d`.
- Merge commit to `epic/313-branch-annotate-v1`: `e8c02eb107aa39a692a98c83bffe649c0609b599`.
- Codex Code Review Bot: 👍 on the latest head before merge.
- Bot review https://github.com/ScottArbeit/Grace/pull/323#pullrequestreview-4456618956 reported two inline findings:
  - P1: Missing-property compatibility for old `ReferenceDto` JSON. Disposition: no code change per product/operational constraint; replied in https://github.com/ScottArbeit/Grace/pull/323#discussion_r3379048149 and resolved.
  - P2: OpenAPI `ReferenceDto` schema missing nullable `CreatedBy`. Disposition: fixed in `fc995b1fe7a10b520c7cf7818abf7697c835d12d`; replied in https://github.com/ScottArbeit/Grace/pull/323#discussion_r3379120350 and resolved.
- Open findings: none.


## Docs Impact

No user-facing docs were expected for this contract slice. Broad branch annotation documentation remains in #322.

## Residual Risk

Low. This is an additive DTO field populated from existing event metadata and covered by focused serialization/replay tests plus Fast validation.



