### PR TITLE
[Branch annotate V1 S5] Traverse effective history attribution

### DIFF
--- a/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
@@ -879,6 +879,34 @@ type AnnotationLineCoreTests() =
         )
 
     [<Test>]
+    member _.BuildAnnotationIgnoresPrunedDifferentPathAncestorWhenBudgetBounded() =
+        let middleReference = sourceReferenceWithType "source-reference-middle" saveReferenceId "Commit" "middle" saveDirectoryVersionId
+
+        let annotation =
+            buildWithMaxReferences
+                2
+                { StartLine = 1; EndLine = 2 }
+                [|
+                    historyDocumentWithPath oldReference "src/RenamedBeforeBudget.fs" "same\nrenamed"
+                    historyDocument middleReference "same\nmiddle"
+                    historyDocument newReference "same\nnew"
+                |]
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 2 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-middle"))
+                Assert.That(annotation.SourceRows[1].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(2)))
+        )
+
+    [<Test>]
     member _.BuildAnnotationRejectsUnknownTargetReferenceTypeWithoutFilter() =
         let unknownReference = sourceReferenceWithType "source-reference-unknown" targetReferenceId "Unknown" "unknown" newDirectoryVersionId
 

--- a/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
@@ -64,6 +64,17 @@ type AnnotationLineCoreTests() =
     let buildWithReferenceTypes referenceTypes requestedRange history =
         buildAnnotation (requestedRange, targetReferenceId, "src/App.fs", referenceTypes, DefaultMaxReferences, true, history)
 
+    let buildFromTraversal requestedRange traversalResult =
+        buildAnnotationFromEffectiveHistoryTraversal (
+            requestedRange,
+            targetReferenceId,
+            "src/App.fs",
+            [| ReferenceType.Commit |],
+            DefaultMaxReferences,
+            true,
+            traversalResult
+        )
+
     let assertOk result =
         match result with
         | Ok value -> value
@@ -740,6 +751,103 @@ type AnnotationLineCoreTests() =
                 Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
                 Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
                 Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1)))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationPreservesUnauthorizedAncestorBoundaryFromTraversalResult() =
+        let oldDocument = historyDocument oldReference "same"
+        let newDocument = historyDocument newReference "same"
+
+        let traversalResult =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument None false
+                |]
+
+        let annotation =
+            traversalResult
+            |> buildFromTraversal { StartLine = 1; EndLine = 1 }
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 1 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(traversalResult.BoundaryKind, Is.EqualTo(Some "UnauthorizedAncestor"))
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1)))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationPreservesMissingParentBoundaryFromTraversalResult() =
+        let newDocument = historyDocument newReference "same"
+
+        let traversalResult =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                |]
+
+        let annotation =
+            traversalResult
+            |> buildFromTraversal { StartLine = 1; EndLine = 1 }
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 1 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(traversalResult.BoundaryKind, Is.EqualTo(Some "MissingParentReference"))
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1)))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationPreservesBasedOnLoopBoundaryFromTraversalResult() =
+        let oldDocument = historyDocument oldReference "same\nold"
+        let newDocument = historyDocument newReference "same\nnew"
+
+        let traversalResult =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument (Some targetReferenceId) true
+                |]
+
+        let annotation =
+            traversalResult
+            |> buildFromTraversal { StartLine = 1; EndLine = 2 }
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 2 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(traversalResult.BoundaryKind, Is.EqualTo(Some "BasedOnLoopOrRepeatedLink"))
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans, Has.Length.EqualTo(2))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.Spans[1].BoundaryId, Is.Empty)
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-old"))
+                Assert.That(annotation.SourceRows[1].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(2)))
         )
 
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs
@@ -15,9 +15,11 @@ type AnnotationLineCoreTests() =
     let targetReferenceId = newReferenceId
     let mismatchedTargetReferenceId = Guid.Parse("11111111-1111-1111-1111-111111111111")
     let saveReferenceId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    let tagReferenceId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc")
     let oldDirectoryVersionId = Guid.Parse("44444444-4444-4444-4444-444444444444")
     let newDirectoryVersionId = Guid.Parse("55555555-5555-5555-5555-555555555555")
     let saveDirectoryVersionId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    let tagDirectoryVersionId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd")
 
     let bytes (text: string) = Encoding.UTF8.GetBytes(text)
 
@@ -36,12 +38,16 @@ type AnnotationLineCoreTests() =
     let oldReference = sourceReference "source-reference-old" oldReferenceId "old" oldDirectoryVersionId
     let newReference = sourceReference "source-reference-new" newReferenceId "new" newDirectoryVersionId
     let saveReference = sourceReferenceWithType "source-reference-save" saveReferenceId "Save" "save" saveDirectoryVersionId
