### PR TITLE
S3: Add grace doctor local state inspection

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1222,6 +1222,61 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor malformed config from nested directory inspects discovered local-state database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+                File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{ not json")
+
+                let nested = Path.Combine(root, "src", "nested")
+                Directory.CreateDirectory(nested) |> ignore
+                let originalDir = Environment.CurrentDirectory
+
+                try
+                    Environment.CurrentDirectory <- nested
+                    let repoDbPath = localStateDbPath root
+                    let cwdDbPath = Path.Combine(nested, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+                    withLocalStateDbOpenTrace root (fun tracePath ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "state.db.schema-version" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        checks.GetArrayLength() |> should equal 1
+
+                        checks[ 0 ].GetProperty("Status").GetString()
+                        |> should equal "Ok"
+
+                        checks[ 0 ].GetProperty("Summary").GetString()
+                        |> should contain "schema_version is 2"
+
+                        let trace = readTrace tracePath
+                        trace |> should contain repoDbPath
+                        trace |> should not' (contain cwdDbPath)
+
+                        File.Exists(cwdDbPath) |> should equal false
+
+                        Directory.Exists(Path.GetDirectoryName(cwdDbPath))
+                        |> should equal false)
+                finally
+                    Environment.CurrentDirectory <- originalDir))
+
+    [<Test>]
     let ``doctor local-state database path occupied by directory reports failure without mutation`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -6,10 +6,12 @@ open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client
 open Grace.Types
+open Microsoft.Data.Sqlite
 open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text
 open System.Text.Json
 
 [<NonParallelizable>]
@@ -137,6 +139,51 @@ module DoctorCliTests =
 
         Path.Combine(graceDir, Constants.GraceConfigFileName)
 
+    let private localStateDbPath root = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+    let private getCorruptBackups root =
+        let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+
+        if Directory.Exists(graceDir) then
+            Directory.GetFiles(graceDir, "grace-local.corrupt.*.db")
+        else
+            Array.empty
+
+    let private ensureValidLocalStateDb root =
+        writeGraceConfig root "http://127.0.0.1:5000"
+        |> ignore
+
+        LocalStateDb
+            .ensureDbInitialized(localStateDbPath root)
+            .GetAwaiter()
+            .GetResult()
+
+    let private openRawConnection (dbPath: string) =
+        let connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+        connection
+
+    let private executeNonQuery (connection: SqliteConnection) (sql: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- sql
+        cmd.ExecuteNonQuery() |> ignore
+
+    let private seedSchemaVersionOnly (dbPath: string) (schemaVersion: string) =
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+        |> ignore
+
+        use connection = openRawConnection dbPath
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+        executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{schemaVersion}');"
+
+    let private snapshotFile (path: string) =
+        if File.Exists(path) then
+            use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+            use reader = new BinaryReader(stream)
+            Some(Convert.ToBase64String(reader.ReadBytes(int stream.Length)), File.GetLastWriteTimeUtc(path))
+        else
+            None
+
     let private snapshotFiles root =
         if Directory.Exists(root) then
             Directory.GetFiles(root, "*", SearchOption.AllDirectories)
@@ -201,6 +248,18 @@ module DoctorCliTests =
 
     let private validPat () = PersonalAccessToken.formatToken "doctor-user" (Guid.NewGuid()) (Array.create 32 7uy)
 
+    let private localStateCheckIds =
+        [|
+            "state.db.file-present"
+            "state.db.read-only-open"
+            "state.db.schema-version"
+            "state.db.required-tables"
+            "state.db.required-indexes"
+            "state.db.integrity-check"
+            "state.db.foreign-key-check"
+            "object-cache.index-readable"
+        |]
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -242,12 +301,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 15
+            |> should equal 23
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 15
+            |> should equal 23
 
             let catalogIds =
                 returnValue
@@ -267,6 +326,30 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration"
+
+            catalogIds
+            |> should contain "state.db.file-present"
+
+            catalogIds
+            |> should contain "state.db.read-only-open"
+
+            catalogIds
+            |> should contain "state.db.schema-version"
+
+            catalogIds
+            |> should contain "state.db.required-tables"
+
+            catalogIds
+            |> should contain "state.db.required-indexes"
+
+            catalogIds
+            |> should contain "state.db.integrity-check"
+
+            catalogIds
+            |> should contain "state.db.foreign-key-check"
+
+            catalogIds
+            |> should contain "object-cache.index-readable"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -311,7 +394,7 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 13
+            catalogIds.Count |> should equal 21
 
             catalogIds |> should contain "config.file.parse"
 
@@ -329,6 +412,12 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration"
+
+            catalogIds
+            |> should contain "state.db.file-present"
+
+            catalogIds
+            |> should contain "object-cache.index-readable"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -869,6 +958,354 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration")
+
+    [<Test>]
+    let ``doctor list checks includes local-state and object-cache catalog ids`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            for checkId in localStateCheckIds do
+                catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor local-state valid database reports read-only metadata checks`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let args =
+                    [|
+                        yield "--output"
+                        yield "Json"
+                        yield "doctor"
+
+                        for checkId in localStateCheckIds do
+                            yield "--check"
+                            yield checkId
+                    |]
+
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength()
+                |> should equal localStateCheckIds.Length
+
+                for checkId in localStateCheckIds do
+                    let check = findCheckById checks checkId
+
+                    check.GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "schema_version is 2"
+
+                (findCheckById checks "object-cache.index-readable")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "without mutation"))
+
+    [<Test>]
+    let ``doctor missing local-state parent reports check result without creating files`` () =
+        withTempDir (fun root ->
+            let beforeRoot = snapshotFiles root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "state.db.file-present"
+                                                  "--check"
+                                                  "state.db.read-only-open" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            (findCheckById checks "state.db.file-present")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Warning"
+
+            (findCheckById checks "state.db.read-only-open")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped"
+
+            Directory.Exists(Path.Combine(root, Constants.GraceConfigDirectory))
+            |> should equal false
+
+            snapshotFiles root |> should equal beforeRoot)
+
+    [<Test>]
+    let ``doctor missing local-state database warns without creating database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                File.Exists(dbPath) |> should equal false
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.file-present"
+                                                      "--check"
+                                                      "state.db.schema-version" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.file-present")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Warning"
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Skipped"
+
+                File.Exists(dbPath) |> should equal false
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor local-state database path occupied by directory reports failure without mutation`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                Directory.CreateDirectory(dbPath) |> ignore
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.file-present"
+                                                      "--check"
+                                                      "state.db.read-only-open" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.file-present")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                (findCheckById checks "state.db.read-only-open")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                Directory.Exists(dbPath) |> should equal true
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor corrupt local-state database reports failure without moving bytes or sidecars`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                let bytes = Encoding.UTF8.GetBytes("not a sqlite database")
+                File.WriteAllBytes(dbPath, bytes)
+
+                let oldTime = DateTime.UtcNow.AddDays(-3.0)
+
+                let sidecars =
+                    [| "-journal"; "-wal"; "-shm" |]
+                    |> Array.map (fun suffix -> dbPath + suffix)
+
+                for sidecar in sidecars do
+                    File.WriteAllText(sidecar, "sentinel")
+                    File.SetLastWriteTimeUtc(sidecar, oldTime)
+
+                let dbBefore = snapshotFile dbPath
+                let sidecarsBefore = sidecars |> Array.map snapshotFile
+                let corruptBefore = getCorruptBackups root |> Array.length
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.read-only-open"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 1
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Failed\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut
+                |> should not' (contain "not a sqlite database")
+
+                snapshotFile dbPath |> should equal dbBefore
+
+                sidecars
+                |> Array.map snapshotFile
+                |> should equal sidecarsBefore
+
+                let corruptAfter = getCorruptBackups root |> Array.length
+                corruptAfter |> should equal corruptBefore))
+
+    [<Test>]
+    let ``doctor schema mismatch fails without corrupt backup`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                seedSchemaVersionOnly dbPath "0"
+                let dbBefore = snapshotFile dbPath
+                let corruptBefore = getCorruptBackups root |> Array.length
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.schema-version"
+                                                      "--check"
+                                                      "state.db.required-tables"
+                                                      "--check"
+                                                      "object-cache.index-readable" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                (findCheckById checks "state.db.required-tables")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "status_meta"
+
+                (findCheckById checks "object-cache.index-readable")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                snapshotFile dbPath |> should equal dbBefore
+
+                let corruptAfter = getCorruptBackups root |> Array.length
+                corruptAfter |> should equal corruptBefore))
+
+    [<Test>]
+    let ``doctor local-state exact check selections are not filtered out`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                for checkId in localStateCheckIds do
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          checkId |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Id").GetString()
+                    |> should equal checkId))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor local-state successful diagnostics emit no output for quiet output modes`` output =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.schema-version" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
 
     [<Test>]
     let ``doctor verbose select returns clean scalar for passing config check`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -97,6 +97,13 @@ module DoctorCliTests =
         finally
             Environment.SetEnvironmentVariable(name, original)
 
