### PR TITLE
[Branch annotate V1 S4] Materialize server text content

### DIFF
--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -1,0 +1,164 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+[<Parallelizable(ParallelScope.All)>]
+type AnnotationMaterializationServerTests() =
+
+    let correlationId = "corr-annotation-materialization"
+
+    let sha256Hex (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let textBytes (text: string) = Encoding.UTF8.GetBytes text
+
+    let fileVersion relativePath isBinary (bytes: byte array) = FileVersion.Create relativePath (sha256Hex bytes) String.Empty isBinary (int64 bytes.Length)
+
+    let readerFrom (objects: IDictionary<string, byte array>) : AnnotationMaterialization.ObjectPayloadReader =
+        fun objectKey correlationId _ ->
+            task {
+                match objects.TryGetValue objectKey with
+                | true, payload -> return Ok payload
+                | false, _ -> return Error(GraceError.Create $"missing object {objectKey}" correlationId)
+            }
+
+    let expectOk result =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected materialization to succeed, got {error.Error}.")
+            Unchecked.defaultof<AnnotationMaterialization.MaterializedTextContent>
+
+    let expectErrorContains expected result =
+        match result with
+        | Ok _ -> Assert.Fail("Expected materialization to fail.")
+        | Error error -> Assert.That(error.Error, Does.Contain(expected))
+
+    let encodeBlock bytes =
+        match ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L bytes ] with
+        | Ok block -> block
+        | Error error ->
+            Assert.Fail($"Expected test ContentBlock to encode, got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    let manifestFor (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex bytes),
+                int64 bytes.Length,
+                [
+                    ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+                ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let manifestFile relativePath bytes =
+        let block = encodeBlock bytes
+        let manifest = manifestFor bytes block
+        let fileVersion = fileVersion relativePath false bytes
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+        fileVersion, block
+
+    let materialize reader fileVersion =
+        AnnotationMaterialization.materializeTextWithObjectReader reader fileVersion correlationId CancellationToken.None
+        |> fun task -> task.GetAwaiter().GetResult()
+
+    [<Test>]
+    member _.WholeFileContentMaterializesExactUtf8Text() =
+        let bytes = textBytes "line one\nline two\n"
+        let target = fileVersion "/src/File.fs" false bytes
+        let objectKey = StorageKeys.wholeFileContentObjectKey target
+        let objects = Dictionary<string, byte array>()
+        objects[objectKey] <- bytes
+
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("line one\nline two\n"))
+        Assert.That(result.Bytes = bytes, Is.True)
+
+    [<Test>]
+    member _.ManifestBackedContentMaterializesExactUtf8Text() =
+        let bytes = textBytes "manifest line one\nmanifest line two\n"
+        let target, block = manifestFile "/src/Large.fs" bytes
+        let objects = Dictionary<string, byte array>()
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("manifest line one\nmanifest line two\n"))
+        Assert.That(result.Bytes = bytes, Is.True)
+
+    [<Test>]
+    member _.BinaryTargetIsRejectedBeforeStorageRead() =
+        let bytes = textBytes "binary flag wins"
+        let target = fileVersion "/src/Binary.dat" true bytes
+        let reader _ _ _ = task { return Error(GraceError.Create "reader should not be called" correlationId) }
+
+        materialize reader target
+        |> expectErrorContains "is binary"
+
+    [<Test>]
+    member _.UndecodableUtf8TargetIsRejected() =
+        let bytes = [| 0xffuy; 0xfeuy; 0xfduy |]
+        let target = fileVersion "/src/Invalid.txt" false bytes
+        let objects = Dictionary<string, byte array>()
+        objects[StorageKeys.wholeFileContentObjectKey target] <- bytes
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "not valid UTF-8"
+
+    [<Test>]
+    member _.TooLargeTargetIsRejectedBeforeStorageRead() =
+        let target =
+            FileVersion.Create
+                "/src/Huge.txt"
+                String.Empty
+                String.Empty
+                false
+                (AnnotationMaterialization.MaxMaterializedTextBytes
+                 + 1L)
+
+        let reader _ _ _ = task { return Error(GraceError.Create "reader should not be called" correlationId) }
+
+        materialize reader target
+        |> expectErrorContains "too large"
+
+    [<Test>]
+    member _.MissingOrUnreadableContentIsReturnedAsMaterializationError() =
+        let bytes = textBytes "missing"
+        let target = fileVersion "/src/Missing.txt" false bytes
+        let objects = Dictionary<string, byte array>()
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "missing object"
+
+    [<Test>]
+    member _.InvalidManifestReconstructionIsRejectedClearly() =
+        let bytes = textBytes "manifest payload"
+        let target, block = manifestFile "/src/Manifest.fs" bytes
+        let objects = Dictionary<string, byte array>()
+        let corrupted = Array.copy block.Payload
+        corrupted[0] <- corrupted[0] ^^^ 0xffuy
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- corrupted
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "Invalid manifest reconstruction"

