### PR TITLE
Extract CLI current-state capture helper

### DIFF
--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -1,0 +1,253 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Services
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Types.Branch
+open Grace.Types.Common
+open Grace.Types.Reference
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.Threading.Tasks
+
+[<NonParallelizable>]
+module CurrentStateCaptureCliTests =
+    let private correlationId = "current-state-capture-tests"
+    let private rootDirectoryId = Guid.NewGuid()
+    let private rootSha = Sha256Hash "current-root-sha"
+    let private savedReferenceId = Guid.NewGuid()
+
+    let private rootDirectoryVersion directoryVersionId sha256Hash =
+        LocalDirectoryVersion.Create
+            directoryVersionId
+            OwnerId.Empty
+            OrganizationId.Empty
+            RepositoryId.Empty
+            Constants.RootDirectoryPath
+            sha256Hash
+            (List<DirectoryVersionId>())
+            (List<LocalFileVersion>())
+            0L
+            DateTime.UtcNow
+
+    let private graceStatus directoryVersionId sha256Hash =
+        let root = rootDirectoryVersion directoryVersionId sha256Hash
+        let index = GraceIndex()
+        index.TryAdd(directoryVersionId, root) |> ignore
+
+        { GraceStatus.Default with Index = index; RootDirectoryId = directoryVersionId; RootDirectorySha256Hash = sha256Hash }
+
+    let private referenceDto referenceId directoryVersionId sha256Hash =
+        { ReferenceDto.Default with ReferenceId = referenceId; ReferenceType = ReferenceType.Save; DirectoryId = directoryVersionId; Sha256Hash = sha256Hash }
+
+    let private branch saveEnabled latestReference =
+        { BranchDto.Default with SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
+
+    let private defaultOperations branchDto =
+        {
+            GetBranch = fun () -> Task.FromResult(Ok(GraceReturnValue.Create branchDto correlationId))
+            GetGraceWatchStatus = fun () -> Task.FromResult(None)
+            ReadGraceStatus = fun () -> Task.FromResult(graceStatus rootDirectoryId rootSha)
+            ScanForDifferences = fun _ -> Task.FromResult(List<FileSystemDifference>())
+            CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
+            BuildUpdatedGraceStatus = fun status _ -> Task.FromResult(status, List<LocalDirectoryVersion>())
+            UploadFileVersions = fun _ -> Task.FromResult(Ok())
+            UploadDirectoryVersions = fun _ -> Task.FromResult(Ok())
+            ApplyGraceStatusIncremental = fun _ _ _ -> Task.FromResult(())
+            CreateSaveReference = fun _ _ -> Task.FromResult(Ok(Guid.NewGuid()))
+        }
+
+    [<Test>]
+    let ``explicit reference bypasses local state capture`` () =
+        let explicitReferenceId = Guid.NewGuid()
+        let mutable getBranchCalled = false
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                GetBranch =
+                    fun () ->
+                        getBranchCalled <- true
+                        Task.FromResult(Ok(GraceReturnValue.Create BranchDto.Default correlationId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations (Some explicitReferenceId) branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal explicitReferenceId
+
+            captured.Source |> should equal ExplicitReference
+            captured.CreatedSaveMessage |> should equal None
+            getBranchCalled |> should equal false
+        | Error error -> Assert.Fail($"Expected explicit reference success, got: {error.Error}")
+
+    [<Test>]
+    let ``GraceWatch state uses matching existing branch reference`` () =
+        let latest = referenceDto savedReferenceId rootDirectoryId rootSha
+
+        let watchStatus: GraceWatchStatus =
+            {
+                UpdatedAt = Grace.Shared.Utilities.getCurrentInstant ()
+                IsStartupClaim = false
+                RootDirectoryId = rootDirectoryId
+                RootDirectorySha256Hash = rootSha
+                LastFileUploadInstant = NodaTime.Instant.MinValue
+                LastDirectoryVersionInstant = NodaTime.Instant.MinValue
+                DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+            }
+
+        let mutable readStatusCalled = false
+
+        let operations =
+            { defaultOperations (branch true latest) with
+                GetGraceWatchStatus = fun () -> Task.FromResult(Some watchStatus)
+                ReadGraceStatus =
+                    fun () ->
+                        readStatusCalled <- true
+                        Task.FromResult(graceStatus rootDirectoryId rootSha)
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal savedReferenceId
+
+            captured.RootDirectoryId
+            |> should equal rootDirectoryId
+
+            captured.Source |> should equal GraceWatch
+            readStatusCalled |> should equal false
+        | Error error -> Assert.Fail($"Expected GraceWatch success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes auto-create save with annotate message`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let mutable uploadedDirectories = false
+        let mutable appliedStatus = false
+        let mutable saveMessage = String.Empty
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "new-folder")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadDirectoryVersions =
+                    fun _ ->
+                        uploadedDirectories <- true
+                        Task.FromResult(Ok())
+                ApplyGraceStatusIncremental =
+                    fun _ _ _ ->
+                        appliedStatus <- true
+                        Task.FromResult(())
+                CreateSaveReference =
+                    fun _ message ->
+                        saveMessage <- message
+                        Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
+            captured.Source |> should equal CreatedSave
+
+            captured.CreatedSaveMessage
+            |> should equal (Some branchAnnotateImplicitSaveMessage)
+
+            saveMessage
+            |> should equal branchAnnotateImplicitSaveMessage
+
+            uploadedDirectories |> should equal true
+            appliedStatus |> should equal true
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``save disabled fails before uploading local changes`` () =
+        let mutable uploadedFiles = false
+        let mutable createdSave = false
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "new-folder")
+                |]
+            )
+
+        let operations =
+            { defaultOperations (branch false ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                UploadFileVersions =
+                    fun _ ->
+                        uploadedFiles <- true
+                        Task.FromResult(Ok())
+                CreateSaveReference =
+                    fun _ _ ->
+                        createdSave <- true
+                        Task.FromResult(Ok(Guid.NewGuid()))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured -> Assert.Fail($"Expected Save-disabled failure, got: {captured}")
+        | Error error ->
+            error.Error
+            |> should contain "Save is disabled on this branch"
+
+            uploadedFiles |> should equal false
+            createdSave |> should equal false
+
+    [<Test>]
+    let ``helper does not write diagnostics to stdout`` () =
+        let explicitReferenceId = Guid.NewGuid()
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+
+            let result =
+                (resolveCliCurrentStateTargetReference
+                    (defaultOperations (branch true ReferenceDto.Default))
+                    (Some explicitReferenceId)
+                    branchAnnotateImplicitSaveMessage
+                    correlationId)
+                    .Result
+
+            match result with
+            | Ok _ -> writer.ToString() |> should equal String.Empty
+            | Error error -> Assert.Fail($"Expected explicit reference success, got: {error.Error}")
+        finally
+            Console.SetOut(originalOut)

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -17,6 +17,8 @@ open System.Threading.Tasks
 [<NonParallelizable>]
 module CurrentStateCaptureCliTests =
     let private correlationId = "current-state-capture-tests"
+    let private currentBranchId = Guid.NewGuid()
+    let private parentBranchId = Guid.NewGuid()
     let private rootDirectoryId = Guid.NewGuid()
     let private rootSha = Sha256Hash "current-root-sha"
     let private savedReferenceId = Guid.NewGuid()
@@ -42,10 +44,16 @@ module CurrentStateCaptureCliTests =
         { GraceStatus.Default with Index = index; RootDirectoryId = directoryVersionId; RootDirectorySha256Hash = sha256Hash }
 
     let private referenceDto referenceId directoryVersionId sha256Hash =
-        { ReferenceDto.Default with ReferenceId = referenceId; ReferenceType = ReferenceType.Save; DirectoryId = directoryVersionId; Sha256Hash = sha256Hash }
+        { ReferenceDto.Default with
+            ReferenceId = referenceId
+            BranchId = currentBranchId
+            ReferenceType = ReferenceType.Save
+            DirectoryId = directoryVersionId
+            Sha256Hash = sha256Hash
+        }
 
     let private branch saveEnabled latestReference =
-        { BranchDto.Default with SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
+        { BranchDto.Default with BranchId = currentBranchId; SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
 
     let private defaultOperations branchDto =
         {
@@ -131,6 +139,44 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected GraceWatch success, got: {error.Error}")
 
     [<Test>]
+    let ``unchanged child branch does not use parent BasedOn reference`` () =
+        let parentReferenceId = Guid.NewGuid()
+        let createdSaveId = Guid.NewGuid()
+        let mutable createdSave = false
+
+        let parentBasedOn = { referenceDto parentReferenceId rootDirectoryId rootSha with BranchId = parentBranchId }
+
+        let branchDto = { branch true ReferenceDto.Default with BasedOn = parentBasedOn }
+
+        let operations =
+            { defaultOperations branchDto with
+                CreateSaveReference =
+                    fun rootDirectoryVersion _ ->
+                        createdSave <- true
+
+                        rootDirectoryVersion.DirectoryVersionId
+                        |> should equal rootDirectoryId
+
+                        rootDirectoryVersion.Sha256Hash
+                        |> should equal rootSha
+
+                        Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.Source |> should equal CreatedSave
+            createdSave |> should equal true
+        | Error error -> Assert.Fail($"Expected implicit Save success, got: {error.Error}")
+
+    [<Test>]
     let ``local changes auto-create save with annotate message`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"
@@ -190,6 +236,81 @@ module CurrentStateCaptureCliTests =
             uploadedDirectories |> should equal true
             appliedStatus |> should equal true
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes upload changed file versions already present in object cache`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/file.txt"
+
+        let changedFile =
+            LocalFileVersion.Create changedPath (Sha256Hash "changed-file-sha") false 12L (Grace.Shared.Utilities.getCurrentInstant ()) true DateTime.UtcNow
+
+        let mutable uploadedFiles = List<LocalFileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile |]))
+                changedFile.Size
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions =
+                    fun fileVersions ->
+                        uploadedFiles <- List<LocalFileVersion>(fileVersions)
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            uploadedFiles.Count |> should equal 1
+
+            uploadedFiles[0].RelativePath
+            |> should equal changedPath
+
+            uploadedFiles[0].Sha256Hash
+            |> should equal changedFile.Sha256Hash
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``created save reference id is parsed from response properties`` () =
+        let createdSaveId = Guid.NewGuid()
+        let properties = Dictionary<string, obj>()
+        properties.Add(nameof ReferenceId, createdSaveId)
+        let returnValue = GraceReturnValue.CreateWithMetadata "Branch command succeeded." correlationId properties
+
+        match parseCreatedReferenceId correlationId returnValue with
+        | Ok referenceId -> referenceId |> should equal createdSaveId
+        | Error error -> Assert.Fail($"Expected ReferenceId property parse success, got: {error.Error}")
 
     [<Test>]
     let ``save disabled fails before uploading local changes`` () =

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="PromotionSet.CLI.Tests.fs" />
     <Compile Include="Maintenance.CLI.Tests.fs" />
     <Compile Include="CommandOutputContract.CLI.Tests.fs" />
+    <Compile Include="CurrentStateCapture.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />
     <Compile Include="LocalPlanner.SDK.Tests.fs" />
     <Compile Include="ManifestUpload.SDK.Tests.fs" />

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -35,7 +35,10 @@ open System.Threading.Tasks
 open System.Reactive.Linq
 open System.Threading
 open Grace.Shared.Parameters
+open Grace.Shared.Parameters.Branch
 open Grace.Shared.Parameters.Storage
+open Grace.Types.Branch
+open Grace.Types.Reference
 open System.Runtime.Intrinsics.Arm
 
 module Services =
@@ -1699,7 +1702,7 @@ module Services =
         }
 
     /// Creates a save reference with the given message.
-    let createSaveReference rootDirectoryVersion message correlationId =
+    let createSaveReference (rootDirectoryVersion: LocalDirectoryVersion) message correlationId =
         task {
             //Activity.Current <- new Activity("createSaveReference")
             let createReferenceParameters =
@@ -1732,6 +1735,167 @@ module Services =
             //Activity.Current.Dispose()
             return result
         }
+
+    type CliCurrentStateCaptureSource =
+        | ExplicitReference
+        | ExistingReference
+        | GraceWatch
+        | CreatedSave
+
+    type CliCurrentStateCaptureResult =
+        {
+            TargetReferenceId: ReferenceId
+            RootDirectoryId: DirectoryVersionId
+            RootDirectorySha256Hash: Sha256Hash
+            Source: CliCurrentStateCaptureSource
+            CreatedSaveMessage: string option
+        }
+
+    type CliCurrentStateCaptureOperations =
+        {
+            GetBranch: unit -> Task<GraceResult<BranchDto>>
+            GetGraceWatchStatus: unit -> Task<GraceWatchStatus option>
+            ReadGraceStatus: unit -> Task<GraceStatus>
+            ScanForDifferences: GraceStatus -> Task<List<FileSystemDifference>>
+            CopyUpdatedFilesToObjectCache: List<FileSystemDifference> -> Task<seq<LocalFileVersion>>
+            BuildUpdatedGraceStatus: GraceStatus -> List<FileSystemDifference> -> Task<GraceStatus * List<LocalDirectoryVersion>>
+            UploadFileVersions: seq<LocalFileVersion> -> Task<Result<unit, GraceError>>
+            UploadDirectoryVersions: List<LocalDirectoryVersion> -> Task<Result<unit, GraceError>>
+            ApplyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>
+            CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
+        }
+
+    let private referenceHasRoot rootDirectoryId rootDirectorySha256Hash (referenceDto: ReferenceDto) =
+        referenceDto.ReferenceId <> ReferenceId.Empty
+        && referenceDto.DirectoryId = rootDirectoryId
+        && referenceDto.Sha256Hash = rootDirectorySha256Hash
+
+    let private tryFindReferenceForRoot rootDirectoryId rootDirectorySha256Hash (branchDto: BranchDto) =
+        [
+            branchDto.LatestReference
+            branchDto.LatestSave
+            branchDto.LatestCommit
+            branchDto.LatestCheckpoint
+            branchDto.LatestPromotion
+            branchDto.BasedOn
+        ]
+        |> Seq.tryFind (referenceHasRoot rootDirectoryId rootDirectorySha256Hash)
+
+    let private saveDisabledError correlationId =
+        GraceError.Create "Save is disabled on this branch, and local changes require a Save before branch annotation can continue." correlationId
+
+    let private createCaptureResult source createdSaveMessage rootDirectoryId rootDirectorySha256Hash targetReferenceId =
+        {
+            TargetReferenceId = targetReferenceId
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = rootDirectorySha256Hash
+            Source = source
+            CreatedSaveMessage = createdSaveMessage
+        }
+
+    let private createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion =
+        task {
+            if not branchDto.SaveEnabled then
+                return Error(saveDisabledError correlationId)
+            else
+                match! operations.CreateSaveReference rootDirectoryVersion saveMessage with
+                | Ok referenceId ->
+                    return
+                        Ok(
+                            createCaptureResult
+                                CreatedSave
+                                (Some saveMessage)
+                                rootDirectoryVersion.DirectoryVersionId
+                                rootDirectoryVersion.Sha256Hash
+                                referenceId
+                        )
+                | Error error -> return Error error
+        }
+
+    let resolveCliCurrentStateTargetReference operations (explicitReferenceId: ReferenceId option) (saveMessage: string) (correlationId: CorrelationId) =
+        task {
+            match explicitReferenceId with
+            | Some referenceId when referenceId <> ReferenceId.Empty ->
+                return Ok(createCaptureResult ExplicitReference None DirectoryVersionId.Empty (Sha256Hash String.Empty) referenceId)
+            | _ ->
+                match! operations.GetBranch() with
+                | Error error -> return Error error
+                | Ok branchReturnValue ->
+                    let branchDto = branchReturnValue.ReturnValue
+
+                    match! operations.GetGraceWatchStatus() with
+                    | Some graceWatchStatus ->
+                        match tryFindReferenceForRoot graceWatchStatus.RootDirectoryId graceWatchStatus.RootDirectorySha256Hash branchDto with
+                        | Some referenceDto ->
+                            return
+                                Ok(
+                                    createCaptureResult
+                                        GraceWatch
+                                        None
+                                        graceWatchStatus.RootDirectoryId
+                                        graceWatchStatus.RootDirectorySha256Hash
+                                        referenceDto.ReferenceId
+                                )
+                        | None ->
+                            let rootDirectoryVersion =
+                                LocalDirectoryVersion.Create
+                                    graceWatchStatus.RootDirectoryId
+                                    (Current().OwnerId)
+                                    (Current().OrganizationId)
+                                    (Current().RepositoryId)
+                                    Constants.RootDirectoryPath
+                                    graceWatchStatus.RootDirectorySha256Hash
+                                    (List<DirectoryVersionId>())
+                                    (List<LocalFileVersion>())
+                                    0L
+                                    DateTime.UtcNow
+
+                            return! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion
+                    | None ->
+                        let! previousGraceStatus = operations.ReadGraceStatus()
+                        let! differences = operations.ScanForDifferences previousGraceStatus
+
+                        if differences.Count = 0 then
+                            match tryFindReferenceForRoot previousGraceStatus.RootDirectoryId previousGraceStatus.RootDirectorySha256Hash branchDto with
+                            | Some referenceDto ->
+                                return
+                                    Ok(
+                                        createCaptureResult
+                                            ExistingReference
+                                            None
+                                            previousGraceStatus.RootDirectoryId
+                                            previousGraceStatus.RootDirectorySha256Hash
+                                            referenceDto.ReferenceId
+                                    )
+                            | None ->
+                                return! createSaveForCurrentRoot operations branchDto saveMessage correlationId (getRootDirectoryVersion previousGraceStatus)
+                        elif not branchDto.SaveEnabled then
+                            return Error(saveDisabledError correlationId)
+                        else
+                            let! newFileVersions = operations.CopyUpdatedFilesToObjectCache differences
+                            let! (updatedGraceStatus, newDirectoryVersions) = operations.BuildUpdatedGraceStatus previousGraceStatus differences
+
+                            match! operations.UploadFileVersions newFileVersions with
+                            | Error error -> return Error error
+                            | Ok () ->
+                                match! operations.UploadDirectoryVersions newDirectoryVersions with
+                                | Error error -> return Error error
+                                | Ok () ->
+                                    let updatedGraceStatus =
+                                        { updatedGraceStatus with
+                                            LastSuccessfulFileUpload = getCurrentInstant ()
+                                            LastSuccessfulDirectoryVersionUpload = getCurrentInstant ()
+                                        }
+
+                                    do! operations.ApplyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
+                                    let rootDirectoryVersion = getRootDirectoryVersion updatedGraceStatus
+                                    return! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion
+        }
+
+    let private parseCreatedReferenceId correlationId (returnValue: GraceReturnValue<string>) =
+        match Guid.TryParse returnValue.ReturnValue with
+        | true, referenceId -> Ok referenceId
+        | false, _ -> Error(GraceError.Create $"Save reference creation returned an invalid ReferenceId: {returnValue.ReturnValue}." correlationId)
 
     /// Generates a temporary file name within the ObjectDirectory, and returns the full file path.
     /// This file name will be used to copy modified files into before renaming them with their proper names and SHA256 values.
@@ -1808,8 +1972,7 @@ module Services =
                 return None
         }
 
-    /// Copies new and updated files found in a list of FileSystemDifferences to the object directory.
-    let copyUpdatedFilesToObjectCache (t: ProgressTask) (differences: List<FileSystemDifference>) =
+    let private copyUpdatedFilesToObjectCacheCore (progressTask: ProgressTask option) (differences: List<FileSystemDifference>) =
         task {
             // Get the list of files that have been added or changed.
             let relativePathsOfUpdatedFiles =
@@ -1831,10 +1994,9 @@ module Services =
 
             // Create new LocalFileVersion instances for each updated file.
             let increment =
-                if differences.Count > 0 then
-                    (100.0 - t.Value) / float differences.Count
-                else
-                    0.0
+                match progressTask with
+                | Some t when differences.Count > 0 -> (100.0 - t.Value) / float differences.Count
+                | _ -> 0.0
 
             let newFileVersions = ConcurrentQueue<LocalFileVersion>()
 
@@ -1853,13 +2015,104 @@ module Services =
                                     logToAnsiConsole Colors.Error $"Failed to copy {relativePath} to object storage."
                                     ()
 
-                                t.Increment(increment)
+                                match progressTask with
+                                | Some t -> t.Increment(increment)
+                                | None -> ()
                             }
                         ))
                 )
 
             return newFileVersions
         }
