### PR TITLE
[Branch annotate V1 S2] Define annotation DTOs and parameters

### DIFF
--- a/src/Grace.Shared/Parameters/Branch.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Branch.Parameters.fs
@@ -4,6 +4,7 @@ open Grace.Shared.Parameters.Common
 open Grace.Types.Annotation
 open Grace.Types.Common
 open System
+open System.Text.Json.Serialization
 
 module Branch =
 
@@ -125,6 +126,7 @@ module Branch =
         member val public MaxReferences = DefaultMaxReferences with get, set
         member val public IncludeLineText = false with get, set
 
+        [<JsonIgnore(Condition = JsonIgnoreCondition.Always)>]
         member this.LineRange = { StartLine = this.StartLine; EndLine = this.EndLine }
 
         member this.Validate() =

--- a/src/Grace.Shared/Parameters/Branch.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Branch.Parameters.fs
@@ -1,6 +1,7 @@
 namespace Grace.Shared.Parameters
 
 open Grace.Shared.Parameters.Common
+open Grace.Types.Annotation
 open Grace.Types.Common
 open System
 
@@ -112,6 +113,33 @@ module Branch =
         inherit BranchParameters()
         member val public References = String.Empty with get, set
         member val public MaxCount = 50 with get, set
+
+    /// Parameters for the /branch/annotate endpoint.
+    type AnnotateParameters() =
+        inherit BranchParameters()
+        member val public TargetReferenceId: ReferenceId = ReferenceId.Empty with get, set
+        member val public Path: RelativePath = String.Empty with get, set
+        member val public StartLine = 1 with get, set
+        member val public EndLine = 1 with get, set
+        member val public ReferenceTypes: ReferenceType array = Array.empty with get, set
+        member val public MaxReferences = DefaultMaxReferences with get, set
+        member val public IncludeLineText = false with get, set
+
+        member this.LineRange = { StartLine = this.StartLine; EndLine = this.EndLine }
+
+        member this.Validate() =
+            [
+                match validateLineRange this.LineRange with
+                | Ok () -> ()
+                | Error errors -> yield! errors
+
+                match validateMaxReferences this.MaxReferences with
+                | Ok () -> ()
+                | Error errors -> yield! errors
+            ]
+            |> function
+                | [] -> Ok()
+                | errors -> Error errors
 
     /// Parameters for the /branch/get endpoint.
     type GetBranchParameters() =

--- a/src/Grace.Types.Tests/Annotation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Annotation.Types.Tests.fs
@@ -52,6 +52,7 @@ type AnnotationContractTests() =
                     ReferenceText = "previous commit"
                     DirectoryVersionId = directoryVersionId
                     CreatedAt = None
+                    CreatedBy = Some "alice@example.test"
                 }
             |]
         )
@@ -82,11 +83,24 @@ type AnnotationContractTests() =
                 Assert.That(root.GetProperty("ReferenceTypeFilter").ValueKind, Is.EqualTo(JsonValueKind.Array))
                 Assert.That(root.GetProperty("SourceReferences").ValueKind, Is.EqualTo(JsonValueKind.Array))
 
+                let serializedSourceReference =
+                    root
+                        .GetProperty("SourceReferences")
+                        .EnumerateArray()
+                    |> Seq.exactlyOne
+
                 Assert.That(
                     root
                         .GetProperty("SourceReferences")
                         .GetArrayLength(),
                     Is.EqualTo(1)
+                )
+
+                Assert.That(
+                    serializedSourceReference
+                        .GetProperty("CreatedBy")
+                        .GetString(),
+                    Is.EqualTo("alice@example.test")
                 )
 
                 Assert.That(root.TryGetProperty("AlgorithmVersion", &algorithmVersion), Is.False))
@@ -109,11 +123,16 @@ type AnnotationContractTests() =
     [<Test>]
     member _.AnnotateParametersDefaultReferenceBudgetIsOneThousand() =
         let parameters = AnnotateParameters()
+        let json = serialize parameters
 
         Assert.Multiple(
             Action (fun () ->
+                use document = JsonDocument.Parse(json)
+                let mutable lineRange = Unchecked.defaultof<JsonElement>
+
                 Assert.That(parameters.MaxReferences, Is.EqualTo(1000))
                 Assert.That(parameters.IncludeLineText, Is.False)
+                Assert.That(document.RootElement.TryGetProperty("LineRange", &lineRange), Is.False)
                 assertOk (parameters.Validate()))
         )
 
@@ -171,6 +190,19 @@ type AnnotationContractTests() =
             )
 
     [<Test>]
+    member _.AnnotationValidationAllowsResolvedSpansWithoutBoundaries() =
+        let annotation =
+            { validAnnotation true with
+                Boundaries = Array.empty
+                Spans =
+                    [|
+                        { SpanId = "span-1"; BoundaryId = String.Empty; LineRange = { StartLine = 10; EndLine = 11 }; SourceRowIds = [| "source-row-1" |] }
+                    |]
+            }
+
+        assertOk (validate annotation)
+
+    [<Test>]
     member _.AnnotationValidationRejectsDuplicateSourceRows() =
         let annotation = validAnnotation true
 
@@ -186,3 +218,90 @@ type AnnotationContractTests() =
         match validate duplicate with
         | Ok () -> Assert.Fail("Duplicate source rows should be rejected.")
         | Error errors -> Assert.That(errors, Has.Some.Contains("duplicate SourceRowId"))