--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -7,6 +7,8 @@ open Grace.Types.Common
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.IO
+open System.IO.Compression
 open System.Security.Cryptography
 open System.Text
 open System.Threading
@@ -23,6 +25,13 @@ type AnnotationMaterializationServerTests() =
         |> fun value -> value.ToLowerInvariant()
 
     let textBytes (text: string) = Encoding.UTF8.GetBytes text
+
+    let gzipBytes (bytes: byte array) =
+        use compressed = new MemoryStream()
+        use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
+        gzipStream.Write(bytes, 0, bytes.Length)
+        gzipStream.Dispose()
+        compressed.ToArray()
 
     let fileVersion relativePath isBinary (bytes: byte array) = FileVersion.Create relativePath (sha256Hex bytes) String.Empty isBinary (int64 bytes.Length)
 
@@ -91,6 +100,21 @@ type AnnotationMaterializationServerTests() =
             |> expectOk
 
         Assert.That(result.Text, Is.EqualTo("line one\nline two\n"))
+        Assert.That(result.Bytes = bytes, Is.True)
+
+    [<Test>]
+    member _.WholeFileContentMaterializesGzipCompressedUtf8Text() =
+        let bytes = textBytes "gzip line one\ngzip line two\n"
+        let target = fileVersion "/src/Compressed.fs" false bytes
+        let objectKey = StorageKeys.wholeFileContentObjectKey target
+        let objects = Dictionary<string, byte array>()
+        objects[objectKey] <- gzipBytes bytes
+
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("gzip line one\ngzip line two\n"))
         Assert.That(result.Bytes = bytes, Is.True)
 
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="StorageAuthorizationResources.Unit.Tests.fs" />
     <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
