### PR TITLE
I02: Add BLAKE3 version hash validation

### DIFF
--- a/src/Grace.Server.Unit.Tests/Validations.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Validations.Server.Tests.fs
@@ -123,6 +123,40 @@ type Validations() =
         Assert.That(result, Is.EqualTo(Common.okResult))
 
     [<Test>]
+    member this.``SHA-256 prefix boundary values return Ok``() =
+        let cases =
+            [|
+                "2 characters", "67"
+                "64 characters", "67a1790dca55b8803ad024ee28f616a284df5dd7b8ba5f68b4b252a5e925af79"
+                "uppercase lookup", "67A1790DCA55B8803AD024EE28F616A284DF5DD7B8BA5F68B4B252A5E925AF79"
+            |]
+
+        for caseName, hash in cases do
+            let result =
+                (String.isValidSha256HashPrefix hash TestError.TestFailed)
+                    .Result
+
+            Assert.That(result, Is.EqualTo(Common.okResult), caseName)
+
+    [<Test>]
+    member this.``SHA-256 version hash requires lowercase full value``() =
+        let valid =
+            (String.isValidSha256VersionHash "67a1790dca55b8803ad024ee28f616a284df5dd7b8ba5f68b4b252a5e925af79" VersionHashError.InvalidSha256VersionHash)
+                .Result
+
+        let uppercase =
+            (String.isValidSha256VersionHash "67A1790DCA55B8803AD024EE28F616A284DF5DD7B8BA5F68B4B252A5E925AF79" VersionHashError.InvalidSha256VersionHash)
+                .Result
+
+        let short =
+            (String.isValidSha256VersionHash "67" VersionHashError.InvalidSha256VersionHash)
+                .Result
+
+        Assert.That(Result.isOk valid, Is.True)
+        Assert.That(Result.isError uppercase, Is.True)
+        Assert.That(Result.isError short, Is.True)
+
+    [<Test>]
     member this.``empty string for SHA-256 value returns Ok``() =
         let result =
             (String.isEmptyOrValidSha256Hash "" TestError.TestFailed)
@@ -137,6 +171,94 @@ type Validations() =
                 .Result
 
         Assert.That(result, Is.EqualTo(Common.errorResult))
+
+    [<Test>]
+    member this.``invalid SHA-256 prefix values return Error``() =
+        let cases =
+            [|
+                "empty", ""
+                "one character", "6"
+                "non-hex", "not-a-sha-256-hash"
+            |]
+
+        for caseName, hash in cases do
+            let result =
+                (String.isValidSha256HashPrefix hash TestError.TestFailed)
+                    .Result
+
+            Assert.That(result, Is.EqualTo(Common.errorResult), caseName)
+
+    [<Test>]
+    member this.``valid BLAKE3 prefix values return Ok``() =
+        let cases =
+            [|
+                "2 characters", "af"
+                "64 characters", "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f"
+                "uppercase lookup", "AF1349B9F5F9A1A6A0404DEA36DCC9499BCB25C9ADCD1E8C76D9A8885F16A39F"
+            |]
+
+        for caseName, hash in cases do
+            let result =
+                (String.isValidBlake3HashPrefix hash VersionHashError.InvalidBlake3Hash)
+                    .Result
+
+            Assert.That(Result.isOk result, Is.True, caseName)
+
+    [<Test>]
+    member this.``invalid BLAKE3 prefix values return Error``() =
+        let cases =
+            [|
+                "empty", ""
+                "one character", "a"
+                "non-hex", "not-a-blake3-hash"
+            |]
+
+        for caseName, hash in cases do
+            let result =
+                (String.isValidBlake3HashPrefix hash VersionHashError.InvalidBlake3Hash)
+                    .Result
+
+            Assert.That(Result.isError result, Is.True, caseName)
+
+    [<Test>]
+    member this.``empty string for optional BLAKE3 prefix returns Ok``() =
+        let result =
+            (String.isEmptyOrValidBlake3HashPrefix "" VersionHashError.InvalidBlake3Hash)
+                .Result
+
+        Assert.That(Result.isOk result, Is.True)
+
+    [<Test>]
+    member this.``BLAKE3 version hash requires lowercase full value``() =
+        let valid =
+            (String.isValidBlake3VersionHash "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f" VersionHashError.InvalidBlake3Hash)
+                .Result
+
+        let uppercase =
+            (String.isValidBlake3VersionHash "AF1349B9F5F9A1A6A0404DEA36DCC9499BCB25C9ADCD1E8C76D9A8885F16A39F" VersionHashError.InvalidBlake3Hash)
+                .Result
+
+        let empty =
+            (String.isValidBlake3VersionHash "" VersionHashError.Blake3HashIsRequired)
+                .Result
+
+        let short =
+            (String.isValidBlake3VersionHash "af" VersionHashError.InvalidBlake3Hash)
+                .Result
+
+        Assert.That(Result.isOk valid, Is.True)
+        Assert.That(Result.isError uppercase, Is.True)
+        Assert.That(Result.isError empty, Is.True)
+        Assert.That(Result.isError short, Is.True)
+
+    [<Test>]
+    member this.``version hash errors return localized text``() =
+        Assert.That(
+            getErrorMessage VersionHashError.InvalidBlake3Hash,
+            Is.EqualTo("The provided BLAKE3 hash is not a valid lowercase 64-character BLAKE3 hash value.")
+        )
+
+        Assert.That(getErrorMessage VersionHashError.Blake3HashIsRequired, Is.EqualTo("The Blake3Hash value is required."))
 
     [<Test>]
     member this.``string length less than max length returns Ok``() =

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -496,6 +496,39 @@ module Constants =
             TimeSpan.FromSeconds(1.0)
         )
 