+
+    /// Copies new and updated files found in a list of FileSystemDifferences to the object directory.
+    let copyUpdatedFilesToObjectCache (t: ProgressTask) (differences: List<FileSystemDifference>) = copyUpdatedFilesToObjectCacheCore (Some t) differences
+
+    let copyUpdatedFilesToObjectCacheWithoutProgress (differences: List<FileSystemDifference>) = copyUpdatedFilesToObjectCacheCore None differences
+
+    let defaultCliCurrentStateCaptureOperations (correlationId: CorrelationId) =
+        let getBranch () =
+            let current = Current()
+
+            let parameters =
+                GetBranchParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OwnerName = current.OwnerName,
+                    OrganizationId = $"{current.OrganizationId}",
+                    OrganizationName = current.OrganizationName,
+                    RepositoryId = $"{current.RepositoryId}",
+                    RepositoryName = current.RepositoryName,
+                    BranchId = $"{current.BranchId}",
+                    BranchName = current.BranchName,
+                    CorrelationId = correlationId
+                )
+
+            Grace.SDK.Branch.Get parameters
+
+        let uploadFileVersions (fileVersions: seq<LocalFileVersion>) =
+            task {
+                let current = Current()
+
+                let parameters =
+                    GetUploadMetadataForFilesParameters(
+                        OwnerId = $"{current.OwnerId}",
+                        OwnerName = current.OwnerName,
+                        OrganizationId = $"{current.OrganizationId}",
+                        OrganizationName = current.OrganizationName,
+                        RepositoryId = $"{current.RepositoryId}",
+                        RepositoryName = current.RepositoryName,
+                        CorrelationId = correlationId,
+                        FileVersions =
+                            (fileVersions
+                             |> Seq.map (fun localFileVersion -> localFileVersion.ToFileVersion)
+                             |> Seq.toArray)
+                    )
+
+                match! uploadFilesToObjectStorage parameters with
+                | Ok _ -> return Ok()
+                | Error error -> return Error error
+            }
+
+        let uploadDirectoryVersionsForCapture directoryVersions =
+            task {
+                match! uploadDirectoryVersions directoryVersions correlationId with
+                | Ok _ -> return Ok()
+                | Error error -> return Error error
+            }
+
+        let createSaveReferenceForCapture rootDirectoryVersion saveMessage =
+            task {
+                match! createSaveReference rootDirectoryVersion saveMessage correlationId with
+                | Ok returnValue -> return parseCreatedReferenceId correlationId returnValue
+                | Error error -> return Error error
+            }
+
+        {
+            GetBranch = getBranch
+            GetGraceWatchStatus = getGraceWatchStatus
+            ReadGraceStatus = readGraceStatusFile
+            ScanForDifferences = scanForDifferences
+            CopyUpdatedFilesToObjectCache =
+                fun differences ->
+                    task {
+                        let! copied = copyUpdatedFilesToObjectCacheWithoutProgress differences
+                        return copied :> seq<LocalFileVersion>
+                    }
+            BuildUpdatedGraceStatus = getNewGraceStatusAndDirectoryVersions
+            UploadFileVersions = uploadFileVersions
+            UploadDirectoryVersions = uploadDirectoryVersionsForCapture
+            ApplyGraceStatusIncremental = applyGraceStatusIncremental
+            CreateSaveReference = createSaveReferenceForCapture
+        }
+
+    let branchAnnotateImplicitSaveMessage = "Created during `grace branch annotate` operation."
+
+    let resolveCliCurrentStateTargetReferenceForBranchAnnotate (explicitReferenceId: ReferenceId option) (correlationId: CorrelationId) =
+        resolveCliCurrentStateTargetReference
+            (defaultCliCurrentStateCaptureOperations correlationId)
+            explicitReferenceId
+            branchAnnotateImplicitSaveMessage
+            correlationId
 
     let private matchesOptionName (option: Option) (optionName: string) =
         let normalizedName = optionName.TrimStart('-')

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1765,8 +1765,9 @@ module Services =
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
         }
 
