### PR TITLE
S1: Add read-only doctor config inspection

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -4,6 +4,7 @@ open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
+open Grace.Shared.Client
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -51,6 +52,85 @@ module DoctorCliTests =
                     Directory.Delete(tempDir, true)
                 with
                 | _ -> ()
+
+    let private withEnv (name: string) (value: string option) (action: unit -> unit) =
+        let original = Environment.GetEnvironmentVariable(name)
+
+        match value with
+        | Some v -> Environment.SetEnvironmentVariable(name, v)
+        | None -> Environment.SetEnvironmentVariable(name, null)
+
+        try
+            action ()
+        finally
+            Environment.SetEnvironmentVariable(name, original)
+
+    let private withIsolatedHome (root: string) (action: string -> unit) =
+        let home = Path.Combine(root, "home")
+        Directory.CreateDirectory(home) |> ignore
+
+        withEnv "USERPROFILE" (Some home) (fun () ->
+            withEnv "HOME" (Some home) (fun () -> withEnv Constants.EnvironmentVariables.GraceServerUri None (fun () -> action home)))
+
+    let private writeGraceConfig root serverUri =
+        let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+        Directory.CreateDirectory(graceDir) |> ignore
+        let ownerId = string (Guid.NewGuid())
+        let organizationId = string (Guid.NewGuid())
+        let repositoryId = string (Guid.NewGuid())
+        let branchId = string (Guid.NewGuid())
+
+        File.WriteAllText(
+            Path.Combine(graceDir, Constants.GraceConfigFileName),
+            sprintf
+                """
+{
+  "ownerId": "%s",
+  "ownerName": "owner",
+  "organizationId": "%s",
+  "organizationName": "org",
+  "repositoryId": "%s",
+  "repositoryName": "repo",
+  "branchId": "%s",
+  "branchName": "main",
+  "serverUri": "%s",
+  "configurationVersion": "0.1",
+  "programVersion": "0.1"
+}
+"""
+                ownerId
+                organizationId
+                repositoryId
+                branchId
+                serverUri
+        )
+
+    let private snapshotFiles root =
+        if Directory.Exists(root) then
+            Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+            |> Array.map (fun path -> Path.GetRelativePath(root, path), File.GetLastWriteTimeUtc(path), FileInfo(path).Length)
+            |> Array.sortBy (fun (relativePath, _, _) -> relativePath)
+        else
+            Array.empty
+
+    let private withUserConfigTemporarilyMissing (action: string -> unit) =
+        let userConfigPath = UserConfiguration.getUserConfigurationPath ()
+        let backupPath = Path.Combine(Path.GetTempPath(), $"grace-userconfig-backup-{Guid.NewGuid():N}.json")
+        let existed = File.Exists(userConfigPath)
+        let userConfigDirectory = Path.GetDirectoryName(userConfigPath)
+
+        try
+            if existed then File.Move(userConfigPath, backupPath)
+
+            action userConfigPath
+        finally
+            if File.Exists(userConfigPath) then File.Delete(userConfigPath)
+
+            if existed then
+                Directory.CreateDirectory(userConfigDirectory)
+                |> ignore
+
+                File.Move(backupPath, userConfigPath)
 
     let private parseJsonOutput (output: string) =
         output
@@ -113,12 +193,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 4
+            |> should equal 11
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 4
+            |> should equal 11
 
             let catalogIds =
                 returnValue
@@ -131,6 +211,13 @@ module DoctorCliTests =
             |> should contain "identity.auth-session"
 
             catalogIds |> should contain "server.connectivity"
+            catalogIds |> should contain "config.file.parse"
+
+            catalogIds
+            |> should contain "user-config.file.discover"
+
+            catalogIds
+            |> should contain "ignore.entries.parse"
 
             let firstCheck = returnValue.GetProperty("Checks")[0]
 
@@ -163,7 +250,12 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 2
+            catalogIds.Count |> should equal 9
+
+            catalogIds |> should contain "config.file.parse"
+
+            catalogIds
+            |> should contain "ignore.entries.parse"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -193,7 +285,8 @@ module DoctorCliTests =
                     .GetProperty("ReturnValue")
                     .GetProperty("Checks")
 
-            checks.GetArrayLength() |> should equal 2)
+            checks.GetArrayLength()
+            |> should be (greaterThanOrEqualTo 5))
 
     [<Test>]
     let ``doctor explicit check includes non-default catalog entry without full`` () =