+    let tagReference = sourceReferenceWithType "source-reference-tag" tagReferenceId "Tag" "tag" tagDirectoryVersionId
 
     let historyDocument sourceReference content = { SourceReference = sourceReference; Path = "src/App.fs"; Content = bytes content }
 
     let historyDocumentWithPath sourceReference path content = { SourceReference = sourceReference; Path = path; Content = bytes content }
 
     let historyDocumentBytes sourceReference content = { SourceReference = sourceReference; Path = "src/App.fs"; Content = content }
+
+    let effectiveHistoryDocument document basedOnReferenceId isAuthorized =
+        { Document = document; BasedOnReferenceId = basedOnReferenceId; IsAuthorized = isAuthorized }
 
     let build requestedRange history =
         buildAnnotation (requestedRange, targetReferenceId, "src/App.fs", [| ReferenceType.Commit |], DefaultMaxReferences, true, history)
@@ -54,6 +60,9 @@ type AnnotationLineCoreTests() =
 
     let buildWithMaxReferences maxReferences requestedRange history =
         buildAnnotation (requestedRange, targetReferenceId, "src/App.fs", [| ReferenceType.Commit |], maxReferences, true, history)
+
+    let buildWithReferenceTypes referenceTypes requestedRange history =
+        buildAnnotation (requestedRange, targetReferenceId, "src/App.fs", referenceTypes, DefaultMaxReferences, true, history)
 
     let assertOk result =
         match result with
@@ -82,6 +91,138 @@ type AnnotationLineCoreTests() =
                 lines
                 |> Array.countBy id
                 |> Array.iter (fun (lineNumber, count) -> Assert.That(count, Is.EqualTo(1), $"line {lineNumber} should be covered once")))
+        )
+
+    let historySourceReferenceIds result =
+        result.History
+        |> Array.map (fun document -> document.SourceReference.SourceReferenceId)
+
+    [<Test>]
+    member _.TraverseEffectiveBranchHistoryOrdersBasedOnAncestorsBeforeTarget() =
+        let oldDocument = historyDocument oldReference "parent"
+        let newDocument = historyDocument newReference "child"
+
+        let result =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument None true
+                |]
+
+        let sourceReferenceIds = historySourceReferenceIds result
+
+        let sourceReferenceIdsMatch =
+            sourceReferenceIds = [|
+                "source-reference-old"
+                "source-reference-new"
+            |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(result.BoundaryKind.IsNone, Is.True)
+
+                Assert.That(sourceReferenceIdsMatch, Is.True))
+        )
+
+    [<Test>]
+    member _.TraverseEffectiveBranchHistoryStopsAtUnauthorizedAncestor() =
+        let oldDocument = historyDocument oldReference "parent"
+        let newDocument = historyDocument newReference "child"
+
+        let result =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument None false
+                |]
+
+        let sourceReferenceIds = historySourceReferenceIds result
+        let sourceReferenceIdsMatch = sourceReferenceIds = [| "source-reference-new" |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(result.BoundaryKind, Is.EqualTo(Some "UnauthorizedAncestor"))
+
+                Assert.That(sourceReferenceIdsMatch, Is.True))
+        )
+
+    [<Test>]
+    member _.TraverseEffectiveBranchHistoryStopsAtMissingParentReference() =
+        let newDocument = historyDocument newReference "child"
+
+        let result =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                |]
+
+        let sourceReferenceIds = historySourceReferenceIds result
+        let sourceReferenceIdsMatch = sourceReferenceIds = [| "source-reference-new" |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(result.BoundaryKind, Is.EqualTo(Some "MissingParentReference"))
+
+                Assert.That(sourceReferenceIdsMatch, Is.True))
+        )
+
+    [<Test>]
+    member _.TraverseEffectiveBranchHistoryStopsAtBasedOnLoopOrRepeatedLink() =
+        let oldDocument = historyDocument oldReference "parent"
+        let newDocument = historyDocument newReference "child"
+
+        let result =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                DefaultMaxReferences
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument (Some targetReferenceId) true
+                |]
+
+        let sourceReferenceIds = historySourceReferenceIds result
+
+        let sourceReferenceIdsMatch =
+            sourceReferenceIds = [|
+                "source-reference-old"
+                "source-reference-new"
+            |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(result.BoundaryKind, Is.EqualTo(Some "BasedOnLoopOrRepeatedLink"))
+
+                Assert.That(sourceReferenceIdsMatch, Is.True))
+        )
+
+    [<Test>]
+    member _.TraverseEffectiveBranchHistoryStopsAtTraversalBudgetBoundary() =
+        let oldDocument = historyDocument oldReference "parent"
+        let newDocument = historyDocument newReference "child"
+
+        let result =
+            traverseEffectiveBranchHistory
+                targetReferenceId
+                1
+                [|
+                    effectiveHistoryDocument newDocument (Some oldReferenceId) true
+                    effectiveHistoryDocument oldDocument None true
+                |]
+
+        let sourceReferenceIds = historySourceReferenceIds result
+        let sourceReferenceIdsMatch = sourceReferenceIds = [| "source-reference-new" |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(result.BoundaryKind, Is.EqualTo(Some "TraversalBudgetReached"))
+
+                Assert.That(sourceReferenceIdsMatch, Is.True))
         )
 
     [<Test>]