+    let private withLocalStateDbOpenTrace root (action: string -> unit) =
+        let tracePath = Path.Combine(root, "local-state-open-trace.log")
+
+        withEnv "GRACE_LOCALSTATE_DB_TRACE_PATH" (Some tracePath) (fun () -> withEnv "GRACE_LOCALSTATE_DB_TRACE_OPEN" (Some "1") (fun () -> action tracePath))
+
+    let private readTrace tracePath = if File.Exists(tracePath) then File.ReadAllText(tracePath) else String.Empty
+
     let private withIsolatedHome (root: string) (action: string -> unit) =
         let home = Path.Combine(root, "home")
         Directory.CreateDirectory(home) |> ignore
@@ -980,6 +987,109 @@ module DoctorCliTests =
 
             for checkId in localStateCheckIds do
                 catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor selected non-local check does not open local-state database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                File.WriteAllText(dbPath, "not a sqlite database")
+                let dbBefore = snapshotFile dbPath
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "config.file.parse" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Id").GetString()
+                    |> should equal "config.file.parse"
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    readTrace tracePath |> should equal String.Empty
+                    snapshotFile dbPath |> should equal dbBefore)))
+
+    [<Test>]
+    let ``doctor selected local-state check opens local-state database read-only`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "state.db.schema-version" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting")))
+
+    [<Test>]
+    let ``doctor default run opens local-state database and includes local-state checks`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    for checkId in localStateCheckIds do
+                        (findCheckById checks checkId)
+                            .GetProperty("Id")
+                            .GetString()
+                        |> should equal checkId
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting")))
 
     [<Test>]
     let ``doctor local-state valid database reports read-only metadata checks`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1061,6 +1061,68 @@ module DoctorCliTests =
                     |> should contain "openReadOnlyConnection starting")))
 
     [<Test>]
+    let ``doctor local-state checks inspect checkpointed wal database without creating missing sidecars`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+                SqliteConnection.ClearAllPools()
+
+                let dbPath = localStateDbPath root
+                let walPath = dbPath + "-wal"
+                let shmPath = dbPath + "-shm"
+
+                for sidecar in [| walPath; shmPath |] do
+                    if File.Exists(sidecar) then File.Delete(sidecar)
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+
+                let dbBefore = snapshotFile dbPath
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "state.db.read-only-open"
+                                                          "--check"
+                                                          "state.db.schema-version"
+                                                          "--check"
+                                                          "state.db.integrity-check"
+                                                          "--check"
+                                                          "object-cache.index-readable" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    for checkId in
+                        [|
+                            "state.db.read-only-open"
+                            "state.db.schema-version"
+                            "state.db.integrity-check"
+                            "object-cache.index-readable"
+                        |] do
+                        (findCheckById checks checkId)
+                            .GetProperty("Status")
+                            .GetString()
+                        |> should equal "Ok"
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting"
+
+                    snapshotFile dbPath |> should equal dbBefore
+                    File.Exists(walPath) |> should equal false
+                    File.Exists(shmPath) |> should equal false)))
+
+    [<Test>]
     let ``doctor default run opens local-state database and includes local-state checks`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -141,6 +141,14 @@ module LocalStateDbTests =
         else
             Directory.GetFiles(directoryPath, "grace-local.corrupt.*.db")
 
+    let private snapshotFile (path: string) =
+        if File.Exists(path) then
+            use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+            use reader = new BinaryReader(stream)
+            Some(reader.ReadBytes(int stream.Length), File.GetLastWriteTimeUtc(path))
+        else
+            None
+
     let private seedSchemaVersionOnly (dbPath: string) (schemaVersion: string) =
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
         |> ignore
@@ -520,6 +528,162 @@ module LocalStateDbTests =
                 if File.Exists(shmPath) then
                     File.GetLastWriteTimeUtc(shmPath)
                     |> should be (greaterThan oldTime)
+            })
+
+    [<Test>]
+    let ``read-only inspection reports valid database metadata`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+                inspection.OpenError |> should equal None
+
+                inspection.SchemaVersion
+                |> should equal (Some "2")
+
+                inspection.MissingRequiredTables
+                |> should equal Array.empty<string>
+
+                inspection.MissingRequiredIndexes
+                |> should equal Array.empty<string>
+
+                inspection.IntegrityCheckRows
+                |> should equal [| "ok" |]
+
+                inspection.ForeignKeyViolations
+                |> should equal Array.empty<string>
+
+                inspection.ObjectCacheReadable
+                |> should equal (Some true)
+
+                inspection.ObjectCacheError |> should equal None
+            })
+
+    [<Test>]
+    let ``read-only inspection does not create missing parent or database`` () =
+        withTempDir (fun root _ ->
+            task {
+                let missingDbPath = Path.Combine(root, "missing-grace", Constants.GraceLocalStateDbFileName)
+
+                let inspection = LocalStateDb.inspectReadOnly missingDbPath
+
+                inspection.ParentDirectoryExists
+                |> should equal false
+
+                inspection.DbFileExists |> should equal false
+                inspection.OpenedReadOnly |> should equal false
+
+                Directory.Exists(Path.GetDirectoryName(missingDbPath))
+                |> should equal false
+
+                File.Exists(missingDbPath) |> should equal false
+            })
+
+    [<Test>]
+    let ``read-only inspection preserves corrupt bytes sidecars and backups`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                Directory.CreateDirectory(Path.GetDirectoryName(configuration.GraceStatusFile))
+                |> ignore
+
+                let corruptBytes = Encoding.UTF8.GetBytes("this is not a sqlite database")
+                File.WriteAllBytes(configuration.GraceStatusFile, corruptBytes)
+
+                let oldTime = DateTime.UtcNow.AddDays(-2.0)
+
+                let sidecars =
+                    [| "-journal"; "-wal"; "-shm" |]
+                    |> Array.map (fun suffix -> configuration.GraceStatusFile + suffix)
+
+                for sidecar in sidecars do
+                    File.WriteAllText(sidecar, $"sentinel-{Path.GetFileName(sidecar)}")
+                    File.SetLastWriteTimeUtc(sidecar, oldTime)
+
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+                let sidecarsBefore = sidecars |> Array.map snapshotFile
+
+                let backupsBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal false
+                inspection.OpenError.IsSome |> should equal true
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                sidecars
+                |> Array.map snapshotFile
+                |> should equal sidecarsBefore
+
+                let backupsAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                backupsAfter |> should equal backupsBefore
+            })
+
+    [<Test>]
+    let ``read-only inspection reports schema mismatch without corrupt backup`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                seedSchemaVersionOnly configuration.GraceStatusFile "0"
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+
+                let backupsBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.SchemaVersion
+                |> should equal (Some "0")
+
+                inspection.MissingRequiredTables
+                |> should contain "status_meta"
+
+                inspection.MissingRequiredIndexes
+                |> should contain "ix_object_cache_files_path_hash"
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                let backupsAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                backupsAfter |> should equal backupsBefore
+            })
+
+    [<Test>]
+    let ``read-only inspection reports foreign-key inconsistency without repair`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery connection "PRAGMA foreign_keys = OFF;"
+
+                executeNonQuery
+                    connection
+                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('00000000-0000-0000-0000-000000000111', 'orphan.txt', 'hash', 0, 1, 0, 0, 0);"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.ForeignKeyViolations.Length
+                |> should be (greaterThan 0)
+
+                let orphanCount = executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directory_files WHERE relative_path = 'orphan.txt';"
+                orphanCount |> should equal 1
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -563,7 +563,7 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``read-only inspection does not create missing wal sidecars`` () =
+    let ``read-only inspection opens checkpointed wal database without creating missing sidecars`` () =
         withTempDir (fun _ configuration ->
             task {
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
@@ -582,11 +582,17 @@ module LocalStateDbTests =
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
 
-                inspection.OpenedReadOnly |> should equal false
+                inspection.OpenedReadOnly |> should equal true
+                inspection.OpenError |> should equal None
 
-                inspection.OpenError
-                |> Option.defaultValue String.Empty
-                |> should contain "required sidecar files are missing"
+                inspection.SchemaVersion
+                |> should equal (Some "2")
+
+                inspection.IntegrityCheckRows
+                |> should equal [| "ok" |]
+
+                inspection.ObjectCacheReadable
+                |> should equal (Some true)
 
                 snapshotFile configuration.GraceStatusFile
                 |> should equal dbBefore

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -563,6 +563,39 @@ module LocalStateDbTests =
             })
 
     [<Test>]
+    let ``read-only inspection does not create missing wal sidecars`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                SqliteConnection.ClearAllPools()
+
+                let walPath = configuration.GraceStatusFile + "-wal"
+                let shmPath = configuration.GraceStatusFile + "-shm"
+
+                for sidecar in [| walPath; shmPath |] do
+                    if File.Exists(sidecar) then File.Delete(sidecar)
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal false
+
+                inspection.OpenError
+                |> Option.defaultValue String.Empty
+                |> should contain "required sidecar files are missing"
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+            })
+
+    [<Test>]
     let ``read-only inspection does not create missing parent or database`` () =
         withTempDir (fun root _ ->
             task {

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -397,7 +397,7 @@ module Doctor =
     type private ConfigurationInspectionState =
         | ConfigurationLoaded of Configuration.GraceConfigurationInspection
         | ConfigurationMissing of string
-        | ConfigurationMalformed of string
+        | ConfigurationMalformed of path: string * message: string
 
     type private DoctorInspectionContext =
         {
@@ -415,13 +415,13 @@ module Doctor =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
             | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
-            | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
+            | Error (Configuration.ConfigurationFileMalformed (path, message)) -> ConfigurationMalformed(path, message)
 
         let localStateDbPath =
             match configurationState with
             | ConfigurationLoaded inspection -> inspection.Configuration.GraceStatusFile
-            | ConfigurationMissing _
-            | ConfigurationMalformed _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+            | ConfigurationMalformed (path, _) -> Path.Combine(Path.GetDirectoryName(path), Constants.GraceLocalStateDbFileName)
+            | ConfigurationMissing _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
 
         {
             ConfigurationState = configurationState
@@ -632,12 +632,12 @@ module Doctor =
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
             | ConfigurationMissing message -> warning $"{message} No configuration file was created."
-            | ConfigurationMalformed _ -> ok $"Found {Constants.GraceConfigFileName}, but parsing is reported by {ConfigFileParseCheckId}."
+            | ConfigurationMalformed (path, _) -> ok $"Found {Constants.GraceConfigFileName} at {path}, but parsing is reported by {ConfigFileParseCheckId}."
         | ConfigFileParseCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Parsed {inspection.Path} without rewriting it."
             | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
-            | ConfigurationMalformed message -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
+            | ConfigurationMalformed (_, message) -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
         | ConfigRepositoryIdentityCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection ->

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1,5 +1,6 @@
 namespace Grace.CLI.Command
 
+open Grace.CLI
 open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
@@ -11,6 +12,7 @@ open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
+open System.IO
 open System.Threading
 open System.Threading.Tasks
 
@@ -57,6 +59,33 @@ module Doctor =
 
     [<Literal>]
     let private AuthOidcConfigurationCheckId = "auth.oidc.configuration"
+
+    [<Literal>]
+    let private StateDbFilePresentCheckId = "state.db.file-present"
+
+    [<Literal>]
+    let private StateDbReadOnlyOpenCheckId = "state.db.read-only-open"
+
+    [<Literal>]
+    let private StateDbSchemaVersionCheckId = "state.db.schema-version"
+
+    [<Literal>]
+    let private StateDbRequiredTablesCheckId = "state.db.required-tables"
+
+    [<Literal>]
+    let private StateDbRequiredIndexesCheckId = "state.db.required-indexes"
+
+    [<Literal>]
+    let private StateDbIntegrityCheckId = "state.db.integrity-check"
+
+    [<Literal>]
+    let private StateDbForeignKeyCheckId = "state.db.foreign-key-check"
+
+    [<Literal>]
+    let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
+
+    [<Literal>]
+    let private ExpectedLocalStateSchemaVersion = "2"
 
     module private Options =
         let full =
@@ -210,6 +239,70 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = StateDbFilePresentCheckId
+                Category = "Local state"
+                Title = "Local state database file"
+                Description = "Checks the configured .grace/grace-local.db path without creating directories or files."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbReadOnlyOpenCheckId
+                Category = "Local state"
+                Title = "Local state read-only open"
+                Description = "Opens the local state SQLite database in read-only mode without initialization, migration, or repair."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbSchemaVersionCheckId
+                Category = "Local state"
+                Title = "Local state schema version"
+                Description = "Reads the local state schema_version metadata without writing defaults."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbRequiredTablesCheckId
+                Category = "Local state"
+                Title = "Local state required tables"
+                Description = "Verifies required local state tables from sqlite_master without creating schema objects."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbRequiredIndexesCheckId
+                Category = "Local state"
+                Title = "Local state required indexes"
+                Description = "Verifies required local state indexes from sqlite_master without creating schema objects."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbIntegrityCheckId
+                Category = "Local state"
+                Title = "SQLite integrity check"
+                Description = "Runs SQLite integrity_check read-only and reports the result without repair."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbForeignKeyCheckId
+                Category = "Local state"
+                Title = "SQLite foreign-key check"
+                Description = "Runs SQLite foreign_key_check read-only and reports violations without mutation."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ObjectCacheIndexReadableCheckId
+                Category = "Object cache"
+                Title = "Object-cache index readability"
+                Description = "Reads object-cache metadata tables from the local state database without repairing rows."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -312,6 +405,7 @@ module Doctor =
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
+            LocalStateInspection: LocalStateDb.ReadOnlyLocalStateInspection
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -323,6 +417,12 @@ module Doctor =
             | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
             | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
 
+        let localStateDbPath =
+            match configurationState with
+            | ConfigurationLoaded inspection -> inspection.Configuration.GraceStatusFile
+            | ConfigurationMissing _
+            | ConfigurationMalformed _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
         {
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
@@ -330,6 +430,7 @@ module Doctor =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
             AuthInspection = Auth.inspectAuthEnvironment ()
+            LocalStateInspection = LocalStateDb.inspectReadOnly localStateDbPath
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -348,6 +449,20 @@ module Doctor =
         |> Array.map (fun field -> field.Name)
 
     let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
+
+    let private formatListOrNone (values: string array) = if Array.isEmpty values then "none" else String.Join(", ", values)
+
+    let private localStateUnavailableSummary checkId (inspection: LocalStateDb.ReadOnlyLocalStateInspection) =
+        if not inspection.ParentDirectoryExists then
+            $"Skipped because {StateDbFilePresentCheckId} did not find the local .grace directory for {inspection.DbPath}; doctor did not create it."
+        elif inspection.DbPathIsDirectory then
+            $"Skipped because {StateDbFilePresentCheckId} found a directory at the database path {inspection.DbPath}."
+        elif not inspection.DbFileExists then
+            $"Skipped because {StateDbFilePresentCheckId} did not find {inspection.DbPath}; doctor did not create it."
+        else
+            match inspection.OpenError with
+            | Some message -> $"Skipped because {StateDbReadOnlyOpenCheckId} could not open the database read-only: {message}"
+            | None -> $"Skipped because {checkId} requires a read-only local state database inspection."
 
     let private oidcSummary (auth: Auth.AuthInspection) =
         let m2mMissing = missingRequiredFields auth.M2mFields
@@ -416,6 +531,103 @@ module Doctor =
             if auth.M2mComplete || auth.CliComplete then ok summary
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
+        | StateDbFilePresentCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.ParentDirectoryExists then
+                warning
+                    $"Local state directory was not found for {inspection.DbPath}; doctor did not create it. Run a Grace command that initializes local state when you are ready to create evidence."
+            elif inspection.DbPathIsDirectory then
+                failed
+                    $"Local state database path is a directory: {inspection.DbPath}. Move the directory aside or restore a valid {Constants.GraceLocalStateDbFileName} file."
+            elif not inspection.DbFileExists then
+                warning
+                    $"Local state database was not found at {inspection.DbPath}; doctor did not create it. Run a Grace command that initializes local state when local status is expected."
+            else
+                ok $"Local state database file exists at {inspection.DbPath}."
+        | StateDbReadOnlyOpenCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if inspection.OpenedReadOnly then
+                ok "Opened the local state database with SQLite read-only mode. No initialization, migration, WAL change, or repair was attempted."
+            elif inspection.DbPathIsDirectory then
+                failed $"Could not open local state read-only because the DB path is a directory: {inspection.DbPath}."
+            elif inspection.ParentDirectoryExists
+                 && inspection.DbFileExists then
+                let openError =
+                    inspection.OpenError
+                    |> Option.defaultValue "unknown SQLite error"
+
+                failed $"Could not open local state read-only: {openError}"
+            else
+                skipped check (localStateUnavailableSummary StateDbReadOnlyOpenCheckId inspection)
+        | StateDbSchemaVersionCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbSchemaVersionCheckId inspection)
+            else
+                match inspection.SchemaVersion with
+                | Some version when version = ExpectedLocalStateSchemaVersion -> ok $"Local state schema_version is {ExpectedLocalStateSchemaVersion}."
+                | Some version ->
+                    failed
+                        $"Local state schema_version is {version}; expected {ExpectedLocalStateSchemaVersion}. Doctor did not migrate, recreate, or move corrupt database files."
+                | None -> failed "Local state schema_version metadata is missing or unreadable. Doctor did not write default metadata."
+        | StateDbRequiredTablesCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbRequiredTablesCheckId inspection)
+            elif Array.isEmpty inspection.MissingRequiredTables then
+                ok "All required local state tables are present."
+            else
+                failed $"Missing required local state tables: {formatListOrNone inspection.MissingRequiredTables}. Doctor did not create schema objects."
+        | StateDbRequiredIndexesCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbRequiredIndexesCheckId inspection)
+            elif Array.isEmpty inspection.MissingRequiredIndexes then
+                ok "All required local state indexes are present."
+            else
+                failed $"Missing required local state indexes: {formatListOrNone inspection.MissingRequiredIndexes}. Doctor did not create schema objects."
+        | StateDbIntegrityCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbIntegrityCheckId inspection)
+            elif inspection.IntegrityCheckRows.Length = 1
+                 && inspection
+                     .IntegrityCheckRows[ 0 ]
+                     .Equals("ok", StringComparison.OrdinalIgnoreCase) then
+                ok "SQLite integrity_check returned ok."
+            else
+                failed $"SQLite integrity_check reported: {formatListOrNone inspection.IntegrityCheckRows}. Doctor did not repair or rewrite the database."
+        | StateDbForeignKeyCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbForeignKeyCheckId inspection)
+            elif Array.isEmpty inspection.ForeignKeyViolations then
+                ok "SQLite foreign_key_check returned no violations."
+            else
+                failed
+                    $"SQLite foreign_key_check reported violations: {formatListOrNone inspection.ForeignKeyViolations}. Doctor did not repair object-cache rows."
+        | ObjectCacheIndexReadableCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary ObjectCacheIndexReadableCheckId inspection)
+            else
+                match inspection.ObjectCacheReadable with
+                | Some true -> ok "Object-cache metadata tables are readable from the local state database without mutation."
+                | Some false ->
+                    let objectCacheError =
+                        inspection.ObjectCacheError
+                        |> Option.defaultValue "unknown SQLite error"
+
+                    failed $"Object-cache metadata is not readable: {objectCacheError}. Doctor did not repair object-cache rows."
+                | None -> skipped check "Object-cache metadata readability was not attempted."
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -405,7 +405,7 @@ module Doctor =
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
-            LocalStateInspection: LocalStateDb.ReadOnlyLocalStateInspection
+            LocalStateInspection: Lazy<LocalStateDb.ReadOnlyLocalStateInspection>
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -430,7 +430,7 @@ module Doctor =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
             AuthInspection = Auth.inspectAuthEnvironment ()