+
+    [<TestCase("source-reference")>]
+    [<TestCase("source-row")>]
+    [<TestCase("boundary")>]
+    [<TestCase("span")>]
+    member _.AnnotationValidationRejectsBlankIdentifiers(identifierKind: string) =
+        let annotation = validAnnotation true
+
+        let blank =
+            match identifierKind with
+            | "source-reference" ->
+                { annotation with
+                    SourceReferences =
+                        [|
+                            { annotation.SourceReferences[0] with SourceReferenceId = " " }
+                        |]
+                }
+            | "source-row" ->
+                { annotation with
+                    SourceRows =
+                        [|
+                            { annotation.SourceRows[0] with SourceRowId = " " }
+                        |]
+                }
+            | "boundary" ->
+                { annotation with
+                    Boundaries =
+                        [|
+                            { annotation.Boundaries[0] with BoundaryId = " " }
+                        |]
+                }
+            | "span" ->
+                { annotation with
+                    Spans =
+                        [|
+                            { annotation.Spans[0] with SpanId = " " }
+                        |]
+                }
+            | unexpected -> failwith $"Unknown identifier kind: {unexpected}"
+
+        match validate blank with
+        | Ok () -> Assert.Fail($"Blank {identifierKind} identifiers should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("blank"))
+
+    [<Test>]
+    member _.AnnotationValidationRejectsSpansOutsideRequestedRange() =
+        let annotation =
+            { validAnnotation true with
+                Spans =
+                    [|
+                        { SpanId = "span-1"; BoundaryId = "boundary-1"; LineRange = { StartLine = 9; EndLine = 11 }; SourceRowIds = [| "source-row-1" |] }
+                    |]
+            }
+
+        match validate annotation with
+        | Ok () -> Assert.Fail("Spans outside the requested line range should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("inside RequestedLineRange"))
+
+    [<Test>]
+    member _.AnnotationValidationRejectsCrossPathSourceRows() =
+        let annotation =
+            { validAnnotation true with
+                SourceRows =
+                    [|
+                        { (validAnnotation true).SourceRows[0] with Path = "src/Other.fs" }
+                    |]
+            }
+
+        match validate annotation with
+        | Ok () -> Assert.Fail("Source rows from a different path should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("Path must match annotation Path"))
+
+    [<Test>]
+    member _.AnnotationValidationRejectsSourceReferencesAboveBudget() =
+        let annotation =
+            { validAnnotation true with
+                MaxReferences = 1
+                SourceReferences =
+                    [|
+                        (validAnnotation true).SourceReferences[0]
+                        { (validAnnotation true).SourceReferences[0] with SourceReferenceId = "source-reference-2" }
+                    |]
+            }
+
+        match validate annotation with
+        | Ok () -> Assert.Fail("SourceReferences above MaxReferences should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("MaxReferences"))

--- a/src/Grace.Types.Tests/Annotation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Annotation.Types.Tests.fs
@@ -22,6 +22,11 @@ type AnnotationContractTests() =
         | Ok () -> ()
         | Error errors -> Assert.Fail(String.Join(Environment.NewLine, errors))
 
+    let assertErrorContains expected (result: Result<unit, string list>) =
+        match result with
+        | Ok () -> Assert.Fail($"Expected validation error containing '{expected}'.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains(expected))
+
     let validAnnotation includeLineText =
         BranchAnnotationDto.Create(
             { StartLine = 10; EndLine = 12 },
@@ -129,6 +134,39 @@ type AnnotationContractTests() =
                 Assert.That(annotation.Lines, Is.Empty)
                 assertOk (validate annotation))
         )
+
+    [<Test>]
+    member _.AnnotationValidationRejectsLineTextWhenNotRequested() =
+        let annotation =
+            { validAnnotation false with
+                Lines =
+                    [|
+                        { LineNumber = 10; Text = "let value = 1" }
+                    |]
+            }
+
+        validate annotation
+        |> assertErrorContains "Lines must be empty when IncludeLineText is false"
+
+    [<Test>]
+    member _.AnnotationValidationRejectsUnknownSourceReferenceType() =
+        let annotation =
+            { validAnnotation true with
+                SourceReferences =
+                    [|
+                        { (validAnnotation true).SourceReferences[0] with ReferenceType = "Bogus" }
+                    |]
+            }
+
+        validate annotation
+        |> assertErrorContains "unknown ReferenceType 'Bogus'"
+
+    [<Test>]
+    member _.AnnotationValidationRejectsUnknownReferenceTypeFilter() =
+        let annotation = { validAnnotation true with ReferenceTypeFilter = [| "Bogus" |] }
+
+        validate annotation
+        |> assertErrorContains "unknown ReferenceType 'Bogus'"
 
     [<Test>]
     member _.AnnotateParametersDefaultReferenceBudgetIsOneThousand() =

--- a/src/Grace.Types.Tests/Annotation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Annotation.Types.Tests.fs
@@ -1,0 +1,188 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared.Utilities
+open Grace.Shared.Parameters.Branch
+open Grace.Types.Annotation
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Text.Json
+
+[<Parallelizable(ParallelScope.All)>]
+type AnnotationContractTests() =
+
+    let targetReferenceId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+    let sourceReferenceId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+    let directoryVersionId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+
+    let assertOk (result: Result<unit, string list>) =
+        match result with
+        | Ok () -> ()
+        | Error errors -> Assert.Fail(String.Join(Environment.NewLine, errors))
+
+    let validAnnotation includeLineText =
+        BranchAnnotationDto.Create(
+            { StartLine = 10; EndLine = 12 },
+            targetReferenceId,
+            "src/App.fs",
+            [|
+                ReferenceType.Commit
+                ReferenceType.Checkpoint
+            |],
+            DefaultMaxReferences,
+            includeLineText,
+            [|
+                { LineNumber = 10; Text = "let value = 1" }
+                { LineNumber = 11; Text = "value + 1" }
+            |],
+            [|
+                { BoundaryId = "boundary-1"; LineRange = { StartLine = 10; EndLine = 12 }; SourceRowIds = [| "source-row-1" |] }
+            |],
+            [|
+                { SpanId = "span-1"; BoundaryId = "boundary-1"; LineRange = { StartLine = 10; EndLine = 11 }; SourceRowIds = [| "source-row-1" |] }
+            |],
+            [|
+                { SourceRowId = "source-row-1"; SourceReferenceId = "source-reference-1"; Path = "src/App.fs"; LineRange = { StartLine = 3; EndLine = 4 } }
+            |],
+            [|
+                {
+                    SourceReferenceId = "source-reference-1"
+                    ReferenceId = sourceReferenceId
+                    ReferenceType = ReferenceType.Commit
+                    ReferenceText = "previous commit"
+                    DirectoryVersionId = directoryVersionId
+                    CreatedAt = None
+                }
+            |]
+        )
+
+    [<Test>]
+    member _.AnnotationDtoSerializationKeepsSourceReferencesAsArray() =
+        let annotation = validAnnotation true
+        let json = serialize annotation
+
+        use document = JsonDocument.Parse(json)
+        let root = document.RootElement
+
+        Assert.Multiple(
+            Action (fun () ->
+                let mutable algorithmVersion = Unchecked.defaultof<JsonElement>
+
+                Assert.That(root.GetProperty("Class").GetString(), Is.EqualTo(nameof BranchAnnotationDto))
+
+                Assert.That(
+                    root
+                        .GetProperty("RequestedLineRange")
+                        .GetProperty("StartLine")
+                        .GetInt32(),
+                    Is.EqualTo(10)
+                )
+
+                Assert.That(root.GetProperty("Path").GetString(), Is.EqualTo("src/App.fs"))
+                Assert.That(root.GetProperty("ReferenceTypeFilter").ValueKind, Is.EqualTo(JsonValueKind.Array))
+                Assert.That(root.GetProperty("SourceReferences").ValueKind, Is.EqualTo(JsonValueKind.Array))
+
+                Assert.That(
+                    root
+                        .GetProperty("SourceReferences")
+                        .GetArrayLength(),
+                    Is.EqualTo(1)
+                )
+
+                Assert.That(root.TryGetProperty("AlgorithmVersion", &algorithmVersion), Is.False))
+        )
+
+        let roundTrip = deserialize<BranchAnnotationDto> json
+        Assert.That(roundTrip, Is.EqualTo(annotation))
+
+    [<Test>]
+    member _.IncludeLineTextFalseYieldsEmptyLines() =
+        let annotation = validAnnotation false
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.IncludeLineText, Is.False)
+                Assert.That(annotation.Lines, Is.Empty)
+                assertOk (validate annotation))
+        )
+
+    [<Test>]
+    member _.AnnotateParametersDefaultReferenceBudgetIsOneThousand() =
+        let parameters = AnnotateParameters()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(parameters.MaxReferences, Is.EqualTo(1000))
+                Assert.That(parameters.IncludeLineText, Is.False)
+                assertOk (parameters.Validate()))
+        )
+
+    [<TestCase(0)>]
+    [<TestCase(5001)>]
+    member _.AnnotateParametersRejectsReferenceBudgetOutsideSupportedRange(maxReferences: int) =
+        let parameters = AnnotateParameters()
+        parameters.MaxReferences <- maxReferences
+
+        Assert.That(parameters.Validate().IsError, Is.True)
+
+    [<Test>]
+    member _.AnnotateParametersAcceptsMaximumReferenceBudget() =
+        let parameters = AnnotateParameters()
+        parameters.MaxReferences <- 5000
+
+        assertOk (parameters.Validate())
+
+    [<TestCase(0, 1)>]
+    [<TestCase(-1, 1)>]
+    [<TestCase(5, 4)>]
+    member _.AnnotateParametersRejectsInvalidLineRanges(startLine: int, endLine: int) =
+        let parameters = AnnotateParameters()
+        parameters.StartLine <- startLine
+        parameters.EndLine <- endLine
+
+        Assert.That(parameters.Validate().IsError, Is.True)
+
+    [<Test>]
+    member _.AnnotationValidationChecksSpanSourceAndBoundaryLinks() =
+        let annotation = validAnnotation true
+
+        assertOk (validate annotation)
+
+        let broken =
+            { annotation with
+                Spans =
+                    [|
+                        { annotation.Spans[0] with BoundaryId = "missing-boundary"; SourceRowIds = [| "missing-source-row" |] }
+                    |]
+                SourceRows =
+                    [|
+                        { annotation.SourceRows[0] with SourceReferenceId = "missing-source-reference" }
+                    |]
+            }
+
+        match validate broken with
+        | Ok () -> Assert.Fail("Broken annotation links should be rejected.")
+        | Error errors ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errors, Has.Some.Contains("missing Boundary"))
+                    Assert.That(errors, Has.Some.Contains("missing SourceRow"))
+                    Assert.That(errors, Has.Some.Contains("missing SourceReference")))
+            )
+
+    [<Test>]
+    member _.AnnotationValidationRejectsDuplicateSourceRows() =
+        let annotation = validAnnotation true
+
+        let duplicate =
+            { annotation with
+                SourceRows =
+                    [|
+                        annotation.SourceRows[0]
+                        annotation.SourceRows[0]
+                    |]
+            }
+
+        match validate duplicate with
+        | Ok () -> Assert.Fail("Duplicate source rows should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("duplicate SourceRowId"))

--- a/src/Grace.Types.Tests/Annotation.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Annotation.Types.Tests.fs
@@ -1,9 +1,11 @@
 namespace Grace.Types.Tests
 
+open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Shared.Parameters.Branch
 open Grace.Types.Annotation
 open Grace.Types.Common
+open MessagePack
 open NUnit.Framework
 open System
 open System.Text.Json
@@ -48,7 +50,7 @@ type AnnotationContractTests() =
                 {
                     SourceReferenceId = "source-reference-1"
                     ReferenceId = sourceReferenceId
-                    ReferenceType = ReferenceType.Commit
+                    ReferenceType = "Commit"
                     ReferenceText = "previous commit"
                     DirectoryVersionId = directoryVersionId
                     CreatedAt = None
@@ -107,6 +109,14 @@ type AnnotationContractTests() =
         )
 
         let roundTrip = deserialize<BranchAnnotationDto> json
+        Assert.That(roundTrip, Is.EqualTo(annotation))
+
+    [<Test>]
+    member _.AnnotationDtoMessagePackRoundTripsThroughGraceOptions() =
+        let annotation = validAnnotation true
+        let bytes = MessagePackSerializer.Serialize(annotation, Constants.messagePackSerializerOptions)
+        let roundTrip = MessagePackSerializer.Deserialize<BranchAnnotationDto>(bytes, Constants.messagePackSerializerOptions)
+
         Assert.That(roundTrip, Is.EqualTo(annotation))
 
     [<Test>]
@@ -203,6 +213,21 @@ type AnnotationContractTests() =
         assertOk (validate annotation)
 
     [<Test>]
+    member _.AnnotationValidationRejectsResolvedSpansWithoutSourceRows() =
+        let annotation =
+            { validAnnotation true with
+                Boundaries = Array.empty
+                Spans =
+                    [|
+                        { SpanId = "span-1"; BoundaryId = String.Empty; LineRange = { StartLine = 10; EndLine = 11 }; SourceRowIds = Array.empty }
+                    |]
+            }
+
+        match validate annotation with
+        | Ok () -> Assert.Fail("Resolved spans without source rows should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("must reference at least one SourceRow"))
+
+    [<Test>]
     member _.AnnotationValidationRejectsDuplicateSourceRows() =
         let annotation = validAnnotation true
 
@@ -274,6 +299,33 @@ type AnnotationContractTests() =
 
         match validate annotation with
         | Ok () -> Assert.Fail("Spans outside the requested line range should be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("inside RequestedLineRange"))
+
+    [<TestCase("line")>]
+    [<TestCase("boundary")>]
+    member _.AnnotationValidationRejectsTargetRowsOutsideRequestedRange(targetKind: string) =
+        let annotation = validAnnotation true
+
+        let outsideRequestedRange =
+            match targetKind with
+            | "line" ->
+                { annotation with
+                    Lines =
+                        [|
+                            { annotation.Lines[0] with LineNumber = 13 }
+                        |]
+                }
+            | "boundary" ->
+                { annotation with
+                    Boundaries =
+                        [|
+                            { annotation.Boundaries[0] with LineRange = { StartLine = 9; EndLine = 12 } }
+                        |]
+                }
+            | unexpected -> failwith $"Unknown target kind: {unexpected}"
+
+        match validate outsideRequestedRange with
+        | Ok () -> Assert.Fail($"{targetKind} outside the requested line range should be rejected.")
         | Error errors -> Assert.That(errors, Has.Some.Contains("inside RequestedLineRange"))
 
     [<Test>]

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="EventMetadata.Types.Tests.fs" />
     <Compile Include="Automation.Types.Tests.fs" />
     <Compile Include="Reference.Types.Tests.fs" />
+    <Compile Include="Annotation.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />
     <Compile Include="Webhooks.Types.Tests.fs" />

--- a/src/Grace.Types/Annotation.Types.fs
+++ b/src/Grace.Types/Annotation.Types.fs
@@ -1,6 +1,7 @@
 namespace Grace.Types
 
 open Grace.Types.Common
+open Grace.Shared.Utilities
 open global.MessagePack
 open global.NodaTime
 open Orleans
@@ -21,6 +22,10 @@ module Annotation =
     type AnnotationSourceReferenceId = string
 
     type AnnotationSourceRowId = string
+
+    type ReferenceTypeName = string
+
+    let private referenceTypeName (referenceType: ReferenceType) = getDiscriminatedUnionCaseName referenceType
 
     [<MessagePackObject; GenerateSerializer>]
     type AnnotationLineRange =
@@ -52,7 +57,7 @@ module Annotation =
             [<Key(1)>]
             ReferenceId: ReferenceId
             [<Key(2)>]
-            ReferenceType: ReferenceType
+            ReferenceType: ReferenceTypeName
             [<Key(3)>]
             ReferenceText: ReferenceText
             [<Key(4)>]
@@ -67,7 +72,7 @@ module Annotation =
             {
                 SourceReferenceId = String.Empty
                 ReferenceId = ReferenceId.Empty
-                ReferenceType = ReferenceType.Commit
+                ReferenceType = referenceTypeName ReferenceType.Commit
                 ReferenceText = String.Empty
                 DirectoryVersionId = DirectoryVersionId.Empty
                 CreatedAt = None
@@ -129,7 +134,7 @@ module Annotation =
             [<Key(3)>]
             Path: RelativePath
             [<Key(4)>]
-            ReferenceTypeFilter: ReferenceType array
+            ReferenceTypeFilter: ReferenceTypeName array
             [<Key(5)>]
             MaxReferences: int
             [<Key(6)>]
@@ -180,7 +185,7 @@ module Annotation =
                 RequestedLineRange = requestedLineRange
                 TargetReferenceId = targetReferenceId
                 Path = path
-                ReferenceTypeFilter = referenceTypeFilter
+                ReferenceTypeFilter = referenceTypeFilter |> Array.map referenceTypeName
                 MaxReferences = maxReferences
                 IncludeLineText = includeLineText
                 Lines = if includeLineText then lines else Array.empty
@@ -274,6 +279,14 @@ module Annotation =
                 |> Seq.map (fun sourceRowId -> $"Span '{span.SpanId}' references missing SourceRow '{sourceRowId}'."))
             |> Seq.toList
 
+        let resolvedSpanSourceRowErrors =
+            annotation.Spans
+            |> Seq.filter (fun span ->
+                String.IsNullOrWhiteSpace span.BoundaryId
+                && span.SourceRowIds.Length = 0)
+            |> Seq.map (fun span -> $"Span '{span.SpanId}' without a BoundaryId must reference at least one SourceRow.")
+            |> Seq.toList
+
         let duplicateErrors =
             []
             |> appendIf
@@ -348,10 +361,21 @@ module Annotation =
             ]
 
         let requestedRangeErrors =
-            annotation.Spans
-            |> Seq.filter (fun span -> not (containsLineRange annotation.RequestedLineRange span.LineRange))
-            |> Seq.map (fun span -> $"Span '{span.SpanId}' LineRange must stay inside RequestedLineRange.")
-            |> Seq.toList
+            [
+                for line in annotation.Lines do
+                    let lineRange = { StartLine = line.LineNumber; EndLine = line.LineNumber }
+
+                    if not (containsLineRange annotation.RequestedLineRange lineRange) then
+                        $"Line '{line.LineNumber}' must stay inside RequestedLineRange."
+
+                for boundary in annotation.Boundaries do
+                    if not (containsLineRange annotation.RequestedLineRange boundary.LineRange) then
+                        $"Boundary '{boundary.BoundaryId}' LineRange must stay inside RequestedLineRange."
+
+                for span in annotation.Spans do
+                    if not (containsLineRange annotation.RequestedLineRange span.LineRange) then
+                        $"Span '{span.SpanId}' LineRange must stay inside RequestedLineRange."
+            ]
 
         let sourceRowPathErrors =
             annotation.SourceRows
@@ -375,6 +399,7 @@ module Annotation =
                 yield! boundarySourceRowErrors
                 yield! spanBoundaryErrors
                 yield! spanSourceRowErrors
+                yield! resolvedSpanSourceRowErrors
                 yield! requestedRangeErrors
                 yield! sourceRowPathErrors
                 yield! sourceReferenceBudgetErrors

--- a/src/Grace.Types/Annotation.Types.fs
+++ b/src/Grace.Types/Annotation.Types.fs
@@ -1,0 +1,337 @@
+namespace Grace.Types
+
+open Grace.Types.Common
+open global.MessagePack
+open global.NodaTime
+open Orleans
+open System
+
+module Annotation =
+
+    [<Literal>]
+    let DefaultMaxReferences = 1000
+
+    [<Literal>]
+    let MaximumMaxReferences = 5000
+
+    type AnnotationBoundaryId = string
+
+    type AnnotationSpanId = string
+
+    type AnnotationSourceReferenceId = string
+
+    type AnnotationSourceRowId = string
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationLineRange =
+        {
+            [<Key(0)>]
+            StartLine: int
+            [<Key(1)>]
+            EndLine: int
+        }
+
+        static member Default = { StartLine = 1; EndLine = 1 }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationLine =
+        {
+            [<Key(0)>]
+            LineNumber: int
+            [<Key(1)>]
+            Text: string
+        }
+
+        static member Default = { LineNumber = 1; Text = String.Empty }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationSourceReference =
+        {
+            [<Key(0)>]
+            SourceReferenceId: AnnotationSourceReferenceId
+            [<Key(1)>]
+            ReferenceId: ReferenceId
+            [<Key(2)>]
+            ReferenceType: ReferenceType
+            [<Key(3)>]
+            ReferenceText: ReferenceText
+            [<Key(4)>]
+            DirectoryVersionId: DirectoryVersionId
+            [<Key(5)>]
+            CreatedAt: Instant option
+        }
+
+        static member Default =
+            {
+                SourceReferenceId = String.Empty
+                ReferenceId = ReferenceId.Empty
+                ReferenceType = ReferenceType.Commit
+                ReferenceText = String.Empty
+                DirectoryVersionId = DirectoryVersionId.Empty
+                CreatedAt = None
+            }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationSourceRow =
+        {
+            [<Key(0)>]
+            SourceRowId: AnnotationSourceRowId
+            [<Key(1)>]
+            SourceReferenceId: AnnotationSourceReferenceId
+            [<Key(2)>]
+            Path: RelativePath
+            [<Key(3)>]
+            LineRange: AnnotationLineRange
+        }
+
+        static member Default = { SourceRowId = String.Empty; SourceReferenceId = String.Empty; Path = String.Empty; LineRange = AnnotationLineRange.Default }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationBoundary =
+        {
+            [<Key(0)>]
+            BoundaryId: AnnotationBoundaryId
+            [<Key(1)>]
+            LineRange: AnnotationLineRange
+            [<Key(2)>]
+            SourceRowIds: AnnotationSourceRowId array
+        }
+
+        static member Default = { BoundaryId = String.Empty; LineRange = AnnotationLineRange.Default; SourceRowIds = Array.empty }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type AnnotationSpan =
+        {
+            [<Key(0)>]
+            SpanId: AnnotationSpanId
+            [<Key(1)>]
+            BoundaryId: AnnotationBoundaryId
+            [<Key(2)>]
+            LineRange: AnnotationLineRange
+            [<Key(3)>]
+            SourceRowIds: AnnotationSourceRowId array
+        }
+
+        static member Default = { SpanId = String.Empty; BoundaryId = String.Empty; LineRange = AnnotationLineRange.Default; SourceRowIds = Array.empty }
+
+    [<MessagePackObject; GenerateSerializer>]
+    type BranchAnnotationDto =
+        {
+            [<Key(0)>]
+            Class: string
+            [<Key(1)>]
+            RequestedLineRange: AnnotationLineRange
+            [<Key(2)>]
+            TargetReferenceId: ReferenceId
+            [<Key(3)>]
+            Path: RelativePath
+            [<Key(4)>]
+            ReferenceTypeFilter: ReferenceType array
+            [<Key(5)>]
+            MaxReferences: int
+            [<Key(6)>]
+            IncludeLineText: bool
+            [<Key(7)>]
+            Lines: AnnotationLine array
+            [<Key(8)>]
+            Boundaries: AnnotationBoundary array
+            [<Key(9)>]
+            Spans: AnnotationSpan array
+            [<Key(10)>]
+            SourceRows: AnnotationSourceRow array
+            [<Key(11)>]
+            SourceReferences: AnnotationSourceReference array
+        }
+
+        static member Default =
+            {
+                Class = nameof BranchAnnotationDto
+                RequestedLineRange = AnnotationLineRange.Default
+                TargetReferenceId = ReferenceId.Empty
+                Path = String.Empty
+                ReferenceTypeFilter = Array.empty
+                MaxReferences = DefaultMaxReferences
+                IncludeLineText = false
+                Lines = Array.empty
+                Boundaries = Array.empty
+                Spans = Array.empty
+                SourceRows = Array.empty
+                SourceReferences = Array.empty
+            }
+
+        static member Create
+            (
+                requestedLineRange: AnnotationLineRange,
+                targetReferenceId: ReferenceId,
+                path: RelativePath,
+                referenceTypeFilter: ReferenceType array,
+                maxReferences: int,
+                includeLineText: bool,
+                lines: AnnotationLine array,
+                boundaries: AnnotationBoundary array,
+                spans: AnnotationSpan array,
+                sourceRows: AnnotationSourceRow array,
+                sourceReferences: AnnotationSourceReference array
+            ) =
+            { BranchAnnotationDto.Default with
+                RequestedLineRange = requestedLineRange
+                TargetReferenceId = targetReferenceId
+                Path = path
+                ReferenceTypeFilter = referenceTypeFilter
+                MaxReferences = maxReferences
+                IncludeLineText = includeLineText
+                Lines = if includeLineText then lines else Array.empty
+                Boundaries = boundaries
+                Spans = spans
+                SourceRows = sourceRows
+                SourceReferences = sourceReferences
+            }
+
+    let private appendIf condition error errors = if condition then error :: errors else errors
+
+    let validateLineRange (lineRange: AnnotationLineRange) =
+        []
+        |> appendIf (lineRange.StartLine < 1) "StartLine must be greater than or equal to 1."
+        |> appendIf (lineRange.EndLine < 1) "EndLine must be greater than or equal to 1."
+        |> appendIf (lineRange.EndLine < lineRange.StartLine) "EndLine must be greater than or equal to StartLine."
+        |> function
+            | [] -> Ok()
+            | errors -> Error(List.rev errors)
+
+    let validateMaxReferences maxReferences =
+        []
+        |> appendIf (maxReferences < 1) "MaxReferences must be greater than or equal to 1."
+        |> appendIf (maxReferences > MaximumMaxReferences) $"MaxReferences must be less than or equal to {MaximumMaxReferences}."
+        |> function
+            | [] -> Ok()
+            | errors -> Error(List.rev errors)
+
+    let private hasDuplicates values =
+        values
+        |> Seq.filter (String.IsNullOrWhiteSpace >> not)
+        |> Seq.countBy id
+        |> Seq.exists (fun (_, count) -> count > 1)
+
+    let private collectRangeErrors label lineRange =
+        match validateLineRange lineRange with
+        | Ok () -> []
+        | Error errors ->
+            errors
+            |> List.map (fun error -> $"{label}: {error}")
+
+    let validateLinkIntegrity (annotation: BranchAnnotationDto) =
+        let sourceReferenceIds =
+            annotation.SourceReferences
+            |> Seq.map (fun sourceReference -> sourceReference.SourceReferenceId)
+            |> Set.ofSeq
+
+        let sourceRowIds =
+            annotation.SourceRows
+            |> Seq.map (fun sourceRow -> sourceRow.SourceRowId)
+            |> Set.ofSeq
+
+        let boundaryIds =
+            annotation.Boundaries
+            |> Seq.map (fun boundary -> boundary.BoundaryId)
+            |> Set.ofSeq
+
+        let sourceRowReferenceErrors =
+            annotation.SourceRows
+            |> Seq.filter (fun sourceRow -> not (sourceReferenceIds.Contains sourceRow.SourceReferenceId))
+            |> Seq.map (fun sourceRow -> $"SourceRow '{sourceRow.SourceRowId}' references missing SourceReference '{sourceRow.SourceReferenceId}'.")
+            |> Seq.toList
+
+        let boundarySourceRowErrors =
+            annotation.Boundaries
+            |> Seq.collect (fun boundary ->
+                boundary.SourceRowIds
+                |> Seq.filter (fun sourceRowId -> not (sourceRowIds.Contains sourceRowId))
+                |> Seq.map (fun sourceRowId -> $"Boundary '{boundary.BoundaryId}' references missing SourceRow '{sourceRowId}'."))
+            |> Seq.toList
+
+        let spanBoundaryErrors =
+            annotation.Spans
+            |> Seq.filter (fun span -> not (boundaryIds.Contains span.BoundaryId))
+            |> Seq.map (fun span -> $"Span '{span.SpanId}' references missing Boundary '{span.BoundaryId}'.")
+            |> Seq.toList
+
+        let spanSourceRowErrors =
+            annotation.Spans
+            |> Seq.collect (fun span ->
+                span.SourceRowIds
+                |> Seq.filter (fun sourceRowId -> not (sourceRowIds.Contains sourceRowId))
+                |> Seq.map (fun sourceRowId -> $"Span '{span.SpanId}' references missing SourceRow '{sourceRowId}'."))
+            |> Seq.toList
+
+        let duplicateErrors =
+            []
+            |> appendIf
+                (hasDuplicates (
+                    annotation.SourceReferences
+                    |> Seq.map (fun sourceReference -> sourceReference.SourceReferenceId)
+                ))
+                "SourceReferences must not contain duplicate SourceReferenceId values."
+            |> appendIf
+                (hasDuplicates (
+                    annotation.SourceRows
+                    |> Seq.map (fun sourceRow -> sourceRow.SourceRowId)
+                ))
+                "SourceRows must not contain duplicate SourceRowId values."
+            |> appendIf
+                (hasDuplicates (
+                    annotation.Boundaries
+                    |> Seq.map (fun boundary -> boundary.BoundaryId)
+                ))
+                "Boundaries must not contain duplicate BoundaryId values."
+            |> appendIf
+                (hasDuplicates (
+                    annotation.Spans
+                    |> Seq.map (fun span -> span.SpanId)
+                ))
+                "Spans must not contain duplicate SpanId values."
+            |> List.rev
+
+        let rangeErrors =
+            [
+                yield! collectRangeErrors "RequestedLineRange" annotation.RequestedLineRange
+
+                for line in annotation.Lines do
+                    yield! collectRangeErrors $"Line '{line.LineNumber}'" { StartLine = line.LineNumber; EndLine = line.LineNumber }
+
+                for sourceRow in annotation.SourceRows do
+                    yield! collectRangeErrors $"SourceRow '{sourceRow.SourceRowId}'" sourceRow.LineRange
+
+                for boundary in annotation.Boundaries do
+                    yield! collectRangeErrors $"Boundary '{boundary.BoundaryId}'" boundary.LineRange
+
+                for span in annotation.Spans do
+                    yield! collectRangeErrors $"Span '{span.SpanId}'" span.LineRange
+            ]
+
+        let errors =
+            [
+                yield! rangeErrors
+                yield! duplicateErrors
+                yield! sourceRowReferenceErrors
+                yield! boundarySourceRowErrors
+                yield! spanBoundaryErrors
+                yield! spanSourceRowErrors
+            ]
+
+        match errors with
+        | [] -> Ok()
+        | errors -> Error errors
+
+    let validate (annotation: BranchAnnotationDto) =
+        [
+            match validateMaxReferences annotation.MaxReferences with
+            | Ok () -> ()
+            | Error errors -> yield! errors
+
+            match validateLinkIntegrity annotation with
+            | Ok () -> ()
+            | Error errors -> yield! errors
+        ]
+        |> function
+            | [] -> Ok()
+            | errors -> Error errors

--- a/src/Grace.Types/Annotation.Types.fs
+++ b/src/Grace.Types/Annotation.Types.fs
@@ -59,6 +59,8 @@ module Annotation =
             DirectoryVersionId: DirectoryVersionId
             [<Key(5)>]
             CreatedAt: Instant option
+            [<Key(6)>]
+            CreatedBy: string option
         }
 
         static member Default =
@@ -69,6 +71,7 @@ module Annotation =
                 ReferenceText = String.Empty
                 DirectoryVersionId = DirectoryVersionId.Empty
                 CreatedAt = None
+                CreatedBy = None
             }
 
     [<MessagePackObject; GenerateSerializer>]
