### PR TITLE
I01: Document BLAKE3 and SHA-256 version hashes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,12 @@ The path-independent BLAKE3 identity of the complete bytes named by a FileVersio
 hexadecimal string. A FileContentHash identifies the whole logical file, while ChunkAddress identifies one ContentChunk.
 _Avoid_: FileVersion hash, path hash, directory hash
 
+**Version Hash**:
+The graph identity hash for a FileVersion, DirectoryVersion, or Reference version object. Version hashes identify Grace
+version graph objects; they are separate from path-independent CAS identities such as FileContentHash, ChunkAddress,
+ContentBlockAddress, and ManifestAddress.
+_Avoid_: FileContentHash, ChunkAddress, ContentBlockAddress, ManifestAddress
+
 **FileManifest**:
 The reconstruction description for large file content that spans ContentChunks stored in ContentBlocks. A FileManifest
 references ordered ContentBlockRanges. FileManifest identity comes from reconstruction content, not from the Repository
@@ -303,6 +309,11 @@ _Avoid_: PromotionSet pending status, blocked status, compute status
 Grace uses FileVersion for path-aware repository meaning, and Content-Addressable Storage for path-independent storage
 identity. Do not describe chunks as belonging to a path; chunks belong to content-addressed storage.
 
+**Version graph hash vs. CAS address**:
+Grace uses version hashes for FileVersion, DirectoryVersion, and Reference graph identity. Grace uses FileContentHash,
+ChunkAddress, ContentBlockAddress, and ManifestAddress for content-addressed storage identity. Do not use a CAS address
+as a version hash, and do not use a version hash as a chunk, block, manifest, or file-content address.
+
 **File content vs. chunk identity**:
 Grace uses FileContentHash for the complete file bytes and ChunkAddress for one ContentChunk inside manifest-backed
 large file content. Do not use ChunkAddress to mean the whole file.
@@ -525,6 +536,11 @@ Developer: "If `src/app.fs` and `backup/app.fs` contain the same bytes, are they
 
 Domain expert: "No. They are two FileVersions because their relative paths differ, but they may refer to the same
 FileContentHash and FileContentReference."
+
+Developer: "Can I use FileContentHash as the FileVersion hash?"
+
+Domain expert: "No. FileContentHash is a path-independent content identity. A FileVersion version hash identifies the
+version graph object that says a specific relative path contains specific content."
 
 Developer: "Can the cache distribute chunks without knowing the original path?"
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,9 +15,11 @@ hexadecimal string. A FileContentHash identifies the whole logical file, while C
 _Avoid_: FileVersion hash, path hash, directory hash
 
 **Version Hash**:
-The graph identity hash for a FileVersion, DirectoryVersion, or Reference version object. Version hashes identify Grace
-version graph objects; they are separate from path-independent CAS identities such as FileContentHash, ChunkAddress,
-ContentBlockAddress, and ManifestAddress.
+In ADR 0006's target model, the graph identity hash for a FileVersion, DirectoryVersion, or Reference version object.
+Version hashes identify Grace version graph objects; they are separate from path-independent CAS identities such as
+FileContentHash, ChunkAddress, ContentBlockAddress, and ManifestAddress. Current SHA-256 values are transition data:
+current file SHA-256 values hash file bytes only, and current references store the root directory hash instead of a
+separate Reference-object hash.
 _Avoid_: FileContentHash, ChunkAddress, ContentBlockAddress, ManifestAddress
 
 **FileManifest**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -312,9 +312,10 @@ Grace uses FileVersion for path-aware repository meaning, and Content-Addressabl
 identity. Do not describe chunks as belonging to a path; chunks belong to content-addressed storage.
 
 **Version graph hash vs. CAS address**:
-Grace uses version hashes for FileVersion, DirectoryVersion, and Reference graph identity. Grace uses FileContentHash,
-ChunkAddress, ContentBlockAddress, and ManifestAddress for content-addressed storage identity. Do not use a CAS address
-as a version hash, and do not use a version hash as a chunk, block, manifest, or file-content address.
+ADR 0006's target behavior uses version hashes for FileVersion, DirectoryVersion, and Reference graph identity during
+the future transition. Grace uses FileContentHash, ChunkAddress, ContentBlockAddress, and ManifestAddress for
+content-addressed storage identity. Do not use a CAS address as a version hash, and do not use a version hash as a
+chunk, block, manifest, or file-content address.
 
 **File content vs. chunk identity**:
 Grace uses FileContentHash for the complete file bytes and ChunkAddress for one ContentChunk inside manifest-backed

