### PR TITLE
S4: Add doctor server probes

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -11,8 +11,10 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Net
 open System.Text
 open System.Text.Json
+open System.Threading.Tasks
 
 [<NonParallelizable>]
 module DoctorCliTests =
@@ -267,6 +269,46 @@ module DoctorCliTests =
             "object-cache.index-readable"
         |]
 
+    let private serverCheckIds =
+        [|
+            "server.healthz.reachable"
+            "server.lifecycle.headers"
+            "server.auth-principal.available"
+        |]
+
+    let private withDoctorServerProbeFactory factory action =
+        Doctor.setServerProbeFactoryForTests factory
+
+        try
+            action ()
+        finally
+            Doctor.resetServerProbeFactoryForTests ()
+
+    let private successfulProbeWithLifecycle diagnostics =
+        Doctor.ServerProbeSucceeded
+            {
+                StatusCode = HttpStatusCode.OK
+                ReasonPhrase = "OK"
+                LifecycleDiagnostics = diagnostics
+                Body = """{"GraceUserId":"doctor-user","Claims":["repo.read"]}"""
+            }
+
+    let private noLifecycleProbe = successfulProbeWithLifecycle None
+
+    let private lifecycleDiagnostics status unsupportedAfter minimumVersion recommendedVersion updateUrl updateUrlIsHttps unsupportedAfterIsMalformed =
+        let diagnostics: Grace.SDK.ClientIdentity.LifecycleDiagnostics =
+            {
+                Status = status
+                UnsupportedAfter = unsupportedAfter
+                UnsupportedAfterIsMalformed = unsupportedAfterIsMalformed
+                MinimumVersion = minimumVersion
+                RecommendedVersion = recommendedVersion
+                UpdateUrl = updateUrl
+                UpdateUrlIsHttps = updateUrlIsHttps
+            }
+
+        Some diagnostics
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -308,12 +350,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 23
+            |> should equal 26
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 23
+            |> should equal 26
 
             let catalogIds =
                 returnValue
@@ -364,6 +406,9 @@ module DoctorCliTests =
             catalogIds |> should contain "server.connectivity"
             catalogIds |> should contain "config.file.parse"
 
+            for checkId in serverCheckIds do
+                catalogIds |> should contain checkId
+
             catalogIds
             |> should contain "user-config.file.discover"
 
@@ -379,58 +424,633 @@ module DoctorCliTests =
             |> should equal false)
 
     [<Test>]
-    let ``doctor list checks offline keeps only offline catalog entries`` () =
+    let ``doctor list checks offline keeps full catalog without probing`` () =
         withTempDir (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "doctor"
-                                                  "--list-checks"
-                                                  "--offline" |]
+            let requestCount = ref 0
 
-            exitCode |> should equal 0
+            withDoctorServerProbeFactory
+                (fun _ ->
+                    incr requestCount
+                    Task.FromResult noLifecycleProbe)
+                (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--list-checks"
+                                                          "--offline" |]
 
-            use document = assertCleanJsonOutput standardOut standardError
+                    exitCode |> should equal 0
 
-            let catalogIds =
-                document
-                    .RootElement
-                    .GetProperty("ReturnValue")
-                    .GetProperty("Catalog")
-                    .EnumerateArray()
-                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
-                |> Set.ofSeq
+                    use document = assertCleanJsonOutput standardOut standardError
 
-            catalogIds.Count |> should equal 21
+                    let catalogIds =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Catalog")
+                            .EnumerateArray()
+                        |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                        |> Set.ofSeq
 
-            catalogIds |> should contain "config.file.parse"
+                    catalogIds.Count |> should equal 26
 
-            catalogIds
-            |> should contain "ignore.entries.parse"
+                    catalogIds |> should contain "config.file.parse"
 
-            catalogIds
-            |> should contain "auth.source.detected"
+                    catalogIds
+                    |> should contain "ignore.entries.parse"
 
-            catalogIds
-            |> should contain "auth.env-token.valid"
+                    catalogIds
+                    |> should contain "auth.source.detected"
 
-            catalogIds
-            |> should contain "auth.token-file.unsupported"
+                    catalogIds
+                    |> should contain "auth.env-token.valid"
 
-            catalogIds
-            |> should contain "auth.oidc.configuration"
+                    catalogIds
+                    |> should contain "auth.token-file.unsupported"
 
-            catalogIds
-            |> should contain "state.db.file-present"
+                    catalogIds
+                    |> should contain "auth.oidc.configuration"
 
-            catalogIds
-            |> should contain "object-cache.index-readable"
+                    catalogIds
+                    |> should contain "state.db.file-present"
 
-            catalogIds
-            |> should not' (contain "identity.auth-session")
+                    catalogIds
+                    |> should contain "object-cache.index-readable"
 