@@ -423,7 +564,7 @@ type AnnotationLineCoreTests() =
         )
 
     [<Test>]
-    member _.BuildAnnotationSkipsFilteredReferenceTypesBeforeTracing() =
+    member _.BuildAnnotationTraversesFilteredSaveAndProjectsAttributionToCommit() =
         let annotation =
             build
                 { StartLine = 1; EndLine = 1 }
@@ -447,14 +588,14 @@ type AnnotationLineCoreTests() =
         )
 
     [<Test>]
-    member _.BuildAnnotationSkipsFilteredReferenceTypesBeforePathValidation() =
+    member _.BuildAnnotationTraversesFilteredSaveWithoutSeveringContinuityToEarlierCommit() =
         let annotation =
             build
                 { StartLine = 1; EndLine = 1 }
                 [|
-                    historyDocument oldReference "old"
-                    historyDocumentWithPath saveReference "src/Renamed.fs" "new"
-                    historyDocument newReference "new"
+                    historyDocument oldReference "stable"
+                    historyDocument saveReference "changed"
+                    historyDocument newReference "stable"
                 |]
             |> assertOk
 
@@ -467,6 +608,166 @@ type AnnotationLineCoreTests() =
                 Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
                 Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1))
                 Assert.That(annotation.SourceReferences[0].ReferenceType, Is.EqualTo("Commit")))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationRejectsFilteredReferenceAtDifferentPathBecauseV1DoesNotFollowRenames() =
+        let result =
+            build
+                { StartLine = 1; EndLine = 1 }
+                [|
+                    historyDocument oldReference "old"
+                    historyDocumentWithPath saveReference "src/Renamed.fs" "new"
+                    historyDocument newReference "new"
+                |]
+
+        match result with
+        | Ok annotation ->
+            assertValid annotation
+            Assert.Fail("Exact-path annotation should not ignore filtered references at a different path.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("must match annotation path"))
+
+    [<Test>]
+    member _.BuildAnnotationKeepsUnchangedRebaseFromBecomingLastChangedReference() =
+        let rebaseReference = sourceReferenceWithType "source-reference-rebase" targetReferenceId "Rebase" "rebase" newDirectoryVersionId
+
+        let annotation =
+            buildAnnotation (
+                { StartLine = 1; EndLine = 1 },
+                targetReferenceId,
+                "src/App.fs",
+                [| ReferenceType.Commit |],
+                DefaultMaxReferences,
+                true,
+                [|
+                    historyDocument oldReference "stable"
+                    historyDocument rebaseReference "stable"
+                |]
+            )
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 1 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.SourceRows, Has.Length.EqualTo(1))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-old"))
+                Assert.That(annotation.SourceReferences[0].ReferenceType, Is.EqualTo("Commit")))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationProjectsChangedRebaseToExplicitBoundaryWhenFilteredOut() =
+        let rebaseReference = sourceReferenceWithType "source-reference-rebase" targetReferenceId "Rebase" "rebase" newDirectoryVersionId
+
+        let annotation =
+            buildAnnotation (
+                { StartLine = 1; EndLine = 1 },
+                targetReferenceId,
+                "src/App.fs",
+                [| ReferenceType.Commit |],
+                DefaultMaxReferences,
+                true,
+                [|
+                    historyDocument oldReference "old"
+                    historyDocument rebaseReference "new"
+                |]
+            )
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 1 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-rebase"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1))
+                Assert.That(annotation.SourceReferences[0].ReferenceType, Is.EqualTo("Rebase")))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationTreatsTagAsEligibleWithoutFilterAndWhenSelected() =
+        let tagTargetReference = { tagReference with ReferenceId = targetReferenceId; DirectoryVersionId = newDirectoryVersionId }
+
+        let withoutFilter =
+            buildWithoutReferenceTypeFilter
+                { StartLine = 1; EndLine = 1 }
+                [|
+                    historyDocument oldReference "old"
+                    historyDocument tagTargetReference "new"
+                |]
+            |> assertOk
+
+        let tagOnly =
+            buildWithReferenceTypes
+                [| ReferenceType.Tag |]
+                { StartLine = 1; EndLine = 1 }
+                [|
+                    historyDocument oldReference "old"
+                    historyDocument tagTargetReference "new"
+                |]
+            |> assertOk
+
+        Assert.Multiple(
+            Action (fun () ->
+                assertValid withoutFilter
+                assertValid tagOnly
+                Assert.That(withoutFilter.SourceReferences[0].ReferenceType, Is.EqualTo("Tag"))
+                Assert.That(tagOnly.SourceReferences[0].ReferenceType, Is.EqualTo("Tag")))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationBoundsUnauthorizedAncestorWhenHistoryStartsMidSpan() =
+        let annotation =
+            buildWithMaxReferences
+                1
+                { StartLine = 1; EndLine = 1 }
+                [|
+                    historyDocument oldReference "same"
+                    historyDocument newReference "same"
+                |]
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 1 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1)))
+        )
+
+    [<Test>]
+    member _.BuildAnnotationBoundsTraversalBudgetReachedMidSpan() =
+        let middleReference = sourceReferenceWithType "source-reference-middle" saveReferenceId "Commit" "middle" saveDirectoryVersionId
+
+        let annotation =
+            buildWithMaxReferences
+                2
+                { StartLine = 1; EndLine = 2 }
+                [|
+                    historyDocument oldReference "same\nold"
+                    historyDocument middleReference "same\nmiddle"
+                    historyDocument newReference "same\nnew"
+                |]
+            |> assertOk
+
+        assertValid annotation
+        assertCoveredExactlyOnce 1 2 annotation
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(annotation.Boundaries, Has.Length.EqualTo(1))
+                Assert.That(annotation.Boundaries[0].LineRange, Is.EqualTo({ StartLine = 1; EndLine = 1 }))
+                Assert.That(annotation.Spans[0].BoundaryId, Is.EqualTo(annotation.Boundaries[0].BoundaryId))
+                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-middle"))
+                Assert.That(annotation.SourceRows[1].SourceReferenceId, Is.EqualTo("source-reference-new"))
+                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(2)))
         )
 
     [<Test>]
