### PR TITLE
S0: Add grace doctor scaffold

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -127,8 +127,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `202`
-- JSON-ready routed commands: `181`
+- Total leaf commands: `203`
+- JSON-ready routed commands: `182`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -212,16 +212,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 202
+        |> should equal 203
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 193
+        |> should equal 194
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 181
+        |> should equal 182
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -262,7 +262,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 181
+        jsonReady |> should equal 182
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -285,7 +285,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 193
+        discovered.Length |> should equal 194
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)
@@ -408,7 +408,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 182
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -425,7 +425,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 182
 
         let parserInvalidEntries =
             commonEntries
@@ -701,6 +701,51 @@ module CommandOutputContractRegistryTests =
             | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
 
     [<Test>]
+    let ``doctor registry entry exposes schema ready local dto metadata`` () =
+        let identity = CommandOutputContract.commandIdentity [] "doctor"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.ReturnValueContract.Status
+            |> should equal SchemaReady
+
+            entry.Features.Schema
+            |> should equal ExistingBehavior
+
+            entry.Features.Examples
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status |> should equal "schema-ready"
+
+                schema.ReturnValueContract
+                |> should equal "DoctorReportDto"
+
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                let returnValueSchema =
+                    successSchema
+                        .RootElement
+                        .GetProperty("properties")
+                        .GetProperty("ReturnValue")
+
+                returnValueSchema.GetProperty("title").GetString()
+                |> should equal "DoctorReportDto"
+            | None -> Assert.Fail("Expected schema document for doctor.")
+
+            let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+            examplesDocument.Examples[0].Name
+            |> should equal "success-envelope-shape"
+        | None -> Assert.Fail("doctor should have a registry entry.")
+
+    [<Test>]
     let ``metadata incomplete registry entries are explicit`` () =
         let identity = CommandOutputContract.commandIdentity [ "repository" ] "init"
 
@@ -826,26 +871,40 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
+        let docsTrackedEntries =
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.Identity.CommandId <> "doctor")
+
+        let countDocsTracked predicate =
+            docsTrackedEntries
+            |> List.filter predicate
+            |> List.length
+
+        let commandIdsForDocsTracked predicate =
+            docsTrackedEntries
+            |> List.filter predicate
+            |> List.map (fun entry -> entry.Identity.CommandId)
+
         let jsonReady =
-            countEntries (fun entry ->
+            countDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, ExistingGraceResultEnvelope _ -> true
                 | _ -> false)
 
         let intentionallyHumanOnly =
-            countEntries (fun entry ->
+            countDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, JsonModeErrorOnly _ -> true
                 | _ -> false)
 
         let deferredV2 =
-            commandIdsFor (fun entry ->
+            commandIdsForDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
                 | _ -> false)
 
         let sourceOnly =
-            commandIdsFor (fun entry ->
+            commandIdsForDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
                 | _ -> false)