-    let private referenceHasRoot rootDirectoryId rootDirectorySha256Hash (referenceDto: ReferenceDto) =
+    let private referenceHasRootOnBranch branchId rootDirectoryId rootDirectorySha256Hash (referenceDto: ReferenceDto) =
         referenceDto.ReferenceId <> ReferenceId.Empty
+        && referenceDto.BranchId = branchId
         && referenceDto.DirectoryId = rootDirectoryId
         && referenceDto.Sha256Hash = rootDirectorySha256Hash
 
@@ -1777,9 +1778,30 @@ module Services =
             branchDto.LatestCommit
             branchDto.LatestCheckpoint
             branchDto.LatestPromotion
-            branchDto.BasedOn
         ]
-        |> Seq.tryFind (referenceHasRoot rootDirectoryId rootDirectorySha256Hash)
+        |> Seq.tryFind (referenceHasRootOnBranch branchDto.BranchId rootDirectoryId rootDirectorySha256Hash)
+
+    let private getChangedFileVersionsReferencedByUpdatedDirectories
+        (differences: List<FileSystemDifference>)
+        (directoryVersions: List<LocalDirectoryVersion>)
+        =
+        let changedFilePaths = HashSet<RelativePath>()
+
+        differences
+        |> Seq.iter (fun difference ->
+            match difference.DifferenceType, difference.FileSystemEntryType with
+            | (DifferenceType.Add
+              | DifferenceType.Change),
+              FileSystemEntryType.File ->
+                changedFilePaths.Add(difference.RelativePath)
+                |> ignore
+            | _ -> ())
+
+        directoryVersions
+        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+        |> Seq.filter (fun fileVersion -> changedFilePaths.Contains fileVersion.RelativePath)
+        |> Seq.distinctBy (fun fileVersion -> fileVersion.RelativePath, fileVersion.Sha256Hash)
+        |> Seq.toList
 
     let private saveDisabledError correlationId =
         GraceError.Create "Save is disabled on this branch, and local changes require a Save before branch annotation can continue." correlationId