-            LocalStateInspection = LocalStateDb.inspectReadOnly localStateDbPath
+            LocalStateInspection = lazy (LocalStateDb.inspectReadOnly localStateDbPath)
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -532,7 +532,7 @@ module Doctor =
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
         | StateDbFilePresentCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.ParentDirectoryExists then
                 warning
@@ -546,7 +546,7 @@ module Doctor =
             else
                 ok $"Local state database file exists at {inspection.DbPath}."
         | StateDbReadOnlyOpenCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if inspection.OpenedReadOnly then
                 ok "Opened the local state database with SQLite read-only mode. No initialization, migration, WAL change, or repair was attempted."
@@ -562,7 +562,7 @@ module Doctor =
             else
                 skipped check (localStateUnavailableSummary StateDbReadOnlyOpenCheckId inspection)
         | StateDbSchemaVersionCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbSchemaVersionCheckId inspection)
@@ -574,7 +574,7 @@ module Doctor =
                         $"Local state schema_version is {version}; expected {ExpectedLocalStateSchemaVersion}. Doctor did not migrate, recreate, or move corrupt database files."
                 | None -> failed "Local state schema_version metadata is missing or unreadable. Doctor did not write default metadata."
         | StateDbRequiredTablesCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbRequiredTablesCheckId inspection)
