### PR TITLE
S2: Add read-only doctor auth inspection

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client
+open Grace.Types
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -36,6 +37,35 @@ module DoctorCliTests =
             Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
 
+    let private authEnvNames =
+        [|
+            Constants.EnvironmentVariables.GraceToken
+            Constants.EnvironmentVariables.GraceTokenFile
+            Constants.EnvironmentVariables.GraceAuthOidcAuthority
+            Constants.EnvironmentVariables.GraceAuthOidcAudience
+            Constants.EnvironmentVariables.GraceAuthOidcCliClientId
+            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort
+            Constants.EnvironmentVariables.GraceAuthOidcCliScopes
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret
+            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes
+            Constants.EnvironmentVariables.GraceServerUri
+        |]
+
+    let private withClearedAuthEnv (action: unit -> unit) =
+        let originalValues =
+            authEnvNames
+            |> Array.map (fun name -> name, Environment.GetEnvironmentVariable(name))
+
+        try
+            authEnvNames
+            |> Array.iter (fun name -> Environment.SetEnvironmentVariable(name, null))
+
+            action ()
+        finally
+            originalValues
+            |> Array.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value))
+
     let private withTempDir (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-doctor-cli-tests-{Guid.NewGuid():N}")
         Directory.CreateDirectory(tempDir) |> ignore
@@ -43,7 +73,7 @@ module DoctorCliTests =
 
         try
             Environment.CurrentDirectory <- tempDir
-            action tempDir
+            withClearedAuthEnv (fun () -> action tempDir)
         finally
             Environment.CurrentDirectory <- originalDir
 
@@ -156,6 +186,21 @@ module DoctorCliTests =
 
         parseJsonOutput standardOut
 
+    let private findCheckById (checks: JsonElement) checkId =
+        checks.EnumerateArray()
+        |> Seq.find (fun check ->
+            check
+                .GetProperty("Id")
+                .GetString()
+                .Equals(checkId, StringComparison.Ordinal))
+
+    let private assertDoesNotContainSecrets (secrets: string list) (standardOut: string) (standardError: string) =
+        for secret in secrets do
+            standardOut |> should not' (contain secret)
+            standardError |> should not' (contain secret)
+
+    let private validPat () = PersonalAccessToken.formatToken "doctor-user" (Guid.NewGuid()) (Array.create 32 7uy)
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -197,12 +242,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 11
+            |> should equal 15
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 11
+            |> should equal 15
 
             let catalogIds =
                 returnValue
@@ -210,6 +255,18 @@ module DoctorCliTests =
                     .EnumerateArray()
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -254,12 +311,24 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 9
+            catalogIds.Count |> should equal 13
 
             catalogIds |> should contain "config.file.parse"
 
             catalogIds
             |> should contain "ignore.entries.parse"
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -348,6 +417,292 @@ module DoctorCliTests =
 
                 checks[ 0 ].GetProperty("Status").GetString()
                 |> should equal "Ok"))