@@ -212,12 +215,18 @@ module Annotation =
         |> Seq.countBy id
         |> Seq.exists (fun (_, count) -> count > 1)
 
+    let private hasBlanks values = values |> Seq.exists String.IsNullOrWhiteSpace
+
     let private collectRangeErrors label lineRange =
         match validateLineRange lineRange with
         | Ok () -> []
         | Error errors ->
             errors
             |> List.map (fun error -> $"{label}: {error}")
+
+    let private containsLineRange (outer: AnnotationLineRange) (inner: AnnotationLineRange) =
+        inner.StartLine >= outer.StartLine
+        && inner.EndLine <= outer.EndLine
 
     let validateLinkIntegrity (annotation: BranchAnnotationDto) =
         let sourceReferenceIds =
@@ -251,7 +260,9 @@ module Annotation =
 
         let spanBoundaryErrors =
             annotation.Spans
-            |> Seq.filter (fun span -> not (boundaryIds.Contains span.BoundaryId))
+            |> Seq.filter (fun span ->
+                not (String.IsNullOrWhiteSpace span.BoundaryId)
+                && not (boundaryIds.Contains span.BoundaryId))
             |> Seq.map (fun span -> $"Span '{span.SpanId}' references missing Boundary '{span.BoundaryId}'.")
             |> Seq.toList
 
