### PR TITLE
I05: Scaffold version BLAKE3 fields

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -938,7 +938,8 @@ module DirectoryVersion =
                                                     totalElapsedMs
                                                 )
 
-                                                let newDirectoryVersion = { directoryVersion with HashesValidated = true }
+                                                directoryVersion.HashesValidated <- true
+                                                let newDirectoryVersion = directoryVersion
                                                 return Ok(Created newDirectoryVersion)
                                     | SetRecursiveSize recursiveSize -> return Ok(RecursiveSizeSet recursiveSize)
                                     | DeleteLogical deleteReason ->

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -938,8 +938,20 @@ module DirectoryVersion =
                                                     totalElapsedMs
                                                 )
 
-                                                directoryVersion.HashesValidated <- true
-                                                let newDirectoryVersion = directoryVersion
+                                                let newDirectoryVersion = DirectoryVersion()
+                                                newDirectoryVersion.Class <- directoryVersion.Class
+                                                newDirectoryVersion.DirectoryVersionId <- directoryVersion.DirectoryVersionId
+                                                newDirectoryVersion.OwnerId <- directoryVersion.OwnerId
+                                                newDirectoryVersion.OrganizationId <- directoryVersion.OrganizationId
+                                                newDirectoryVersion.RepositoryId <- directoryVersion.RepositoryId
+                                                newDirectoryVersion.RelativePath <- directoryVersion.RelativePath
+                                                newDirectoryVersion.Sha256Hash <- directoryVersion.Sha256Hash
+                                                newDirectoryVersion.Blake3Hash <- directoryVersion.Blake3Hash
+                                                newDirectoryVersion.Directories <- directoryVersion.Directories
+                                                newDirectoryVersion.Files <- directoryVersion.Files
+                                                newDirectoryVersion.Size <- directoryVersion.Size
+                                                newDirectoryVersion.CreatedAt <- directoryVersion.CreatedAt
+                                                newDirectoryVersion.HashesValidated <- true
                                                 return Ok(Created newDirectoryVersion)
                                     | SetRecursiveSize recursiveSize -> return Ok(RecursiveSizeSet recursiveSize)
                                     | DeleteLogical deleteReason ->

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -86,6 +86,9 @@ module LocalStateDbTests =
     let private createFileVersion relativePath sha256Hash isBinary size createdAt lastWriteTime =
         LocalFileVersion.Create relativePath sha256Hash isBinary size createdAt true lastWriteTime
 
+    let private createFileVersionWithHashes relativePath sha256Hash blake3Hash isBinary size createdAt lastWriteTime =
+        LocalFileVersion.CreateWithHashes relativePath sha256Hash blake3Hash isBinary size createdAt true lastWriteTime
+
     let private createDirectoryVersion
         (configuration: GraceConfiguration)
         (directoryVersionId: DirectoryVersionId)
@@ -205,7 +208,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -222,7 +225,7 @@ module LocalStateDbTests =
                 let srcId = Guid.NewGuid()
 
                 let rootFile = createFileVersion "root.txt" "root-hash" false 12L now lastWrite
-                let srcFile = createFileVersion "src/file.txt" "src-hash" false 34L now lastWrite
+                let srcFile = createFileVersionWithHashes "src/file.txt" "src-hash" "src-blake3" false 34L now lastWrite
 
                 let srcDirectory = createDirectoryVersion configuration srcId "src" "src-dir-hash" [||] [| srcFile |] srcFile.Size lastWrite
 
@@ -272,6 +275,7 @@ module LocalStateDbTests =
                     |> Seq.find (fun file -> file.RelativePath = "src/file.txt")
 
                 srcRead.Sha256Hash |> should equal "src-hash"
+                srcRead.Blake3Hash |> should equal "src-blake3"
                 srcRead.Size |> should equal 34L
             })
 
@@ -321,7 +325,7 @@ module LocalStateDbTests =
 
                 let newRootId = Guid.NewGuid()
                 let newSrcId = Guid.NewGuid()
-                let changedFile = createFileVersion "src/file.txt" "src-hash-2" false 25L now lastWrite
+                let changedFile = createFileVersionWithHashes "src/file.txt" "src-hash-2" "src-blake3-2" false 25L now lastWrite
                 let newFile = createFileVersion "src/new.txt" "new-hash" false 5L now lastWrite
 
                 let newSrcDirectory =
@@ -382,6 +386,12 @@ module LocalStateDbTests =
                 |> Seq.exists (fun file -> file.RelativePath = "src/new.txt")
                 |> should equal true
 
+                let changedRead =
+                    srcRead.Files
+                    |> Seq.find (fun file -> file.RelativePath = "src/file.txt")
+
+                changedRead.Blake3Hash |> should equal "src-blake3-2"
+
                 readBack.Index.Values
                 |> Seq.collect (fun dv -> dv.Files)
                 |> Seq.exists (fun file -> file.RelativePath = "root.txt")
@@ -395,7 +405,7 @@ module LocalStateDbTests =
                 let now = getCurrentInstant ()
                 let lastWrite = DateTime.UtcNow
                 let directoryId = Guid.NewGuid()
-                let fileVersion = createFileVersion "src/cache.txt" "cache-hash" false 12L now lastWrite
+                let fileVersion = createFileVersionWithHashes "src/cache.txt" "cache-hash" "cache-blake3" false 12L now lastWrite
 
                 let directory = createDirectoryVersion configuration directoryId "src" "cache-dir-hash" [||] [| fileVersion |] fileVersion.Size lastWrite
 
@@ -408,6 +418,11 @@ module LocalStateDbTests =
                 let! fileExists = LocalStateDb.isFileVersionInObjectCache configuration.GraceStatusFile fileVersion
 
                 fileExists |> should equal true
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarString connection "SELECT blake3_hash FROM object_cache_directory_files WHERE relative_path = 'src/cache.txt';"
+                |> should equal "cache-blake3"
             })
 
     [<Test>]
@@ -454,7 +469,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -481,7 +496,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -602,7 +617,7 @@ module LocalStateDbTests =
                     connection
                     "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
 
-                executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '2');"
+                executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3');"
 
                 executeNonQuery
                     connection
@@ -794,7 +809,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -820,7 +835,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
             })
 
     [<Test>]
@@ -1073,7 +1088,7 @@ module LocalStateDbTests =
 
                 executeNonQuery
                     connection
-                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ('.', '', '00000000-0000-0000-0000-000000000001', 'root', 0, 0, 0);"
+                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ('.', '', '00000000-0000-0000-0000-000000000001', 'root', '', 0, 0, 0);"
 
                 let orphanId = Guid.NewGuid()
 
@@ -1081,7 +1096,7 @@ module LocalStateDbTests =
                     Action (fun () ->
                         executeNonQuery
                             connection
-                            $"INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('orphan.txt', 'missing', '{orphanId}', 'hash', 0, 1, 0, 0, 0);")
+                            $"INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('orphan.txt', 'missing', '{orphanId}', 'hash', '', 0, 1, 0, 0, 0);")
                 )
                 |> ignore
             })
