### PR TITLE
I06: Propagate file BLAKE3 through manifest workflows

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -169,6 +169,12 @@ module DirectoryVersion =
                 Error(manifestValidationError correlationId fileVersion "must include a ChunkingSuiteId before Save.")
             elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
                 Error(manifestValidationError correlationId fileVersion "has an invalid FileContentHash before Save.")
+            elif String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+                Error(manifestValidationError correlationId fileVersion "must include FileVersion.Blake3Hash before Save.")
+            elif not (ContentAddress.isValidAddress fileVersion.Blake3Hash) then
+                Error(manifestValidationError correlationId fileVersion "has an invalid FileVersion.Blake3Hash before Save.")
+            elif fileVersion.Blake3Hash <> manifest.FileContentHash then
+                Error(manifestValidationError correlationId fileVersion "must have FileVersion.Blake3Hash equal FileManifest.FileContentHash before Save.")
             elif manifest.Size <= 0L then
                 Error(manifestValidationError correlationId fileVersion "must have a positive size before Save.")
             elif fileVersion.Size <> manifest.Size then

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -43,16 +43,41 @@ open Azure.Storage
 
 module DirectoryVersion =
 
-    /// Result of validating a single file's SHA-256 hash.
+    /// Result of validating a single whole-file content object's hashes.
     type FileValidationResult =
-        | Valid of fileVersion: FileVersion * computedHash: Sha256Hash * elapsedMs: float
-        | HashMismatch of fileVersion: FileVersion * expectedHash: Sha256Hash * computedHash: Sha256Hash * elapsedMs: float
+        | Valid of fileVersion: FileVersion * computedSha256Hash: Sha256Hash * computedBlake3Hash: Blake3Hash * elapsedMs: float
+        | Sha256HashMismatch of fileVersion: FileVersion * expectedHash: Sha256Hash * computedHash: Sha256Hash * elapsedMs: float
+        | Blake3HashMismatch of fileVersion: FileVersion * expectedHash: Blake3Hash * computedHash: Blake3Hash * elapsedMs: float
         | MissingInStorage of fileVersion: FileVersion * elapsedMs: float
         | ValidationError of fileVersion: FileVersion * errorMessage: string * elapsedMs: float
 
-    /// Validates a single file's SHA-256 hash by downloading from storage and computing.
+    let validateWholeFileHashesForSaveBoundary (fileVersion: FileVersion) (computedSha256Hash: Sha256Hash) (computedBlake3Hash: Blake3Hash) elapsedMs =
+        if computedSha256Hash <> fileVersion.Sha256Hash then
+            Sha256HashMismatch(fileVersion, fileVersion.Sha256Hash, computedSha256Hash, elapsedMs)
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+            && computedBlake3Hash <> fileVersion.Blake3Hash
+        then
+            Blake3HashMismatch(fileVersion, fileVersion.Blake3Hash, computedBlake3Hash, elapsedMs)
+        else
+            if String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+                fileVersion.Blake3Hash <- computedBlake3Hash
+
+            Valid(fileVersion, computedSha256Hash, computedBlake3Hash, elapsedMs)
+
+    let private computeWholeFileContentHashes (stream: Stream) =
+        task {
+            use content = new MemoryStream()
+            do! stream.CopyToAsync(content)
+            let bytes = content.ToArray()
+            let sha256Hash = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+            let blake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+            return sha256Hash, blake3Hash
+        }
+
+    /// Validates a single file's SHA-256 and BLAKE3 hashes by downloading from storage and computing.
     /// Note: Non-binary files are stored as GZip-compressed streams, so we need to decompress them first.
-    let validateFileSha256 (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
+    let validateWholeFileContentHashes (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
         task {
             let stopwatch = Stopwatch.StartNew()
 
@@ -67,23 +92,20 @@ module DirectoryVersion =
                     // Download the stream from blob storage
                     use! blobStream = blobClient.OpenReadAsync(position = 0, bufferSize = (64 * 1024))
 
-                    // Compute SHA-256 hash using the server-specific validation function.
-                    // Text files are stored as GZip streams and need decompression.
-                    let! computedHash =
+                    // Compute file hashes from the exact persisted content bytes.
+                    // Text files are stored as GZip streams and need decompression before validation.
+                    let! (computedSha256Hash, computedBlake3Hash) =
                         if fileVersion.IsBinary then
-                            computeSha256ForFile blobStream fileVersion.RelativePath
+                            computeWholeFileContentHashes blobStream
                         else
                             task {
                                 use gzStream = new GZipStream(stream = blobStream, mode = CompressionMode.Decompress, leaveOpen = false)
-                                return! computeSha256ForFile gzStream fileVersion.RelativePath
+                                return! computeWholeFileContentHashes gzStream
                             }
 
                     stopwatch.Stop()
 
-                    if computedHash = fileVersion.Sha256Hash then
-                        return Valid(fileVersion, computedHash, stopwatch.Elapsed.TotalMilliseconds)
-                    else
-                        return HashMismatch(fileVersion, fileVersion.Sha256Hash, computedHash, stopwatch.Elapsed.TotalMilliseconds)
+                    return validateWholeFileHashesForSaveBoundary fileVersion computedSha256Hash computedBlake3Hash stopwatch.Elapsed.TotalMilliseconds
             with
             | ex ->
                 stopwatch.Stop()
@@ -785,7 +807,7 @@ module DirectoryVersion =
                                                 | None -> getFilesToValidateForSaveBoundary directoryVersion.Files (List<FileVersion>())
 
                                             log.LogDebug(
-                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting SHA-256 validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
+                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting whole-file content hash validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
                                                 getCurrentInstantExtended (),
                                                 getMachineName,
                                                 metadata.CorrelationId,
@@ -805,7 +827,8 @@ module DirectoryVersion =
                                                     (fun fileVersion ct ->
                                                         ValueTask(
                                                             task {
-                                                                let! result = validateFileSha256 repositoryDto fileVersion metadata.CorrelationId
+                                                                let! result = validateWholeFileContentHashes repositoryDto fileVersion metadata.CorrelationId
+
                                                                 validationResults.Enqueue result
                                                             }
                                                         ))
@@ -834,27 +857,40 @@ module DirectoryVersion =
                                                 validationResults
                                                 |> Array.sumBy (fun result ->
                                                     match result with
-                                                    | Valid (_, _, ms) -> ms
-                                                    | HashMismatch (_, _, _, ms) -> ms
+                                                    | Valid (_, _, _, ms) -> ms
+                                                    | Sha256HashMismatch (_, _, _, ms) -> ms
+                                                    | Blake3HashMismatch (_, _, _, ms) -> ms
                                                     | MissingInStorage (_, ms) -> ms
                                                     | ValidationError (_, _, ms) -> ms)
 
                                             // Log validation results
                                             for result in validationResults do
                                                 match result with
-                                                | Valid (fv, computedHash, elapsedMs) ->
+                                                | Valid (fv, computedSha256Hash, computedBlake3Hash, elapsedMs) ->
                                                     log.LogDebug(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation passed; File: {RelativePath}; Hash: {Hash}; ElapsedMs: {ElapsedMs}.",
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; whole-file content hash validation passed; File: {RelativePath}; Sha256Hash: {Sha256Hash}; Blake3Hash: {Blake3Hash}; ElapsedMs: {ElapsedMs}.",
                                                         getCurrentInstantExtended (),
                                                         getMachineName,
                                                         metadata.CorrelationId,
                                                         fv.RelativePath,
+                                                        computedSha256Hash,
+                                                        computedBlake3Hash,
+                                                        elapsedMs
+                                                    )
+                                                | Sha256HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
+                                                    log.LogWarning(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        fv.RelativePath,
+                                                        expectedHash,
                                                         computedHash,
                                                         elapsedMs
                                                     )
-                                                | HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
+                                                | Blake3HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
                                                     log.LogWarning(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; BLAKE3 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
                                                         getCurrentInstantExtended (),
                                                         getMachineName,
                                                         metadata.CorrelationId,
@@ -891,15 +927,17 @@ module DirectoryVersion =
                                                     failures
                                                     |> List.map (fun failure ->
                                                         match failure with
-                                                        | HashMismatch (fv, expected, computed, _) ->
-                                                            $"File '{fv.RelativePath}': hash mismatch (expected: {expected}, computed: {computed})"
+                                                        | Sha256HashMismatch (fv, expected, computed, _) ->
+                                                            $"File '{fv.RelativePath}': SHA-256 hash mismatch (expected: {expected}, computed: {computed})"
+                                                        | Blake3HashMismatch (fv, expected, computed, _) ->
+                                                            $"File '{fv.RelativePath}': BLAKE3 hash mismatch (expected: {expected}, computed: {computed})"
                                                         | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
                                                         | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
                                                         | _ -> "Unknown error")
                                                     |> String.concat "; "
 
                                                 log.LogWarning(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; whole-file content hash validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
                                                     getCurrentInstantExtended (),
                                                     getMachineName,
                                                     metadata.CorrelationId,
@@ -911,11 +949,11 @@ module DirectoryVersion =
                                                 )
 
                                                 // Determine the appropriate error type
-                                                let hasHashMismatch =
+                                                let hasSha256HashMismatch =
                                                     failures
                                                     |> List.exists (fun f ->
                                                         match f with
-                                                        | HashMismatch _ -> true
+                                                        | Sha256HashMismatch _ -> true
                                                         | _ -> false)
 
                                                 let hasMissing =
@@ -930,7 +968,7 @@ module DirectoryVersion =
                                                         DirectoryVersionError.getErrorMessage DirectoryVersionError.FileNotFoundInObjectStorage
                                                         + " "
                                                         + errorDetails
-                                                    elif hasHashMismatch then
+                                                    elif hasSha256HashMismatch then
                                                         DirectoryVersionError.getErrorMessage DirectoryVersionError.FileSha256HashDoesNotMatch
                                                         + " "
                                                         + errorDetails
@@ -940,7 +978,7 @@ module DirectoryVersion =
                                                 return Error(GraceError.Create errorMessage metadata.CorrelationId)
                                             else
                                                 log.LogInformation(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; whole-file content hash validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
                                                     getCurrentInstantExtended (),
                                                     getMachineName,
                                                     metadata.CorrelationId,

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -169,30 +169,36 @@ module DirectoryVersion =
                 Error(manifestValidationError correlationId fileVersion "must include a ChunkingSuiteId before Save.")
             elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
                 Error(manifestValidationError correlationId fileVersion "has an invalid FileContentHash before Save.")
-            elif String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
-                Error(manifestValidationError correlationId fileVersion "must include FileVersion.Blake3Hash before Save.")
-            elif not (ContentAddress.isValidAddress fileVersion.Blake3Hash) then
-                Error(manifestValidationError correlationId fileVersion "has an invalid FileVersion.Blake3Hash before Save.")
-            elif fileVersion.Blake3Hash <> manifest.FileContentHash then
-                Error(manifestValidationError correlationId fileVersion "must have FileVersion.Blake3Hash equal FileManifest.FileContentHash before Save.")
-            elif manifest.Size <= 0L then
-                Error(manifestValidationError correlationId fileVersion "must have a positive size before Save.")
-            elif fileVersion.Size <> manifest.Size then
-                Error(manifestValidationError correlationId fileVersion "must match the FileVersion size before Save.")
             else
-                validateManifestBlocks correlationId fileVersion manifest
-                |> Result.bind (fun () ->
-                    let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
-
-                    if expectedAddress <> manifest.ManifestAddress then
-                        Error(
-                            manifestValidationError
-                                correlationId
-                                fileVersion
-                                "must have a finalized ManifestAddress that matches its reconstruction contract before Save."
-                        )
+                let effectiveFileVersionBlake3Hash =
+                    if String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+                        Blake3Hash $"{manifest.FileContentHash}"
                     else
-                        Ok())
+                        fileVersion.Blake3Hash
+
+                if not (ContentAddress.isValidAddress effectiveFileVersionBlake3Hash) then
+                    Error(manifestValidationError correlationId fileVersion "has an invalid FileVersion.Blake3Hash before Save.")
+                elif effectiveFileVersionBlake3Hash
+                     <> manifest.FileContentHash then
+                    Error(manifestValidationError correlationId fileVersion "must have FileVersion.Blake3Hash equal FileManifest.FileContentHash before Save.")
+                elif manifest.Size <= 0L then
+                    Error(manifestValidationError correlationId fileVersion "must have a positive size before Save.")
+                elif fileVersion.Size <> manifest.Size then
+                    Error(manifestValidationError correlationId fileVersion "must match the FileVersion size before Save.")
+                else
+                    validateManifestBlocks correlationId fileVersion manifest
+                    |> Result.bind (fun () ->
+                        let expectedAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+                        if expectedAddress <> manifest.ManifestAddress then
+                            Error(
+                                manifestValidationError
+                                    correlationId
+                                    fileVersion
+                                    "must have a finalized ManifestAddress that matches its reconstruction contract before Save."
+                            )
+                        else
+                            Ok())
         with
         | ex -> Error(GraceError.CreateWithException ex $"FileManifest reference for '{fileVersion.RelativePath}' is invalid before Save." correlationId)
 

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -39,6 +39,7 @@ open System.Threading.Tasks
 open System.Reflection.Metadata
 open MessagePack
 open System.Threading
+open Blake3
 open Azure.Storage
 
 module DirectoryVersion =
@@ -65,14 +66,43 @@ module DirectoryVersion =
 
             Valid(fileVersion, computedSha256Hash, computedBlake3Hash, elapsedMs)
 
-    let private computeWholeFileContentHashes (stream: Stream) =
+    let internal computeWholeFileContentHashes (stream: Stream) =
         task {
-            use content = new MemoryStream()
-            do! stream.CopyToAsync(content)
-            let bytes = content.ToArray()
-            let sha256Hash = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
-            let blake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
-            return sha256Hash, blake3Hash
+            if isNull stream then nullArg (nameof stream)
+
+            let bufferLength = 64 * 1024
+            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
+            use sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256)
+            let mutable blake3 = Hasher.New()
+
+            try
+                let mutable moreToRead = true
+
+                while moreToRead do
+                    let! bytesRead = stream.ReadAsync(buffer, 0, bufferLength)
+
+                    if bytesRead > 0 then
+                        let chunk = buffer.AsSpan(0, bytesRead)
+                        sha256.AppendData(chunk)
+                        blake3.Update(chunk)
+                    else
+                        moreToRead <- false
+
+                let sha256Bytes = stackalloc<byte> SHA256.HashSizeInBytes
+                sha256.GetHashAndReset(sha256Bytes) |> ignore
+
+                let blake3Bytes = stackalloc<byte> Hash.Size
+                blake3.Finalize(blake3Bytes)
+
+                let sha256Hash = Sha256Hash(byteArrayToString sha256Bytes)
+                let blake3Hash = Blake3Hash(byteArrayToString blake3Bytes)
+
+                return sha256Hash, blake3Hash
+            finally
+                if not <| isNull buffer then
+                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
+
+                blake3.Dispose()
         }
 
     /// Validates a single file's SHA-256 and BLAKE3 hashes by downloading from storage and computing.

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -139,8 +139,31 @@ module DirectoryVersion =
         (normalizeContentReference fileVersion)
             .ReferenceType = FileContentReferenceType.WholeFileContent
 
+    let private contentReferenceValidationKey (fileVersion: FileVersion) =
+        let contentReference = normalizeContentReference fileVersion
+
+        let manifestAddress =
+            match contentReference.Manifest with
+            | Some manifest -> $"{manifest.ManifestAddress}"
+            | None -> String.Empty
+
+        (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash, contentReference.ReferenceType, manifestAddress)
+
     let getFilesToValidateForSaveBoundary (newFiles: List<FileVersion>) (previouslyValidatedFiles: List<FileVersion>) : FileVersion array =
-        getFilesToValidate newFiles previouslyValidatedFiles
+        let changedFiles =
+            if previouslyValidatedFiles.Count > 0 then
+                let previousFilesLookup =
+                    previouslyValidatedFiles
+                    |> Seq.map contentReferenceValidationKey
+                    |> HashSet
+
+                newFiles
+                    .Where(fun fileVersion -> not (previousFilesLookup.Contains(contentReferenceValidationKey fileVersion)))
+                    .ToArray()
+            else
+                newFiles.ToArray()
+
+        changedFiles
         |> Array.filter isWholeFileContentReference
 
     let private manifestValidationError correlationId (fileVersion: FileVersion) message =

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -119,7 +119,7 @@ module CurrentStateCaptureCliTests =
             CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
             BuildUpdatedGraceStatus = fun status _ -> Task.FromResult(status, List<LocalDirectoryVersion>())
             UploadFileVersions = fun _ -> Task.FromResult(Ok([]))
-            UploadDirectoryVersions = fun _ _ -> Task.FromResult(Ok())
+            UploadDirectoryVersions = fun _ _ _ -> Task.FromResult(Ok())
             ApplyGraceStatusIncremental = fun _ _ _ -> Task.FromResult(())
             CreateSaveReference = fun _ _ -> Task.FromResult(Ok(Guid.NewGuid()))
         }
@@ -255,7 +255,7 @@ module CurrentStateCaptureCliTests =
                 ScanForDifferences = fun _ -> Task.FromResult(differences)
                 BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
                 UploadDirectoryVersions =
-                    fun _ _ ->
+                    fun _ _ _ ->
                         uploadedDirectories <- true
                         Task.FromResult(Ok())
                 ApplyGraceStatusIncremental =
@@ -425,7 +425,66 @@ module CurrentStateCaptureCliTests =
                 localFileVersion.Size
                 DateTime.UtcNow
 
-        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedFileVersion ] localDirectoryVersion
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedFileVersion ] [] localDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .Manifest
+        |> should equal (Some manifest)
+
+    [<Test>]
+    let ``directory upload overlay preserves prior manifest backed unchanged file version`` () =
+        let manifest = finalizedManifest ()
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "manifest-sha")
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let priorFileVersion = localFileVersion.ToFileVersion
+        priorFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let previousDirectoryVersion =
+            DirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "previous-directory-sha")
+                (Blake3Hash "previous-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| priorFileVersion |]))
+                localFileVersion.Size
+
+        let localDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "new-directory-sha")
+                (Blake3Hash "new-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [] [ previousDirectoryVersion ] localDirectoryVersion
 
         directoryVersion.Files.Count |> should equal 1
 

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -298,6 +298,7 @@ module CurrentStateCaptureCliTests =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"
         let mutable createdSave = false
+        let mutable appliedStatus = false
 
         let differences =
             List<FileSystemDifference>(
@@ -315,6 +316,10 @@ module CurrentStateCaptureCliTests =
                 ScanForDifferences = fun _ -> Task.FromResult(differences)
                 BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
                 UploadDirectoryVersions = fun _ _ _ -> Task.FromResult(Error uploadError)
+                ApplyGraceStatusIncremental =
+                    fun _ _ _ ->
+                        appliedStatus <- true
+                        Task.FromResult(())
                 CreateSaveReference =
                     fun _ _ ->
                         createdSave <- true
@@ -332,6 +337,7 @@ module CurrentStateCaptureCliTests =
             |> should contain "previous directory lookup failed"
 
             createdSave |> should equal false
+            appliedStatus |> should equal false
 
     [<Test>]
     let ``local changes upload changed file versions already present in object cache`` () =

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -422,6 +422,115 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``manifest upload source falls back to working tree file when object cache copy is absent`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = "src/legacy-large.bin"
+                        let fullPath = Path.Combine(root, relativePath)
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(fullPath))
+                        |> ignore
+
+                        File.WriteAllBytes(fullPath, Encoding.UTF8.GetBytes("legacy implicit save upload source"))
+
+                        let! localFileVersion = createLocalFileVersion (FileInfo fullPath)
+
+                        match localFileVersion with
+                        | Some localFileVersion ->
+                            let uploadSourcePath = localFilePathForManifestUpload localFileVersion.ToFileVersion
+
+                            uploadSourcePath
+                            |> should equal (getNativeFilePath fullPath)
+                        | None -> Assert.Fail("Expected local file version creation to succeed.")
+                    })
+        }
+
+    [<Test>]
+    let ``manifest upload source prefers stable object cache copy when present`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = "src/cached-large.bin"
+                        let fullPath = Path.Combine(root, relativePath)
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(fullPath))
+                        |> ignore
+
+                        File.WriteAllBytes(fullPath, Encoding.UTF8.GetBytes("cached implicit save upload source"))
+
+                        let! localFileVersion = createLocalFileVersion (FileInfo fullPath)
+
+                        match localFileVersion with
+                        | Some localFileVersion ->
+                            let! copiedFileVersion = copyToObjectDirectory fullPath
+
+                            copiedFileVersion.IsSome |> should equal true
+
+                            let uploadSourcePath = localFilePathForManifestUpload localFileVersion.ToFileVersion
+
+                            uploadSourcePath
+                            |> should equal localFileVersion.FullObjectPath
+                        | None -> Assert.Fail("Expected local file version creation to succeed.")
+                    })
+        }
+
+    [<Test>]
+    let ``copy to object directory returns file version for cache hit`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = "src/reverted-large.bin"
+                        let fullPath = Path.Combine(root, relativePath)
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(fullPath))
+                        |> ignore
+
+                        File.WriteAllBytes(fullPath, Encoding.UTF8.GetBytes("cached large file revert content"))
+
+                        let! firstCopy = copyToObjectDirectory fullPath
+                        let! secondCopy = copyToObjectDirectory fullPath
+
+                        match firstCopy, secondCopy with
+                        | Some firstFileVersion, Some secondFileVersion ->
+                            secondFileVersion.RelativePath
+                            |> should equal firstFileVersion.RelativePath
+
+                            secondFileVersion.Sha256Hash
+                            |> should equal firstFileVersion.Sha256Hash
+
+                            secondFileVersion.Blake3Hash
+                            |> should equal firstFileVersion.Blake3Hash
+                        | _ -> Assert.Fail("Expected both first copy and object-cache hit to return file versions.")
+                    })
+        }
+
+    [<Test>]
+    let ``diff implicit save failure does not apply rejected local status`` () =
+        let mutable appliedStatus = false
+        let updatedStatus = graceStatus (Guid.NewGuid()) (Sha256Hash "rejected-root-sha")
+        let saveError = GraceError.Create "SaveDirectoryVersions rejected the implicit save." correlationId
+
+        let applyStatus _ _ _ =
+            appliedStatus <- true
+            Task.FromResult(())
+
+        let result =
+            (Grace.CLI.Command.Diff.applyImplicitSaveStatusIfSuccessful
+                (Some saveError)
+                applyStatus
+                updatedStatus
+                Seq.empty<LocalDirectoryVersion>
+                Seq.empty<FileSystemDifference>)
+                .Result
+
+        result |> should equal false
+        appliedStatus |> should equal false
+
+    [<Test>]
     let ``createLocalFileVersion captures complete file BLAKE3`` () =
         task {
             do!

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -15,6 +15,7 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Linq
+open System.Security.Cryptography
 open System.Text
 open System.Threading.Tasks
 
@@ -78,6 +79,10 @@ module CurrentStateCaptureCliTests =
             )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let private computeSha256Hash (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> fun hash -> Sha256Hash(byteArrayToString (hash.AsSpan()))
 
     let private ensureConfigFile root =
         let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
@@ -441,6 +446,84 @@ module CurrentStateCaptureCliTests =
         }
 
     [<Test>]
+    let ``changed file version is captured when only BLAKE3 changes`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = RelativePath "file.txt"
+                        let fullPath = Path.Combine(root, $"{relativePath}")
+                        let bytes = Encoding.UTF8.GetBytes("same sha seeded file with new blake3")
+
+                        File.WriteAllBytes(fullPath, bytes)
+
+                        let sha256Hash = computeSha256Hash bytes
+                        let newBlake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+
+                        let previousFileVersion =
+                            LocalFileVersion.CreateWithHashes
+                                relativePath
+                                sha256Hash
+                                (Blake3Hash "previous-blake3")
+                                false
+                                (int64 bytes.Length)
+                                (getCurrentInstant ())
+                                true
+                                DateTime.UtcNow
+
+                        let previousRoot =
+                            LocalDirectoryVersion.CreateWithHashes
+                                rootDirectoryId
+                                OwnerId.Empty
+                                OrganizationId.Empty
+                                RepositoryId.Empty
+                                Constants.RootDirectoryPath
+                                rootSha
+                                (Blake3Hash "previous-root-blake3")
+                                (List<DirectoryVersionId>())
+                                (List<LocalFileVersion>([| previousFileVersion |]))
+                                previousFileVersion.Size
+                                DateTime.UtcNow
+
+                        let index = GraceIndex()
+
+                        index.TryAdd(previousRoot.DirectoryVersionId, previousRoot)
+                        |> ignore
+
+                        let previousStatus =
+                            { GraceStatus.Default with
+                                Index = index
+                                RootDirectoryId = previousRoot.DirectoryVersionId
+                                RootDirectorySha256Hash = previousRoot.Sha256Hash
+                            }
+
+                        let differences =
+                            List<FileSystemDifference>(
+                                [|
+                                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File relativePath
+                                |]
+                            )
+
+                        let! (_, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousStatus differences
+
+                        newDirectoryVersions.Count |> should equal 1
+
+                        let updatedRoot = newDirectoryVersions.Single()
+
+                        updatedRoot.DirectoryVersionId
+                        |> should not' (equal previousRoot.DirectoryVersionId)
+
+                        let updatedFile = updatedRoot.Files.Single()
+
+                        updatedFile.Sha256Hash
+                        |> should equal previousFileVersion.Sha256Hash
+
+                        updatedFile.Blake3Hash
+                        |> should equal newBlake3Hash
+                    })
+        }
+
+    [<Test>]
     let ``directory upload overlay uses manifest backed uploaded file version`` () =
         let manifest = finalizedManifest ()
 