-            catalogIds
-            |> should not' (contain "server.connectivity"))
+                    catalogIds
+                    |> should contain "identity.auth-session"
+
+                    for checkId in serverCheckIds do
+                        catalogIds |> should contain checkId
+
+                    !requestCount |> should equal 0))
+
+    [<Test>]
+    let ``doctor server healthz reachable passes and lifecycle headers are surfaced`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://configured.example.test/base"
+                |> ignore
+
+                let requests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                let diagnostics =
+                    lifecycleDiagnostics
+                        (Some "deprecated")
+                        (Some "2026-12-01")
+                        (Some "0.1.0")
+                        (Some "0.2.0")
+                        (Some "https://github.com/ScottArbeit/Grace/releases")
+                        (Some true)
+                        false
+
+                withDoctorServerProbeFactory
+                    (fun request ->
+                        requests.Add(request)
+                        Task.FromResult(successfulProbeWithLifecycle diagnostics))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--check"
+                                                              "server.lifecycle.headers" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        (findCheckById checks "server.healthz.reachable")
+                            .GetProperty("Status")
+                            .GetString()
+                        |> should equal "Ok"
+
+                        let lifecycle = findCheckById checks "server.lifecycle.headers"
+
+                        lifecycle.GetProperty("Status").GetString()
+                        |> should equal "Ok"
+
+                        lifecycle.GetProperty("Summary").GetString()
+                        |> should contain "deprecated"
+
+                        requests.Count |> should equal 1
+
+                        requests[0].BaseUri.AbsoluteUri
+                        |> should equal "http://configured.example.test/base"
+
+                        requests[0].RelativePath |> should equal "healthz"
+                        requests[0].BearerToken |> should equal None)))
+
+    [<Test>]
+    let ``doctor server healthz uses GRACE_SERVER_URI over config and reports mismatch separately`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://configured.example.test"
+                |> ignore
+
+                let requests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                withEnv Constants.EnvironmentVariables.GraceServerUri (Some "http://environment.example.test") (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun request ->
+                            requests.Add(request)
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server-uri.consistency"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 0
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let checks =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")
+
+                            (findCheckById checks "server-uri.consistency")
+                                .GetProperty("Status")
+                                .GetString()
+                            |> should equal "Warning"
+
+                            (findCheckById checks "server.healthz.reachable")
+                                .GetProperty("Status")
+                                .GetString()
+                            |> should equal "Ok"
+
+                            requests.Count |> should equal 1
+
+                            requests[0].BaseUri.AbsoluteUri
+                            |> should equal "http://environment.example.test/"))))
+
+    [<Test>]
+    let ``doctor server healthz classifies non-success timeout tls connection and malformed uri findings`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                for probeResult, expectedText in
+                    [
+                        Doctor.ServerProbeSucceeded
+                            { StatusCode = HttpStatusCode.ServiceUnavailable; ReasonPhrase = "Service Unavailable"; LifecycleDiagnostics = None; Body = "" },
+                        "503"
+                        Doctor.ServerProbeTimedOut "Timed out after 1500 ms while probing http://example.test/healthz.", "Timed out"
+                        Doctor.ServerProbeTlsFailed "TLS negotiation failed while probing https://example.test/healthz: certificate error", "TLS"
+                        Doctor.ServerProbeConnectionFailed "Could not connect to http://example.test/healthz: connection refused", "connect"
+                    ] do
+                    writeGraceConfig root "http://example.test"
+                    |> ignore
+
+                    withDoctorServerProbeFactory
+                        (fun _ -> Task.FromResult probeResult)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 1
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Failed"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain expectedText)
+
+                writeGraceConfig root "not-a-uri" |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable" |]
+
+                        exitCode |> should equal 1
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "not an absolute URI"
+
+                        !requestCount |> should equal 0)))
+
+    [<Test>]
+    let ``doctor server lifecycle malformed date and non https update url warn cleanly`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let diagnostics =
+                    lifecycleDiagnostics (Some "unsupported") (Some "not-a-date") (Some "0.1.0") None (Some "http://example.test/update") (Some false) true
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult(successfulProbeWithLifecycle diagnostics))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.lifecycle.headers" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Warning"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "not-a-date"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "http://example.test/update")))
+
+    [<Test>]
+    let ``doctor server explicit checks offline skip without network calls`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--offline"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--check"
+                                                              "server.lifecycle.headers"
+                                                              "--check"
+                                                              "server.auth-principal.available" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        checks.GetArrayLength() |> should equal 3
+
+                        for check in checks.EnumerateArray() do
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Skipped"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain "--offline"
+
+                        !requestCount |> should equal 0)))
+
+    [<Test>]
+    let ``doctor server principal skips without valid PAT and runs with non refreshing PAT only`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.auth-principal.available" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Skipped"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "no valid non-refreshing"
+
+                        !requestCount |> should equal 0)
+
+                withEnv Constants.EnvironmentVariables.GraceToken (Some "not-a-pat") (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun _ ->
+                            incr requestCount
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.auth-principal.available" |]
+
+                            exitCode |> should equal 0
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Skipped"
+
+                            !requestCount |> should equal 0))
+
+                let token = validPat ()
+                let principalRequests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun request ->
+                            principalRequests.Add(request)
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.auth-principal.available" |]
+
+                            exitCode |> should equal 0
+                            assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Ok"
+
+                            principalRequests.Count |> should equal 1
+
+                            principalRequests[0].RelativePath
+                            |> should equal "auth/me"
+
+                            principalRequests[0].BearerToken
+                            |> should equal (Some token)))))
+
+    [<Test>]
+    let ``doctor server output modes and select stay clean`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        for output in [ "Silent"; "Minimal" ] do
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  output
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 0
+                            standardOut |> should equal String.Empty
+                            standardError |> should equal String.Empty
+
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Verbose"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--select"
+                                                              "Status" |]
+
+                        exitCode |> should equal 0
+                        standardError |> should equal String.Empty
+                        standardOut.Trim() |> should equal "\"Ok\""
+
+                        standardOut
+                        |> should not' (contain "Grace doctor")
+
+                        standardOut |> should not' (contain "healthz"))))
+
+    [<Test>]
+    let ``doctor server selected output is clean for failure warning offline and principal cases`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let assertSelectedStatus expectedExitCode expectedStatus args probeResult token =
+                    let requestCount = ref 0
+
+                    withEnv Constants.EnvironmentVariables.GraceToken token (fun () ->
+                        withDoctorServerProbeFactory
+                            (fun _ ->
+                                incr requestCount
+                                Task.FromResult probeResult)
+                            (fun () ->
+                                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                                exitCode |> should equal expectedExitCode
+                                standardError |> should equal String.Empty
+                                standardOut.Trim() |> should equal expectedStatus
+
+                                standardOut
+                                |> should not' (contain "Grace doctor")
+
+                                standardOut |> should not' (contain "EventTime")
+
+                                if Array.contains "--offline" args then !requestCount |> should equal 0))
+
+                assertSelectedStatus
+                    1
+                    "\"Failed\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.healthz.reachable"
+                        "--select"
+                        "Status"
+                    |]
+                    (Doctor.ServerProbeConnectionFailed "Could not connect to http://example.test/healthz: connection refused")
+                    None
+
+                let warningDiagnostics =
+                    lifecycleDiagnostics (Some "unsupported") (Some "not-a-date") (Some "0.1.0") None (Some "http://example.test/update") (Some false) true
+
+                assertSelectedStatus
+                    0
+                    "\"Warning\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.lifecycle.headers"
+                        "--select"
+                        "Status"
+                    |]
+                    (successfulProbeWithLifecycle warningDiagnostics)
+                    None
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--offline"
+                        "--check"
+                        "server.healthz.reachable"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    None
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.auth-principal.available"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    None
+
+                let token = validPat ()
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.auth-principal.available"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    (Some token)))
+
+    [<Test>]
+    let ``doctor server exact check selections are not filtered out`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let assertExactCheck checkId =
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          checkId |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    let actualCheckId = checks[ 0 ].GetProperty("Id").GetString()
+                    actualCheckId |> should equal checkId
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        assertExactCheck "server.healthz.reachable"
+                        assertExactCheck "server.lifecycle.headers"
+                        assertExactCheck "server.auth-principal.available")))
 
     [<Test>]
     let ``doctor check filter accepts mixed case ids and categories`` () =
@@ -1966,7 +2586,7 @@ notes.txt # inline comment
     [<Test>]
     let ``doctor diagnostic exit codes map warning and failure reports`` () =
         let warningReport =
-            Doctor.createReportForChecks false false false Doctor.catalog
+            Doctor.createReportForChecks false true false Doctor.catalog
             |> Doctor.withStatus "Warning"
 
         Doctor.diagnosticExitCode false warningReport

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -487,7 +487,7 @@ module DoctorCliTests =
                     !requestCount |> should equal 0))
 
     [<Test>]
-    let ``doctor server healthz reachable passes and lifecycle headers are surfaced`` () =
+    let ``doctor server healthz reachable warns when lifecycle status is deprecated`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://configured.example.test/base"
@@ -537,7 +537,7 @@ module DoctorCliTests =
                         let lifecycle = findCheckById checks "server.lifecycle.headers"
 
                         lifecycle.GetProperty("Status").GetString()