@@ -1872,10 +1894,11 @@ module Services =
                         elif not branchDto.SaveEnabled then
                             return Error(saveDisabledError correlationId)
                         else
-                            let! newFileVersions = operations.CopyUpdatedFilesToObjectCache differences
+                            let! _ = operations.CopyUpdatedFilesToObjectCache differences
                             let! (updatedGraceStatus, newDirectoryVersions) = operations.BuildUpdatedGraceStatus previousGraceStatus differences
+                            let fileVersionsToUpload = getChangedFileVersionsReferencedByUpdatedDirectories differences newDirectoryVersions
 
-                            match! operations.UploadFileVersions newFileVersions with
+                            match! operations.UploadFileVersions fileVersionsToUpload with
                             | Error error -> return Error error
                             | Ok () ->
                                 match! operations.UploadDirectoryVersions newDirectoryVersions with
@@ -1892,10 +1915,15 @@ module Services =
                                     return! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion
         }
 
-    let private parseCreatedReferenceId correlationId (returnValue: GraceReturnValue<string>) =
-        match Guid.TryParse returnValue.ReturnValue with
-        | true, referenceId -> Ok referenceId
-        | false, _ -> Error(GraceError.Create $"Save reference creation returned an invalid ReferenceId: {returnValue.ReturnValue}." correlationId)
+    let parseCreatedReferenceId correlationId (returnValue: GraceReturnValue<string>) =
+        let mutable referenceIdProperty = Unchecked.defaultof<obj>
+
+        if returnValue.Properties.TryGetValue(nameof ReferenceId, &referenceIdProperty) then
+            match Guid.TryParse(string referenceIdProperty) with
+            | true, referenceId -> Ok referenceId
+            | false, _ -> Error(GraceError.Create $"Save reference creation returned an invalid ReferenceId property: {referenceIdProperty}." correlationId)
+        else
+            Error(GraceError.Create "Save reference creation did not return a ReferenceId property." correlationId)
 
     /// Generates a temporary file name within the ObjectDirectory, and returns the full file path.
     /// This file name will be used to copy modified files into before renaming them with their proper names and SHA256 values.