@@ -583,7 +583,7 @@ module Doctor =
             else
                 failed $"Missing required local state tables: {formatListOrNone inspection.MissingRequiredTables}. Doctor did not create schema objects."
         | StateDbRequiredIndexesCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbRequiredIndexesCheckId inspection)
@@ -592,7 +592,7 @@ module Doctor =
             else
                 failed $"Missing required local state indexes: {formatListOrNone inspection.MissingRequiredIndexes}. Doctor did not create schema objects."
         | StateDbIntegrityCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbIntegrityCheckId inspection)
@@ -604,7 +604,7 @@ module Doctor =
             else
                 failed $"SQLite integrity_check reported: {formatListOrNone inspection.IntegrityCheckRows}. Doctor did not repair or rewrite the database."
         | StateDbForeignKeyCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbForeignKeyCheckId inspection)
@@ -614,7 +614,7 @@ module Doctor =
                 failed
                     $"SQLite foreign_key_check reported violations: {formatListOrNone inspection.ForeignKeyViolations}. Doctor did not repair object-cache rows."
         | ObjectCacheIndexReadableCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary ObjectCacheIndexReadableCheckId inspection)

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -5,6 +5,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.IO
+open System.Text
 open System.Threading
 open System.Threading.Tasks
 open Grace.Shared.Client.Configuration
