### PR TITLE
I04: Add formal DirectoryVersion hash preimage helpers

### DIFF
--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -44,6 +44,21 @@ module PromotionSet =
 
     type private DirectorySnapshot = { DirectoriesByPath: Dictionary<RelativePath, DirectoryVersion>; FilesByPath: Dictionary<RelativePath, FileVersion> }
 
+    type internal ComputedDirectoryMetadata = { DirectoryVersionId: DirectoryVersionId; Sha256Hash: Sha256Hash; Size: int64 }
+
+    let internal localDirectoryVersionForPromotionHash ownerId organizationId repositoryId relativePath metadata lastWriteTimeUtc =
+        LocalDirectoryVersion.Create
+            metadata.DirectoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            relativePath
+            metadata.Sha256Hash
+            (List<DirectoryVersionId>())
+            (List<LocalFileVersion>())
+            metadata.Size
+            lastWriteTimeUtc
+
     type private StepConflictFile =
         {
             FilePath: RelativePath
@@ -893,7 +908,7 @@ module PromotionSet =
 
                     directoryPathIndex <- directoryPathIndex + 1
 
-                let computedDirectoryMetadata = Dictionary<RelativePath, DirectoryVersionId * Sha256Hash>(StringComparer.OrdinalIgnoreCase)
+                let computedDirectoryMetadata = Dictionary<RelativePath, ComputedDirectoryMetadata>(StringComparer.OrdinalIgnoreCase)
                 let directoryVersionsToCreate = ResizeArray<DirectoryVersion>()
                 let mutable materializationError: GraceError option = Option.None
                 let mutable buildIndex = 0
@@ -917,20 +932,16 @@ module PromotionSet =
 
                     while childIndex < childDirectoryPathsArray.Length do
                         let childDirectoryPath = childDirectoryPathsArray[childIndex]
-                        let childDirectoryId, childSha = computedDirectoryMetadata[childDirectoryPath]
-                        childDirectoryIds.Add(childDirectoryId)
+                        let childMetadata = computedDirectoryMetadata[childDirectoryPath]
+                        childDirectoryIds.Add(childMetadata.DirectoryVersionId)
 
                         localChildDirectories.Add(
-                            LocalDirectoryVersion.Create
-                                childDirectoryId
+                            localDirectoryVersionForPromotionHash
                                 promotionSetDto.OwnerId
                                 promotionSetDto.OrganizationId
                                 promotionSetDto.RepositoryId
                                 childDirectoryPath
-                                childSha
-                                (List<DirectoryVersionId>())
-                                (List<LocalFileVersion>())
-                                0L
+                                childMetadata
                                 DateTime.UtcNow
                         )
 
@@ -954,6 +965,7 @@ module PromotionSet =
                             localDirectoryFiles.Add(fileVersion.ToLocalFileVersion DateTime.UtcNow)
                             orderedFileIndex <- orderedFileIndex + 1
 
+                    let directorySize = getDirectorySize directoryFiles
                     let computedSha = computeSha256ForDirectory directoryPath localChildDirectories localDirectoryFiles
 
                     let tryReuseDirectoryId (snapshot: DirectorySnapshot) =
@@ -990,11 +1002,12 @@ module PromotionSet =
                                 computedSha
                                 childDirectoryIds
                                 directoryFiles
-                                (getDirectorySize directoryFiles)
+                                directorySize
 
                         directoryVersionsToCreate.Add(directoryVersion)
 
-                    computedDirectoryMetadata[directoryPath] <- (directoryVersionId, computedSha)
+                    computedDirectoryMetadata[directoryPath] <- { DirectoryVersionId = directoryVersionId; Sha256Hash = computedSha; Size = directorySize }
+
                     buildIndex <- buildIndex + 1
 
                 let mutable createIndex = 0
@@ -1019,10 +1032,10 @@ module PromotionSet =
                 match materializationError with
                 | Option.Some graceError -> return Error graceError
                 | Option.None ->
-                    let mutable rootDirectory = Unchecked.defaultof<(DirectoryVersionId * Sha256Hash)>
+                    let mutable rootDirectory = Unchecked.defaultof<ComputedDirectoryMetadata>
 
                     if computedDirectoryMetadata.TryGetValue(RootDirectoryPath, &rootDirectory) then
-                        return Ok(fst rootDirectory)
+                        return Ok rootDirectory.DirectoryVersionId
                     else
                         return
                             Error(

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
+    <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />
     <Compile Include="UploadSession.Actor.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/PromotionSet.DirectoryHash.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/PromotionSet.DirectoryHash.Tests.fs
@@ -1,0 +1,60 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors
+open Grace.Shared
+open Grace.Shared.Services
+open Grace.Types.Common
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+[<Parallelizable(ParallelScope.All)>]
+type PromotionSetDirectoryHashTests() =
+
+    let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+    let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+    let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+    let childDirectoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+    let lastWriteTimeUtc = DateTime(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc)
+
+    let childSha256 = "27a1f6b711aa88117824253726920929081e2bc06e66b40bdd62f75c12d1c809"
+    let rootFileSha256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+    let rootFile = LocalFileVersion.Create (RelativePath "README.md") rootFileSha256 false 12L (Instant.FromUtc(2026, 6, 10, 12, 0)) true lastWriteTimeUtc
+
+    [<Test>]
+    member _.PromotionHashChildDirectoryPreservesComputedSizeInParentSha256Preimage() =
+        let childMetadata: PromotionSet.ComputedDirectoryMetadata = { DirectoryVersionId = childDirectoryId; Sha256Hash = childSha256; Size = 27L }
+
+        let childDirectory =
+            PromotionSet.localDirectoryVersionForPromotionHash ownerId organizationId repositoryId (RelativePath "src") childMetadata lastWriteTimeUtc
+
+        Assert.That(childDirectory.Size, Is.EqualTo(27L))
+
+        let actualChildDirectories = List<LocalDirectoryVersion>()
+        actualChildDirectories.Add(childDirectory)
+
+        let rootFiles = List<LocalFileVersion>()
+        rootFiles.Add(rootFile)
+
+        let actual = Services.computeSha256ForDirectory (RelativePath ".") actualChildDirectories rootFiles
+
+        let expected =
+            Services.computeSha256ForDirectoryEntries
+                (RelativePath ".")
+                [
+                    Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 27L String.Empty childSha256
+                    Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L String.Empty rootFileSha256
+                ]
+
+        let zeroSizeRegression =
+            Services.computeSha256ForDirectoryEntries
+                (RelativePath ".")
+                [
+                    Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 0L String.Empty childSha256
+                    Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L String.Empty rootFileSha256
+                ]
+
+        Assert.That(actual, Is.EqualTo(expected))
+        Assert.That(actual, Is.Not.EqualTo(zeroSizeRegression))

--- a/src/Grace.Shared/Services.Shared.fs
+++ b/src/Grace.Shared/Services.Shared.fs
@@ -24,10 +24,10 @@ module Services =
 
             match result with
             | Ok result ->
-                result.Properties[ key ] <- safeValue
+                result.Properties[key] <- safeValue
                 Ok result
             | Error error ->
-                error.Properties[ key ] <- safeValue
+                error.Properties[key] <- safeValue
                 Error error
         else
             result
@@ -45,9 +45,7 @@ module Services =
                 true // Indicates that the object is okay to be returned to the pool
 
     /// An ObjectPool for IncrementalHash instances.
-    let incrementalHashPool =
-        DefaultObjectPoolProvider()
-            .Create(IncrementalHashPolicy())
+    let incrementalHashPool = DefaultObjectPoolProvider().Create(IncrementalHashPolicy())
 
     /// Computes the BLAKE3 value for a given file, presented as a stream.
     ///
@@ -59,7 +57,7 @@ module Services =
             // I did some informal perf testing on large files. This size was best, larger didn't help, and 64K keeps it on the small object heap.
             let bufferLength = 64 * 1024
 
-            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
+            let buffer = ArrayPool<byte>.Shared.Rent(bufferLength)
             let mutable hasher = Hasher.New()
 
             try
@@ -79,7 +77,7 @@ module Services =
                 return FileContentHash(byteArrayToString blake3Bytes)
             finally
                 if not <| isNull buffer then
-                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
+                    ArrayPool<byte>.Shared.Return(buffer, clearArray = true)
 
                 hasher.Dispose()
         }
@@ -103,7 +101,7 @@ module Services =
                     int (stream.Length)
 
             // Get a buffer to hold the part of the file we're going to check.
-            let startingBytes = ArrayPool<byte>.Shared.Rent (bytesToCheck)
+            let startingBytes = ArrayPool<byte>.Shared.Rent(bytesToCheck)
             //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Rented byte array of length {bytesToCheck}."
 
             try
@@ -115,18 +113,13 @@ module Services =
                     //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Finished reading stream."
 
                     // Search for a 0x00 character.
-                    return
-                        startingBytes
-                            .Take(bytesRead)
-                            .Any(fun b -> char (b) = nulChar)
-                with
-                | ex ->
+                    return startingBytes.Take(bytesRead).Any(fun b -> char (b) = nulChar)
+                with ex ->
                     //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Caught exception: {ExceptionResponse.Create ex}."
                     return false
             finally
                 // Return the rented buffer to the pool, even if an exception is thrown.
-                if not <| isNull startingBytes then
-                    ArrayPool<byte>.Shared.Return (startingBytes)
+                if not <| isNull startingBytes then ArrayPool<byte>.Shared.Return(startingBytes)
         }
 
     /// Computes the SHA-256 value for a given file, presented as a stream.