@@ -485,6 +568,76 @@ module CurrentStateCaptureCliTests =
             .ContentReference
             .Manifest
         |> should equal (Some manifest)
+
+    [<Test>]
+    let ``directory upload overlay does not preserve prior manifest when BLAKE3 changes`` () =
+        let manifest = finalizedManifest ()
+        let relativePath = RelativePath "large.bin"
+        let sameSha256Hash = Sha256Hash "manifest-sha"
+
+        let priorLocalFileVersion =
+            LocalFileVersion.CreateWithHashes
+                relativePath
+                sameSha256Hash
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let priorFileVersion = priorLocalFileVersion.ToFileVersion
+        priorFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let previousDirectoryVersion =
+            DirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "previous-directory-sha")
+                (Blake3Hash "previous-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| priorFileVersion |]))
+                priorLocalFileVersion.Size
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                relativePath
+                sameSha256Hash
+                (Blake3Hash "changed-blake3")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let localDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "new-directory-sha")
+                (Blake3Hash "new-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [] [ previousDirectoryVersion ] localDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.WholeFileContent
+
+        directoryVersion.Files[0].Blake3Hash
+        |> should equal localFileVersion.Blake3Hash
 
     [<Test>]
     let ``previous directory lookup parameters use requested repository ids`` () =

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -4,7 +4,9 @@ open FsUnit
 open Grace.CLI
 open Grace.CLI.Services
 open Grace.Shared
+open Grace.Shared.Client.Configuration
 open Grace.Shared.Constants
+open Grace.Shared.Utilities
 open Grace.Types.Branch
 open Grace.Types.Common
 open Grace.Types.Reference
@@ -12,6 +14,7 @@ open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.IO
+open System.Text
 open System.Threading.Tasks
 
 [<NonParallelizable>]
@@ -52,6 +55,58 @@ module CurrentStateCaptureCliTests =
             Sha256Hash = sha256Hash
         }
 
+    let private finalizedManifest () =
+        let bytes = Encoding.UTF8.GetBytes("manifest-backed current-state file")
+
+        let block =
+            match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
+            | Ok block -> block
+            | Error error ->
+                Assert.Fail($"Expected content block encoding to succeed, got {error}.")
+                Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex bytes),
+                int64 bytes.Length,
+                [
+                    ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+                ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let private ensureConfigFile root =
+        let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
+
+        Directory.CreateDirectory(graceDirectory)
+        |> ignore
+
+        let graceConfigPath = Path.Combine(graceDirectory, Constants.GraceConfigFileName)
+
+        if not (File.Exists(graceConfigPath)) then
+            File.WriteAllText(graceConfigPath, "{}")
+
+    let private withTempConfiguration action =
+        task {
+            let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-{Guid.NewGuid():N}")
+            let previousDirectory = Environment.CurrentDirectory
+
+            try
+                Directory.CreateDirectory(root) |> ignore
+                Environment.CurrentDirectory <- root
+                ensureConfigFile root
+                resetConfiguration ()
+                return! action root
+            finally
+                Environment.CurrentDirectory <- previousDirectory
+                resetConfiguration ()
+
+                if Directory.Exists(root) then Directory.Delete(root, true)
+        }
+
     let private branch saveEnabled latestReference =
         { BranchDto.Default with BranchId = currentBranchId; SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
 
@@ -63,8 +118,8 @@ module CurrentStateCaptureCliTests =
             ScanForDifferences = fun _ -> Task.FromResult(List<FileSystemDifference>())
             CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
             BuildUpdatedGraceStatus = fun status _ -> Task.FromResult(status, List<LocalDirectoryVersion>())
-            UploadFileVersions = fun _ -> Task.FromResult(Ok())
-            UploadDirectoryVersions = fun _ -> Task.FromResult(Ok())
+            UploadFileVersions = fun _ -> Task.FromResult(Ok([]))
+            UploadDirectoryVersions = fun _ _ -> Task.FromResult(Ok())
             ApplyGraceStatusIncremental = fun _ _ _ -> Task.FromResult(())
             CreateSaveReference = fun _ _ -> Task.FromResult(Ok(Guid.NewGuid()))
         }
@@ -200,7 +255,7 @@ module CurrentStateCaptureCliTests =
                 ScanForDifferences = fun _ -> Task.FromResult(differences)
                 BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
                 UploadDirectoryVersions =
-                    fun _ ->
+                    fun _ _ ->
                         uploadedDirectories <- true
                         Task.FromResult(Ok())
                 ApplyGraceStatusIncremental =
@@ -243,9 +298,10 @@ module CurrentStateCaptureCliTests =
         let updatedRootSha = Sha256Hash "updated-root-sha"
         let createdSaveId = Guid.NewGuid()
         let changedPath = RelativePath "src/file.txt"
+        let changedBlake3 = Blake3Hash "changed-file-blake3"
 
         let changedFile =
-            LocalFileVersion.Create changedPath (Sha256Hash "changed-file-sha") false 12L (Grace.Shared.Utilities.getCurrentInstant ()) true DateTime.UtcNow
+            LocalFileVersion.CreateWithHashes changedPath (Sha256Hash "changed-file-sha") changedBlake3 false 12L (getCurrentInstant ()) true DateTime.UtcNow
 
         let mutable uploadedFiles = List<LocalFileVersion>()
 
@@ -279,7 +335,14 @@ module CurrentStateCaptureCliTests =
                 UploadFileVersions =
                     fun fileVersions ->
                         uploadedFiles <- List<LocalFileVersion>(fileVersions)
-                        Task.FromResult(Ok())
+
+                        Task.FromResult(
+                            Ok(
+                                uploadedFiles
+                                |> Seq.map (fun fileVersion -> fileVersion.ToFileVersion)
+                                |> Seq.toList
+                            )
+                        )
                 CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
             }
 
@@ -299,7 +362,82 @@ module CurrentStateCaptureCliTests =
 
             uploadedFiles[0].Sha256Hash
             |> should equal changedFile.Sha256Hash
+
+            uploadedFiles[0].Blake3Hash
+            |> should equal changedBlake3
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``createLocalFileVersion captures complete file BLAKE3`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = "src/file.txt"
+                        let fullPath = Path.Combine(root, relativePath)
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(fullPath))
+                        |> ignore
+
+                        let bytes = Encoding.UTF8.GetBytes("new local file content")
+                        File.WriteAllBytes(fullPath, bytes)
+
+                        match! createLocalFileVersion (FileInfo(fullPath)) with
+                        | Some fileVersion ->
+                            fileVersion.RelativePath
+                            |> should equal (RelativePath relativePath)
+
+                            fileVersion.Blake3Hash
+                            |> should equal (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+                        | None -> Assert.Fail("Expected LocalFileVersion capture to succeed.")
+                    })
+        }
+
+    [<Test>]
+    let ``directory upload overlay uses manifest backed uploaded file version`` () =
+        let manifest = finalizedManifest ()
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "manifest-sha")
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let uploadedFileVersion = localFileVersion.ToFileVersion
+        uploadedFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let localDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "directory-sha")
+                (Blake3Hash "directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedFileVersion ] localDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .Manifest
+        |> should equal (Some manifest)
 
     [<Test>]
     let ``created save reference id is parsed from response properties`` () =
@@ -330,7 +468,7 @@ module CurrentStateCaptureCliTests =
                 UploadFileVersions =
                     fun _ ->
                         uploadedFiles <- true
-                        Task.FromResult(Ok())
+                        Task.FromResult(Ok([]))
                 CreateSaveReference =
                     fun _ _ ->
                         createdSave <- true

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -294,6 +294,46 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``local changes propagate directory upload failure before creating save reference`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let mutable createdSave = false
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "new-folder")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+        let uploadError = GraceError.Create "previous directory lookup failed" correlationId
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadDirectoryVersions = fun _ _ _ -> Task.FromResult(Error uploadError)
+                CreateSaveReference =
+                    fun _ _ ->
+                        createdSave <- true
+                        Task.FromResult(Ok(Guid.NewGuid()))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured -> Assert.Fail($"Expected directory upload failure, got: {captured}")
+        | Error error ->
+            error.Error
+            |> should contain "previous directory lookup failed"
+
+            createdSave |> should equal false
+
+    [<Test>]
     let ``local changes upload changed file versions already present in object cache`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"
@@ -604,17 +644,21 @@ module CurrentStateCaptureCliTests =
                 (Sha256Hash "new-directory-sha")
                 (Blake3Hash "new-directory-blake3")
                 (List<DirectoryVersionId>())
-                (List<LocalFileVersion>([| unchangedLocalFileVersion; changedLocalFileVersion |]))
-                (unchangedLocalFileVersion.Size + changedLocalFileVersion.Size)
+                (List<LocalFileVersion>(
+                    [|
+                        unchangedLocalFileVersion
+                        changedLocalFileVersion
+                    |]
+                ))
+                (unchangedLocalFileVersion.Size
+                 + changedLocalFileVersion.Size)
                 DateTime.UtcNow
 
-        let directoryVersion =
-            toDirectoryVersionWithUploadedFiles [ uploadedChangedFileVersion ] [ previousDirectoryVersion ] localDirectoryVersion
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedChangedFileVersion ] [ previousDirectoryVersion ] localDirectoryVersion
 
         directoryVersion.Files.Count |> should equal 2
 
-        let unchangedFile =
-            directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = unchangedLocalFileVersion.RelativePath)
+        let unchangedFile = directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = unchangedLocalFileVersion.RelativePath)
 
         unchangedFile.ContentReference.ReferenceType
         |> should equal FileContentReferenceType.FileManifest
@@ -622,8 +666,7 @@ module CurrentStateCaptureCliTests =
         unchangedFile.ContentReference.Manifest
         |> should equal (Some unchangedManifest)
 
-        let changedFile =
-            directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = changedLocalFileVersion.RelativePath)
+        let changedFile = directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = changedLocalFileVersion.RelativePath)
 
         changedFile.ContentReference.ReferenceType
         |> should equal FileContentReferenceType.FileManifest

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -105,9 +105,11 @@ module CurrentStateCaptureCliTests =
                 Environment.CurrentDirectory <- root
                 ensureConfigFile root
                 resetConfiguration ()
+                parseResult <- GraceCommand.rootCommand.Parse([||])
                 return! action root
             finally
                 Environment.CurrentDirectory <- previousDirectory
+                parseResult <- null
                 resetConfiguration ()
 
                 if Directory.Exists(root) then Directory.Delete(root, true)
@@ -520,6 +522,80 @@ module CurrentStateCaptureCliTests =
 
                         updatedFile.Blake3Hash
                         |> should equal newBlake3Hash
+                    })
+        }
+
+    [<Test>]
+    let ``scanForDifferences detects file change when only BLAKE3 changes`` () =
+        task {
+            do!
+                withTempConfiguration (fun root ->
+                    task {
+                        let relativePath = RelativePath "file.txt"
+                        let fullPath = Path.Combine(root, $"{relativePath}")
+                        let bytes = Encoding.UTF8.GetBytes("same sha seeded scan file with new blake3")
+
+                        File.WriteAllBytes(fullPath, bytes)
+
+                        let currentLastWriteTime = DateTime(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc)
+                        let previousLastWriteTime = currentLastWriteTime.AddMinutes(-5.0)
+
+                        File.SetLastWriteTimeUtc(fullPath, currentLastWriteTime)
+
+                        let sha256Hash = computeSha256Hash bytes
+                        let currentBlake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+
+                        let previousFileVersion =
+                            LocalFileVersion.CreateWithHashes
+                                relativePath
+                                sha256Hash
+                                (Blake3Hash "previous-blake3")
+                                false
+                                (int64 bytes.Length)
+                                (getCurrentInstant ())
+                                true
+                                previousLastWriteTime
+
+                        previousFileVersion.Blake3Hash
+                        |> should not' (equal currentBlake3Hash)
+
+                        let previousRoot =
+                            LocalDirectoryVersion.CreateWithHashes
+                                rootDirectoryId
+                                OwnerId.Empty
+                                OrganizationId.Empty
+                                RepositoryId.Empty
+                                Constants.RootDirectoryPath
+                                rootSha
+                                (Blake3Hash "previous-root-blake3")
+                                (List<DirectoryVersionId>())
+                                (List<LocalFileVersion>([| previousFileVersion |]))
+                                previousFileVersion.Size
+                                previousLastWriteTime
+
+                        let index = GraceIndex()
+
+                        index.TryAdd(previousRoot.DirectoryVersionId, previousRoot)
+                        |> ignore
+
+                        let previousStatus =
+                            { GraceStatus.Default with
+                                Index = index
+                                RootDirectoryId = previousRoot.DirectoryVersionId
+                                RootDirectorySha256Hash = previousRoot.Sha256Hash
+                            }
+
+                        let! differences = scanForDifferences previousStatus
+
+                        let matchingChanges =
+                            differences
+                                .Where(fun difference ->
+                                    difference.DifferenceType = DifferenceType.Change
+                                    && difference.FileSystemEntryType = FileSystemEntryType.File
+                                    && difference.RelativePath = relativePath)
+                                .ToList()
+
+                        matchingChanges.Count |> should equal 1
                     })
         }
 

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -14,6 +14,7 @@ open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.IO
+open System.Linq
 open System.Text
 open System.Threading.Tasks
 
@@ -546,6 +547,89 @@ module CurrentStateCaptureCliTests =
             .ContentReference
             .Manifest
         |> should equal (Some manifest)
+
+    [<Test>]
+    let ``directory upload overlay preserves prior manifest backed file when sibling file changes`` () =
+        let unchangedManifest = finalizedManifest ()
+        let changedManifest = finalizedManifest ()
+
+        let unchangedLocalFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "unchanged-manifest-sha")
+                (Blake3Hash $"{unchangedManifest.FileContentHash}")
+                true
+                unchangedManifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let changedLocalFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "changed.txt")
+                (Sha256Hash "changed-uploaded-sha")
+                (Blake3Hash $"{changedManifest.FileContentHash}")
+                true
+                changedManifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let priorUnchangedFileVersion = unchangedLocalFileVersion.ToFileVersion
+        priorUnchangedFileVersion.ContentReference <- FileContentReference.FileManifest unchangedManifest
+
+        let uploadedChangedFileVersion = changedLocalFileVersion.ToFileVersion
+        uploadedChangedFileVersion.ContentReference <- FileContentReference.FileManifest changedManifest
+
+        let previousDirectoryVersion =
+            DirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "previous-directory-sha")
+                (Blake3Hash "previous-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| priorUnchangedFileVersion |]))
+                unchangedLocalFileVersion.Size
+
+        let localDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "new-directory-sha")
+                (Blake3Hash "new-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| unchangedLocalFileVersion; changedLocalFileVersion |]))
+                (unchangedLocalFileVersion.Size + changedLocalFileVersion.Size)
+                DateTime.UtcNow
+
+        let directoryVersion =
+            toDirectoryVersionWithUploadedFiles [ uploadedChangedFileVersion ] [ previousDirectoryVersion ] localDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 2
+
+        let unchangedFile =
+            directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = unchangedLocalFileVersion.RelativePath)
+
+        unchangedFile.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        unchangedFile.ContentReference.Manifest
+        |> should equal (Some unchangedManifest)
+
+        let changedFile =
+            directoryVersion.Files.Single(fun fileVersion -> fileVersion.RelativePath = changedLocalFileVersion.RelativePath)
+
+        changedFile.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        changedFile.ContentReference.Manifest
+        |> should equal (Some changedManifest)
 
     [<Test>]
     let ``created save reference id is parsed from response properties`` () =

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -440,6 +440,55 @@ module CurrentStateCaptureCliTests =
         |> should equal (Some manifest)
 
     [<Test>]
+    let ``directory upload overlay replaces local whole file content with uploaded manifest version`` () =
+        let manifest = finalizedManifest ()
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "manifest-sha")
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        localFileVersion.ToFileVersion.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.WholeFileContent
+
+        let uploadedFileVersion = localFileVersion.ToFileVersion
+        uploadedFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let localDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "directory-sha")
+                (Blake3Hash "directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedFileVersion ] [] localDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .Manifest
+        |> should equal (Some manifest)
+
+    [<Test>]
     let ``directory upload overlay preserves prior manifest backed unchanged file version`` () =
         let manifest = finalizedManifest ()
 

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -481,6 +481,56 @@ module CurrentStateCaptureCliTests =
         |> should equal (Some manifest)
 
     [<Test>]
+    let ``previous directory lookup parameters use requested repository ids`` () =
+        let requestedOwnerId = Guid.NewGuid()
+        let requestedOrganizationId = Guid.NewGuid()
+        let requestedRepositoryId = Guid.NewGuid()
+        let previousDirectoryVersionId = Guid.NewGuid()
+
+        let graceIds =
+            { GraceIds.Default with
+                OwnerId = requestedOwnerId
+                OwnerIdString = $"{requestedOwnerId}"
+                OwnerName = "requested-owner"
+                OrganizationId = requestedOrganizationId
+                OrganizationIdString = $"{requestedOrganizationId}"
+                OrganizationName = "requested-org"
+                RepositoryId = requestedRepositoryId
+                RepositoryIdString = $"{requestedRepositoryId}"
+                RepositoryName = "requested-repo"
+                CorrelationId = correlationId
+                HasOwner = true
+                HasOrganization = true
+                HasRepository = true
+            }
+
+        let parameters = createPreviousDirectoryVersionsParameters graceIds (List<DirectoryVersionId>([| previousDirectoryVersionId |])) correlationId
+
+        parameters.OwnerId
+        |> should equal $"{requestedOwnerId}"
+
+        parameters.OwnerName
+        |> should equal "requested-owner"
+
+        parameters.OrganizationId
+        |> should equal $"{requestedOrganizationId}"
+
+        parameters.OrganizationName
+        |> should equal "requested-org"
+
+        parameters.RepositoryId
+        |> should equal $"{requestedRepositoryId}"
+
+        parameters.RepositoryName
+        |> should equal "requested-repo"
+
+        parameters.DirectoryVersionId
+        |> should equal $"{previousDirectoryVersionId}"
+
+        parameters.DirectoryIds
+        |> should equal (List<DirectoryVersionId>([| previousDirectoryVersionId |]))
+
+    [<Test>]
     let ``directory upload overlay replaces local whole file content with uploaded manifest version`` () =
         let manifest = finalizedManifest ()
 

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -40,6 +40,8 @@ type ManifestUploadSdkTests() =
 
     static member private ComputeSha256Hash(bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
 
+    static member private ComputeBlake3Hash(bytes: byte array) = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+
     static member private UploadParameters correlationId fileVersions =
         let parameters = GetUploadMetadataForFilesParameters()
         parameters.OwnerId <- "22222222-2222-2222-2222-222222222222"
@@ -148,7 +150,14 @@ type ManifestUploadSdkTests() =
             try
                 File.WriteAllBytes(tempPath, payload)
 
-                let fileVersion = FileVersion.Create "large.bin" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty true (int64 payload.Length)
+                let fileVersion =
+                    FileVersion.CreateWithHashes
+                        "large.bin"
+                        (ManifestUploadSdkTests.ComputeSha256Hash payload)
+                        String.Empty
+                        String.Empty
+                        true
+                        (int64 payload.Length)
 
                 let client: ManifestUpload.ManifestUploadClient =
                     {
@@ -211,6 +220,9 @@ type ManifestUploadSdkTests() =
                     Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
                     Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
                     Assert.That(uploadResult.Manifest, Is.EqualTo(finalizedManifest))
+                    Assert.That(uploadResult.FileVersion.Blake3Hash, Is.EqualTo(uploadResult.Manifest.Value.FileContentHash))
+                    Assert.That(uploadResult.FileVersion.Blake3Hash, Is.EqualTo(ManifestUploadSdkTests.ComputeBlake3Hash payload))
+                    Assert.That(uploadResult.FileVersion.Sha256Hash, Is.EqualTo(ManifestUploadSdkTests.ComputeSha256Hash payload))
                     Assert.That(sessionIds |> Seq.distinct |> Seq.length, Is.EqualTo(1))
                     Assert.That(calls[0], Is.EqualTo("start"))
                     Assert.That(calls[calls.Count - 1], Is.EqualTo("finalize"))
@@ -234,7 +246,14 @@ type ManifestUploadSdkTests() =
             try
                 File.WriteAllBytes(tempPath, payload)
 
-                let fileVersion = FileVersion.Create "Tiny.fs" (ManifestUploadSdkTests.ComputeSha256Hash payload) String.Empty false (int64 payload.Length)
+                let fileVersion =
+                    FileVersion.CreateWithHashes
+                        "Tiny.fs"
+                        (ManifestUploadSdkTests.ComputeSha256Hash payload)
+                        String.Empty
+                        String.Empty
+                        false
+                        (int64 payload.Length)
 
                 let client: ManifestUpload.ManifestUploadClient =
                     {
@@ -257,6 +276,8 @@ type ManifestUploadSdkTests() =
                     Assert.That(uploadResult.UsedManifestUpload, Is.False)
                     Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(0))
                     Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
+                    Assert.That(uploadResult.FileVersion.Blake3Hash, Is.EqualTo(ManifestUploadSdkTests.ComputeBlake3Hash payload))
+                    Assert.That(uploadResult.FileVersion.Sha256Hash, Is.EqualTo(ManifestUploadSdkTests.ComputeSha256Hash payload))
                     Assert.That(uploadResult.Manifest, Is.EqualTo(None))
                     Assert.That(uploadResult.UploadSessionId, Is.EqualTo(None))
             finally

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -388,8 +388,6 @@ type ManifestUploadSdkTests() =
             match result with
             | Error error -> Assert.Fail($"{error.Error}{Environment.NewLine}{serialize error.Properties}")
             | Ok returnValue ->
-                Assert.That(returnValue.ReturnValue, Is.True)
-
                 Assert.That(
                     manifestAttempts,
                     Is.EquivalentTo(
@@ -405,6 +403,9 @@ type ManifestUploadSdkTests() =
                 let fallbackFileVersion = wholeFileFallbacks[0][0]
                 Assert.That(fallbackFileVersion, Is.EqualTo(ineligibleFallbackFile))
                 Assert.That(fallbackFileVersion.Blake3Hash, Is.EqualTo(Blake3Hash "fallback-blake3"))
+                Assert.That(returnValue.ReturnValue, Has.Length.EqualTo(2))
+                Assert.That(returnValue.ReturnValue, Does.Contain(manifestFile))
+                Assert.That(returnValue.ReturnValue, Does.Contain(ineligibleFallbackFile))
         }
 
     [<Test>]

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -342,6 +342,16 @@ type ManifestUploadSdkTests() =
             let correlationId = "corr-cli-manifest-fallback-routing"
             let manifestFile = FileVersion.Create "large.bin" (Sha256Hash "manifest-sha") String.Empty true 2048L
             let ineligibleFile = FileVersion.Create "small.fs" (Sha256Hash "ineligible-sha") String.Empty false 128L
+
+            let ineligibleFallbackFile =
+                FileVersion.CreateWithHashes
+                    ineligibleFile.RelativePath
+                    ineligibleFile.Sha256Hash
+                    (Blake3Hash "fallback-blake3")
+                    ineligibleFile.BlobUri
+                    ineligibleFile.IsBinary
+                    ineligibleFile.Size
+
             let manifestAttempts = ResizeArray<string>()
             let wholeFileFallbacks = ResizeArray<FileVersion array>()
 
@@ -351,7 +361,11 @@ type ManifestUploadSdkTests() =
 
                     let result: ManifestUpload.ManifestUploadResult =
                         {
-                            FileVersion = fileVersion
+                            FileVersion =
+                                if fileVersion.RelativePath = ineligibleFile.RelativePath then
+                                    ineligibleFallbackFile
+                                else
+                                    fileVersion
                             Manifest = None
                             UploadSessionId = None
                             UploadedBlockCount = if fileVersion.RelativePath = manifestFile.RelativePath then 1 else 0
@@ -388,7 +402,9 @@ type ManifestUploadSdkTests() =
 
                 Assert.That(wholeFileFallbacks.Count, Is.EqualTo(1))
                 Assert.That(wholeFileFallbacks[0].Length, Is.EqualTo(1))
-                Assert.That(wholeFileFallbacks[0][0], Is.EqualTo(ineligibleFile))
+                let fallbackFileVersion = wholeFileFallbacks[0][0]
+                Assert.That(fallbackFileVersion, Is.EqualTo(ineligibleFallbackFile))
+                Assert.That(fallbackFileVersion.Blake3Hash, Is.EqualTo(Blake3Hash "fallback-blake3"))
         }
 
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -353,6 +353,81 @@ module WatchTests =
         |> should equal (Some manifest)
 
     [<Test>]
+    let ``watch pending upload list preserves manifest uploads across file batches`` () =
+        let firstManifest = finalizedManifest ()
+        let secondManifest = finalizedManifest ()
+
+        let createLocalFileVersion (relativePath: string) (sha256Hash: string) (manifest: FileManifest) =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath relativePath)
+                (Sha256Hash sha256Hash)
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let firstLocalFileVersion = createLocalFileVersion "first-large.bin" "watch-first-uploaded-manifest-sha" firstManifest
+        let secondLocalFileVersion = createLocalFileVersion "second-large.bin" "watch-second-uploaded-manifest-sha" secondManifest
+
+        let firstUploadedFileVersion = firstLocalFileVersion.ToFileVersion
+        firstUploadedFileVersion.ContentReference <- FileContentReference.FileManifest firstManifest
+
+        let secondUploadedFileVersion = secondLocalFileVersion.ToFileVersion
+        secondUploadedFileVersion.ContentReference <- FileContentReference.FileManifest secondManifest
+
+        let pendingFileVersions = List<FileVersion>()
+        Watch.addUploadedFileVersionsForWatchBatch pendingFileVersions [ firstUploadedFileVersion ]
+        Watch.addUploadedFileVersionsForWatchBatch pendingFileVersions [ secondUploadedFileVersion ]
+
+        let uploadedFileVersions = Watch.snapshotUploadedFileVersionsForGraceStatusUpdate pendingFileVersions
+
+        uploadedFileVersions.Count |> should equal 2
+
+        let changedLocalDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "watch-batched-directory-sha")
+                (Blake3Hash "watch-batched-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>(
+                    [|
+                        firstLocalFileVersion
+                        secondLocalFileVersion
+                    |]
+                ))
+                (firstLocalFileVersion.Size
+                 + secondLocalFileVersion.Size)
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles uploadedFileVersions Seq.empty<DirectoryVersion> changedLocalDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 2
+
+        let firstFileVersion = directoryVersion.Files.Find(fun fileVersion -> fileVersion.RelativePath = RelativePath "first-large.bin")
+        let secondFileVersion = directoryVersion.Files.Find(fun fileVersion -> fileVersion.RelativePath = RelativePath "second-large.bin")
+
+        firstFileVersion.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        firstFileVersion.ContentReference.Manifest
+        |> should equal (Some firstManifest)
+
+        secondFileVersion.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        secondFileVersion.ContentReference.Manifest
+        |> should equal (Some secondManifest)
+
+        Watch.clearUploadedFileVersionsAfterGraceStatusUpdate pendingFileVersions
+        pendingFileVersions.Count |> should equal 0
+
+    [<Test>]
     let ``watch exits with auth guidance when no token is configured`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3,6 +3,7 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