+    /// Validates that a string is a lowercase full SHA-256 hash value.
+    ///
+    /// Regex: ^[0-9a-f]{64}$
+    let Sha256FullHashRegex =
+        new Regex(
+            "^[0-9a-f]{64}$",
+            RegexOptions.CultureInvariant
+            ||| RegexOptions.Compiled,
+            TimeSpan.FromSeconds(1.0)
+        )
+
+    /// Validates that a string is a full or partial valid BLAKE3 hash value, between 2 and 64 hexadecimal characters.
+    ///
+    /// Regex: ^[0-9a-fA-F]{2,64}$
+    let Blake3HashPrefixRegex =
+        new Regex(
+            "^[0-9a-fA-F]{2,64}$",
+            RegexOptions.CultureInvariant
+            ||| RegexOptions.Compiled,
+            TimeSpan.FromSeconds(1.0)
+        )
+
+    /// Validates that a string is a lowercase full BLAKE3 hash value.
+    ///
+    /// Regex: ^[0-9a-f]{64}$
+    let Blake3FullHashRegex =
+        new Regex(
+            "^[0-9a-f]{64}$",
+            RegexOptions.CultureInvariant
+            ||| RegexOptions.Compiled,
+            TimeSpan.FromSeconds(1.0)
+        )
+
     /// The backoff policy used by Grace for server requests.
     let private backoffWithJitter = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay = (TimeSpan.FromSeconds(0.25)), retryCount = 7, fastFirst = false)
 

--- a/src/Grace.Shared/Resources/Text/Languages.Resources.fs
+++ b/src/Grace.Shared/Resources/Text/Languages.Resources.fs
@@ -13,6 +13,7 @@ module Text =
 
     type StringResourceName =
         | AssignIsDisabled
+        | Blake3HashIsRequired
         | Branch
         | BranchAlreadyExists
         | BranchDoesNotExist
@@ -63,6 +64,7 @@ module Text =
         | InterprocessFileDeleted
         | InvalidBranchId
         | InvalidBranchName
+        | InvalidBlake3Hash
         | InvalidCheckpointDaysValue
         | InvalidConflictResolutionPolicy
         | InvalidDiffCacheDaysValue
@@ -88,6 +90,7 @@ module Text =
         | InvalidSearchVisibility
         | InvalidServerApiVersion
         | InvalidSha256Hash