@@ -138,7 +131,7 @@ module Services =
             let bufferLength = 64 * 1024
 
             // Using object pooling for both of these.
-            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
+            let buffer = ArrayPool<byte>.Shared.Rent(bufferLength)
             let hasher = incrementalHashPool.Get()
 
             try
@@ -165,55 +158,121 @@ module Services =
                 return Sha256Hash sha256Hash
             finally
                 if not <| isNull buffer then
-                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
+                    ArrayPool<byte>.Shared.Return(buffer, clearArray = true)
 
                 if not <| isNull hasher then incrementalHashPool.Return(hasher)
         }
 
+    /// The hash algorithm to use for a DirectoryVersion preimage.
+    type DirectoryVersionHashAlgorithm =
+        | Blake3
+        | Sha256
+
+    /// Identifies the kind of child entry included in a DirectoryVersion preimage.
+    type DirectoryVersionPreimageEntryKind =
+        | Directory
+        | File
+
+    /// A child entry included in a DirectoryVersion preimage.
+    type DirectoryVersionPreimageEntry =
+        { Kind: DirectoryVersionPreimageEntryKind
+          RelativePath: RelativePath
+          Size: int64
+          Blake3Hash: Blake3Hash
+          Sha256Hash: Sha256Hash }
+
+        static member Create kind relativePath size blake3Hash sha256Hash =
+            { Kind = kind; RelativePath = RelativePath(normalizeFilePath $"{relativePath}"); Size = size; Blake3Hash = blake3Hash; Sha256Hash = sha256Hash }
+
+        static member Directory relativePath size blake3Hash sha256Hash =
+            DirectoryVersionPreimageEntry.Create DirectoryVersionPreimageEntryKind.Directory relativePath size blake3Hash sha256Hash
+
+        static member File relativePath size blake3Hash sha256Hash =
+            DirectoryVersionPreimageEntry.Create DirectoryVersionPreimageEntryKind.File relativePath size blake3Hash sha256Hash
+
+    let private directoryVersionAlgorithmName algorithm =
+        match algorithm with
+        | DirectoryVersionHashAlgorithm.Blake3 -> "blake3"
+        | DirectoryVersionHashAlgorithm.Sha256 -> "sha256"
+
+    let private directoryVersionEntryKindName kind =
+        match kind with
+        | DirectoryVersionPreimageEntryKind.Directory -> "directory"
+        | DirectoryVersionPreimageEntryKind.File -> "file"
+
+    let private directoryVersionEntryHash algorithm (entry: DirectoryVersionPreimageEntry) =
+        match algorithm with
+        | DirectoryVersionHashAlgorithm.Blake3 -> entry.Blake3Hash
+        | DirectoryVersionHashAlgorithm.Sha256 -> entry.Sha256Hash
+
+    let private encodeDirectoryVersionPath (path: RelativePath) = normalizeFilePath $"{path}" |> Encoding.UTF8.GetBytes |> Convert.ToBase64String
+
+    /// Builds the versioned DirectoryVersion preimage used by both BLAKE3 and SHA-256 directory hashes.
+    let directoryVersionPreimage algorithm (relativeDirectoryPath: RelativePath) (entries: seq<DirectoryVersionPreimageEntry>) =
+        if isNull entries then nullArg (nameof entries)
+
+        let sortedEntries =
+            entries
+            |> Seq.sortWith (fun left right ->
+                let pathComparison = StringComparer.Ordinal.Compare(normalizeFilePath $"{left.RelativePath}", normalizeFilePath $"{right.RelativePath}")
+
+                if pathComparison <> 0 then
+                    pathComparison
+                else
+                    StringComparer.Ordinal.Compare(directoryVersionEntryKindName left.Kind, directoryVersionEntryKindName right.Kind))
+            |> Seq.toArray
+
+        let lines = List<string>()
+        lines.Add("grace.directory-version.v1")
+        lines.Add($"algorithm:{directoryVersionAlgorithmName algorithm}")
+        lines.Add($"path:{encodeDirectoryVersionPath relativeDirectoryPath}")
+        lines.Add($"child-count:{sortedEntries.Length}")
+
+        sortedEntries
+        |> Array.iteri (fun index entry ->
+            lines.Add(
+                $"child:{index}:{directoryVersionEntryKindName entry.Kind}:{encodeDirectoryVersionPath entry.RelativePath}:{entry.Size}:{directoryVersionEntryHash algorithm entry}"
+            ))
+
+        String.Join("\n", lines) + "\n"
+
+    /// Computes the BLAKE3 hash for a DirectoryVersion preimage.
+    let computeBlake3ForDirectory (relativeDirectoryPath: RelativePath) (entries: seq<DirectoryVersionPreimageEntry>) =
+        let preimage = directoryVersionPreimage DirectoryVersionHashAlgorithm.Blake3 relativeDirectoryPath entries
+        let preimageBytes = Encoding.UTF8.GetBytes preimage
+        use hasher = Hasher.New()
+        hasher.Update(preimageBytes.AsSpan())
+        let blake3Bytes = stackalloc<byte> Hash.Size
+        hasher.Finalize(blake3Bytes)
+        Blake3Hash(byteArrayToString blake3Bytes)
+
+    /// Computes the SHA-256 hash for a DirectoryVersion preimage.
+    let computeSha256ForDirectoryEntries (relativeDirectoryPath: RelativePath) (entries: seq<DirectoryVersionPreimageEntry>) =
+        let preimage = directoryVersionPreimage DirectoryVersionHashAlgorithm.Sha256 relativeDirectoryPath entries
+        let preimageBytes = Encoding.UTF8.GetBytes preimage
+        let sha256Bytes = SHA256.HashData preimageBytes
+        Sha256Hash(byteArrayToString sha256Bytes)
+
     /// Computes the SHA-256 value for a given relative directory.
     ///