@@ -853,7 +912,7 @@ module CommandOutputContractRegistryTests =
         let deleted = 0
 
         [
-            $"Total leaf commands: `{CommandOutputContract.entries.Length}`"
+            $"Total leaf commands: `{docsTrackedEntries.Length}`"
             $"JSON-ready routed commands: `{jsonReady}`"
             $"Intentionally human-only commands: `{intentionallyHumanOnly}`"
             $"Deferred routed commands with explicit V2 scope: `{deferredV2.Length}`"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -871,9 +871,7 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
-        let docsTrackedEntries =
-            CommandOutputContract.entries
-            |> List.filter (fun entry -> entry.Identity.CommandId <> "doctor")
+        let docsTrackedEntries = CommandOutputContract.entries
 
         let countDocsTracked predicate =
             docsTrackedEntries

--- a/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
@@ -7,6 +7,8 @@ open NUnit.Framework
 [<Parallelizable(ParallelScope.All)>]
 module DoctorCliParsingTests =
 
+    let emptyCheckCases: obj array = [| [| "doctor"; "--check" |] :> obj |]
+
     [<Test>]
     let ``doctor command accepts v1 options`` () =
         let parseResult =
@@ -49,6 +51,13 @@ module DoctorCliParsingTests =
     [<Test>]
     let ``doctor command rejects repair option in scaffold slice`` () =
         let parseResult = GraceCommand.rootCommand.Parse([| "doctor"; "--repair" |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
+
+    [<TestCaseSource(nameof emptyCheckCases)>]
+    let ``doctor command rejects check option without value`` (args: string array) =
+        let parseResult = GraceCommand.rootCommand.Parse(args)
 
         parseResult.Errors.Count
         |> should be (greaterThan 0)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
@@ -1,0 +1,54 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+module DoctorCliParsingTests =
+
+    [<Test>]
+    let ``doctor command accepts v1 options`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "doctor"
+                    "--full"
+                    "--offline"
+                    "--list-checks"
+                    "--check"
+                    "config"
+                    "--check"
+                    "cli.catalog"
+                    "--strict"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``doctor command accepts global introspection and selection options`` () =
+        let cases =
+            [
+                [| "doctor"; "--schema" |]
+                [| "doctor"; "--examples" |]
+                [|
+                    "--output"
+                    "Json"
+                    "doctor"
+                    "--select"
+                    "Status"
+                |]
+            ]
+
+        for args in cases do
+            let parseResult = GraceCommand.rootCommand.Parse(args)
+
+            parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``doctor command rejects repair option in scaffold slice`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "doctor"; "--repair" |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -113,7 +113,24 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should be (greaterThan 0)
+            |> should equal 4
+
+            returnValue
+                .GetProperty("Catalog")
+                .GetArrayLength()
+            |> should equal 4
+
+            let catalogIds =
+                returnValue
+                    .GetProperty("Catalog")
+                    .EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds
+            |> should contain "identity.auth-session"
+
+            catalogIds |> should contain "server.connectivity"
 
             let firstCheck = returnValue.GetProperty("Checks")[0]
 
@@ -122,6 +139,37 @@ module DoctorCliTests =
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
+
+    [<Test>]
+    let ``doctor list checks offline keeps only offline catalog entries`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--list-checks"
+                                                  "--offline" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let catalogIds =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Catalog")
+                    .EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds.Count |> should equal 2
+
+            catalogIds
+            |> should not' (contain "identity.auth-session")
+
+            catalogIds
+            |> should not' (contain "server.connectivity"))
 
     [<Test>]
     let ``doctor check filter accepts mixed case ids and categories`` () =
@@ -190,6 +238,30 @@ module DoctorCliTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should contain "Unknown doctor check token"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor check followed by option-shaped token emits GraceError`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "--strict" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unknown doctor check token: --strict"
 
             let mutable returnValue = Unchecked.defaultof<JsonElement>
 

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1,0 +1,256 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.Shared
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+
+[<NonParallelizable>]
+module DoctorCliTests =
+
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
+    let private withTempDir (action: string -> unit) =
+        let tempDir = Path.Combine(Path.GetTempPath(), $"grace-doctor-cli-tests-{Guid.NewGuid():N}")
+        Directory.CreateDirectory(tempDir) |> ignore
+        let originalDir = Environment.CurrentDirectory
+
+        try
+            Environment.CurrentDirectory <- tempDir
+            action tempDir
+        finally
+            Environment.CurrentDirectory <- originalDir
+
+            if Directory.Exists(tempDir) then
+                try
+                    Directory.Delete(tempDir, true)
+                with
+                | _ -> ()
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    let private assertCleanJsonOutput (standardOut: string) (standardError: string) =
+        standardError |> should equal String.Empty
+        standardOut |> should not' (contain "Elapsed:")
+
+        standardOut
+        |> should not' (contain "Grace Version Control System")
+
+        standardOut
+        |> should not' (contain "Doctor checks")
+
+        parseJsonOutput standardOut
+
+    [<Test>]
+    let ``doctor help works without config and shows v1 options`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--help" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+            standardOut |> should contain "--full"
+            standardOut |> should contain "--offline"
+            standardOut |> should contain "--list-checks"
+            standardOut |> should contain "--check"
+            standardOut |> should contain "--strict"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor list checks emits clean json envelope without config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--list-checks" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty("ReportVersion")
+                .GetString()
+            |> should equal "doctor-report-v1"
+
+            returnValue.GetProperty("Status").GetString()
+            |> should equal "Ok"
+
+            returnValue.GetProperty("Checks").GetArrayLength()
+            |> should be (greaterThan 0)
+
+            let firstCheck = returnValue.GetProperty("Checks")[0]
+
+            firstCheck.GetProperty("Id").GetString()
+            |> should not' (equal String.Empty)
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor check filter accepts mixed case ids and categories`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "CLI.CATALOG"
+                                                  "--check"
+                                                  "configuration" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            checks.GetArrayLength() |> should equal 2)
+
+    [<Test>]
+    let ``doctor invalid check emits GraceError in json mode`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "unknown, configuration, also-unknown" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unknown doctor check token"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor schema and examples work without config`` () =
+        withTempDir (fun root ->
+            for args, expectedKind in
+                [
+                    [| "doctor"; "--schema" |], "schema"
+                    [| "doctor"; "--examples" |], "examples"
+                ] do
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+                let rootElement = document.RootElement
+
+                rootElement.GetProperty("Kind").GetString()
+                |> should equal expectedKind
+
+                rootElement
+                    .GetProperty("Command")
+                    .GetProperty("Id")
+                    .GetString()
+                |> should equal "doctor"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select projects return value property without config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--select"
+                                                  "Status" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+            standardOut.Trim() |> should equal "\"Ok\""
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select rejects envelope-qualified path before config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--select"
+                                                  "ReturnValue.Status" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+
+            document
+                .RootElement
+                .GetProperty("Error")
+                .GetString()
+            |> should contain "cannot project 'ReturnValue'"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor diagnostic exit codes map warning and failure reports`` () =
+        let warningReport =
+            Doctor.createReportForChecks false false false Doctor.catalog
+            |> Doctor.withStatus "Warning"
+
+        Doctor.diagnosticExitCode false warningReport
+        |> should equal 0
+
+        Doctor.diagnosticExitCode true warningReport
+        |> should equal 1
+
+        let failedReport = warningReport |> Doctor.withStatus "Failed"
+
+        Doctor.diagnosticExitCode false failedReport
+        |> should equal 1

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -312,12 +312,13 @@ module DoctorCliTests =
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
 
-    [<Test>]
-    let ``doctor select projects return value property without config`` () =
+    [<TestCase("Json")>]
+    [<TestCase("Verbose")>]
+    let ``doctor select projects return value property without config`` output =
         withTempDir (fun root ->
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
+                                                  output
                                                   "doctor"
                                                   "--select"
                                                   "Status" |]

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -148,6 +148,31 @@ module DoctorCliTests =
             checks.GetArrayLength() |> should equal 2)
 
     [<Test>]
+    let ``doctor explicit check includes non-default catalog entry without full`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "identity.auth-session" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            checks.GetArrayLength() |> should equal 1
+
+            checks[ 0 ].GetProperty("Id").GetString()
+            |> should equal "identity.auth-session")
+
+    [<Test>]
     let ``doctor invalid check emits GraceError in json mode`` () =
         withTempDir (fun _ ->
             let exitCode, standardOut, standardError =
@@ -199,6 +224,22 @@ module DoctorCliTests =
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
 
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor suppresses successful human output for quiet output modes`` output =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  output
+                                                  "doctor" |]
+
+            exitCode |> should equal 0
+            standardOut |> should equal String.Empty
+            standardError |> should equal String.Empty
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
     [<Test>]
     let ``doctor select projects return value property without config`` () =
         withTempDir (fun root ->
@@ -212,6 +253,28 @@ module DoctorCliTests =
             exitCode |> should equal 0
             standardError |> should equal String.Empty
             standardOut.Trim() |> should equal "\"Ok\""
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select missing property returns projection failure exit code`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--select"
+                                                  "NoSuchProperty" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+
+            document
+                .RootElement
+                .GetProperty("Error")
+                .GetString()
+            |> should contain "NoSuchProperty"
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -40,6 +40,8 @@
     <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
     <Compile Include="Maintenance.CLI.Tests.fs" />
+    <Compile Include="Doctor.CLI.Parsing.Tests.fs" />
+    <Compile Include="Doctor.CLI.Tests.fs" />
     <Compile Include="CommandOutputContract.CLI.Tests.fs" />
     <Compile Include="CurrentStateCapture.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -118,6 +118,27 @@ module Common =
                 NewDirectoryVersions: MaintenanceScanDirectoryVersionDto array
             }
 
+        type DoctorCheckDto = { Id: string; Category: string; Title: string; Description: string; DefaultEnabled: bool; SupportsOffline: bool }
+
+        type DoctorCheckResultDto = { Id: string; Category: string; Title: string; Status: string; Severity: string; Summary: string }
+
+        type DoctorSummaryDto = { Total: int; Ok: int; Warning: int; Failed: int; Skipped: int }
+
+        type DoctorReportDto =
+            {
+                ReportVersion: string
+                Status: string
+                ExitCode: int
+                Full: bool
+                Offline: bool
+                Strict: bool
+                ListOnly: bool
+                RequestedChecks: string array
+                Catalog: DoctorCheckDto array
+                Checks: DoctorCheckResultDto array
+                Summary: DoctorSummaryDto
+            }
+
         type WatchResultDto = { Started: bool; Completed: bool; Message: string; RootDirectory: string; ServerUri: string; RepositoryId: Guid; BranchId: Guid }
 
     /// The output format for the command.

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -51,7 +51,7 @@ module Doctor =
                 OptionName.Check,
                 Required = false,
                 Description = "Filter the scaffolded doctor report by check ID or category. Repeat or separate values with commas.",
-                Arity = ArgumentArity.ZeroOrMore
+                Arity = ArgumentArity.OneOrMore
             )
 
         let strict =
@@ -117,11 +117,11 @@ module Doctor =
         | Unknown of string array
         | OfflineExcluded of string array
 
-    let private selectedCatalogEntries full offline requestedTokens =
+    let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
             |> Array.filter (fun check ->
-                (full || check.DefaultEnabled)
+                (full || listOnly || check.DefaultEnabled)
                 && (not offline || check.SupportsOffline))
 
         if Array.isEmpty requestedTokens then
@@ -159,8 +159,8 @@ module Doctor =
             else
                 Ok(selected |> Seq.toArray)
 
-    let private validateChecks parseResult full offline requestedTokens =
-        match selectedCatalogEntries full offline requestedTokens with
+    let private validateChecks parseResult full offline listOnly requestedTokens =
+        match selectedCatalogEntries full offline listOnly requestedTokens with
         | Ok checks -> Ok checks
         | Error (OfflineExcluded tokens) ->
             let tokens = String.Join(", ", tokens)
@@ -286,7 +286,7 @@ module Doctor =
                 parseResult.GetValue(Options.check)
                 |> tokenizeChecks
 
-            match validateChecks parseResult full offline requestedTokens with
+            match validateChecks parseResult full offline listChecks requestedTokens with
             | Error error -> renderOutput parseResult (Error error)
             | Ok checks ->
                 let report = createReport full offline strict listChecks requestedTokens checks

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -113,6 +113,10 @@ module Doctor =
             |> Array.filter (String.IsNullOrWhiteSpace >> not)
             |> Array.distinctBy (fun value -> value.ToUpperInvariant())
 
+    type private SelectionError =
+        | Unknown of string array
+        | OfflineExcluded of string array
+
     let private selectedCatalogEntries full offline requestedTokens =
         let profileEntries =
             catalog
@@ -125,6 +129,7 @@ module Doctor =
         else
             let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
             let unknown = ResizeArray<string>()
+            let excludedOffline = ResizeArray<string>()
 
             for token in requestedTokens do
                 let matches =
@@ -137,17 +142,36 @@ module Doctor =
                     unknown.Add(token)
                 else
                     for check in matches do
-                        if
-                            (full || check.DefaultEnabled)
-                            && (not offline || check.SupportsOffline)
-                            && not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase)))
-                        then
+                        if offline && not check.SupportsOffline then
+                            excludedOffline.Add(check.Id)
+                        elif not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
                             selected.Add(check)
 
             if unknown.Count > 0 then
-                Error(unknown |> Seq.toArray)
+                Error(Unknown(unknown |> Seq.toArray))
+            elif excludedOffline.Count > 0 then
+                let tokens =
+                    excludedOffline
+                    |> Seq.distinctBy (fun value -> value.ToUpperInvariant())
+                    |> Seq.toArray
+
+                Error(OfflineExcluded tokens)
             else
                 Ok(selected |> Seq.toArray)
+
+    let private validateChecks parseResult full offline requestedTokens =
+        match selectedCatalogEntries full offline requestedTokens with
+        | Ok checks -> Ok checks
+        | Error (OfflineExcluded tokens) ->
+            let tokens = String.Join(", ", tokens)
+            Error(GraceError.Create $"Doctor check token is not available in offline mode: {tokens}." (getCorrelationId parseResult))
+        | Error (Unknown unknown) ->
+            let tokens = String.Join(", ", unknown)
+            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
+
+    let private shouldRenderHumanReport parseResult =
+        not (parseResult |> json)
+        && (parseResult |> hasOutput)
 
     let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         {
@@ -247,13 +271,6 @@ module Doctor =
 
         AnsiConsole.Write(table)
 
-    let private validateChecks parseResult full offline requestedTokens =
-        match selectedCatalogEntries full offline requestedTokens with
-        | Ok checks -> Ok checks
-        | Error unknown ->
-            let tokens = String.Join(", ", unknown)
-            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
-
     type Invoke() =
         inherit SynchronousCommandLineAction()
 
@@ -273,14 +290,13 @@ module Doctor =
             | Error error -> renderOutput parseResult (Error error)
             | Ok checks ->
                 let report = createReport full offline strict listChecks requestedTokens checks
+                let renderResult = renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
 
-                if parseResult |> json then
-                    renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
-                    |> ignore
-                else
+                if renderResult = 0
+                   && shouldRenderHumanReport parseResult then
                     renderHumanReport report
 
-                diagnosticExitCode strict report
+                if renderResult <> 0 then renderResult else diagnosticExitCode strict report
 
     let Build =
         let doctorCommand =

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -275,7 +275,11 @@ module Doctor =
         inherit SynchronousCommandLineAction()
 
         override _.Invoke(parseResult: ParseResult) : int =
-            if parseResult |> verbose then printParseResult parseResult
+            if
+                (parseResult |> verbose)
+                && not (parseResult |> hasSelect)
+            then
+                printParseResult parseResult
 
             let full = parseResult.GetValue(Options.full)
             let offline = parseResult.GetValue(Options.offline)

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1,0 +1,295 @@
+namespace Grace.CLI.Command
+
+open Grace.CLI.Common
+open Grace.CLI.Text
+open Grace.Shared
+open Grace.Types.Common
+open Spectre.Console
+open System
+open System.Collections.Generic
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Threading
+open System.Threading.Tasks
+
+module Doctor =
+
+    [<Literal>]
+    let ReportVersion = "doctor-report-v1"
+
+    module private Options =
+        let full =
+            new Option<bool>(
+                OptionName.Full,
+                Required = false,
+                Description = "Include checks reserved for the full doctor profile.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let offline =
+            new Option<bool>(
+                OptionName.Offline,
+                Required = false,
+                Description = "Limit the scaffolded report to checks that can run without network access.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let listChecks =
+            new Option<bool>(
+                OptionName.ListChecks,
+                Required = false,
+                Description = "List the inert doctor check catalog without running diagnostics.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let check =
+            new Option<string []>(
+                OptionName.Check,
+                Required = false,
+                Description = "Filter the scaffolded doctor report by check ID or category. Repeat or separate values with commas.",
+                Arity = ArgumentArity.ZeroOrMore
+            )
+
+        let strict =
+            new Option<bool>(
+                OptionName.Strict,
+                Required = false,
+                Description = "Return a failing exit code when the doctor report status is Warning.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+    let catalog: LocalOutputDto.DoctorCheckDto array =
+        [|
+            {
+                Id = "cli.catalog"
+                Category = "CLI"
+                Title = "CLI command catalog"
+                Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = "configuration.config-file"
+                Category = "Configuration"
+                Title = "Grace configuration file"
+                Description = "Reserved for a later configuration-file diagnostic. Scaffold only; no file is read in this slice."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = "identity.auth-session"
+                Category = "Identity"
+                Title = "Authentication session"
+                Description = "Reserved for a later authentication diagnostic. Scaffold only; no auth state is read in this slice."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = "server.connectivity"
+                Category = "Server"
+                Title = "Grace server connectivity"
+                Description = "Reserved for a later server connectivity diagnostic. Scaffold only; no network probe is executed."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+        |]
+
+    let private tokenizeChecks (values: string array) =
+        if isNull values then
+            Array.empty
+        else
+            values
+            |> Array.collect (fun value ->
+                value.Split(
+                    ',',
+                    StringSplitOptions.RemoveEmptyEntries
+                    ||| StringSplitOptions.TrimEntries
+                ))
+            |> Array.filter (String.IsNullOrWhiteSpace >> not)
+            |> Array.distinctBy (fun value -> value.ToUpperInvariant())
+
+    let private selectedCatalogEntries full offline requestedTokens =
+        let profileEntries =
+            catalog
+            |> Array.filter (fun check ->
+                (full || check.DefaultEnabled)
+                && (not offline || check.SupportsOffline))
+
+        if Array.isEmpty requestedTokens then
+            Ok(profileEntries)
+        else
+            let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
+            let unknown = ResizeArray<string>()
+
+            for token in requestedTokens do
+                let matches =
+                    catalog
+                    |> Array.filter (fun check ->
+                        check.Id.Equals(token, StringComparison.OrdinalIgnoreCase)
+                        || check.Category.Equals(token, StringComparison.OrdinalIgnoreCase))
+
+                if Array.isEmpty matches then
+                    unknown.Add(token)
+                else
+                    for check in matches do
+                        if
+                            (full || check.DefaultEnabled)
+                            && (not offline || check.SupportsOffline)
+                            && not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase)))
+                        then
+                            selected.Add(check)
+
+            if unknown.Count > 0 then
+                Error(unknown |> Seq.toArray)
+            else
+                Ok(selected |> Seq.toArray)
+
+    let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+        {
+            Id = check.Id
+            Category = check.Category
+            Title = check.Title
+            Status = "Ok"
+            Severity = "Info"
+            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+        }
+
+    let private summarize (checks: LocalOutputDto.DoctorCheckResultDto array) =
+        let count status =
+            checks
+            |> Array.filter (fun check -> check.Status.Equals(status, StringComparison.OrdinalIgnoreCase))
+            |> Array.length
+
+        {
+            LocalOutputDto.DoctorSummaryDto.Total = checks.Length
+            LocalOutputDto.DoctorSummaryDto.Ok = count "Ok"
+            LocalOutputDto.DoctorSummaryDto.Warning = count "Warning"
+            LocalOutputDto.DoctorSummaryDto.Failed = count "Failed"
+            LocalOutputDto.DoctorSummaryDto.Skipped = count "Skipped"
+        }
+
+    let private reportStatus (summary: LocalOutputDto.DoctorSummaryDto) =
+        if summary.Failed > 0 then "Failed"
+        elif summary.Warning > 0 then "Warning"
+        else "Ok"
+
+    let diagnosticExitCode strict (report: LocalOutputDto.DoctorReportDto) =
+        if report.Status.Equals("Failed", StringComparison.OrdinalIgnoreCase) then
+            1
+        elif
+            strict
+            && report.Status.Equals("Warning", StringComparison.OrdinalIgnoreCase)
+        then
+            1
+        else
+            0
+
+    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+        let results = checks |> Array.map resultForCheck
+        let summary = summarize results
+        let status = reportStatus summary
+
+        let report: LocalOutputDto.DoctorReportDto =
+            {
+                ReportVersion = ReportVersion
+                Status = status
+                ExitCode = 0
+                Full = full
+                Offline = offline
+                Strict = false
+                ListOnly = listOnly
+                RequestedChecks = Array.empty
+                Catalog = checks
+                Checks = results
+                Summary = summary
+            }
+
+        { report with ExitCode = diagnosticExitCode false report }
+
+    let withStatus status (report: LocalOutputDto.DoctorReportDto) =
+        let checks =
+            if report.Checks.Length = 0 then
+                report.Checks
+            else
+                report.Checks
+                |> Array.mapi (fun index check -> if index = 0 then { check with Status = status } else check)
+
+        let summary = summarize checks
+        let normalizedStatus = reportStatus summary
+        let updated = { report with Status = normalizedStatus; Checks = checks; Summary = summary }
+        { updated with ExitCode = diagnosticExitCode updated.Strict updated }
+
+    let private createReport full offline strict listOnly requestedTokens checks =
+        let report = createReportForChecks full offline listOnly checks
+
+        let report = { report with Strict = strict; RequestedChecks = requestedTokens }
+
+        { report with ExitCode = diagnosticExitCode strict report }
+
+    let private renderHumanReport (report: LocalOutputDto.DoctorReportDto) =
+        AnsiConsole.MarkupLine("[bold]Grace doctor[/]")
+        AnsiConsole.MarkupLine($"Status: {report.Status}; checks: {report.Summary.Total}; exit code: {report.ExitCode}")
+
+        let table = Table(Border = TableBorder.Rounded)
+        table.AddColumn("Check") |> ignore
+        table.AddColumn("Category") |> ignore
+        table.AddColumn("Status") |> ignore
+        table.AddColumn("Summary") |> ignore
+
+        for check in report.Checks do
+            table.AddRow(Markup.Escape(check.Id), Markup.Escape(check.Category), Markup.Escape(check.Status), Markup.Escape(check.Summary))
+            |> ignore
+
+        AnsiConsole.Write(table)
+
+    let private validateChecks parseResult full offline requestedTokens =
+        match selectedCatalogEntries full offline requestedTokens with
+        | Ok checks -> Ok checks
+        | Error unknown ->
+            let tokens = String.Join(", ", unknown)
+            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
+
+    type Invoke() =
+        inherit SynchronousCommandLineAction()
+
+        override _.Invoke(parseResult: ParseResult) : int =
+            if parseResult |> verbose then printParseResult parseResult
+
+            let full = parseResult.GetValue(Options.full)
+            let offline = parseResult.GetValue(Options.offline)
+            let strict = parseResult.GetValue(Options.strict)
+            let listChecks = parseResult.GetValue(Options.listChecks)
+
+            let requestedTokens =
+                parseResult.GetValue(Options.check)
+                |> tokenizeChecks
+
+            match validateChecks parseResult full offline requestedTokens with
+            | Error error -> renderOutput parseResult (Error error)
+            | Ok checks ->
+                let report = createReport full offline strict listChecks requestedTokens checks
+
+                if parseResult |> json then
+                    renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
+                    |> ignore
+                else
+                    renderHumanReport report
+
+                diagnosticExitCode strict report
+
+    let Build =
+        let doctorCommand =
+            new Command("doctor", Description = "Inspect the local Grace environment with inert scaffolded diagnostics.")
+            |> addOption Options.full
+            |> addOption Options.offline
+            |> addOption Options.listChecks
+            |> addOption Options.check
+            |> addOption Options.strict
+
+        doctorCommand.Action <- Invoke()
+        doctorCommand

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -374,6 +374,130 @@ module CommandOutputContract =
                     |]
             |}
 
+    let private doctorCheckSchema =
+        schemaObject
+            "DoctorCheckDto"
+            [
+                "Id", scalarSchema "string"
+                "Category", scalarSchema "string"
+                "Title", scalarSchema "string"
+                "Description", scalarSchema "string"
+                "DefaultEnabled", scalarSchema "boolean"
+                "SupportsOffline", scalarSchema "boolean"
+            ]
+            [|
+                "Id"
+                "Category"
+                "Title"
+                "Description"
+                "DefaultEnabled"
+                "SupportsOffline"
+            |]
+
+    let private doctorCheckResultSchema =
+        schemaObject
+            "DoctorCheckResultDto"
+            [
+                "Id", scalarSchema "string"
+                "Category", scalarSchema "string"
+                "Title", scalarSchema "string"
+                "Status", scalarSchema "string"
+                "Severity", scalarSchema "string"
+                "Summary", scalarSchema "string"
+            ]
+            [|
+                "Id"
+                "Category"
+                "Title"
+                "Status"
+                "Severity"
+                "Summary"
+            |]
+
+    let private doctorSummarySchema =
+        schemaObject
+            "DoctorSummaryDto"
+            [
+                "Total", scalarSchema "integer"
+                "Ok", scalarSchema "integer"
+                "Warning", scalarSchema "integer"
+                "Failed", scalarSchema "integer"
+                "Skipped", scalarSchema "integer"
+            ]
+            [|
+                "Total"
+                "Ok"
+                "Warning"
+                "Failed"
+                "Skipped"
+            |]
+
+    let private doctorReportSchema =
+        schemaObject
+            "DoctorReportDto"
+            [
+                "ReportVersion", scalarSchema "string"
+                "Status", scalarSchema "string"
+                "ExitCode", scalarSchema "integer"
+                "Full", scalarSchema "boolean"
+                "Offline", scalarSchema "boolean"
+                "Strict", scalarSchema "boolean"
+                "ListOnly", scalarSchema "boolean"
+                "RequestedChecks", arraySchema (scalarSchema "string") "Requested check IDs or categories after token normalization."
+                "Catalog", arraySchema doctorCheckSchema "Inert doctor check catalog entries included in the report."
+                "Checks", arraySchema doctorCheckResultSchema "Scaffolded check results; no real diagnostics run in this slice."
+                "Summary", doctorSummarySchema
+            ]
+            [|
+                "ReportVersion"
+                "Status"
+                "ExitCode"
+                "Full"
+                "Offline"
+                "Strict"
+                "ListOnly"
+                "RequestedChecks"
+                "Catalog"
+                "Checks"
+                "Summary"
+            |]
+
+    let private doctorReportExample =
+        box
+            {|
+                ReportVersion = "doctor-report-v1"
+                Status = "Ok"
+                ExitCode = 0
+                Full = false
+                Offline = false
+                Strict = false
+                ListOnly = true
+                RequestedChecks = [| "cli.catalog" |]
+                Catalog =
+                    [|
+                        {|
+                            Id = "cli.catalog"
+                            Category = "CLI"
+                            Title = "CLI command catalog"
+                            Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                            DefaultEnabled = true
+                            SupportsOffline = true
+                        |}
+                    |]
+                Checks =
+                    [|
+                        {|
+                            Id = "cli.catalog"
+                            Category = "CLI"
+                            Title = "CLI command catalog"
+                            Status = "Ok"
+                            Severity = "Info"
+                            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+                        |}
+                    |]
+                Summary = {| Total = 1; Ok = 1; Warning = 0; Failed = 0; Skipped = 0 |}
+            |}
+
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
 
@@ -468,6 +592,16 @@ module CommandOutputContract =
                 maintenanceStatsExample
                 [
                     "Command-specific CLI DTO emitted by maintenance update-index in the common Grace result envelope after the local index is updated."
+                ]
+        | "doctor", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "DoctorReportDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                doctorReportSchema
+                doctorReportExample
+                [
+                    "Command-specific CLI DTO emitted by grace doctor in the common Grace result envelope."
+                    "Doctor schema and examples are intentionally available in the S0 scaffold because later slices add real diagnostics behind the stable DTO."
                 ]
         | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
@@ -719,7 +853,11 @@ module CommandOutputContract =
             ExecutionScope = executionScope
             Mutating = mutating
             EnvelopeContract = envelopeContract
-            Features = featuresFor behavior
+            Features =
+                if identity.CommandId.Equals("doctor", StringComparison.Ordinal) then
+                    { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
+                else
+                    featuresFor behavior
             ReturnValueContract = returnValueContractFor identity envelopeContract
         }
 
@@ -849,6 +987,7 @@ module CommandOutputContract =
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
             row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [] "doctor" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "check-ignore-entries" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "list-contents" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "scan" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -41,6 +41,7 @@
 		<Compile Include="Command\DirectoryVersion.CLI.fs" />
 		<Compile Include="Command\Watch.CLI.fs" />
 		<Compile Include="Command\Maintenance.CLI.fs" />
+		<Compile Include="Command\Doctor.CLI.fs" />
                 
                 <Compile Include="Command\WorkItem.CLI.fs" />
                 <Compile Include="Command\Review.CLI.fs" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -509,7 +509,16 @@ module GraceCommand =
                         "admin"
                     ]
             }
-            { Heading = "Local utilities"; CommandNames = [ "history"; "maintenance"; "alias" ] }
+            {
+                Heading = "Local utilities"
+                CommandNames =
+                    [
+                        "doctor"
+                        "history"
+                        "maintenance"
+                        "alias"
+                    ]
+            }
         ]
 
     let private repositoryHelpSections =
@@ -830,6 +839,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(History.Build)
         rootCommand.Subcommands.Add(Auth.Build)
         rootCommand.Subcommands.Add(Maintenance.Build)
+        rootCommand.Subcommands.Add(Doctor.Build)
         rootCommand.Subcommands.Add(WorkItemCommand.Build)
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
@@ -945,6 +955,14 @@ module GraceCommand =
 
     /// Checks if the command is a `grace watch` command.
     let isGraceWatch (parseResult: ParseResult) = if (parseResult.CommandResult.Command.Name = "watch") then true else false
+
+    /// Checks if the command is a `grace doctor` command.
+    let isGraceDoctor (parseResult: ParseResult) =
+        if isNull parseResult then
+            false
+        else
+            Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
+            |> Seq.exists (fun command -> command.Name.Equals("doctor", StringComparison.OrdinalIgnoreCase))
 
     /// Checks if the command is a foreground `grace watch` command.
     let isGraceWatchForeground (parseResult: ParseResult) =
@@ -1094,7 +1112,8 @@ module GraceCommand =
                                 raise (IntrospectionExit returnValue)
                             | None -> ()
 
-                        LocalStateDb.setVerbose (parseResult |> verbose)
+                        if not (parseResult |> isGraceDoctor) then
+                            LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
                         match parseResult.Action with
@@ -1264,6 +1283,9 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
+                    else if parseResult |> isGraceDoctor then
+                        let invokedReturnValue = parseResult.Invoke()
+                        returnValue <- invokedReturnValue
                     else if configurationFileExists () then
                         match tryGetJsonConfigurationError parseResult with
                         | Some error ->
@@ -1349,6 +1371,7 @@ module GraceCommand =
                                 "auth"
                                 "connect"
                                 "alias"
+                                "doctor"
                             ]
 
                         let isAllowed =
@@ -1410,7 +1433,10 @@ module GraceCommand =
                     (finishTime - startTime).TotalMilliseconds
                     |> int64
 
-                if not isIntrospection then
+                if
+                    not isIntrospection
+                    && not (parseResult |> isGraceDoctor)
+                then
                     HistoryStorage.tryRecordInvocation
                         {
                             argvOriginal = argvOriginal

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -73,6 +73,9 @@ module Text =
         let ForceRecompute = "--force-recompute"
 
         [<Literal>]
+        let Full = "--full"
+
+        [<Literal>]
         let FullSha = "--full-sha"
 
         [<Literal>]
@@ -94,6 +97,9 @@ module Text =
         let ListFiles = "--list-files"
 
         [<Literal>]
+        let ListChecks = "--list-checks"
+
+        [<Literal>]
         let LogicalDeleteDays = "--logical-delete-days"
 
         [<Literal>]
@@ -110,6 +116,9 @@ module Text =
 
         [<Literal>]
         let NewName = "--new-name"
+
+        [<Literal>]
+        let Offline = "--offline"
 
         [<Literal>]
         let OrganizationId = "--organization-id"
@@ -248,6 +257,9 @@ module Text =
 
         [<Literal>]
         let Since = "--since"
+
+        [<Literal>]
+        let Strict = "--strict"
 
         [<Literal>]
         let Status = "--status"


### PR DESCRIPTION
## Summary

Part of #333.
Related to #334.

- Adds the inert root-level `grace doctor` command scaffold and grouped root help entry.
- Adds v1 doctor options: `--full`, `--offline`, `--list-checks`, `--check`, and `--strict`.
- Adds stable doctor report DTOs, inert check catalog behavior, diagnostic exit-code mapping, and schema/example/select metadata through the existing CLI output contract.
- Keeps command/input failures on the existing `GraceError` path and diagnostic results inside the existing `GraceReturnValue<T>` envelope.

## Write Set

- `src/Grace.CLI/Command/Doctor.CLI.fs`
- `src/Grace.CLI/Command/Common.CLI.fs`
- `src/Grace.CLI/CommandOutputContract.CLI.fs`
- `src/Grace.CLI/Grace.CLI.fsproj`
- `src/Grace.CLI/Program.CLI.fs`
- `src/Grace.CLI/Text.CLI.fs`
- `src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs`
- `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`
- `src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs`
- `src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`

## Validation

- `dotnet tool run fantomas --recurse .` from `C:\Source\Grace-gh-334\src`: passed.
- Targeted follow-up Fantomas runs on touched files: passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor`: passed, 11/11.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter CommandOutputContract`: passed, 20/20.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: skipped for this focused S0 worker; the epic integration/final gates will run Fast after the behavior slices converge.

## Review Status

- Implementation worker `Bacon` completed and pushed `c93acde`.
- Validate workflow on initial PR head `c93acde`: passed.
- Codex Code Review Bot reviewed head `c93acde` and posted three inline findings.
- Fix worker `Chandrasekhar` completed and pushed `2288651`; all first-round bot findings were replied to and resolved.
- Validate workflow on head `2288651`: passed.
- Codex Code Review Bot reviewed head `2288651` and posted three second-round inline findings.
- Fix worker `Carson` completed and pushed `c409614`; all second-round bot findings were replied to and resolved.
- Validate workflow on head `c409614`: passed.
- Codex Code Review Bot reviewed head `c409614` and posted one third-round inline finding.
- Fix worker `Planck` completed and pushed `81e875b`; the third-round bot finding was replied to and resolved.
- Validate workflow on head `81e875b`: passed.
- Codex Code Review Bot on head `81e875b`: final no-issues `👍🏻` observed.
- Open bot findings: none.
- Final no-issues bot review: complete for S0.
## Docs Impact

Docs are intentionally deferred to S6 (#340). This slice includes command help text and a narrow machine-readable CLI docs-freshness waiver for `doctor` until the final docs slice updates `docs/Machine-readable CLI output.md`.

## Residual Risk

Low for runtime behavior because this is an inert scaffold only. Follow-on slices still own the read-only config, auth, local-state, server, working-tree, and docs/audit behavior.