+    <Compile Include="AnnotationMaterialization.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -1,0 +1,244 @@
+namespace Grace.Server
+
+open Azure
+open Grace.Actors.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.Repository
+open System
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+module internal AnnotationMaterialization =
+
+    [<Literal>]
+    let MaxMaterializedTextBytes = 10L * 1024L * 1024L
+
+    [<Literal>]
+    let private MaxContentBlockPayloadBytes = MaxMaterializedTextBytes + 1024L * 1024L
+
+    type MaterializedTextContent = { FileVersion: FileVersion; Bytes: byte array; Text: string }
+
+    type ObjectPayloadReader = string -> CorrelationId -> CancellationToken -> Task<Result<byte array, GraceError>>
+
+    let private error correlationId message = GraceError.Create message correlationId
+
+    let private copyBytes (bytes: byte array) =
+        let copy = Array.zeroCreate<byte> bytes.Length
+        Array.Copy(bytes, copy, bytes.Length)
+        copy
+
+    let private sha256Hex (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let private validateFileVersionShape (fileVersion: FileVersion) correlationId =
+        if isNull (box fileVersion) then
+            Error(error correlationId "Annotation target FileVersion is required.")
+        elif fileVersion.IsBinary then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' is binary and cannot be materialized as text.")
+        elif fileVersion.Size < 0L then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has an invalid negative size.")
+        elif fileVersion.Size > MaxMaterializedTextBytes then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' is too large to materialize as text. Size {fileVersion.Size} bytes exceeds the {MaxMaterializedTextBytes} byte limit."
+            )
+        elif isNull (box fileVersion.ContentReference) then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has no ContentReference.")
+        else
+            Ok()
+
+    let private validateExactFileBytes (fileVersion: FileVersion) (bytes: byte array) correlationId =
+        if isNull bytes then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' content reader returned null bytes.")
+        elif int64 bytes.Length <> fileVersion.Size then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' materialized {bytes.Length} bytes, but FileVersion.Size is {fileVersion.Size} bytes."
+            )
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Sha256Hash)
+            && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
+        then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
+        else
+            Ok(copyBytes bytes)
+
+    let private decodeUtf8Text (fileVersion: FileVersion) (bytes: byte array) correlationId =
+        if int64 bytes.Length > MaxMaterializedTextBytes then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' decoded text payload is too large. Materialized {bytes.Length} bytes exceeds the {MaxMaterializedTextBytes} byte limit."
+            )
+        else
+            try
+                let strictUtf8 = UTF8Encoding(encoderShouldEmitUTF8Identifier = false, throwOnInvalidBytes = true)
+                Ok(strictUtf8.GetString bytes)
+            with
+            | :? DecoderFallbackException as ex ->
+                Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' is not valid UTF-8 text: {ex.Message}")
+
+    let private describeManifestValidationError validationError = $"Invalid manifest reconstruction: {validationError}."
+
+    let private manifestPayloads (manifest: FileManifest) (readObjectPayload: ObjectPayloadReader) correlationId (cancellationToken: CancellationToken) =
+        task {
+            let payloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
+
+            let blockAddresses =
+                if isNull (box manifest) || isNull manifest.Blocks then
+                    Array.empty
+                else
+                    manifest.Blocks
+                    |> Seq.map (fun block -> if isNull (box block) then String.Empty else block.Address)
+                    |> Seq.distinct
+                    |> Seq.toArray
+
+            let mutable error = None
+            let mutable index = 0
+
+            while index < blockAddresses.Length
+                  && Option.isNone error do
+                let address = blockAddresses[index]
+                let objectKey = StorageKeys.contentBlockObjectKey address
+
+                match! readObjectPayload objectKey correlationId cancellationToken with
+                | Ok payload -> payloads.Add(ManifestValidation.createBlockPayload address payload)
+                | Error readError -> error <- Some readError
+
+                index <- index + 1
+
+            match error with
+            | Some error -> return Error error
+            | None -> return Ok(payloads.ToArray())
+        }
+
+    let private materializeManifestBytes
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (readObjectPayload: ObjectPayloadReader)
+        correlationId
+        cancellationToken
+        =
+        task {
+            if isNull (box manifest) then
+                return Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' FileManifest ContentReference is missing its manifest.")
+            elif manifest.Size <> fileVersion.Size then
+                return
+                    Error(
+                        error
+                            correlationId
+                            $"Annotation target '{fileVersion.RelativePath}' FileManifest.Size {manifest.Size} does not match FileVersion.Size {fileVersion.Size}."
+                    )
+            elif manifest.Size > MaxMaterializedTextBytes then
+                return
+                    Error(
+                        error
+                            correlationId
+                            $"Annotation target '{fileVersion.RelativePath}' is too large to materialize as text. FileManifest.Size {manifest.Size} bytes exceeds the {MaxMaterializedTextBytes} byte limit."
+                    )
+            else
+                match! manifestPayloads manifest readObjectPayload correlationId cancellationToken with
+                | Error readError -> return Error readError
+                | Ok payloads ->
+                    match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
+                    | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+                    | Error validationError ->
+                        return Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}")
+        }
+
+    let private materializeWholeFileBytes (fileVersion: FileVersion) (readObjectPayload: ObjectPayloadReader) correlationId cancellationToken =
+        task {
+            let objectKey = StorageKeys.wholeFileContentObjectKey fileVersion
+
+            match! readObjectPayload objectKey correlationId cancellationToken with
+            | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+            | Error readError -> return Error readError
+        }
+
+    let materializeTextWithObjectReader
+        (readObjectPayload: ObjectPayloadReader)
+        (fileVersion: FileVersion)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            match validateFileVersionShape fileVersion correlationId with
+            | Error validationError -> return Error validationError
+            | Ok () ->
+                let! bytesResult =
+                    match fileVersion.ContentReference.ReferenceType with
+                    | FileContentReferenceType.WholeFileContent -> materializeWholeFileBytes fileVersion readObjectPayload correlationId cancellationToken
+                    | FileContentReferenceType.FileManifest ->
+                        match fileVersion.ContentReference.Manifest with
+                        | Some manifest -> materializeManifestBytes fileVersion manifest readObjectPayload correlationId cancellationToken
+                        | None ->
+                            Task.FromResult(
+                                Error(
+                                    error correlationId $"Annotation target '{fileVersion.RelativePath}' FileManifest ContentReference is missing its manifest."
+                                )
+                            )
+                    | unsupported ->
+                        Task.FromResult(
+                            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has unsupported ContentReference type '{unsupported}'.")
+                        )
+
+                match bytesResult with
+                | Error materializationError -> return Error materializationError
+                | Ok bytes ->
+                    match decodeUtf8Text fileVersion bytes correlationId with
+                    | Error decodeError -> return Error decodeError
+                    | Ok text -> return Ok { FileVersion = fileVersion; Bytes = bytes; Text = text }
+        }
+
+    let private azureObjectPayloadReader
+        (repositoryDto: RepositoryDto)
+        (maxPayloadBytes: int64)
+        objectKey
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            match repositoryDto.ObjectStorageProvider with
+            | AzureBlobStorage ->
+                try
+                    let! blobClient = getAzureBlobClient repositoryDto objectKey correlationId
+                    let! properties = blobClient.GetPropertiesAsync(cancellationToken = cancellationToken)
+
+                    if properties.Value.ContentLength > maxPayloadBytes then
+                        return
+                            Error(
+                                error
+                                    correlationId
+                                    $"Annotation content object '{objectKey}' is too large to read. Content length {properties.Value.ContentLength} bytes exceeds the {maxPayloadBytes} byte read limit."
+                            )
+                    else
+                        let! download = blobClient.DownloadContentAsync(cancellationToken)
+                        return Ok(download.Value.Content.ToArray())
+                with
+                | :? RequestFailedException as ex ->
+                    return Error(error correlationId $"Annotation content object '{objectKey}' could not be read from object storage: {ex.Message}")
+            | AWSS3 -> return Error(error correlationId "Annotation content materialization is not implemented for AWS S3 object storage.")
+            | GoogleCloudStorage -> return Error(error correlationId "Annotation content materialization is not implemented for Google Cloud Storage.")
+            | ObjectStorageProvider.Unknown ->
+                return Error(error correlationId "Annotation content materialization cannot use an unknown object storage provider.")
+        }
+
+    let materializeTargetText (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId cancellationToken =
+        let reader (objectKey: string) correlationId cancellationToken =
+            let maxPayloadBytes =
+                if objectKey.StartsWith(StorageKeys.contentBlockObjectKey String.Empty, StringComparison.Ordinal) then
+                    MaxContentBlockPayloadBytes
+                else
+                    MaxMaterializedTextBytes
+
+            azureObjectPayloadReader repositoryDto maxPayloadBytes objectKey correlationId cancellationToken
+
+        materializeTextWithObjectReader reader fileVersion correlationId cancellationToken

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -7,6 +7,8 @@ open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Repository
 open System
+open System.IO
+open System.IO.Compression
 open System.Security.Cryptography
 open System.Text
 open System.Threading
@@ -70,6 +72,33 @@ module internal AnnotationMaterialization =
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
         else
             Ok(copyBytes bytes)
+
+    let private looksLikeGzip (bytes: byte array) =
+        not (isNull bytes)
+        && bytes.Length >= 2
+        && bytes[0] = 0x1fuy
+        && bytes[1] = 0x8buy
+
+    let private decompressGzipWholeFileBytes (fileVersion: FileVersion) (bytes: byte array) correlationId =
+        if looksLikeGzip bytes then
+            try
+                use source = new MemoryStream(bytes, writable = false)
+                use gzipStream = new GZipStream(source, CompressionMode.Decompress, leaveOpen = false)
+                use decompressed = new MemoryStream()
+                let buffer = Array.zeroCreate<byte> 81920
+                let mutable bytesRead = gzipStream.Read(buffer, 0, buffer.Length)
+
+                while bytesRead > 0
+                      && decompressed.Length <= fileVersion.Size do
+                    decompressed.Write(buffer, 0, bytesRead)
+                    bytesRead <- gzipStream.Read(buffer, 0, buffer.Length)
+
+                Ok(decompressed.ToArray())
+            with
+            | :? InvalidDataException as ex ->
+                Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' gzip content could not be decompressed: {ex.Message}")
+        else
+            Ok bytes
 
     let private decodeUtf8Text (fileVersion: FileVersion) (bytes: byte array) correlationId =
         if int64 bytes.Length > MaxMaterializedTextBytes then
@@ -159,7 +188,10 @@ module internal AnnotationMaterialization =
             let objectKey = StorageKeys.wholeFileContentObjectKey fileVersion
 
             match! readObjectPayload objectKey correlationId cancellationToken with
-            | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+            | Ok bytes ->
+                match decompressGzipWholeFileBytes fileVersion bytes correlationId with
+                | Ok decompressedBytes -> return validateExactFileBytes fileVersion decompressedBytes correlationId
+                | Error decompressionError -> return Error decompressionError
             | Error readError -> return Error readError
         }
 