@@ -254,6 +255,32 @@ module LocalStateDb =
 
             raise ex
 
+    let private sqliteHeaderMagic = Encoding.ASCII.GetBytes("SQLite format 3" + string (char 0))
+
+    let private isWalModeHeader (dbPath: string) =
+        try
+            use stream = new FileStream(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+
+            if stream.Length < 20L then
+                false
+            else
+                let header = Array.zeroCreate<byte> 20
+                let bytesRead = stream.Read(header, 0, header.Length)
+
+                bytesRead = header.Length
+                && header[0..15] = sqliteHeaderMagic
+                && header[18] = 2uy
+                && header[19] = 2uy
+        with
+        | _ -> false
+
+    let private missingWalSidecars (dbPath: string) =
+        if isWalModeHeader dbPath then
+            [| dbPath + "-wal"; dbPath + "-shm" |]
+            |> Array.filter (File.Exists >> not)
+        else
+            Array.empty
+
     let private readTextRows (connection: SqliteConnection) (sql: string) =
         use cmd = connection.CreateCommand()
         cmd.CommandText <- sql
@@ -337,56 +364,73 @@ module LocalStateDb =
            || dbPathIsDirectory then
             emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
         else
-            try
-                use connection = openReadOnlyConnection normalizedPath
-                let tableNames = readObjectNames connection "table"
-                let indexNames = readObjectNames connection "index"
+            let missingWalSidecars = missingWalSidecars normalizedPath
 
-                let missingRequiredTables =
-                    requiredTableNames
-                    |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
+            if missingWalSidecars.Length > 0 then
+                let missingNames =
+                    missingWalSidecars
+                    |> Array.map Path.GetFileName
+                    |> String.concat ", "
 
-                let missingRequiredIndexes =
-                    requiredIndexNames
-                    |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
+                emptyReadOnlyInspection
+                    normalizedPath
+                    parentDirectoryExists
+                    dbFileExists
+                    dbPathIsDirectory
+                    false
+                    (Some
+                        $"Database is in WAL mode but required sidecar files are missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files.")
+            else
+                try
+                    use connection = openReadOnlyConnection normalizedPath
+                    let tableNames = readObjectNames connection "table"
+                    let indexNames = readObjectNames connection "index"
 
-                let schemaVersion =
-                    try
-                        readSchemaVersionReadOnly connection
-                    with
-                    | _ -> None
+                    let missingRequiredTables =
+                        requiredTableNames
+                        |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
 
-                let integrityRows =
-                    try
-                        readTextRows connection "PRAGMA integrity_check;"
-                    with
-                    | ex -> [| ex.Message |]
+                    let missingRequiredIndexes =
+                        requiredIndexNames
+                        |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
 
-                let foreignKeyViolations =
-                    try
-                        readForeignKeyViolations connection
-                    with
-                    | ex -> [| ex.Message |]
+                    let schemaVersion =
+                        try
+                            readSchemaVersionReadOnly connection
+                        with
+                        | _ -> None
 
-                let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+                    let integrityRows =
+                        try
+                            readTextRows connection "PRAGMA integrity_check;"
+                        with
+                        | ex -> [| ex.Message |]
 
-                {
-                    DbPath = normalizedPath
-                    ParentDirectoryExists = parentDirectoryExists
-                    DbFileExists = dbFileExists
-                    DbPathIsDirectory = dbPathIsDirectory
-                    OpenedReadOnly = true
-                    OpenError = None
-                    SchemaVersion = schemaVersion
-                    MissingRequiredTables = missingRequiredTables
-                    MissingRequiredIndexes = missingRequiredIndexes
-                    IntegrityCheckRows = integrityRows
-                    ForeignKeyViolations = foreignKeyViolations
-                    ObjectCacheReadable = objectCacheReadable
-                    ObjectCacheError = objectCacheError
-                }
-            with
-            | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
+                    let foreignKeyViolations =
+                        try
+                            readForeignKeyViolations connection
+                        with
+                        | ex -> [| ex.Message |]
+
+                    let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+
+                    {
+                        DbPath = normalizedPath
+                        ParentDirectoryExists = parentDirectoryExists
+                        DbFileExists = dbFileExists
+                        DbPathIsDirectory = dbPathIsDirectory
+                        OpenedReadOnly = true
+                        OpenError = None
+                        SchemaVersion = schemaVersion
+                        MissingRequiredTables = missingRequiredTables
+                        MissingRequiredIndexes = missingRequiredIndexes
+                        IntegrityCheckRows = integrityRows
+                        ForeignKeyViolations = foreignKeyViolations
+                        ObjectCacheReadable = objectCacheReadable
+                        ObjectCacheError = objectCacheError
+                    }
+                with
+                | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
 
     let private tryGetMetaValue (connection: SqliteConnection) (key: string) =
         use cmd = connection.CreateCommand()

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -159,6 +159,224 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
         |]
 