@@ -1590,7 +1605,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "2"
+                    schemaVersion |> should equal "3"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -282,7 +282,7 @@ module Maintenance =
                                         Parallel.ForEach(
                                             graceStatus.Index.Values,
                                             Constants.ParallelOptions,
-                                            (fun ldv ->
+                                            (fun (ldv: LocalDirectoryVersion) ->
                                                 for fileVersion in ldv.Files do
                                                     fileVersions.TryAdd(fileVersion.RelativePath, fileVersion)
                                                     |> ignore)
@@ -521,7 +521,7 @@ module Maintenance =
                         Parallel.ForEach(
                             graceStatus.Index.Values,
                             Constants.ParallelOptions,
-                            (fun ldv ->
+                            (fun (ldv: LocalDirectoryVersion) ->
                                 for fileVersion in ldv.Files do
                                     fileVersions.TryAdd(fileVersion.RelativePath, fileVersion)
                                     |> ignore)

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -480,7 +480,7 @@ module Repository =
                                                         Parallel.ForEach(
                                                             graceStatus.Index.Values,
                                                             Constants.ParallelOptions,
-                                                            (fun ldv ->
+                                                            (fun (ldv: LocalDirectoryVersion) ->
                                                                 for fileVersion in ldv.Files do
                                                                     fileVersions.TryAdd(fileVersion.RelativePath, fileVersion)
                                                                     |> ignore)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1104,7 +1104,8 @@ module Services =
             match! createLocalFileVersion fileInfo with
             | Some fileVersion ->
                 directoryVersion.Files.Add(fileVersion)
-                let updated = { directoryVersion with Size = directoryVersion.Files.Sum(fun file -> int64 (file.Size)) }
+                directoryVersion.Size <- directoryVersion.Files.Sum(fun file -> int64 (file.Size))
+                let updated = directoryVersion
 
                 changedDirectoryVersions.AddOrUpdate(directoryVersion.RelativePath, (fun _ -> updated), (fun _ _ -> updated))
                 |> ignore
@@ -1137,10 +1138,11 @@ module Services =
             match! createLocalFileVersion fileInfo with
             | Some fileVersion ->
                 if fileVersion.Sha256Hash
-                   <> existingFileVersion.Sha256Hash then
+                    <> existingFileVersion.Sha256Hash then
                     directoryVersion.Files.RemoveAt(existingFileIndex)
                     directoryVersion.Files.Add(fileVersion)
-                    let updated = { directoryVersion with Size = directoryVersion.Files.Sum(fun file -> int64 (file.Size)) }
+                    directoryVersion.Size <- directoryVersion.Files.Sum(fun file -> int64 (file.Size))
+                    let updated = directoryVersion
 
                     changedDirectoryVersions.AddOrUpdate(directoryVersion.RelativePath, (fun _ -> updated), (fun _ _ -> updated))
                     |> ignore
@@ -1170,7 +1172,8 @@ module Services =
             let dv = directoryVersion[0]
             let index = dv.Files.FindIndex(fun file -> file.RelativePath = difference.RelativePath)
             dv.Files.RemoveAt(index)
-            let updated = { dv with Size = dv.Files.Sum(fun file -> int64 (file.Size)) }
+            dv.Size <- dv.Files.Sum(fun file -> int64 (file.Size))
+            let updated = dv
 
             changedDirectoryVersions.AddOrUpdate(dv.RelativePath, (fun _ -> updated), (fun _ _ -> updated))
             |> ignore

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -16,7 +16,7 @@ open SQLitePCL
 
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "2"
+    let private SchemaVersion = "3"
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
@@ -144,18 +144,18 @@ module LocalStateDb =
         [|
             "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
             "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
-            "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
             "CREATE INDEX IF NOT EXISTS ix_status_directories_parent ON status_directories(parent_path);"
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
-            "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
+            "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_version_id ON status_files(directory_version_id);"
             "CREATE INDEX IF NOT EXISTS ix_status_files_sha256 ON status_files(sha256_hash);"
-            "CREATE TABLE IF NOT EXISTS object_cache_directories (directory_version_id TEXT PRIMARY KEY, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS object_cache_directories (directory_version_id TEXT PRIMARY KEY, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_directories_relative_path ON object_cache_directories(relative_path);"
             "CREATE TABLE IF NOT EXISTS object_cache_directory_children (parent_directory_version_id TEXT NOT NULL, child_directory_version_id TEXT NOT NULL, ordinal INTEGER NOT NULL, PRIMARY KEY (parent_directory_version_id, child_directory_version_id), FOREIGN KEY (parent_directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE, FOREIGN KEY (child_directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE RESTRICT);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
-            "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
+            "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
         |]
 
@@ -392,7 +392,7 @@ module LocalStateDb =
                                 use directoryCommand = connection.CreateCommand()
 
                                 directoryCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $size_bytes, $created_at, $last_write);"
+                                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write);"
 
                                 directoryCommand.Parameters.Add("$relative_path", SqliteType.Text)
                                 |> ignore
@@ -404,6 +404,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
@@ -418,7 +421,7 @@ module LocalStateDb =
                                 use fileCommand = connection.CreateCommand()
 
                                 fileCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
+                                    "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
 
                                 fileCommand.Parameters.Add("$relative_path", SqliteType.Text)
                                 |> ignore
@@ -430,6 +433,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 fileCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                fileCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 fileCommand.Parameters.Add("$is_binary", SqliteType.Integer)
@@ -458,6 +464,7 @@ module LocalStateDb =
                                     directoryCommand.Parameters["$parent_path"].Value <- parentPath
                                     directoryCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
                                     directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
+                                    directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
                                     directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
                                     directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
                                     directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
@@ -469,6 +476,7 @@ module LocalStateDb =
                                         fileCommand.Parameters["$directory_path"].Value <- directory.RelativePath
                                         fileCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
                                         fileCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
+                                        fileCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
                                         fileCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
                                         fileCommand.Parameters["$size_bytes"].Value <- file.Size
                                         fileCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
@@ -514,7 +522,7 @@ module LocalStateDb =
                                 use directoryCommand = connection.CreateCommand()
 
                                 directoryCommand.CommandText <-
-                                    "INSERT INTO object_cache_directories (directory_version_id, relative_path, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $size_bytes, $created_at, $last_write) ON CONFLICT(directory_version_id) DO UPDATE SET relative_path = excluded.relative_path, sha256_hash = excluded.sha256_hash, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
+                                    "INSERT INTO object_cache_directories (directory_version_id, relative_path, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write) ON CONFLICT(directory_version_id) DO UPDATE SET relative_path = excluded.relative_path, sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
 
                                 directoryCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
                                 |> ignore
@@ -523,6 +531,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
@@ -565,7 +576,7 @@ module LocalStateDb =
                                 use insertFileCommand = connection.CreateCommand()
 
                                 insertFileCommand.CommandText <-
-                                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write) ON CONFLICT(directory_version_id, relative_path) DO UPDATE SET sha256_hash = excluded.sha256_hash, is_binary = excluded.is_binary, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, uploaded_to_object_storage = excluded.uploaded_to_object_storage, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
+                                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write) ON CONFLICT(directory_version_id, relative_path) DO UPDATE SET sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, is_binary = excluded.is_binary, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, uploaded_to_object_storage = excluded.uploaded_to_object_storage, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
 
                                 insertFileCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
                                 |> ignore
@@ -574,6 +585,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 insertFileCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                insertFileCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 insertFileCommand.Parameters.Add("$is_binary", SqliteType.Integer)
@@ -598,6 +612,7 @@ module LocalStateDb =
                                     directoryCommand.Parameters["$directory_version_id"].Value <- directoryVersionId
                                     directoryCommand.Parameters["$relative_path"].Value <- directory.RelativePath
                                     directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
+                                    directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
                                     directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
                                     directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
                                     directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
@@ -633,6 +648,7 @@ module LocalStateDb =
                                         insertFileCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
                                         insertFileCommand.Parameters["$relative_path"].Value <- file.RelativePath
                                         insertFileCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
+                                        insertFileCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
                                         insertFileCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
                                         insertFileCommand.Parameters["$size_bytes"].Value <- file.Size
                                         insertFileCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
@@ -742,7 +758,7 @@ module LocalStateDb =
                                 use directoryCommand = connection.CreateCommand()
 
                                 directoryCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $size_bytes, $created_at, $last_write);"
+                                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write);"
 
                                 directoryCommand.Parameters.Add("$relative_path", SqliteType.Text)
                                 |> ignore
@@ -754,6 +770,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
@@ -776,6 +795,7 @@ module LocalStateDb =
                                     directoryCommand.Parameters["$parent_path"].Value <- parentPath
                                     directoryCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
                                     directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
+                                    directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
                                     directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
                                     directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
                                     directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
@@ -784,7 +804,7 @@ module LocalStateDb =
                                 use fileUpsertCommand = connection.CreateCommand()
 
                                 fileUpsertCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
+                                    "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
 
                                 fileUpsertCommand.Parameters.Add("$relative_path", SqliteType.Text)
                                 |> ignore
@@ -796,6 +816,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 fileUpsertCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                |> ignore
+
+                                fileUpsertCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
                                 |> ignore
 
                                 fileUpsertCommand.Parameters.Add("$is_binary", SqliteType.Integer)
@@ -836,6 +859,7 @@ module LocalStateDb =
                                     fileUpsertCommand.Parameters["$directory_path"].Value <- directory.RelativePath
                                     fileUpsertCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
                                     fileUpsertCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
+                                    fileUpsertCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
                                     fileUpsertCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
                                     fileUpsertCommand.Parameters["$size_bytes"].Value <- file.Size
                                     fileUpsertCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
@@ -869,6 +893,7 @@ module LocalStateDb =
             ParentPath: string
             DirectoryVersionId: DirectoryVersionId
             Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
             SizeBytes: int64
             CreatedAt: Instant
             LastWriteTimeUtc: DateTime
@@ -879,6 +904,7 @@ module LocalStateDb =
             RelativePath: string
             DirectoryVersionId: DirectoryVersionId
             Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
             IsBinary: bool
             SizeBytes: int64
             CreatedAt: Instant
@@ -911,7 +937,7 @@ module LocalStateDb =
                 use directoryCommand = connection.CreateCommand()
 
                 directoryCommand.CommandText <-
-                    "SELECT relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
+                    "SELECT relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
 
                 use directoryReader = directoryCommand.ExecuteReader()
 
@@ -920,9 +946,10 @@ module LocalStateDb =
                     let parentPath = directoryReader.GetString(1)
                     let directoryVersionId = Guid.Parse(directoryReader.GetString(2))
                     let sha256Hash = directoryReader.GetString(3)