+open Grace.CLI.Services
 open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
@@ -14,6 +15,7 @@ open System
 open System.Collections.Generic
 open System.Diagnostics
 open System.IO
+open System.Text
 open System.Text.Json
 open System.Threading.Tasks
 
@@ -162,6 +164,29 @@ module WatchTests =
 
         if File.Exists(ipcFileName) then File.Delete(ipcFileName)
 
+    let private finalizedManifest () =
+        let bytes = Encoding.UTF8.GetBytes("watch manifest-backed file")
+
+        let block =
+            match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
+            | Ok block -> block
+            | Error error ->
+                Assert.Fail($"Expected content block encoding to succeed, got {error}.")
+                Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex bytes),
+                int64 bytes.Length,
+                [
+                    ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+                ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
     let private withTempRepo (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-watch-tests-{Guid.NewGuid():N}")
         let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
@@ -218,6 +243,65 @@ module WatchTests =
             |> should contain "Unable to acquire an access token for SignalR notifications:"
 
             error |> should contain "test error"
+
+    [<Test>]
+    let ``watch save overlay preserves prior manifest backed unchanged file version`` () =
+        let manifest = finalizedManifest ()
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "watch-manifest-sha")
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let priorFileVersion = localFileVersion.ToFileVersion
+        priorFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let previousDirectoryVersion =
+            DirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "watch-previous-directory-sha")
+                (Blake3Hash "watch-previous-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| priorFileVersion |]))
+                localFileVersion.Size
+
+        let changedLocalDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "watch-new-directory-sha")
+                (Blake3Hash "watch-new-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles Seq.empty<FileVersion> [ previousDirectoryVersion ] changedLocalDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .Manifest
+        |> should equal (Some manifest)
 
     [<Test>]
     let ``watch exits with auth guidance when no token is configured`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -304,6 +304,55 @@ module WatchTests =
         |> should equal (Some manifest)
 
     [<Test>]
+    let ``watch save overlay preserves newly uploaded manifest backed file version`` () =
+        let manifest = finalizedManifest ()
+
+        let localFileVersion =
+            LocalFileVersion.CreateWithHashes
+                (RelativePath "large.bin")
+                (Sha256Hash "watch-uploaded-manifest-sha")
+                (Blake3Hash $"{manifest.FileContentHash}")
+                true
+                manifest.Size
+                (getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        localFileVersion.ToFileVersion.ContentReference.ReferenceType
+        |> should equal FileContentReferenceType.WholeFileContent
+
+        let uploadedFileVersion = localFileVersion.ToFileVersion
+        uploadedFileVersion.ContentReference <- FileContentReference.FileManifest manifest
+
+        let changedLocalDirectoryVersion =
+            LocalDirectoryVersion.CreateWithHashes
+                (Guid.NewGuid())
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "watch-uploaded-directory-sha")
+                (Blake3Hash "watch-uploaded-directory-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| localFileVersion |]))
+                localFileVersion.Size
+                DateTime.UtcNow
+
+        let directoryVersion = toDirectoryVersionWithUploadedFiles [ uploadedFileVersion ] Seq.empty<DirectoryVersion> changedLocalDirectoryVersion
+
+        directoryVersion.Files.Count |> should equal 1
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .ReferenceType
+        |> should equal FileContentReferenceType.FileManifest
+
+        directoryVersion.Files[0]
+            .ContentReference
+            .Manifest
+        |> should equal (Some manifest)
+
+    [<Test>]
     let ``watch exits with auth guidance when no token is configured`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1277,9 +1277,12 @@ module Branch =
 
                                                     saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                                    let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-
-                                                    lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                    | Ok _ -> lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    | Error error ->
+                                                        t4.Value <- 50.0
+                                                        priorDirectoryLookupError <- Some error
+                                                        implicitSaveError <- Some error
                                                 | Error error ->
                                                     logToAnsiConsole Colors.Error $"Error retrieving previous directory versions for save: {error.Error}"
 
@@ -1396,27 +1399,29 @@ module Branch =
                                     .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
                                     .ToList()
 
-                            let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-                            let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                            match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                            | Error error -> return Error error
+                            | Ok _ ->
+                                let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
-                            let sdkParameters =
-                                Parameters.Branch.CreateReferenceParameters(
-                                    BranchId = graceIds.BranchIdString,
-                                    BranchName = graceIds.BranchName,
-                                    OwnerId = graceIds.OwnerIdString,
-                                    OwnerName = graceIds.OwnerName,
-                                    OrganizationId = graceIds.OrganizationIdString,
-                                    OrganizationName = graceIds.OrganizationName,
-                                    RepositoryId = graceIds.RepositoryIdString,
-                                    RepositoryName = graceIds.RepositoryName,
-                                    DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
-                                    Sha256Hash = rootDirectoryVersion.Sha256Hash,
-                                    Message = referenceMessage,
-                                    CorrelationId = graceIds.CorrelationId
-                                )
+                                let sdkParameters =
+                                    Parameters.Branch.CreateReferenceParameters(
+                                        BranchId = graceIds.BranchIdString,
+                                        BranchName = graceIds.BranchName,
+                                        OwnerId = graceIds.OwnerIdString,
+                                        OwnerName = graceIds.OwnerName,
+                                        OrganizationId = graceIds.OrganizationIdString,
+                                        OrganizationName = graceIds.OrganizationName,
+                                        RepositoryId = graceIds.RepositoryIdString,
+                                        RepositoryName = graceIds.RepositoryName,
+                                        DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
+                                        Sha256Hash = rootDirectoryVersion.Sha256Hash,
+                                        Message = referenceMessage,
+                                        CorrelationId = graceIds.CorrelationId
+                                    )
 
-                            let! result = command sdkParameters
-                            return result
+                                let! result = command sdkParameters
+                                return result
                 | Error error, _ -> return Error error
                 | _, Error error -> return Error error
             with

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1255,6 +1255,7 @@ module Branch =
                                             if newDirectoryVersions.Count > 0 then
                                                 match!
                                                     getPreviousDirectoryVersionsForChangedDirectories
+                                                        graceIds
                                                         previousGraceStatus
                                                         newDirectoryVersions
                                                         (getCorrelationId parseResult)
@@ -1376,7 +1377,9 @@ module Branch =
                             | Ok returnValue -> returnValue.ReturnValue
                             | Error _ -> Array.empty
 
-                        match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions (getCorrelationId parseResult) with
+                        match!
+                            getPreviousDirectoryVersionsForChangedDirectories graceIds previousGraceStatus newDirectoryVersions (getCorrelationId parseResult)
+                            with
                         | Error error -> return Error error
                         | Ok previousDirectoryVersions ->
                             let saveParameters = SaveDirectoryVersionsParameters()
@@ -2931,7 +2934,12 @@ module Branch =
 
                             if currentBranch.SaveEnabled
                                && newDirectoryVersions.Any() then
-                                match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions (getCorrelationId parseResult)
+                                match!
+                                    getPreviousDirectoryVersionsForChangedDirectories
+                                        graceIds
+                                        previousGraceStatus
+                                        newDirectoryVersions
+                                        (getCorrelationId parseResult)
                                     with
                                 | Error error ->
                                     t |> setProgressTaskValue showOutput 50.0

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1251,25 +1251,36 @@ module Branch =
                                             let mutable lastDirectoryVersionUpload = newGraceStatus.LastSuccessfulDirectoryVersionUpload
 
                                             if newDirectoryVersions.Count > 0 then
-                                                let saveParameters = SaveDirectoryVersionsParameters()
-                                                saveParameters.OwnerId <- graceIds.OwnerIdString
-                                                saveParameters.OwnerName <- graceIds.OwnerName
-                                                saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                                                saveParameters.OrganizationName <- graceIds.OrganizationName
-                                                saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                                                saveParameters.RepositoryName <- graceIds.RepositoryName
-                                                saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
+                                                match!
+                                                    getPreviousDirectoryVersionsForChangedDirectories
+                                                        previousGraceStatus
+                                                        newDirectoryVersions
+                                                        (getCorrelationId parseResult)
+                                                with
+                                                | Ok previousDirectoryVersions ->
+                                                    let saveParameters = SaveDirectoryVersionsParameters()
+                                                    saveParameters.OwnerId <- graceIds.OwnerIdString
+                                                    saveParameters.OwnerName <- graceIds.OwnerName
+                                                    saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                                                    saveParameters.OrganizationName <- graceIds.OrganizationName
+                                                    saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                                                    saveParameters.RepositoryName <- graceIds.RepositoryName
+                                                    saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
-                                                saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                                        .ToList()
+                                                    saveParameters.DirectoryVersions <-
+                                                        newDirectoryVersions
+                                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                                            .ToList()
 
-                                                saveParameters.CorrelationId <- getCorrelationId parseResult
+                                                    saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                                                    let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
 
-                                                lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                | Error error ->
+                                                    logToAnsiConsole
+                                                        Colors.Error
+                                                        $"Error retrieving previous directory versions for save: {error.Error}"
 
                                             t4.Value <- 100.0
 
@@ -1356,41 +1367,49 @@ module Branch =
                             | Ok returnValue -> returnValue.ReturnValue
                             | Error _ -> Array.empty
 
-                        let saveParameters = SaveDirectoryVersionsParameters()
-                        saveParameters.OwnerId <- graceIds.OwnerIdString
-                        saveParameters.OwnerName <- graceIds.OwnerName
-                        saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                        saveParameters.OrganizationName <- graceIds.OrganizationName
-                        saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                        saveParameters.RepositoryName <- graceIds.RepositoryName
-                        saveParameters.CorrelationId <- getCorrelationId parseResult
+                        match!
+                            getPreviousDirectoryVersionsForChangedDirectories
+                                previousGraceStatus
+                                newDirectoryVersions
+                                (getCorrelationId parseResult)
+                        with
+                        | Error error -> return Error error
+                        | Ok previousDirectoryVersions ->
+                            let saveParameters = SaveDirectoryVersionsParameters()
+                            saveParameters.OwnerId <- graceIds.OwnerIdString
+                            saveParameters.OwnerName <- graceIds.OwnerName
+                            saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                            saveParameters.OrganizationName <- graceIds.OrganizationName
+                            saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                            saveParameters.RepositoryName <- graceIds.RepositoryName
+                            saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                        saveParameters.DirectoryVersions <-
-                            newDirectoryVersions
-                                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                .ToList()
+                            saveParameters.DirectoryVersions <-
+                                newDirectoryVersions
+                                    .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                    .ToList()
 
-                        let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-                        let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                            let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                            let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
-                        let sdkParameters =
-                            Parameters.Branch.CreateReferenceParameters(
-                                BranchId = graceIds.BranchIdString,
-                                BranchName = graceIds.BranchName,
-                                OwnerId = graceIds.OwnerIdString,
-                                OwnerName = graceIds.OwnerName,
-                                OrganizationId = graceIds.OrganizationIdString,
-                                OrganizationName = graceIds.OrganizationName,
-                                RepositoryId = graceIds.RepositoryIdString,
-                                RepositoryName = graceIds.RepositoryName,
-                                DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
-                                Sha256Hash = rootDirectoryVersion.Sha256Hash,
-                                Message = referenceMessage,
-                                CorrelationId = graceIds.CorrelationId
-                            )
+                            let sdkParameters =
+                                Parameters.Branch.CreateReferenceParameters(
+                                    BranchId = graceIds.BranchIdString,
+                                    BranchName = graceIds.BranchName,
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OwnerName = graceIds.OwnerName,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    OrganizationName = graceIds.OrganizationName,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    RepositoryName = graceIds.RepositoryName,
+                                    DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
+                                    Sha256Hash = rootDirectoryVersion.Sha256Hash,
+                                    Message = referenceMessage,
+                                    CorrelationId = graceIds.CorrelationId
+                                )
 
-                        let! result = command sdkParameters
-                        return result
+                            let! result = command sdkParameters
+                            return result
                 | Error error, _ -> return Error error
                 | _, Error error -> return Error error
             with
@@ -2908,30 +2927,38 @@ module Branch =
 
                             if currentBranch.SaveEnabled
                                && newDirectoryVersions.Any() then
-                                let saveParameters = SaveDirectoryVersionsParameters()
-                                saveParameters.OwnerId <- graceIds.OwnerIdString
-                                saveParameters.OwnerName <- graceIds.OwnerName
-                                saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                                saveParameters.OrganizationName <- graceIds.OrganizationName
-                                saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                                saveParameters.RepositoryName <- graceIds.RepositoryName
-                                saveParameters.CorrelationId <- getCorrelationId parseResult
-
-                                saveParameters.DirectoryVersions <-
-                                    newDirectoryVersions
-                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                        .ToList()
-
-                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-
-                                match! DirectoryVersion.SaveDirectoryVersions saveParameters with
-                                | Ok returnValue ->
-                                    t |> setProgressTaskValue showOutput 100.0
-
-                                    return Ok(showOutput, parseResult, parameters, currentBranch, $"Save created prior to branch switch.")
+                                match!
+                                    getPreviousDirectoryVersionsForChangedDirectories
+                                        previousGraceStatus
+                                        newDirectoryVersions
+                                        (getCorrelationId parseResult)
+                                with
                                 | Error error ->
                                     t |> setProgressTaskValue showOutput 50.0
                                     return Error error
+                                | Ok previousDirectoryVersions ->
+                                    let saveParameters = SaveDirectoryVersionsParameters()
+                                    saveParameters.OwnerId <- graceIds.OwnerIdString
+                                    saveParameters.OwnerName <- graceIds.OwnerName
+                                    saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                                    saveParameters.OrganizationName <- graceIds.OrganizationName
+                                    saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                                    saveParameters.RepositoryName <- graceIds.RepositoryName
+                                    saveParameters.CorrelationId <- getCorrelationId parseResult
+
+                                    saveParameters.DirectoryVersions <-
+                                        newDirectoryVersions
+                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                            .ToList()
+
+                                    match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                    | Ok returnValue ->
+                                        t |> setProgressTaskValue showOutput 100.0
+
+                                        return Ok(showOutput, parseResult, parameters, currentBranch, $"Save created prior to branch switch.")
+                                    | Error error ->
+                                        t |> setProgressTaskValue showOutput 50.0
+                                        return Error error
                             else
                                 t |> setProgressTaskValue showOutput 100.0
 

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1162,6 +1162,7 @@ module Branch =
                                         //let mutable rootDirectoryId = DirectoryId.Empty
                                         //let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
                                         let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty)