@@ -237,7 +269,7 @@ module internal AnnotationMaterialization =
                 if objectKey.StartsWith(StorageKeys.contentBlockObjectKey String.Empty, StringComparison.Ordinal) then
                     MaxContentBlockPayloadBytes
                 else
-                    MaxMaterializedTextBytes
+                    MaxContentBlockPayloadBytes
 
             azureObjectPayloadReader repositoryDto maxPayloadBytes objectKey correlationId cancellationToken
 

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -81,6 +81,7 @@
 		<Compile Include="Owner.Server.fs" />
 		<Compile Include="Organization.Server.fs" />
 		<Compile Include="Repository.Server.fs" />
+		<Compile Include="AnnotationMaterialization.Server.fs" />
 		<Compile Include="Branch.Server.fs" />
                 
                 <Compile Include="ApprovalPolicy.Server.fs" />


### PR DESCRIPTION
## Summary

- Adds an internal server materialization boundary for annotation target text.
- Supports WholeFileContent and FileManifest-backed content using FileVersion.ContentReference as source of truth.
- Rejects binary, invalid UTF-8, too-large, missing/unreadable, size/hash mismatch, missing manifest, unsupported content reference, and invalid manifest reconstruction failures as hard materialization errors.

## Issue Links

Part of #313
Related to #317