+        | InvalidSha256VersionHash
         | InvalidSize
         | InvalidVisibilityValue
         | PromotionIsDisabled
@@ -146,6 +149,7 @@ module Text =
         | Sha256HashDoesNotExist
         | Sha256HashDoesNotMatch
         | Sha256HashIsRequired
+        | Sha256VersionHashIsRequired
         | StringIsTooLong
         | TagIsDisabled
         | TestFailed

--- a/src/Grace.Shared/Resources/Text/en-US.fs
+++ b/src/Grace.Shared/Resources/Text/en-US.fs
@@ -16,6 +16,7 @@ module en_US =
     let getString stringResourceName =
         match stringResourceName with
         | AssignIsDisabled -> "This branch has disabled assign."
+        | Blake3HashIsRequired -> "The Blake3Hash value is required."
         | Branch -> "Branch"
         | BranchAlreadyExists -> "The branch already exists."
         | BranchDoesNotExist -> "The branch was not found."
@@ -72,6 +73,7 @@ module en_US =
         | InvalidBranchId -> "The provided BranchId is not a valid Guid."
         | InvalidBranchName ->
             "The BranchName is not a valid Grace name. A valid object name in Grace has between 2 and 64 characters, has a letter for the first character ([A-Za-z]), and letters, numbers, or - for the rest ([A-Za-z0-9\-]{1,63})."
+        | InvalidBlake3Hash -> "The provided BLAKE3 hash is not a valid lowercase 64-character BLAKE3 hash value."
         | InvalidCheckpointDaysValue -> "The provided value for CheckpointDays is invalid."
         | InvalidConflictResolutionPolicy ->
             $"The Conflict Resolution Policy provided is not a valid value. Valid values: {listCasesAsString<Common.ConflictResolutionPolicy> ()}."
@@ -102,6 +104,7 @@ module en_US =
         | InvalidSearchVisibility -> "The SearchVisibility provided is not a valid SearchVisibility value."
         | InvalidServerApiVersion -> "The provided ServerApiVersion is not recognized. Please use a published Grace API version identifier."
         | InvalidSha256Hash -> "The provided SHA-256 hash is not a valid SHA-256 hash value."
+        | InvalidSha256VersionHash -> "The provided SHA-256 version hash is not a valid lowercase 64-character SHA-256 hash value."
         | InvalidSize -> "The provided size does not match the size calculated by adding the sizes of all files in the directory."
         | InvalidVisibilityValue -> "The provided visibility value is not valid."
         | PromotionIsDisabled -> "This branch has disabled promotions."
@@ -165,6 +168,7 @@ module en_US =
         | Sha256HashDoesNotExist -> "The Sha256Hash value was not found."
         | Sha256HashDoesNotMatch -> "The provided SHA-256 hash for this directory version does not match the SHA-256 hash calculated by Grace Server."
         | Sha256HashIsRequired -> "The Sha256Hash value is required."
+        | Sha256VersionHashIsRequired -> "The SHA-256 version hash value is required."
         | StringIsTooLong -> "The provided string is longer than allowed."
         | TagIsDisabled -> "This branch has disabled tags."
         | TestFailed -> "The test failed."

--- a/src/Grace.Shared/Validation/Common.Validation.fs
+++ b/src/Grace.Shared/Validation/Common.Validation.fs
@@ -63,7 +63,7 @@ module Common =
             else
                 Ok() |> returnValueTask
 
-        /// Validates that a string is either empty or a valid partial or full SHA-256 hash value.
+        /// Validates that a string is either empty or a valid SHA-256 hash prefix value.
         ///
         /// Regex: ^[0-9a-fA-F]{2,64}$
         let isEmptyOrValidSha256Hash<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
@@ -75,11 +75,60 @@ module Common =
             else
                 Error error |> returnValueTask
 
-        /// Validates that a string is a valid partial or full SHA-256 hash value.
+        /// Validates that a string is a valid SHA-256 hash prefix value.
         ///
         /// Regex: ^[0-9a-fA-F]{2,64}$
         let isValidSha256Hash<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
             if Constants.Sha256Regex.IsMatch(s) then
