### PR TITLE
I03: Add byte-only BLAKE3 file hashing

### DIFF
--- a/src/Grace.Shared/Services.Shared.fs
+++ b/src/Grace.Shared/Services.Shared.fs
@@ -1,5 +1,6 @@
 namespace Grace.Shared
 
+open Blake3
 open Grace.Types.Common
 open Grace.Shared.Utilities
 open Microsoft.Extensions.Logging
@@ -47,6 +48,41 @@ module Services =
     let incrementalHashPool =
         DefaultObjectPoolProvider()
             .Create(IncrementalHashPolicy())
+
+    /// Computes the BLAKE3 value for a given file, presented as a stream.
+    ///
+    /// FileContentHash values for files are computed by hashing only the file's contents.
+    let computeBlake3ForFile (stream: Stream) =
+        task {
+            if isNull stream then nullArg (nameof stream)
+
+            // I did some informal perf testing on large files. This size was best, larger didn't help, and 64K keeps it on the small object heap.
+            let bufferLength = 64 * 1024
+
+            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
+            let mutable hasher = Hasher.New()
+
+            try
+                let mutable moreToRead = true
+
+                while moreToRead do
+                    let! bytesRead = stream.ReadAsync(buffer, 0, bufferLength)
+
+                    if bytesRead > 0 then
+                        hasher.Update(buffer.AsSpan(0, bytesRead))
+                    else
+                        moreToRead <- false
+
+                let blake3Bytes = stackalloc<byte> Hash.Size
+                hasher.Finalize(blake3Bytes)
+
+                return FileContentHash(byteArrayToString blake3Bytes)
+            finally
+                if not <| isNull buffer then
+                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
+
+                hasher.Dispose()
+        }
 
     /// The 0x00 character.
     let nulChar = char (0)

--- a/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
@@ -1,12 +1,23 @@
 namespace Grace.Types.Tests
 
+open System
+open System.IO
 open System.Text
+open System.Threading
 open Grace.Shared
 open Grace.Types.Common
 open NUnit.Framework
 
+type private ChunkedReadStream(bytes: byte array, maxBytesPerRead: int) =
+    inherit MemoryStream(bytes)
+
+    override this.ReadAsync(buffer: byte array, offset: int, count: int, cancellationToken: CancellationToken) =
+        ``base``.ReadAsync(buffer, offset, Math.Min(count, maxBytesPerRead), cancellationToken)
+
 [<Parallelizable(ParallelScope.All)>]
 type ContentAddressTypesTests() =
+    let runTask (work: System.Threading.Tasks.Task<'T>) = work.GetAwaiter().GetResult()
+
     [<Test>]
     member _.Blake3KnownVectorsPass() =
         Assert.That(ContentAddress.computeBlake3Hex Array.empty, Is.EqualTo("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"))
@@ -15,6 +26,64 @@ type ContentAddressTypesTests() =
             ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes("abc")),
             Is.EqualTo("6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85")
         )
+
+    [<Test>]
+    member _.FileHashKnownVectorsAreByteOnly() =
+        let vectors =
+            [
+                "empty",
+                Array.empty,
+                "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                "abc",
+                Encoding.UTF8.GetBytes("abc"),
+                "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                "binary",
+                [|
+                    0uy
+                    1uy
+                    2uy
+                    3uy
+                    4uy
+                    255uy
+                    128uy
+                    64uy
+                    10uy
+                    13uy
+                |],
+                "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
+                "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2"
+            ]
+
+        for name, bytes, expectedBlake3, expectedSha256 in vectors do
+            use blake3Stream = new ChunkedReadStream(bytes, 3)
+            let blake3Hash = runTask (Services.computeBlake3ForFile blake3Stream)
+
+            use sha256Stream = new ChunkedReadStream(bytes, 3)
+            let sha256Hash = runTask (Services.computeSha256ForFile sha256Stream (RelativePath $"vectors/{name}.bin"))
+
+            Assert.That(blake3Hash, Is.EqualTo(FileContentHash expectedBlake3), $"BLAKE3 vector failed for {name}.")
+            Assert.That(sha256Hash, Is.EqualTo(Sha256Hash expectedSha256), $"SHA-256 vector failed for {name}.")
+
+    [<Test>]
+    member _.FileHashesIgnoreRelativePath() =
+        let bytes = Encoding.UTF8.GetBytes("same file bytes, different paths")
+
+        use firstBlake3Stream = new ChunkedReadStream(bytes, 5)
+        use secondBlake3Stream = new ChunkedReadStream(bytes, 5)
+        let firstBlake3 = runTask (Services.computeBlake3ForFile firstBlake3Stream)
+        let secondBlake3 = runTask (Services.computeBlake3ForFile secondBlake3Stream)
+
+        use firstSha256Stream = new ChunkedReadStream(bytes, 5)
+        use secondSha256Stream = new ChunkedReadStream(bytes, 5)
+
+        let firstSha256 = runTask (Services.computeSha256ForFile firstSha256Stream (RelativePath "src/one.bin"))
+
+        let secondSha256 = runTask (Services.computeSha256ForFile secondSha256Stream (RelativePath "other/two.bin"))
+
+        Assert.That(firstBlake3, Is.EqualTo(secondBlake3))
+        Assert.That(firstSha256, Is.EqualTo(secondSha256))
 
     [<Test>]
     member _.AddressValidationRequiresLowercaseSixtyFourHexCharacters() =


### PR DESCRIPTION
## Summary

- Adds streaming `Services.computeBlake3ForFile` for byte-only file BLAKE3 computation.
- Protects file SHA-256 byte-only behavior with golden vectors.
- Adds BLAKE3 vectors for empty, `abc`, representative binary bytes, small-read streams, and same-bytes/different-path invariance.
- Leaves CAS address algorithms unchanged.

Part of #343
Related to #346

## Validation

- `dotnet fantomas C:\Source\Grace-gh-346\src\Grace.Shared\Services.Shared.fs C:\Source\Grace-gh-346\src\Grace.Types.Tests\ContentAddress.Types.Tests.fs`: passed
- `dotnet build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed
- `dotnet test --no-build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed, 99 passed, 0 failed, 0 skipped
- `pwsh ./scripts/validate.ps1 -Fast`: passed
  - Build succeeded, 0 warnings, 0 errors
  - `Grace.Types.Tests`: 99 passed
  - `Grace.Authorization.Tests`: 39 passed
  - `Grace.Server.Unit.Tests`: 506 passed
  - `Grace.CLI.Tests`: 409 passed, 1 skipped
  - `Grace.Server.Tests`: no tests matched the Fast unit filter in that assembly
- `git diff --check`: passed
- Skipped validation: none

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed domain-contract slice in `C:\Source\Grace-gh-346`.
- Commit under review: `1ae9aafe35dd3aa57f88a2b53973752a387f20cd`
- Codex Code Review Bot: 👍🏻 no-issues reaction observed on the PR body for the latest head.
- Bot comments/review threads: none observed.
- Open findings: none.
- Fix commits: none.

## Docs Impact

No user-facing docs change in this slice. I01 owns baseline documentation and later slices own OpenAPI/docs refresh.

## Residual Risk

Moderate. This adds a shared streaming helper and test vectors; the worker ran focused type tests plus the Fast gate.