@@ -291,6 +302,34 @@ module Annotation =
                 "Spans must not contain duplicate SpanId values."
             |> List.rev
 
+        let blankIdentifierErrors =
+            []
+            |> appendIf
+                (hasBlanks (
+                    annotation.SourceReferences
+                    |> Seq.map (fun sourceReference -> sourceReference.SourceReferenceId)
+                ))
+                "SourceReferences must not contain blank SourceReferenceId values."
+            |> appendIf
+                (hasBlanks (
+                    annotation.SourceRows
+                    |> Seq.map (fun sourceRow -> sourceRow.SourceRowId)
+                ))
+                "SourceRows must not contain blank SourceRowId values."
+            |> appendIf
+                (hasBlanks (
+                    annotation.Boundaries
+                    |> Seq.map (fun boundary -> boundary.BoundaryId)
+                ))
+                "Boundaries must not contain blank BoundaryId values."
+            |> appendIf
+                (hasBlanks (
+                    annotation.Spans
+                    |> Seq.map (fun span -> span.SpanId)
+                ))
+                "Spans must not contain blank SpanId values."
+            |> List.rev
+
         let rangeErrors =
             [
                 yield! collectRangeErrors "RequestedLineRange" annotation.RequestedLineRange
@@ -308,14 +347,37 @@ module Annotation =
                     yield! collectRangeErrors $"Span '{span.SpanId}'" span.LineRange
             ]
 