+    let private requiredTableNames =
+        [|
+            "meta"
+            "status_meta"
+            "status_directories"
+            "status_files"
+            "object_cache_directories"
+            "object_cache_directory_children"
+            "object_cache_directory_files"
+        |]
+
+    let private requiredIndexNames =
+        [|
+            "ix_status_directories_parent"
+            "ix_status_directories_directory_version_id"
+            "ix_status_files_directory_path"
+            "ix_status_files_directory_version_id"
+            "ix_status_files_sha256"
+            "ix_object_cache_directories_relative_path"
+            "ix_object_cache_children_parent"
+            "ix_object_cache_files_path_hash"
+        |]
+
+    type ReadOnlyLocalStateInspection =
+        {
+            DbPath: string
+            ParentDirectoryExists: bool
+            DbFileExists: bool
+            DbPathIsDirectory: bool
+            OpenedReadOnly: bool
+            OpenError: string option
+            SchemaVersion: string option
+            MissingRequiredTables: string array
+            MissingRequiredIndexes: string array
+            IntegrityCheckRows: string array
+            ForeignKeyViolations: string array
+            ObjectCacheReadable: bool option
+            ObjectCacheError: string option
+        }
+
+    let private emptyReadOnlyInspection dbPath parentDirectoryExists dbFileExists dbPathIsDirectory openedReadOnly openError =
+        {
+            DbPath = dbPath
+            ParentDirectoryExists = parentDirectoryExists
+            DbFileExists = dbFileExists
+            DbPathIsDirectory = dbPathIsDirectory
+            OpenedReadOnly = openedReadOnly
+            OpenError = openError
+            SchemaVersion = None
+            MissingRequiredTables = requiredTableNames
+            MissingRequiredIndexes = requiredIndexNames
+            IntegrityCheckRows = Array.empty
+            ForeignKeyViolations = Array.empty
+            ObjectCacheReadable = None
+            ObjectCacheError = None
+        }
+
+    let private openReadOnlyConnection (dbPath: string) =
+        sqliteInitialized.Value |> ignore
+
+        let connectionString =
+            let builder = SqliteConnectionStringBuilder()
+            builder.DataSource <- dbPath
+            builder.Mode <- SqliteOpenMode.ReadOnly
+            builder.Pooling <- false
+            builder.DefaultTimeout <- BusyTimeoutMs / 1000
+            builder.ToString()
+
+        let connection = new SqliteConnection(connectionString)
+
+        try
+            connection.Open()
+            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
+            executePragma connection "PRAGMA query_only = ON;"
+            connection
+        with
+        | ex ->
+            try
+                connection.Dispose()
+            with
+            | _ -> ()
+
+            raise ex
+
+    let private readTextRows (connection: SqliteConnection) (sql: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- sql
+        use reader = cmd.ExecuteReader()
+        let rows = ResizeArray<string>()
+
+        while reader.Read() do
+            rows.Add(reader.GetString(0))
+
+        rows |> Seq.toArray
+
+    let private readObjectNames (connection: SqliteConnection) objectType =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT name FROM sqlite_master WHERE type = $type;"
+
+        cmd.Parameters.AddWithValue("$type", objectType)
+        |> ignore
+
+        use reader = cmd.ExecuteReader()
+        let names = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+
+        while reader.Read() do
+            names.Add(reader.GetString(0)) |> ignore
+
+        names
+
+    let private readSchemaVersionReadOnly (connection: SqliteConnection) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version' LIMIT 1;"
+        let value = cmd.ExecuteScalar()
+
+        if isNull value || value = DBNull.Value then
+            None
+        else
+            Some(Convert.ToString(value))
+
+    let private readForeignKeyViolations (connection: SqliteConnection) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "PRAGMA foreign_key_check;"
+        use reader = cmd.ExecuteReader()
+        let violations = ResizeArray<string>()
+
+        while reader.Read() do
+            let tableName = reader.GetString(0)
+            let rowId = reader.GetInt64(1)
+            let parent = reader.GetString(2)
+            let foreignKeyId = reader.GetInt32(3)
+            violations.Add($"{tableName}:{rowId}->{parent}#{foreignKeyId}")
+
+        violations |> Seq.toArray
+
+    let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
+        try
+            for tableName in
+                [|
+                    "object_cache_directories"
+                    "object_cache_directory_children"
+                    "object_cache_directory_files"
+                |] do
+                use cmd = connection.CreateCommand()
+                cmd.CommandText <- $"SELECT COUNT(*) FROM {tableName};"
+                cmd.ExecuteScalar() |> ignore
+
+            Some true, None
+        with
+        | ex -> Some false, Some ex.Message
+
+    let inspectReadOnly (dbPath: string) =
+        let normalizedPath = Path.GetFullPath(dbPath)
+        let directoryPath = Path.GetDirectoryName(normalizedPath)
+
+        let parentDirectoryExists =
+            String.IsNullOrWhiteSpace(directoryPath)
+            || Directory.Exists(directoryPath)
+
+        let dbFileExists = File.Exists(normalizedPath)
+        let dbPathIsDirectory = Directory.Exists(normalizedPath)
+
+        if not parentDirectoryExists
+           || (not dbFileExists && not dbPathIsDirectory)
+           || dbPathIsDirectory then
+            emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
+        else
+            try
+                use connection = openReadOnlyConnection normalizedPath
+                let tableNames = readObjectNames connection "table"
+                let indexNames = readObjectNames connection "index"
+
+                let missingRequiredTables =
+                    requiredTableNames
+                    |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
+
+                let missingRequiredIndexes =
+                    requiredIndexNames
+                    |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
+
+                let schemaVersion =
+                    try
+                        readSchemaVersionReadOnly connection
+                    with
+                    | _ -> None
+
+                let integrityRows =
+                    try
+                        readTextRows connection "PRAGMA integrity_check;"
+                    with
+                    | ex -> [| ex.Message |]
+
+                let foreignKeyViolations =
+                    try
+                        readForeignKeyViolations connection
+                    with
+                    | ex -> [| ex.Message |]
+
+                let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+
+                {
+                    DbPath = normalizedPath
+                    ParentDirectoryExists = parentDirectoryExists
+                    DbFileExists = dbFileExists
+                    DbPathIsDirectory = dbPathIsDirectory
+                    OpenedReadOnly = true
+                    OpenError = None
+                    SchemaVersion = schemaVersion
+                    MissingRequiredTables = missingRequiredTables
+                    MissingRequiredIndexes = missingRequiredIndexes
+                    IntegrityCheckRows = integrityRows
+                    ForeignKeyViolations = foreignKeyViolations
+                    ObjectCacheReadable = objectCacheReadable
+                    ObjectCacheError = objectCacheError
+                }
+            with
+            | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
+
     let private tryGetMetaValue (connection: SqliteConnection) (key: string) =
         use cmd = connection.CreateCommand()
         cmd.CommandText <- "SELECT value FROM meta WHERE key = $key LIMIT 1;"

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -26,8 +26,8 @@ module LocalStateDb =
     let mutable private verboseEnabled = false
 
     let setVerbose enabled = verboseEnabled <- enabled
-    let private traceFilePath = Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_PATH")
-    let private traceOpenConnections = not (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_OPEN")))
+    let private getTraceFilePath () = Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_PATH")
+    let private shouldTraceOpenConnections () = not (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_OPEN")))
     let private initLocks = ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase)
     let private initializedDbs = ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
 
@@ -39,6 +39,8 @@ module LocalStateDb =
     let private logVerbose message = if verboseEnabled then Log.LogVerbose message
 
     let private logTrace message =
+        let traceFilePath = getTraceFilePath ()
+
         if not (String.IsNullOrWhiteSpace(traceFilePath)) then
             try
                 File.AppendAllText(traceFilePath, $"{DateTime.UtcNow:O} {message}{Environment.NewLine}")
@@ -100,6 +102,7 @@ module LocalStateDb =
     let private openConnection (dbPath: string) =
         sqliteInitialized.Value |> ignore
         let directoryPath = Path.GetDirectoryName(dbPath)
+        let traceOpenConnections = shouldTraceOpenConnections ()
         logVerbose $"LocalStateDb.openConnection starting. dbPath={dbPath} dir={directoryPath}"
 
         if traceOpenConnections then
@@ -218,6 +221,10 @@ module LocalStateDb =
 
     let private openReadOnlyConnection (dbPath: string) =
         sqliteInitialized.Value |> ignore
+        let traceOpenConnections = shouldTraceOpenConnections ()
+
+        if traceOpenConnections then
+            logTrace $"openReadOnlyConnection starting. dbPath={dbPath}"
 
         let connectionString =
             let builder = SqliteConnectionStringBuilder()
@@ -233,6 +240,10 @@ module LocalStateDb =
             connection.Open()
             executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
             executePragma connection "PRAGMA query_only = ON;"
+
+            if traceOpenConnections then
+                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath}"
+
             connection
         with
         | ex ->

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -220,41 +220,6 @@ module LocalStateDb =
             ObjectCacheError = None
         }
 