@@ -579,8 +880,8 @@ type AnnotationLineCoreTests() =
         | Error errors -> Assert.That(errors, Has.Some.Contains("TargetReferenceId"))
 
     [<Test>]
-    member _.BuildAnnotationSkipsFilteredInvalidUtf8ReferenceBeforeDecoding() =
-        let annotation =
+    member _.BuildAnnotationRejectsFilteredInvalidUtf8ReferenceBecauseTraversalNeedsContent() =
+        let result =
             build
                 { StartLine = 1; EndLine = 1 }
                 [|
@@ -588,18 +889,12 @@ type AnnotationLineCoreTests() =
                     historyDocumentBytes saveReference [| 0xC3uy; 0x28uy |]
                     historyDocument newReference "new"
                 |]
-            |> assertOk
 
-        assertValid annotation
-        assertCoveredExactlyOnce 1 1 annotation
-
-        Assert.Multiple(
-            Action (fun () ->
-                Assert.That(annotation.SourceRows, Has.Length.EqualTo(1))
-                Assert.That(annotation.SourceRows[0].SourceReferenceId, Is.EqualTo("source-reference-new"))
-                Assert.That(annotation.SourceReferences, Has.Length.EqualTo(1))
-                Assert.That(annotation.SourceReferences[0].ReferenceType, Is.EqualTo("Commit")))
-        )
+        match result with
+        | Ok annotation ->
+            assertValid annotation
+            Assert.Fail("Filtered references still participate in traversal, so invalid UTF-8 must be rejected.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("invalid UTF-8"))
 
     [<Test>]
     member _.BuildAnnotationCoalescesOnlyContiguousMatchingSourceDetails() =

--- a/src/Grace.Shared/AnnotationLineCore.Shared.fs
+++ b/src/Grace.Shared/AnnotationLineCore.Shared.fs
@@ -588,14 +588,24 @@ module AnnotationLineCore =
             |> Array.map referenceTypeName
             |> Set.ofArray
 
-        let sourceReferenceErrors = validateSourceReferences history
+        let traversalWasBudgetBounded =
+            maxReferences > 0
+            && history.Length > maxReferences
+
+        let traceHistory =
+            if traversalWasBudgetBounded then
+                history[history.Length - maxReferences ..]
+            else
+                history
+
+        let sourceReferenceErrors = validateSourceReferences traceHistory
 
         let historyErrors =
             [
                 if history.Length = 0 then
                     "Annotation history must contain at least the target document."
 
-                for document in history do
+                for document in traceHistory do
                     if not (String.Equals(document.Path, path, StringComparison.Ordinal)) then
                         $"Annotation history path '{document.Path}' must match annotation path '{path}'."
 
@@ -615,19 +625,11 @@ module AnnotationLineCore =
             with
         | _ :: _ as errors -> Error errors
         | [] ->
-            let traversalWasBudgetBounded = history.Length > maxReferences
-
             let effectiveTraversalBoundaryKind =
                 if traversalWasBudgetBounded then
                     Some "TraversalBudgetReached"
                 else
                     traversalBoundaryKind
-
-            let traceHistory =
-                if traversalWasBudgetBounded then
-                    history[history.Length - maxReferences ..]
-                else
-                    history
 
             let decoded =
                 traceHistory

--- a/src/Grace.Shared/AnnotationLineCore.Shared.fs
+++ b/src/Grace.Shared/AnnotationLineCore.Shared.fs
@@ -14,6 +14,10 @@ module AnnotationLineCore =
 
     type AnnotationHistoryDocument = { SourceReference: AnnotationSourceReference; Path: RelativePath; Content: byte array }
 
+    type EffectiveHistoryDocument = { Document: AnnotationHistoryDocument; BasedOnReferenceId: ReferenceId option; IsAuthorized: bool }
+
+    type EffectiveHistoryTraversalResult = { History: AnnotationHistoryDocument array; BoundaryKind: string option }
+
     type AnnotationLineSource = { SourceReferenceId: AnnotationSourceReferenceId; Path: RelativePath; LineNumber: int }
 
     type AnnotationBoundaryState = { BoundaryKind: string; SourceRows: AnnotationLineSource array }
@@ -80,6 +84,37 @@ module AnnotationLineCore =
                 { LineNumber = lineNumber; Text = document.Lines[index] }
         |]
 
+    let traverseEffectiveBranchHistory targetReferenceId maxReferences (history: EffectiveHistoryDocument array) =
+        let byReferenceId =
+            history
+            |> Array.map (fun entry -> entry.Document.SourceReference.ReferenceId, entry)
+            |> Map.ofArray
+
+        let chronological = ResizeArray<AnnotationHistoryDocument>()
+        let mutable boundary = None
+        let mutable currentReferenceId = Some targetReferenceId
+        let mutable visited = Set.empty<ReferenceId>
+
+        while Option.isNone boundary
+              && currentReferenceId.IsSome do
+            let referenceId = currentReferenceId.Value
+
+            if visited.Contains referenceId then
+                boundary <- Some "BasedOnLoopOrRepeatedLink"
+            elif chronological.Count >= maxReferences then
+                boundary <- Some "TraversalBudgetReached"
+            else
+                visited <- visited.Add referenceId
+
+                match byReferenceId.TryFind referenceId with
+                | None -> boundary <- Some "MissingParentReference"
+                | Some entry when not entry.IsAuthorized -> boundary <- Some "UnauthorizedAncestor"
+                | Some entry ->
+                    chronological.Add entry.Document
+                    currentReferenceId <- entry.BasedOnReferenceId
+
+        { History = chronological.ToArray() |> Array.rev; BoundaryKind = boundary }
+
     let private sourceKey (source: AnnotationLineSource) = source.SourceReferenceId, source.Path
 
     let private boundaryKey (boundary: AnnotationBoundaryState) =
@@ -116,7 +151,7 @@ module AnnotationLineCore =
         || (isKnownReferenceTypeName document.SourceReference.ReferenceType
             && referenceTypeNames.Contains document.SourceReference.ReferenceType)
 
-    let private validateIncludedSourceReferences (history: AnnotationHistoryDocument array) =
+    let private validateSourceReferences (history: AnnotationHistoryDocument array) =
         [
             for document in history do
                 let sourceReference = document.SourceReference
@@ -220,6 +255,10 @@ module AnnotationLineCore =
     let private missingTargetLine = { BoundaryKind = "TargetLineMissing"; SourceRows = Array.empty }
 
     let private shiftedAlignmentBudgetExceeded = { BoundaryKind = "ShiftedAlignmentBudgetExceeded"; SourceRows = Array.empty }
+
+    let private traversalBudgetReached source = { BoundaryKind = "TraversalBudgetReached"; SourceRows = [| source |] }
+
+    let private referenceTypeFiltered source = { BoundaryKind = "ReferenceTypeFiltered"; SourceRows = [| source |] }
 
     let private maxShiftedAlignmentPairScans = 16_384L
 
@@ -400,7 +439,43 @@ module AnnotationLineCore =
         else
             None, false
 
-    let private traceLineSource lineNumber (documents: (AnnotationHistoryDocument * VisibleTextDocument) array) (lineAlignments: LineAlignment array) =
+    let private tryGetNextLineNumber lineNumber (alignment: LineAlignment) =
+        alignment.Values
+        |> Array.tryFindIndex (fun previousLineNumber -> previousLineNumber = lineNumber)
+        |> Option.map (fun index -> alignment.FirstLineNumber + index)
+
+    let private lineSourceFromDocument lineNumber document =
+        { SourceReferenceId = document.SourceReference.SourceReferenceId; Path = document.Path; LineNumber = lineNumber }
+
+    let private tryProjectAttributionSource sourceIndex sourceLineNumber documents (lineAlignments: LineAlignment array) referenceTypeNames =
+        let mutable projected = None
+        let mutable index = sourceIndex
+        let mutable lineNumber = sourceLineNumber
+
+        while Option.isNone projected
+              && index < Array.length documents do
+            let document, _ = documents[index]
+
+            if matchesReferenceTypeFilter referenceTypeNames document then
+                projected <- Some(index, lineNumber)
+
+            if Option.isNone projected
+               && index < lineAlignments.Length then
+                match tryGetNextLineNumber lineNumber lineAlignments[index] with
+                | Some nextLineNumber -> lineNumber <- nextLineNumber
+                | None -> index <- Array.length documents
+
+            index <- index + 1
+
+        projected
+
+    let private traceLineSource
+        lineNumber
+        (documents: (AnnotationHistoryDocument * VisibleTextDocument) array)
+        (lineAlignments: LineAlignment array)
+        referenceTypeNames
+        traversalWasBudgetBounded
+        =
         let targetDocument = documents[documents.Length - 1] |> snd
 
         match lineAt lineNumber targetDocument with
@@ -430,11 +505,26 @@ module AnnotationLineCore =
             if alignmentWasUnknown then
                 Boundary shiftedAlignmentBudgetExceeded
             else
-                let sourceDocument = documents[sourceIndex] |> fst
+                let sourceDocument, _ = documents[sourceIndex]
+                let sourceLine = lineSourceFromDocument sourceLineNumber sourceDocument
 
-                Resolved { SourceReferenceId = sourceDocument.SourceReference.SourceReferenceId; Path = sourceDocument.Path; LineNumber = sourceLineNumber }
+                if traversalWasBudgetBounded && sourceIndex = 0 then
+                    Boundary(traversalBudgetReached sourceLine)
+                else
+                    match tryProjectAttributionSource sourceIndex sourceLineNumber documents lineAlignments referenceTypeNames with
+                    | Some (projectedIndex, projectedLineNumber) ->
+                        let projectedDocument, _ = documents[projectedIndex]
+                        Resolved(lineSourceFromDocument projectedLineNumber projectedDocument)
+                    | None -> Boundary(referenceTypeFiltered sourceLine)
 
-    let private traceRequestedSegments requestedLineRange (targetDocument: VisibleTextDocument) traceDocuments (lineAlignments: LineAlignment array) =
+    let private traceRequestedSegments
+        requestedLineRange
+        (targetDocument: VisibleTextDocument)
+        traceDocuments
+        (lineAlignments: LineAlignment array)
+        referenceTypeNames
+        traversalWasBudgetBounded
+        =
         let segments = ResizeArray<int * int * AnnotationLineState>()
         let firstExistingLine = max requestedLineRange.StartLine 1
         let lastExistingLine = min requestedLineRange.EndLine targetDocument.Lines.Length
@@ -444,12 +534,13 @@ module AnnotationLineCore =
 
         if firstExistingLine <= lastExistingLine then
             let mutable segmentStart = firstExistingLine
-            let mutable segmentState = traceLineSource firstExistingLine traceDocuments lineAlignments
+            let mutable segmentState = traceLineSource firstExistingLine traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
+
             let mutable previousLine = firstExistingLine
             let mutable previousState = segmentState
 
             for lineNumber in firstExistingLine + 1 .. lastExistingLine do
-                let currentState = traceLineSource lineNumber traceDocuments lineAlignments
+                let currentState = traceLineSource lineNumber traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
 
                 if canAppend previousState currentState previousLine lineNumber then
                     previousLine <- lineNumber
@@ -496,18 +587,14 @@ module AnnotationLineCore =
             |> Array.map referenceTypeName
             |> Set.ofArray
 
-        let includedHistory =
-            history
-            |> Array.filter (matchesReferenceTypeFilter referenceTypeNames)
-
-        let sourceReferenceErrors = validateIncludedSourceReferences includedHistory
+        let sourceReferenceErrors = validateSourceReferences history
 
         let historyErrors =
             [
                 if history.Length = 0 then
                     "Annotation history must contain at least the target document."
 
-                for document in includedHistory do
+                for document in history do
                     if not (String.Equals(document.Path, path, StringComparison.Ordinal)) then
                         $"Annotation history path '{document.Path}' must match annotation path '{path}'."
 
@@ -519,14 +606,6 @@ module AnnotationLineCore =
                     $"Target SourceReference '{history[history.Length - 1]
                                                    .SourceReference
                                                    .SourceReferenceId}' must match TargetReferenceId."
-
-                if
-                    history.Length > 0
-                    && not (matchesReferenceTypeFilter referenceTypeNames history[history.Length - 1])
-                then
-                    $"Target SourceReference '{history[history.Length - 1]
-                                                   .SourceReference
-                                                   .SourceReferenceId}' must match ReferenceTypeFilter."
             ]
 
         match lineRangeErrors