+        let requestedRangeErrors =
+            annotation.Spans
+            |> Seq.filter (fun span -> not (containsLineRange annotation.RequestedLineRange span.LineRange))
+            |> Seq.map (fun span -> $"Span '{span.SpanId}' LineRange must stay inside RequestedLineRange.")
+            |> Seq.toList
+
+        let sourceRowPathErrors =
+            annotation.SourceRows
+            |> Seq.filter (fun sourceRow -> not (String.Equals(sourceRow.Path, annotation.Path, StringComparison.Ordinal)))
+            |> Seq.map (fun sourceRow -> $"SourceRow '{sourceRow.SourceRowId}' Path must match annotation Path '{annotation.Path}'.")
+            |> Seq.toList
+
+        let sourceReferenceBudgetErrors =
+            []
+            |> appendIf
+                (annotation.SourceReferences.Length > annotation.MaxReferences)
+                $"SourceReferences must contain no more than MaxReferences ({annotation.MaxReferences}) entries."
+            |> List.rev
+
         let errors =
             [
                 yield! rangeErrors
                 yield! duplicateErrors
+                yield! blankIdentifierErrors
                 yield! sourceRowReferenceErrors
                 yield! boundarySourceRowErrors
                 yield! spanBoundaryErrors
                 yield! spanSourceRowErrors
+                yield! requestedRangeErrors
+                yield! sourceRowPathErrors
+                yield! sourceReferenceBudgetErrors
             ]
 
         match errors with