+                                        let mutable implicitSaveError = None
 
                                         match! getGraceWatchStatus () with
                                         | Some graceWatchStatus ->
@@ -1249,6 +1250,7 @@ module Branch =
                                             t4.StartTask() // Upload directory versions.
 
                                             let mutable lastDirectoryVersionUpload = newGraceStatus.LastSuccessfulDirectoryVersionUpload
+                                            let mutable priorDirectoryLookupError = None
 
                                             if newDirectoryVersions.Count > 0 then
                                                 match!
@@ -1256,7 +1258,7 @@ module Branch =
                                                         previousGraceStatus
                                                         newDirectoryVersions
                                                         (getCorrelationId parseResult)
-                                                with
+                                                    with
                                                 | Ok previousDirectoryVersions ->
                                                     let saveParameters = SaveDirectoryVersionsParameters()
                                                     saveParameters.OwnerId <- graceIds.OwnerIdString
@@ -1278,44 +1280,51 @@ module Branch =
 
                                                     lastDirectoryVersionUpload <- getCurrentInstant ()
                                                 | Error error ->
-                                                    logToAnsiConsole
-                                                        Colors.Error
-                                                        $"Error retrieving previous directory versions for save: {error.Error}"
+                                                    logToAnsiConsole Colors.Error $"Error retrieving previous directory versions for save: {error.Error}"
 
-                                            t4.Value <- 100.0
+                                                    t4.Value <- 50.0
+                                                    priorDirectoryLookupError <- Some error
 
-                                            newGraceStatus <-
-                                                { newGraceStatus with
-                                                    LastSuccessfulFileUpload = lastFileUploadInstant
-                                                    LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
-                                                }
+                                            match priorDirectoryLookupError with
+                                            | Some error -> implicitSaveError <- Some error
+                                            | None ->
+                                                t4.Value <- 100.0
 
-                                            do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
+                                                newGraceStatus <-
+                                                    { newGraceStatus with
+                                                        LastSuccessfulFileUpload = lastFileUploadInstant
+                                                        LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
+                                                    }
 
-                                        t5.StartTask() // Create new reference.
+                                                do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
 
-                                        let (rootDirectoryId, rootDirectorySha256Hash) = rootDirectoryVersion.Value
+                                        match implicitSaveError with
+                                        | Some error -> return Error error
+                                        | None ->
+                                            t5.StartTask() // Create new reference.
 
-                                        let sdkParameters =
-                                            Parameters.Branch.CreateReferenceParameters(
-                                                BranchId = graceIds.BranchIdString,
-                                                BranchName = graceIds.BranchName,
-                                                OwnerId = graceIds.OwnerIdString,
-                                                OwnerName = graceIds.OwnerName,
-                                                OrganizationId = graceIds.OrganizationIdString,
-                                                OrganizationName = graceIds.OrganizationName,
-                                                RepositoryId = graceIds.RepositoryIdString,
-                                                RepositoryName = graceIds.RepositoryName,
-                                                DirectoryVersionId = rootDirectoryId,
-                                                Sha256Hash = rootDirectorySha256Hash,
-                                                Message = referenceMessage,
-                                                CorrelationId = graceIds.CorrelationId
-                                            )
+                                            let (rootDirectoryId, rootDirectorySha256Hash) = rootDirectoryVersion.Value
 
-                                        let! result = command sdkParameters
-                                        t5.Value <- 100.0
+                                            let sdkParameters =
+                                                Parameters.Branch.CreateReferenceParameters(
+                                                    BranchId = graceIds.BranchIdString,
+                                                    BranchName = graceIds.BranchName,
+                                                    OwnerId = graceIds.OwnerIdString,
+                                                    OwnerName = graceIds.OwnerName,
+                                                    OrganizationId = graceIds.OrganizationIdString,
+                                                    OrganizationName = graceIds.OrganizationName,
+                                                    RepositoryId = graceIds.RepositoryIdString,
+                                                    RepositoryName = graceIds.RepositoryName,
+                                                    DirectoryVersionId = rootDirectoryId,
+                                                    Sha256Hash = rootDirectorySha256Hash,
+                                                    Message = referenceMessage,
+                                                    CorrelationId = graceIds.CorrelationId
+                                                )
 
-                                        return result
+                                            let! result = command sdkParameters
+                                            t5.Value <- 100.0
+
+                                            return result
                                     })
                     else
                         let! previousGraceStatus = readGraceStatusFile ()
@@ -1367,12 +1376,7 @@ module Branch =
                             | Ok returnValue -> returnValue.ReturnValue
                             | Error _ -> Array.empty
 
-                        match!
-                            getPreviousDirectoryVersionsForChangedDirectories
-                                previousGraceStatus
-                                newDirectoryVersions
-                                (getCorrelationId parseResult)
-                        with
+                        match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions (getCorrelationId parseResult) with
                         | Error error -> return Error error
                         | Ok previousDirectoryVersions ->
                             let saveParameters = SaveDirectoryVersionsParameters()
@@ -2927,12 +2931,8 @@ module Branch =
 
                             if currentBranch.SaveEnabled
                                && newDirectoryVersions.Any() then
-                                match!
-                                    getPreviousDirectoryVersionsForChangedDirectories
-                                        previousGraceStatus
-                                        newDirectoryVersions
-                                        (getCorrelationId parseResult)
-                                with
+                                match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions (getCorrelationId parseResult)
+                                    with
                                 | Error error ->
                                     t |> setProgressTaskValue showOutput 50.0
                                     return Error error

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1219,6 +1219,8 @@ module Branch =
 
                                             let mutable lastFileUploadInstant = newGraceStatus.LastSuccessfulFileUpload
 
+                                            let mutable uploadedFileVersions = Array.empty
+
                                             if newFileVersions.Count() > 0 then
                                                 let getUploadMetadataForFilesParameters =
                                                     Storage.GetUploadMetadataForFilesParameters(
@@ -1236,7 +1238,8 @@ module Branch =
                                                     )
 
                                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                                | Ok returnValue -> () //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
+                                                | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
+                                                //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
                                                 | Error error -> logToAnsiConsole Colors.Error $"Error uploading files to object storage: {error.Error}"
 
                                                 lastFileUploadInstant <- getCurrentInstant ()
@@ -1259,7 +1262,7 @@ module Branch =
 
                                                 saveParameters.DirectoryVersions <-
                                                     newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
+                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                                         .ToList()
 
                                                 saveParameters.CorrelationId <- getCorrelationId parseResult
@@ -1347,6 +1350,12 @@ module Branch =
                             )
 
                         let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                        let uploadedFileVersions =
+                            match uploadResult with
+                            | Ok returnValue -> returnValue.ReturnValue
+                            | Error _ -> Array.empty
+
                         let saveParameters = SaveDirectoryVersionsParameters()
                         saveParameters.OwnerId <- graceIds.OwnerIdString
                         saveParameters.OwnerName <- graceIds.OwnerName
@@ -1358,7 +1367,7 @@ module Branch =
 
                         saveParameters.DirectoryVersions <-
                             newDirectoryVersions
-                                .Select(fun dv -> dv.ToDirectoryVersion)
+                                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                 .ToList()
 
                         let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
@@ -2875,13 +2884,13 @@ module Branch =
                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
                                 | Ok returnValue ->
                                     t |> setProgressTaskValue showOutput 100.0
-                                    return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions)
+                                    return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions, returnValue.ReturnValue)
                                 | Error error ->
                                     t |> setProgressTaskValue showOutput 50.0
                                     return Error error
                             else
                                 t |> setProgressTaskValue showOutput 100.0
-                                return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions)
+                                return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions, Array.empty)
                         }
 
                     // 5. Upload new directory versions.
@@ -2891,7 +2900,8 @@ module Branch =
                          parseResult: ParseResult,
                          parameters: SwitchParameters,
                          currentBranch: BranchDto,
-                         newDirectoryVersions: List<LocalDirectoryVersion>)
+                         newDirectoryVersions: List<LocalDirectoryVersion>,
+                         uploadedFileVersions)
                         =
                         task {
                             t |> startProgressTask showOutput
@@ -2909,7 +2919,7 @@ module Branch =
 
                                 saveParameters.DirectoryVersions <-
                                     newDirectoryVersions
-                                        .Select(fun dv -> dv.ToDirectoryVersion)
+                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                         .ToList()
 
                                 let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -266,6 +266,8 @@ module Diff =
                 let graceIds = getNormalizedIdsAndNames parseResult
 
                 if parseResult |> hasOutput then
+                    let mutable implicitSaveError: GraceError option = None
+
                     do!
                         progress
                             .Columns(progressColumns)
@@ -378,8 +380,11 @@ module Diff =
 
                                                     match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                     | Ok returnValue -> ()
-                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                    | Error error ->
+                                                        implicitSaveError <- Some error
+                                                        logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
                                                 | Error error ->
+                                                    implicitSaveError <- Some error
                                                     logToAnsiConsole Colors.Error $"Failed to retrieve previous directory versions for save. {error}"
                                             })
                                                 .Wait()
@@ -388,7 +393,8 @@ module Diff =
 
                                         t5.StartTask()
 
-                                        if newDirectoryVersions.Count > 0 then
+                                        if newDirectoryVersions.Count > 0
+                                           && implicitSaveError.IsNone then
                                             (task {
                                                 match!
                                                     createSaveReference
@@ -515,10 +521,13 @@ module Diff =
                                 //AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
                                 })
 
-                    for markup in markupList do
-                        writeMarkup markup
+                    match implicitSaveError with
+                    | Some error -> return (Error error) |> renderOutput parseResult
+                    | None ->
+                        for markup in markupList do
+                            writeMarkup markup
 
-                    return 0
+                        return 0
                 else
                     // Do the thing here
                     return 0
@@ -584,6 +593,8 @@ module Diff =
                     let graceIds = getNormalizedIdsAndNames parseResult
 
                     if parseResult |> hasOutput then
+                        let mutable implicitSaveError: GraceError option = None
+
                         do!
                             progress
                                 .Columns(progressColumns)
@@ -692,8 +703,11 @@ module Diff =
 
                                                         match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                         | Ok returnValue -> ()
-                                                        | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                        | Error error ->
+                                                            implicitSaveError <- Some error
+                                                            logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
                                                     | Error error ->
+                                                        implicitSaveError <- Some error
                                                         logToAnsiConsole Colors.Error $"Failed to retrieve previous directory versions for save. {error}"
                                                 })
                                                     .Wait()
@@ -702,7 +716,8 @@ module Diff =
 
                                             t5.StartTask()
 
-                                            if newDirectoryVersions.Count > 0 then
+                                            if newDirectoryVersions.Count > 0
+                                               && implicitSaveError.IsNone then
                                                 (task {
                                                     match!
                                                         createSaveReference
@@ -746,10 +761,13 @@ module Diff =
                                         t6.Value <- 100.0
                                     })
 
-                        for markup in markupList do
-                            writeMarkup markup
+                        match implicitSaveError with
+                        | Some error -> return (Error error) |> renderOutput parseResult
+                        | None ->
+                            for markup in markupList do
+                                writeMarkup markup
 
-                        return 0
+                            return 0
                     else
                         // Do the thing here
                         return 0

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -37,6 +37,21 @@ open Grace.Shared.Parameters.Storage
 
 module Diff =
 
+    let internal applyImplicitSaveStatusIfSuccessful
+        (implicitSaveError: GraceError option)
+        (applyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>)
+        (updatedGraceStatus: GraceStatus)
+        (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
+        (differences: IEnumerable<FileSystemDifference>)
+        =
+        task {
+            match implicitSaveError with
+            | Some _ -> return false
+            | None ->
+                do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
+                return true
+        }
+
     module private Options =
         let ownerId =
             new Option<OwnerId>(
@@ -312,6 +327,9 @@ module Diff =
                                         previousDirectoryIds <- graceWatchStatus.DirectoryIds
                                     | None ->
                                         let! previousGraceStatus = readGraceStatusFile ()
+                                        rootDirectoryId <- previousGraceStatus.RootDirectoryId
+                                        rootDirectorySha256Hash <- previousGraceStatus.RootDirectorySha256Hash
+                                        previousDirectoryIds <- previousGraceStatus.Index.Keys.ToHashSet()
                                         t0.Value <- 100.0
                                         t1.StartTask()
                                         let! differences = scanForDifferences previousGraceStatus
@@ -322,10 +340,6 @@ module Diff =
 
                                         let! (updatedGraceStatus, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
 
-                                        do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
-                                        rootDirectoryId <- updatedGraceStatus.RootDirectoryId
-                                        rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
-                                        previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
                                         t2.Value <- 100.0
 
                                         t3.StartTask()
@@ -349,7 +363,9 @@ module Diff =
 
                                         match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
                                         | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
-                                        | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
+                                        | Error error ->
+                                            implicitSaveError <- Some error
+                                            logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
 
                                         t3.Value <- 100.0
 
@@ -405,11 +421,26 @@ module Diff =
                                                         (getCorrelationId parseResult)
                                                     with
                                                 | Ok saveReference -> ()
-                                                | Error error -> logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
+                                                | Error error ->
+                                                    implicitSaveError <- Some error
+                                                    logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
                                             })
                                                 .Wait()
 
                                         t5.Value <- 100.0
+
+                                        let! appliedGraceStatus =
+                                            applyImplicitSaveStatusIfSuccessful
+                                                implicitSaveError
+                                                applyGraceStatusIncremental
+                                                updatedGraceStatus
+                                                newDirectoryVersions
+                                                differences
+
+                                        if appliedGraceStatus then
+                                            rootDirectoryId <- updatedGraceStatus.RootDirectoryId
+                                            rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
+                                            previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
 
                                     // Check for latest reference of the given type from the server.
                                     t6.StartTask()
@@ -635,6 +666,9 @@ module Diff =
                                         | None ->
                                             let! previousGraceStatus = readGraceStatusFile ()
                                             let mutable graceStatus = previousGraceStatus
+                                            rootDirectoryId <- previousGraceStatus.RootDirectoryId
+                                            rootDirectorySha256Hash <- previousGraceStatus.RootDirectorySha256Hash
+                                            previousDirectoryIds <- previousGraceStatus.Index.Keys.ToHashSet()
                                             t0.Value <- 100.0
                                             t1.StartTask()
                                             let! differences = scanForDifferences previousGraceStatus
@@ -646,10 +680,6 @@ module Diff =
                                             let! (updatedGraceStatus, newDirectoryVersions) =
                                                 getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
 
-                                            do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
-                                            rootDirectoryId <- updatedGraceStatus.RootDirectoryId
-                                            rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
-                                            previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
                                             t2.Value <- 100.0
 
                                             t3.StartTask()
@@ -673,7 +703,9 @@ module Diff =
 
                                             match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
                                             | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
-                                            | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
+                                            | Error error ->
+                                                implicitSaveError <- Some error
+                                                logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
 
                                             t3.Value <- 100.0
 
@@ -728,11 +760,26 @@ module Diff =
                                                             (getCorrelationId parseResult)
                                                         with
                                                     | Ok saveReference -> ()
-                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
+                                                    | Error error ->
+                                                        implicitSaveError <- Some error
+                                                        logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
                                                 })
                                                     .Wait()
 
                                             t5.Value <- 100.0
+
+                                            let! appliedGraceStatus =
+                                                applyImplicitSaveStatusIfSuccessful
+                                                    implicitSaveError
+                                                    applyGraceStatusIncremental
+                                                    updatedGraceStatus
+                                                    newDirectoryVersions
+                                                    differences
+
+                                            if appliedGraceStatus then
+                                                rootDirectoryId <- updatedGraceStatus.RootDirectoryId
+                                                rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
+                                                previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
 
                                         // Check for latest reference of the given type from the server.
                                         t6.StartTask()

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -359,6 +359,7 @@ module Diff =
                                             (task {
                                                 match!
                                                     getPreviousDirectoryVersionsForChangedDirectories
+                                                        graceIds
                                                         previousGraceStatus
                                                         newDirectoryVersions
                                                         (getCorrelationId parseResult)
@@ -682,6 +683,7 @@ module Diff =
                                                 (task {
                                                     match!
                                                         getPreviousDirectoryVersionsForChangedDirectories
+                                                            graceIds
                                                             previousGraceStatus
                                                             newDirectoryVersions
                                                             (getCorrelationId parseResult)

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -343,8 +343,10 @@ module Diff =
                                                      |> Seq.toArray)
                                             )
 
+                                        let mutable uploadedFileVersions = Array.empty
+
                                         match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                        | Ok returnValue -> ()
+                                        | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
                                         | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
 
                                         t3.Value <- 100.0
@@ -364,7 +366,7 @@ module Diff =
 
                                                 saveParameters.DirectoryVersions <-
                                                     newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
+                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                                         .ToList()
 
                                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
@@ -646,8 +648,10 @@ module Diff =
                                                          |> Seq.toArray)
                                                 )
 
+                                            let mutable uploadedFileVersions = Array.empty
+
                                             match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                            | Ok returnValue -> ()
+                                            | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
                                             | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
 
                                             t3.Value <- 100.0
@@ -667,7 +671,7 @@ module Diff =
 
                                                     saveParameters.DirectoryVersions <-
                                                         newDirectoryVersions
-                                                            .Select(fun dv -> dv.ToDirectoryVersion)
+                                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                                             .ToList()
 
                                                     match! DirectoryVersion.SaveDirectoryVersions saveParameters with

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -355,23 +355,32 @@ module Diff =
 
                                         if (newDirectoryVersions.Count > 0) then
                                             (task {
-                                                let saveParameters = SaveDirectoryVersionsParameters()
-                                                saveParameters.OwnerId <- graceIds.OwnerIdString
-                                                saveParameters.OwnerName <- graceIds.OwnerName
-                                                saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                                                saveParameters.OrganizationName <- graceIds.OrganizationName
-                                                saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                                                saveParameters.RepositoryName <- graceIds.RepositoryName
-                                                saveParameters.CorrelationId <- getCorrelationId parseResult
+                                                match!
+                                                    getPreviousDirectoryVersionsForChangedDirectories
+                                                        previousGraceStatus
+                                                        newDirectoryVersions
+                                                        (getCorrelationId parseResult)
+                                                    with
+                                                | Ok previousDirectoryVersions ->
+                                                    let saveParameters = SaveDirectoryVersionsParameters()
+                                                    saveParameters.OwnerId <- graceIds.OwnerIdString
+                                                    saveParameters.OwnerName <- graceIds.OwnerName
+                                                    saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                                                    saveParameters.OrganizationName <- graceIds.OrganizationName
+                                                    saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                                                    saveParameters.RepositoryName <- graceIds.RepositoryName
+                                                    saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                                saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                                        .ToList()
+                                                    saveParameters.DirectoryVersions <-
+                                                        newDirectoryVersions
+                                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                                            .ToList()
 
-                                                match! DirectoryVersion.SaveDirectoryVersions saveParameters with
-                                                | Ok returnValue -> ()
-                                                | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                    match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                    | Ok returnValue -> ()
+                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                | Error error ->
+                                                    logToAnsiConsole Colors.Error $"Failed to retrieve previous directory versions for save. {error}"
                                             })
                                                 .Wait()
 