@@ -535,8 +614,16 @@ module AnnotationLineCore =
             with
         | _ :: _ as errors -> Error errors
         | [] ->
+            let traversalWasBudgetBounded = history.Length > maxReferences
+
+            let traceHistory =
+                if traversalWasBudgetBounded then
+                    history[history.Length - maxReferences ..]
+                else
+                    history
+
             let decoded =
-                includedHistory
+                traceHistory
                 |> Array.map (fun document ->
                     match decodeVisibleText document.Content with
                     | Ok visible -> Ok(document, visible)
@@ -574,7 +661,8 @@ module AnnotationLineCore =
                     else
                         Array.empty
 
-                let segments = traceRequestedSegments requestedLineRange targetDocument traceDocuments lineAlignments
+                let segments =
+                    traceRequestedSegments requestedLineRange targetDocument traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
 
                 let components = buildComponentsFromSegments lines segments
 

--- a/src/Grace.Shared/AnnotationLineCore.Shared.fs
+++ b/src/Grace.Shared/AnnotationLineCore.Shared.fs
@@ -256,7 +256,7 @@ module AnnotationLineCore =
 
     let private shiftedAlignmentBudgetExceeded = { BoundaryKind = "ShiftedAlignmentBudgetExceeded"; SourceRows = Array.empty }
 
-    let private traversalBudgetReached source = { BoundaryKind = "TraversalBudgetReached"; SourceRows = [| source |] }
+    let private traversalBoundaryReached boundaryKind source = { BoundaryKind = boundaryKind; SourceRows = [| source |] }
 
     let private referenceTypeFiltered source = { BoundaryKind = "ReferenceTypeFiltered"; SourceRows = [| source |] }
 
@@ -474,7 +474,7 @@ module AnnotationLineCore =
         (documents: (AnnotationHistoryDocument * VisibleTextDocument) array)
         (lineAlignments: LineAlignment array)
         referenceTypeNames
-        traversalWasBudgetBounded
+        traversalBoundaryKind
         =
         let targetDocument = documents[documents.Length - 1] |> snd
 
@@ -508,9 +508,9 @@ module AnnotationLineCore =
                 let sourceDocument, _ = documents[sourceIndex]
                 let sourceLine = lineSourceFromDocument sourceLineNumber sourceDocument
 
-                if traversalWasBudgetBounded && sourceIndex = 0 then
-                    Boundary(traversalBudgetReached sourceLine)
-                else
+                match traversalBoundaryKind with
+                | Some boundaryKind when sourceIndex = 0 -> Boundary(traversalBoundaryReached boundaryKind sourceLine)
+                | _ ->
                     match tryProjectAttributionSource sourceIndex sourceLineNumber documents lineAlignments referenceTypeNames with
                     | Some (projectedIndex, projectedLineNumber) ->
                         let projectedDocument, _ = documents[projectedIndex]
@@ -523,7 +523,7 @@ module AnnotationLineCore =
         traceDocuments
         (lineAlignments: LineAlignment array)
         referenceTypeNames
-        traversalWasBudgetBounded
+        traversalBoundaryKind
         =
         let segments = ResizeArray<int * int * AnnotationLineState>()
         let firstExistingLine = max requestedLineRange.StartLine 1
@@ -534,13 +534,13 @@ module AnnotationLineCore =
 
         if firstExistingLine <= lastExistingLine then
             let mutable segmentStart = firstExistingLine
-            let mutable segmentState = traceLineSource firstExistingLine traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
+            let mutable segmentState = traceLineSource firstExistingLine traceDocuments lineAlignments referenceTypeNames traversalBoundaryKind
 
             let mutable previousLine = firstExistingLine
             let mutable previousState = segmentState
 
             for lineNumber in firstExistingLine + 1 .. lastExistingLine do
-                let currentState = traceLineSource lineNumber traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
+                let currentState = traceLineSource lineNumber traceDocuments lineAlignments referenceTypeNames traversalBoundaryKind
 
                 if canAppend previousState currentState previousLine lineNumber then
                     previousLine <- lineNumber
@@ -561,7 +561,7 @@ module AnnotationLineCore =
 
         segments.ToArray()
 
-    let buildAnnotation
+    let private buildAnnotationWithTraversalBoundary
         (
             requestedLineRange: AnnotationLineRange,
             targetReferenceId: ReferenceId,
@@ -569,6 +569,7 @@ module AnnotationLineCore =
             referenceTypeFilter: ReferenceType array,
             maxReferences: int,
             includeLineText: bool,
+            traversalBoundaryKind: string option,
             history: AnnotationHistoryDocument array
         )
         =
@@ -616,6 +617,12 @@ module AnnotationLineCore =
         | [] ->
             let traversalWasBudgetBounded = history.Length > maxReferences
 
+            let effectiveTraversalBoundaryKind =
+                if traversalWasBudgetBounded then
+                    Some "TraversalBudgetReached"
+                else
+                    traversalBoundaryKind
+
             let traceHistory =
                 if traversalWasBudgetBounded then
                     history[history.Length - maxReferences ..]
@@ -662,7 +669,7 @@ module AnnotationLineCore =
                         Array.empty
 
                 let segments =
-                    traceRequestedSegments requestedLineRange targetDocument traceDocuments lineAlignments referenceTypeNames traversalWasBudgetBounded
+                    traceRequestedSegments requestedLineRange targetDocument traceDocuments lineAlignments referenceTypeNames effectiveTraversalBoundaryKind
 
                 let components = buildComponentsFromSegments lines segments
 
@@ -694,3 +701,38 @@ module AnnotationLineCore =
                             sourceReferences
                         )
                     )