-    let private openReadOnlyConnection (dbPath: string) =
-        sqliteInitialized.Value |> ignore
-        let traceOpenConnections = shouldTraceOpenConnections ()
-
-        if traceOpenConnections then
-            logTrace $"openReadOnlyConnection starting. dbPath={dbPath}"
-
-        let connectionString =
-            let builder = SqliteConnectionStringBuilder()
-            builder.DataSource <- dbPath
-            builder.Mode <- SqliteOpenMode.ReadOnly
-            builder.Pooling <- false
-            builder.DefaultTimeout <- BusyTimeoutMs / 1000
-            builder.ToString()
-
-        let connection = new SqliteConnection(connectionString)
-
-        try
-            connection.Open()
-            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
-            executePragma connection "PRAGMA query_only = ON;"
-
-            if traceOpenConnections then
-                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath}"
-
-            connection
-        with
-        | ex ->
-            try
-                connection.Dispose()
-            with
-            | _ -> ()
-
-            raise ex
-
     let private sqliteHeaderMagic = Encoding.ASCII.GetBytes("SQLite format 3" + string (char 0))
 
     let private isWalModeHeader (dbPath: string) =
@@ -274,12 +239,65 @@ module LocalStateDb =
         with
         | _ -> false
 
-    let private missingWalSidecars (dbPath: string) =
-        if isWalModeHeader dbPath then
-            [| dbPath + "-wal"; dbPath + "-shm" |]
-            |> Array.filter (File.Exists >> not)
-        else
+    let private walSidecarPaths (dbPath: string) = dbPath + "-wal", dbPath + "-shm"
+
+    let private missingPartialWalSidecars (dbPath: string) =
+        let walPath, shmPath = walSidecarPaths dbPath
+        let walExists = File.Exists(walPath)
+        let shmExists = File.Exists(shmPath)
+
+        if walExists = shmExists then
             Array.empty