@@ -660,23 +669,32 @@ module Diff =
 
                                             if (newDirectoryVersions.Count > 0) then
                                                 (task {
-                                                    let saveParameters = SaveDirectoryVersionsParameters()
-                                                    saveParameters.OwnerId <- graceIds.OwnerIdString
-                                                    saveParameters.OwnerName <- graceIds.OwnerName
-                                                    saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                                                    saveParameters.OrganizationName <- graceIds.OrganizationName
-                                                    saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                                                    saveParameters.RepositoryName <- graceIds.RepositoryName
-                                                    saveParameters.CorrelationId <- getCorrelationId parseResult
+                                                    match!
+                                                        getPreviousDirectoryVersionsForChangedDirectories
+                                                            previousGraceStatus
+                                                            newDirectoryVersions
+                                                            (getCorrelationId parseResult)
+                                                        with
+                                                    | Ok previousDirectoryVersions ->
+                                                        let saveParameters = SaveDirectoryVersionsParameters()
+                                                        saveParameters.OwnerId <- graceIds.OwnerIdString
+                                                        saveParameters.OwnerName <- graceIds.OwnerName
+                                                        saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                                                        saveParameters.OrganizationName <- graceIds.OrganizationName
+                                                        saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                                                        saveParameters.RepositoryName <- graceIds.RepositoryName
+                                                        saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                                    saveParameters.DirectoryVersions <-
-                                                        newDirectoryVersions
-                                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                                            .ToList()
+                                                        saveParameters.DirectoryVersions <-
+                                                            newDirectoryVersions
+                                                                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                                                .ToList()
 
-                                                    match! DirectoryVersion.SaveDirectoryVersions saveParameters with
-                                                    | Ok returnValue -> ()
-                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                        match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                        | Ok returnValue -> ()
+                                                        | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                    | Error error ->
+                                                        logToAnsiConsole Colors.Error $"Failed to retrieve previous directory versions for save. {error}"
                                                 })
                                                     .Wait()
 

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -679,6 +679,8 @@ module Reference =
 
                                             let mutable lastFileUploadInstant = newGraceStatus.LastSuccessfulFileUpload
 
+                                            let mutable uploadedFileVersions = Array.empty
+
                                             if newFileVersions.Count() > 0 then
                                                 let getUploadMetadataForFilesParameters =
                                                     GetUploadMetadataForFilesParameters(
@@ -696,7 +698,8 @@ module Reference =
                                                     )
 
                                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                                | Ok returnValue -> () //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
+                                                | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
+                                                //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
                                                 | Error error -> logToAnsiConsole Colors.Error $"Error uploading files to object storage: {error.Error}"
 
                                                 lastFileUploadInstant <- getCurrentInstant ()
@@ -720,7 +723,7 @@ module Reference =
 
                                                 saveParameters.DirectoryVersions <-
                                                     newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
+                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                                         .ToList()
 
                                                 let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
@@ -806,6 +809,12 @@ module Reference =
                             )
 
                         let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                        let uploadedFileVersions =
+                            match uploadResult with
+                            | Ok returnValue -> returnValue.ReturnValue
+                            | Error _ -> Array.empty
+
                         let saveParameters = SaveDirectoryVersionsParameters()
                         saveParameters.OwnerId <- graceIds.OwnerIdString
                         saveParameters.OwnerName <- graceIds.OwnerName
@@ -817,7 +826,7 @@ module Reference =
 
                         saveParameters.DirectoryVersions <-
                             newDirectoryVersions
-                                .Select(fun dv -> dv.ToDirectoryVersion)
+                                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
                                 .ToList()
 
                         let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -715,6 +715,7 @@ module Reference =
                                             if newDirectoryVersions.Count > 0 then
                                                 match!
                                                     getPreviousDirectoryVersionsForChangedDirectories
+                                                        graceIds
                                                         previousGraceStatus
                                                         newDirectoryVersions
                                                         graceIds.CorrelationId
@@ -833,7 +834,7 @@ module Reference =
                             | Ok returnValue -> returnValue.ReturnValue
                             | Error _ -> Array.empty
 
-                        match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions graceIds.CorrelationId with
+                        match! getPreviousDirectoryVersionsForChangedDirectories graceIds previousGraceStatus newDirectoryVersions graceIds.CorrelationId with
                         | Error error -> return Error error
                         | Ok previousDirectoryVersions ->
                             let saveParameters = SaveDirectoryVersionsParameters()

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -622,6 +622,7 @@ module Reference =
                                         //let mutable rootDirectoryId = DirectoryId.Empty
                                         //let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
                                         let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty)
+                                        let mutable implicitSaveError = None
 
                                         match! getGraceWatchStatus () with
                                         | Some graceWatchStatus ->
@@ -709,61 +710,78 @@ module Reference =
                                             t4.StartTask() // Upload directory versions.
 
                                             let mutable lastDirectoryVersionUpload = newGraceStatus.LastSuccessfulDirectoryVersionUpload
+                                            let mutable priorDirectoryLookupError = None
 
                                             if newDirectoryVersions.Count > 0 then
-                                                let saveParameters = SaveDirectoryVersionsParameters()
-                                                saveParameters.OwnerId <- graceIds.OwnerIdString
-                                                saveParameters.OwnerName <- graceIds.OwnerName
-                                                saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                                                saveParameters.OrganizationName <- graceIds.OrganizationName
-                                                saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                                                saveParameters.RepositoryName <- graceIds.RepositoryName
-                                                saveParameters.CorrelationId <- graceIds.CorrelationId
-                                                saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
+                                                match!
+                                                    getPreviousDirectoryVersionsForChangedDirectories
+                                                        previousGraceStatus
+                                                        newDirectoryVersions
+                                                        graceIds.CorrelationId
+                                                    with
+                                                | Error error ->
+                                                    t4.Value <- 50.0
+                                                    priorDirectoryLookupError <- Some error
+                                                | Ok previousDirectoryVersions ->
+                                                    let saveParameters = SaveDirectoryVersionsParameters()
+                                                    saveParameters.OwnerId <- graceIds.OwnerIdString
+                                                    saveParameters.OwnerName <- graceIds.OwnerName
+                                                    saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                                                    saveParameters.OrganizationName <- graceIds.OrganizationName
+                                                    saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                                                    saveParameters.RepositoryName <- graceIds.RepositoryName
+                                                    saveParameters.CorrelationId <- graceIds.CorrelationId
+                                                    saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
-                                                saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                                        .ToList()
+                                                    saveParameters.DirectoryVersions <-
+                                                        newDirectoryVersions
+                                                            .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                                            .ToList()
 
-                                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                                                    let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
 
-                                                lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    lastDirectoryVersionUpload <- getCurrentInstant ()
 
-                                            t4.Value <- 100.0
+                                            match priorDirectoryLookupError with
+                                            | Some error -> implicitSaveError <- Some error
+                                            | None ->
+                                                t4.Value <- 100.0
 
-                                            newGraceStatus <-
-                                                { newGraceStatus with
-                                                    LastSuccessfulFileUpload = lastFileUploadInstant
-                                                    LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
-                                                }
+                                                newGraceStatus <-
+                                                    { newGraceStatus with
+                                                        LastSuccessfulFileUpload = lastFileUploadInstant
+                                                        LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
+                                                    }
 
-                                            do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
+                                                do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
 
-                                        t5.StartTask() // Create new reference.
+                                        match implicitSaveError with
+                                        | Some error -> return Error error
+                                        | None ->
+                                            t5.StartTask() // Create new reference.
 
-                                        let (rootDirectoryId, rootDirectorySha256Hash) = rootDirectoryVersion.Value
+                                            let (rootDirectoryId, rootDirectorySha256Hash) = rootDirectoryVersion.Value
 
-                                        let sdkParameters =
-                                            Parameters.Branch.CreateReferenceParameters(
-                                                BranchId = graceIds.BranchIdString,
-                                                BranchName = graceIds.BranchName,
-                                                OwnerId = graceIds.OwnerIdString,
-                                                OwnerName = graceIds.OwnerName,
-                                                OrganizationId = graceIds.OrganizationIdString,
-                                                OrganizationName = graceIds.OrganizationName,
-                                                RepositoryId = graceIds.RepositoryIdString,
-                                                RepositoryName = graceIds.RepositoryName,
-                                                DirectoryVersionId = rootDirectoryId,
-                                                Sha256Hash = rootDirectorySha256Hash,
-                                                Message = message,
-                                                CorrelationId = graceIds.CorrelationId
-                                            )
+                                            let sdkParameters =
+                                                Parameters.Branch.CreateReferenceParameters(
+                                                    BranchId = graceIds.BranchIdString,
+                                                    BranchName = graceIds.BranchName,
+                                                    OwnerId = graceIds.OwnerIdString,
+                                                    OwnerName = graceIds.OwnerName,
+                                                    OrganizationId = graceIds.OrganizationIdString,
+                                                    OrganizationName = graceIds.OrganizationName,
+                                                    RepositoryId = graceIds.RepositoryIdString,
+                                                    RepositoryName = graceIds.RepositoryName,
+                                                    DirectoryVersionId = rootDirectoryId,
+                                                    Sha256Hash = rootDirectorySha256Hash,
+                                                    Message = message,
+                                                    CorrelationId = graceIds.CorrelationId
+                                                )
 
-                                        let! result = command sdkParameters
-                                        t5.Value <- 100.0
+                                            let! result = command sdkParameters
+                                            t5.Value <- 100.0
 
-                                        return result
+                                            return result
                                     })
                     else
                         let! previousGraceStatus = readGraceStatusFile ()
@@ -815,41 +833,44 @@ module Reference =
                             | Ok returnValue -> returnValue.ReturnValue
                             | Error _ -> Array.empty
 
-                        let saveParameters = SaveDirectoryVersionsParameters()
-                        saveParameters.OwnerId <- graceIds.OwnerIdString
-                        saveParameters.OwnerName <- graceIds.OwnerName
-                        saveParameters.OrganizationId <- graceIds.OrganizationIdString
-                        saveParameters.OrganizationName <- graceIds.OrganizationName
-                        saveParameters.RepositoryId <- graceIds.RepositoryIdString
-                        saveParameters.RepositoryName <- graceIds.RepositoryName
-                        saveParameters.CorrelationId <- graceIds.CorrelationId
+                        match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus newDirectoryVersions graceIds.CorrelationId with
+                        | Error error -> return Error error
+                        | Ok previousDirectoryVersions ->
+                            let saveParameters = SaveDirectoryVersionsParameters()
+                            saveParameters.OwnerId <- graceIds.OwnerIdString
+                            saveParameters.OwnerName <- graceIds.OwnerName
+                            saveParameters.OrganizationId <- graceIds.OrganizationIdString
+                            saveParameters.OrganizationName <- graceIds.OrganizationName
+                            saveParameters.RepositoryId <- graceIds.RepositoryIdString
+                            saveParameters.RepositoryName <- graceIds.RepositoryName
+                            saveParameters.CorrelationId <- graceIds.CorrelationId
 
-                        saveParameters.DirectoryVersions <-
-                            newDirectoryVersions
-                                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions [])
-                                .ToList()
+                            saveParameters.DirectoryVersions <-
+                                newDirectoryVersions
+                                    .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
+                                    .ToList()
 
-                        let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-                        let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                            let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                            let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
-                        let sdkParameters =
-                            Parameters.Branch.CreateReferenceParameters(
-                                BranchId = graceIds.BranchIdString,
-                                BranchName = graceIds.BranchName,
-                                OwnerId = graceIds.OwnerIdString,
-                                OwnerName = graceIds.OwnerName,
-                                OrganizationId = graceIds.OrganizationIdString,
-                                OrganizationName = graceIds.OrganizationName,
-                                RepositoryId = graceIds.RepositoryIdString,
-                                RepositoryName = graceIds.RepositoryName,
-                                DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
-                                Sha256Hash = rootDirectoryVersion.Sha256Hash,
-                                Message = message,
-                                CorrelationId = graceIds.CorrelationId
-                            )
+                            let sdkParameters =
+                                Parameters.Branch.CreateReferenceParameters(
+                                    BranchId = graceIds.BranchIdString,
+                                    BranchName = graceIds.BranchName,
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OwnerName = graceIds.OwnerName,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    OrganizationName = graceIds.OrganizationName,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    RepositoryName = graceIds.RepositoryName,
+                                    DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
+                                    Sha256Hash = rootDirectoryVersion.Sha256Hash,
+                                    Message = message,
+                                    CorrelationId = graceIds.CorrelationId
+                                )
 
-                        let! result = command sdkParameters
-                        return result
+                            let! result = command sdkParameters
+                            return result
                 | Error error -> return Error error
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -739,9 +739,12 @@ module Reference =
                                                             .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
                                                             .ToList()
 
-                                                    let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-
-                                                    lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                    | Ok _ -> lastDirectoryVersionUpload <- getCurrentInstant ()
+                                                    | Error error ->
+                                                        t4.Value <- 50.0
+                                                        priorDirectoryLookupError <- Some error
+                                                        implicitSaveError <- Some error
 
                                             match priorDirectoryLookupError with
                                             | Some error -> implicitSaveError <- Some error
@@ -851,27 +854,29 @@ module Reference =
                                     .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
                                     .ToList()
 
-                            let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
-                            let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                            match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                            | Error error -> return Error error
+                            | Ok _ ->
+                                let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
-                            let sdkParameters =
-                                Parameters.Branch.CreateReferenceParameters(
-                                    BranchId = graceIds.BranchIdString,
-                                    BranchName = graceIds.BranchName,
-                                    OwnerId = graceIds.OwnerIdString,
-                                    OwnerName = graceIds.OwnerName,
-                                    OrganizationId = graceIds.OrganizationIdString,
-                                    OrganizationName = graceIds.OrganizationName,
-                                    RepositoryId = graceIds.RepositoryIdString,
-                                    RepositoryName = graceIds.RepositoryName,
-                                    DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
-                                    Sha256Hash = rootDirectoryVersion.Sha256Hash,
-                                    Message = message,
-                                    CorrelationId = graceIds.CorrelationId
-                                )
+                                let sdkParameters =
+                                    Parameters.Branch.CreateReferenceParameters(
+                                        BranchId = graceIds.BranchIdString,
+                                        BranchName = graceIds.BranchName,
+                                        OwnerId = graceIds.OwnerIdString,
+                                        OwnerName = graceIds.OwnerName,
+                                        OrganizationId = graceIds.OrganizationIdString,
+                                        OrganizationName = graceIds.OrganizationName,
+                                        RepositoryId = graceIds.RepositoryIdString,
+                                        RepositoryName = graceIds.RepositoryName,
+                                        DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
+                                        Sha256Hash = rootDirectoryVersion.Sha256Hash,
+                                        Message = message,
+                                        CorrelationId = graceIds.CorrelationId
+                                    )
 
-                            let! result = command sdkParameters
-                            return result
+                                let! result = command sdkParameters
+                                return result
                 | Error error -> return Error error
             with
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1138,7 +1138,7 @@ module Services =
             match! createLocalFileVersion fileInfo with
             | Some fileVersion ->
                 if fileVersion.Sha256Hash
-                    <> existingFileVersion.Sha256Hash then
+                   <> existingFileVersion.Sha256Hash then
                     directoryVersion.Files.RemoveAt(existingFileIndex)
                     directoryVersion.Files.Add(fileVersion)
                     directoryVersion.Size <- directoryVersion.Files.Sum(fun file -> int64 (file.Size))
@@ -1950,7 +1950,7 @@ module Services =
                         //logToAnsiConsole Colors.Deemphasized $"Attempt #{iteration} to copy file to object directory..."
                         File.Copy(sourceFileName = filePath, destFileName = tempFilePath, overwrite = true))
 
-                    // Now that we've copied it, compute the SHA-256 hash.
+                    // Now that we've copied it, compute the file content hashes.
                     let relativeFilePath = Path.GetRelativePath(Current().RootDirectory, filePath)
 
                     use tempFileStream = File.Open(tempFilePath, fileStreamOptionsRead)
@@ -1958,6 +1958,8 @@ module Services =
                     let! isBinary = isBinaryFile tempFileStream
                     tempFileStream.Position <- 0
                     let! sha256Hash = computeSha256ForFile tempFileStream relativeFilePath
+                    tempFileStream.Position <- 0
+                    let! blake3Hash = computeBlake3ForFile tempFileStream
                     //logToConsole $"filePath: {filePath}; tempFilePath: {tempFilePath}; SHA256: {sha256Hash}"
 
                     // I'm going to rename the temp file below, using the SHA-256 hash, so I'll close the file and dispose the stream first.
@@ -1987,7 +1989,16 @@ module Services =
                         //logToConsole $"Finished copyToObjectDirectory for {filePath}; isBinary: {isBinary}; moved temp file to object directory."
                         let relativePath = Path.GetRelativePath(Current().RootDirectory, filePath)
 
-                        return Some(FileVersion.Create (RelativePath relativePath) (Sha256Hash $"{sha256Hash}") ("") isBinary (objectFilePathInfo.Length))
+                        return
+                            Some(
+                                FileVersion.CreateWithHashes
+                                    (RelativePath relativePath)
+                                    (Sha256Hash $"{sha256Hash}")
+                                    (Blake3Hash $"{blake3Hash}")
+                                    ("")
+                                    isBinary
+                                    (objectFilePathInfo.Length)
+                            )
                     else
                         // If we do already have this exact version of the file, just delete the temp file.
                         File.Delete(tempFilePath)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1354,7 +1354,25 @@ module Services =
             .Distinct()
             .ToList()
 
+    let internal createPreviousDirectoryVersionsParameters
+        (graceIds: GraceIds)
+        (previousDirectoryVersionIds: List<DirectoryVersionId>)
+        (correlationId: CorrelationId)
+        =
+        Parameters.DirectoryVersion.GetByDirectoryIdsParameters(
+            OwnerId = graceIds.OwnerIdString,
+            OwnerName = graceIds.OwnerName,
+            OrganizationId = graceIds.OrganizationIdString,
+            OrganizationName = graceIds.OrganizationName,
+            RepositoryId = graceIds.RepositoryIdString,
+            RepositoryName = graceIds.RepositoryName,
+            DirectoryVersionId = $"{previousDirectoryVersionIds[0]}",
+            DirectoryIds = previousDirectoryVersionIds,
+            CorrelationId = correlationId
+        )
+
     let internal getPreviousDirectoryVersionsForChangedDirectories
+        (graceIds: GraceIds)
         (previousGraceStatus: GraceStatus)
         (localDirectoryVersions: List<LocalDirectoryVersion>)
         (correlationId: CorrelationId)
@@ -1365,20 +1383,7 @@ module Services =
             if previousDirectoryVersionIds.Count = 0 then
                 return Ok(List<Grace.Types.Common.DirectoryVersion>())
             else
-                let current = Current()
-
-                let getByDirectoryIdParameters =
-                    Parameters.DirectoryVersion.GetByDirectoryIdsParameters(
-                        OwnerId = $"{current.OwnerId}",
-                        OwnerName = current.OwnerName,
-                        OrganizationId = $"{current.OrganizationId}",
-                        OrganizationName = current.OrganizationName,
-                        RepositoryId = $"{current.RepositoryId}",
-                        RepositoryName = current.RepositoryName,
-                        DirectoryVersionId = $"{previousDirectoryVersionIds[0]}",
-                        DirectoryIds = previousDirectoryVersionIds,
-                        CorrelationId = correlationId
-                    )
+                let getByDirectoryIdParameters = createPreviousDirectoryVersionsParameters graceIds previousDirectoryVersionIds correlationId
 
                 match! DirectoryVersion.GetByDirectoryIds getByDirectoryIdParameters with
                 | Ok returnValue ->
@@ -1388,6 +1393,25 @@ module Services =
                         |> List<Grace.Types.Common.DirectoryVersion>
                         |> Ok
                 | Error error -> return Error error
+        }
+
+    let internal currentRepositoryGraceIds correlationId =
+        let current = Current()
+
+        { GraceIds.Default with
+            OwnerId = current.OwnerId
+            OwnerIdString = $"{current.OwnerId}"
+            OwnerName = current.OwnerName
+            OrganizationId = current.OrganizationId
+            OrganizationIdString = $"{current.OrganizationId}"
+            OrganizationName = current.OrganizationName
+            RepositoryId = current.RepositoryId
+            RepositoryIdString = $"{current.RepositoryId}"
+            RepositoryName = current.RepositoryName
+            CorrelationId = correlationId
+            HasOwner = true
+            HasOrganization = true
+            HasRepository = true
         }
 
     let internal toDirectoryVersionWithUploadedFiles