### PR DESCRIPTION
## Summary

- Extracts a reusable CLI current-state capture helper for branch annotation callers.
- Reuses GraceWatch status, existing matching branch references, or the existing local scan/upload/directory-version/save primitives instead of adding an annotate-specific upload pipeline.
- Adds focused CLI tests for explicit Reference ID bypass, GraceWatch resolution, auto-created Save resolution, Save-disabled failure, and stdout cleanliness.

Part of #313
Related to #320

## Implicit Save Message

```text
Created during `grace branch annotate` operation.
```

## Validation

- `dotnet tool run fantomas -- C:\Source\Grace-gh-320\src\Grace.CLI\Command\Services.CLI.fs C:\Source\Grace-gh-320\src\Grace.CLI.Tests\CurrentStateCapture.CLI.Tests.fs`
- `dotnet test --configuration Release C:\Source\Grace-gh-320\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter FullyQualifiedName~CurrentStateCaptureCliTests` (8 passed)
- `pwsh ./scripts/validate.ps1 -Fast` (passed)
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD` (passed)

## Review Status

Codex Code Review Bot reviewed head `105174c9feb5183763003b0294649aecc2f8abbd` and reported three P2 findings on 2026-06-10. Fresh fix worker resolved them in `24229dc887f85a071e48d39facc95f3569912de4`:

- `PRRT_kwDOILVrb86IVQ1w` / `PRRC_kwDOILVrb87JwN0T`: Fixed parent/ancestor `BasedOn` selection by restricting implicit annotate targets to current-branch references and creating a current-branch Save for unchanged child branch cases.
- `PRRT_kwDOILVrb86IVQ1y` / `PRRC_kwDOILVrb87JwN0V`: Fixed implicit Save ReferenceId extraction to read `GraceReturnValue.Properties["ReferenceId"]` instead of parsing the status text return value.
- `PRRT_kwDOILVrb86IVQ1z` / `PRRC_kwDOILVrb87JwN0W`: Fixed retry uploads to derive changed file versions from updated directory versions so object-cache hits are still uploaded before directory-version save.

Validation for `24229dc887f85a071e48d39facc95f3569912de4`:

- Targeted Fantomas on touched F# files: passed.
- Focused `CurrentStateCaptureCliTests`: passed, 8 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD`: passed.

Replied to and resolved all three Codex Code Review Bot conversations. Waiting for the next Codex Code Review Bot pass on new head `24229dc887f85a071e48d39facc95f3569912de4`.