-                    let sizeBytes = directoryReader.GetInt64(4)
-                    let createdAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(5))
-                    let lastWriteTimeUtc = DateTime(directoryReader.GetInt64(6), DateTimeKind.Utc)
+                    let blake3Hash = directoryReader.GetString(4)
+                    let sizeBytes = directoryReader.GetInt64(5)
+                    let createdAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(6))
+                    let lastWriteTimeUtc = DateTime(directoryReader.GetInt64(7), DateTimeKind.Utc)
 
                     directories.Add(
                         {
@@ -930,6 +957,7 @@ module LocalStateDb =
                             ParentPath = parentPath
                             DirectoryVersionId = directoryVersionId
                             Sha256Hash = sha256Hash
+                            Blake3Hash = blake3Hash
                             SizeBytes = sizeBytes
                             CreatedAt = createdAt
                             LastWriteTimeUtc = lastWriteTimeUtc
@@ -939,7 +967,7 @@ module LocalStateDb =
                 use fileCommand = connection.CreateCommand()
 
                 fileCommand.CommandText <-
-                    "SELECT relative_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+                    "SELECT relative_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
 
                 use fileReader = fileCommand.ExecuteReader()
 
@@ -947,17 +975,19 @@ module LocalStateDb =
                     let relativePath = fileReader.GetString(0)
                     let directoryVersionId = Guid.Parse(fileReader.GetString(1))
                     let sha256Hash = fileReader.GetString(2)
-                    let isBinary = fileReader.GetInt64(3) = 1L
-                    let sizeBytes = fileReader.GetInt64(4)
-                    let createdAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(5))
-                    let uploaded = fileReader.GetInt64(6) = 1L
-                    let lastWriteTimeUtc = DateTime(fileReader.GetInt64(7), DateTimeKind.Utc)
+                    let blake3Hash = fileReader.GetString(3)
+                    let isBinary = fileReader.GetInt64(4) = 1L
+                    let sizeBytes = fileReader.GetInt64(5)
+                    let createdAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
+                    let uploaded = fileReader.GetInt64(7) = 1L
+                    let lastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
 
                     files.Add(
                         {
                             RelativePath = relativePath
                             DirectoryVersionId = directoryVersionId
                             Sha256Hash = sha256Hash
+                            Blake3Hash = blake3Hash
                             IsBinary = isBinary
                             SizeBytes = sizeBytes
                             CreatedAt = createdAt
@@ -982,9 +1012,10 @@ module LocalStateDb =
                 files
                 |> Seq.iter (fun file ->
                     let localFile =
-                        LocalFileVersion.Create
+                        LocalFileVersion.CreateWithHashes
                             file.RelativePath
                             file.Sha256Hash
+                            file.Blake3Hash
                             file.IsBinary
                             file.SizeBytes
                             file.CreatedAt
@@ -1019,13 +1050,14 @@ module LocalStateDb =
                             List<LocalFileVersion>()
 
                     let localDirectory =
-                        LocalDirectoryVersion.Create
+                        LocalDirectoryVersion.CreateWithHashes
                             directory.DirectoryVersionId
                             (Current().OwnerId)
                             (Current().OrganizationId)
                             (Current().RepositoryId)
                             directory.RelativePath
                             directory.Sha256Hash
+                            directory.Blake3Hash
                             directoriesForPath
                             filesForPath
                             directory.SizeBytes

--- a/src/Grace.Types.Tests/Common.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Common.Types.Tests.fs
@@ -6,6 +6,8 @@ open Grace.Types.Common
 open Grace.Types.Repository
 open MessagePack
 open NUnit.Framework
+open System
+open System.Collections.Generic
 open System.IO
 open System.IO.Compression
 
@@ -96,10 +98,26 @@ module ManifestEligibilityTestData =
 
 [<Parallelizable(ParallelScope.All)>]
 type CommonTypesTests() =
+    let messagePackKeyFor (targetType: Type) propertyName =
+        let property = targetType.GetProperty(propertyName)
+        let keyAttribute = Attribute.GetCustomAttribute(property, typeof<KeyAttribute>) :?> KeyAttribute
+        keyAttribute.IntKey
+
     [<Test>]
     member _.Blake3HashAliasExistsBesideSha256Hash() =
         Assert.That(HashAliasTestData.blake3Hash, Is.EqualTo("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f"))
         Assert.That(HashAliasTestData.sha256Hash, Is.EqualTo("67a1790dca55b8803ad024ee28f616a284df5dd7b8ba5f68b4b252a5e925af79"))
+
+    [<Test>]
+    member _.VersionHashFieldsUseDistinctMessagePackKeys() =
+        Assert.That(messagePackKeyFor typeof<FileVersion> "Sha256Hash", Is.EqualTo(2))
+        Assert.That(messagePackKeyFor typeof<FileVersion> "Blake3Hash", Is.EqualTo(8))
+        Assert.That(messagePackKeyFor typeof<LocalFileVersion> "Sha256Hash", Is.EqualTo(2))
+        Assert.That(messagePackKeyFor typeof<LocalFileVersion> "Blake3Hash", Is.EqualTo(8))
+        Assert.That(messagePackKeyFor typeof<DirectoryVersion> "Sha256Hash", Is.EqualTo(6))
+        Assert.That(messagePackKeyFor typeof<DirectoryVersion> "Blake3Hash", Is.EqualTo(12))
+        Assert.That(messagePackKeyFor typeof<LocalDirectoryVersion> "Sha256Hash", Is.EqualTo(6))
+        Assert.That(messagePackKeyFor typeof<LocalDirectoryVersion> "Blake3Hash", Is.EqualTo(12))
 
     [<Test>]
     member _.ManifestEligibilityPolicyDefaultUsesOneMiBThresholdAndEightKiBScanWindow() =
@@ -132,6 +150,23 @@ type CommonTypesTests() =
         let fileVersion = FileVersion.Create "src/app.fs" "abc123" "https://example.test/blob" false 123L
 
         Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+        Assert.That(fileVersion.Sha256Hash, Is.EqualTo(Sha256Hash "abc123"))
+        Assert.That(fileVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+
+    [<Test>]
+    member _.FileVersionCreatePopulatesBothHashFields() =
+        let fileVersion =
+            FileVersion.CreateWithHashes "src/app.fs" (Sha256Hash "sha256-abc123") (Blake3Hash "blake3-def456") "https://example.test/blob" false 123L
+
+        Assert.That(fileVersion.Sha256Hash, Is.EqualTo(Sha256Hash "sha256-abc123"))
+        Assert.That(fileVersion.Blake3Hash, Is.EqualTo(Blake3Hash "blake3-def456"))
+        Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+
+    [<Test>]
+    member _.FileVersionDefaultUsesEmptyBlake3ScaffoldValue() =
+        Assert.That(FileVersion.Default.Sha256Hash, Is.EqualTo(Sha256Hash String.Empty))
+        Assert.That(FileVersion.Default.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        Assert.That(FileVersion.Default.Blake3Hash, Is.Not.EqualTo(HashAliasTestData.blake3Hash))
 
     [<Test>]
     member _.FileVersionJsonWithoutContentReferenceDefaultsToWholeFileContent() =
@@ -151,6 +186,8 @@ type CommonTypesTests() =
         let fileVersion = deserialize<FileVersion> legacyJson
 
         Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+        Assert.That(fileVersion.Sha256Hash, Is.EqualTo(Sha256Hash "abc123"))
+        Assert.That(fileVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
 
     [<Test>]
     member _.FileVersionMessagePackWithoutContentReferenceDefaultsToWholeFileContent() =
@@ -169,6 +206,8 @@ type CommonTypesTests() =
         let fileVersion = MessagePackSerializer.Deserialize<FileVersion>(bytes, Constants.messagePackSerializerOptions)
 
         Assert.That(fileVersion.ContentReference, Is.EqualTo(FileContentReference.WholeFileContent))
+        Assert.That(fileVersion.Sha256Hash, Is.EqualTo(Sha256Hash "abc123"))
+        Assert.That(fileVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
 
     [<Test>]
     member _.FileVersionManifestContentReferenceRoundTripsThroughJsonAndMessagePack() =
@@ -181,7 +220,9 @@ type CommonTypesTests() =
                 ]
             )
 
-        let fileVersion = FileVersion.Create "src/large.bin" "abc123" "https://example.test/blob" true 4096L
+        let fileVersion =
+            FileVersion.CreateWithHashes "src/large.bin" (Sha256Hash "sha256-abc123") (Blake3Hash "blake3-def456") "https://example.test/blob" true 4096L
+
         fileVersion.CreatedAt <- NodaTime.Instant.FromUtc(2025, 1, 1, 0, 0)
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
 
@@ -196,6 +237,7 @@ type CommonTypesTests() =
         Assert.That(jsonRoundTrip.Class, Is.EqualTo(fileVersion.Class))
         Assert.That(jsonRoundTrip.RelativePath, Is.EqualTo(fileVersion.RelativePath))
         Assert.That(jsonRoundTrip.Sha256Hash, Is.EqualTo(fileVersion.Sha256Hash))
+        Assert.That(jsonRoundTrip.Blake3Hash, Is.EqualTo(fileVersion.Blake3Hash))
         Assert.That(jsonRoundTrip.IsBinary, Is.EqualTo(fileVersion.IsBinary))
         Assert.That(jsonRoundTrip.Size, Is.EqualTo(fileVersion.Size))
         Assert.That(jsonRoundTrip.CreatedAt, Is.EqualTo(fileVersion.CreatedAt))
@@ -204,3 +246,71 @@ type CommonTypesTests() =
         Assert.That(messagePackRoundTrip.Equals(fileVersion), Is.True)
         Assert.That(jsonRoundTrip.GetHashCode(), Is.EqualTo(fileVersion.GetHashCode()))
         Assert.That(messagePackRoundTrip.GetHashCode(), Is.EqualTo(fileVersion.GetHashCode()))
+
+    [<Test>]
+    member _.FileVersionEqualityAndHashCodeIncludeBlake3Hash() =
+        let left = FileVersion.CreateWithHashes "src/app.fs" (Sha256Hash "sha256") (Blake3Hash "left-blake3") "blob" false 123L
+
+        let right = FileVersion.CreateWithHashes "src/app.fs" (Sha256Hash "sha256") (Blake3Hash "right-blake3") "blob" false 123L
+        let createdAt = NodaTime.Instant.FromUtc(2025, 1, 1, 0, 0)
+
+        left.CreatedAt <- createdAt
+        right.CreatedAt <- createdAt
+
+        Assert.That(left.Equals(right), Is.False)
+        Assert.That(left.GetHashCode(), Is.Not.EqualTo(right.GetHashCode()))
+
+    [<Test>]
+    member _.LocalFileVersionConversionsPreserveBothHashFields() =
+        let createdAt = NodaTime.Instant.FromUtc(2025, 1, 1, 0, 0)
+        let lastWriteTimeUtc = DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes "src/app.fs" (Sha256Hash "sha256-abc123") (Blake3Hash "blake3-def456") false 123L createdAt true lastWriteTimeUtc
+
+        let fileVersion = localFileVersion.ToFileVersion
+        let localRoundTrip = fileVersion.ToLocalFileVersion lastWriteTimeUtc
+
+        Assert.That(localFileVersion.Sha256Hash, Is.EqualTo(Sha256Hash "sha256-abc123"))
+        Assert.That(localFileVersion.Blake3Hash, Is.EqualTo(Blake3Hash "blake3-def456"))
+        Assert.That(fileVersion.Sha256Hash, Is.EqualTo(localFileVersion.Sha256Hash))
+        Assert.That(fileVersion.Blake3Hash, Is.EqualTo(localFileVersion.Blake3Hash))
+        Assert.That(localRoundTrip.Sha256Hash, Is.EqualTo(localFileVersion.Sha256Hash))
+        Assert.That(localRoundTrip.Blake3Hash, Is.EqualTo(localFileVersion.Blake3Hash))
+
+    [<Test>]
+    member _.DirectoryVersionDefaultsUseEmptyHashScaffoldValues() =
+        Assert.That(DirectoryVersion.Default.Sha256Hash, Is.EqualTo(Sha256Hash String.Empty))
+        Assert.That(DirectoryVersion.Default.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        Assert.That(LocalDirectoryVersion.Default.Sha256Hash, Is.EqualTo(Sha256Hash String.Empty))
+        Assert.That(LocalDirectoryVersion.Default.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        Assert.That(DirectoryVersion.Default.Blake3Hash, Is.Not.EqualTo(HashAliasTestData.blake3Hash))
+
+    [<Test>]
+    member _.DirectoryVersionConversionsPreserveBothHashFields() =
+        let directories = List<DirectoryVersionId>()
+        let files = List<FileVersion>()
+        let lastWriteTimeUtc = DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+
+        let directoryVersion =
+            DirectoryVersion.CreateWithHashes
+                (Guid.Parse("11111111-1111-1111-1111-111111111111"))
+                (Guid.Parse("22222222-2222-2222-2222-222222222222"))
+                (Guid.Parse("33333333-3333-3333-3333-333333333333"))
+                (Guid.Parse("44444444-4444-4444-4444-444444444444"))
+                (RelativePath "src")
+                (Sha256Hash "sha256-directory")
+                (Blake3Hash "blake3-directory")
+                directories
+                files
+                123L
+
+        let localDirectoryVersion = directoryVersion.ToLocalDirectoryVersion lastWriteTimeUtc
+        let directoryRoundTrip = localDirectoryVersion.ToDirectoryVersion
+
+        Assert.That(directoryVersion.Sha256Hash, Is.EqualTo(Sha256Hash "sha256-directory"))
+        Assert.That(directoryVersion.Blake3Hash, Is.EqualTo(Blake3Hash "blake3-directory"))
+        Assert.That(localDirectoryVersion.Sha256Hash, Is.EqualTo(directoryVersion.Sha256Hash))
+        Assert.That(localDirectoryVersion.Blake3Hash, Is.EqualTo(directoryVersion.Blake3Hash))
+        Assert.That(directoryRoundTrip.Sha256Hash, Is.EqualTo(directoryVersion.Sha256Hash))
+        Assert.That(directoryRoundTrip.Blake3Hash, Is.EqualTo(directoryVersion.Blake3Hash))

--- a/src/Grace.Types.Tests/Common.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Common.Types.Tests.fs
@@ -210,6 +210,60 @@ type CommonTypesTests() =
         Assert.That(fileVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
 
     [<Test>]
+    member _.DirectoryVersionJsonWithoutBlake3HashDefaultsToEmptyScaffoldValue() =
+        let legacyJson =
+            """
+{
+  "Class": "DirectoryVersion",
+  "DirectoryVersionId": "11111111-1111-1111-1111-111111111111",
+  "OwnerId": "22222222-2222-2222-2222-222222222222",
+  "OrganizationId": "33333333-3333-3333-3333-333333333333",
+  "RepositoryId": "44444444-4444-4444-4444-444444444444",
+  "RelativePath": "src",
+  "Sha256Hash": "sha256-directory",
+  "Directories": [],
+  "Files": [],
+  "Size": 123,
+  "CreatedAt": "2025-01-01T00:00:00Z",
+  "HashesValidated": false
+}
+"""
+
+        let directoryVersion = deserialize<DirectoryVersion> legacyJson
+
+        Assert.That(directoryVersion.Sha256Hash, Is.EqualTo(Sha256Hash "sha256-directory"))
+        Assert.That(directoryVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        Assert.That(directoryVersion.Directories.Count, Is.EqualTo(0))
+        Assert.That(directoryVersion.Files.Count, Is.EqualTo(0))
+
+    [<Test>]
+    member _.LocalDirectoryVersionJsonWithoutBlake3HashDefaultsToEmptyScaffoldValue() =
+        let legacyJson =
+            """
+{
+  "Class": "LocalDirectoryVersion",
+  "DirectoryVersionId": "11111111-1111-1111-1111-111111111111",
+  "OwnerId": "22222222-2222-2222-2222-222222222222",
+  "OrganizationId": "33333333-3333-3333-3333-333333333333",
+  "RepositoryId": "44444444-4444-4444-4444-444444444444",
+  "RelativePath": "src",
+  "Sha256Hash": "sha256-directory",
+  "Directories": [],
+  "Files": [],
+  "Size": 123,
+  "CreatedAt": "2025-01-01T00:00:00Z",
+  "LastWriteTimeUtc": "2025-01-01T00:00:00Z"
+}
+"""
+
+        let directoryVersion = deserialize<LocalDirectoryVersion> legacyJson
+
+        Assert.That(directoryVersion.Sha256Hash, Is.EqualTo(Sha256Hash "sha256-directory"))
+        Assert.That(directoryVersion.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        Assert.That(directoryVersion.Directories.Count, Is.EqualTo(0))
+        Assert.That(directoryVersion.Files.Count, Is.EqualTo(0))
+
+    [<Test>]
     member _.FileVersionManifestContentReferenceRoundTripsThroughJsonAndMessagePack() =
         let manifest =
             FileManifest.Create(

--- a/src/Grace.Types/Common.Types.fs
+++ b/src/Grace.Types/Common.Types.fs
@@ -402,7 +402,8 @@ module Common =
         static member FileManifest manifest =
             { Class = "FileContentReference"; ReferenceType = FileContentReferenceType.FileManifest; Manifest = Some manifest }
 
-    /// A FileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
+    /// A FileVersion represents a version of a file in a repository with unique contents, and therefore with unique
+    /// SHA-256 and BLAKE3 hashes. It is immutable.
     ///
     /// It is the server-side representation of the LocalFileVersion type, used for the local object cache.
     [<MessagePackObject; GenerateSerializer>]
@@ -416,6 +417,9 @@ module Common =
 
         [<Key(2)>]
         member val Sha256Hash: Sha256Hash = String.Empty with get, set
+
+        [<Key(8)>]
+        member val Blake3Hash: Blake3Hash = String.Empty with get, set
 
         [<Key(3)>]
         member val IsBinary: bool = false with get, set
@@ -432,10 +436,11 @@ module Common =
         [<Key(7)>]
         member val ContentReference: FileContentReference = FileContentReference.WholeFileContent with get, set
 
-        static member Create
+        static member CreateWithHashes
             //(repositoryId: RepositoryId)
             (relativePath: RelativePath)
             (sha256Hash: Sha256Hash)
+            (blake3Hash: Blake3Hash)
             (blobUri: string)
             (isBinary: bool)
             (size: int64)
@@ -445,6 +450,7 @@ module Common =
             //fileVersion.RepositoryId <- repositoryId
             fileVersion.RelativePath <- RelativePath(normalizeFilePath $"{relativePath}")
             fileVersion.Sha256Hash <- sha256Hash
+            fileVersion.Blake3Hash <- blake3Hash
             fileVersion.BlobUri <- blobUri
             fileVersion.IsBinary <- isBinary
             fileVersion.Size <- size
@@ -452,11 +458,21 @@ module Common =
             fileVersion.ContentReference <- FileContentReference.WholeFileContent
             fileVersion
 
+        static member Create
+            //(repositoryId: RepositoryId)
+            (relativePath: RelativePath)
+            (sha256Hash: Sha256Hash)
+            (blobUri: string)
+            (isBinary: bool)
+            (size: int64)
+            =
+            FileVersion.CreateWithHashes relativePath sha256Hash (Blake3Hash String.Empty) blobUri isBinary size
+
         static member Default = FileVersion.Create String.Empty String.Empty String.Empty false 0L
 
         /// Converts a FileVersion to a LocalFileVersion.
         member this.ToLocalFileVersion lastWriteTimeUtc =
-            LocalFileVersion.Create this.RelativePath this.Sha256Hash this.IsBinary this.Size this.CreatedAt true lastWriteTimeUtc
+            LocalFileVersion.CreateWithHashes this.RelativePath this.Sha256Hash this.Blake3Hash this.IsBinary this.Size this.CreatedAt true lastWriteTimeUtc
 
         /// Get the object directory file name, which includes the SHA256 Hash value. Example: hello.js -> hello_04bef0a4b298de9c02930234.js
         [<IgnoreMember>]
@@ -472,6 +488,7 @@ module Common =
                 this.Class = otherFileVersion.Class
                 && this.RelativePath = otherFileVersion.RelativePath
                 && this.Sha256Hash = otherFileVersion.Sha256Hash
+                && this.Blake3Hash = otherFileVersion.Blake3Hash
                 && this.IsBinary = otherFileVersion.IsBinary
                 && this.Size = otherFileVersion.Size
                 && this.CreatedAt = otherFileVersion.CreatedAt
@@ -480,9 +497,20 @@ module Common =
             | _ -> false
 
         override this.GetHashCode() =
-            HashCode.Combine(this.Class, this.RelativePath, this.Sha256Hash, this.IsBinary, this.Size, this.CreatedAt, this.BlobUri, this.ContentReference)
+            let mutable hashCode = HashCode()
+            hashCode.Add(this.Class)
+            hashCode.Add(this.RelativePath)
+            hashCode.Add(this.Sha256Hash)
+            hashCode.Add(this.Blake3Hash)
+            hashCode.Add(this.IsBinary)
+            hashCode.Add(this.Size)
+            hashCode.Add(this.CreatedAt)
+            hashCode.Add(this.BlobUri)
+            hashCode.Add(this.ContentReference)
+            hashCode.ToHashCode()
 
-    /// A LocalFileVersion represents a version of a file in a repository with unique contents, and therefore with a unique SHA-256 hash. It is immutable.
+    /// A LocalFileVersion represents a version of a file in a repository with unique contents, and therefore with
+    /// unique SHA-256 and BLAKE3 hashes. It is immutable.
     ///
     /// It is the local representation of the FileVersion type, used on the server.
     and [<CLIMutable; MessagePackObject>] LocalFileVersion =
@@ -495,6 +523,8 @@ module Common =
             RelativePath: RelativePath
             [<Key(2)>]
             Sha256Hash: Sha256Hash
+            [<Key(8)>]
+            Blake3Hash: Blake3Hash
             [<Key(3)>]
             IsBinary: bool
             [<Key(4)>]
@@ -507,10 +537,11 @@ module Common =
             LastWriteTimeUtc: DateTime
         }
 
-        static member Create
+        static member CreateWithHashes
             //(repositoryId: RepositoryId)
             (relativePath: RelativePath)
             (sha256Hash: Sha256Hash)
+            (blake3Hash: Blake3Hash)
             (isBinary: bool)
             (size: int64)
             (createdAt: Instant)
@@ -522,6 +553,7 @@ module Common =
                 //RepositoryId = repositoryId
                 RelativePath = RelativePath(normalizeFilePath $"{relativePath}")
                 Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
                 IsBinary = isBinary
                 Size = size
                 CreatedAt = createdAt
@@ -529,9 +561,21 @@ module Common =
                 LastWriteTimeUtc = lastWriteTimeUtc
             }
 
+        static member Create
+            //(repositoryId: RepositoryId)
+            (relativePath: RelativePath)
+            (sha256Hash: Sha256Hash)
+            (isBinary: bool)
+            (size: int64)
+            (createdAt: Instant)
+            (uploadedToObjectStorage: bool)
+            (lastWriteTimeUtc: DateTime)
+            =
+            LocalFileVersion.CreateWithHashes relativePath sha256Hash (Blake3Hash String.Empty) isBinary size createdAt uploadedToObjectStorage lastWriteTimeUtc
+
         /// Converts a LocalFileVersion to a FileVersion. NOTE: at this point, we don't know the BlobUri.
         [<IgnoreMember>]
-        member this.ToFileVersion = FileVersion.Create this.RelativePath this.Sha256Hash String.Empty this.IsBinary this.Size
+        member this.ToFileVersion = FileVersion.CreateWithHashes this.RelativePath this.Sha256Hash this.Blake3Hash String.Empty this.IsBinary this.Size
 
         /// Get the object directory file name, which includes the SHA256 Hash value. Example: hello.js -> hello_04bef0a4b298de9c02930234.js
         [<IgnoreMember>]
@@ -541,7 +585,8 @@ module Common =
         [<IgnoreMember>]
         member this.RelativeDirectory = getRelativeDirectory $"{this.RelativePath}" ""
 
-    /// A DirectoryVersion represents a version of a directory in a repository with unique contents, and therefore with a unique SHA-256 hash.
+    /// A DirectoryVersion represents a version of a directory in a repository with unique contents, and therefore with
+    /// unique SHA-256 and BLAKE3 hashes.
     ///
     /// It is the server-side representation of the LocalDirectoryVersion type. LocalDirectoryVersion is used for the local object cache.
     [<CLIMutable; MessagePackObject; GenerateSerializer>]
@@ -561,6 +606,8 @@ module Common =
             RelativePath: RelativePath
             [<Key(6)>]
             Sha256Hash: Sha256Hash
+            [<Key(12)>]
+            Blake3Hash: Blake3Hash
             [<Key(7)>]
             Directories: List<DirectoryVersionId>
             [<Key(8)>]
@@ -584,10 +631,39 @@ module Common =
                 RepositoryId = RepositoryId.Empty
                 RelativePath = RelativePath String.Empty
                 Sha256Hash = Sha256Hash String.Empty
+                Blake3Hash = Blake3Hash String.Empty
                 Directories = List<DirectoryVersionId>()
                 Files = List<FileVersion>()
                 Size = InitialDirectorySize
                 CreatedAt = DefaultTimestamp
+                HashesValidated = false
+            }
+
+        static member CreateWithHashes
+            (directoryVersionId: DirectoryVersionId)
+            (ownerId: OwnerId)
+            (organizationId: OrganizationId)
+            (repositoryId: RepositoryId)
+            (relativePath: RelativePath)
+            (sha256Hash: Sha256Hash)
+            (blake3Hash: Blake3Hash)
+            (directories: List<DirectoryVersionId>)
+            (files: List<FileVersion>)
+            (size: int64)
+            =
+            {
+                Class = nameof DirectoryVersion
+                DirectoryVersionId = directoryVersionId
+                OwnerId = ownerId
+                OrganizationId = organizationId
+                RepositoryId = repositoryId
+                RelativePath = relativePath
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
+                Directories = directories
+                Files = files
+                Size = size
+                CreatedAt = getCurrentInstant ()
                 HashesValidated = false
             }
 
@@ -602,29 +678,27 @@ module Common =
             (files: List<FileVersion>)
             (size: int64)
             =
-            {
-                Class = nameof DirectoryVersion
-                DirectoryVersionId = directoryVersionId
-                OwnerId = ownerId
-                OrganizationId = organizationId
-                RepositoryId = repositoryId
-                RelativePath = relativePath
-                Sha256Hash = sha256Hash
-                Directories = directories
-                Files = files
-                Size = size
-                CreatedAt = getCurrentInstant ()
-                HashesValidated = false
-            }
+            DirectoryVersion.CreateWithHashes
+                directoryVersionId
+                ownerId
+                organizationId
+                repositoryId
+                relativePath
+                sha256Hash
+                (Blake3Hash String.Empty)
+                directories
+                files
+                size
 
         member this.ToLocalDirectoryVersion lastWriteTimeUtc =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 this.DirectoryVersionId
                 this.OwnerId
                 this.OrganizationId
                 this.RepositoryId
                 this.RelativePath
                 this.Sha256Hash
+                this.Blake3Hash
                 this.Directories
                 (this
                     .Files
@@ -633,7 +707,8 @@ module Common =
                 this.Size
                 lastWriteTimeUtc
 
-    /// A LocalDirectoryVersion represents a version of a directory in a repository with unique contents, and therefore with a unique SHA-256 hash.
+    /// A LocalDirectoryVersion represents a version of a directory in a repository with unique contents, and therefore
+    /// with unique SHA-256 and BLAKE3 hashes.
     ///
     /// It is the local representation of the DirectoryVersion type. DirectoryVersion is used on the server.
     and [<CLIMutable; MessagePackObject>] LocalDirectoryVersion =
@@ -652,6 +727,8 @@ module Common =
             RelativePath: RelativePath
             [<Key(6)>]
             Sha256Hash: Sha256Hash
+            [<Key(12)>]
+            Blake3Hash: Blake3Hash
             [<Key(7)>]
             Directories: List<DirectoryVersionId>
             [<Key(8)>]
@@ -673,11 +750,41 @@ module Common =
                 DirectoryVersionId = DirectoryVersionId.Empty
                 RelativePath = RelativePath String.Empty
                 Sha256Hash = Sha256Hash String.Empty
+                Blake3Hash = Blake3Hash String.Empty
                 Directories = List<DirectoryVersionId>()
                 Files = List<LocalFileVersion>()
                 Size = InitialDirectorySize
                 CreatedAt = DefaultTimestamp
                 LastWriteTimeUtc = DateTime.UtcNow
+            }
+
+        static member CreateWithHashes
+            (directoryVersionId: DirectoryVersionId)
+            (ownerId: OwnerId)
+            (organizationId: OrganizationId)
+            (repositoryId: RepositoryId)
+            (relativePath: RelativePath)
+            (sha256Hash: Sha256Hash)
+            (blake3Hash: Blake3Hash)
+            (directories: List<DirectoryVersionId>)
+            (files: List<LocalFileVersion>)
+            (size: int64)
+            (lastWriteTimeUtc: DateTime)
+            =
+            {
+                Class = "LocalDirectoryVersion"
+                DirectoryVersionId = directoryVersionId
+                OwnerId = ownerId
+                OrganizationId = organizationId
+                RepositoryId = repositoryId
+                RelativePath = relativePath
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
+                Directories = directories
+                Files = files
+                Size = size
+                CreatedAt = getCurrentInstant ()
+                LastWriteTimeUtc = lastWriteTimeUtc
             }
 
         static member Create
@@ -692,31 +799,30 @@ module Common =
             (size: int64)
             (lastWriteTimeUtc: DateTime)
             =
-            {
-                Class = "LocalDirectoryVersion"
-                DirectoryVersionId = directoryVersionId
-                OwnerId = ownerId
-                OrganizationId = organizationId
-                RepositoryId = repositoryId
-                RelativePath = relativePath
-                Sha256Hash = sha256Hash
-                Directories = directories
-                Files = files
-                Size = size
-                CreatedAt = getCurrentInstant ()
-                LastWriteTimeUtc = lastWriteTimeUtc
-            }
+            LocalDirectoryVersion.CreateWithHashes
+                directoryVersionId
+                ownerId
+                organizationId
+                repositoryId
+                relativePath
+                sha256Hash
+                (Blake3Hash String.Empty)
+                directories
+                files
+                size
+                lastWriteTimeUtc
 
         /// Converts a LocalDirectoryVersion to a DirectoryVersion.
         [<IgnoreMember>]
         member this.ToDirectoryVersion =
-            DirectoryVersion.Create
+            DirectoryVersion.CreateWithHashes
                 this.DirectoryVersionId
                 this.OwnerId
                 this.OrganizationId
                 this.RepositoryId
                 this.RelativePath
                 this.Sha256Hash
+                this.Blake3Hash
                 this.Directories
                 (this
                     .Files

--- a/src/Grace.Types/Common.Types.fs
+++ b/src/Grace.Types/Common.Types.fs
@@ -589,55 +589,50 @@ module Common =
     /// unique SHA-256 and BLAKE3 hashes.
     ///
     /// It is the server-side representation of the LocalDirectoryVersion type. LocalDirectoryVersion is used for the local object cache.
-    [<CLIMutable; MessagePackObject; GenerateSerializer>]
-    type DirectoryVersion =
-        {
-            [<Key(0)>]
-            Class: string
-            [<Key(1)>]
-            DirectoryVersionId: DirectoryVersionId
-            [<Key(2)>]
-            OwnerId: OwnerId
-            [<Key(3)>]
-            OrganizationId: OrganizationId
-            [<Key(4)>]
-            RepositoryId: RepositoryId
-            [<Key(5)>]
-            RelativePath: RelativePath
-            [<Key(6)>]
-            Sha256Hash: Sha256Hash
-            [<Key(12)>]
-            Blake3Hash: Blake3Hash
-            [<Key(7)>]
-            Directories: List<DirectoryVersionId>
-            [<Key(8)>]
-            Files: List<FileVersion>
-            [<Key(9)>]
-            Size: int64
-            [<Key(10)>]
-            CreatedAt: Instant
-            [<Key(11)>]
-            HashesValidated: bool
-        }
+    [<MessagePackObject; GenerateSerializer>]
+    type DirectoryVersion() =
+        [<Key(0)>]
+        member val Class: string = nameof DirectoryVersion with get, set
+
+        [<Key(1)>]
+        member val DirectoryVersionId: DirectoryVersionId = DirectoryVersionId.Empty with get, set
+
+        [<Key(2)>]
+        member val OwnerId: OwnerId = OwnerId.Empty with get, set
+
+        [<Key(3)>]
+        member val OrganizationId: OrganizationId = OrganizationId.Empty with get, set
+
+        [<Key(4)>]
+        member val RepositoryId: RepositoryId = RepositoryId.Empty with get, set
+
+        [<Key(5)>]
+        member val RelativePath: RelativePath = RelativePath String.Empty with get, set
+
+        [<Key(6)>]
+        member val Sha256Hash: Sha256Hash = Sha256Hash String.Empty with get, set
+
+        [<Key(12)>]
+        member val Blake3Hash: Blake3Hash = Blake3Hash String.Empty with get, set
+
+        [<Key(7)>]
+        member val Directories: List<DirectoryVersionId> = List<DirectoryVersionId>() with get, set
+
+        [<Key(8)>]
+        member val Files: List<FileVersion> = List<FileVersion>() with get, set
+
+        [<Key(9)>]
+        member val Size: int64 = InitialDirectorySize with get, set
+
+        [<Key(10)>]
+        member val CreatedAt: Instant = DefaultTimestamp with get, set
+
+        [<Key(11)>]
+        member val HashesValidated: bool = false with get, set
 
         static member GetKnownTypes() = GetKnownTypes<DirectoryVersion>()
 
-        static member Default =
-            {
-                Class = nameof DirectoryVersion
-                DirectoryVersionId = DirectoryVersionId.Empty
-                OwnerId = OwnerId.Empty
-                OrganizationId = OrganizationId.Empty
-                RepositoryId = RepositoryId.Empty
-                RelativePath = RelativePath String.Empty
-                Sha256Hash = Sha256Hash String.Empty
-                Blake3Hash = Blake3Hash String.Empty
-                Directories = List<DirectoryVersionId>()
-                Files = List<FileVersion>()
-                Size = InitialDirectorySize
-                CreatedAt = DefaultTimestamp
-                HashesValidated = false
-            }
+        static member Default = DirectoryVersion()
 
         static member CreateWithHashes
             (directoryVersionId: DirectoryVersionId)
@@ -651,21 +646,21 @@ module Common =
             (files: List<FileVersion>)
             (size: int64)
             =
-            {
-                Class = nameof DirectoryVersion
-                DirectoryVersionId = directoryVersionId
-                OwnerId = ownerId
-                OrganizationId = organizationId
-                RepositoryId = repositoryId
-                RelativePath = relativePath
-                Sha256Hash = sha256Hash
-                Blake3Hash = blake3Hash
-                Directories = directories
-                Files = files
-                Size = size
-                CreatedAt = getCurrentInstant ()
-                HashesValidated = false
-            }
+            let directoryVersion = DirectoryVersion()
+            directoryVersion.Class <- nameof DirectoryVersion
+            directoryVersion.DirectoryVersionId <- directoryVersionId
+            directoryVersion.OwnerId <- ownerId
+            directoryVersion.OrganizationId <- organizationId
+            directoryVersion.RepositoryId <- repositoryId
+            directoryVersion.RelativePath <- relativePath
+            directoryVersion.Sha256Hash <- sha256Hash
+            directoryVersion.Blake3Hash <- blake3Hash
+            directoryVersion.Directories <- directories
+            directoryVersion.Files <- files
+            directoryVersion.Size <- size
+            directoryVersion.CreatedAt <- getCurrentInstant ()
+            directoryVersion.HashesValidated <- false
+            directoryVersion
 
         static member Create
             (directoryVersionId: DirectoryVersionId)
@@ -707,56 +702,91 @@ module Common =
                 this.Size
                 lastWriteTimeUtc
 
+        override this.Equals(other: obj) =
+            match other with
+            | :? DirectoryVersion as otherDirectoryVersion ->
+                this.Class = otherDirectoryVersion.Class
+                && this.DirectoryVersionId = otherDirectoryVersion.DirectoryVersionId
+                && this.OwnerId = otherDirectoryVersion.OwnerId
+                && this.OrganizationId = otherDirectoryVersion.OrganizationId
+                && this.RepositoryId = otherDirectoryVersion.RepositoryId
+                && this.RelativePath = otherDirectoryVersion.RelativePath
+                && this.Sha256Hash = otherDirectoryVersion.Sha256Hash
+                && this.Blake3Hash = otherDirectoryVersion.Blake3Hash
+                && this.Directories.SequenceEqual(otherDirectoryVersion.Directories)
+                && this.Files.SequenceEqual(otherDirectoryVersion.Files)
+                && this.Size = otherDirectoryVersion.Size
+                && this.CreatedAt = otherDirectoryVersion.CreatedAt
+                && this.HashesValidated = otherDirectoryVersion.HashesValidated
+            | _ -> false
+
+        override this.GetHashCode() =
+            let mutable hashCode = HashCode()
+            hashCode.Add(this.Class)
+            hashCode.Add(this.DirectoryVersionId)
+            hashCode.Add(this.OwnerId)
+            hashCode.Add(this.OrganizationId)
+            hashCode.Add(this.RepositoryId)
+            hashCode.Add(this.RelativePath)
+            hashCode.Add(this.Sha256Hash)
+            hashCode.Add(this.Blake3Hash)
+
+            for directoryId in this.Directories do
+                hashCode.Add(directoryId)
+
+            for file in this.Files do
+                hashCode.Add(file)
+
+            hashCode.Add(this.Size)
+            hashCode.Add(this.CreatedAt)
+            hashCode.Add(this.HashesValidated)
+            hashCode.ToHashCode()
+
     /// A LocalDirectoryVersion represents a version of a directory in a repository with unique contents, and therefore
     /// with unique SHA-256 and BLAKE3 hashes.
     ///
     /// It is the local representation of the DirectoryVersion type. DirectoryVersion is used on the server.
-    and [<CLIMutable; MessagePackObject>] LocalDirectoryVersion =
-        {
-            [<Key(0)>]
-            Class: string
-            [<Key(1)>]
-            DirectoryVersionId: DirectoryVersionId
-            [<Key(2)>]
-            OwnerId: OwnerId
-            [<Key(3)>]
-            OrganizationId: OrganizationId
-            [<Key(4)>]
-            RepositoryId: RepositoryId
-            [<Key(5)>]
-            RelativePath: RelativePath
-            [<Key(6)>]
-            Sha256Hash: Sha256Hash
-            [<Key(12)>]
-            Blake3Hash: Blake3Hash
-            [<Key(7)>]
-            Directories: List<DirectoryVersionId>
-            [<Key(8)>]
-            Files: List<LocalFileVersion>
-            [<Key(9)>]
-            Size: int64
-            [<Key(10)>]
-            CreatedAt: Instant
-            [<Key(11)>]
-            LastWriteTimeUtc: DateTime
-        }
+    and [<MessagePackObject>] LocalDirectoryVersion() =
+        [<Key(0)>]
+        member val Class: string = "LocalDirectoryVersion" with get, set
 
-        static member Default =
-            {
-                Class = "LocalDirectoryVersion"
-                OwnerId = OwnerId.Empty
-                OrganizationId = OrganizationId.Empty
-                RepositoryId = RepositoryId.Empty
-                DirectoryVersionId = DirectoryVersionId.Empty
-                RelativePath = RelativePath String.Empty
-                Sha256Hash = Sha256Hash String.Empty
-                Blake3Hash = Blake3Hash String.Empty
-                Directories = List<DirectoryVersionId>()
-                Files = List<LocalFileVersion>()
-                Size = InitialDirectorySize
-                CreatedAt = DefaultTimestamp
-                LastWriteTimeUtc = DateTime.UtcNow
-            }
+        [<Key(1)>]
+        member val DirectoryVersionId: DirectoryVersionId = DirectoryVersionId.Empty with get, set
+
+        [<Key(2)>]
+        member val OwnerId: OwnerId = OwnerId.Empty with get, set
+
+        [<Key(3)>]
+        member val OrganizationId: OrganizationId = OrganizationId.Empty with get, set
+
+        [<Key(4)>]
+        member val RepositoryId: RepositoryId = RepositoryId.Empty with get, set
+
+        [<Key(5)>]
+        member val RelativePath: RelativePath = RelativePath String.Empty with get, set
+
+        [<Key(6)>]
+        member val Sha256Hash: Sha256Hash = Sha256Hash String.Empty with get, set
+
+        [<Key(12)>]
+        member val Blake3Hash: Blake3Hash = Blake3Hash String.Empty with get, set
+
+        [<Key(7)>]
+        member val Directories: List<DirectoryVersionId> = List<DirectoryVersionId>() with get, set
+
+        [<Key(8)>]
+        member val Files: List<LocalFileVersion> = List<LocalFileVersion>() with get, set
+
+        [<Key(9)>]
+        member val Size: int64 = InitialDirectorySize with get, set
+
+        [<Key(10)>]
+        member val CreatedAt: Instant = DefaultTimestamp with get, set
+
+        [<Key(11)>]
+        member val LastWriteTimeUtc: DateTime = DateTime.UtcNow with get, set
+
+        static member Default = LocalDirectoryVersion()
 
         static member CreateWithHashes
             (directoryVersionId: DirectoryVersionId)
@@ -771,21 +801,21 @@ module Common =
             (size: int64)
             (lastWriteTimeUtc: DateTime)
             =
-            {
-                Class = "LocalDirectoryVersion"
-                DirectoryVersionId = directoryVersionId
-                OwnerId = ownerId
-                OrganizationId = organizationId
-                RepositoryId = repositoryId
-                RelativePath = relativePath
-                Sha256Hash = sha256Hash
-                Blake3Hash = blake3Hash
-                Directories = directories
-                Files = files
-                Size = size
-                CreatedAt = getCurrentInstant ()
-                LastWriteTimeUtc = lastWriteTimeUtc
-            }
+            let directoryVersion = LocalDirectoryVersion()
+            directoryVersion.Class <- "LocalDirectoryVersion"
+            directoryVersion.DirectoryVersionId <- directoryVersionId
+            directoryVersion.OwnerId <- ownerId
+            directoryVersion.OrganizationId <- organizationId
+            directoryVersion.RepositoryId <- repositoryId
+            directoryVersion.RelativePath <- relativePath
+            directoryVersion.Sha256Hash <- sha256Hash
+            directoryVersion.Blake3Hash <- blake3Hash
+            directoryVersion.Directories <- directories
+            directoryVersion.Files <- files
+            directoryVersion.Size <- size
+            directoryVersion.CreatedAt <- getCurrentInstant ()
+            directoryVersion.LastWriteTimeUtc <- lastWriteTimeUtc
+            directoryVersion
 
         static member Create
             (directoryVersionId: DirectoryVersionId)
@@ -829,6 +859,46 @@ module Common =
                     .Select(fun f -> f.ToFileVersion)
                     .ToList())
                 this.Size
+
+        override this.Equals(other: obj) =
+            match other with
+            | :? LocalDirectoryVersion as otherDirectoryVersion ->
+                this.Class = otherDirectoryVersion.Class
+                && this.DirectoryVersionId = otherDirectoryVersion.DirectoryVersionId
+                && this.OwnerId = otherDirectoryVersion.OwnerId
+                && this.OrganizationId = otherDirectoryVersion.OrganizationId
+                && this.RepositoryId = otherDirectoryVersion.RepositoryId
+                && this.RelativePath = otherDirectoryVersion.RelativePath
+                && this.Sha256Hash = otherDirectoryVersion.Sha256Hash
+                && this.Blake3Hash = otherDirectoryVersion.Blake3Hash
+                && this.Directories.SequenceEqual(otherDirectoryVersion.Directories)
+                && this.Files.SequenceEqual(otherDirectoryVersion.Files)
+                && this.Size = otherDirectoryVersion.Size
+                && this.CreatedAt = otherDirectoryVersion.CreatedAt
+                && this.LastWriteTimeUtc = otherDirectoryVersion.LastWriteTimeUtc
+            | _ -> false
+
+        override this.GetHashCode() =
+            let mutable hashCode = HashCode()
+            hashCode.Add(this.Class)
+            hashCode.Add(this.DirectoryVersionId)
+            hashCode.Add(this.OwnerId)
+            hashCode.Add(this.OrganizationId)
+            hashCode.Add(this.RepositoryId)
+            hashCode.Add(this.RelativePath)
+            hashCode.Add(this.Sha256Hash)
+            hashCode.Add(this.Blake3Hash)
+
+            for directoryId in this.Directories do
+                hashCode.Add(directoryId)
+
+            for file in this.Files do
+                hashCode.Add(file)
+
+            hashCode.Add(this.Size)
+            hashCode.Add(this.CreatedAt)
+            hashCode.Add(this.LastWriteTimeUtc)
+            hashCode.ToHashCode()
 
     /// Specifies whether a specific entry in a directory is a DirectoryVersion or a FileVersion.
     and [<KnownType("GetKnownTypes"); GenerateSerializer>] DirectoryEntry =


### PR DESCRIPTION
## Summary

- Adds explicit `Blake3Hash` scaffold fields beside `Sha256Hash` on `FileVersion`, `LocalFileVersion`, `DirectoryVersion`, and `LocalDirectoryVersion`.
- Keeps existing `Create` factories source-compatible with deterministic empty BLAKE3 defaults.
- Adds `CreateWithHashes` factories for follow-on behavior slices that will supply explicit SHA-256 and BLAKE3 values.
- Keeps legacy directory-version JSON readable when `Blake3Hash` is missing by defaulting to the scaffold empty value.
- Persists and reloads local-state BLAKE3 values for status/object-cache files and directories.
- Avoids mutating active `DirectoryVersionActor` state before the `Created` event is persisted and applied.
- Covers distinct MessagePack keys, deterministic empty defaults, JSON/MessagePack legacy/default behavior, BLAKE3 equality/hash-code inclusion, local conversion helper propagation, local-state persistence, and legacy JSON compatibility.

Part of #343
Related to #348

## Validation

Initial implementation:

- `dotnet tool run fantomas -- src/Grace.Types/Common.Types.fs src/Grace.Types.Tests/Common.Types.Tests.fs`: passed
- `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter FullyQualifiedName~CommonTypesTests`: passed, 15 tests
- `pwsh ./scripts/validate.ps1 -Fast`: passed
- `git diff --check`: passed

Freshness refresh after #365/#368 merged to epic:

- Merged current `origin/epic/343-blake3-sha256-version-hashes` at `50eb14cacc26579c52f5a78ac898e88ae28bccf5` into the branch cleanly.
- `dotnet tool run fantomas -- src/Grace.Types/Common.Types.fs src/Grace.Types.Tests/Common.Types.Tests.fs`: passed; files unchanged.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after the sandbox-blocked attempt was rerun with escalation.
- `git diff --check`: passed.

Review-fix validation after #371 merged to epic:

- Merged current `origin/epic/343-blake3-sha256-version-hashes` at `0c472535599c5eb57a1a0cb14ef25fb29b7336f9` into the branch cleanly.
- `dotnet test src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~DirectoryVersionJsonWithoutBlake3HashDefaultsToEmptyScaffoldValue|FullyQualifiedName~LocalDirectoryVersionJsonWithoutBlake3HashDefaultsToEmptyScaffoldValue"`: passed, 2/2.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~LocalStateDbTests"`: passed, 33/33.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after escalation.
  - Build succeeded with 0 warnings and 0 errors.
  - `Grace.Types.Tests`: 113 passed.
  - `Grace.Authorization.Tests`: 39 passed.
  - `Grace.Server.Unit.Tests`: 507 passed.
  - `Grace.CLI.Tests`: 410 passed.
  - `Grace.Server.Tests`: selected filter had no matching tests in that assembly.
- `git diff --check`: passed.

Actor mutation-order fix validation:

- `dotnet tool restore`: passed.
- `dotnet tool run fantomas C:\Source\Grace-gh-348\src\Grace.Actors\DirectoryVersion.Actor.fs`: passed; repo-local Fantomas 4.7.9 reported the file unchanged.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after the sandbox-blocked attempt was rerun outside the sandbox.
  - Build succeeded with 0 warnings and 0 errors.
  - `Grace.Types.Tests`: 113 passed.
  - `Grace.Authorization.Tests`: 39 passed.
  - `Grace.Server.Unit.Tests`: 507 passed.
  - `Grace.CLI.Tests`: 410 passed.
- `git diff --check`: passed.

## Notes

Initial sandboxed restore/build attempts failed due restricted NuGet/build-output access, then the same commands passed with escalation. The refresh Fast gate had the same sandbox boundary and also passed after escalation.

For the first review fix, targeted Fantomas did not successfully run after the minimal reapply. `dotnet tool restore` succeeded with escalation and restored repo-local `fantomas-tool` 4.7.9, but both `dotnet tool run fantomas ...` and `dotnet fantomas ...` still reported `Run "dotnet tool restore" to make the "fantomas" command available.` The PATH command was global Fantomas 7.x, which the worker intentionally did not rerun because it had previously caused broad style churn. `scripts/validate.ps1 -Fast` reported its format phase is temporarily disabled. The branch still passed focused tests, the Fast gate, and `git diff --check`.

For the actor mutation-order fix, repo-local Fantomas 4.7.9 ran successfully on the touched file. No focused regression test was added because reproducing the exact failure requires injecting a failed Orleans persistent-state write after hash validation succeeds; there was no suitable existing narrow seam without building new actor/state harness machinery. The final Fast gate covered compile and existing fast actor/server-unit coverage.

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed domain-contract slice in `C:\Source\Grace-gh-348`.
- Freshness worker: GPT-5.5 Medium worker refreshed the branch against current epic in `C:\Source\Grace-gh-348`.
- First fix worker: GPT-5.5 Medium worker addressed Codex Code Review Bot DTO/local-state findings in `C:\Source\Grace-gh-348`.
- Second fix worker: GPT-5.5 Medium worker addressed Codex Code Review Bot actor mutation-order finding in `C:\Source\Grace-gh-348`.
- Initial implementation commit: `0998e49532c23e74ca1ae00cdcb45fc6d9bcae90`
- First refresh merge commit: `93b5cfd2398c3321fccd04748fe654684a6234f4`
- Current epic refresh merge commit: `6a23d5f`
- First fix commit pushed: `8b34686dabf96e8590f165cf10b7ca8aed55b476`
- Second fix commit pushed: `87626b276465fb759364e2b7da73f649c2bd71b2`
- Bot findings addressed and resolved:
  - Legacy `DirectoryVersion` and `LocalDirectoryVersion` JSON without `Blake3Hash` now defaults to the scaffold empty value instead of failing deserialization.
  - Local state now persists and reloads BLAKE3 hashes for status directories, status files, object-cache directories, and object-cache files.
  - Successful `DirectoryVersionActor` hash validation now prepares a separate `Created` event payload and no longer mutates active DTO state before `ApplyEvent` persists/applies the event.
- Codex Code Review Bot state: latest-head `+1` review signal at `87626b276465fb759364e2b7da73f649c2bd71b2` on 2026-06-10T12:51:34Z.
- Open findings: none; all bot review threads are resolved.

## Docs Impact

No user-facing docs change in this slice. Follow-on propagation, OpenAPI, and docs slices own external contract documentation.

## Residual Risk

Moderate. This touches core DTO shapes, JSON compatibility, local SQLite state, and an actor mutation-order path. Focused DTO/local-state tests and the Fast gate passed on a branch refreshed against the current epic. The actor mutation-order fix is small and formatted; it relies on Fast validation rather than a new injected-persistence-failure test because no narrow existing seam was available.