+
+    [<Test>]
+    let ``doctor auth detects valid GRACE_TOKEN without printing raw value`` () =
+        withTempDir (fun _ ->
+            let token = validPat ()
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.source.detected"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                (findCheckById checks "auth.source.detected")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "GRACE_TOKEN PAT"
+
+                (findCheckById checks "auth.env-token.valid")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
+
+    [<TestCase("not-a-pat")>]
+    [<TestCase("Bearer not-a-pat")>]
+    [<TestCase("")>]
+    let ``doctor auth rejects invalid GRACE_TOKEN safely`` token =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 1
+
+                if not (String.IsNullOrEmpty token) then
+                    assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN"))
+
+    [<Test>]
+    let ``doctor auth reports unsupported GRACE_TOKEN_FILE with GRACE_TOKEN remediation`` () =
+        withTempDir (fun _ ->
+            let tokenFilePath = "C:\\secret\\grace-token.txt"
+
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFilePath) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.token-file.unsupported" |]
+
+                exitCode |> should equal 1
+                assertDoesNotContainSecrets [ tokenFilePath ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN"))
+
+    [<Test>]
+    let ``doctor auth missing environment warns and skips token validation`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "auth.source.detected"
+                                                  "--check"
+                                                  "auth.env-token.valid"
+                                                  "--check"
+                                                  "auth.oidc.configuration" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            (findCheckById checks "auth.source.detected")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Warning"
+
+            (findCheckById checks "auth.env-token.valid")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped"
+
+            (findCheckById checks "auth.oidc.configuration")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped")
+
+    [<Test>]
+    let ``doctor auth reports partial OIDC M2M and CLI configuration without secret values`` () =
+        withTempDir (fun _ ->
+            let authority = "https://tenant.example.invalid/very-secret-authority"
+            let m2mSecret = "m2m-client-secret-value"
+            let cliClientId = "cli-client-secret-looking-id"
+
+            withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some authority) (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some m2mSecret) (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcCliClientId (Some cliClientId) (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "auth.oidc.configuration" |]
+
+                        exitCode |> should equal 0
+                        assertDoesNotContainSecrets [ authority; m2mSecret; cliClientId ] standardOut standardError
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Warning"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "partial"))))
+
+    [<Test>]
+    let ``doctor auth exact check selections are not filtered out`` () =
+        withTempDir (fun _ ->
+            for checkId in
+                [
+                    "auth.env-token.valid"
+                    "auth.token-file.unsupported"
+                    "auth.oidc.configuration"
+                ] do
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      checkId |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 1
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal checkId)
+
+    [<TestCase("Json")>]
+    [<TestCase("Verbose")>]
+    let ``doctor auth select output is clean for valid and invalid auth states`` output =
+        withTempDir (fun _ ->
+            for token, expectedStatus in
+                [
+                    validPat (), "\"Ok\""
+                    "not-a-pat", "\"Failed\""
+                ] do
+                withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          output
+                                                          "doctor"
+                                                          "--check"
+                                                          "auth.env-token.valid"
+                                                          "--select"
+                                                          "Status" |]
+
+                    if expectedStatus = "\"Ok\"" then
+                        exitCode |> should equal 0
+                    else
+                        exitCode |> should equal 1
+
+                    standardError |> should equal String.Empty
+                    standardOut.Trim() |> should equal expectedStatus
+                    assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                    standardOut
+                    |> should not' (contain "Grace doctor")
+
+                    standardOut |> should not' (contain "EventTime")))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor auth successful diagnostics emit no output for quiet output modes`` output =
+        withTempDir (fun _ ->
+            let token = validPat ()
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
+
+    [<Test>]
+    let ``doctor auth list checks includes S2 auth catalog ids`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration")
 
     [<Test>]
     let ``doctor verbose select returns clean scalar for passing config check`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -456,9 +456,45 @@ module DoctorCliTests =
                     .GetString()
                 |> should equal "Ok"))
 
+    [<Test>]
+    let ``doctor auth accepts bearer GRACE_TOKEN without printing raw value`` () =
+        withTempDir (fun _ ->
+            let token = validPat ()
+            let bearerToken = $"  Bearer {token}  "
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some bearerToken) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.source.detected"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                assertDoesNotContainSecrets [ token; bearerToken ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "auth.source.detected")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "GRACE_TOKEN PAT"
+
+                (findCheckById checks "auth.env-token.valid")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
+
     [<TestCase("not-a-pat")>]
     [<TestCase("Bearer not-a-pat")>]
-    [<TestCase("")>]
     let ``doctor auth rejects invalid GRACE_TOKEN safely`` token =
         withTempDir (fun _ ->
             withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
@@ -487,6 +523,52 @@ module DoctorCliTests =
 
                 check.GetProperty("Summary").GetString()
                 |> should contain "GRACE_TOKEN"))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN as unset and continues OIDC inspection`` token =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some "https://tenant.example.invalid/") (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience (Some "https://api.example.invalid/") (fun () ->
+                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId (Some "m2m-client-id") (fun () ->
+                            withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some "m2m-client-secret") (fun () ->
+                                let exitCode, standardOut, standardError =
+                                    runWithCapturedStdoutAndStderr [| "--output"
+                                                                      "Json"
+                                                                      "doctor"
+                                                                      "--check"
+                                                                      "auth.source.detected"
+                                                                      "--check"
+                                                                      "auth.env-token.valid"
+                                                                      "--check"
+                                                                      "auth.oidc.configuration" |]
+
+                                exitCode |> should equal 0
+                                assertDoesNotContainSecrets [ "m2m-client-secret" ] standardOut standardError
+
+                                use document = assertCleanJsonOutput standardOut standardError
+
+                                let checks =
+                                    document
+                                        .RootElement
+                                        .GetProperty("ReturnValue")
+                                        .GetProperty("Checks")
+
+                                (findCheckById checks "auth.source.detected")
+                                    .GetProperty("Summary")
+                                    .GetString()
+                                |> should contain "OIDC M2M environment"
+
+                                (findCheckById checks "auth.env-token.valid")
+                                    .GetProperty("Status")
+                                    .GetString()
+                                |> should equal "Skipped"
+
+                                (findCheckById checks "auth.oidc.configuration")
+                                    .GetProperty("Status")
+                                    .GetString()
+                                |> should equal "Ok"))))))
 
     [<Test>]
     let ``doctor auth reports unsupported GRACE_TOKEN_FILE with GRACE_TOKEN remediation`` () =
@@ -517,6 +599,59 @@ module DoctorCliTests =
 
                 check.GetProperty("Summary").GetString()
                 |> should contain "GRACE_TOKEN"))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN_FILE as unset for explicit checks`` tokenFileValue =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFileValue) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.token-file.unsupported" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN_FILE is not set."))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN_FILE as unset in default checks`` tokenFileValue =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFileValue) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "auth.token-file.unsupported")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
 
     [<Test>]
     let ``doctor auth missing environment warns and skips token validation`` () =
@@ -590,6 +725,37 @@ module DoctorCliTests =
 
                         check.GetProperty("Summary").GetString()
                         |> should contain "partial"))))
+
+    [<Test>]
+    let ``doctor auth treats blank OIDC required values as missing`` () =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some "   ") (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience (Some "https://api.example.invalid/") (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId (Some "m2m-client-id") (fun () ->
+                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some "m2m-client-secret") (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "auth.oidc.configuration" |]
+
+                            exitCode |> should equal 0
+                            assertDoesNotContainSecrets [ "m2m-client-secret" ] standardOut standardError
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Warning"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain Constants.EnvironmentVariables.GraceAuthOidcAuthority)))))
 
     [<Test>]
     let ``doctor auth exact check selections are not filtered out`` () =

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -68,15 +68,122 @@ module Auth =
 
     type TokenStore = { Helper: MsalCacheHelper; StorageProperties: StorageCreationProperties; LockFilePath: string; InProcessLock: SemaphoreSlim }
 
+    type AuthEnvironmentFieldStatus = { Name: string; IsSet: bool; Required: bool }
+
+    type AuthInspection =
+        {
+            GraceTokenPresent: bool
+            GraceTokenValid: bool
+            GraceTokenError: string option
+            GraceTokenFilePresent: bool
+            M2mFields: AuthEnvironmentFieldStatus array
+            CliFields: AuthEnvironmentFieldStatus array
+            M2mComplete: bool
+            CliComplete: bool
+            HasPartialM2m: bool
+            HasPartialCli: bool
+            ActiveSource: string
+            HasUsableCredentialSource: bool
+        }
+
     let private tryGetEnv name =
         let value = Environment.GetEnvironmentVariable(name)
         if String.IsNullOrWhiteSpace value then None else Some value
+
+    let private isEnvSet name =
+        isNull (Environment.GetEnvironmentVariable(name))
+        |> not
 
     let private normalizeBearerToken (token: string) =
         if token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
             token.Substring("Bearer ".Length).Trim()
         else
             token.Trim()
+
+    let private authField required name = { Name = name; IsSet = isEnvSet name; Required = required }
+
+    let private requiredFieldsComplete fields =
+        fields
+        |> Array.filter (fun field -> field.Required)
+        |> Array.forall (fun field -> field.IsSet)
+
+    let private anyFieldsSet fields = fields |> Array.exists (fun field -> field.IsSet)
+
+    let private hasPartialRequiredFields fields =
+        anyFieldsSet fields
+        && not (requiredFieldsComplete fields)
+
+    let inspectAuthEnvironment () =
+        let tokenValue = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+        let graceTokenPresent = not (isNull tokenValue)
+
+        let graceTokenValid, graceTokenError =
+            if not graceTokenPresent then
+                false, None
+            elif String.IsNullOrWhiteSpace tokenValue then
+                false, Some $"GRACE_TOKEN is set but empty. Provide a Grace PAT or unset {Constants.EnvironmentVariables.GraceToken}."
+            else
+                let trimmed = tokenValue.Trim()
+
+                match Grace.Types.PersonalAccessToken.tryParseToken trimmed with
+                | Some _ -> true, None
+                | None ->
+                    false,
+                    Some
+                        $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens and bearer prefixes are not valid here."
+
+        let m2mFields =
+            [|
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAuthority
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAudience
+                authField true Constants.EnvironmentVariables.GraceAuthOidcM2mClientId
+                authField true Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret
+                authField false Constants.EnvironmentVariables.GraceAuthOidcM2mScopes
+            |]
+
+        let cliFields =
+            [|
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAuthority
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAudience
+                authField true Constants.EnvironmentVariables.GraceAuthOidcCliClientId
+                authField false Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort
+                authField false Constants.EnvironmentVariables.GraceAuthOidcCliScopes
+            |]
+
+        let m2mComplete = requiredFieldsComplete m2mFields
+        let cliComplete = requiredFieldsComplete cliFields
+        let hasPartialM2m = hasPartialRequiredFields m2mFields
+        let hasPartialCli = hasPartialRequiredFields cliFields
+        let graceTokenFilePresent = isEnvSet Constants.EnvironmentVariables.GraceTokenFile
+
+        let activeSource, hasUsableCredentialSource =
+            if graceTokenValid then
+                $"{Constants.EnvironmentVariables.GraceToken} PAT", true
+            elif graceTokenError.IsSome then
+                $"{Constants.EnvironmentVariables.GraceToken} invalid", false
+            elif graceTokenFilePresent then
+                $"{Constants.EnvironmentVariables.GraceTokenFile} unsupported", false
+            elif m2mComplete then
+                "OIDC M2M environment", true
+            elif cliComplete then
+                "OIDC CLI environment", true
+            else
+                "None", false
+
+        {
+            GraceTokenPresent = graceTokenPresent
+            GraceTokenValid = graceTokenValid
+            GraceTokenError = graceTokenError
+            GraceTokenFilePresent = graceTokenFilePresent
+            M2mFields = m2mFields
+            CliFields = cliFields
+            M2mComplete = m2mComplete
+            CliComplete = cliComplete
+            HasPartialM2m = hasPartialM2m
+            HasPartialCli = hasPartialCli
+            ActiveSource = activeSource
+            HasUsableCredentialSource = hasUsableCredentialSource
+        }
 
     let private normalizeAuthority (authority: string) =
         let trimmed = authority.Trim()

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -90,15 +90,15 @@ module Auth =
         let value = Environment.GetEnvironmentVariable(name)
         if String.IsNullOrWhiteSpace value then None else Some value
 
-    let private isEnvSet name =
-        isNull (Environment.GetEnvironmentVariable(name))
-        |> not
+    let private isEnvSet name = tryGetEnv name |> Option.isSome
 
     let private normalizeBearerToken (token: string) =
-        if token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
-            token.Substring("Bearer ".Length).Trim()
+        let trimmed = token.Trim()
+
+        if trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
+            trimmed.Substring("Bearer ".Length).Trim()
         else
-            token.Trim()
+            trimmed
 
     let private authField required name = { Name = name; IsSet = isEnvSet name; Required = required }
 
@@ -114,23 +114,20 @@ module Auth =
         && not (requiredFieldsComplete fields)
 
     let inspectAuthEnvironment () =
-        let tokenValue = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
-        let graceTokenPresent = not (isNull tokenValue)
+        let tokenValue = tryGetEnv Constants.EnvironmentVariables.GraceToken
+        let graceTokenPresent = tokenValue.IsSome
 
         let graceTokenValid, graceTokenError =
-            if not graceTokenPresent then
-                false, None
-            elif String.IsNullOrWhiteSpace tokenValue then
-                false, Some $"GRACE_TOKEN is set but empty. Provide a Grace PAT or unset {Constants.EnvironmentVariables.GraceToken}."
-            else
-                let trimmed = tokenValue.Trim()
+            match tokenValue with
+            | None -> false, None
+            | Some value ->
+                let normalized = normalizeBearerToken value
 
-                match Grace.Types.PersonalAccessToken.tryParseToken trimmed with
+                match Grace.Types.PersonalAccessToken.tryParseToken normalized with
                 | Some _ -> true, None
                 | None ->
                     false,
-                    Some
-                        $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens and bearer prefixes are not valid here."
+                    Some $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens are not valid here."
 
         let m2mFields =
             [|

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -46,6 +46,18 @@ module Doctor =
     [<Literal>]
     let private IgnoreEntriesParseCheckId = "ignore.entries.parse"
 
+    [<Literal>]
+    let private AuthSourceDetectedCheckId = "auth.source.detected"
+
+    [<Literal>]
+    let private AuthEnvTokenValidCheckId = "auth.env-token.valid"
+
+    [<Literal>]
+    let private AuthTokenFileUnsupportedCheckId = "auth.token-file.unsupported"
+
+    [<Literal>]
+    let private AuthOidcConfigurationCheckId = "auth.oidc.configuration"
+
     module private Options =
         let full =
             new Option<bool>(
@@ -166,6 +178,38 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = AuthSourceDetectedCheckId
+                Category = "Authentication"
+                Title = "Authentication source"
+                Description = "Classifies the likely local authentication source from environment configuration without acquiring credentials."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthEnvTokenValidCheckId
+                Category = "Authentication"
+                Title = "GRACE_TOKEN PAT shape"
+                Description = "Validates GRACE_TOKEN with the pure Grace PAT parser without printing or verifying the token."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthTokenFileUnsupportedCheckId
+                Category = "Authentication"
+                Title = "GRACE_TOKEN_FILE unsupported"
+                Description = "Reports unsupported token-file configuration and recommends GRACE_TOKEN."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthOidcConfigurationCheckId
+                Category = "Authentication"
+                Title = "OIDC environment configuration"
+                Description = "Checks OIDC M2M and CLI environment completeness without token requests or secure-store reads."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -267,6 +311,7 @@ module Doctor =
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
+            AuthInspection: Auth.AuthInspection
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -284,12 +329,42 @@ module Doctor =
             EnvironmentServerUri =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
+            AuthInspection = Auth.inspectAuthEnvironment ()
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
         { Id = checkId; Category = category; Title = title; Status = status; Severity = severity; Summary = summary }
 
     let private skipped (check: LocalOutputDto.DoctorCheckDto) summary = checkResult check.Id check.Category check.Title "Skipped" "Info" summary
+
+    let private missingRequiredFields (fields: Auth.AuthEnvironmentFieldStatus array) =
+        fields
+        |> Array.filter (fun field -> field.Required && not field.IsSet)
+        |> Array.map (fun field -> field.Name)
+
+    let private presentFieldNames (fields: Auth.AuthEnvironmentFieldStatus array) =
+        fields
+        |> Array.filter (fun field -> field.IsSet)
+        |> Array.map (fun field -> field.Name)
+
+    let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
+
+    let private oidcSummary (auth: Auth.AuthInspection) =
+        let m2mMissing = missingRequiredFields auth.M2mFields
+        let cliMissing = missingRequiredFields auth.CliFields
+        let m2mPresent = presentFieldNames auth.M2mFields
+        let cliPresent = presentFieldNames auth.CliFields
+
+        if auth.M2mComplete && auth.CliComplete then
+            "OIDC M2M and CLI environment configuration are complete. No token was requested and no secure token storage was read."
+        elif auth.M2mComplete then
+            $"OIDC M2M environment configuration is complete; CLI OIDC is incomplete with missing required keys: {formatFieldNames cliMissing}. No token was requested."
+        elif auth.CliComplete then
+            $"OIDC CLI environment configuration is complete; M2M OIDC is incomplete with missing required keys: {formatFieldNames m2mMissing}. No browser, device-code flow, or secure token storage was used."
+        elif auth.HasPartialM2m || auth.HasPartialCli then
+            $"OIDC environment configuration is partial. M2M present keys: {formatFieldNames m2mPresent}; M2M missing required keys: {formatFieldNames m2mMissing}. CLI present keys: {formatFieldNames cliPresent}; CLI missing required keys: {formatFieldNames cliMissing}."
+        else
+            "No OIDC environment configuration was detected. Set the OIDC M2M or CLI environment keys, or provide GRACE_TOKEN."
 
     let private resultForCheck (context: DoctorInspectionContext) (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         let ok summary = checkResult check.Id check.Category check.Title "Ok" "Info" summary
@@ -298,6 +373,49 @@ module Doctor =
 
         match check.Id with
         | CliCatalogCheckId -> ok "Doctor check catalog is available."
+        | AuthSourceDetectedCheckId ->
+            let auth = context.AuthInspection
+
+            if auth.HasUsableCredentialSource then
+                ok $"Likely authentication source: {auth.ActiveSource}. Doctor did not acquire, refresh, store, or validate credentials with a provider."
+            elif auth.GraceTokenError.IsSome then
+                warning $"Likely authentication source: {auth.ActiveSource}. {auth.GraceTokenError.Value}"
+            elif auth.GraceTokenFilePresent then
+                warning
+                    $"Likely authentication source: {auth.ActiveSource}. Local token files are unsupported; unset {Constants.EnvironmentVariables.GraceTokenFile} and set {Constants.EnvironmentVariables.GraceToken}."
+            elif auth.HasPartialM2m || auth.HasPartialCli then
+                warning $"No complete authentication source was detected. {oidcSummary auth}"
+            else
+                warning $"No authentication source was detected. Set {Constants.EnvironmentVariables.GraceToken}, OIDC M2M variables, or OIDC CLI variables."
+        | AuthEnvTokenValidCheckId ->
+            let auth = context.AuthInspection
+
+            if not auth.GraceTokenPresent then
+                skipped check $"{Constants.EnvironmentVariables.GraceToken} is not set; no environment PAT was validated."
+            elif auth.GraceTokenValid then
+                ok
+                    $"{Constants.EnvironmentVariables.GraceToken} is set and has a valid Grace PAT shape. The token value was not printed or verified against the server."
+            else
+                failed (
+                    auth.GraceTokenError
+                    |> Option.defaultValue
+                        $"{Constants.EnvironmentVariables.GraceToken} is not a valid Grace PAT. Set a token with prefix {Grace.Types.PersonalAccessToken.TokenPrefix}."
+                )
+        | AuthTokenFileUnsupportedCheckId ->
+            let auth = context.AuthInspection
+
+            if auth.GraceTokenFilePresent then
+                failed
+                    $"Local token files are unsupported. Unset {Constants.EnvironmentVariables.GraceTokenFile} and set {Constants.EnvironmentVariables.GraceToken} to a Grace PAT."
+            else
+                ok $"{Constants.EnvironmentVariables.GraceTokenFile} is not set."
+        | AuthOidcConfigurationCheckId ->
+            let auth = context.AuthInspection
+            let summary = oidcSummary auth
+
+            if auth.M2mComplete || auth.CliComplete then ok summary
+            elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
+            else skipped check summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."


### PR DESCRIPTION
## Summary

Part of #333.
Related to #336.

- Adds read-only `grace doctor` auth checks for `GRACE_TOKEN`, unsupported `GRACE_TOKEN_FILE`, OIDC/M2M environment completeness, and likely auth source detection.
- Uses a pure auth environment inspector from `Auth.CLI.fs` so doctor does not acquire, refresh, store, read secure tokens, launch browser/device-code flows, configure SDK auth providers, or make network calls.
- Redacts secret-bearing values across human, JSON, selected, verbose, silent/minimal, and error-adjacent test surfaces while preserving existing non-doctor auth behavior.
- Preserves S0/S1 CLI output semantics for JSON, selected output, silent/minimal output, verbose+select output, exact `--check`, and list-catalog behavior.

## Write Set

- `src/Grace.CLI/Command/Auth.CLI.fs`
- `src/Grace.CLI/Command/Doctor.CLI.fs`
- `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`

## Validation

Implementation worker on `521b52a`:

- `dotnet tool run fantomas src/Grace.CLI/Command/Auth.CLI.fs src/Grace.CLI/Command/Doctor.CLI.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor`: passed, 39 tests.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Auth`: passed, 5 tests.
- `git diff --check`: passed.
- Source-search proof: `Doctor.CLI.fs` references `Auth.inspectAuthEnvironment` for auth inspection; forbidden acquisition/network/secure-store/browser/token-cache helpers remain in existing auth command paths and are not referenced by doctor.

Fix worker on `3f7cc15`:

- `dotnet tool run fantomas src/Grace.CLI/Command/Auth.CLI.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor`: passed, 46 tests.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Auth`: passed, 5 tests.
- `git diff --check`: passed.
- Source-search proof: `Doctor.CLI.fs` calls `Auth.inspectAuthEnvironment()` and does not reference token acquisition, OIDC network config fetch, secure store, token cache, browser, or device-code helpers.

PR validation:

- `Validate / full` on head `3f7cc15`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: skipped for focused S2 worker/fix validation; PR CI and later epic gates cover broader integration.

## Review-Prevention Evidence

- JSON/select cleanliness covered for valid PAT, invalid PAT, missing auth, `GRACE_TOKEN_FILE`, and partial OIDC/M2M cases.
- Silent/minimal no-output behavior covered for successful auth diagnostics.
- Verbose plus `--select` remains clean machine-readable output.
- Exact selection covered for `auth.env-token.valid`, `auth.token-file.unsupported`, and OIDC/M2M checks.
- Redaction tests assert raw secret values are absent from stdout and stderr across human, JSON, selected, and verbose modes.
- Source-search evidence proves doctor does not call token acquisition, refresh, secure-store, browser/device-code, SDK auth provider, token-cache, or network paths.
- Review-fix regressions cover bearer-normalized `GRACE_TOKEN`, blank `GRACE_TOKEN`, blank `GRACE_TOKEN_FILE`, and blank OIDC required values.

## Review Status

- Implementation worker completed and pushed `521b52a`.
- Codex Code Review Bot reviewed head `521b52a` and posted four inline findings:
  - Normalize `GRACE_TOKEN` before doctor PAT parsing so `Bearer grace_pat_v1_...` matches the real auth path.
  - Ignore blank OIDC env values when checking M2M/CLI completeness.
  - Treat blank `GRACE_TOKEN_FILE` as unset.
  - Treat blank `GRACE_TOKEN` as unset so lower-priority OIDC sources can still be detected.
- Fix worker completed and pushed `3f7cc15`.
- Bot finding replies posted with fix and validation evidence:
  - https://github.com/ScottArbeit/Grace/pull/366#discussion_r3387707588
  - https://github.com/ScottArbeit/Grace/pull/366#discussion_r3387707700
  - https://github.com/ScottArbeit/Grace/pull/366#discussion_r3387707829
  - https://github.com/ScottArbeit/Grace/pull/366#discussion_r3387707998
- Bot conversations resolved: 4 of 4.
- Validate workflow on PR head `3f7cc15`: passed.
- Codex Code Review Bot final signal: `THUMBS_UP` reaction with no unresolved review threads.
- Final no-issues bot review: satisfied.

## Docs Impact

No docs changed in S2. S6 should document these auth source names/remediations: `GRACE_TOKEN PAT`, `GRACE_TOKEN invalid`, `GRACE_TOKEN_FILE unsupported`, `OIDC M2M environment`, `OIDC CLI environment`, and `None`; unset `GRACE_TOKEN_FILE` and set `GRACE_TOKEN`; use a Grace PAT with prefix `grace_pat_v1_`; complete OIDC M2M or CLI environment keys.

## Residual Risk

Low to medium. This slice intentionally reports OIDC environment completeness only and does not prove provider reachability or user identity; `/auth/me` probing belongs to S4. The review fix narrowed parity gaps between doctor and the real auth path for bearer normalization and blank environment values.