### PR TITLE
Document branch annotation V1 audit

### DIFF
--- a/docs/Branch annotation final audit.md
+++ b/docs/Branch annotation final audit.md
@@ -1,0 +1,81 @@
+# Branch Annotation Final Audit
+
+Issue #322 closes the docs, ADR, and final-audit slice for branch annotation V1 under epic #313. This audit maps the
+accepted R1-R12 design decisions to the live implementation, tests, and committed documentation on the current
+`epic/313-branch-annotate-v1` integration branch.
+
+## Audit Scope
+
+- Parent epic: [#313](https://github.com/ScottArbeit/Grace/issues/313).
+- Final audit issue: [#322](https://github.com/ScottArbeit/Grace/issues/322).
+- Epic integration branch: `epic/313-branch-annotate-v1`.
+- Final child branch: `agent/322-docs-adr-final-audit`.
+- ADR: [ADR 0005](adr/0005-use-exact-path-reference-based-branch-annotation.md).
+- User-facing docs: [Branch annotation](Branch%20annotation.md).
+
+Status terms:
+
+- `Implemented and proven`: live code exists and is covered by committed tests or route-contract evidence.
+- `Documented`: committed docs or help text state the behavior.
+- `Audited`: this final audit checked for the requested negative proof.
+
+## Contract Summary
+
+Branch annotation V1 explains visible text lines at one repository-relative path by mapping those lines to Grace
+References in effective branch history.
+
+The invariant tuple for this slice is satisfied by the current branch:
+
+- Docs and ADR describe the exact-path Reference-based V1 contract and non-goals.
+- CLI help exposes `grace branch annotate`, V1 options, exact-path scope, and the main non-goals.
+- API and SDK surfaces annotate existing server-known References and do not save local workspace state.
+- CLI implicit Save behavior is limited to the no-explicit-`--reference-id` path.
+- DTO and JSON behavior expose spans, boundaries, source rows, and source References as arrays.
+
+## R1-R12 Decision Traceability
+
+| ID | Decision | Final status | Evidence |
+| -- | -------- | ------------ | -------- |
+| R1 | Branch annotation explains visible lines through Grace References. | Implemented and documented | `BranchAnnotationDto` and source Reference rows live in `src/Grace.Types/Annotation.Types.fs`. CLI help at `src/Grace.CLI/Command/Branch.CLI.fs:4510` describes Last changed and Introduced References. |
+| R2 | V1 is exact-path only. | Implemented and documented | `AnnotationValidationRejectsCrossPathSourceRows` in `src/Grace.Types.Tests/Annotation.Types.Tests.fs:370` rejects cross-path source rows. CLI help at `src/Grace.CLI/Command/Branch.CLI.fs:4510` and ADR 0005 document exact-path scope. |
+| R3 | Effective branch history includes authorized BasedOn relationships. | Implemented and proven | `buildEffectiveHistory` and BasedOn traversal live in `src/Grace.Server/Branch.Server.fs:145`. Unit tests cover ordering, unauthorized ancestors, missing parents, repeated links, traversal budget, and unreadable ancestors in `src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs:115`. Hosted child-rebase coverage is in `src/Grace.Server.Tests/Branch.Server.Tests.fs:679`. |
+| R4 | The line model is deterministic. | Implemented and proven | `decodeVisibleText` and annotation line core live in `src/Grace.Shared/AnnotationLineCore.Shared.fs`. Tests reject invalid UTF-8, accept UTF-8 BOM, normalize line endings, and count whitespace changes in `src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs:299` and `src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs:319`. |
+| R5 | Target content supports whole-file and manifest-backed text content. | Implemented and proven | `AnnotationMaterialization.Server.fs` materializes text content. Whole-file and manifest-backed tests are in `src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs:91` and `src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs:121`. |
+| R6 | CLI current state is saved before annotate when needed and no explicit Target Reference is supplied. | Implemented and proven | `resolveAnnotationTargetReferenceWith` and annotate handler flow live in `src/Grace.CLI/Command/Branch.CLI.fs`. CLI handler tests map explicit options and target resolution in `src/Grace.CLI.Tests/Branch.CLI.Tests.fs:131`; this doc records that `--reference-id` suppresses implicit Save behavior. |
+| R7 | Reference-type filter projects attribution only. | Implemented and proven | `AnnotateParameters.ReferenceTypes` is validated in `src/Grace.Shared/Parameters/Branch.Parameters.fs:118`. Projection and boundary tests live in `src/Grace.Server.Unit.Tests/AnnotationLineCore.Tests.fs`, including reference-type filtering and boundary-state coverage. |
+| R8 | Boundaries are explicit and line-scoped. | Implemented and proven | `AnnotationBoundary`, `AnnotationSpan`, `SourceRows`, and validation live in `src/Grace.Types/Annotation.Types.fs:100` and `src/Grace.Types/Annotation.Types.fs:240`. DTO tests validate boundary/span links and requested-range containment in `src/Grace.Types.Tests/Annotation.Types.Tests.fs:213` and `src/Grace.Types.Tests/Annotation.Types.Tests.fs:329`. |
+| R9 | `/branch/annotate` requires Branch read permission. | Implemented and proven | The endpoint authorization manifest includes `/branch/annotate` at `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs:78`. `BranchAnnotateRequiresBranchReadAndPathRead` proves Branch read and path read requirements in `src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs:254`. |
+| R10 | JSON output is one Grace result document. | Implemented and proven | The CLI uses `renderOutput` for annotate results. `json output remains a single Grace result document and skips human spans` is covered in `src/Grace.CLI.Tests/Branch.CLI.Tests.fs:371`. ADR 0004 remains the general CLI JSON contract. |
+| R11 | V1 has no durable annotation-result cache. | Audited | Repository search found annotation DTOs, line-core helpers, materialization helpers, server route logic, CLI command logic, OpenAPI, generated docs, and tests. It did not find an annotation cache actor, setting, storage table, or cache lifetime for V1. `AnnotationDtoSerializationKeepsSourceReferencesAsArray` also proves no `AlgorithmVersion` field in `src/Grace.Types.Tests/Annotation.Types.Tests.fs:68`. |
+| R12 | Docs and help list V1 non-goals and ADR captures the exact-path decision. | Implemented and documented | CLI help states the exact-path boundary and no rename, copy, or moved-block support in `src/Grace.CLI/Command/Branch.CLI.fs:4510`. ADR 0005 and [Branch annotation](Branch%20annotation.md) record the full V1 non-goal list. |
+
+## API, SDK, CLI, And OpenAPI Alignment
+
+| Surface | Current state | Evidence |
+| ------- | ------------- | -------- |
+| CLI command | `grace branch annotate` is routed with `--path`, `--reference-id`, `--line-range`, `--start-line`, `--end-line`, `--reference-types`, `--show`, and `--max-references`. | `src/Grace.CLI/Command/Branch.CLI.fs:4508`; parsing tests at `src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs:41`. |
+| CLI JSON | JSON mode emits one Grace result document and ignores human `--show` shaping. | `src/Grace.CLI.Tests/Branch.CLI.Tests.fs:371`. |
+| API route | `POST /branch/annotate` reads server-stored Reference content and does not save local workspace state. | `src/OpenAPI/Branch.Paths.OpenAPI.yaml:402` and `src/OpenAPI/Branch.Paths.OpenAPI.yaml:407`. |
+| SDK | `Grace.SDK.Branch.Annotate` posts `AnnotateParameters` and returns `BranchAnnotationDto`. | `src/Grace.SDK/Branch.SDK.fs:31`; hosted route and SDK test at `src/Grace.Server.Tests/Branch.Server.Tests.fs:506`. |
+| DTO | `BranchAnnotationDto` carries target metadata, lines, boundaries, spans, source rows, and source References. | `src/Grace.Types/Annotation.Types.fs:128`. |
+| OpenAPI schema | `AnnotateParameters`, `BranchAnnotationApiDto`, and `BranchAnnotationReturnValue` are modeled. | `src/OpenAPI/Branch.Components.OpenAPI.yaml:132` and `src/OpenAPI/Branch.Components.OpenAPI.yaml:541`. |
+
+## Negative Proof Audit
+
+- No public docs added in this slice claim renamed-path following, copied-file detection, or moved-block detection.
+- No public docs added in this slice claim API or SDK implicit Save behavior.
+- No public docs added in this slice use alternative source-control attribution vocabulary for branch annotation.
+- No durable annotation-result cache was found in source or configuration.
+- ADR numbering was checked before writing: existing repo ADRs were `0001` through `0004`, so `0005` is the next ADR.
+- `CONTEXT.md` already contains the branch annotation glossary and did not require correction for this slice.
+- Nearby `AGENTS.md` files did not need durable guidance changes because no new workflow or agent behavior was added.
+
+## Validation Plan For This Slice
+
+The final worker validation for #322 should include:
+
+- MarkdownLint for ADR 0005, this audit, and the branch annotation doc.
+- CLI help/render checks for `grace branch annotate`.
+- `pwsh ./scripts/validate.ps1 -Full` as the final build/test gate, because the epic includes server, storage, API, and
+  SDK branch annotation behavior.
+- `git diff --check <epic-target-ref>...HEAD`.

--- a/docs/Branch annotation.md
+++ b/docs/Branch annotation.md
@@ -1,0 +1,121 @@
+# Branch Annotation
+
+`grace branch annotate` explains visible text lines at one repository-relative path by mapping those lines to Grace
+References in the selected Branch's effective branch history.
+
+Use branch annotation when you need to inspect how a line in a Branch reached its current visible content. V1 is an
+exact-path feature: it explains the requested path only, using server-known Reference and content state.
+
+## CLI Usage
+
+PowerShell:
+
+```powershell
+grace branch annotate --path src/App.fs --start-line 12 --end-line 18
+grace branch annotate --path src/App.fs --line-range 12,18 --reference-id c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+grace --output Json branch annotate --path src/App.fs --line-range 12,18 --reference-types Commit,Save
+```
+
+bash / zsh:
+
+```bash
+grace branch annotate --path src/App.fs --start-line 12 --end-line 18
+grace branch annotate --path src/App.fs --line-range 12,18 --reference-id c8f9bac8-d489-46c7-917f-b36b7d9efa9a
+grace --output Json branch annotate --path src/App.fs --line-range 12,18 --reference-types Commit,Save
+```
+
+Supported V1 options:
+
+- `--path`: required repository-relative file path to annotate.
+- `--reference-id`: optional Target Reference. Passing it suppresses CLI implicit Save behavior.
+- `--line-range`, `-L`: optional inclusive `start,end` line range.
+- `--start-line`: optional first 1-based line to annotate. Defaults to `1`.
+- `--end-line`: optional final 1-based line. Defaults to `--start-line` when omitted.
+- `--reference-types`: optional comma-separated attribution filter, such as `Commit,Save`.
+- `--show`: human output source details, one of `last-changed`, `introduced`, or `both`.
+- `--max-references`: maximum References to traverse. The default is `1000`; the server maximum is `5000`.
+- Common Grace options, including `--output Json`, apply as usual.
+
+## Target Reference Behavior
+
+The Target Reference is the Reference whose directory and file state branch annotation explains.
+
+When `--reference-id` is supplied, the CLI annotates that existing server-known Reference and does not create a Save.
+When `--reference-id` is omitted, the CLI resolves the current Branch state. If local changes are present and Save is
+enabled for the Branch, the CLI uses the existing Save workflow before it calls the annotation API.
+
+The API and SDK do not save local workspace state. `POST /branch/annotate` and `Grace.SDK.Branch.Annotate` require an
+existing server-known `TargetReferenceId`.
+
+## API And SDK Contract
+
+The HTTP route is:
+
+```text
+POST /branch/annotate
+```
+
+The SDK method is:
+
+```text
+Grace.SDK.Branch.Annotate(parameters: AnnotateParameters)
+```
+
+`AnnotateParameters` includes Branch identity, `TargetReferenceId`, `Path`, `StartLine`, `EndLine`,
+`ReferenceTypes`, `MaxReferences`, and `IncludeLineText`.
+
+The route requires Branch read permission and path read permission for the requested path.
+
+## JSON Output
+
+`--output Json` emits one Grace result document. Human spans, labels, and tables are not mixed into JSON stdout.
+
+The `ReturnValue` is `BranchAnnotationDto`, which includes:
+
+- `Class`: `BranchAnnotationDto`.
+- `RequestedLineRange`: the inclusive target line range.
+- `TargetReferenceId`: the server-known Reference being explained.
+- `Path`: the repository-relative path.
+- `ReferenceTypeFilter`: the attribution filter applied to source References.
+- `MaxReferences`: the traversal budget.
+- `IncludeLineText`: whether `Lines` contains visible target text.
+- `Lines`: ordered target lines when line text was requested; otherwise empty.
+- `Boundaries`: line-scoped incomplete proof.
+- `Spans`: contiguous target-line ranges and their source-row or boundary links.
+- `SourceRows`: source line ranges for annotation spans.
+- `SourceReferences`: Reference metadata as an array.
+
+`--show` affects human output only. JSON always includes the complete DTO for the selected request.
+
+## Line And Path Semantics
+
+Branch annotation V1 uses visible text lines:
+
+- Lines are 1-based.
+- CRLF and CR line endings are normalized to LF for comparison.
+- A terminal newline does not create an extra visible line.
+- Whitespace changes count as content changes.
+- Text must decode as UTF-8; a UTF-8 byte-order mark is accepted.
+- Target decoded text above 10 MiB is rejected.
+- Whole-file content and manifest-backed text content are supported.
+
+V1 is exact-path annotation. It explains the requested `Path` only.
+
+## V1 Non-Goals
+
+Branch annotation V1 does not:
+
+- Follow renamed paths.
+- Detect copied files.
+- Detect moved blocks.
+- Annotate binary files.
+- Ignore whitespace.
+- Annotate unsaved local state through the API or SDK.
+- Create or depend on a durable annotation-result cache.
+
+These boundaries are product decisions, not hidden gaps in the command syntax.
+
+## Related Design Records
+
+- [ADR 0005: Use exact-path Reference-based branch annotation](adr/0005-use-exact-path-reference-based-branch-annotation.md)
+- [Branch annotation final audit](Branch%20annotation%20final%20audit.md)

--- a/docs/adr/0005-use-exact-path-reference-based-branch-annotation.md
+++ b/docs/adr/0005-use-exact-path-reference-based-branch-annotation.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Use exact-path Reference-based branch annotation
+
+Grace branch annotation V1 explains visible text lines at one repository-relative path by mapping those lines to
+References in the selected Branch's effective branch history. The V1 contract is exact-path, Reference-based, and
+intentionally narrow so every annotation result can be tested against Grace's stored Reference graph.
+
+## Context
+
+Grace already stores Branches, References, BasedOn links, and directory content as first-class domain objects. Users and
+agents need a supported way to ask why visible lines at a path look the way they do without switching vocabulary or
+leaving Grace's server-known Reference model.
+
+The completed branch annotation design accepted these V1 boundaries:
+
+- The command is `grace branch annotate`.
+- The HTTP route is `POST /branch/annotate`.
+- API and SDK callers annotate existing server-known References.
+- The CLI may create a Save first when the working tree has local changes and no explicit `--reference-id` is supplied.
+- Annotation follows effective branch history, including authorized BasedOn relationships.
+- Line comparison is deterministic: visible text lines are 1-based, CRLF and CR are normalized to LF, and whitespace
+  changes count.
+- Results use annotation spans, line-scoped boundaries, source rows, and source References.
+
+## Decision
+
+Grace will implement branch annotation V1 as exact-path annotation at the requested `RelativePath`.
+
+The Target Reference is the Reference whose directory and file state is being explained. API and SDK callers must supply
+an existing server-known Target Reference through `AnnotateParameters.TargetReferenceId`. CLI callers can either pass
+`--reference-id` explicitly or let `grace branch annotate` resolve the current Branch state. When the CLI resolves the
+current state and finds local changes, it uses the existing Save workflow before calling the annotation API.
+
+The annotation algorithm walks effective branch history through stored Reference relationships. A Reference-type filter
+limits attribution only; it does not cut traversal. If the selected filter excludes an otherwise relevant Reference,
+the result projects attribution to included Reference types or records an explicit boundary when proof cannot continue.
+
+The result DTO is `BranchAnnotationDto`. It includes:
+
+- `TargetReferenceId`, `Path`, `RequestedLineRange`, `ReferenceTypeFilter`, `MaxReferences`, and `IncludeLineText`.
+- `Lines` only when line text was requested.
+- `Boundaries` for line-scoped incomplete proof.
+- `Spans` for contiguous target-line ranges.
+- `SourceRows` for source line ranges.
+- `SourceReferences` as an array of Reference metadata.
+
+V1 does not persist annotation results in a durable annotation cache. Results are computed from stored Reference and
+content state for the current request.
+
+## Non-Goals
+
+Branch annotation V1 does not:
+
+- Follow renamed paths.
+- Detect copied files.
+- Detect moved blocks.
+- Annotate binary files.
+- Ignore whitespace.
+- Annotate unsaved local state through the API or SDK.
+- Create or depend on a durable annotation-result cache.
+- Add broad provenance heuristics outside the exact-path Reference contract.
+
+## Consequences
+
+Documentation, CLI help, SDK comments, OpenAPI descriptions, and tests must describe one contract:
+
+- `grace branch annotate` is the CLI entry point.
+- `POST /branch/annotate` and `Grace.SDK.Branch.Annotate` work on existing server-known References.
+- CLI implicit Save behavior exists only when no explicit `--reference-id` is supplied.
+- API and SDK callers do not save local workspace state.
+- V1 is exact-path only and does not make rename, copy, or moved-block claims.
+
+Future versions may add broader path-history or movement-aware behavior, but those capabilities need their own product
+decision, proof model, DTO/API compatibility review, and documentation update.


### PR DESCRIPTION
## Summary

Part of #313
Related to #322

This PR completes the branch annotation V1 docs/ADR/final-audit slice:

- Adds ADR 0005 for the exact-path Reference-based branch annotation decision.
- Adds a user-facing `grace branch annotate` doc covering CLI options, Target Reference behavior, API/SDK boundaries, JSON output, line semantics, and V1 non-goals.
- Adds the final R1-R12 traceability audit for the epic branch, mapping decisions to live code, tests, OpenAPI, SDK, CLI help, docs, and negative proof checks.

## Validation

- `npx --yes markdownlint-cli2 "docs/Branch annotation.md" "docs/Branch annotation final audit.md" "docs/adr/0005-use-exact-path-reference-based-branch-annotation.md"`: passed.
- `dotnet run --project src\Grace.CLI\Grace.CLI.fsproj -- branch annotate --help`: passed; help renders supported V1 options and exact-path/non-goal description.
- Forbidden terminology check over edited docs: passed.
- Durable annotation-result cache audit: passed; no cache actor/setting/storage/lifetime found, only the expected negative `AlgorithmVersion` DTO test.
- `pwsh ./scripts/validate.ps1 -Full`: passed. Build succeeded; Authorization, Types, Server.Unit, CLI, and Server tests passed. Server.Tests passed 176/176.
- `git diff --check origin/epic/313-branch-annotate-v1...HEAD`: passed.

## Review Status

GitHub `full` passed on `c3ec9441bc147bbe51cdebbbd53d384d3b8fd2f6`; Codex Code Review Bot added 👍 to the PR body, with no review threads reported.