+                Ok() |> returnValueTask
+            else
+                Error error |> returnValueTask
+
+        /// Validates that a string is either empty or a valid SHA-256 hash prefix value.
+        ///
+        /// Regex: ^[0-9a-fA-F]{2,64}$
+        let isEmptyOrValidSha256HashPrefix<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) = isEmptyOrValidSha256Hash s error
+
+        /// Validates that a string is a valid SHA-256 hash prefix value.
+        ///
+        /// Regex: ^[0-9a-fA-F]{2,64}$
+        let isValidSha256HashPrefix<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) = isValidSha256Hash s error
+
+        /// Validates that a string is a lowercase full SHA-256 version hash value.
+        ///
+        /// Regex: ^[0-9a-f]{64}$
+        let isValidSha256VersionHash<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
+            if Constants.Sha256FullHashRegex.IsMatch(s) then
+                Ok() |> returnValueTask
+            else
+                Error error |> returnValueTask
+
+        /// Validates that a string is a valid BLAKE3 hash prefix value.
+        ///
+        /// Regex: ^[0-9a-fA-F]{2,64}$
+        let isValidBlake3HashPrefix<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
+            if Constants.Blake3HashPrefixRegex.IsMatch(s) then
+                Ok() |> returnValueTask
+            else
+                Error error |> returnValueTask
+
+        /// Validates that a string is either empty or a valid BLAKE3 hash prefix value.
+        ///
+        /// Regex: ^[0-9a-fA-F]{2,64}$
+        let isEmptyOrValidBlake3HashPrefix<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
+            if
+                String.IsNullOrEmpty(s)
+                || Constants.Blake3HashPrefixRegex.IsMatch(s)
+            then
+                Ok() |> returnValueTask
+            else
+                Error error |> returnValueTask
+
+        /// Validates that a string is a lowercase full BLAKE3 version hash value.
+        ///
+        /// Regex: ^[0-9a-f]{64}$
+        let isValidBlake3VersionHash<'T when 'T :> IErrorDiscriminatedUnion> (s: string) (error: 'T) =
+            if Constants.Blake3FullHashRegex.IsMatch(s) then
                 Ok() |> returnValueTask
             else
                 Error error |> returnValueTask

--- a/src/Grace.Shared/Validation/Errors.Validation.fs
+++ b/src/Grace.Shared/Validation/Errors.Validation.fs
@@ -144,6 +144,26 @@ module Errors =
             | Some error -> ConfigError.getErrorMessage error
             | None -> String.Empty
 
+    type VersionHashError =
+        | Blake3HashIsRequired
+        | InvalidBlake3Hash
+        | InvalidSha256VersionHash
+        | Sha256VersionHashIsRequired
+
+        interface IErrorDiscriminatedUnion
+
+        static member getErrorMessage(versionHashError: VersionHashError) : string =
+            match versionHashError with
+            | Blake3HashIsRequired -> getLocalizedString StringResourceName.Blake3HashIsRequired
+            | InvalidBlake3Hash -> getLocalizedString StringResourceName.InvalidBlake3Hash
+            | InvalidSha256VersionHash -> getLocalizedString StringResourceName.InvalidSha256VersionHash
+            | Sha256VersionHashIsRequired -> getLocalizedString StringResourceName.Sha256VersionHashIsRequired
+
+        static member getErrorMessage(versionHashError: VersionHashError option) : string =
+            match versionHashError with
+            | Some error -> VersionHashError.getErrorMessage error
+            | None -> String.Empty
+
     type ConnectError =
         | RepositoryDoesNotExist
         | InvalidRepositoryId
@@ -873,6 +893,7 @@ module Errors =
         | :? PolicyError as policyError -> PolicyError.getErrorMessage policyError
         | :? ReviewError as reviewError -> ReviewError.getErrorMessage reviewError
         | :? QueueError as queueError -> QueueError.getErrorMessage queueError
+        | :? VersionHashError as versionHashError -> VersionHashError.getErrorMessage versionHashError
         | :? ValidationSetError as validationSetError -> ValidationSetError.getErrorMessage validationSetError
         | :? ValidationResultError as validationResultError -> ValidationResultError.getErrorMessage validationResultError
         | :? ArtifactError as artifactError -> ArtifactError.getErrorMessage artifactError

--- a/src/Grace.Types.Tests/Common.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Common.Types.Tests.fs
@@ -28,6 +28,10 @@ type LegacyFileVersion =
         BlobUri: string
     }
 