-                        |> should equal "Ok"
+                        |> should equal "Warning"
 
                         lifecycle.GetProperty("Summary").GetString()
                         |> should contain "deprecated"
@@ -641,6 +641,58 @@ module DoctorCliTests =
                             check.GetProperty("Summary").GetString()
                             |> should contain expectedText)
 
+                let lifecycleRejectionDiagnostics =
+                    lifecycleDiagnostics
+                        (Some "unsupported")
+                        (Some "2026-12-01")
+                        (Some "0.1.0")
+                        (Some "0.2.0")
+                        (Some "https://github.com/ScottArbeit/Grace/releases")
+                        (Some true)
+                        false
+
+                let lifecycleRejection =
+                    Doctor.ServerProbeSucceeded
+                        {
+                            StatusCode = HttpStatusCode.UpgradeRequired
+                            ReasonPhrase = "Upgrade Required"
+                            LifecycleDiagnostics = lifecycleRejectionDiagnostics
+                            Body = ""
+                        }
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult lifecycleRejection)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable" |]
+
+                        exitCode |> should equal 1
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        let summary = check.GetProperty("Summary").GetString()
+
+                        summary |> should contain "unsupported"
+
+                        summary
+                        |> should contain "Update the Grace CLI/SDK"
+
+                        summary
+                        |> should not' (contain "check server health and GRACE_SERVER_URI"))
+
                 writeGraceConfig root "not-a-uri" |> ignore
 
                 let requestCount = ref 0