+
+    let buildAnnotation
+        (
+            requestedLineRange: AnnotationLineRange,
+            targetReferenceId: ReferenceId,
+            path: RelativePath,
+            referenceTypeFilter: ReferenceType array,
+            maxReferences: int,
+            includeLineText: bool,
+            history: AnnotationHistoryDocument array
+        )
+        =
+        buildAnnotationWithTraversalBoundary (requestedLineRange, targetReferenceId, path, referenceTypeFilter, maxReferences, includeLineText, None, history)
+
+    let buildAnnotationFromEffectiveHistoryTraversal
+        (
+            requestedLineRange: AnnotationLineRange,
+            targetReferenceId: ReferenceId,
+            path: RelativePath,
+            referenceTypeFilter: ReferenceType array,
+            maxReferences: int,
+            includeLineText: bool,
+            traversalResult: EffectiveHistoryTraversalResult
+        )
+        =
+        buildAnnotationWithTraversalBoundary (
+            requestedLineRange,
+            targetReferenceId,
+            path,
+            referenceTypeFilter,
+            maxReferences,
+            includeLineText,
+            traversalResult.BoundaryKind,
+            traversalResult.History
+        )


### PR DESCRIPTION
## Summary

- Add pure effective branch history traversal for annotation inputs, following `BasedOn` links from the target reference through authorized ancestors and returning explicit boundary kinds for missing parents, unauthorized ancestors, loops/repeated links, and traversal budget exhaustion.
- Update annotation line attribution so reference-type filtering affects projection only: filtered references still participate in traversal, unchanged Rebase content does not become the last changed source, and filtered/unknown proof gaps are represented with line-scoped boundaries.
- Expand `AnnotationLineCoreTests` with S5 coverage for BasedOn history, rebase unchanged/changed content, Save-to-Commit projection, Tag eligibility, unauthorized/missing ancestor boundaries, traversal budget boundaries, invalid filtered content, and no rename-following behavior.