This PR targets the epic integration branch, so it intentionally uses non-closing issue wording. The sub-issue will be closed manually after merge to `epic/313-branch-annotate-v1`.

## Touched Paths

- `src/Grace.Server/AnnotationMaterialization.Server.fs`
- `src/Grace.Server/Grace.Server.fsproj`
- `src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs`
- `src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`

## Validation

Worker validation on `7cea7f7270fd8590081d66806c7f2ab236b0e6f5`:

- `dotnet tool run fantomas C:\Source\Grace-gh-317\src\Grace.Server\AnnotationMaterialization.Server.fs C:\Source\Grace-gh-317\src\Grace.Server.Unit.Tests\AnnotationMaterialization.Server.Tests.fs`: passed; files formatted/unchanged on final run.
- `dotnet build --configuration Release C:\Source\Grace-gh-317\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`: passed with `0` warnings and `0` errors.
- `dotnet test --no-build --configuration Release C:\Source\Grace-gh-317\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~AnnotationMaterializationServerTests"`: passed, `7/7`.
- `pwsh ./scripts/validate.ps1 -Full`: passed. Build succeeded with `0` warnings and `0` errors; Authorization `37/37`, Types `95/95`, Server.Unit `447/447`, CLI `380` passed / `1` skipped, Server integration `168/168`.
- `git diff --check`: passed.

No user-requested or issue-required validation was skipped. The repo validation script's format phase is temporarily disabled, so targeted Fantomas was run before validation.

## Review Status

- Implementation worker: Faraday, fresh GPT-5.5 Medium worker.
- Current head commit before fix round: `7cea7f7270fd8590081d66806c7f2ab236b0e6f5`.
- Fix worker: Euclid, fresh GPT-5.5 Medium fix worker.
- Fix commit: `87b3d211446253aca945d67ad66622a39beef389` (`Handle gzip whole-file annotation text`).
- Codex Code Review Bot finding `PRRT_kwDOILVrb86IHdqM` / `3379922941`: fixed by decompressing gzip WholeFileContent payloads before existing size/hash/UTF-8 validation and adding gzip whole-file regression coverage.
- Fix validation: targeted Fantomas passed; focused Server.Unit build passed; focused `AnnotationMaterializationServerTests` passed `8/8`; `pwsh ./scripts/validate.ps1 -Full` passed; `git diff --check origin/epic/313-branch-annotate-v1...HEAD` passed.
- Bot thread reply/resolution: replied to comment `3380019470` and resolved thread `PRRT_kwDOILVrb86IHdqM`.
- Waiting on: next Codex Code Review Bot pass on `87b3d211446253aca945d67ad66622a39beef389`.
## Docs Impact

No broad docs update expected for this internal server materialization boundary.

## Residual Risk

Moderate. This touches server/storage reconstruction behavior, manifest-backed content, and hard error classification; review should focus on bounded reads, manifest validation, and error semantics.