+        else
+            [|
+                if not walExists then Path.GetFileName(walPath)
+
+                if not shmExists then Path.GetFileName(shmPath)
+            |]
+
+    let private shouldUseImmutableReadOnlySnapshot (dbPath: string) =
+        let walPath, shmPath = walSidecarPaths dbPath
+
+        isWalModeHeader dbPath
+        && not (File.Exists(walPath))
+        && not (File.Exists(shmPath))
+
+    let private openReadOnlyConnection (dbPath: string) immutableSnapshot =
+        sqliteInitialized.Value |> ignore
+        let traceOpenConnections = shouldTraceOpenConnections ()
+
+        if traceOpenConnections then
+            logTrace $"openReadOnlyConnection starting. dbPath={dbPath} immutableSnapshot={immutableSnapshot}"
+
+        let connectionString =
+            let builder = SqliteConnectionStringBuilder()
+
+            builder.DataSource <- if immutableSnapshot then $"{Uri(dbPath).AbsoluteUri}?immutable=1" else dbPath
+
+            builder.Mode <- SqliteOpenMode.ReadOnly
+            builder.Pooling <- false
+            builder.DefaultTimeout <- BusyTimeoutMs / 1000
+            builder.ToString()
+
+        let connection = new SqliteConnection(connectionString)
+
+        try
+            connection.Open()
+            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
+            executePragma connection "PRAGMA query_only = ON;"
+
+            if traceOpenConnections then
+                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath} immutableSnapshot={immutableSnapshot}"
+
+            connection
+        with
+        | ex ->
+            try
+                connection.Dispose()
+            with
+            | _ -> ()
+
+            raise ex
 
     let private readTextRows (connection: SqliteConnection) (sql: string) =
         use cmd = connection.CreateCommand()
@@ -364,13 +382,10 @@ module LocalStateDb =
            || dbPathIsDirectory then
             emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
         else
-            let missingWalSidecars = missingWalSidecars normalizedPath
+            let missingPartialWalSidecars = missingPartialWalSidecars normalizedPath
 
-            if missingWalSidecars.Length > 0 then
-                let missingNames =
-                    missingWalSidecars
-                    |> Array.map Path.GetFileName
-                    |> String.concat ", "
+            if missingPartialWalSidecars.Length > 0 then
+                let missingNames = String.concat ", " missingPartialWalSidecars
 
                 emptyReadOnlyInspection
                     normalizedPath
@@ -379,10 +394,11 @@ module LocalStateDb =
                     dbPathIsDirectory
                     false
                     (Some
-                        $"Database is in WAL mode but required sidecar files are missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files.")
+                        $"Database has an incomplete WAL sidecar set; missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files or ignoring live WAL content.")
             else
                 try
-                    use connection = openReadOnlyConnection normalizedPath
+                    let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+                    use connection = openReadOnlyConnection normalizedPath immutableSnapshot
                     let tableNames = readObjectNames connection "table"
                     let indexNames = readObjectNames connection "index"
 

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -226,7 +226,7 @@ module Configuration =
 
     type GraceConfigurationInspectionError =
         | ConfigurationFileNotFound of string
-        | ConfigurationFileMalformed of string
+        | ConfigurationFileMalformed of path: string * message: string
 
     let private tryGetGraceIgnoreEntries graceIgnorePath =
         try
@@ -261,7 +261,7 @@ module Configuration =
         | Error errorMessage -> Error(ConfigurationFileNotFound errorMessage)
         | Ok graceConfigurationFilePath ->
             match parseConfigurationFile graceConfigurationFilePath with
-            | Error errorMessage -> Error(ConfigurationFileMalformed errorMessage)
+            | Error errorMessage -> Error(ConfigurationFileMalformed(graceConfigurationFilePath, errorMessage))
             | Ok graceConfigurationFromFile ->
                 let configuration = populateConfigurationPaths graceConfigurationFilePath graceConfigurationFromFile
                 let ignore = inspectGraceIgnore configuration.RootDirectory


### PR DESCRIPTION
## Summary

- Adds read-only `.grace/grace-local.db` inspection checks to `grace doctor`.
- Reports schema version, required tables, required indexes, SQLite integrity checks, SQLite foreign-key checks, and object-cache index readability.
- Keeps doctor from initializing, migrating, repairing, deleting, or otherwise mutating local state while diagnosing repository state.

## Tracking

Part of #333.
Related to #337.

## Validation

Initial worker verification on head `2271037`:

- `dotnet tool run fantomas Grace.CLI/LocalStateDb.CLI.fs Grace.CLI/Command/Doctor.CLI.fs Grace.CLI.Tests/LocalStateDb.Tests.fs Grace.CLI.Tests/Doctor.CLI.Tests.fs`
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter LocalStateDb` passed 38/38
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor` passed 56/56
- `git diff --check`

First review fix verification on head `c68f36d`:

- `dotnet tool run fantomas -- src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI/Command/Doctor.CLI.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor` passed 59/59
- `git diff --check`

Second review fix verification on head `a9a0849`:

- `dotnet tool run fantomas src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.Shared/Client/Configuration.Shared.fs src/Grace.CLI/Command/Doctor.CLI.fs src/Grace.CLI.Tests/LocalStateDb.Tests.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~Doctor|FullyQualifiedName~LocalStateDb"` passed 99/99
- `git diff --check`

Third review fix verification on head `bc20a7c`:

- `dotnet tool run fantomas src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI.Tests/LocalStateDb.Tests.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~Doctor|FullyQualifiedName~LocalStateDb"` passed 100/100
- `git diff --check`

GitHub `Validate / full` passed on `bc20a7c`.

Skipped `pwsh ./scripts/validate.ps1 -Fast` in the worker handoffs because this slice used focused validation and this PR's CI/epic gates provide the broader integration gate.

## Review Status

- 2026-06-10: Codex reviewed head `2271037` and found P2 `3388014074`, eager local-state inspection for unrelated selected checks.
- 2026-06-10: Fixed in `c68f36d`; replied to and resolved the Codex thread with validation evidence.
- 2026-06-10: CI passed on `c68f36d`; fresh Codex review found P2 `3388120505` for WAL sidecar mutation risk and P2 `3388120511` for malformed-config nested-path drift.
- 2026-06-10: Fixed in `a9a0849`; replied to and resolved both Codex threads with validation evidence.
- 2026-06-10: CI passed on `a9a0849`; fresh Codex review found P2 `3388260748` for false failures on valid checkpointed WAL databases without sidecars.
- 2026-06-10: Fixed in `bc20a7c`; replied to and resolved the Codex thread with validation evidence.
- 2026-06-10: CI passed on `bc20a7c`; Codex Code Review Bot gave `THUMBS_UP`; no unresolved review threads remain.

## Review Prevention

- Issue #337 includes the 2026-06-10 review-prevention addendum covering output-mode cross products, exact `--check` selection, invalid select precedence, `--list-checks`, silent/minimal behavior, verbose+select cleanliness, and no-mutation proof.
- Worker evidence includes source-search proof that the doctor path avoids forbidden local-state mutations such as initialization, schema creation, WAL changes, writes, corrupt-file moves, sidecar deletion, object-cache repair, and status snapshot writes.
- Prevention line: Lazy local-state inspection now has regression coverage proving unrelated selected checks do not open the local DB.
- Prevention line: Malformed-config discovery now preserves the found config path, with nested-directory regression coverage preventing fallback drift to `<cwd>/.grace`.
- Prevention line: WAL/no-sidecar inspection now has regression coverage at both the read-only helper and doctor command layers, proving checkpointed WAL databases are inspected without recreating `-wal` or `-shm`; incomplete live-WAL sidecar sets are the only pre-open failure case, preventing sidecar mutation and avoiding silent live-WAL data loss.