-    /// Sha256Hash values for directories are computed by concatenating the relative path of the directory, and the Sha256Hash values of all subdirectories and files.
+    /// Sha256Hash values for directories are computed from a versioned DirectoryVersion preimage.
     let computeSha256ForDirectory (relativeDirectoryPath: RelativePath) (directories: List<LocalDirectoryVersion>) (files: List<LocalFileVersion>) =
-        let hasher = incrementalHashPool.Get()
+        let directoryEntries =
+            directories
+            |> Seq.map (fun directory ->
+                DirectoryVersionPreimageEntry.Directory directory.RelativePath directory.Size (Blake3Hash String.Empty) directory.Sha256Hash)
 
-        try
-            hasher.AppendData(Encoding.UTF8.GetBytes(relativeDirectoryPath))
+        let fileEntries =
+            files
+            |> Seq.map (fun file -> DirectoryVersionPreimageEntry.File file.RelativePath file.Size (Blake3Hash String.Empty) file.Sha256Hash)
 
-            // We're sorting just to get consistent ordering; inconsistent ordering would produce difference SHA-256 hashes.
-            let sortedDirectories =
-                directories
-                |> Seq.sortBy (fun subdirectory -> subdirectory.RelativePath)
-
-            for subdirectory in sortedDirectories do
-                hasher.AppendData(Encoding.UTF8.GetBytes(subdirectory.Sha256Hash))
-
-            // Again, sorting to ensure consistent ordering.
-            let sortedFiles =
-                files
-                |> Seq.sortBy (fun file -> file.RelativePath)
-
-            for file in sortedFiles do
-                hasher.AppendData(Encoding.UTF8.GetBytes(file.Sha256Hash))
-
-            // Get the SHA-256 hash as a byte array.
-            let sha256Bytes = stackalloc<byte> SHA256.HashSizeInBytes
-            hasher.GetHashAndReset(sha256Bytes) |> ignore
-
-            // Convert the SHA-256 value from a byte[] to a string, and return it.
-            //   Example: byte[]{0x43, 0x2a, 0x01, 0xfa} -> "432a01fa"
-            Sha256Hash(byteArrayToString sha256Bytes)
-        finally
-            if not <| isNull hasher then incrementalHashPool.Return(hasher)
+        computeSha256ForDirectoryEntries relativeDirectoryPath (Seq.append directoryEntries fileEntries)
 
     /// Gets the total size of the files contained within this specific directory. This does not include the size of any subdirectories.