@@ -219,6 +312,209 @@ module DoctorCliTests =
 
             checks[ 0 ].GetProperty("Id").GetString()
             |> should equal "identity.auth-session")
+
+    [<Test>]
+    let ``doctor explicit config check is not filtered out without full`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 1
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"))
+
+    [<Test>]
+    let ``doctor verbose select returns clean scalar for passing config check`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Ok\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut |> should not' (contain "EventTime")))
+
+    [<Test>]
+    let ``doctor reports config server uri mismatch and ignore counts without mutating files`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                File.WriteAllText(
+                    Path.Combine(root, Constants.GraceIgnoreFileName),
+                    """
+# comment
+bin/
+obj/
+*.tmp
+
+notes.txt # inline comment
+"""
+                )
+
+                let beforeRoot = snapshotFiles root
+                let beforeHome = snapshotFiles home
+
+                withEnv Constants.EnvironmentVariables.GraceServerUri (Some "http://127.0.0.1:6000") (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "config.file.parse"
+                                                          "--check"
+                                                          "server-uri.consistency"
+                                                          "--check"
+                                                          "ignore.entries.parse" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 3
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    checks[ 1 ].GetProperty("Status").GetString()
+                    |> should equal "Warning"
+
+                    checks[ 2 ].GetProperty("Summary").GetString()
+                    |> should contain "4 active entries"
+
+                    snapshotFiles root |> should equal beforeRoot
+                    snapshotFiles home |> should equal beforeHome
+
+                    File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
+                    |> should equal false)))
+
+    [<Test>]
+    let ``doctor malformed config fails parse and selected skipped dependent output stays clean`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+                Directory.CreateDirectory(graceDir) |> ignore
+                File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{ not json")
+
+                let beforeRoot = snapshotFiles root
+                let beforeHome = snapshotFiles home
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--check"
+                                                      "ignore.entries.parse"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 1
+                standardError |> should equal String.Empty
+
+                standardOut
+                    .TrimStart()
+                    .StartsWith("[", StringComparison.Ordinal)
+                |> should equal true
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut |> should not' (contain "EventTime")
+
+                use document = JsonDocument.Parse(standardOut)
+                let checks = document.RootElement
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                snapshotFiles root |> should equal beforeRoot
+                snapshotFiles home |> should equal beforeHome))
+
+    [<Test>]
+    let ``doctor missing user config reports warning without creating user grace directory`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                withUserConfigTemporarilyMissing (fun userConfigPath ->
+                    let beforeHome = snapshotFiles home
+                    let beforeUserConfigExists = File.Exists(userConfigPath)
+
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "user-config.file.discover" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let check =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")[0]
+
+                    check.GetProperty("Status").GetString()
+                    |> should equal "Warning"
+
+                    check.GetProperty("Summary").GetString()
+                    |> should contain "no file was created"
+
+                    snapshotFiles home |> should equal beforeHome
+
+                    File.Exists(userConfigPath)
+                    |> should equal beforeUserConfigExists
+
+                    Directory.Exists(Path.Combine(home, Constants.GraceConfigDirectory))
+                    |> should equal false)))
 
     [<Test>]
     let ``doctor invalid check emits GraceError in json mode`` () =
@@ -300,17 +596,22 @@ module DoctorCliTests =
     [<TestCase("Minimal")>]
     let ``doctor suppresses successful human output for quiet output modes`` output =
         withTempDir (fun root ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  output
-                                                  "doctor" |]
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
 
-            exitCode |> should equal 0
-            standardOut |> should equal String.Empty
-            standardError |> should equal String.Empty
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse" |]
 
-            Directory.Exists(Path.Combine(root, ".grace"))
-            |> should equal false)
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty
+
+                File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
+                |> should equal false))
 
     [<TestCase("Json")>]
     [<TestCase("Verbose")>]
@@ -325,7 +626,7 @@ module DoctorCliTests =
 
             exitCode |> should equal 0
             standardError |> should equal String.Empty
-            standardOut.Trim() |> should equal "\"Ok\""
+            standardOut.Trim() |> should equal "\"Warning\""
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -105,6 +105,8 @@ module DoctorCliTests =
                 serverUri
         )
 
+        Path.Combine(graceDir, Constants.GraceConfigFileName)
+
     let private snapshotFiles root =
         if Directory.Exists(root) then
             Directory.GetFiles(root, "*", SearchOption.AllDirectories)
@@ -112,6 +114,8 @@ module DoctorCliTests =
             |> Array.sortBy (fun (relativePath, _, _) -> relativePath)
         else
             Array.empty
+
+    let private openExclusiveReadLock path = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None)
 
     let private withUserConfigTemporarilyMissing (action: string -> unit) =
         let userConfigPath = UserConfiguration.getUserConfigurationPath ()
@@ -318,6 +322,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
@@ -349,6 +354,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
@@ -373,6 +379,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun home ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 File.WriteAllText(
                     Path.Combine(root, Constants.GraceIgnoreFileName),
@@ -476,6 +483,101 @@ notes.txt # inline comment
 
                 snapshotFiles root |> should equal beforeRoot
                 snapshotFiles home |> should equal beforeHome))
+
+    [<Test>]
+    let ``doctor treats unreadable config file as parse failure instead of missing config`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                let configPath = writeGraceConfig root "http://127.0.0.1:5000"
+
+                use _lock = openExclusiveReadLock configPath
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.discover"
+                                                      "--check"
+                                                      "config.file.parse" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.discover"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                checks[ 0 ].GetProperty("Summary").GetString()
+                |> should contain "parsing is reported"
+
+                checks[ 1 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Summary").GetString()
+                |> should contain "Could not parse"))
+
+    [<Test>]
+    let ``doctor carries unreadable graceignore into ignore parse result without affecting config parse`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+                File.WriteAllText(graceIgnorePath, "bin/")
+
+                use _lock = openExclusiveReadLock graceIgnorePath
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--check"
+                                                      "ignore.entries.parse" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                checks[ 1 ].GetProperty("Id").GetString()
+                |> should equal "ignore.entries.parse"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Summary").GetString()
+                |> should contain "Could not parse"))
 
     [<Test>]
     let ``doctor missing user config reports warning without creating user grace directory`` () =
@@ -598,6 +700,7 @@ notes.txt # inline comment
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -3,6 +3,7 @@ namespace Grace.CLI.Command
 open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
+open Grace.Shared.Client
 open Grace.Types.Common
 open Spectre.Console
 open System
@@ -17,6 +18,33 @@ module Doctor =
 
     [<Literal>]
     let ReportVersion = "doctor-report-v1"
+
+    [<Literal>]
+    let private CliCatalogCheckId = "cli.catalog"
+
+    [<Literal>]
+    let private ConfigFileDiscoverCheckId = "config.file.discover"
+
+    [<Literal>]
+    let private ConfigFileParseCheckId = "config.file.parse"
+
+    [<Literal>]
+    let private ConfigRepositoryIdentityCheckId = "config.repository.identity"
+
+    [<Literal>]
+    let private ConfigServerUriCheckId = "config.server-uri.valid"
+
+    [<Literal>]
+    let private ServerUriConsistencyCheckId = "server-uri.consistency"
+
+    [<Literal>]
+    let private UserConfigDiscoverCheckId = "user-config.file.discover"
+
+    [<Literal>]
+    let private UserConfigParseCheckId = "user-config.file.parse"
+
+    [<Literal>]
+    let private IgnoreEntriesParseCheckId = "ignore.entries.parse"
 
     module private Options =
         let full =
@@ -66,18 +94,74 @@ module Doctor =
     let catalog: LocalOutputDto.DoctorCheckDto array =
         [|
             {
-                Id = "cli.catalog"
+                Id = CliCatalogCheckId
                 Category = "CLI"
                 Title = "CLI command catalog"
-                Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                Description = "Verifies that the Grace CLI command catalog is available."
                 DefaultEnabled = true
                 SupportsOffline = true
             }
             {
-                Id = "configuration.config-file"
+                Id = ConfigFileDiscoverCheckId
                 Category = "Configuration"
-                Title = "Grace configuration file"
-                Description = "Reserved for a later configuration-file diagnostic. Scaffold only; no file is read in this slice."
+                Title = "Grace configuration discovery"
+                Description = "Finds .grace/graceconfig.json by walking upward from the current directory without creating it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigFileParseCheckId
+                Category = "Configuration"
+                Title = "Grace configuration parse"
+                Description = "Reads .grace/graceconfig.json without rewriting or normalizing it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigRepositoryIdentityCheckId
+                Category = "Configuration"
+                Title = "Repository identity"
+                Description = "Reports whether the repository configuration includes owner, organization, repository, and branch identity values."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigServerUriCheckId
+                Category = "Configuration"
+                Title = "Configured server URI"
+                Description = "Validates the server URI stored in .grace/graceconfig.json without probing the server."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ServerUriConsistencyCheckId
+                Category = "Configuration"
+                Title = "Server URI consistency"
+                Description = "Compares the configured server URI with GRACE_SERVER_URI when both are present."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = UserConfigDiscoverCheckId
+                Category = "User configuration"
+                Title = "User configuration discovery"
+                Description = "Checks whether ~/.grace/userconfig.json exists without creating it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = UserConfigParseCheckId
+                Category = "User configuration"
+                Title = "User configuration parse"
+                Description = "Reads ~/.grace/userconfig.json without creating or rewriting it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = IgnoreEntriesParseCheckId
+                Category = "Ignore"
+                Title = ".graceignore entries"
+                Description = "Reads .graceignore entries, ignoring comments and blank lines, without creating the file."
                 DefaultEnabled = true
                 SupportsOffline = true
             }
@@ -173,14 +257,156 @@ module Doctor =
         not (parseResult |> json)
         && (parseResult |> hasOutput)
 
-    let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+    type private ConfigurationInspectionState =
+        | ConfigurationLoaded of Configuration.GraceConfigurationInspection
+        | ConfigurationMissing of string
+        | ConfigurationMalformed of string
+
+    type private DoctorInspectionContext =
+        {
+            ConfigurationState: ConfigurationInspectionState
+            UserConfiguration: UserConfiguration.UserConfigurationInspection
+            EnvironmentServerUri: string option
+        }
+
+    let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
+
+    let private createInspectionContext () =
+        let configurationState =
+            match Configuration.tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection -> ConfigurationLoaded inspection
+            | Error message when message.Contains(Constants.GraceConfigFileName, StringComparison.OrdinalIgnoreCase) -> ConfigurationMissing message
+            | Error message -> ConfigurationMalformed message
+
+        {
+            ConfigurationState = configurationState
+            UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
+            EnvironmentServerUri =
+                Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+                |> normalizeOptionalText
+        }
+
+    let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
+        { Id = checkId; Category = category; Title = title; Status = status; Severity = severity; Summary = summary }
+
+    let private skipped (check: LocalOutputDto.DoctorCheckDto) summary = checkResult check.Id check.Category check.Title "Skipped" "Info" summary
+
+    let private resultForCheck (context: DoctorInspectionContext) (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+        let ok summary = checkResult check.Id check.Category check.Title "Ok" "Info" summary
+        let warning summary = checkResult check.Id check.Category check.Title "Warning" "Warning" summary
+        let failed summary = checkResult check.Id check.Category check.Title "Failed" "Error" summary
+
+        match check.Id with
+        | CliCatalogCheckId -> ok "Doctor check catalog is available."
+        | ConfigFileDiscoverCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
+            | ConfigurationMissing message -> warning $"{message} No configuration file was created."
+            | ConfigurationMalformed _ -> ok $"Found {Constants.GraceConfigFileName}, but parsing is reported by {ConfigFileParseCheckId}."
+        | ConfigFileParseCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection -> ok $"Parsed {inspection.Path} without rewriting it."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed message -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
+        | ConfigRepositoryIdentityCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                let configuration = inspection.Configuration
+
+                let missing =
+                    [|
+                        if configuration.OwnerId = OwnerId.Empty then "ownerId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.OwnerName) then "ownerName"
+
+                        if configuration.OrganizationId = OrganizationId.Empty then "organizationId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.OrganizationName) then
+                            "organizationName"
+
+                        if configuration.RepositoryId = RepositoryId.Empty then "repositoryId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.RepositoryName) then
+                            "repositoryName"
+
+                        if configuration.BranchId = BranchId.Empty then "branchId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.BranchName) then "branchName"
+                    |]
+
+                if Array.isEmpty missing then
+                    ok $"Repository identity is populated for root {inspection.RootDirectory}."
+                else
+                    let missingText = String.Join(", ", missing)
+                    warning $"Repository identity has blank or empty values: {missingText}."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigServerUriCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                match Uri.TryCreate(inspection.Configuration.ServerUri, UriKind.Absolute) with
+                | true, uri when
+                    uri.Scheme = Uri.UriSchemeHttp
+                    || uri.Scheme = Uri.UriSchemeHttps
+                    ->
+                    let normalizedUri = uri.AbsoluteUri.TrimEnd('/')
+                    ok $"Configured server URI is {normalizedUri}."
+                | true, uri -> warning $"Configured server URI uses unsupported scheme '{uri.Scheme}'."
+                | false, _ -> failed $"Configured server URI is not an absolute URI: {inspection.Configuration.ServerUri}."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | ServerUriConsistencyCheckId ->
+            match context.ConfigurationState, context.EnvironmentServerUri with
+            | ConfigurationLoaded inspection, Some environmentServerUri ->
+                match Uri.TryCreate(inspection.Configuration.ServerUri, UriKind.Absolute), Uri.TryCreate(environmentServerUri, UriKind.Absolute) with
+                | (true, configured), (true, environmentValue) ->
+                    let configuredValue = configured.AbsoluteUri.TrimEnd('/')
+                    let environmentValue = environmentValue.AbsoluteUri.TrimEnd('/')
+
+                    if configuredValue.Equals(environmentValue, StringComparison.OrdinalIgnoreCase) then
+                        ok $"Configured server URI and {Constants.EnvironmentVariables.GraceServerUri} match."
+                    else
+                        warning $"Configured server URI '{configuredValue}' differs from {Constants.EnvironmentVariables.GraceServerUri} '{environmentValue}'."
+                | _, (false, _) -> warning $"{Constants.EnvironmentVariables.GraceServerUri} is not an absolute URI: {environmentServerUri}."
+                | (false, _), _ -> skipped check $"Skipped because {ConfigServerUriCheckId} did not produce a valid configured URI."
+            | ConfigurationLoaded _, None ->
+                ok $"{Constants.EnvironmentVariables.GraceServerUri} is not set; configuration server URI is the active local value."
+            | ConfigurationMissing _, _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _, _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | UserConfigDiscoverCheckId ->
+            if context.UserConfiguration.Exists then
+                ok $"Found user configuration at {context.UserConfiguration.Path}."
+            else
+                warning $"User configuration file was not found at {context.UserConfiguration.Path}; no file was created."
+        | UserConfigParseCheckId ->
+            if not context.UserConfiguration.Exists then
+                skipped check $"Skipped because {UserConfigDiscoverCheckId} did not find userconfig.json."
+            else
+                match context.UserConfiguration.ErrorMessage with
+                | Some message -> failed $"Could not parse user configuration: {message}"
+                | None -> ok $"Parsed user configuration at {context.UserConfiguration.Path} without rewriting it."
+        | IgnoreEntriesParseCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                let ignore = inspection.Ignore
+
+                if ignore.Exists then
+                    ok
+                        $".graceignore has {ignore.Entries.Length} active entries: {ignore.FileEntries.Length} file patterns and {ignore.DirectoryEntries.Length} directory patterns."
+                else
+                    warning $".graceignore was not found at {ignore.Path}; no file was created."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | _ -> skipped check "No diagnostic implementation is registered for this check."
+
+    let private listOnlyResultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         {
             Id = check.Id
             Category = check.Category
             Title = check.Title
-            Status = "Ok"
+            Status = "Skipped"
             Severity = "Info"
-            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+            Summary = "Catalog discovery only; diagnostic probes were not run."
         }
 
     let private summarize (checks: LocalOutputDto.DoctorCheckResultDto array) =
@@ -214,7 +440,13 @@ module Doctor =
             0
 
     let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
-        let results = checks |> Array.map resultForCheck
+        let results =
+            if listOnly then
+                checks |> Array.map listOnlyResultForCheck
+            else
+                let context = createInspectionContext ()
+                checks |> Array.map (resultForCheck context)
+
         let summary = summarize results
         let status = reportStatus summary
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -275,8 +275,8 @@ module Doctor =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
-            | Error message when message.Contains(Constants.GraceConfigFileName, StringComparison.OrdinalIgnoreCase) -> ConfigurationMissing message
-            | Error message -> ConfigurationMalformed message
+            | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
+            | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
 
         {
             ConfigurationState = configurationState
@@ -390,11 +390,12 @@ module Doctor =
             | ConfigurationLoaded inspection ->
                 let ignore = inspection.Ignore
 
-                if ignore.Exists then
+                match ignore.ErrorMessage with
+                | Some message -> failed $"Could not parse {Constants.GraceIgnoreFileName}: {message}"
+                | None when ignore.Exists ->
                     ok
                         $".graceignore has {ignore.Entries.Length} active entries: {ignore.FileEntries.Length} file patterns and {ignore.DirectoryEntries.Length} directory patterns."
-                else
-                    warning $".graceignore was not found at {ignore.Path}; no file was created."
+                | None -> warning $".graceignore was not found at {ignore.Path}; no file was created."
             | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
             | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
         | _ -> skipped check "No diagnostic implementation is registered for this check."

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -147,7 +147,10 @@ module Configuration =
             // Deserialize the JSON configuration file into a GraceConfiguration object
             let graceConfiguration = JsonSerializer.Deserialize<GraceConfiguration>(buffer, Constants.JsonSerializerOptions)
 
-            Ok graceConfiguration
+            if obj.ReferenceEquals(graceConfiguration, null) then
+                Error "Configuration file is empty or invalid JSON."
+            else
+                Ok graceConfiguration
         with
         | ex -> Error $"Exception: {ex.Message}{Environment.NewLine}Stack trace: {ex.StackTrace}"
 
@@ -201,6 +204,43 @@ module Configuration =
 
         graceConfiguration.IsPopulated <- true
         graceConfiguration
+
+    type GraceIgnoreInspection = { Path: string; Exists: bool; Entries: string array; FileEntries: string array; DirectoryEntries: string array }
+
+    type GraceConfigurationInspection = { Path: string; RootDirectory: string; Configuration: GraceConfiguration; Ignore: GraceIgnoreInspection }
+
+    let inspectGraceIgnore rootDirectory =
+        let graceIgnorePath = Path.Combine(rootDirectory, Constants.GraceIgnoreFileName)
+        let entries = getGraceIgnoreEntries graceIgnorePath
+
+        {
+            Path = graceIgnorePath
+            Exists = File.Exists(graceIgnorePath)
+            Entries = entries
+            FileEntries =
+                entries
+                |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
+            DirectoryEntries =
+                entries
+                |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+        }
+
+    let tryInspectCurrentDirectoryConfiguration () =
+        match findGraceConfigurationFile () with
+        | Error errorMessage -> Error errorMessage
+        | Ok graceConfigurationFilePath ->
+            match parseConfigurationFile graceConfigurationFilePath with
+            | Error errorMessage -> Error errorMessage
+            | Ok graceConfigurationFromFile ->
+                let configuration = populateDerivedFields graceConfigurationFilePath graceConfigurationFromFile
+
+                Ok
+                    {
+                        Path = graceConfigurationFilePath
+                        RootDirectory = configuration.RootDirectory
+                        Configuration = configuration
+                        Ignore = inspectGraceIgnore configuration.RootDirectory
+                    }
 
     let private createDefaultConfigurationFile () =
         let graceConfigurationFilePath = Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -170,7 +170,19 @@ module Configuration =
         else
             Array.empty
 
-    let private populateDerivedFields (graceConfigurationFilePath: string) (graceConfiguration: GraceConfiguration) =
+    let private populateGraceIgnoreFields (graceConfiguration: GraceConfiguration) graceIgnoreEntries =
+        graceConfiguration.GraceIgnoreEntries <- graceIgnoreEntries
+
+        graceConfiguration.GraceFileIgnoreEntries <-
+            graceIgnoreEntries
+            |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
+
+        graceConfiguration.GraceDirectoryIgnoreEntries <-
+            graceIgnoreEntries
+            |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+            |> Array.map (fun graceIgnoreLine -> $"*{graceIgnoreLine}")
+
+    let private populateConfigurationPaths (graceConfigurationFilePath: string) (graceConfiguration: GraceConfiguration) =
         let graceConfigurationDirectory = Path.GetDirectoryName(graceConfigurationFilePath)
 
         graceConfiguration.RootDirectory <- Path.GetFullPath(Path.Combine(graceConfigurationDirectory, ".."))
@@ -187,35 +199,53 @@ module Configuration =
 
         graceConfiguration.ConfigurationDirectory <- FileInfo(graceConfigurationFilePath).DirectoryName
 
+        graceConfiguration
+
+    let private populateDerivedFields graceConfigurationFilePath graceConfiguration =
+        let graceConfiguration = populateConfigurationPaths graceConfigurationFilePath graceConfiguration
         let graceIgnoreFullPath = (Path.Combine(graceConfiguration.RootDirectory, Constants.GraceIgnoreFileName))
 
         let graceIgnoreEntries = getGraceIgnoreEntries graceIgnoreFullPath
 
-        graceConfiguration.GraceIgnoreEntries <- graceIgnoreEntries
-
-        graceConfiguration.GraceFileIgnoreEntries <-
-            graceIgnoreEntries
-            |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
-
-        graceConfiguration.GraceDirectoryIgnoreEntries <-
-            graceIgnoreEntries
-            |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
-            |> Array.map (fun graceIgnoreLine -> $"*{graceIgnoreLine}")
+        populateGraceIgnoreFields graceConfiguration graceIgnoreEntries
 
         graceConfiguration.IsPopulated <- true
         graceConfiguration
 
-    type GraceIgnoreInspection = { Path: string; Exists: bool; Entries: string array; FileEntries: string array; DirectoryEntries: string array }
+    type GraceIgnoreInspection =
+        {
+            Path: string
+            Exists: bool
+            Entries: string array
+            FileEntries: string array
+            DirectoryEntries: string array
+            ErrorMessage: string option
+        }
 
     type GraceConfigurationInspection = { Path: string; RootDirectory: string; Configuration: GraceConfiguration; Ignore: GraceIgnoreInspection }
 
+    type GraceConfigurationInspectionError =
+        | ConfigurationFileNotFound of string
+        | ConfigurationFileMalformed of string
+
+    let private tryGetGraceIgnoreEntries graceIgnorePath =
+        try
+            Ok(getGraceIgnoreEntries graceIgnorePath)
+        with
+        | ex -> Error $"Exception: {ex.Message}{Environment.NewLine}Stack trace: {ex.StackTrace}"
+
     let inspectGraceIgnore rootDirectory =
         let graceIgnorePath = Path.Combine(rootDirectory, Constants.GraceIgnoreFileName)
-        let entries = getGraceIgnoreEntries graceIgnorePath
+        let exists = File.Exists(graceIgnorePath)
+
+        let entries, errorMessage =
+            match tryGetGraceIgnoreEntries graceIgnorePath with
+            | Ok entries -> entries, None
+            | Error errorMessage -> Array.empty, Some errorMessage
 
         {
             Path = graceIgnorePath
-            Exists = File.Exists(graceIgnorePath)
+            Exists = exists
             Entries = entries
             FileEntries =
                 entries
@@ -223,24 +253,22 @@ module Configuration =
             DirectoryEntries =
                 entries
                 |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+            ErrorMessage = errorMessage
         }
 
     let tryInspectCurrentDirectoryConfiguration () =
         match findGraceConfigurationFile () with
-        | Error errorMessage -> Error errorMessage
+        | Error errorMessage -> Error(ConfigurationFileNotFound errorMessage)
         | Ok graceConfigurationFilePath ->
             match parseConfigurationFile graceConfigurationFilePath with
-            | Error errorMessage -> Error errorMessage
+            | Error errorMessage -> Error(ConfigurationFileMalformed errorMessage)
             | Ok graceConfigurationFromFile ->
-                let configuration = populateDerivedFields graceConfigurationFilePath graceConfigurationFromFile
+                let configuration = populateConfigurationPaths graceConfigurationFilePath graceConfigurationFromFile
+                let ignore = inspectGraceIgnore configuration.RootDirectory
+                populateGraceIgnoreFields configuration ignore.Entries
+                configuration.IsPopulated <- true
 
-                Ok
-                    {
-                        Path = graceConfigurationFilePath
-                        RootDirectory = configuration.RootDirectory
-                        Configuration = configuration
-                        Ignore = inspectGraceIgnore configuration.RootDirectory
-                    }
+                Ok { Path = graceConfigurationFilePath; RootDirectory = configuration.RootDirectory; Configuration = configuration; Ignore = ignore }
 
     let private createDefaultConfigurationFile () =
         let graceConfigurationFilePath = Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)

--- a/src/Grace.Shared/Client/UserConfiguration.Shared.fs
+++ b/src/Grace.Shared/Client/UserConfiguration.Shared.fs
@@ -62,6 +62,8 @@ module UserConfiguration =
 
     type UserConfigurationLoadResult = { Configuration: UserConfiguration; WasCorrupt: bool; ErrorMessage: string option; CreatedNew: bool }
 
+    type UserConfigurationInspection = { Path: string; Exists: bool; Configuration: UserConfiguration option; ErrorMessage: string option }
+
     let private normalizeHistory (history: HistoryConfiguration) =
         let normalized = if obj.ReferenceEquals(history, null) then HistoryConfiguration() else history
 
@@ -163,3 +165,20 @@ module UserConfiguration =
                 ErrorMessage = Some $"Failed to read user configuration: {ex.Message}"
                 CreatedNew = false
             }
+
+    let tryInspectUserConfiguration () =
+        let path = getUserConfigurationPath ()
+
+        if not <| File.Exists(path) then
+            { Path = path; Exists = false; Configuration = None; ErrorMessage = None }
+        else
+            try
+                let json = File.ReadAllText(path)
+                let configuration = JsonSerializer.Deserialize<UserConfiguration>(json, Constants.JsonSerializerOptions)
+
+                if obj.ReferenceEquals(configuration, null) then
+                    { Path = path; Exists = true; Configuration = None; ErrorMessage = Some "User configuration file is empty or invalid JSON." }
+                else
+                    { Path = path; Exists = true; Configuration = Some(normalizeConfiguration configuration); ErrorMessage = None }
+            with
+            | ex -> { Path = path; Exists = true; Configuration = None; ErrorMessage = Some $"Failed to read user configuration: {ex.Message}" }


### PR DESCRIPTION
## Summary

Part of #333.
Related to #335.

- Adds read-only `grace doctor` diagnostics for repository config, user config, server URI consistency, and `.graceignore` inspection.
- Adds read-only shared inspectors so doctor does not call mutating config/user-config helpers.
- Represents missing/malformed/unreadable config and dependent-check skips as `DoctorReportDto` findings instead of command failures or filesystem mutations.
- Preserves S0 CLI output semantics for JSON, selected output, silent/minimal output, verbose+select output, exact `--check`, and list-catalog behavior.

## Write Set

- `src/Grace.Shared/Client/Configuration.Shared.fs`
- `src/Grace.Shared/Client/UserConfiguration.Shared.fs`
- `src/Grace.CLI/Command/Doctor.CLI.fs`
- `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`

## Validation

Initial implementation worker `James` on `550ffe8`:

- `dotnet tool run fantomas C:\Source\Grace-gh-335\src\Grace.Shared\Client\Configuration.Shared.fs C:\Source\Grace-gh-335\src\Grace.Shared\Client\UserConfiguration.Shared.fs C:\Source\Grace-gh-335\src\Grace.CLI\Command\Doctor.CLI.fs C:\Source\Grace-gh-335\src\Grace.CLI.Tests\Doctor.CLI.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor`: passed, 24 tests.
- Source search in `Doctor.CLI.fs` for `Configuration.Current(` and `loadUserConfiguration(`: no matches.
- `git diff --check`: passed.

Fix worker `Descartes` on `fdd167b`:

- Fantomas passed for touched F# files.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor`: passed, 26 tests.
- `git diff --check`: passed.
- PowerShell-native search confirmed the doctor command path does not call `Configuration.Current(` or `loadUserConfiguration(`.

PR validation:

- `Validate / full` on head `fdd167b`, attempt 1: failed in `Grace.Server.Tests` setup while waiting for Service Bus readiness; no S1 server-code paths were touched.
- `Validate / full` on head `fdd167b`, attempt 2: passed.

## Review-Prevention Evidence

- JSON/select cleanliness covered for S1 doctor output.
- Silent/minimal output behavior covered for successful diagnostics.
- Verbose plus `--select` remains clean machine-readable output.
- Exact `--check` selection is not filtered out.
- Filesystem before/after assertions prove missing config/user config cases do not create files.
- Unreadable config and unreadable `.graceignore` cases now have issue-owned regression coverage.

## Review Status

- Implementation worker `James` completed and pushed `550ffe8`.
- Validate workflow on PR head `550ffe8`: passed.
- Codex Code Review Bot reviewed head `550ffe8` and posted two inline findings:
  - Unreadable `.grace/graceconfig.json` must be classified as a parse/open failure, not missing config.
  - Unreadable `.graceignore` must be carried into `ignore.entries.parse` instead of throwing while building context.
- Fix worker `Descartes` completed and pushed `fdd167b`.
- Bot finding replies posted with fix and validation evidence:
  - https://github.com/ScottArbeit/Grace/pull/342#discussion_r3387374944
  - https://github.com/ScottArbeit/Grace/pull/342#discussion_r3387375053
- Bot conversations resolved: 2 of 2.
- Validate workflow on PR head `fdd167b`: passed on rerun attempt 2.
- Codex Code Review Bot final signal: `THUMBS_UP` reaction with no unresolved review threads.
- Final no-issues bot review: satisfied.

## Docs Impact

No docs changed in S1. User-facing doctor docs remain deferred to S6 (#340).

## Residual Risk

Low to medium. This slice deliberately touches shared config/user-config helper modules and the central doctor runner. The implementation adds read-only helpers without changing existing mutating helper behavior, and the new unreadable-file regressions cover the review findings.