@@ -711,8 +763,13 @@ module DoctorCliTests =
                         check.GetProperty("Summary").GetString()
                         |> should contain "not-a-date"
 
-                        check.GetProperty("Summary").GetString()
-                        |> should contain "http://example.test/update")))
+                        let summary = check.GetProperty("Summary").GetString()
+
+                        summary
+                        |> should contain "updateUrl=<suppressed because server value was not HTTPS>"
+
+                        summary
+                        |> should not' (contain "http://example.test/update"))))
 
     [<Test>]
     let ``doctor server explicit checks offline skip without network calls`` () =

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -5,6 +5,7 @@ open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Client
+open Grace.SDK
 open Grace.Types.Common
 open Spectre.Console
 open System
@@ -13,6 +14,9 @@ open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
 open System.IO
+open System.Net
+open System.Net.Http
+open System.Net.Http.Headers
 open System.Threading
 open System.Threading.Tasks
 
@@ -85,7 +89,19 @@ module Doctor =
     let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
 
     [<Literal>]
+    let private ServerHealthzReachableCheckId = "server.healthz.reachable"
+
+    [<Literal>]
+    let private ServerLifecycleHeadersCheckId = "server.lifecycle.headers"
+
+    [<Literal>]
+    let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
+
+    [<Literal>]
     let private ExpectedLocalStateSchemaVersion = "2"
+
+    [<Literal>]
+    let private DoctorServerProbeTimeoutMilliseconds = 1500
 
     module private Options =
         let full =
@@ -314,7 +330,32 @@ module Doctor =
                 Id = "server.connectivity"
                 Category = "Server"
                 Title = "Grace server connectivity"
-                Description = "Reserved for a later server connectivity diagnostic. Scaffold only; no network probe is executed."
+                Description =
+                    "Reserved compatibility catalog entry. Use the specific server.healthz, server.lifecycle, or server.auth-principal checks for active probes."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerHealthzReachableCheckId
+                Category = "Server"
+                Title = "Grace server /healthz reachability"
+                Description = "Resolves the effective Grace server URI and probes /healthz with a short timeout."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerLifecycleHeadersCheckId
+                Category = "Server"
+                Title = "Grace server lifecycle headers"
+                Description = "Surfaces Grace SDK lifecycle response headers from the anonymous /healthz probe."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerAuthPrincipalAvailableCheckId
+                Category = "Server"
+                Title = "Grace authenticated principal"
+                Description = "Optionally probes /auth/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
                 DefaultEnabled = false
                 SupportsOffline = false
             }
@@ -334,23 +375,20 @@ module Doctor =
             |> Array.filter (String.IsNullOrWhiteSpace >> not)
             |> Array.distinctBy (fun value -> value.ToUpperInvariant())
 
-    type private SelectionError =
-        | Unknown of string array
-        | OfflineExcluded of string array
+    type private SelectionError = Unknown of string array
 
     let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
             |> Array.filter (fun check ->
                 (full || listOnly || check.DefaultEnabled)
-                && (not offline || check.SupportsOffline))
+                && (listOnly || not offline || check.SupportsOffline))
 
         if Array.isEmpty requestedTokens then
             Ok(profileEntries)
         else
             let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
             let unknown = ResizeArray<string>()
-            let excludedOffline = ResizeArray<string>()
 
             for token in requestedTokens do
                 let matches =