--- a/src/Grace.Types/Annotation.Types.fs
+++ b/src/Grace.Types/Annotation.Types.fs
@@ -27,6 +27,8 @@ module Annotation =
 
     let private referenceTypeName (referenceType: ReferenceType) = getDiscriminatedUnionCaseName referenceType
 
+    let private referenceTypeNames = listCases<ReferenceType> () |> Set.ofArray
+
     [<MessagePackObject; GenerateSerializer>]
     type AnnotationLineRange =
         {
@@ -214,6 +216,8 @@ module Annotation =
             | [] -> Ok()
             | errors -> Error(List.rev errors)
 
+    let private isUnknownReferenceTypeName referenceTypeName = not (referenceTypeNames.Contains referenceTypeName)
+
     let private hasDuplicates values =
         values
         |> Seq.filter (String.IsNullOrWhiteSpace >> not)
@@ -390,6 +394,25 @@ module Annotation =
                 $"SourceReferences must contain no more than MaxReferences ({annotation.MaxReferences}) entries."
             |> List.rev
 
+        let lineTextErrors =
+            []
+            |> appendIf
+                (not annotation.IncludeLineText
+                 && annotation.Lines.Length > 0)
+                "Lines must be empty when IncludeLineText is false."
+            |> List.rev
+
+        let referenceTypeErrors =
+            [
+                for referenceTypeName in annotation.ReferenceTypeFilter do
+                    if isUnknownReferenceTypeName referenceTypeName then
+                        $"ReferenceTypeFilter contains unknown ReferenceType '{referenceTypeName}'."
+
+                for sourceReference in annotation.SourceReferences do
+                    if isUnknownReferenceTypeName sourceReference.ReferenceType then
+                        $"SourceReference '{sourceReference.SourceReferenceId}' contains unknown ReferenceType '{sourceReference.ReferenceType}'."
+            ]
+
         let errors =
             [
                 yield! rangeErrors
@@ -403,6 +426,8 @@ module Annotation =
                 yield! requestedRangeErrors
                 yield! sourceRowPathErrors
                 yield! sourceReferenceBudgetErrors
+                yield! lineTextErrors
+                yield! referenceTypeErrors
             ]
 
         match errors with

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -28,6 +28,7 @@
         <Compile Include="Organization.Types.fs" />
         <Compile Include="Repository.Types.fs" />
         <Compile Include="Reference.Types.fs" />
+        <Compile Include="Annotation.Types.fs" />
         <Compile Include="Branch.Types.fs" />
         
         <Compile Include="PromotionSet.Types.fs" />


### PR DESCRIPTION
## Summary

- Defines V1 branch annotation DTO contracts for line ranges, spans, boundaries, line/source rows, and source references.
- Adds `/branch/annotate` parameter contract with max-reference defaults and bounds.
- Adds focused contract tests for serialization shape, range/budget validation, line-text omission, and link integrity.

## Issue Links

Part of #313
Related to #315

This PR targets the epic integration branch, so it intentionally uses non-closing issue wording. The sub-issue will be closed manually after merge to `epic/313-branch-annotate-v1`.

## Touched Paths

- `src/Grace.Types/Annotation.Types.fs`
- `src/Grace.Types/Grace.Types.fsproj`
- `src/Grace.Shared/Parameters/Branch.Parameters.fs`
- `src/Grace.Types.Tests/Annotation.Types.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

Worker validation on `3421b63f35f142724a28cb658a43e462c5cd6194`:

- `dotnet tool run fantomas src\Grace.Types\Annotation.Types.fs src\Grace.Shared\Parameters\Branch.Parameters.fs src\Grace.Types.Tests\Annotation.Types.Tests.fs`: passed; final run reported files unchanged.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Build succeeded with `0` warnings and `0` errors. Fast tests passed: Authorization `37`, Types `80`, Server.Unit `440`, CLI `380` passed / `1` skipped.
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD`: passed.

OpenAPI/generated freshness was not run because the write set stayed inside `Grace.Types`, `Grace.Shared/Parameters`, and `Grace.Types.Tests`; no server route, OpenAPI, SDK generation, or generated artifact path was edited.

`pwsh ./scripts/validate.ps1 -Full` was skipped because this contract/parameter slice does not affect Aspire, emulators, storage, Service Bus, Redis, deployment/runtime behavior, or cross-service integration.

## Review Status

- Implementation worker: Curie, fresh GPT-5.5 Medium worker.
- Freshness worker: Raman, fresh GPT-5.5 Medium worker.
- First bot-fix worker: Laplace, fresh GPT-5.5 Medium worker.
- Second bot-fix worker: Lorentz, fresh GPT-5.5 Medium fix worker.
- Third bot-fix worker: Huygens, fresh GPT-5.5 Medium fix worker.
- Current base commit: `d369d4ab27944ac06b7a442ba91dc1a79b91bf75` after rebasing the epic branch onto `origin/main` commit `766b97b`.
- Current head commit after third fix round: `64baa10ceaba993841184f7e9557a7f1fab6d664`.
- Local validation on `64baa10`: targeted Fantomas passed; focused `AnnotationContractTests` passed 26/26; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check origin/epic/313-branch-annotate-v1...HEAD` passed.
- Codex Code Review Bot reviewed `3f93ff71f9` at 2026-06-09 10:00 UTC and reported two P2 findings.
- Huygens fixed both P2 findings in `64baa10ceaba993841184f7e9557a7f1fab6d664`:
  - P2: Reject line text when not requested: fixed, replied, and resolved in thread `PRRT_kwDOILVrb86IG1Tq`.
  - P2: Validate string reference-type names: fixed, replied, and resolved in thread `PRRT_kwDOILVrb86IG1Tv`.
- Prior bot findings were fixed, replied to, and resolved.
- Waiting on: next Codex Code Review Bot pass on the new head commit.
## Docs Impact

No broad user-facing docs were expected for this contract slice. Broad branch annotation documentation remains in #322.

## Residual Risk

Moderate-low. This establishes public contract shapes that later S3-S8 slices depend on; review should pay close attention to DTO naming, validation boundaries, and whether generated/API schema freshness is required earlier than planned.