+module HashAliasTestData =
+    let sha256Hash: Sha256Hash = Sha256Hash "67a1790dca55b8803ad024ee28f616a284df5dd7b8ba5f68b4b252a5e925af79"
+    let blake3Hash: Blake3Hash = Blake3Hash "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f"
+
 module ManifestEligibilityTestData =
     let thresholdBytes = 1024 * 1024
 
@@ -92,6 +96,11 @@ module ManifestEligibilityTestData =
 
 [<Parallelizable(ParallelScope.All)>]
 type CommonTypesTests() =
+    [<Test>]
+    member _.Blake3HashAliasExistsBesideSha256Hash() =
+        Assert.That(HashAliasTestData.blake3Hash, Is.EqualTo("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f"))
+        Assert.That(HashAliasTestData.sha256Hash, Is.EqualTo("67a1790dca55b8803ad024ee28f616a284df5dd7b8ba5f68b4b252a5e925af79"))
+
     [<Test>]
     member _.ManifestEligibilityPolicyDefaultUsesOneMiBThresholdAndEightKiBScanWindow() =
         let policy = ManifestEligibilityPolicy.Default

--- a/src/Grace.Types/Common.Types.fs
+++ b/src/Grace.Types/Common.Types.fs
@@ -128,6 +128,9 @@ module Common =
     /// A SHA-256 hash value.
     type Sha256Hash = string
 
+    /// A BLAKE3 hash value.
+    type Blake3Hash = string
+
     /// The content-addressed identifier for one chunk of manifest-backed file content.
     type ChunkAddress = string
 


### PR DESCRIPTION
## Summary

- Adds explicit `Blake3Hash` vocabulary beside existing SHA-256 version hash vocabulary.
- Adds shared validation helpers and error text for BLAKE3 full hashes and lookup prefixes.
- Preserves existing SHA-256 validation compatibility and avoids CAS address validation changes.
- Expands the owned write set to `src/Grace.Shared/Resources/Text/Languages.Resources.fs` so the new resource text compiles.

Part of #343
Related to #345

## Validation

- `dotnet fantomas src\Grace.Types\Common.Types.fs src\Grace.Shared\Constants.Shared.fs src\Grace.Shared\Validation\Common.Validation.fs src\Grace.Shared\Validation\Errors.Validation.fs src\Grace.Shared\Resources\Text\en-US.fs src\Grace.Shared\Resources\Text\Languages.Resources.fs src\Grace.Server.Unit.Tests\Validations.Server.Tests.fs src\Grace.Types.Tests\Common.Types.Tests.fs`: passed
- `dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~Validations"`: passed, 34/34
- `dotnet test --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj --filter "FullyQualifiedName~CommonTypesTests"`: passed, 8/8
- `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings and 0 errors; Fast test profile passed (`Grace.Types.Tests` 97/97, `Grace.Authorization.Tests` 39/39, `Grace.Server.Unit.Tests` 506/506, `Grace.CLI.Tests` 409 passed / 1 skipped)
- `git diff --check`: passed
- Skipped validation: none

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed domain-contract slice in `C:\Source\Grace-gh-345`.
- Commit under review: `4a79fa146f20c3f93f2a5aee03e5e689eee9fdf2`
- Codex Code Review Bot: 👍🏻 no-issues reaction observed on the PR body for the latest head.
- Bot comments/review threads: none observed.
- Open findings: none.
- Fix commits: none.

## Docs Impact

No user-facing docs change in this slice. This is a prerequisite contract/validation change for later behavior and OpenAPI/docs slices.

## Residual Risk

Moderate, because this touches shared type and validation vocabulary. The worker ran focused validation plus the repo Fast gate.