-    let getDirectorySize (files: IList<FileVersion>) =
-        files
-        |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
+    let getDirectorySize (files: IList<FileVersion>) = files |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
 
     /// Gets the total size of the files contained within this specific directory. This does not include the size of any subdirectories.
-    let getLocalDirectorySize (files: IList<LocalFileVersion>) =
-        files
-        |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
+    let getLocalDirectorySize (files: IList<LocalFileVersion>) = files |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
 
     /// Gets the number of path segments for the longest relative path in GraceIndex.
     ///

--- a/src/Grace.Types.Tests/DirectoryVersionPreimage.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/DirectoryVersionPreimage.Shared.Tests.fs
@@ -1,0 +1,203 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.Common
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+type DirectoryVersionPreimageSharedTests() =
+    static member private File (path: string) size (blake3: string) (sha256: string) =
+        Services.DirectoryVersionPreimageEntry.File (RelativePath path) size (Blake3Hash blake3) (Sha256Hash sha256)
+
+    static member private Directory (path: string) size (blake3: string) (sha256: string) =
+        Services.DirectoryVersionPreimageEntry.Directory (RelativePath path) size (Blake3Hash blake3) (Sha256Hash sha256)
+
+    static member private RootEntries =
+        [ DirectoryVersionPreimageSharedTests.File
+              "README.md"
+              12L
+              "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" ]
+
+    static member private NestedEntries =
+        [ DirectoryVersionPreimageSharedTests.File
+              "src/App.fs"
+              27L
+              "9f3a6d1a5aa02b523a9240993cd141a2103a2ff96f24fa470e6de980d45cd966"
+              "086f7e4373e8509d3db67f333fda8cf2cef4e883030282da1e6fe7dbb7653bb2" ]
+
+    static member private MixedTreeEntries =
+        [ DirectoryVersionPreimageSharedTests.Directory
+              "src"
+              27L
+              "0d6f7b0418c61086d4be1a0c5d44dc8abcb4d0d5c08f3556e455891aefde7d41"
+              "27a1f6b711aa88117824253726920929081e2bc06e66b40bdd62f75c12d1c809"
+          DirectoryVersionPreimageSharedTests.File
+              "README.md"
+              12L
+              "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+          DirectoryVersionPreimageSharedTests.File
+              "docs/README.md"
+              12L
+              "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" ]
+
+    [<Test>]
+    member _.DirectoryVersionPreimageUsesVersionAlgorithmAndEncodedPaths() =
+        let entry =
+            DirectoryVersionPreimageSharedTests.File
+                "src\\colon:name\nfile.txt"
+                99L
+                "1111111111111111111111111111111111111111111111111111111111111111"
+                "2222222222222222222222222222222222222222222222222222222222222222"
+
+        let preimage = Services.directoryVersionPreimage Services.DirectoryVersionHashAlgorithm.Sha256 (RelativePath ".") [ entry ]
+
+        let expected =
+            [ "grace.directory-version.v1"
+              "algorithm:sha256"
+              "path:Lg=="
+              "child-count:1"
+              "child:0:file:c3JjL2NvbG9uOm5hbWUKZmlsZS50eHQ=:99:2222222222222222222222222222222222222222222222222222222222222222" ]
+            |> String.concat "\n"
+            |> fun value -> value + "\n"
+
+        Assert.That(preimage, Is.EqualTo(expected))
+
+    [<Test>]
+    member _.DirectoryVersionGoldenVectorsAreStable() =
+        let cases =
+            [ "empty-root",
+              ".",
+              [],
+              "6c2f433e475de7dbe60583e374fabdc098eb7a23bab24bd871820fe5c9dd7fc0",
+              "69fbcbbe1e5203155bbc0a1d537628319107726d54b77ea33e91ec503120f712"
+              "root-with-file",
+              ".",
+              DirectoryVersionPreimageSharedTests.RootEntries,
+              "6c03bb1f203dd4632db6a30966cc40c70a28c6f66aaa19c42fa6ccc84b81a896",
+              "7fa9438440decafc86602975f376fe1220ba420d9084ed9427dcb85b4e61c46b"
+              "nested-directory",
+              "src",
+              DirectoryVersionPreimageSharedTests.NestedEntries,
+              "8d4f8fdb0657859e2b15dd506396d015821c91d3dd511f637fbdd44f00c1d7d2",
+              "02634546989fdf7ba6910dc7473922ef4df5e8eef055667359156deb6d7763a1"
+              "mixed-tree",
+              ".",
+              DirectoryVersionPreimageSharedTests.MixedTreeEntries,
+              "d93d3a2eb1c5c5f1b4919d3b8283fb348248f57cf0904e6adfd26fe7bb6b76d1",
+              "bd5ba4daccd0fa41c5e5998c41ffac46f6ddbf5d5d83688ed46c3a22dd60e4eb" ]
+
+        for name, path, entries, expectedBlake3, expectedSha256 in cases do
+            let actualBlake3 = Services.computeBlake3ForDirectory (RelativePath path) entries
+            let actualSha256 = Services.computeSha256ForDirectoryEntries (RelativePath path) entries
+
+            Assert.That(actualBlake3, Is.EqualTo(Blake3Hash expectedBlake3), $"{name} BLAKE3")
+            Assert.That(actualSha256, Is.EqualTo(Sha256Hash expectedSha256), $"{name} SHA-256")
+
+    [<Test>]
+    member _.DirectoryVersionHashesChangeForSemanticDirectoryChanges() =
+        let baseline = DirectoryVersionPreimageSharedTests.MixedTreeEntries
+        let baselineBlake3 = Services.computeBlake3ForDirectory (RelativePath ".") baseline
+        let baselineSha256 = Services.computeSha256ForDirectoryEntries (RelativePath ".") baseline
+
+        let cases =
+            [ "directory path", RelativePath "different", baseline
+              "renamed child",
+              RelativePath ".",
+              [ DirectoryVersionPreimageSharedTests.Directory
+                    "source"
+                    27L
+                    "0d6f7b0418c61086d4be1a0c5d44dc8abcb4d0d5c08f3556e455891aefde7d41"
+                    "27a1f6b711aa88117824253726920929081e2bc06e66b40bdd62f75c12d1c809"
+                baseline[1]
+                baseline[2] ]
+              "file size",
+              RelativePath ".",
+              [ baseline[0]
+                DirectoryVersionPreimageSharedTests.File
+                    "README.md"
+                    13L
+                    "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+                    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                baseline[2] ]
+              "child kind",
+              RelativePath ".",
+              [ DirectoryVersionPreimageSharedTests.File
+                    "src"
+                    27L
+                    "0d6f7b0418c61086d4be1a0c5d44dc8abcb4d0d5c08f3556e455891aefde7d41"
+                    "27a1f6b711aa88117824253726920929081e2bc06e66b40bdd62f75c12d1c809"
+                baseline[1]
+                baseline[2] ] ]
+
+        for name, path, entries in cases do
+            Assert.That(Services.computeBlake3ForDirectory path entries, Is.Not.EqualTo(baselineBlake3), $"{name} BLAKE3")
+            Assert.That(Services.computeSha256ForDirectoryEntries path entries, Is.Not.EqualTo(baselineSha256), $"{name} SHA-256")
+
+    [<Test>]
+    member _.DirectoryVersionHashesAreOrderIndependentAndKindSensitive() =
+        let ordered = DirectoryVersionPreimageSharedTests.MixedTreeEntries
+        let reordered = [ ordered[2]; ordered[0]; ordered[1] ]
+
+        Assert.That(Services.computeBlake3ForDirectory (RelativePath ".") reordered, Is.EqualTo(Services.computeBlake3ForDirectory (RelativePath ".") ordered))
+
+        Assert.That(
+            Services.computeSha256ForDirectoryEntries (RelativePath ".") reordered,
+            Is.EqualTo(Services.computeSha256ForDirectoryEntries (RelativePath ".") ordered)
+        )
+
+        let samePathDifferentKind =
+            [ DirectoryVersionPreimageSharedTests.Directory
+                  "same-name"
+                  1L
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              DirectoryVersionPreimageSharedTests.File
+                  "same-name"
+                  1L
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
+
+        Assert.That(
+            Services.directoryVersionPreimage Services.DirectoryVersionHashAlgorithm.Sha256 (RelativePath ".") samePathDifferentKind,
+            Does.Contain("child:0:directory:").And.Contain("child:1:file:")
+        )
+
+    [<Test>]
+    member _.Blake3DirectoryHashUsesBlake3ChildHashes() =
+        let baseline = DirectoryVersionPreimageSharedTests.MixedTreeEntries
+
+        let shaOnlyChanged =
+            [ baseline[0]
+              DirectoryVersionPreimageSharedTests.File
+                  "README.md"
+                  12L
+                  "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+                  "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+              baseline[2] ]
+
+        let blake3Changed =
+            [ baseline[0]
+              DirectoryVersionPreimageSharedTests.File
+                  "README.md"
+                  12L
+                  "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+              baseline[2] ]
+
+        Assert.That(
+            Services.computeBlake3ForDirectory (RelativePath ".") shaOnlyChanged,
+            Is.EqualTo(Services.computeBlake3ForDirectory (RelativePath ".") baseline)
+        )
+
+        Assert.That(
+            Services.computeBlake3ForDirectory (RelativePath ".") blake3Changed,
+            Is.Not.EqualTo(Services.computeBlake3ForDirectory (RelativePath ".") baseline)
+        )
+
+        Assert.That(
+            Services.computeSha256ForDirectoryEntries (RelativePath ".") shaOnlyChanged,
+            Is.Not.EqualTo(Services.computeSha256ForDirectoryEntries (RelativePath ".") baseline)
+        )

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="Common.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />
+    <Compile Include="DirectoryVersionPreimage.Shared.Tests.fs" />
     <Compile Include="ContentBlockFormat.Shared.Tests.fs" />
     <Compile Include="ManifestValidation.Shared.Tests.fs" />
     <Compile Include="ProtocolVectors.Tests.fs" />


### PR DESCRIPTION
## Summary

- Adds formal `grace.directory-version.v1` helpers for DirectoryVersion hashing.
- Adds explicit preimage entry types for same-algorithm child hashes.
- Adds BLAKE3 and SHA-256 directory helpers while wrapping the existing SHA-256 directory helper onto the versioned preimage semantics.
- Adds focused golden/adversarial coverage for root, nested, mixed, and empty directories plus path, child name, kind, size, delimiter, ordering, and same-algorithm child-hash cases.

Part of #343
Related to #347

## Validation

Initial implementation:

- `C:\Users\scott\.dotnet\tools\fantomas.exe C:\Source\Grace-gh-347\src\Grace.Shared\Services.Shared.fs C:\Source\Grace-gh-347\src\Grace.Types.Tests\DirectoryVersionPreimage.Shared.Tests.fs`: passed; final run reported `Unchanged 2`.
- `dotnet test C:\Source\Grace-gh-347\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~DirectoryVersionPreimageSharedTests" --logger "console;verbosity=normal"`: passed, 5/5.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build: 0 warnings, 0 errors.
  - `Grace.Types.Tests`: 104 passed.
  - `Grace.Authorization.Tests`: 39 passed.
  - `Grace.Server.Unit.Tests`: 506 passed.
  - `Grace.CLI.Tests`: 409 passed, 1 skipped.
  - `Grace.Server.Tests`: no tests matched the Fast filter in that assembly.
- `git diff --check`: passed.
- `git diff --cached --check`: passed after staging so the new test file was included.
- Skipped `pwsh ./scripts/validate.ps1 -Full`: this slice is pure shared algorithm/test work and does not touch Aspire, emulators, storage runtime behavior, Service Bus, Cosmos DB, Redis, or cross-service integration.

Fix validation for Codex Code Review Bot finding:

- `dotnet tool restore`: passed after sandbox-blocked rerun with escalation.
- `dotnet tool run fantomas -- src\Grace.Actors\PromotionSet.Actor.fs src\Grace.Server.Unit.Tests\PromotionSet.DirectoryHash.Tests.fs`: passed after sandbox-blocked rerun with escalation.
- `dotnet test src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "FullyQualifiedName~PromotionSetDirectoryHashTests"`: passed, 1 passed, 0 failed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after sandbox-blocked rerun with escalation.
  - Build succeeded with 0 warnings and 0 errors.
  - `Grace.Types.Tests`: 104 passed.
  - `Grace.Authorization.Tests`: 39 passed.
  - `Grace.Server.Unit.Tests`: 507 passed.
  - `Grace.CLI.Tests`: 409 passed, 1 skipped.
- `git diff --check`: passed.
- Skipped validation: none; sandbox-blocked attempts were rerun successfully with the same commands outside the sandbox.

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed the algorithm/test slice in `C:\Source\Grace-gh-347`.
- Initial implementation commit reviewed: `c2d099db893f63ae02363918262bbcea5368d805`
- Fix worker: GPT-5.5 Medium worker completed the promotion child-size fix in `C:\Source\Grace-gh-347`.
- Fix commit pushed: `af3c99b87a90dbe72027ddc63d10be61ea412a3d`
- Bot findings addressed and resolved:
  - Promotion directory materialization now carries each child directory's computed direct-file size into parent SHA-256 hashing, with a focused zero-size regression test.
- Codex Code Review Bot: 👍🏻 no-issues reaction observed on the PR body for latest head `af3c99b87a90dbe72027ddc63d10be61ea412a3d`.
- Bot comments/review threads: original finding resolved; no open latest-head findings observed.
- Open findings: none.

## Docs Impact

No user-facing docs change in this slice. I01 documented the target model; later propagation/OpenAPI/docs slices own external behavior docs.

## Residual Risk

Moderate. The helper surface is pure/shared and well covered, but durable DTO/server storage integration is intentionally left to later epic slices. The BLAKE3 directory helper requires explicit entries with BLAKE3 child hashes and does not wrap SHA-256 child hashes. The promotion SHA-256 path now preserves child directory size metadata for the formal preimage.