## Issue Links

Part of #313
Related to #318

## Touched Paths

- `src/Grace.Shared/AnnotationLineCore.Shared.fs`
- `src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs`

## Validation

- `dotnet tool run fantomas C:\Source\Grace-gh-318\src\Grace.Shared\AnnotationLineCore.Shared.fs C:\Source\Grace-gh-318\src\Grace.Server.Unit.Tests\AnnotationLineCore.Tests.fs` - passed; shared core formatted, unit test file unchanged.
- `pwsh ./scripts/validate.ps1 -Fast` - passed; Release build succeeded with 0 warnings and 0 errors; Fast test profile passed: Grace.Types.Tests 95/95, Grace.Authorization.Tests 37/37, Grace.Server.Unit.Tests 491/491, Grace.CLI.Tests 380 passed / 1 skipped.
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD` - passed with no whitespace errors.
## Review Status

Codex Code Review Bot findings fixed; waiting for the next Codex Code Review Bot pass on commit `73575d6eed3869a07f2966067f25308f4719717a`.

- `PRRT_kwDOILVrb86IRL3n` / `PRRC_kwDOILVrb87JqknF`: P2 Preserve non-budget traversal boundaries.
  - Fixed in `76cb3b7` by preserving non-budget traversal boundary kinds through `buildAnnotationFromEffectiveHistoryTraversal` and line tracing.
  - Added focused regressions for unauthorized ancestor, missing parent reference, and BasedOn loop traversal results.
  - Validation: targeted Fantomas passed; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check origin/epic/313-branch-annotate-v1...HEAD` passed.
  - Replied to the bot review thread and resolved the GitHub conversation.