--- a/docs/How Grace computes the SHA-256 value.md
+++ b/docs/How Grace computes the SHA-256 value.md
@@ -2,10 +2,13 @@
 
 ## Introduction
 
-Grace currently uses SHA-256 values in file, directory, reference, diff, and lookup workflows. These values are version
-graph hashes: they identify stored Grace `FileVersion`, `DirectoryVersion`, and `Reference` version objects. They are
-separate from content-addressed storage identities such as `FileContentHash`, `ChunkAddress`, `ContentBlockAddress`, and
-`ManifestAddress`.
+Grace currently uses SHA-256 values in file, directory, reference, diff, and lookup workflows. These values sit in the
+version graph, but their current meaning depends on the object type. Current file SHA-256 values are byte hashes; they
+do not by themselves identify stored `FileVersion` objects because a `FileVersion` also carries `RelativePath`.
+Directory SHA-256 values are computed from the directory's own path plus child version hashes. References store the
+referenced root directory hash; Grace does not compute a separate SHA-256 preimage over the `Reference` object itself.
+These values are separate from content-addressed storage identities such as `FileContentHash`, `ChunkAddress`,
+`ContentBlockAddress`, and `ManifestAddress`.
 
 ADR [0006](adr/0006-blake3-and-sha256-version-hashes.md) accepts a future model where BLAKE3 is the default version-hash
 algorithm for new version objects and SHA-256 remains retained for compatibility, verification, and transition tooling.
@@ -52,7 +55,9 @@ The file SHA-256 value is computed with this algorithm:
 For example, `byte[] { 0x43, 0x2a, 0x01, 0xfa }` is represented as `432a01fa`.
 
 The file relative path still matters to Grace's domain model because a `FileVersion` says a specific relative path
-contains specific file content in a repository version. The current file SHA-256 calculation itself is byte-only.
+contains specific file content in a repository version. Two files with the same bytes at different relative paths have
+the same current file SHA-256 value, but they are different `FileVersion` records because their `RelativePath` values
+differ. The current file SHA-256 calculation itself is byte-only.
 
 ### Directories
 
@@ -68,7 +73,13 @@ The directory SHA-256 value is computed with this algorithm:
 1. Append each child file SHA-256 value, in sorted order, as UTF-8 bytes.
 1. Finalize the SHA-256 hash and convert it to lowercase hexadecimal text.
 
-This keeps directory identity sensitive to path and tree shape without making the file byte hash include path data.
+The current implementation uses child names for sorting, but it does not append those child names to the hash input. A
+current directory SHA-256 preimage is the directory's own relative path followed by each child SHA-256 value. The future
+`grace.directory-version.v1` preimage from ADR 0006 is planned to be child-name-aware; this page does not describe that
+future behavior as shipped.
+
+This keeps the current directory SHA-256 value sensitive to the directory path and ordered child hash sequence without
+making the file byte hash include path data.
 
 ### Version Hash Transition
 

--- a/docs/How Grace computes the SHA-256 value.md
+++ b/docs/How Grace computes the SHA-256 value.md
@@ -1,89 +1,92 @@
-# Computing the SHA-256 value for files and directories
+# Computing SHA-256 values for files and directories
 
 ## Introduction
 
-Grace uses the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm to compute cryptographically verifiable hash values for files and directories stored in Grace. The use of SHA-256 hashes for this purpose is inspired by Git's use of SHA-1, and their ongoing work to migrate to SHA-256.
+Grace currently uses SHA-256 values in file, directory, reference, diff, and lookup workflows. These values are version
+graph hashes: they identify stored Grace `FileVersion`, `DirectoryVersion`, and `Reference` version objects. They are
+separate from content-addressed storage identities such as `FileContentHash`, `ChunkAddress`, `ContentBlockAddress`, and
+`ManifestAddress`.
 