@@ -2246,7 +2270,9 @@ module Services =
 
         let uploadDirectoryVersionsForCapture previousGraceStatus directoryVersions uploadedFileVersions =
             task {
-                match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus directoryVersions correlationId with
+                let graceIds = currentRepositoryGraceIds correlationId
+
+                match! getPreviousDirectoryVersionsForChangedDirectories graceIds previousGraceStatus directoryVersions correlationId with
                 | Error error -> return Error error
                 | Ok previousDirectoryVersions ->
                     match! uploadDirectoryVersionsWithUploadedFiles directoryVersions uploadedFileVersions previousDirectoryVersions correlationId with

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -254,11 +254,14 @@ module Services =
 
                     stream.Position <- 0
                     let! sha256Hash = computeSha256ForFile stream relativePath
+                    stream.Position <- 0
+                    let! blake3Hash = computeBlake3ForFile stream
 
                     let returnValue =
-                        LocalFileVersion.Create
+                        LocalFileVersion.CreateWithHashes
                             relativePath
                             sha256Hash
+                            blake3Hash
                             isBinary
                             fileInfo.Length
                             (Instant.FromDateTimeUtc(fileInfo.LastWriteTimeUtc))
@@ -915,6 +918,8 @@ module Services =
         copy.FileVersions <- fileVersions
         copy
 
+    let private createSuccessfulFileUploadResult correlationId fileVersions = Ok(GraceReturnValue.Create fileVersions correlationId)
+
     let private storageIdOrCurrent<'Id> (rawValue: string) (currentValue: 'Id) (parse: string -> 'Id) =
         if String.IsNullOrWhiteSpace rawValue then currentValue else parse rawValue
 
@@ -945,9 +950,10 @@ module Services =
         =
         task {
             if parameters.FileVersions.Count() = 0 then
-                return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                return createSuccessfulFileUploadResult parameters.CorrelationId Array.empty<FileVersion>
             else
                 let fallbackFileVersions = ConcurrentQueue<FileVersion>()
+                let uploadedFileVersions = ConcurrentQueue<FileVersion>()
                 let errors = ConcurrentQueue<GraceError>()
                 let mutable fileVersionIndex = 0
 
@@ -955,8 +961,11 @@ module Services =
                     let fileVersion = parameters.FileVersions[fileVersionIndex]
 
                     match! manifestUpload fileVersion with
-                    | Ok result when not result.ReturnValue.UsedManifestUpload -> fallbackFileVersions.Enqueue(result.ReturnValue.FileVersion)
-                    | Ok _ -> ()
+                    | Ok result ->
+                        uploadedFileVersions.Enqueue(result.ReturnValue.FileVersion)
+
+                        if not result.ReturnValue.UsedManifestUpload then
+                            fallbackFileVersions.Enqueue(result.ReturnValue.FileVersion)
                     | Error error -> errors.Enqueue(error)
 
                     fileVersionIndex <- fileVersionIndex + 1
@@ -972,17 +981,25 @@ module Services =
                     let fallback = fallbackFileVersions.ToArray()
 
                     if fallback.Length = 0 then
-                        return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                        return createSuccessfulFileUploadResult parameters.CorrelationId (uploadedFileVersions.ToArray())
                     else
-                        return! wholeFileUpload (copyStorageParameters parameters fallback)
+                        match! wholeFileUpload (copyStorageParameters parameters fallback) with
+                        | Ok _ -> return createSuccessfulFileUploadResult parameters.CorrelationId (uploadedFileVersions.ToArray())
+                        | Error error -> return Error error
         }
 
     /// Uploads all new or changed files from a directory to object storage.
     let uploadFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
-        uploadFilesToObjectStorageWithClients
-            (fun fileVersion -> ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion))
-            uploadWholeFilesToObjectStorage
-            parameters
+        task {
+            match!
+                uploadFilesToObjectStorageWithClients
+                    (fun fileVersion -> ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion))
+                    uploadWholeFilesToObjectStorage
+                    parameters
+                with
+            | Ok _ -> return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+            | Error error -> return Error error
+        }
 
     /// Creates an updated LocalDirectoryVersion instance, with a new DirectoryId, based on changes to an existing one.
     ///
@@ -1314,12 +1331,39 @@ module Services =
                 return (previousGraceStatus, newDirectoryVersions)
         }
 
+    let internal toDirectoryVersionWithUploadedFiles (uploadedFileVersions: seq<FileVersion>) (localDirectoryVersion: LocalDirectoryVersion) =
+        let uploadedByIdentity =
+            uploadedFileVersions
+                .GroupBy(fun fileVersion -> (fileVersion.RelativePath, fileVersion.Sha256Hash))
+                .ToDictionary((fun group -> group.Key), (fun group -> group.First()))
+
+        let files =
+            localDirectoryVersion
+                .Files
+                .Select(fun localFileVersion ->
+                    match uploadedByIdentity.TryGetValue((localFileVersion.RelativePath, localFileVersion.Sha256Hash)) with
+                    | true, uploadedFileVersion -> uploadedFileVersion
+                    | false, _ -> localFileVersion.ToFileVersion)
+                .ToList()
+
+        DirectoryVersion.CreateWithHashes
+            localDirectoryVersion.DirectoryVersionId
+            localDirectoryVersion.OwnerId
+            localDirectoryVersion.OrganizationId
+            localDirectoryVersion.RepositoryId
+            localDirectoryVersion.RelativePath
+            localDirectoryVersion.Sha256Hash
+            localDirectoryVersion.Blake3Hash
+            localDirectoryVersion.Directories
+            files
+            localDirectoryVersion.Size
+
     /// Ensures that the provided directory versions are uploaded to Grace Server.
     /// This will add new directory versions, and ignore existing directory versions, as they are immutable.
-    let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
+    let uploadDirectoryVersionsWithUploadedFiles (localDirectoryVersions: List<LocalDirectoryVersion>) uploadedFileVersions correlationId =
         let directoryVersions =
             localDirectoryVersions
-                .Select(fun ldv -> ldv.ToDirectoryVersion)
+                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions)
                 .ToList()
 
         let saveParameters = SaveDirectoryVersionsParameters()
@@ -1333,6 +1377,11 @@ module Services =
         saveParameters.DirectoryVersions <- directoryVersions
 
         DirectoryVersion.SaveDirectoryVersions saveParameters
+
+    /// Ensures that the provided directory versions are uploaded to Grace Server.
+    /// This will add new directory versions, and ignore existing directory versions, as they are immutable.
+    let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
+        uploadDirectoryVersionsWithUploadedFiles localDirectoryVersions Seq.empty<FileVersion> correlationId
 
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
@@ -1762,8 +1811,8 @@ module Services =
             ScanForDifferences: GraceStatus -> Task<List<FileSystemDifference>>
             CopyUpdatedFilesToObjectCache: List<FileSystemDifference> -> Task<seq<LocalFileVersion>>
             BuildUpdatedGraceStatus: GraceStatus -> List<FileSystemDifference> -> Task<GraceStatus * List<LocalDirectoryVersion>>
-            UploadFileVersions: seq<LocalFileVersion> -> Task<Result<unit, GraceError>>
-            UploadDirectoryVersions: List<LocalDirectoryVersion> -> Task<Result<unit, GraceError>>
+            UploadFileVersions: seq<LocalFileVersion> -> Task<Result<FileVersion list, GraceError>>
+            UploadDirectoryVersions: List<LocalDirectoryVersion> -> seq<FileVersion> -> Task<Result<unit, GraceError>>
             ApplyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
         }
@@ -1903,8 +1952,8 @@ module Services =
 
                             match! operations.UploadFileVersions fileVersionsToUpload with
                             | Error error -> return Error error
-                            | Ok () ->
-                                match! operations.UploadDirectoryVersions newDirectoryVersions with
+                            | Ok uploadedFileVersions ->
+                                match! operations.UploadDirectoryVersions newDirectoryVersions uploadedFileVersions with
                                 | Error error -> return Error error
                                 | Ok () ->
                                     let updatedGraceStatus =
@@ -2110,14 +2159,19 @@ module Services =
                              |> Seq.toArray)
                     )
 
-                match! uploadFilesToObjectStorage parameters with
-                | Ok _ -> return Ok()
+                match!
+                    uploadFilesToObjectStorageWithClients
+                        (fun fileVersion -> ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion))
+                        uploadWholeFilesToObjectStorage
+                        parameters
+                    with
+                | Ok returnValue -> return Ok(returnValue.ReturnValue |> Seq.toList)
                 | Error error -> return Error error
             }
 
-        let uploadDirectoryVersionsForCapture directoryVersions =
+        let uploadDirectoryVersionsForCapture directoryVersions uploadedFileVersions =
             task {
-                match! uploadDirectoryVersions directoryVersions correlationId with
+                match! uploadDirectoryVersionsWithUploadedFiles directoryVersions uploadedFileVersions correlationId with
                 | Ok _ -> return Ok()
                 | Error error -> return Error error
             }

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1155,7 +1155,9 @@ module Services =
             match! createLocalFileVersion fileInfo with
             | Some fileVersion ->
                 if fileVersion.Sha256Hash
-                   <> existingFileVersion.Sha256Hash then
+                   <> existingFileVersion.Sha256Hash
+                   || fileVersion.Blake3Hash
+                      <> existingFileVersion.Blake3Hash then
                     directoryVersion.Files.RemoveAt(existingFileIndex)
                     directoryVersion.Files.Add(fileVersion)
                     directoryVersion.Size <- directoryVersion.Files.Sum(fun file -> int64 (file.Size))
@@ -1428,14 +1430,15 @@ module Services =
 
         let fileVersionOverlaysByIdentity =
             fileVersionOverlays
-                .GroupBy(fun fileVersion -> (fileVersion.RelativePath, fileVersion.Sha256Hash))
+                .GroupBy(fun fileVersion -> (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash))
                 .ToDictionary((fun group -> group.Key), (fun group -> group.First()))
 
         let files =
             localDirectoryVersion
                 .Files
                 .Select(fun localFileVersion ->
-                    match fileVersionOverlaysByIdentity.TryGetValue((localFileVersion.RelativePath, localFileVersion.Sha256Hash)) with
+                    match fileVersionOverlaysByIdentity.TryGetValue((localFileVersion.RelativePath, localFileVersion.Sha256Hash, localFileVersion.Blake3Hash))
+                        with
                     | true, uploadedFileVersion -> uploadedFileVersion
                     | false, _ -> localFileVersion.ToFileVersion)
                 .ToList()

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -923,6 +923,15 @@ module Services =
     let private storageIdOrCurrent<'Id> (rawValue: string) (currentValue: 'Id) (parse: string -> 'Id) =
         if String.IsNullOrWhiteSpace rawValue then currentValue else parse rawValue
 
+    let internal localFilePathForManifestUpload (fileVersion: FileVersion) =
+        let current = Current()
+        let objectFilePath = getNativeFilePath (Path.Combine(current.ObjectDirectory, fileVersion.RelativePath, fileVersion.GetObjectFileName))
+
+        if File.Exists(objectFilePath) then
+            objectFilePath
+        else
+            getNativeFilePath (Path.Combine(current.RootDirectory, $"{fileVersion.RelativePath}"))
+
     let private createManifestUploadRequest (parameters: GetUploadMetadataForFilesParameters) (fileVersion: FileVersion) =
         let current = Current()
 
@@ -936,7 +945,7 @@ module Services =
                 RepositoryName = parameters.RepositoryName
                 AuthorizedScope = fileVersion.RelativePath
                 FileVersion = fileVersion
-                LocalFilePath = Path.Combine(current.ObjectDirectory, fileVersion.RelativePath, fileVersion.GetObjectFileName)
+                LocalFilePath = localFilePathForManifestUpload fileVersion
                 CorrelationId = parameters.CorrelationId
                 PlannerOptions = LocalPlanner.Options.Default
             }
@@ -2154,7 +2163,19 @@ module Services =
                         // If we do already have this exact version of the file, just delete the temp file.
                         File.Delete(tempFilePath)
                         //logToConsole $"Finished copyToObjectDirectory for {filePath}; object file already exists; deleted temp file."
-                        return None
+                        let objectFilePathInfo = FileInfo(objectFilePath)
+                        let relativePath = Path.GetRelativePath(Current().RootDirectory, filePath)
+
+                        return
+                            Some(
+                                FileVersion.CreateWithHashes
+                                    (RelativePath relativePath)
+                                    (Sha256Hash $"{sha256Hash}")
+                                    (Blake3Hash $"{blake3Hash}")
+                                    ("")
+                                    isBinary
+                                    (objectFilePathInfo.Length)
+                            )
                 //return result
                 else
                     logToAnsiConsole Colors.Error $"File {filePath} does not exist."

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1354,7 +1354,7 @@ module Services =
             .Distinct()
             .ToList()
 
-    let private getPreviousDirectoryVersionsForChangedDirectories
+    let internal getPreviousDirectoryVersionsForChangedDirectories
         (previousGraceStatus: GraceStatus)
         (localDirectoryVersions: List<LocalDirectoryVersion>)
         (correlationId: CorrelationId)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1331,9 +1331,79 @@ module Services =
                 return (previousGraceStatus, newDirectoryVersions)
         }
 
-    let internal toDirectoryVersionWithUploadedFiles (uploadedFileVersions: seq<FileVersion>) (localDirectoryVersion: LocalDirectoryVersion) =
-        let uploadedByIdentity =
-            uploadedFileVersions
+    let private hasManifestContentReference (fileVersion: FileVersion) =
+        not (isNull (box fileVersion))
+        && not (isNull (box fileVersion.ContentReference))
+        && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
+        && fileVersion.ContentReference.Manifest.IsSome
+
+    let private previousDirectoryVersionIdsForChangedDirectories (previousGraceStatus: GraceStatus) (localDirectoryVersions: seq<LocalDirectoryVersion>) =
+        let changedDirectoryPaths =
+            localDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> HashSet<RelativePath>
+
+        previousGraceStatus
+            .Index
+            .Values
+            .Where(fun directoryVersion ->
+                changedDirectoryPaths.Contains directoryVersion.RelativePath
+                && directoryVersion.DirectoryVersionId
+                   <> DirectoryVersionId.Empty)
+            .Select(fun directoryVersion -> directoryVersion.DirectoryVersionId)
+            .Distinct()
+            .ToList()
+
+    let private getPreviousDirectoryVersionsForChangedDirectories
+        (previousGraceStatus: GraceStatus)
+        (localDirectoryVersions: List<LocalDirectoryVersion>)
+        (correlationId: CorrelationId)
+        =
+        task {
+            let previousDirectoryVersionIds = previousDirectoryVersionIdsForChangedDirectories previousGraceStatus localDirectoryVersions
+
+            if previousDirectoryVersionIds.Count = 0 then
+                return Ok(List<Grace.Types.Common.DirectoryVersion>())
+            else
+                let current = Current()
+
+                let getByDirectoryIdParameters =
+                    Parameters.DirectoryVersion.GetByDirectoryIdsParameters(
+                        OwnerId = $"{current.OwnerId}",
+                        OwnerName = current.OwnerName,
+                        OrganizationId = $"{current.OrganizationId}",
+                        OrganizationName = current.OrganizationName,
+                        RepositoryId = $"{current.RepositoryId}",
+                        RepositoryName = current.RepositoryName,
+                        DirectoryVersionId = $"{previousDirectoryVersionIds[0]}",
+                        DirectoryIds = previousDirectoryVersionIds,
+                        CorrelationId = correlationId
+                    )
+
+                match! DirectoryVersion.GetByDirectoryIds getByDirectoryIdParameters with
+                | Ok returnValue ->
+                    return
+                        returnValue.ReturnValue
+                        |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
+                        |> List<Grace.Types.Common.DirectoryVersion>
+                        |> Ok
+                | Error error -> return Error error
+        }
+
+    let internal toDirectoryVersionWithUploadedFiles
+        (uploadedFileVersions: seq<FileVersion>)
+        (previousDirectoryVersions: seq<Grace.Types.Common.DirectoryVersion>)
+        (localDirectoryVersion: LocalDirectoryVersion)
+        =
+        let fileVersionOverlays =
+            Seq.append
+                uploadedFileVersions
+                (previousDirectoryVersions
+                 |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+                 |> Seq.filter hasManifestContentReference)
+
+        let fileVersionOverlaysByIdentity =
+            fileVersionOverlays
                 .GroupBy(fun fileVersion -> (fileVersion.RelativePath, fileVersion.Sha256Hash))
                 .ToDictionary((fun group -> group.Key), (fun group -> group.First()))
 
@@ -1341,7 +1411,7 @@ module Services =
             localDirectoryVersion
                 .Files
                 .Select(fun localFileVersion ->
-                    match uploadedByIdentity.TryGetValue((localFileVersion.RelativePath, localFileVersion.Sha256Hash)) with
+                    match fileVersionOverlaysByIdentity.TryGetValue((localFileVersion.RelativePath, localFileVersion.Sha256Hash)) with
                     | true, uploadedFileVersion -> uploadedFileVersion
                     | false, _ -> localFileVersion.ToFileVersion)
                 .ToList()
@@ -1360,10 +1430,15 @@ module Services =
 
     /// Ensures that the provided directory versions are uploaded to Grace Server.
     /// This will add new directory versions, and ignore existing directory versions, as they are immutable.
-    let uploadDirectoryVersionsWithUploadedFiles (localDirectoryVersions: List<LocalDirectoryVersion>) uploadedFileVersions correlationId =
+    let uploadDirectoryVersionsWithUploadedFiles
+        (localDirectoryVersions: List<LocalDirectoryVersion>)
+        uploadedFileVersions
+        previousDirectoryVersions
+        correlationId
+        =
         let directoryVersions =
             localDirectoryVersions
-                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions)
+                .Select(toDirectoryVersionWithUploadedFiles uploadedFileVersions previousDirectoryVersions)
                 .ToList()
 
         let saveParameters = SaveDirectoryVersionsParameters()
@@ -1381,7 +1456,7 @@ module Services =
     /// Ensures that the provided directory versions are uploaded to Grace Server.
     /// This will add new directory versions, and ignore existing directory versions, as they are immutable.
     let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
-        uploadDirectoryVersionsWithUploadedFiles localDirectoryVersions Seq.empty<FileVersion> correlationId
+        uploadDirectoryVersionsWithUploadedFiles localDirectoryVersions Seq.empty<FileVersion> Seq.empty<Grace.Types.Common.DirectoryVersion> correlationId
 
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
@@ -1812,7 +1887,7 @@ module Services =
             CopyUpdatedFilesToObjectCache: List<FileSystemDifference> -> Task<seq<LocalFileVersion>>
             BuildUpdatedGraceStatus: GraceStatus -> List<FileSystemDifference> -> Task<GraceStatus * List<LocalDirectoryVersion>>
             UploadFileVersions: seq<LocalFileVersion> -> Task<Result<FileVersion list, GraceError>>
-            UploadDirectoryVersions: List<LocalDirectoryVersion> -> seq<FileVersion> -> Task<Result<unit, GraceError>>
+            UploadDirectoryVersions: GraceStatus -> List<LocalDirectoryVersion> -> seq<FileVersion> -> Task<Result<unit, GraceError>>
             ApplyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
         }
@@ -1953,7 +2028,7 @@ module Services =
                             match! operations.UploadFileVersions fileVersionsToUpload with
                             | Error error -> return Error error
                             | Ok uploadedFileVersions ->
-                                match! operations.UploadDirectoryVersions newDirectoryVersions uploadedFileVersions with
+                                match! operations.UploadDirectoryVersions previousGraceStatus newDirectoryVersions uploadedFileVersions with
                                 | Error error -> return Error error
                                 | Ok () ->
                                     let updatedGraceStatus =
@@ -2169,11 +2244,14 @@ module Services =
                 | Error error -> return Error error
             }
 
-        let uploadDirectoryVersionsForCapture directoryVersions uploadedFileVersions =
+        let uploadDirectoryVersionsForCapture previousGraceStatus directoryVersions uploadedFileVersions =
             task {
-                match! uploadDirectoryVersionsWithUploadedFiles directoryVersions uploadedFileVersions correlationId with
-                | Ok _ -> return Ok()
+                match! getPreviousDirectoryVersionsForChangedDirectories previousGraceStatus directoryVersions correlationId with
                 | Error error -> return Error error
+                | Ok previousDirectoryVersions ->
+                    match! uploadDirectoryVersionsWithUploadedFiles directoryVersions uploadedFileVersions previousDirectoryVersions correlationId with
+                    | Ok _ -> return Ok()
+                    | Error error -> return Error error
             }
 
         let createSaveReferenceForCapture rootDirectoryVersion saveMessage =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -997,7 +997,7 @@ module Services =
                     uploadWholeFilesToObjectStorage
                     parameters
                 with
-            | Ok _ -> return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+            | Ok returnValue -> return Ok returnValue
             | Error error -> return Error error
         }
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -955,7 +955,7 @@ module Services =
                     let fileVersion = parameters.FileVersions[fileVersionIndex]
 
                     match! manifestUpload fileVersion with
-                    | Ok result when not result.ReturnValue.UsedManifestUpload -> fallbackFileVersions.Enqueue(fileVersion)
+                    | Ok result when not result.ReturnValue.UsedManifestUpload -> fallbackFileVersions.Enqueue(result.ReturnValue.FileVersion)
                     | Ok _ -> ()
                     | Error error -> errors.Enqueue(error)
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -362,7 +362,7 @@ module Services =
     let scanForDifferences (previousGraceStatus: GraceStatus) =
         task {
             try
-                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, (DateTime * Sha256Hash)>()
+                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, (DateTime * Sha256Hash * Blake3Hash)>()
 
                 let differences = ConcurrentStack<FileSystemDifference>()
 
@@ -373,14 +373,14 @@ module Services =
 
                     lookupCache.TryAdd(
                         (FileSystemEntryType.Directory, directoryVersion.RelativePath),
-                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash)
+                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash, directoryVersion.Blake3Hash)
                     )
                     |> ignore
 
                     for file in directoryVersion.Files do
                         fileCount <- fileCount + 1
 
-                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash))
+                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash, file.Blake3Hash))
                         |> ignore
 
                 if parseResult |> isOutputFormat "Verbose" then