- `PRRT_kwDOILVrb86IRgGR` / `PRRC_kwDOILVrb87JrA8Z`: P2 Validate only the history kept by the budget.
  - Fixed in `73575d6eed3869a07f2966067f25308f4719717a` by validating paths/source references against the `MaxReferences` suffix that annotation will trace, while preserving exact-path validation for kept records.
  - Added focused regression coverage for a pruned older different-path/rename-before-budget ancestor annotating the reachable suffix with a traversal boundary instead of returning a path mismatch error.
  - Validation: targeted Fantomas passed; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check origin/epic/313-branch-annotate-v1...HEAD` passed.
  - Replied to the bot review thread and resolved the GitHub conversation.

## Docs Impact

No broad docs update in this slice. Boundary behavior and traversal assumptions are documented through focused unit tests; later API/CLI/docs slices can surface user-facing wording.

## Residual Risk

- This slice adds pure traversal/projection support and no durable annotation cache.
- Server authorization and materialized endpoint wiring are expected in later S6 work; this slice models authorized effective-history inputs and explicit boundary results without adding hosted integration behavior.
- V1 remains exact-path only and intentionally does not follow renames, copies, or moved blocks.




- Final Codex Code Review Bot state for `73575d6eed3869a07f2966067f25308f4719717a`: clean 👍 reaction from `chatgpt-codex-connector[bot]`; `full` check passed; `2` review threads total, `0` unresolved.