-The SHA-256 hash values are used throughout Grace to identify unique versions of files and directories, primarily to minimize the size of change captured by each reference (i.e. each save, checkpoint, commit, and tag).
+ADR [0006](adr/0006-blake3-and-sha256-version-hashes.md) accepts a future model where BLAKE3 is the default version-hash
+algorithm for new version objects and SHA-256 remains retained for compatibility, verification, and transition tooling.
+That dual-hash behavior is the target for epic #343; this page still documents the current SHA-256 behavior where it is
+useful for understanding today's code and stale data.
 
-Hash values in Grace are meant to provide cryptographic proof that the directory and file versions stored for each reference match what was originally uploaded. To be more precise, when a user downloads a specific version of a branch, the files and directory versions should provably be the same versions that were originally stored in Grace. Grace Server, as part of maintenance routines, should also be able to verify file and directory versions at any time.
+Hash values in Grace provide cryptographic evidence that the file, directory, and reference versions stored for a
+reference match what was originally uploaded. When a user downloads a specific branch version, Grace should be able to
+prove that the files and directory versions match the stored version graph. Grace Server maintenance routines should
+also be able to verify stored versions.
 
-Unlike Git, the SHA-256 values provide no linkage between references. Each SHA-256 value is specific to that version of the repository, with no connection to previous or subsequent versions. This enables Grace to be able to delete references and versions, such as saves that are no longer necessary, without the manipulation of history required in Git.
-
-The choice of SHA-256, as opposed to SHA-384 or other stronger algorithms, comes from a desire to provide excellent runtime performance with strong cryptographic hashing. SHA-256 has been studied extensively [for over 20 years](https://en.wikipedia.org/wiki/SHA-2), and [seems to be collision-resistant to quantum algorithms](https://crypto.stackexchange.com/questions/59375/are-hash-functions-strong-against-quantum-cryptanalysis-and-or-independent-enoug). Because Grace, like Git, uses it here solely for hashing, and not for encryption, any potential long-term issues with SHA-256 leave only a small opportunity for misuse.
-
-> This information is valid as of April, 2022. The implementation may change as Grace matures.
+Unlike Git commit history, Grace version hashes do not create a linkage chain between references. Each version hash is
+specific to a stored version object, with no required connection to earlier or later references. This lets Grace delete
+references and versions, such as saves that are no longer necessary, without rewriting history.
 
 ## Implementation
 
-In ordinary usage, SHA-256 values are computed by Grace CLI, and those values are used when uploading versions of files and directories, and when creating references on the server.
+In ordinary usage, SHA-256 values are computed by Grace CLI and reused by Grace Server when uploading file and directory
+versions and creating references.
 
-Specifically, Grace relies on the .NET implementation of [SHA-256](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256), found in the [System.Security.Cryptography](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography) namespace.
+Grace relies on the .NET implementation of
+[SHA-256](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256) in
+`System.Security.Cryptography`.
 
-.NET implementations of Grace clients are welcome to use the hashing implementation in Grace.Shared, which is used by both Grace CLI and Grace Server. Implementations in other languages will need to implement this algorithm separately.
-
-Grace Server rechecks each SHA-256 hash as versions arrive at the server. In the event of a discrepancy, which could indicate malicious behavior, the invalid versions will be deleted, and Grace administrators and repository owners will be notified.
+.NET implementations of Grace clients can use the hashing implementation in Grace.Shared, which is used by both Grace
+CLI and Grace Server. Implementations in other languages need to reproduce the same inputs and encoding.
 
 ### Files
-When computing the SHA-256 value for a file, Grace uses a stream - FileStream when reading a local file, and Stream when reading a file from object storage - and the [IncrementalHash](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.incrementalhash) class, to keep memory use constant, no matter the size of the file.
 
-The SHA-256 value for a file is computed with the following algorithm.
+The current file SHA-256 value is computed from the file byte stream only. The file relative path and file length are not
+appended to the file SHA-256 input.
 
-1. An instance of the [IncrementalHash](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.incrementalhash) class is created using the SHA-256 hash algorithm.
-2. Bytes from the file are read from the stream into a 64KB buffer, and appended to the IncrementalHash's input data, until the stream is consumed.
-3. The relative path of the file (based on the repository root), represented as a string, is converted to bytes using UTF-8 encoding, and appended to the IncrementalHash's input data.
+When computing the SHA-256 value for a file, Grace reads from a stream and uses `IncrementalHash` so memory use stays
+constant no matter how large the file is.
 
-    > For consistency between Windows and Unix-y OS's, Grace converts backslashes `\` in the relative path into forward slashes `/` before converting to bytes.
+The file SHA-256 value is computed with this algorithm:
 
-    - For example: a file is being uploaded on Windows with full path name `C:\Source\MyRepo\SomeDir\myfile.md`. The root of the repository is in `C:\Source\MyRepo`. Therefore, the relative path of the file is `.\SomeDir\myfile.md`. This string will be converted to `./SomeDir/myfile.md` before being converted to a byte array and appended to the IncrementalHash's input.
-4. The length of the file, represented as an `Int64` value, is converted to bytes and appended to the IncrementalHash's input data.
-5. The SHA-256 hash is computed as a `byte[]`.
-6. The SHA-256 hash is converted to a string by converting each byte to a two-character hexadecimal value.
-    - For example, `byte[]{0x43, 0x2a, 0x01, 0xfa}` would be converted to a string `"432a01fa"`.
+1. Create an `IncrementalHash` instance using the SHA-256 hash algorithm.
+1. Read bytes from the file stream into a 64 KiB buffer.
+1. Append each populated buffer span to the hash input until the stream is consumed.
+1. Finalize the SHA-256 hash as a byte array.
+1. Convert each byte to a two-character lowercase hexadecimal value.
 
-The code for this can be found in the Grace.Shared project, in Utilities.Shared.fs.
+For example, `byte[] { 0x43, 0x2a, 0x01, 0xfa }` is represented as `432a01fa`.
 
-``` fsharp
-let computeSha256ForFile (stream: Stream) (relativeFilePath: String) =
-    task {
-        let bufferLength = 64 * 1024
-        let buffer = ArrayPool<byte>.Shared.Rent(bufferLength)
-
-        try
-            // 1. Create an IncrementalHash instance.
-            use hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256)
-            // 2. Read bytes from the stream and feed them into the hasher.
-            let mutable loop = true
-            while loop do
-                let! bytesRead = stream.ReadAsync(buffer.AsMemory(0, bufferLength))
-                if bytesRead > 0 then
-                    hasher.AppendData(buffer.AsSpan(0, bytesRead))
-                else
-                    loop <- false
-            // 3. Convert the relative path of the file to a byte array, and add it to the hasher.
-            hasher.AppendData(Encoding.UTF8.GetBytes(relativeFilePath))
-            // 4. Convert the Int64 file length into a byte array, and add it to the hasher.
-            hasher.AppendData(BitConverter.GetBytes(stream.Length))
-            // 5. Get the SHA-256 hash as a `byte[]`.
-            let sha256Bytes = hasher.GetHashAndReset()
-            // 6. Convert the SHA-256 value from a byte[] to a string, and return it.
-            //    Example: byte[]{0x43, 0x2a, 0x01, 0xfa} -> "432a01fa"
-            return byteArrayAsString(sha256Bytes)
-        finally
-            ArrayPool<byte>.Shared.Return(buffer, clearArray = true)
-    }
-```
+The file relative path still matters to Grace's domain model because a `FileVersion` says a specific relative path
+contains specific file content in a repository version. The current file SHA-256 calculation itself is byte-only.
 
 ### Directories
-The SHA-256 hash of a directory is computed using the following algorithm.
 
-1. The relative path of the directory (based on the repository root), represented as a string, is converted to bytes and stored in a `List<byte>`.
-    - For example: a directory version is being uploaded with full path name `C:\Source\MyRepo\SomeDir\SomeSubDir`. The root of the repository is in `C:\Source\MyRepo`. Therefore, the relative path of the directory is `.\SomeDir\SomeSubDir`. This string will be converted to `./SomeDir/SomeSubDir` before being converted to a byte array and used to create the `List<byte>`.
-2. The list of _subdirectories_ is sorted by name, using [CultureInfo.InvariantCulture](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture). The SHA-256 value for each subdirectory is converted to a `byte[]` using UTF-8 encoding, and appended, in order, to the `List<byte>`. The sorted list of subdirectories does not include the `/.` and `/..` directories.
-3. The list of _files_ in the directory is sorted by name, using [CultureInfo.InvariantCulture](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture). The SHA-256 value for each file is converted to a `byte[]` using UTF-8 encoding, and appended, in order, to the `List<byte>`.
-4. The entire `List<byte>` is used as input to compute the SHA-256 value. The SHA-256 value is represented as a `byte[]`.
-5. The SHA-256 hash is converted to a string by converting each byte to a two-character hexadecimal value.
-    - For example, `byte[]{0x43, 0x2a, 0x01, 0xfa}` would be converted to a string `"432a01fa"`.
+The current directory SHA-256 value is path-sensitive. A `DirectoryVersion` represents a relative path and the sorted set
+of child directory and file versions at that path.
+
+The directory SHA-256 value is computed with this algorithm:
+
+1. Convert the directory's repository-relative path to bytes using UTF-8 and append those bytes to the hash input.
+1. Sort child directories by name with invariant culture.
+1. Append each child directory SHA-256 value, in sorted order, as UTF-8 bytes.
+1. Sort child files by name with invariant culture.
+1. Append each child file SHA-256 value, in sorted order, as UTF-8 bytes.
+1. Finalize the SHA-256 hash and convert it to lowercase hexadecimal text.
+
+This keeps directory identity sensitive to path and tree shape without making the file byte hash include path data.
+
+### Version Hash Transition
+
+After ADR 0006 is implemented, new `FileVersion`, `DirectoryVersion`, and `Reference` version objects use BLAKE3 as the
+default version-hash algorithm. SHA-256 remains retained where Grace needs compatibility with existing data, transition
+checks, or verification flows.
+
+That transition does not change the meaning of CAS identities:
+
+- `FileContentHash` identifies the complete unencoded bytes of a logical file.
+- `ChunkAddress` identifies one `ContentChunk`.
+- `ContentBlockAddress` identifies one `ContentBlock`.
+- `ManifestAddress` identifies one `FileManifest`.
+
+Small and regular `FileVersion` objects can continue to use `WholeFileContent`; this documentation does not make them
+manifest-backed or StoragePool-wide deduped.
 
 ### Validation
-Grace will provide a command - `grace branch verify` - that will compute the SHA-256 values for on-disk versions of files and directories, and compare them to the SHA-256 values stored in Grace's database.
+
+Grace has planned and in-progress verification workflows that recompute stored version hashes and compare them with
+values stored in Grace's database. Documentation should describe only shipped commands and options as shipped behavior.

--- a/docs/What grace watch does.md
+++ b/docs/What grace watch does.md
@@ -41,7 +41,8 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
   - `grace watch` doesn't keep the Grace Status file in memory while it's running. It's so fast to read and deserialize it when it's needed that we make the tradeoff to release the memory rather than hold it indefinitely, especially given that there will be many times that the user isn't coding and `grace watch` should have as small of a memory footprint as possible.
 - When a new or updated file is detected, `grace watch` will:
   - Copy the file to your user temp directory, using a system-generated temporary file name.
-  - Compute the SHA-256 hash of the file, using the algorithm described [here](How%20Grace%20computes%20the%20SHA-256%20value.md).
+  - Compute the current byte-only SHA-256 hash of the file, using the algorithm described
+    in the [SHA-256 value documentation](How%20Grace%20computes%20the%20SHA-256%20value.md).
   - Rename the file, inserting the SHA-256 hash, and move it to the repository's `.grace/objects` directory.
   - Upload the file from `.grace/objects` to the Object Storage provider that the repository is configured to use.
   - Recompute the directory versions from the file that was updated up to the root directory.
@@ -50,19 +51,20 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
   - Create a Save reference by calling Grace Server's `/branch/createSave` endpoint.
 - When a promotion event from your parent branch is sent to `grace watch` by the server, `grace watch` will run auto-rebase.
 - Every 4.8 minutes, `grace watch` will recompute and rewrite the Grace interprocess-communication (IPC) file, which requires reading and deserializing the local Grace Status file. The size of the IPC file is under 1K for small repos, and scales with the number of directories in the repo. A repo with 275 directories would fit in a 10K IPC file, and a repo with 2,750 directories would fit in a 100K IPC file. They're usually very small.
-  > Long story about why we rewrite the file: Imagine that you're at the command line, and you run `grace checkpoint -m ...`. That instance of Grace uses the existence of the IPC file as proof that `grace watch` is running in a separate process. `grace watch` writes the IPC file as soon as it starts, and, deletes it in a `try...finally` clause when it exits. In other words: in any normal exit, including exits caused by unhandled exceptions, the IPC file will be deleted when `grace watch` exits. However: it's possible that `grace watch` could be killed before it has a chance to execute that `finally` clause. For instance, in Windows, if I open Task Manager, right-click on the `grace watch` process, and hit `End Task`, the process dies immediately, and does not execute the `finally` clause. To ensure that there's not a stale IPC file laying around, Grace checks the value of the UpdatedAt field; if it's more than 5 minutes old, Grace will ignore the IPC file and assume that `grace watch` isn't running. So: _that's_ why the IPC file gets refreshed every 4.8 minutes: it resets the UpdatedAt field so the file stays under 5 minutes old.
+  > Long story about why we rewrite the file: Imagine that you're at the command line, and you run `grace checkpoint -m ...`. That instance of Grace uses the existence of the IPC file as proof that `grace watch` is running in a separate process. `grace watch` writes the IPC file as soon as it starts, and, deletes it in a `try...finally` clause when it exits. In other words: in any normal exit, including exits caused by unhandled exceptions, the IPC file will be deleted when `grace watch` exits. However: it's possible that `grace watch` could be killed before it has a chance to execute that `finally` clause. For instance, in Windows, if I open Task Manager, right-click on the `grace watch` process, and hit `End Task`, the process dies immediately, and does not execute the `finally` clause. To ensure that there's not a stale IPC file laying around, Grace checks the value of the UpdatedAt field; if it's more than 5 minutes old, Grace will ignore the IPC file and assume that `grace watch` isn't running. So: *that's* why the IPC file gets refreshed every 4.8 minutes: it resets the UpdatedAt field so the file stays under 5 minutes old.
 - Once a minute, `grace watch` does the fullest of garbage collection:
-  
+
   `GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)`
-  
+
   This ensures that `grace watch` keeps the smallest possible memory footprint, and takes single-digit µs when there's nothing to collect.
-  
+
   > The .NET Runtime has excellent heuristics for when to run GC, but the biggest factor is memory pressure. If the OS isn't signaling that there's memory pressure on the system, GC's don't happen much. With `grace watch` running on a developer box with many GB's of RAM available, it's likely that there won't be much memory pressure, and it would rarely perform garbage collection. `grace watch` might look like it's taking up a lot of memory (from doing things like auto-upload, auto-rebase, and updating the IPC file), but it would all be Gen 0 references, ready to be collected.
   >
   > Given that there will be many times that a user isn't working in a repository, releasing memory proactively is the right thing to do.
 
 ## Process Monitor: `grace watch` is very quiet
-This is a Windows-specific story, but it illustrates what `grace watch` is doing, or _not_ doing, regardless of platform. Those of you familiar with Windows administration will be familiar with [Sysinternals Tools](https://learn.microsoft.com/en-us/sysinternals/), originally written by, and still partially maintained by, Microsoft Azure CTO Mark Russinovich. Before he was the CTO and Chief Architect of Azure, he was the Chief Architect of Windows, and he literally wrote the book _Windows Internals_, which is a great read if you're an OS nerd of any kind. Sysinternals Tools, after 20+ years, are still essential advanced tools to know on Windows.
+
+This is a Windows-specific story, but it illustrates what `grace watch` is doing, or *not* doing, regardless of platform. Those of you familiar with Windows administration will be familiar with [Sysinternals Tools](https://learn.microsoft.com/en-us/sysinternals/), originally written by, and still partially maintained by, Microsoft Azure CTO Mark Russinovich. Before he was the CTO and Chief Architect of Azure, he was the Chief Architect of Windows, and he literally wrote the book *Windows Internals*, which is a great read if you're an OS nerd of any kind. Sysinternals Tools, after 20+ years, are still essential advanced tools to know on Windows.
 
 One of the Sysinternals Tools is [Process Monitor](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon), which allows you to watch every file, networking, registry, and process/thread event happening in the system in real-time. Process Monitor has excellent filtering, and when using it just to observe `grace watch`, what I can tell you is: if nothing from the list above is happening at exactly that moment, `grace watch` does nothing that Process Monitor can detect. No file events, no network events, just sometimes a thread creation/deletion event, managed by the .NET Runtime and not controlled by `grace watch`.
 
@@ -71,10 +73,13 @@ I left it running for 20 minutes with Process Monitor; aside from the IPC file r
 I can't make it any quieter than that.
 
 ## Future items
+
 ### Running local tasks
+
 `grace watch` is intended to be able to run local tasks in response to repository events, but, aside from `grace rebase`, that functionality hasn't been written yet. When it is, we'll document it and add it to the section above.
 
 ### Telemetry
+
 `grace watch` does not currently collect or send any telemetry, but I intend to before Grace ships. There will be clearly-documented ways to turn it off, if you'd prefer, and proper GDPR (and related) handling in place. The intention of this telemetry is to understand usage patterns and errors in using Grace, and to then use that data to improve both functionality and performance.
 
 For any of you who have used a telemetry provider – like Datadog, or Azure Monitor, or Application Insights, or any of a hundred others – to understand the usage of your own apps, you know what I mean. Detailed telemetry will never be kept longer than 30 days.

--- a/docs/adr/0006-blake3-and-sha256-version-hashes.md
+++ b/docs/adr/0006-blake3-and-sha256-version-hashes.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Use BLAKE3 and SHA-256 version hashes
+
+Grace will identify `FileVersion`, `DirectoryVersion`, and `Reference` version objects with version hashes that can
+carry both BLAKE3 and SHA-256 values. BLAKE3 becomes the default version-hash algorithm for new version objects after
+this ADR is implemented, while SHA-256 remains retained for compatibility, verification, and comparison with existing
+stored data.
+
+This ADR records the target model for epic #343. It does not claim that the dual-hash behavior has already shipped.
+
+## Context
+
+Grace currently stores SHA-256 values on version objects and uses those values in file, directory, reference, diff, and
+lookup workflows. Existing code also computes the SHA-256 value for a file by hashing the file bytes only. The older
+SHA-256 documentation incorrectly said that the file relative path and file length were also appended to the file hash.
+
+Grace now also has content-addressed storage vocabulary:
+
+- `FileContentHash` identifies the complete unencoded bytes of a logical file.
+- `ChunkAddress` identifies one `ContentChunk`.
+- `ContentBlockAddress` identifies a `ContentBlock`.
+- `ManifestAddress` identifies a `FileManifest`.
+
+Those CAS identities are path-independent content identities. They are not the same thing as version graph hashes for
+`FileVersion`, `DirectoryVersion`, and `Reference` objects. Version graph hashes identify Grace version objects in the
+repository graph, where a directory version is path-sensitive through its own relative path and ordered child entries.
+
+The hash transition has to keep these concepts separate:
+
+- A `FileVersion` says a specific relative path contains specific content in a repository version.
+- A `DirectoryVersion` says a specific relative path contains a sorted set of child directory and file versions.
+- A `Reference` names a saved repository root and points at a root `DirectoryVersion`.
+- CAS addresses identify file content objects, chunks, blocks, and manifests.
+
+## Decision
+
+Grace will support version hashes as an explicit version-object concept rather than overloading any CAS address.
+
+After implementation:
+
+- New `FileVersion`, `DirectoryVersion`, and `Reference` version hash calculations use BLAKE3 by default.
+- SHA-256 values remain retained where Grace needs compatibility with existing data, persisted fields, verification
+  workflows, or transition tooling.
+- A file's current SHA-256 value is computed from the file byte stream only.
+- Directory version hashes remain path-sensitive by including the directory relative path and ordered child version
+  hash inputs.
+- File content CAS identities remain path-independent and byte/content based.
+
+The implementation may introduce explicit DTO or storage fields for multiple version-hash algorithms, but this ADR does
+not require a global rename of existing `Sha256Hash` or `FileContentHash` terms as part of the documentation slice.
+
+## Non-Goals
+
+This ADR does not:
+
+- Globally rename `FileContentHash`.
+- Redefine `FileContentHash` as a `FileVersion` hash.
+- Redefine `ChunkAddress`, `ContentBlockAddress`, or `ManifestAddress` as version graph hashes.
+- Introduce content identifiers with algorithm prefixes.
+- Add a user-facing hash selection switch.
+- Make small or regular `FileVersion` objects participate in StoragePool-wide chunk dedupe.
+
+## Consequences
+
+Documentation and contracts should use these terms consistently:
+
+- Use `FileContentHash` for the path-independent hash of complete file bytes.
+- Use `ChunkAddress`, `ContentBlockAddress`, and `ManifestAddress` for CAS addresses.
+- Use version hash wording for `FileVersion`, `DirectoryVersion`, and `Reference` graph identity.
+- Explain that directory version hashes are path-sensitive without implying that file byte hashes include the path.
+
+During the epic, documentation can describe both the current SHA-256 behavior and the accepted future BLAKE3 plus
+SHA-256 model. Until the implementation ships, docs must avoid saying that BLAKE3 version hashes are already present in
+runtime behavior.


### PR DESCRIPTION
## Summary

- Adds ADR `0006-blake3-and-sha256-version-hashes` for the epic transition model.
- Corrects SHA-256 documentation so file SHA-256 is byte-only.
- Keeps CAS address terminology distinct from version graph hashes.
- Updates a nearby `grace watch` doc reference that pointed at the stale SHA-256 model.

Part of #343
Related to #344

## Validation

- `npx --yes markdownlint-cli2 "docs/adr/0006-blake3-and-sha256-version-hashes.md" "docs/How Grace computes the SHA-256 value.md" "CONTEXT.md"`: passed
- `npx --yes markdownlint-cli2 "docs/What grace watch does.md"`: passed
- `git diff --check`: passed
- `git diff --cached --check`: passed before commit
- Code tests: skipped, docs-only issue with explicit N/A waiver for code tests
- Fantomas: skipped, no F# files changed

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed docs-only slice in `C:\Source\Grace-gh-344`.
- Initial commit reviewed: `98d8414a3774f894e4e2b4b8a56a61f5413e6c42`
- First fix commit pushed: `689915eee96e3fd8a01b814426061c93ac2ecf72`
- Second fix commit pushed: `baeb8fb078059177fce0f25db310970d446c2931`
- Third fix commit pushed: `a42c7a03796e7005f869810b4d36c9267a6a31f4`
- Fix validation:
  - `npx --yes markdownlint-cli2 "docs/adr/0006-blake3-and-sha256-version-hashes.md" "docs/How Grace computes the SHA-256 value.md" "CONTEXT.md"`: passed
  - `npx --yes markdownlint-cli2 "docs/What grace watch does.md"`: passed
  - `git diff --check`: passed
  - Code tests: skipped, docs-only task
- Bot findings addressed and resolved:
  - File SHA-256 values clarified as byte hashes, not standalone `FileVersion` identity.
  - Current directory SHA-256 clarified as not child-name-aware; future `grace.directory-version.v1` remains planned.
  - References clarified as storing the referenced root directory hash, not hashing the `Reference` object.
  - `CONTEXT.md` glossary now scopes `Version Hash` to the ADR 0006 target model and separates current SHA-256 behavior.
  - `CONTEXT.md` Flagged Ambiguities paragraph now says ADR 0006 target behavior uses version hashes during the future transition.
- Codex Code Review Bot: 👍🏻 no-issues reaction observed on the PR body for latest head `a42c7a03796e7005f869810b4d36c9267a6a31f4`.
- Bot comments/review threads: all findings resolved; no open latest-head findings observed.
- Open findings: none.

## Docs Impact

This PR is itself the docs baseline slice. It intentionally avoids claiming later code behavior is already shipped.

## Residual Risk

Low. This is documentation-only and does not modify source code, OpenAPI generated artifacts, or CAS protocol behavior.