@@ -404,7 +404,7 @@ module Services =
 
                     // Check for changes
                     if lookupCache.ContainsKey((fileSystemEntryType, relativePath)) then
-                        let (knownLastWriteTimeUtc, existingSha256Hash) = lookupCache[(fileSystemEntryType, relativePath)]
+                        let (knownLastWriteTimeUtc, existingSha256Hash, existingBlake3Hash) = lookupCache[(fileSystemEntryType, relativePath)]
                         // Has the LastWriteTimeUtc changed from the one in GraceStatus?
                         if fileSystemEntryType.IsFile
                            && lastWriteTimeUtc <> knownLastWriteTimeUtc then
@@ -414,19 +414,19 @@ module Services =
 
                             match! createLocalFileVersion fileInfo with
                             | Some newFileVersion ->
-                                if newFileVersion.Sha256Hash <> existingSha256Hash then
+                                if newFileVersion.Sha256Hash <> existingSha256Hash
+                                   || newFileVersion.Blake3Hash <> existingBlake3Hash then
                                     differences.Push(FileSystemDifference.Create Change fileSystemEntryType relativePath)
 
                                     if parseResult |> isOutputFormat "Verbose" then
                                         logToAnsiConsole
                                             Colors.Verbose
-                                            $"scanForDifferences: Found change in file: {relativePath}; existing Sha256Hash: {getShortSha256Hash existingSha256Hash}; new Sha256Hash: {getShortSha256Hash newFileVersion.Sha256Hash}."
+                                            $"scanForDifferences: Found change in file: {relativePath}; existing Sha256Hash: {getShortSha256Hash existingSha256Hash}; new Sha256Hash: {getShortSha256Hash newFileVersion.Sha256Hash}; existing Blake3Hash: {existingBlake3Hash}; new Blake3Hash: {newFileVersion.Blake3Hash}."
                             | None -> ()
 
                 // Check for deletions
                 for keyValuePair in lookupCache do
                     let (fileSystemEntryType, relativePath) = keyValuePair.Key
-                    let (knownLastWriteTimeUtc, existingSha256Hash) = keyValuePair.Value
 
                     if
                         not

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -332,8 +332,16 @@ module Watch =
                     Colors.Verbose
                     $"new Sha256Hash: {dv.Sha256Hash.Substring(0, 8)}; DirectoryId: {dv.DirectoryVersionId.ToString().Substring(0, 9)}...; RelativePath: {dv.RelativePath}"
 
-            // Upload the new directory versions.
-            let! result = uploadDirectoryVersions newDirectoryVersions correlationId
+            // Upload the new directory versions, preserving any manifest references from the previous server versions.
+            let graceIds = currentRepositoryGraceIds correlationId
+
+            let! result =
+                task {
+                    match! getPreviousDirectoryVersionsForChangedDirectories graceIds graceStatus newDirectoryVersions correlationId with
+                    | Error error -> return Error error
+                    | Ok previousDirectoryVersions ->
+                        return! uploadDirectoryVersionsWithUploadedFiles newDirectoryVersions Seq.empty<FileVersion> previousDirectoryVersions correlationId
+                }
 
             match result with
             | Ok returnValue ->

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -142,6 +142,14 @@ module Watch =
     let mutable private graceStatusDirectoryIds = HashSet<DirectoryVersionId>()
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
+    let private pendingUploadedFileVersions = List<FileVersion>()
+
+    let internal addUploadedFileVersionsForWatchBatch (pendingFileVersions: List<FileVersion>) (uploadedFileVersions: seq<FileVersion>) =
+        pendingFileVersions.AddRange(uploadedFileVersions)
+
+    let internal snapshotUploadedFileVersionsForGraceStatusUpdate (pendingFileVersions: List<FileVersion>) = List<FileVersion>(pendingFileVersions)
+
+    let internal clearUploadedFileVersionsAfterGraceStatusUpdate (pendingFileVersions: List<FileVersion>) = pendingFileVersions.Clear()
 
     let fileDeleted filePath = logToConsole $"In Delete: filePath: {filePath}"
 
@@ -469,7 +477,6 @@ module Watch =
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
-                    let uploadedFileVersions = List<FileVersion>()
 
                     /// This is just a way to throw away the unit value from the ConcurrentDictionary.
                     let mutable unitValue = ()
@@ -489,7 +496,7 @@ module Watch =
                         if filesToProcess.TryRemove(fileName, &unitValue) then
                             logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
                             let! uploadedFileVersion = copyFileToObjectDirectoryAndUploadToStorage getUploadMetadataForFilesParameters (FilePath fileName)
-                            uploadedFileVersions.AddRange(uploadedFileVersion)
+                            addUploadedFileVersionsForWatchBatch pendingUploadedFileVersions uploadedFileVersion
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
@@ -502,9 +509,12 @@ module Watch =
                     if filesToProcess.IsEmpty then
                         let! graceStatusSnapshot = readGraceStatusFile ()
                         graceStatus <- graceStatusSnapshot
+                        let uploadedFileVersions = snapshotUploadedFileVersionsForGraceStatusUpdate pendingUploadedFileVersions
 
                         match! (updateGraceStatus graceStatus uploadedFileVersions correlationId) with
-                        | Some newGraceStatus -> graceStatus <- newGraceStatus
+                        | Some newGraceStatus ->
+                            graceStatus <- newGraceStatus
+                            clearUploadedFileVersionsAfterGraceStatusUpdate pendingUploadedFileVersions
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -317,7 +317,7 @@ module Watch =
     let updateObjectCacheFile (newDirectoryVersions: List<LocalDirectoryVersion>) = task { do! upsertObjectCache newDirectoryVersions }
 
     /// Updates the Grace Status file's Index with updates detected from the file system.
-    let updateGraceStatus graceStatus correlationId =
+    let updateGraceStatus graceStatus uploadedFileVersions correlationId =
         task {
             // Get the list of differences between what's in the working directory, and what Grace Index knows about.
             let! differences = scanForDifferences graceStatus
@@ -340,7 +340,7 @@ module Watch =
                     match! getPreviousDirectoryVersionsForChangedDirectories graceIds graceStatus newDirectoryVersions correlationId with
                     | Error error -> return Error error
                     | Ok previousDirectoryVersions ->
-                        return! uploadDirectoryVersionsWithUploadedFiles newDirectoryVersions Seq.empty<FileVersion> previousDirectoryVersions correlationId
+                        return! uploadDirectoryVersionsWithUploadedFiles newDirectoryVersions uploadedFileVersions previousDirectoryVersions correlationId
                 }
 
             match result with
@@ -408,9 +408,13 @@ module Watch =
                 getUploadMetadataForFilesParameters.FileVersions <- [| fileVersion |]
 
                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                | Ok returnValue -> logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
-                | Error error -> logToAnsiConsole Colors.Error $"**Failed to upload {fileVersion.GetObjectFileName} to storage."
-            | None -> ()
+                | Ok returnValue ->
+                    logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
+                    return returnValue.ReturnValue :> seq<FileVersion>
+                | Error error ->
+                    logToAnsiConsole Colors.Error $"**Failed to upload {fileVersion.GetObjectFileName} to storage."
+                    return Seq.empty<FileVersion>
+            | None -> return Seq.empty<FileVersion>
         }
 
     /// Decompresses the GraceStatus information from the memory stream.
@@ -465,6 +469,7 @@ module Watch =
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
+                    let uploadedFileVersions = List<FileVersion>()
 
                     /// This is just a way to throw away the unit value from the ConcurrentDictionary.
                     let mutable unitValue = ()
@@ -483,7 +488,8 @@ module Watch =
                     for fileName in filesToProcess.Keys.Take(50) do
                         if filesToProcess.TryRemove(fileName, &unitValue) then
                             logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
-                            do! copyFileToObjectDirectoryAndUploadToStorage getUploadMetadataForFilesParameters (FilePath fileName)
+                            let! uploadedFileVersion = copyFileToObjectDirectoryAndUploadToStorage getUploadMetadataForFilesParameters (FilePath fileName)
+                            uploadedFileVersions.AddRange(uploadedFileVersion)
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
@@ -497,7 +503,7 @@ module Watch =
                         let! graceStatusSnapshot = readGraceStatusFile ()
                         graceStatus <- graceStatusSnapshot
 
-                        match! (updateGraceStatus graceStatus correlationId) with
+                        match! (updateGraceStatus graceStatus uploadedFileVersions correlationId) with
                         | Some newGraceStatus -> graceStatus <- newGraceStatus
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -169,8 +169,21 @@ module ManifestUpload =
         parameters.Manifest <- manifest
         parameters
 
-    let private manifestFileVersion (fileVersion: FileVersion) manifest =
-        let manifestVersion = FileVersion.Create fileVersion.RelativePath fileVersion.Sha256Hash fileVersion.BlobUri fileVersion.IsBinary fileVersion.Size
+    let private fileVersionWithBlake3Hash (fileVersion: FileVersion) (fileContentHash: FileContentHash) =
+        let version =
+            FileVersion.CreateWithHashes
+                fileVersion.RelativePath
+                fileVersion.Sha256Hash
+                (Blake3Hash $"{fileContentHash}")
+                fileVersion.BlobUri
+                fileVersion.IsBinary
+                fileVersion.Size
+
+        version.CreatedAt <- fileVersion.CreatedAt
+        version
+
+    let private manifestFileVersion (fileVersion: FileVersion) (manifest: FileManifest) =
+        let manifestVersion = fileVersionWithBlake3Hash fileVersion manifest.FileContentHash
         manifestVersion.CreatedAt <- fileVersion.CreatedAt
         manifestVersion.ContentReference <- FileContentReference.FileManifest manifest
         manifestVersion
@@ -237,7 +250,7 @@ module ManifestUpload =
                 claimedRangeIndex <- claimedRangeIndex + 1
 
     let uploadFileWithClient (client: ManifestUploadClient) (request: ManifestUploadRequest) : Task<GraceResult<ManifestUploadResult>> =
-        task {
+        async {
             if isNull (box request.FileVersion) then
                 return error request.CorrelationId "FileVersion is required for manifest upload."
             elif String.IsNullOrWhiteSpace request.LocalFilePath then
@@ -269,12 +282,18 @@ module ManifestUpload =
                     | None ->
                         let uploadSessionId = Guid.NewGuid()
 
-                        match! client.StartSession(buildStartParameters request uploadSessionId plan) with
+                        match!
+                            client.StartSession(buildStartParameters request uploadSessionId plan)
+                            |> Async.AwaitTask
+                            with
                         | Error error -> return Error error
                         | Ok _ ->
                             let claimedBlockAddresses = HashSet<ContentBlockAddress>()
 
-                            match! client.DiscoverContentBlocks(buildDiscoveryParameters request plan) with
+                            match!
+                                client.DiscoverContentBlocks(buildDiscoveryParameters request plan)
+                                |> Async.AwaitTask
+                                with
                             | Ok discoveryResult when
                                 not (isNull discoveryResult.ReturnValue.CandidateContentBlocks)
                                 && discoveryResult.ReturnValue.CandidateContentBlocks.Length > 0
@@ -292,11 +311,15 @@ module ManifestUpload =
                                             discoveryResult.ReturnValue.Policy.MinimumAcceptedReuseRunLength
                                             reuseHints
 
-                                    match! client.IssueDedupeDiscovery issueParameters with
+                                    match! client.IssueDedupeDiscovery issueParameters
+                                           |> Async.AwaitTask
+                                        with
                                     | Ok _ ->
                                         let claimParameters = buildClaimReuseRangesParameters request uploadSessionId 0 issueParameters.OperationId reuseHints
 
-                                        match! client.ClaimReuseRanges claimParameters with
+                                        match! client.ClaimReuseRanges claimParameters
+                                               |> Async.AwaitTask
+                                            with
                                         | Ok claimResult -> addFullyClaimedBlockAddresses plan claimedBlockAddresses claimResult.ReturnValue.Session
                                         | Error _ -> ()
                                     | Error _ -> ()
@@ -330,6 +353,7 @@ module ManifestUpload =
                                                         logicalBlockPlan.Offset
                                                         logicalBlockPlan.Size
                                                 )
+                                            |> Async.AwaitTask
                                             with
                                         | Error error -> errors.Add error
                                         | Ok _ -> ()
@@ -345,12 +369,15 @@ module ManifestUpload =
                                 if claimedBlockAddresses.Contains encodedBlock.Address then
                                     ()
                                 else
-                                    match! client.UploadContentBlock (buildUploadUriParameters request encodedBlock.Address) encodedBlock.Payload with
+                                    match! client.UploadContentBlock (buildUploadUriParameters request encodedBlock.Address) encodedBlock.Payload
+                                           |> Async.AwaitTask
+                                        with
                                     | Error error -> errors.Add error
                                     | Ok placementResult ->
                                         match!
                                             client.ConfirmBlockUploaded
                                                 (buildConfirmParameters request uploadSessionId index encodedBlock placementResult.ReturnValue)
+                                            |> Async.AwaitTask
                                             with
                                         | Error error -> errors.Add error
                                         | Ok _ -> uploadedBlockCount <- uploadedBlockCount + 1
@@ -360,14 +387,19 @@ module ManifestUpload =
                             if errors.Count > 0 then
                                 return Error errors[0]
                             else
-                                match! client.FinalizeManifest(buildFinalizeParameters request uploadSessionId manifest) with
+                                match!
+                                    client.FinalizeManifest(buildFinalizeParameters request uploadSessionId manifest)
+                                    |> Async.AwaitTask
+                                    with
                                 | Error error -> return Error error
                                 | Ok _ ->
+                                    let uploadedFileVersion = manifestFileVersion request.FileVersion manifest
+
                                     return
                                         Ok(
                                             GraceReturnValue.Create
                                                 {
-                                                    FileVersion = manifestFileVersion request.FileVersion manifest
+                                                    FileVersion = uploadedFileVersion
                                                     Manifest = Some manifest
                                                     UploadSessionId = Some uploadSessionId
                                                     UploadedBlockCount = uploadedBlockCount
@@ -376,11 +408,13 @@ module ManifestUpload =
                                                 request.CorrelationId
                                         )
                 | _ ->
+                    let fallbackFileVersion = fileVersionWithBlake3Hash request.FileVersion plan.FileContentHash
+
                     return
                         Ok(
                             GraceReturnValue.Create
                                 {
-                                    FileVersion = request.FileVersion
+                                    FileVersion = fallbackFileVersion
                                     Manifest = None
                                     UploadSessionId = None
                                     UploadedBlockCount = 0
@@ -389,6 +423,7 @@ module ManifestUpload =
                                 request.CorrelationId
                         )
         }
+        |> Async.StartAsTask
 
     let serverClient =
         {

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -211,6 +211,7 @@ module Storage =
                 metadata[nameof RepositoryName] <- $"{Current().RepositoryName}"
                 metadata[nameof RepositoryId] <- $"{Current().RepositoryId}"
                 metadata[nameof Sha256Hash] <- fileVersion.Sha256Hash
+                metadata[nameof Blake3Hash] <- fileVersion.Blake3Hash
                 metadata["UncompressedSize"] <- $"{fileInfo.Length}"
 
                 match Current().ObjectStorageProvider with
@@ -300,6 +301,7 @@ module Storage =
                             let returnValue = GraceReturnValue.Create "File successfully saved to object storage." correlationId
 
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue
@@ -308,6 +310,7 @@ module Storage =
                             let returnValue = GraceReturnValue.Create "File already exists in object storage." correlationId
 
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue
@@ -320,6 +323,7 @@ module Storage =
                             // If the file already exists in Blob Storage, we don't need to do anything.
                             let returnValue = GraceReturnValue.Create "File already exists in object storage." correlationId
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue

--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -223,12 +223,16 @@ type AnnotationMaterializationServerTests() =
         Assert.That(result.Bytes = bytes, Is.True)
 
     [<Test>]
-    member _.ManifestBackedContentWithMissingBlake3HashIsRejected() =
+    member _.LegacyManifestBackedContentWithMissingBlake3HashMaterializesUsingManifestFileContentHash() =
         let bytes = textBytes "manifest missing blake3 text"
         let target, block = manifestFile "/src/ManifestMissingBlake3.fs" bytes
         target.Blake3Hash <- String.Empty
         let objects = Dictionary<string, byte array>()
         objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
 
-        materialize (readerFrom objects) target
-        |> expectErrorContains "has no FileVersion.Blake3Hash"
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("manifest missing blake3 text"))
+        Assert.That(result.Bytes = bytes, Is.True)

--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -33,7 +33,14 @@ type AnnotationMaterializationServerTests() =
         gzipStream.Dispose()
         compressed.ToArray()
 
-    let fileVersion relativePath isBinary (bytes: byte array) = FileVersion.Create relativePath (sha256Hex bytes) String.Empty isBinary (int64 bytes.Length)
+    let fileVersion relativePath isBinary (bytes: byte array) =
+        FileVersion.CreateWithHashes
+            relativePath
+            (sha256Hex bytes)
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            String.Empty
+            isBinary
+            (int64 bytes.Length)
 
     let readerFrom (objects: IDictionary<string, byte array>) : AnnotationMaterialization.ObjectPayloadReader =
         fun objectKey correlationId _ ->
@@ -186,3 +193,27 @@ type AnnotationMaterializationServerTests() =
 
         materialize (readerFrom objects) target
         |> expectErrorContains "Invalid manifest reconstruction"
+
+    [<Test>]
+    member _.MaterializedBytesWithMismatchedBlake3HashAreRejected() =
+        let bytes = textBytes "actual materialized text"
+        let target = fileVersion "/src/Mismatch.fs" false bytes
+        target.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex (textBytes "different text"))
+        let objectKey = StorageKeys.wholeFileContentObjectKey target
+        let objects = Dictionary<string, byte array>()
+        objects[objectKey] <- bytes
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "FileVersion.Blake3Hash"
+
+    [<Test>]
+    member _.MaterializedBytesWithMissingBlake3HashAreRejected() =
+        let bytes = textBytes "missing blake3 text"
+        let target = fileVersion "/src/MissingBlake3.fs" false bytes
+        target.Blake3Hash <- String.Empty
+        let objectKey = StorageKeys.wholeFileContentObjectKey target
+        let objects = Dictionary<string, byte array>()
+        objects[objectKey] <- bytes
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "has no FileVersion.Blake3Hash"

--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -207,13 +207,28 @@ type AnnotationMaterializationServerTests() =
         |> expectErrorContains "FileVersion.Blake3Hash"
 
     [<Test>]
-    member _.MaterializedBytesWithMissingBlake3HashAreRejected() =
-        let bytes = textBytes "missing blake3 text"
-        let target = fileVersion "/src/MissingBlake3.fs" false bytes
+    member _.LegacyWholeFileContentWithMissingBlake3HashMaterializes() =
+        let bytes = textBytes "legacy missing blake3 text"
+        let target = fileVersion "/src/LegacyMissingBlake3.fs" false bytes
         target.Blake3Hash <- String.Empty
         let objectKey = StorageKeys.wholeFileContentObjectKey target
         let objects = Dictionary<string, byte array>()
         objects[objectKey] <- bytes
+
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("legacy missing blake3 text"))
+        Assert.That(result.Bytes = bytes, Is.True)
+
+    [<Test>]
+    member _.ManifestBackedContentWithMissingBlake3HashIsRejected() =
+        let bytes = textBytes "manifest missing blake3 text"
+        let target, block = manifestFile "/src/ManifestMissingBlake3.fs" bytes
+        target.Blake3Hash <- String.Empty
+        let objects = Dictionary<string, byte array>()
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
 
         materialize (readerFrom objects) target
         |> expectErrorContains "has no FileVersion.Blake3Hash"

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -9,13 +9,54 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.IO
 open System.Security.Cryptography
 open System.Text
+open System.Threading
+open System.Threading.Tasks
 
 module DirectoryVersionActor = Grace.Actors.DirectoryVersion
 module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
 module ReferenceActor = Grace.Actors.Reference
 module RepositoryContentCounterActor = Grace.Actors.RepositoryContentCounter
+
+type private ChunkedReadOnlyStream(bytes: byte array) =
+    inherit Stream()
+
+    let mutable position = 0
+    let mutable maxRequestedReadCount = 0
+
+    member _.MaxRequestedReadCount = maxRequestedReadCount
+
+    override _.CanRead = true
+    override _.CanSeek = false
+    override _.CanWrite = false
+    override _.Length = int64 bytes.Length
+
+    override _.Position
+        with get () = int64 position
+        and set _ = raise (NotSupportedException())
+
+    override _.Flush() = ()
+    override _.Seek(_, _) = raise (NotSupportedException())
+    override _.SetLength(_) = raise (NotSupportedException())
+    override _.Write(_, _, _) = raise (NotSupportedException())
+
+    override _.Read(buffer, offset, count) =
+        maxRequestedReadCount <- max maxRequestedReadCount count
+
+        if position >= bytes.Length then
+            0
+        else
+            let bytesToCopy = min count (bytes.Length - position)
+            Array.Copy(bytes, position, buffer, offset, bytesToCopy)
+            position <- position + bytesToCopy
+            bytesToCopy
+
+    override this.ReadAsync(buffer, offset, count, _cancellationToken) = Task.FromResult(this.Read(buffer, offset, count))
+
+    override _.CopyToAsync(_destination, _bufferSize, _cancellationToken) =
+        raise (InvalidOperationException("Whole-stream buffering is not allowed in this test."))
 
 [<Parallelizable(ParallelScope.All)>]
 type SaveBoundaryActorTests() =