@@ -363,29 +401,17 @@ module Doctor =
                     unknown.Add(token)
                 else
                     for check in matches do
-                        if offline && not check.SupportsOffline then
-                            excludedOffline.Add(check.Id)
-                        elif not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
+                        if not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
                             selected.Add(check)
 
             if unknown.Count > 0 then
                 Error(Unknown(unknown |> Seq.toArray))
-            elif excludedOffline.Count > 0 then
-                let tokens =
-                    excludedOffline
-                    |> Seq.distinctBy (fun value -> value.ToUpperInvariant())
-                    |> Seq.toArray
-
-                Error(OfflineExcluded tokens)
             else
                 Ok(selected |> Seq.toArray)
 
     let private validateChecks parseResult full offline listOnly requestedTokens =
         match selectedCatalogEntries full offline listOnly requestedTokens with
         | Ok checks -> Ok checks
-        | Error (OfflineExcluded tokens) ->
-            let tokens = String.Join(", ", tokens)
-            Error(GraceError.Create $"Doctor check token is not available in offline mode: {tokens}." (getCorrelationId parseResult))
         | Error (Unknown unknown) ->
             let tokens = String.Join(", ", unknown)
             Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
@@ -401,16 +427,157 @@ module Doctor =
 
     type private DoctorInspectionContext =
         {
+            Offline: bool
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
             LocalStateInspection: Lazy<LocalStateDb.ReadOnlyLocalStateInspection>
+            ServerHealthzInspection: Lazy<ServerProbeInspection>
         }
+
+    and private EffectiveServerUri =
+        | EffectiveServerUriResolved of Uri * string
+        | EffectiveServerUriUnavailable of string
+
+    and ServerProbeResponse =
+        {
+            StatusCode: HttpStatusCode
+            ReasonPhrase: string
+            LifecycleDiagnostics: ClientIdentity.LifecycleDiagnostics option
+            Body: string
+        }
+
+    and ServerProbeInspection =
+        | ServerProbeSucceeded of ServerProbeResponse
+        | ServerProbeSkipped of string
+        | ServerProbeInvalidUri of string
+        | ServerProbeTimedOut of string
+        | ServerProbeTlsFailed of string
+        | ServerProbeConnectionFailed of string
+        | ServerProbeFailed of string
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
 
