### PR TITLE
Add branch annotate CLI command

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -127,8 +127,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `201`
-- JSON-ready routed commands: `180`
+- Total leaf commands: `202`
+- JSON-ready routed commands: `181`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`

--- a/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
@@ -1,0 +1,106 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+open System
+
+[<Parallelizable(ParallelScope.All)>]
+module BranchCommandParsingTests =
+    let private ownerId = Guid.NewGuid()
+    let private organizationId = Guid.NewGuid()
+    let private repositoryId = Guid.NewGuid()
+    let private branchId = Guid.NewGuid()
+    let private referenceId = Guid.NewGuid()
+
+    let private withIds (args: string array) =
+        Array.append
+            args
+            [|
+                "--owner-id"
+                ownerId.ToString()
+                "--organization-id"
+                organizationId.ToString()
+                "--repository-id"
+                repositoryId.ToString()
+                "--branch-id"
+                branchId.ToString()
+            |]
+
+    let private assertParses args =
+        let parseResult = GraceCommand.rootCommand.Parse(withIds args)
+        parseResult.Errors.Count |> should equal 0
+        parseResult
+
+    let private assertDoesNotParse args =
+        let parseResult = GraceCommand.rootCommand.Parse(withIds args)
+        Assert.That(parseResult.Errors.Count, Is.GreaterThan(0))
+        parseResult
+
+    [<Test>]
+    let ``branch annotate parses V1 options`` () =
+        assertParses [| "branch"
+                        "annotate"
+                        "--path"
+                        "src/App.fs"
+                        "--reference-id"
+                        referenceId.ToString()
+                        "-L"
+                        "10,12"
+                        "--reference-types"
+                        "Commit, Promotion"
+                        "--show"
+                        "both"
+                        "--max-references"
+                        "250" |]
+        |> ignore
+
+    [<Test>]
+    let ``branch annotate requires path`` () =
+        assertDoesNotParse [| "branch"
+                              "annotate"
+                              "--reference-id"
+                              referenceId.ToString() |]
+        |> ignore
+
+    [<TestCase("last-changed")>]
+    [<TestCase("introduced")>]
+    [<TestCase("both")>]
+    let ``branch annotate show accepts V1 human modes`` showMode =
+        assertParses [| "branch"
+                        "annotate"
+                        "--path"
+                        "src/App.fs"
+                        "--show"
+                        showMode |]
+        |> ignore
+
+    [<Test>]
+    let ``branch annotate rejects unsupported show mode`` () =
+        assertDoesNotParse [| "branch"
+                              "annotate"
+                              "--path"
+                              "src/App.fs"
+                              "--show"
+                              "source" |]
+        |> ignore
+
+    [<Test>]
+    let ``forbidden branch annotate V1 options are unavailable`` () =
+        for forbiddenOption in
+            [|
+                "--current-branch-only"
+                "--ignore-whitespace"
+                "--no-save"
+                "--force-save"
+            |] do
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    withIds [| "branch"
+                               "annotate"
+                               "--path"
+                               "src/App.fs"
+                               forbiddenOption |]
+                )
+
+            Assert.That(parseResult.Errors.Count, Is.GreaterThan(0), forbiddenOption)

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -1,0 +1,346 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.CLI.Services
+open Grace.Shared
+open Grace.Shared.Parameters.Branch
+open Grace.Shared.Utilities
+open Grace.Types.Annotation
+open Grace.Types.Common
+open Grace.Types.Reference
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+open System.Threading.Tasks
+
+[<NonParallelizable>]
+module BranchCommandTests =
+    let private ownerId = Guid.NewGuid()
+    let private organizationId = Guid.NewGuid()
+    let private repositoryId = Guid.NewGuid()
+    let private branchId = Guid.NewGuid()
+    let private targetReferenceId = Guid.NewGuid()
+    let private correlationId = "branch-annotate-tests"
+
+    let private withIds (args: string array) =
+        Array.append
+            args
+            [|
+                "--owner-id"
+                ownerId.ToString()
+                "--organization-id"
+                organizationId.ToString()
+                "--repository-id"
+                repositoryId.ToString()
+                "--branch-id"
+                branchId.ToString()
+                "--correlation-id"
+                correlationId
+            |]
+
+    let private parse args = GraceCommand.rootCommand.Parse(withIds args)
+
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private captureOutput (action: unit -> int) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+            let exitCode = action ()
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    let private targetReferenceResult =
+        {
+            TargetReferenceId = targetReferenceId
+            RootDirectoryId = Guid.NewGuid()
+            RootDirectorySha256Hash = Sha256Hash "root-sha"
+            Source = ExplicitReference
+            CreatedSaveMessage = None
+        }
+
+    let private sampleAnnotation =
+        let lastChangedReferenceId = Guid.NewGuid()
+        let introducedReferenceId = Guid.NewGuid()
+
+        BranchAnnotationDto.Create(
+            { StartLine = 7; EndLine = 9 },
+            targetReferenceId,
+            "src/App.fs",
+            [|
+                ReferenceType.Commit
+                ReferenceType.Promotion
+            |],
+            250,
+            true,
+            [|
+                { LineNumber = 7; Text = "let one = 1" }
+                { LineNumber = 8; Text = "let two = 2" }
+                { LineNumber = 9; Text = "let three = 3" }
+            |],
+            [|
+                { BoundaryId = "boundary-1"; LineRange = { StartLine = 9; EndLine = 9 }; SourceRowIds = [| "row-3" |] }
+            |],
+            [|
+                { SpanId = "span-1"; BoundaryId = String.Empty; LineRange = { StartLine = 7; EndLine = 8 }; SourceRowIds = [| "row-1"; "row-2" |] }
+                { SpanId = "span-2"; BoundaryId = "boundary-1"; LineRange = { StartLine = 9; EndLine = 9 }; SourceRowIds = [| "row-3" |] }
+            |],
+            [|
+                { SourceRowId = "row-1"; SourceReferenceId = "source-last"; Path = "src/App.fs"; LineRange = { StartLine = 5; EndLine = 6 } }
+                { SourceRowId = "row-2"; SourceReferenceId = "source-introduced"; Path = "src/App.fs"; LineRange = { StartLine = 1; EndLine = 2 } }
+                { SourceRowId = "row-3"; SourceReferenceId = "source-boundary"; Path = "src/App.fs"; LineRange = { StartLine = 9; EndLine = 9 } }
+            |],
+            [|
+                { AnnotationSourceReference.Default with
+                    SourceReferenceId = "source-last"
+                    ReferenceId = lastChangedReferenceId
+                    ReferenceType = "Commit"
+                    ReferenceText = "Change line constants"
+                    CreatedBy = Some "alice"
+                }
+                { AnnotationSourceReference.Default with
+                    SourceReferenceId = "source-introduced"
+                    ReferenceId = introducedReferenceId
+                    ReferenceType = "Promotion"
+                    ReferenceText = "Introduce file"
+                    CreatedBy = Some "bob"
+                }
+                { AnnotationSourceReference.Default with
+                    SourceReferenceId = "source-boundary"
+                    ReferenceId = lastChangedReferenceId
+                    ReferenceType = "Commit"
+                    ReferenceText = "Boundary row"
+                    CreatedBy = None
+                }
+            |]
+        )
+
+    [<Test>]
+    let ``annotate handler maps options to parameters`` () =
+        let explicitReferenceId = Guid.NewGuid()
+        let mutable captured = Unchecked.defaultof<AnnotateParameters>
+        let mutable resolverReferenceId = None
+
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src\\App.fs"
+                     "--reference-id"
+                     explicitReferenceId.ToString()
+                     "-L"
+                     "7,9"
+                     "--reference-types"
+                     "commit, Promotion"
+                     "--show"
+                     "introduced"
+                     "--max-references"
+                     "250" |]
+
+        let annotate (parameters: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            captured <- parameters
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (referenceId: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            resolverReferenceId <- referenceId
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok returnValue ->
+            returnValue.ReturnValue.Path
+            |> should equal "src/App.fs"
+
+            captured.Path |> should equal "src/App.fs"
+
+            captured.TargetReferenceId
+            |> should equal targetReferenceId
+
+            captured.StartLine |> should equal 7
+            captured.EndLine |> should equal 9
+            captured.MaxReferences |> should equal 250
+            captured.IncludeLineText |> should equal true
+
+            captured.ReferenceTypes
+            |> should
+                equal
+                [|
+                    ReferenceType.Commit
+                    ReferenceType.Promotion
+                |]
+
+            resolverReferenceId
+            |> should equal (Some explicitReferenceId)
+        | Error error -> Assert.Fail($"Expected annotate handler success, got: {error.Error}")
+
+    [<TestCase("C:\\repo\\src\\App.fs", "--path must be repository-relative")>]
+    [<TestCase("../src/App.fs", "--path must not contain traversal")>]
+    [<TestCase("src/../App.fs", "--path must not contain traversal")>]
+    let ``annotate handler rejects invalid repository relative paths`` path expectedError =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     path |]
+
+        let annotate (_: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (_: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected invalid path failure.")
+        | Error error -> error.Error |> should contain expectedError
+
+    [<Test>]
+    let ``annotate handler rejects invalid line range`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "-L"
+                     "9,7" |]
+
+        let annotate (_: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (_: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected invalid line range failure.")
+        | Error error ->
+            error.Error
+            |> should contain "Invalid annotation line range"
+
+    [<Test>]
+    let ``annotate handler rejects reference type typo`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--reference-types"
+                     "Commit,Typo" |]
+
+        let annotate (_: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (_: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected invalid Reference type failure.")
+        | Error error ->
+            error.Error
+            |> should contain "Unknown Reference type"
+
+    [<Test>]
+    let ``human output is span grouped with requested line numbers and text`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--show"
+                     "both" |]
+
+        let _, output =
+            captureOutput (fun () ->
+                Branch.renderBranchAnnotationHumanOutput parseResult Branch.Both sampleAnnotation
+                0)
+
+        output |> should contain "Lines 7-8"
+        output |> should contain "Line 9"
+        output |> should contain "Last changed Reference"
+        output |> should contain "Introduced Reference"
+        output |> should contain "boundary-1"
+        output |> should contain "7"
+        output |> should contain "let one = 1"
+        output |> should contain "9"
+        output |> should contain "let three = 3"
+
+    [<Test>]
+    let ``show introduced suppresses last changed human label`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--show"
+                     "introduced" |]
+
+        let _, output =
+            captureOutput (fun () ->
+                Branch.renderBranchAnnotationHumanOutput parseResult Branch.Introduced sampleAnnotation
+                0)
+
+        output |> should contain "Introduced Reference"
+
+        output
+        |> should not' (contain "Last changed Reference")
+
+    [<Test>]
+    let ``json output remains a single Grace result document and skips human spans`` () =
+        let parseResult =
+            parse [| "--output"
+                     "Json"
+                     "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--show"
+                     "introduced" |]
+
+        let exitCode, output =
+            captureOutput (fun () ->
+                let result = Ok(GraceReturnValue.Create sampleAnnotation correlationId)
+                let rendered = Common.renderOutput parseResult result
+                Branch.renderBranchAnnotationHumanOutput parseResult Branch.Introduced sampleAnnotation
+                rendered)
+
+        exitCode |> should equal 0
+
+        output
+        |> should not' (contain "Introduced Reference")
+
+        use document = JsonDocument.Parse(output)
+
+        document.RootElement.ValueKind
+        |> should equal JsonValueKind.Object
+
+        document
+            .RootElement
+            .GetProperty("ReturnValue")
+            .GetProperty("Path")
+            .GetString()
+        |> should equal "src/App.fs"

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -189,6 +189,7 @@ module BranchCommandTests =
         | Error error -> Assert.Fail($"Expected annotate handler success, got: {error.Error}")
 
     [<TestCase("C:\\repo\\src\\App.fs", "--path must be repository-relative")>]
+    [<TestCase("D:/repo/src/App.fs", "--path must be repository-relative")>]
     [<TestCase("../src/App.fs", "--path must not contain traversal")>]
     [<TestCase("src/../App.fs", "--path must not contain traversal")>]
     let ``annotate handler rejects invalid repository relative paths`` path expectedError =

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -240,6 +240,63 @@ module BranchCommandTests =
             |> should contain "Invalid annotation line range"
 
     [<Test>]
+    let ``annotate handler rejects explicit zero end line`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--start-line"
+                     "5"
+                     "--end-line"
+                     "0" |]
+
+        let annotate (_: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (_: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected explicit zero end line failure.")
+        | Error error ->
+            error.Error
+            |> should contain "Invalid annotation line range"
+
+    [<Test>]
+    let ``annotate handler defaults omitted end line to start line`` () =
+        let mutable captured = Unchecked.defaultof<AnnotateParameters>
+
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--start-line"
+                     "5" |]
+
+        let annotate (parameters: AnnotateParameters) : Task<GraceResult<BranchAnnotationDto>> =
+            captured <- parameters
+            Task.FromResult(Ok(GraceReturnValue.Create sampleAnnotation correlationId))
+
+        let resolveTargetReference (_: ReferenceId option) (_: CorrelationId) : Task<Result<CliCurrentStateCaptureResult, GraceError>> =
+            Task.FromResult(Ok targetReferenceResult)
+
+        let result =
+            (Branch.annotateHandlerWith annotate resolveTargetReference parseResult)
+                .Result
+
+        match result with
+        | Ok _ ->
+            captured.StartLine |> should equal 5
+            captured.EndLine |> should equal 5
+        | Error error -> Assert.Fail($"Expected omitted end line success, got: {error.Error}")
+
+    [<Test>]
     let ``annotate handler rejects reference type typo`` () =
         let parseResult =
             parse [| "branch"

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -345,3 +345,38 @@ module BranchCommandTests =
             .GetProperty("Path")
             .GetString()
         |> should equal "src/App.fs"
+
+    [<Test>]
+    let ``select output remains one machine readable document and skips human spans`` () =
+        let parseResult =
+            parse [| "branch"
+                     "annotate"
+                     "--path"
+                     "src/App.fs"
+                     "--show"
+                     "introduced"
+                     "--select"
+                     "Path" |]
+
+        let exitCode, output =
+            captureOutput (fun () ->
+                let result = Ok(GraceReturnValue.Create sampleAnnotation correlationId)
+                let rendered = Common.renderOutput parseResult result
+                Branch.renderBranchAnnotationHumanOutput parseResult Branch.Introduced sampleAnnotation
+                rendered)
+
+        exitCode |> should equal 0
+
+        output
+        |> should not' (contain "Introduced Reference")
+
+        output
+        |> should not' (contain "Branch annotation for")
+
+        use document = JsonDocument.Parse(output)
+
+        document.RootElement.ValueKind
+        |> should equal JsonValueKind.String
+
+        document.RootElement.GetString()
+        |> should equal "src/App.fs"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -212,16 +212,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 201
+        |> should equal 202
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 192
+        |> should equal 193
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 180
+        |> should equal 181
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -262,7 +262,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 180
+        jsonReady |> should equal 181
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -285,7 +285,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 192
+        discovered.Length |> should equal 193
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)
@@ -393,7 +393,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 180
+        commonEntries.Length |> should equal 181
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -410,7 +410,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 180
+        commonEntries.Length |> should equal 181
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -388,6 +388,21 @@ module CommandOutputContractRegistryTests =
         | None -> Assert.Fail("connect should have a registry entry.")
 
     [<Test>]
+    let ``branch annotate registry entry is mutating because implicit save can update local state`` () =
+        let identity = CommandOutputContract.commandIdentity [ "branch" ] "annotate"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.Mutating |> should equal true
+
+            entry.Category
+            |> should equal MutatingStateTransition
+
+            entry.ExecutionScope
+            |> should equal CompositeLocalAndServer
+        | None -> Assert.Fail("branch annotate should have a registry entry.")
+
+    [<Test>]
     let ``current common renderer entries keep the Grace envelope model`` () =
         let commonEntries =
             CommandOutputContract.entries

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -18,6 +18,8 @@
     <Compile Include="Agent.CLI.Tests.fs" />
     <Compile Include="Auth.Tests.fs" />
     <Compile Include="AuthTokenBundle.Tests.fs" />
+    <Compile Include="Branch.CLI.Parsing.Tests.fs" />
+    <Compile Include="Branch.CLI.Tests.fs" />
     <Compile Include="Connect.CLI.Parsing.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
     <Compile Include="BuildInfo.Tests.fs" />

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1816,10 +1816,11 @@ module Branch =
             else
                 Ok(RelativePath normalized)
 
-    let internal parseBranchAnnotateLineRange correlationId (lineRange: string) startLine endLine =
+    let internal parseBranchAnnotateLineRange correlationId (lineRange: string) startLine endLine endLineWasSpecified =
         let parsedRange =
             if String.IsNullOrWhiteSpace(lineRange) then
-                let effectiveEndLine = if endLine = 0 then startLine else endLine
+                let effectiveEndLine = if endLine = 0 && not endLineWasSpecified then startLine else endLine
+
                 { StartLine = startLine; EndLine = effectiveEndLine }
             else
                 let parts =
@@ -1962,12 +1963,16 @@ module Branch =
                 else
                     parseResult.GetValue(Options.annotateLineRange)
 
+            let endLineResult = parseResult.GetResult(Options.annotateEndLine)
+
             let rangeResult =
                 parseBranchAnnotateLineRange
                     correlationId
                     lineRangeText
                     (parseResult.GetValue(Options.annotateStartLine))
                     (parseResult.GetValue(Options.annotateEndLine))
+                    (not (isNull endLineResult)
+                     && not endLineResult.Implicit)
 
             let referenceTypesText =
                 if isNull (parseResult.GetResult(Options.annotateReferenceTypes)) then

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -17,6 +17,7 @@ open Grace.Shared.Validation
 open Grace.Shared.Validation.Errors
 open Grace.Types.Branch
 open Grace.Types.DirectoryVersion
+open Grace.Types.Annotation
 open Grace.Types.Reference
 open Grace.Types.Common
 open NodaTime
@@ -205,6 +206,69 @@ module Branch =
 
         let referenceId =
             new Option<ReferenceId>(OptionName.ReferenceId, [||], Required = false, Description = "The reference ID <Guid>.", Arity = ArgumentArity.ExactlyOne)
+
+        let annotatePath =
+            new Option<String>(OptionName.Path, Required = true, Description = "The repository-relative path to annotate.", Arity = ArgumentArity.ExactlyOne)
+
+        let annotateLineRange =
+            new Option<String>(
+                "--line-range",
+                [| "-L" |],
+                Required = false,
+                Description = "The inclusive 1-based line range to annotate, formatted as start,end.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let annotateStartLine =
+            new Option<int>(
+                "--start-line",
+                Required = false,
+                Description = "The first 1-based line to annotate. [default: 1]",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 1)
+            )
+
+        let annotateEndLine =
+            new Option<int>(
+                "--end-line",
+                Required = false,
+                Description = "The final 1-based line to annotate. Defaults to --start-line when omitted.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> 0)
+            )
+
+        let annotateReferenceTypes =
+            new Option<String>(
+                "--reference-types",
+                Required = false,
+                Description = "Comma-separated Reference types to use for attribution, for example Commit,Promotion.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
+        let annotateShow =
+            (new Option<String>(
+                "--show",
+                Required = false,
+                Description = "Human output source details to show: last-changed, introduced, or both. JSON always includes the complete DTO.",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> "last-changed")
+            ))
+                .AcceptOnlyFromAmong(
+                    [|
+                        "last-changed"
+                        "introduced"
+                        "both"
+                    |]
+                )
+
+        let annotateMaxReferences =
+            new Option<int>(
+                "--max-references",
+                Required = false,
+                Description = $"Maximum References to traverse while annotating. [default: {DefaultMaxReferences}; maximum: {MaximumMaxReferences}]",
+                Arity = ArgumentArity.ExactlyOne,
+                DefaultValueFactory = (fun _ -> DefaultMaxReferences)
+            )
 
         let sha256Hash =
             new Option<String>(
@@ -1672,6 +1736,300 @@ module Branch =
             }
 
     type EnableFeatureCommand = EnableFeatureParameters -> Task<GraceResult<string>>
+
+    type BranchAnnotateShow =
+        | LastChanged
+        | Introduced
+        | Both
+
+    type BranchAnnotateCommand = AnnotateParameters -> Task<GraceResult<BranchAnnotationDto>>
+
+    type BranchAnnotateTargetReferenceResolver = ReferenceId option -> CorrelationId -> Task<Result<CliCurrentStateCaptureResult, GraceError>>
+
+    let private validReferenceTypeNames = listCases<ReferenceType> ()
+
+    let private tryParseReferenceType (value: string) =
+        validReferenceTypeNames
+        |> Array.tryFind (fun name -> String.Equals(name, value.Trim(), StringComparison.OrdinalIgnoreCase))
+        |> Option.bind (fun canonicalName -> discriminatedUnionFromString<ReferenceType> canonicalName)
+
+    let internal tryParseBranchAnnotateReferenceTypes correlationId (value: string) =
+        if String.IsNullOrWhiteSpace(value) then
+            Ok Array.empty
+        else
+            let tokens = value.Split(',', StringSplitOptions.None)
+
+            let invalid =
+                tokens
+                |> Array.choose (fun token ->
+                    if String.IsNullOrWhiteSpace(token) then
+                        Some "<blank>"
+                    else
+                        match tryParseReferenceType token with
+                        | Some _ -> None
+                        | None -> Some(token.Trim()))
+
+            if invalid.Length > 0 then
+                let invalidText = String.Join(", ", invalid)
+                let validText = String.Join(", ", validReferenceTypeNames)
+
+                Error(GraceError.Create $"Unknown Reference type(s): {invalidText}. Allowed values: {validText}." correlationId)
+            else
+                tokens
+                |> Array.choose tryParseReferenceType
+                |> Array.distinct
+                |> Ok
+
+    let private normalizeBranchAnnotatePath correlationId (path: string) =
+        let trimmed = if isNull path then String.Empty else path.Trim()
+
+        if String.IsNullOrWhiteSpace(trimmed) then
+            Error(GraceError.Create "--path is required and must be repository-relative." correlationId)
+        elif
+            Path.IsPathFullyQualified(trimmed)
+            || trimmed.StartsWith("/", StringComparison.Ordinal)
+            || trimmed.StartsWith("\\", StringComparison.Ordinal)
+        then
+            Error(GraceError.Create "--path must be repository-relative; absolute paths are not allowed." correlationId)
+        else
+            let normalized = trimmed.Replace('\\', '/')
+
+            let hasTraversal =
+                normalized.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                |> Array.exists (fun segment -> segment = ".." || segment = ".")
+
+            if
+                hasTraversal
+                || normalized.Contains("../", StringComparison.Ordinal)
+                || normalized.EndsWith("/..", StringComparison.Ordinal)
+            then
+                Error(GraceError.Create "--path must not contain traversal segments." correlationId)
+            elif normalized.Contains(":", StringComparison.Ordinal) then
+                Error(GraceError.Create "--path must not contain drive or URI separators." correlationId)
+            else
+                Ok(RelativePath normalized)
+
+    let internal parseBranchAnnotateLineRange correlationId (lineRange: string) startLine endLine =
+        let parsedRange =
+            if String.IsNullOrWhiteSpace(lineRange) then
+                let effectiveEndLine = if endLine = 0 then startLine else endLine
+                { StartLine = startLine; EndLine = effectiveEndLine }
+            else
+                let parts =
+                    lineRange.Split(
+                        ',',
+                        StringSplitOptions.TrimEntries
+                        ||| StringSplitOptions.RemoveEmptyEntries
+                    )
+
+                if parts.Length <> 2 then
+                    { StartLine = 0; EndLine = -1 }
+                else
+                    match Int32.TryParse(parts[0]), Int32.TryParse(parts[1]) with
+                    | (true, parsedStart), (true, parsedEnd) -> { StartLine = parsedStart; EndLine = parsedEnd }
+                    | _ -> { StartLine = 0; EndLine = -1 }
+
+        match validateLineRange parsedRange with
+        | Ok () -> Ok parsedRange
+        | Error errors ->
+            let errorText = String.Join(" ", errors)
+            Error(GraceError.Create $"Invalid annotation line range: {errorText}" correlationId)
+
+    let private parseBranchAnnotateShow (value: string) =
+        match value with
+        | value when String.Equals(value, "introduced", StringComparison.OrdinalIgnoreCase) -> Introduced
+        | value when String.Equals(value, "both", StringComparison.OrdinalIgnoreCase) -> Both
+        | _ -> LastChanged
+
+    let private tryGetSourceReference (annotation: BranchAnnotationDto) sourceReferenceId =
+        annotation.SourceReferences
+        |> Array.tryFind (fun sourceReference -> sourceReference.SourceReferenceId = sourceReferenceId)
+
+    let private tryGetSourceRowAndReference annotation sourceRowId =
+        annotation.SourceRows
+        |> Array.tryFind (fun sourceRow -> sourceRow.SourceRowId = sourceRowId)
+        |> Option.bind (fun sourceRow ->
+            tryGetSourceReference annotation sourceRow.SourceReferenceId
+            |> Option.map (fun sourceReference -> sourceRow, sourceReference))
+
+    let private sourceReferenceText label (source: AnnotationSourceRow * AnnotationSourceReference) =
+        let sourceRow, sourceReference = source
+
+        let createdBy =
+            sourceReference.CreatedBy
+            |> Option.defaultValue "unknown Reference creator"
+
+        let referenceText =
+            if String.IsNullOrWhiteSpace(sourceReference.ReferenceText) then
+                String.Empty
+            else
+                $" - {sourceReference.ReferenceText}"
+
+        $"{label}: {sourceReference.ReferenceType} {sourceReference.ReferenceId} lines {sourceRow.LineRange.StartLine}-{sourceRow.LineRange.EndLine}; creator {createdBy}{referenceText}"
+
+    let private renderBranchAnnotationSpan (parseResult: ParseResult) (showMode: BranchAnnotateShow) (annotation: BranchAnnotationDto) (span: AnnotationSpan) =
+        let spanLines =
+            annotation.Lines
+            |> Array.filter (fun line ->
+                line.LineNumber >= span.LineRange.StartLine
+                && line.LineNumber <= span.LineRange.EndLine)
+            |> Array.sortBy (fun line -> line.LineNumber)
+
+        let lineHeader =
+            if span.LineRange.StartLine = span.LineRange.EndLine then
+                $"Line {span.LineRange.StartLine}"
+            else
+                $"Lines {span.LineRange.StartLine}-{span.LineRange.EndLine}"
+
+        AnsiConsole.MarkupLine($"[{Colors.Important}]{Markup.Escape(lineHeader)}[/]")
+
+        let sourceRows =
+            span.SourceRowIds
+            |> Array.choose (tryGetSourceRowAndReference annotation)
+
+        match showMode, sourceRows with
+        | (LastChanged
+          | Both),
+          rows when rows.Length > 0 ->
+            let sourceText = sourceReferenceText "Last changed Reference" rows[0]
+            AnsiConsole.MarkupLine($"  [{Colors.Deemphasized}]{Markup.Escape(sourceText)}[/]")
+        | _ -> ()
+
+        match showMode, sourceRows with
+        | (Introduced
+          | Both),
+          rows when rows.Length > 1 ->
+            let sourceText = sourceReferenceText "Introduced Reference" rows[1]
+            AnsiConsole.MarkupLine($"  [{Colors.Deemphasized}]{Markup.Escape(sourceText)}[/]")
+        | (Introduced
+          | Both),
+          rows when rows.Length > 0 ->
+            let sourceText = sourceReferenceText "Introduced Reference" rows[0]
+            AnsiConsole.MarkupLine($"  [{Colors.Deemphasized}]{Markup.Escape(sourceText)}[/]")
+        | _ -> ()
+
+        if not (String.IsNullOrWhiteSpace(span.BoundaryId)) then
+            AnsiConsole.MarkupLine($"  [{Colors.Important}]Annotation boundary:[/] {Markup.Escape(span.BoundaryId)}")
+
+        for line in spanLines do
+            AnsiConsole.MarkupLine($"  [{Colors.Highlighted}]{line.LineNumber, 5}[/] {Markup.Escape(line.Text)}")
+
+        AnsiConsole.WriteLine()
+
+    let internal renderBranchAnnotationHumanOutput parseResult showMode (annotation: BranchAnnotationDto) =
+        if parseResult |> hasOutput then
+            AnsiConsole.MarkupLine($"[{Colors.Important}]Branch annotation for {Markup.Escape(annotation.Path)} at Reference {annotation.TargetReferenceId}[/]")
+
+            annotation.Spans
+            |> Array.sortBy (fun span -> span.LineRange.StartLine)
+            |> Array.iter (renderBranchAnnotationSpan parseResult showMode annotation)
+
+            AnsiConsole.MarkupLine($"[{Colors.Important}]Returned {annotation.Spans.Length} annotation spans.[/]")
+
+    let internal annotateHandlerWith
+        (annotateCommand: BranchAnnotateCommand)
+        (resolveTargetReference: BranchAnnotateTargetReferenceResolver)
+        (parseResult: ParseResult)
+        =
+        task {
+            let correlationId = getCorrelationId parseResult
+            let graceIds = parseResult |> getNormalizedIdsAndNames
+
+            let explicitReferenceId =
+                if isNull (parseResult.GetResult(Options.referenceId)) then
+                    None
+                else
+                    let referenceId = parseResult.GetValue(Options.referenceId)
+                    if referenceId = ReferenceId.Empty then None else Some referenceId
+
+            let pathResult =
+                parseResult.GetValue(Options.annotatePath)
+                |> normalizeBranchAnnotatePath correlationId
+
+            let lineRangeText =
+                if isNull (parseResult.GetResult(Options.annotateLineRange)) then
+                    String.Empty
+                else
+                    parseResult.GetValue(Options.annotateLineRange)
+
+            let rangeResult =
+                parseBranchAnnotateLineRange
+                    correlationId
+                    lineRangeText
+                    (parseResult.GetValue(Options.annotateStartLine))
+                    (parseResult.GetValue(Options.annotateEndLine))
+
+            let referenceTypesText =
+                if isNull (parseResult.GetResult(Options.annotateReferenceTypes)) then
+                    String.Empty
+                else
+                    parseResult.GetValue(Options.annotateReferenceTypes)
+
+            let referenceTypesResult = tryParseBranchAnnotateReferenceTypes correlationId referenceTypesText
+            let maxReferences = parseResult.GetValue(Options.annotateMaxReferences)
+
+            match pathResult, rangeResult, referenceTypesResult, validateMaxReferences maxReferences with
+            | Error error, _, _, _ -> return Error error
+            | _, Error error, _, _ -> return Error error
+            | _, _, Error error, _ -> return Error error
+            | _, _, _, Error errors ->
+                let errorText = String.Join(" ", errors)
+                return Error(GraceError.Create $"Invalid --max-references: {errorText}" correlationId)
+            | Ok path, Ok lineRange, Ok referenceTypes, Ok () ->
+                match! resolveTargetReference explicitReferenceId correlationId with
+                | Error error -> return Error error
+                | Ok targetReference ->
+                    let parameters =
+                        AnnotateParameters(
+                            OwnerId = graceIds.OwnerIdString,
+                            OwnerName = graceIds.OwnerName,
+                            OrganizationId = graceIds.OrganizationIdString,
+                            OrganizationName = graceIds.OrganizationName,
+                            RepositoryId = graceIds.RepositoryIdString,
+                            RepositoryName = graceIds.RepositoryName,
+                            BranchId = graceIds.BranchIdString,
+                            BranchName = graceIds.BranchName,
+                            TargetReferenceId = targetReference.TargetReferenceId,
+                            Path = path,
+                            StartLine = lineRange.StartLine,
+                            EndLine = lineRange.EndLine,
+                            ReferenceTypes = referenceTypes,
+                            MaxReferences = maxReferences,
+                            IncludeLineText = true,
+                            CorrelationId = correlationId
+                        )
+
+                    return! annotateCommand parameters
+        }
+
+    type Annotate() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let! result =
+                        annotateHandlerWith (fun parameters -> Branch.Annotate parameters) resolveCliCurrentStateTargetReferenceForBranchAnnotate parseResult
+
+                    let rendered = result |> renderOutput parseResult
+
+                    match result with
+                    | Ok returnValue ->
+                        let showMode =
+                            parseResult.GetValue(Options.annotateShow)
+                            |> parseBranchAnnotateShow
+
+                        renderBranchAnnotationHumanOutput parseResult showMode returnValue.ReturnValue
+                    | Error _ -> ()
+
+                    return rendered
+                with
+                | ex ->
+                    let graceError = GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)
+                    return renderOutput parseResult (GraceResult.Error graceError)
+            }
 
     let private enableFeatureHandler (parseResult: ParseResult) (enabled: bool) (command: EnableFeatureCommand) =
         task {
@@ -4131,6 +4489,25 @@ module Branch =
 
         getRecursiveSizeCommand.Action <- new GetRecursiveSize()
         branchCommand.Subcommands.Add(getRecursiveSizeCommand)
+
+        let annotateCommand =
+            new Command(
+                "annotate",
+                Description =
+                    "Annotate visible text lines at a repository-relative path with Last changed and Introduced References. V1 is exact-path only and does not follow renames, copies, or moved blocks."
+            )
+            |> addOption Options.annotatePath
+            |> addOption Options.referenceId
+            |> addOption Options.annotateLineRange
+            |> addOption Options.annotateStartLine
+            |> addOption Options.annotateEndLine
+            |> addOption Options.annotateReferenceTypes
+            |> addOption Options.annotateShow
+            |> addOption Options.annotateMaxReferences
+            |> addCommonOptions
+
+        annotateCommand.Action <- new Annotate()
+        branchCommand.Subcommands.Add(annotateCommand)
 
         let enableAssignCommand =
             new Command("enable-assign", Description = "Enable or disable assigning promotions on this branch.")

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1924,7 +1924,10 @@ module Branch =
         AnsiConsole.WriteLine()
 
     let internal renderBranchAnnotationHumanOutput parseResult showMode (annotation: BranchAnnotationDto) =
-        if parseResult |> hasOutput then
+        if
+            (parseResult |> hasOutput)
+            && not (parseResult |> hasSelect)
+        then
             AnsiConsole.MarkupLine($"[{Colors.Important}]Branch annotation for {Markup.Escape(annotation.Path)} at Reference {annotation.TargetReferenceId}[/]")
 
             annotation.Spans

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1780,13 +1780,20 @@ module Branch =
                 |> Array.distinct
                 |> Ok
 
+    let private isWindowsDriveRootedPath (path: string) =
+        path.Length >= 3
+        && Char.IsLetter(path[0])
+        && path[1] = ':'
+        && (path[2] = '/' || path[2] = '\\')
+
     let private normalizeBranchAnnotatePath correlationId (path: string) =
         let trimmed = if isNull path then String.Empty else path.Trim()
 
         if String.IsNullOrWhiteSpace(trimmed) then
             Error(GraceError.Create "--path is required and must be repository-relative." correlationId)
         elif
-            Path.IsPathFullyQualified(trimmed)
+            isWindowsDriveRootedPath trimmed
+            || Path.IsPathFullyQualified(trimmed)
             || trimmed.StartsWith("/", StringComparison.Ordinal)
             || trimmed.StartsWith("\\", StringComparison.Ordinal)
         then

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -793,6 +793,7 @@ module CommandOutputContract =
             row [ "auth"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "auth"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "auth" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "branch" ] "annotate" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
             row [ "branch" ] "assign" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "commit" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -793,7 +793,7 @@ module CommandOutputContract =
             row [ "auth"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "auth"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "auth" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "branch" ] "annotate" true false common_renderOutput_envelope read_list_search composite_local_server ReuseExistingApiOrSdkDto
+            row [ "branch" ] "annotate" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
             row [ "branch" ] "assign" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "commit" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -559,6 +559,7 @@ module GraceCommand =
                 CommandNames =
                     [
                         "status"
+                        "annotate"
                         "list-contents"
                         "get-recursive-size"
                         "get"


### PR DESCRIPTION
Part of #313
Related to #321

## Summary

- Adds `grace branch annotate` with required `--path`, optional `--reference-id`, `-L/--line-range`, `--start-line`, `--end-line`, comma-separated `--reference-types`, `--show last-changed|introduced|both`, and `--max-references`.
- Reuses the S7 current-state target Reference resolver so explicit References bypass local capture and implicit targets use GraceWatch or Save capture as needed.
- Renders human output grouped by annotation spans while preserving the common Grace JSON envelope for machine-readable output.
- Updates CLI command help grouping and machine-readable command inventory evidence.

## Validation

- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` (405 passed)
- `dotnet tool run fantomas -- C:\Source\Grace-gh-321\src\Grace.CLI\Command\Branch.CLI.fs C:\Source\Grace-gh-321\src\Grace.CLI\CommandOutputContract.CLI.fs C:\Source\Grace-gh-321\src\Grace.CLI\Program.CLI.fs C:\Source\Grace-gh-321\src\Grace.CLI.Tests\Branch.CLI.Parsing.Tests.fs C:\Source\Grace-gh-321\src\Grace.CLI.Tests\Branch.CLI.Tests.fs C:\Source\Grace-gh-321\src\Grace.CLI.Tests\CommandOutputContract.CLI.Tests.fs`
- `npx --yes markdownlint-cli2 "docs/Machine-readable CLI output.md"`
- `pwsh ./scripts/validate.ps1 -Fast`
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD`

## Review Status

Codex Code Review Bot reviewed head `9574b1c820ceb4c9d6ca6e228ba225d366865db9` and reported three findings on 2026-06-10. A fresh fix worker completed that review-thread loop on head `a179c7dd990aa9ca0aaff97296d156e360916674`.

- `PRRT_kwDOILVrb86IVstW` / `PRRC_kwDOILVrb87Jw1Jd` (P1): Verified fixed by prior head `6231b1571f94946a69142f6223c0e18541fc6a91`; no new code change needed. Reply posted in `PRRC_kwDOILVrb87JxIST`; conversation resolved.
- `PRRT_kwDOILVrb86IVstb` / `PRRC_kwDOILVrb87Jw1Jj` (P2): Fixed by `a179c7dd990aa9ca0aaff97296d156e360916674` by suppressing annotate human spans when `--select` is present and adding a focused regression. Reply posted in `PRRC_kwDOILVrb87JxIUX`; conversation resolved.
- `PRRT_kwDOILVrb86IVstc` / `PRRC_kwDOILVrb87Jw1Jm` (P2): Fixed by `a179c7dd990aa9ca0aaff97296d156e360916674` by marking `branch annotate` mutating in the command output contract and adding focused registry coverage. Reply posted in `PRRC_kwDOILVrb87JxIV7`; conversation resolved.

Codex Code Review Bot then reviewed head `a179c7dd990aa9ca0aaff97296d156e360916674` and reported one new finding. A fresh fix worker completed that review-thread loop on head `40fa6808755000dd1868964911ba3f3c862b8501`.

- `PRRT_kwDOILVrb86IV9Bf` / `PRRC_kwDOILVrb87JxMlk` (P2): Fixed by `40fa6808755000dd1868964911ba3f3c862b8501` by distinguishing an omitted `--end-line` from an explicitly supplied zero before applying the default. Reply posted in `PRRC_kwDOILVrb87JxUrk`; conversation resolved.

Latest fix-worker validation on 2026-06-10:

- `dotnet tool run fantomas C:\Source\Grace-gh-321\src\Grace.CLI\Command\Branch.CLI.fs C:\Source\Grace-gh-321\src\Grace.CLI.Tests\Branch.CLI.Tests.fs`
- `dotnet test --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~BranchCommandTests"` (13 passed)
- `pwsh ./scripts/validate.ps1 -Fast`
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD`

GitHub `full` passed on `40fa6808755000dd1868964911ba3f3c862b8501`; Codex Code Review Bot added 👍 to the PR body after the latest head, with no unresolved review threads remaining.