@@ -217,6 +258,19 @@ type SaveBoundaryActorTests() =
             Assert.That(validatedFileVersion.Blake3Hash, Is.EqualTo(actualBlake3))
             Assert.That(fileVersion.Blake3Hash, Is.EqualTo(actualBlake3))
         | other -> Assert.Fail($"Expected successful validation with BLAKE3 backfill, got {other}.")
+
+    [<Test>]
+    member _.DirectoryVersionWholeFileHashComputationStreamsWithoutCopyingWholeObject() =
+        let bytes = Array.init ((64 * 1024 * 2) + 17) (fun index -> byte (index % 251))
+        use stream = new ChunkedReadOnlyStream(bytes)
+
+        let computedSha256Hash, computedBlake3Hash =
+            (DirectoryVersionActor.computeWholeFileContentHashes stream)
+                .Result
+
+        Assert.That(computedSha256Hash, Is.EqualTo(Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))))
+        Assert.That(computedBlake3Hash, Is.EqualTo(Blake3Hash(ContentAddress.computeBlake3Hex bytes)))
+        Assert.That(stream.MaxRequestedReadCount, Is.LessThanOrEqualTo(64 * 1024))
 
     [<Test>]
     member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -174,6 +174,19 @@ type SaveBoundaryActorTests() =
         Assert.That(filesToValidate[0].RelativePath, Is.EqualTo(wholeFile.RelativePath))
 
     [<Test>]
+    member _.DirectoryVersionWholeFileValidationSetIncludesSameShaWhenBlake3Changes() =
+        let previousFile = wholeFile ()
+        let newFile = wholeFile ()
+        newFile.Blake3Hash <- Blake3Hash "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"
+
+        let filesToValidate = DirectoryVersionActor.getFilesToValidateForSaveBoundary (List<FileVersion>([ newFile ])) (List<FileVersion>([ previousFile ]))
+
+        Assert.That(filesToValidate, Has.Length.EqualTo(1))
+        Assert.That(filesToValidate[0].RelativePath, Is.EqualTo(newFile.RelativePath))
+        Assert.That(filesToValidate[0].Sha256Hash, Is.EqualTo(previousFile.Sha256Hash))
+        Assert.That(filesToValidate[0].Blake3Hash, Is.EqualTo(newFile.Blake3Hash))
+
+    [<Test>]
     member _.SaveBoundaryRejectsWholeFileWhenFileVersionBlake3DoesNotMatchStoredBytes() =
         let bytes = Encoding.UTF8.GetBytes("whole-file content with stale blake3")
         let fileVersion = wholeFileFromBytes "/small.txt" bytes

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -62,11 +62,26 @@ type SaveBoundaryActorTests() =
     let finalizedManifest () = finalizedManifestWithBlockCopies 1
 
     let manifestFile (manifest: FileManifest) =
-        let fileVersion = FileVersion.Create "/large.bin" "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" String.Empty true manifest.Size
+        let fileVersion =
+            FileVersion.CreateWithHashes
+                "/large.bin"
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                (Blake3Hash $"{manifest.FileContentHash}")
+                String.Empty
+                true
+                manifest.Size
+
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
         fileVersion
 
-    let wholeFile () = FileVersion.Create "/small.txt" "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" String.Empty false 42L
+    let wholeFile () =
+        FileVersion.CreateWithHashes
+            "/small.txt"
+            "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+            String.Empty
+            false
+            42L
 
     let referenceDto referenceType =
         { Grace.Types.Reference.ReferenceDto.Default with
@@ -108,6 +123,19 @@ type SaveBoundaryActorTests() =
         match result with
         | Ok _ -> Assert.Fail("Expected an unfinalized manifest reference to reject before save publication.")
         | Error error -> Assert.That(error.Error, Does.Contain("must be finalized before Save"))
+
+    [<Test>]
+    member _.SaveBoundaryRejectsManifestWhenFileVersionBlake3DoesNotMatchFileContentHash() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes("stale manifest bytes")))
+        let directoryVersion = directoryWith [ fileVersion ]
+
+        let result = ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-blake3-mismatch"
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected mismatched FileVersion.Blake3Hash to reject before save publication.")
+        | Error error -> Assert.That(error.Error, Does.Contain("FileVersion.Blake3Hash equal FileManifest.FileContentHash"))
 
     [<Test>]
     member _.DirectoryVersionWholeFileValidationSetIgnoresFinalizedManifestBackedFiles() =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -138,6 +138,20 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.That(error.Error, Does.Contain("FileVersion.Blake3Hash equal FileManifest.FileContentHash"))
 
     [<Test>]
+    member _.SaveBoundaryAcceptsLegacyManifestBackedFileVersionWithMissingBlake3Hash() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = directoryWith [ fileVersion ]
+
+        let plan =
+            ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-legacy-manifest-blake3"
+            |> expectPlan
+
+        Assert.That(plan.Manifest.ManifestAddress, Is.EqualTo(manifest.ManifestAddress))
+        Assert.That(plan.Manifest.FileContentHash, Is.EqualTo(manifest.FileContentHash))
+
+    [<Test>]
     member _.DirectoryVersionWholeFileValidationSetIgnoresFinalizedManifestBackedFiles() =
         let manifest = finalizedManifest ()
         let wholeFile = wholeFile ()

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.RepositoryContentCounter
 open Grace.Types.Common
@@ -8,6 +9,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Security.Cryptography
 open System.Text
 
 module DirectoryVersionActor = Grace.Actors.DirectoryVersion
@@ -82,6 +84,15 @@ type SaveBoundaryActorTests() =
             String.Empty
             false
             42L
+
+    let wholeFileFromBytes relativePath (bytes: byte array) =
+        FileVersion.CreateWithHashes
+            relativePath
+            (Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan())))
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            String.Empty
+            false
+            (int64 bytes.Length)
 
     let referenceDto referenceType =
         { Grace.Types.Reference.ReferenceDto.Default with
@@ -161,6 +172,38 @@ type SaveBoundaryActorTests() =
 
         Assert.That(filesToValidate, Has.Length.EqualTo(1))
         Assert.That(filesToValidate[0].RelativePath, Is.EqualTo(wholeFile.RelativePath))
+
+    [<Test>]
+    member _.SaveBoundaryRejectsWholeFileWhenFileVersionBlake3DoesNotMatchStoredBytes() =
+        let bytes = Encoding.UTF8.GetBytes("whole-file content with stale blake3")
+        let fileVersion = wholeFileFromBytes "/small.txt" bytes
+        let actualBlake3 = fileVersion.Blake3Hash
+        fileVersion.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes("stale whole-file bytes")))
+
+        let result = DirectoryVersionActor.validateWholeFileHashesForSaveBoundary fileVersion fileVersion.Sha256Hash actualBlake3 1.0
+
+        match result with
+        | DirectoryVersionActor.Blake3HashMismatch (mismatchedFileVersion, expected, computed, _) ->
+            Assert.That(mismatchedFileVersion.RelativePath, Is.EqualTo(fileVersion.RelativePath))
+            Assert.That(expected, Is.EqualTo(fileVersion.Blake3Hash))
+            Assert.That(computed, Is.EqualTo(actualBlake3))
+        | other -> Assert.Fail($"Expected BLAKE3 hash mismatch, got {other}.")
+
+    [<Test>]
+    member _.SaveBoundaryBackfillsLegacyWholeFileWithMissingBlake3HashAfterStoredBytesValidate() =
+        let bytes = Encoding.UTF8.GetBytes("legacy whole-file content missing blake3")
+        let fileVersion = wholeFileFromBytes "/legacy-small.txt" bytes
+        let actualBlake3 = fileVersion.Blake3Hash
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+
+        let result = DirectoryVersionActor.validateWholeFileHashesForSaveBoundary fileVersion fileVersion.Sha256Hash actualBlake3 1.0
+
+        match result with
+        | DirectoryVersionActor.Valid (validatedFileVersion, _, computedBlake3, _) ->
+            Assert.That(computedBlake3, Is.EqualTo(actualBlake3))
+            Assert.That(validatedFileVersion.Blake3Hash, Is.EqualTo(actualBlake3))
+            Assert.That(fileVersion.Blake3Hash, Is.EqualTo(actualBlake3))
+        | other -> Assert.Fail($"Expected successful validation with BLAKE3 backfill, got {other}.")
 
     [<Test>]
     member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -58,7 +58,7 @@ module internal AnnotationMaterialization =
         else
             Ok()
 
-    let private validateExactFileBytes (fileVersion: FileVersion) (bytes: byte array) correlationId =
+    let private validateExactFileBytes requireBlake3Hash (fileVersion: FileVersion) (bytes: byte array) correlationId =
         if isNull bytes then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' content reader returned null bytes.")
         elif int64 bytes.Length <> fileVersion.Size then
@@ -72,9 +72,13 @@ module internal AnnotationMaterialization =
             && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
         then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
-        elif String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+        elif requireBlake3Hash
+             && String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has no FileVersion.Blake3Hash.")
-        elif not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase)) then
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+            && not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase))
+        then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
         else
             Ok(copyBytes bytes)
@@ -184,7 +188,7 @@ module internal AnnotationMaterialization =
                 | Error readError -> return Error readError
                 | Ok payloads ->
                     match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
-                    | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+                    | Ok bytes -> return validateExactFileBytes true fileVersion bytes correlationId
                     | Error validationError ->
                         return Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}")
         }
@@ -196,7 +200,7 @@ module internal AnnotationMaterialization =
             match! readObjectPayload objectKey correlationId cancellationToken with
             | Ok bytes ->
                 match decompressGzipWholeFileBytes fileVersion bytes correlationId with
-                | Ok decompressedBytes -> return validateExactFileBytes fileVersion decompressedBytes correlationId
+                | Ok decompressedBytes -> return validateExactFileBytes false fileVersion decompressedBytes correlationId
                 | Error decompressionError -> return Error decompressionError
             | Error readError -> return Error readError
         }

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -58,7 +58,13 @@ module internal AnnotationMaterialization =
         else
             Ok()
 
-    let private validateExactFileBytes requireBlake3Hash (fileVersion: FileVersion) (bytes: byte array) correlationId =
+    let private validateExactFileBytes fallbackBlake3Hash (fileVersion: FileVersion) (bytes: byte array) correlationId =
+        let expectedBlake3Hash =
+            if String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+                fallbackBlake3Hash
+            else
+                Some fileVersion.Blake3Hash
+
         if isNull bytes then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' content reader returned null bytes.")
         elif int64 bytes.Length <> fileVersion.Size then
@@ -72,16 +78,11 @@ module internal AnnotationMaterialization =
             && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
         then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
-        elif requireBlake3Hash
-             && String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
-            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has no FileVersion.Blake3Hash.")
-        elif
-            not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
-            && not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase))
-        then
-            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
         else
-            Ok(copyBytes bytes)
+            match expectedBlake3Hash with
+            | Some blake3Hash when not (String.Equals(blake3Hex bytes, blake3Hash, StringComparison.OrdinalIgnoreCase)) ->
+                Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
+            | _ -> Ok(copyBytes bytes)
 
     let private looksLikeGzip (bytes: byte array) =
         not (isNull bytes)
@@ -188,7 +189,7 @@ module internal AnnotationMaterialization =
                 | Error readError -> return Error readError
                 | Ok payloads ->
                     match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
-                    | Ok bytes -> return validateExactFileBytes true fileVersion bytes correlationId
+                    | Ok bytes -> return validateExactFileBytes (Some(Blake3Hash $"{manifest.FileContentHash}")) fileVersion bytes correlationId
                     | Error validationError ->
                         return Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}")
         }
@@ -200,7 +201,7 @@ module internal AnnotationMaterialization =
             match! readObjectPayload objectKey correlationId cancellationToken with
             | Ok bytes ->
                 match decompressGzipWholeFileBytes fileVersion bytes correlationId with
-                | Ok decompressedBytes -> return validateExactFileBytes false fileVersion decompressedBytes correlationId
+                | Ok decompressedBytes -> return validateExactFileBytes None fileVersion decompressedBytes correlationId
                 | Error decompressionError -> return Error decompressionError
             | Error readError -> return Error readError
         }

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -38,6 +38,8 @@ module internal AnnotationMaterialization =
         |> Convert.ToHexString
         |> fun value -> value.ToLowerInvariant()
 
+    let private blake3Hex (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
+
     let private validateFileVersionShape (fileVersion: FileVersion) correlationId =
         if isNull (box fileVersion) then
             Error(error correlationId "Annotation target FileVersion is required.")
@@ -70,6 +72,10 @@ module internal AnnotationMaterialization =
             && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
         then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
+        elif String.IsNullOrWhiteSpace fileVersion.Blake3Hash then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' has no FileVersion.Blake3Hash.")
+        elif not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase)) then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
         else
             Ok(copyBytes bytes)
 


### PR DESCRIPTION
## Summary

- Propagates complete-file BLAKE3 through local file capture and `FileVersion` creation.
- Ensures manifest-backed `FileVersion.Blake3Hash` equals `FileManifest.FileContentHash`.
- Adds `Blake3Hash` metadata/properties to whole-file storage while preserving existing `Sha256Hash` metadata/properties.
- Hardens manifest and whole-file save-boundary validation for BLAKE3 while preserving explicit legacy compatibility paths.
- Verifies annotation materialization output against `FileVersion.Blake3Hash` over materialized uncompressed bytes.
- Preserves uploaded, unchanged, legacy-caller, watch-batched, and manifest-backed file references into directory saves.
- Computes BLAKE3 in rebuilt local directory entries/status.
- Reviews non-version SHA-256 uses in touched files; protected dedupe SHA-256 labels in `ManifestUpload.SDK.fs` remain SHA-256 by design.

Part of #343
Related to #349

## Validation

Initial implementation, `3f20b31893da0314c7013364d0564b05603e151d`:

- Targeted Fantomas on touched F# files: passed.
- `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~ManifestUploadSdkTests"`: passed, 13/13.
- `dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~AnnotationMaterializationServerTests|FullyQualifiedName~SaveBoundaryActorTests"`: passed, 23/23.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Bot/fix validation summary:

- `a7c3a6b7390ce2ea85a095b569bae3c51e377c68`: targeted Fantomas, focused CLI/server-unit tests, `validate -Fast`, and `git diff --check` passed.
- `51aa4a12f9c1b6f3a553220f0dde3f1d51ca11ad`: targeted Fantomas, focused CLI/SaveBoundary tests, `validate -Fast`, and `git diff --check` passed.
- `e7e42c905158e7968ee7a5487282c9110449f259`: targeted Fantomas, focused CurrentStateCapture/AnnotationMaterialization tests, `validate -Fast`, and `git diff --check` passed.
- `183e6c6ca4fbbb30a07a0fe4cf77c76dc648fc3c`: targeted Fantomas, focused CurrentStateCapture tests, `validate -Fast`, and `git diff --check` passed.
- `a09323bfa36ccd919e830dffa5b1fb0027f3050c`: CLI Release build, focused CurrentStateCapture no-build tests, `validate -Fast`, and `git diff --check` passed. Targeted Fantomas was attempted; no formatting-only churn was kept.
- `1a7a7f560a73fc1e2aa6ba0ea94936bb13876a81`: targeted Fantomas, CLI Release build/test, `validate -Fast`, and `git diff --check` passed.
- `fa71e2ce7542ab58656b06f5fcf9662a0b30a074`: targeted Fantomas, `validate -Fast`, and `git diff --check` passed.
- `b54363af7a411e8de8fb7f6aaa392431aa8b55cb`: targeted Fantomas, `validate -Fast`, and `git diff --check` passed.
- `a4ed5a29716b0977acef9e3e9f710cc27852c945`: targeted Fantomas, CLI Release build/test 419/419, Server.Unit Release build/test 516/516, and `git diff --check` passed. `validate -Fast` was intentionally skipped to avoid duplicating the broad build/test loop after focused Release gates.
- `b9ac55b9603cc2d46dd6020f274c662250b4fa3f`: targeted Fantomas, CLI Release build/test 420/420, and `git diff --check` passed. `validate -Fast` was intentionally skipped to avoid duplicating the broad build/test loop after the focused CLI Release gate.
- `73dc5bc05f10be7a21c99314c19614b3cd287368`: targeted Fantomas, `pwsh ./scripts/validate.ps1 -Fast`, and `git diff --check` passed.
- `ef086987092b83b7c6a51a5ded4bc2e5ca49e5e2`: targeted Fantomas, focused `CurrentStateCaptureCliTests` 18/18, and `git diff --check` passed. `validate -Fast` was intentionally skipped to avoid duplicating the focused CLI build/test gate for a tightly scoped scan regression.`r`n- `ad3430d4822f8196b0ac0def7d0c43d0c5057f4f`: targeted Fantomas, focused `CurrentStateCaptureCliTests` 22/22, full `Grace.CLI.Tests` 427/427, and `git diff --check` passed. `validate -Fast` was intentionally skipped because the touched surface was CLI-only and the full CLI project gate had already built and passed.

Hosted validation:

- `Validate / full` passed on `fa71e2ce7542ab58656b06f5fcf9662a0b30a074`.
- `Validate / full` passed on `b54363af7a411e8de8fb7f6aaa392431aa8b55cb`.
- `Validate / full` passed on `a4ed5a29716b0977acef9e3e9f710cc27852c945`.
- `Validate / full` passed on `b9ac55b9603cc2d46dd6020f274c662250b4fa3f`.
- `Validate / full` passed on `73dc5bc05f10be7a21c99314c19614b3cd287368`.
- `Validate / full` passed on `ef086987092b83b7c6a51a5ded4bc2e5ca49e5e2`.`r`n- `Validate / full` is running on `ad3430d4822f8196b0ac0def7d0c43d0c5057f4f`.

## Review Status

- Implementation worker: GPT-5.5 Medium worker completed issue #349 in `C:\Source\Grace-gh-349`.
- Codex Code Review Bot pass on `3f20b31893`: two P2 findings, fixed by `a7c3a6b7390ce2ea85a095b569bae3c51e377c68`, replied, and resolved.
- Codex Code Review Bot pass on `a7c3a6b739`: three P2 findings, fixed by `51aa4a12f9c1b6f3a553220f0dde3f1d51ca11ad`, replied, and resolved.
- Codex Code Review Bot pass on `51aa4a12f9`: two P2 findings, fixed by `e7e42c905158e7968ee7a5487282c9110449f259`, replied, and resolved.
- Codex Code Review Bot pass on `e7e42c9051`: one P2 finding, fixed by `183e6c6ca4fbbb30a07a0fe4cf77c76dc648fc3c`, replied, and resolved.
- Codex Code Review Bot pass on `183e6c6ca4`: one P2 finding, fixed by `a09323bfa36ccd919e830dffa5b1fb0027f3050c`, replied, and resolved.
- Codex Code Review Bot pass on `a09323bfa3`: six P2 threads, three unique findings, fixed by `1a7a7f560a73fc1e2aa6ba0ea94936bb13876a81`, replied, and resolved.
- Codex Code Review Bot pass on `1a7a7f560a`: two P2 findings, fixed by `fa71e2ce7542ab58656b06f5fcf9662a0b30a074`, replied, and resolved.
- Codex Code Review Bot pass on `fa71e2ce75`: three P2 findings, fixed by `b54363af7a411e8de8fb7f6aaa392431aa8b55cb`, replied, and resolved.
- Codex Code Review Bot pass on `b54363af7a`: four P2 findings, fixed by `a4ed5a29716b0977acef9e3e9f710cc27852c945`, replied, and resolved.
- Codex Code Review Bot pass on `a4ed5a2971`: one P1 finding, fixed by `b9ac55b9603cc2d46dd6020f274c662250b4fa3f`, replied, and resolved.
- Codex Code Review Bot pass on `b9ac55b960`: two P2 findings, fixed by `73dc5bc05f10be7a21c99314c19614b3cd287368`, replied, and resolved.
- Codex Code Review Bot pass on `73dc5bc05f10`: one P2 finding from automatic review output, fixed by `ef086987092b83b7c6a51a5ded4bc2e5ca49e5e2`. Prevention: `scanForDifferences` now compares prior and newly computed BLAKE3 in addition to SHA-256 before suppressing unchanged-file differences, with a focused regression for same-SHA-256/different-BLAKE3 evidence.
- Codex Code Review Bot pass on `ef08698709`: one P1 review-body finding and four P2 inline threads representing two unique findings, fixed by `ad3430d4822f8196b0ac0def7d0c43d0c5057f4f`, inline threads replied to and resolved. Prevention: manifest upload now uses available working-tree or cache source paths for legacy callers, cache-hit changed files stay in the manifest overlay set, and diff status is applied only after implicit save success with focused regressions for each case.`r`n- Current state: waiting for hosted validation and the automatic Codex Code Review Bot review on `ad3430d4822f8196b0ac0def7d0c43d0c5057f4f`. Do not request review manually.
- Open findings: none currently unresolved after the thirteenth fix.

## Docs Impact

No user-facing documentation change in this slice. Directory hash propagation, public lookup surfaces, OpenAPI, CLI output, and final docs/audit remain in later epic issues.

## Residual Risk

- `DirectoryVersion` hash propagation is intentionally not handled here per the issue waiver; that remains I07-owned.
- `LocalFileVersion` still cannot persist a `FileContentReference`; this slice preserves local BLAKE3 in local status and overlays server manifest-backed `FileVersion`s at directory upload time.
- The previous-manifest overlay depends on fetching prior server `DirectoryVersion`s for changed directory paths. If that fetch fails, the save fails clearly instead of silently degrading unchanged manifest-backed files to whole-file references.
- The legacy-wrapper fix preserves existing upload-error behavior and does not broaden error propagation semantics.
- Full Aspire/storage emulator validation was not run locally; hosted `Validate / full` has passed on the latest head.