-    let private createInspectionContext () =
+    type ServerProbeRequest = { BaseUri: Uri; RelativePath: string; BearerToken: string option; Timeout: TimeSpan }
+
+    let private normalizeBearerToken (token: string) =
+        let trimmed = token.Trim()
+
+        if trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
+            trimmed.Substring("Bearer ".Length).Trim()
+        else
+            trimmed
+
+    let private buildProbeUri (baseUri: Uri) (relativePath: string) =
+        if not baseUri.IsAbsoluteUri then
+            Error "Effective server URI is not absolute."
+        elif
+            not (baseUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            && not (baseUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        then
+            Error $"Effective server URI uses unsupported scheme '{baseUri.Scheme}'."
+        else
+            let baseText = baseUri.AbsoluteUri.TrimEnd('/')
+            let pathText = relativePath.TrimStart('/')
+            Ok(Uri($"{baseText}/{pathText}"))
+
+    let private defaultServerProbe (request: ServerProbeRequest) =
+        task {
+            match buildProbeUri request.BaseUri request.RelativePath with
+            | Error message -> return ServerProbeInvalidUri message
+            | Ok requestUri ->
+                use cancellationSource = new CancellationTokenSource(request.Timeout)
+                use httpClient = new HttpClient()
+                httpClient.Timeout <- Timeout.InfiniteTimeSpan
+                ClientIdentity.applyHeaders httpClient |> ignore
+
+                use httpRequest = new HttpRequestMessage(HttpMethod.Get, requestUri)
+
+                match request.BearerToken with
+                | Some token -> httpRequest.Headers.Authorization <- AuthenticationHeaderValue("Bearer", token)
+                | None -> ()
+
+                try
+                    use! response = httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationSource.Token)
+                    let! body = response.Content.ReadAsStringAsync(cancellationSource.Token)
+
+                    return
+                        ServerProbeSucceeded
+                            {
+                                StatusCode = response.StatusCode
+                                ReasonPhrase =
+                                    response.ReasonPhrase
+                                    |> Option.ofObj
+                                    |> Option.defaultValue String.Empty
+                                LifecycleDiagnostics = ClientIdentity.parseLifecycleDiagnostics response
+                                Body = body
+                            }
+                with
+                | :? OperationCanceledException when cancellationSource.IsCancellationRequested ->
+                    return ServerProbeTimedOut $"Timed out after {int request.Timeout.TotalMilliseconds} ms while probing {requestUri}."
+                | :? HttpRequestException as ex when
+                    not (isNull ex.InnerException)
+                    && ex
+                        .InnerException
+                        .GetType()
+                        .Name.Contains("Authentication", StringComparison.OrdinalIgnoreCase)
+                    ->
+                    return ServerProbeTlsFailed $"TLS negotiation failed while probing {requestUri}: {ex.Message}"
+                | :? HttpRequestException as ex -> return ServerProbeConnectionFailed $"Could not connect to {requestUri}: {ex.Message}"
+                | ex -> return ServerProbeFailed $"Unexpected server probe failure for {requestUri}: {ex.Message}"
+        }
+
+    let mutable private serverProbeFactory: ServerProbeRequest -> Task<ServerProbeInspection> = defaultServerProbe
+
+    let setServerProbeFactoryForTests factory = serverProbeFactory <- factory
+
+    let resetServerProbeFactoryForTests () = serverProbeFactory <- defaultServerProbe
+
+    let private resolveEffectiveServerUri (configurationState: ConfigurationInspectionState) environmentServerUri =
+        let tryResolve source value =
+            match Uri.TryCreate(value, UriKind.Absolute) with
+            | true, uri when
+                uri.Scheme = Uri.UriSchemeHttp
+                || uri.Scheme = Uri.UriSchemeHttps
+                ->
+                EffectiveServerUriResolved(uri, source)
+            | true, uri -> EffectiveServerUriUnavailable $"Effective server URI from {source} uses unsupported scheme '{uri.Scheme}'."
+            | false, _ -> EffectiveServerUriUnavailable $"Effective server URI from {source} is not an absolute URI: {value}."
+
+        match environmentServerUri with
+        | Some value -> tryResolve Constants.EnvironmentVariables.GraceServerUri value
+        | None ->
+            match configurationState with
+            | ConfigurationLoaded inspection -> tryResolve Constants.GraceConfigFileName inspection.Configuration.ServerUri
+            | ConfigurationMissing _ ->
+                EffectiveServerUriUnavailable
+                    $"No effective server URI was available because {Constants.GraceConfigFileName} was not found and {Constants.EnvironmentVariables.GraceServerUri} is not set."
+            | ConfigurationMalformed _ ->
+                EffectiveServerUriUnavailable
+                    $"No effective server URI was available because {ConfigFileParseCheckId} failed and {Constants.EnvironmentVariables.GraceServerUri} is not set."
+
+    let private validEnvironmentPat (authInspection: Auth.AuthInspection) =
+        if authInspection.GraceTokenValid then
+            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+            |> normalizeOptionalText
+            |> Option.map normalizeBearerToken
+        else
+            None
+
+    let private probeServer relativePath bearerToken effectiveServerUri =
+        match effectiveServerUri with
+        | EffectiveServerUriUnavailable message -> Task.FromResult(ServerProbeInvalidUri message)
+        | EffectiveServerUriResolved (uri, _) ->
+            {
+                BaseUri = uri
+                RelativePath = relativePath
+                BearerToken = bearerToken
+                Timeout = TimeSpan.FromMilliseconds(float DoctorServerProbeTimeoutMilliseconds)
+            }
+            |> serverProbeFactory
+
+    let private createInspectionContext offline =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
@@ -423,14 +590,26 @@ module Doctor =
             | ConfigurationMalformed (path, _) -> Path.Combine(Path.GetDirectoryName(path), Constants.GraceLocalStateDbFileName)
             | ConfigurationMissing _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
 
+        let environmentServerUri =
+            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+            |> normalizeOptionalText
+
+        let effectiveServerUri = resolveEffectiveServerUri configurationState environmentServerUri
+
         {
+            Offline = offline
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
-            EnvironmentServerUri =
-                Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
-                |> normalizeOptionalText
+            EnvironmentServerUri = environmentServerUri
             AuthInspection = Auth.inspectAuthEnvironment ()
             LocalStateInspection = lazy (LocalStateDb.inspectReadOnly localStateDbPath)
+            ServerHealthzInspection =
+                lazy
+                    (if offline then
+                         ServerProbeSkipped "Skipped because --offline is set; doctor did not perform any server network probe."
+                     else
+                         probeServer "healthz" None effectiveServerUri
+                         |> fun task -> task.GetAwaiter().GetResult())
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -451,6 +630,45 @@ module Doctor =
     let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
 
     let private formatListOrNone (values: string array) = if Array.isEmpty values then "none" else String.Join(", ", values)
+
+    let private lifecycleSummary (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        let details = ResizeArray<string>()
+
+        match diagnostics.Status with
+        | Some status -> details.Add($"status={status}")
+        | None -> ()
+
+        match diagnostics.UnsupportedAfter with
+        | Some unsupportedAfter -> details.Add($"unsupportedAfter={unsupportedAfter}")
+        | None -> ()
+
+        match diagnostics.MinimumVersion with
+        | Some minimumVersion -> details.Add($"minimumVersion={minimumVersion}")
+        | None -> ()
+
+        match diagnostics.RecommendedVersion with
+        | Some recommendedVersion -> details.Add($"recommendedVersion={recommendedVersion}")
+        | None -> ()
+
+        match diagnostics.UpdateUrl with
+        | Some updateUrl -> details.Add($"updateUrl={updateUrl}")
+        | None -> ()
+
+        String.Join("; ", details)
+
+    let private lifecycleHasWarning (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        diagnostics.UnsupportedAfterIsMalformed
+        || diagnostics.UpdateUrlIsHttps = Some false
+
+    let private probeFailureSummary inspection =
+        match inspection with
+        | ServerProbeSkipped message -> message
+        | ServerProbeInvalidUri message -> message
+        | ServerProbeTimedOut message -> message
+        | ServerProbeTlsFailed message -> message
+        | ServerProbeConnectionFailed message -> message
+        | ServerProbeFailed message -> message
+        | ServerProbeSucceeded response -> $"Server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}."
 
     let private localStateUnavailableSummary checkId (inspection: LocalStateDb.ReadOnlyLocalStateInspection) =
         if not inspection.ParentDirectoryExists then
@@ -531,6 +749,67 @@ module Doctor =
             if auth.M2mComplete || auth.CliComplete then ok summary
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
+        | ServerHealthzReachableCheckId ->
+            match context.ServerHealthzInspection.Value with
+            | ServerProbeSkipped message -> skipped check message
+            | ServerProbeSucceeded response when
+                int response.StatusCode >= 200
+                && int response.StatusCode <= 299
+                ->
+                ok $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}; timeout was {DoctorServerProbeTimeoutMilliseconds} ms."
+            | ServerProbeSucceeded response ->
+                failed
+                    $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
+            | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
+            | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
+            | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."
+            | ServerProbeInvalidUri message ->
+                failed
+                    $"{message} Set {Constants.EnvironmentVariables.GraceServerUri} or {Constants.GraceConfigFileName} serverUri to an absolute http/https URI."
+            | ServerProbeFailed message -> failed message
+        | ServerLifecycleHeadersCheckId ->
+            match context.ServerHealthzInspection.Value with
+            | ServerProbeSkipped message -> skipped check message
+            | ServerProbeSucceeded response ->
+                match response.LifecycleDiagnostics with
+                | None -> ok "No Grace SDK lifecycle headers were returned by /healthz."
+                | Some diagnostics when lifecycleHasWarning diagnostics ->
+                    warning
+                        $"Lifecycle headers were returned by /healthz with advisory warnings: {lifecycleSummary diagnostics}. Malformed unsupported-after dates or non-HTTPS update URLs should be corrected server-side."
+                | Some diagnostics -> ok $"Lifecycle headers were returned by /healthz: {lifecycleSummary diagnostics}."
+            | failure -> failed $"Could not inspect lifecycle headers because /healthz did not produce a response: {probeFailureSummary failure}"
+        | ServerAuthPrincipalAvailableCheckId ->
+            if context.Offline then
+                skipped check "Skipped because --offline is set; doctor did not perform the authenticated principal probe."
+            else
+                match validEnvironmentPat context.AuthInspection with
+                | None ->
+                    skipped
+                        check
+                        $"Skipped because no valid non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT is available. Doctor did not use OIDC, token refresh, secure storage, browser, device-code, or SDK auth provider paths."
+                | Some token ->
+                    let effectiveServerUri = resolveEffectiveServerUri context.ConfigurationState context.EnvironmentServerUri
+
+                    match probeServer "auth/me" (Some token) effectiveServerUri
+                          |> fun task -> task.GetAwaiter().GetResult()
+                        with
+                    | ServerProbeSucceeded response when
+                        int response.StatusCode >= 200
+                        && int response.StatusCode <= 299
+                        ->
+                        ok
+                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
+                    | ServerProbeSucceeded response ->
+                        failed
+                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
+                    | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
+                    | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
+                    | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."
+                    | ServerProbeInvalidUri message ->
+                        failed
+                            $"{message} Set {Constants.EnvironmentVariables.GraceServerUri} or {Constants.GraceConfigFileName} serverUri to an absolute http/https URI."
+                    | ServerProbeSkipped message -> skipped check message
+                    | ServerProbeFailed message -> failed message
         | StateDbFilePresentCheckId ->
             let inspection = context.LocalStateInspection.Value
 
@@ -775,7 +1054,7 @@ module Doctor =
             if listOnly then
                 checks |> Array.map listOnlyResultForCheck
             else
-                let context = createInspectionContext ()
+                let context = createInspectionContext offline
                 checks |> Array.map (resultForCheck context)
 
         let summary = summarize results

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -650,15 +650,30 @@ module Doctor =
         | Some recommendedVersion -> details.Add($"recommendedVersion={recommendedVersion}")
         | None -> ()
 
-        match diagnostics.UpdateUrl with
-        | Some updateUrl -> details.Add($"updateUrl={updateUrl}")
-        | None -> ()
+        match diagnostics.UpdateUrl, diagnostics.UpdateUrlIsHttps with
+        | Some updateUrl, Some true -> details.Add($"updateUrl={updateUrl}")
+        | Some _, Some false -> details.Add("updateUrl=<suppressed because server value was not HTTPS>")
+        | Some updateUrl, _ -> details.Add($"updateUrl={updateUrl}")
+        | None, _ -> ()
 
         String.Join("; ", details)
 
+    let private lifecycleStatusNeedsUserAction (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        match diagnostics.Status with
+        | Some status when status.Equals("deprecated", StringComparison.OrdinalIgnoreCase) -> true
+        | Some status when status.Equals("unsupported", StringComparison.OrdinalIgnoreCase) -> true
+        | _ -> false
+
     let private lifecycleHasWarning (diagnostics: ClientIdentity.LifecycleDiagnostics) =
-        diagnostics.UnsupportedAfterIsMalformed
+        lifecycleStatusNeedsUserAction diagnostics
+        || diagnostics.UnsupportedAfterIsMalformed
         || diagnostics.UpdateUrlIsHttps = Some false
+
+    let private healthzLifecycleRejectionSummary (response: ServerProbeResponse) =
+        response.LifecycleDiagnostics
+        |> Option.filter lifecycleStatusNeedsUserAction
+        |> Option.map (fun diagnostics ->
+            $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}, and Grace SDK lifecycle headers reported client status requiring action: {lifecycleSummary diagnostics}. Update the Grace CLI/SDK or otherwise address the lifecycle status before retrying.")
 
     let private probeFailureSummary inspection =
         match inspection with
@@ -758,8 +773,11 @@ module Doctor =
                 ->
                 ok $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}; timeout was {DoctorServerProbeTimeoutMilliseconds} ms."
             | ServerProbeSucceeded response ->
-                failed
-                    $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
+                match healthzLifecycleRejectionSummary response with
+                | Some summary -> failed summary
+                | None ->
+                    failed
+                        $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
             | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
             | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
             | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."


### PR DESCRIPTION
## Summary

- Adds explicit/full-catalog `grace doctor` server checks for `/healthz` reachability, lifecycle headers, and safe principal availability.
- Keeps `--offline` as a hard no-network mode while preserving full catalog discovery for `--list-checks`.
- Restricts `/auth/me` probing to a valid non-refreshing `GRACE_TOKEN` PAT and records all server probe outcomes as `DoctorReportDto` checks.
- Adds focused Doctor CLI coverage for output cleanliness, exact checks, offline no-network behavior, lifecycle warning cases, timeout/error classification, and principal boundaries.

## Related Work

Related to #338
Part of #333

## Validation

- Targeted Fantomas passed for touched F# files.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor` passed: 70/70.
- `git diff --check` passed.
- Focused source search found no forbidden auth provider, token acquire/refresh, secure-store, browser/device-code, OIDC discovery, or Azure dependency probe calls in `Doctor.CLI.fs`.
- PR `full` CI passed on `03b59c8`.
- `ClientIdentity` filter skipped because `ClientIdentity.SDK.fs` and `ClientIdentity.SDK.Tests.fs` were not changed.
- `validate -Fast` skipped locally to avoid duplicating the focused build/test gate; PR `full` CI passed.

## Review Status

- 2026-06-10: CI passed on `92c24db`; Codex reviewed head `92c24db` and found P2 threads `3388681625`, `3388681637`, and `3388681642`.
- 2026-06-10: Fixed in `03b59c8`; replied to and resolved all three Codex threads with validation evidence.
- 2026-06-10: Prevention: focused Doctor tests now cover deprecated/unsupported lifecycle warnings, non-HTTPS lifecycle update URL redaction, and lifecycle-oriented healthz rejection remediation.
- 2026-06-10: CI passed on `03b59c8`; Codex Code Review Bot reported no major issues on `03b59c8`; no unresolved current review threads remain.

## Notes For S6 Docs

- Server URI remediation: check `GRACE_SERVER_URI` or `graceconfig` `serverUri` for an absolute `http`/`https` URI, then start or reach the Grace server.
- TLS remediation: fix server TLS certificates or use the intended trusted local endpoint.
- Lifecycle remediation: correct unsupported-after dates and use HTTPS update URLs.
- Principal remediation: set a valid non-refreshing `GRACE_TOKEN` PAT when principal checks are desired.