### PR TITLE
S5: Add doctor working-tree drift scan

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1912,6 +1912,59 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor working-tree scan prunes trailing-slash ignored directories`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, [| "bin/"; "obj/"; "home/cache/" |]))
+
+                seedWorkingTreeSnapshot root |> ignore
+
+                let ignoredPaths =
+                    [|
+                        Path.Combine(root, "bin", "added-from-bin.txt")
+                        Path.Combine(root, "obj", "Debug", "generated.txt")
+                        Path.Combine(root, "home", "cache", "generated.txt")
+                    |]
+
+                for ignoredPath in ignoredPaths do
+                    Directory.CreateDirectory(Path.GetDirectoryName(ignoredPath))
+                    |> ignore
+
+                    File.WriteAllText(ignoredPath, "ignored generated content")
+
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should contain "1 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
     let ``doctor working-tree category selector runs scan`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -12,9 +12,11 @@ open Spectre.Console
 open System
 open System.IO
 open System.Net
+open System.Security.Cryptography
 open System.Text
 open System.Text.Json
 open System.Threading.Tasks
+open Grace.Types.Common
 
 [<NonParallelizable>]
 module DoctorCliTests =
@@ -166,6 +168,116 @@ module DoctorCliTests =
             .ensureDbInitialized(localStateDbPath root)
             .GetAwaiter()
             .GetResult()
+
+    let private sha256Hex (text: string) =
+        use sha256 = SHA256.Create()
+
+        Encoding.UTF8.GetBytes(text)
+        |> sha256.ComputeHash
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let private createSnapshotFile relativePath content lastWriteTime =
+        LocalFileVersion.Create
+            relativePath
+            (sha256Hex content)
+            false
+            (int64 (Encoding.UTF8.GetByteCount(content)))
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            lastWriteTime
+
+    let private seedWorkingTreeSnapshot root =
+        writeGraceConfig root "http://127.0.0.1:5000"
+        |> ignore
+
+        let dbPath = localStateDbPath root
+
+        LocalStateDb.ensureDbInitialized (dbPath)
+        |> fun task -> task.GetAwaiter().GetResult()
+
+        let ownerId = Guid.NewGuid()
+        let organizationId = Guid.NewGuid()
+        let repositoryId = Guid.NewGuid()
+        let rootDirectoryId = Guid.NewGuid()
+        let homeDirectoryId = Guid.NewGuid()
+        let indexedWriteTime = DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        let changedPath = Path.Combine(root, "changed.txt")
+        let unchangedPath = Path.Combine(root, "mtime-only.txt")
+        let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+
+        File.WriteAllText(changedPath, "old content")
+        File.SetLastWriteTimeUtc(changedPath, indexedWriteTime)
+        File.WriteAllText(unchangedPath, "same content")
+        File.SetLastWriteTimeUtc(unchangedPath, indexedWriteTime)
+
+        let files =
+            ResizeArray(
+                [|
+                    createSnapshotFile "changed.txt" "old content" indexedWriteTime
+                    createSnapshotFile "deleted.txt" "deleted content" indexedWriteTime
+                    createSnapshotFile "mtime-only.txt" "same content" indexedWriteTime
+                |]
+            )
+
+        if File.Exists(graceIgnorePath) then
+            files.Add(createSnapshotFile Constants.GraceIgnoreFileName (File.ReadAllText(graceIgnorePath)) (File.GetLastWriteTimeUtc(graceIgnorePath)))
+
+        let homeDirectory =
+            LocalDirectoryVersion.Create
+                homeDirectoryId
+                ownerId
+                organizationId
+                repositoryId
+                "home"
+                "home-snapshot-hash"
+                (System.Collections.Generic.List<DirectoryVersionId>())
+                (System.Collections.Generic.List<LocalFileVersion>())
+                0L
+                indexedWriteTime
+
+        let rootChildDirectories =
+            if Directory.Exists(Path.Combine(root, "home")) then
+                System.Collections.Generic.List<DirectoryVersionId>([| homeDirectoryId |])
+            else
+                System.Collections.Generic.List<DirectoryVersionId>()
+
+        let rootFiles = files |> Seq.toArray
+
+        let rootDirectory =
+            LocalDirectoryVersion.Create
+                rootDirectoryId
+                ownerId
+                organizationId
+                repositoryId
+                Constants.RootDirectoryPath
+                "root-snapshot-hash"
+                rootChildDirectories
+                (System.Collections.Generic.List<LocalFileVersion>(rootFiles))
+                (rootFiles |> Array.sumBy (fun file -> file.Size))
+                indexedWriteTime
+
+        let indexEntries =
+            [|
+                System.Collections.Generic.KeyValuePair(rootDirectoryId, rootDirectory)
+
+                if Directory.Exists(Path.Combine(root, "home")) then
+                    System.Collections.Generic.KeyValuePair(homeDirectoryId, homeDirectory)
+            |]
+
+        let status =
+            { GraceStatus.Default with Index = GraceIndex(indexEntries); RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = "root-snapshot-hash" }
+
+        LocalStateDb.replaceStatusSnapshot dbPath status
+        |> fun task -> task.GetAwaiter().GetResult()
+
+        File.WriteAllText(changedPath, "new content")
+        File.SetLastWriteTimeUtc(changedPath, indexedWriteTime.AddMinutes(5.0))
+        File.WriteAllText(Path.Combine(root, "added.txt"), "added content")
+        File.WriteAllText(unchangedPath, "same content")
+        File.SetLastWriteTimeUtc(unchangedPath, indexedWriteTime.AddMinutes(10.0))
+
+        dbPath
 
     let private openRawConnection (dbPath: string) =
         let connection = new SqliteConnection($"Data Source={dbPath}")
@@ -350,12 +462,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 26
+            |> should equal 27
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 26
+            |> should equal 27
 
             let catalogIds =
                 returnValue
@@ -399,6 +511,8 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "object-cache.index-readable"
+
+            catalogIds |> should contain "working-tree.scan"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -453,7 +567,7 @@ module DoctorCliTests =
                         |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                         |> Set.ofSeq
 
-                    catalogIds.Count |> should equal 26
+                    catalogIds.Count |> should equal 27
 
                     catalogIds |> should contain "config.file.parse"
 
@@ -1664,6 +1778,255 @@ module DoctorCliTests =
 
             for checkId in localStateCheckIds do
                 catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor list checks includes working-tree scan catalog id`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds |> should contain "working-tree.scan")
+
+    [<Test>]
+    let ``doctor default working-tree scan is skipped without traversing changed files`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                let dbPath = seedWorkingTreeSnapshot root
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let checks = document.RootElement
+                let workingTree = findCheckById checks "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should contain "Skipped in the default profile"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should not' (contain "differs")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor full working-tree scan reports drift warning without mutation`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--full"
+                                                      "--offline"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should contain "1 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+                summary |> should contain "grace maintenance scan"
+
+                summary
+                |> should contain "grace maintenance update-index"
+
+                summary |> should not' (contain "mtime-only.txt")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor exact working-tree scan runs without full and excludes ignored and grace-owned paths`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "ignored.txt")
+                seedWorkingTreeSnapshot root |> ignore
+                File.WriteAllText(Path.Combine(root, "ignored.txt"), "ignored content")
+                File.WriteAllText(Path.Combine(root, Constants.GraceConfigDirectory, "grace-local.db-wal.extra"), "sidecar-ish content")
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should not' (contain "ignored.txt")
+                summary |> should not' (contain ".grace")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor working-tree category selector runs scan`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor working-tree default quiet modes emit no successful diagnostic output`` output =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+                let indexedWriteTime = DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                File.WriteAllText(Path.Combine(root, "changed.txt"), "old content")
+                File.SetLastWriteTimeUtc(Path.Combine(root, "changed.txt"), indexedWriteTime)
+                File.WriteAllText(Path.Combine(root, "deleted.txt"), "deleted content")
+                File.SetLastWriteTimeUtc(Path.Combine(root, "deleted.txt"), indexedWriteTime)
+                File.Delete(Path.Combine(root, "added.txt"))
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
+
+    [<Test>]
+    let ``doctor working-tree verbose select emits clean scalar without progress text`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--full"
+                                                      "--offline"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Warning\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut
+                |> should not' (contain "scanForDifferences")
+
+                standardOut
+                |> should not' (contain "Working tree differs")))
+
+    [<Test>]
+    let ``doctor working-tree scan skips unreadable snapshot inside report without creating database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+
+                Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+                |> ignore
+
+                File.WriteAllText(dbPath, "not a sqlite database")
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should contain "Skipped because"
+
+                snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
     let ``doctor selected non-local check does not open local-state database`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -396,6 +396,14 @@ module DoctorCliTests =
         finally
             Doctor.resetServerProbeFactoryForTests ()
 
+    let private withWorkingTreeScanner scanner action =
+        Doctor.setWorkingTreeScannerForTests scanner
+
+        try
+            action ()
+        finally
+            Doctor.resetWorkingTreeScannerForTests ()
+
     let private successfulProbeWithLifecycle diagnostics =
         Doctor.ServerProbeSucceeded
             {
@@ -1965,6 +1973,90 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor working-tree scan does not prune directories from file-only ignore entries`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "build")
+
+                seedWorkingTreeSnapshot root |> ignore
+
+                let buildOutput = Path.Combine(root, "build", "generated.txt")
+
+                Directory.CreateDirectory(Path.GetDirectoryName(buildOutput))
+                |> ignore
+
+                File.WriteAllText(buildOutput, "generated content that should be detected")
+
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "5 total"
+                summary |> should contain "3 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor strict exact working-tree scan fails when read-only scan execution fails`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                withWorkingTreeScanner
+                    (fun _ _ -> Task.FromResult(Error "simulated read-only scan failure"))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "working-tree.scan"
+                                                              "--strict"
+                                                              "--select"
+                                                              "Checks" |]
+
+                        exitCode |> should equal 1
+                        standardError |> should equal String.Empty
+                        use document = JsonDocument.Parse(standardOut)
+
+                        document.RootElement.GetArrayLength()
+                        |> should equal 1
+
+                        let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                        workingTree.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        workingTree.GetProperty("Severity").GetString()
+                        |> should equal "Error"
+
+                        workingTree.GetProperty("Summary").GetString()
+                        |> should contain "Working-tree scan failed without updating local state: simulated read-only scan failure")))
+
+    [<Test>]
     let ``doctor working-tree category selector runs scan`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
@@ -2706,6 +2798,9 @@ notes.txt # inline comment
 
                     checks[ 2 ].GetProperty("Summary").GetString()
                     |> should contain "4 active entries"
+
+                    checks[ 2 ].GetProperty("Summary").GetString()
+                    |> should contain "2 file patterns and 2 directory patterns"
 
                     snapshotFiles root |> should equal beforeRoot
                     snapshotFiles home |> should equal beforeHome

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -777,8 +777,9 @@ module Doctor =
                                 GraceDirectory = configuration.GraceDirectory
                                 GraceStatusFile = configuration.GraceStatusFile
                                 DirectoryIgnoreEntries =
-                                    inspection.Ignore.DirectoryEntries
+                                    inspection.Ignore.Entries
                                     |> Array.map (fun entry -> $"*{entry}")
+                                    |> Array.distinct
                                 FileIgnoreEntries = inspection.Ignore.FileEntries
                             }
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -733,20 +733,33 @@ module Doctor =
     let private workingTreeScanRemediation =
         "Run `grace maintenance scan` to inspect details or `grace maintenance update-index` when you intentionally want local state to match the current working tree."
 
+    type private WorkingTreeScanSummaryResult =
+        | WorkingTreeScanPrerequisiteSkipped of string
+        | WorkingTreeScanFailed of string
+        | WorkingTreeScanSummary of string
+
+    let mutable private workingTreeScanner = Services.scanWorkingTreeForDifferencesReadOnly
+
+    let setWorkingTreeScannerForTests scanner = workingTreeScanner <- scanner
+
+    let resetWorkingTreeScannerForTests () = workingTreeScanner <- Services.scanWorkingTreeForDifferencesReadOnly
+
     let private workingTreeScanSummary (context: DoctorInspectionContext) =
         match context.ConfigurationState with
-        | ConfigurationMissing _ -> Error $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
-        | ConfigurationMalformed _ -> Error $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigurationMissing _ ->
+            WorkingTreeScanPrerequisiteSkipped $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+        | ConfigurationMalformed _ -> WorkingTreeScanPrerequisiteSkipped $"Skipped because {ConfigFileParseCheckId} failed."
         | ConfigurationLoaded inspection ->
             let localStateInspection = context.LocalStateInspection.Value
 
             if not localStateInspection.OpenedReadOnly then
-                Error(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
+                WorkingTreeScanPrerequisiteSkipped(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
             elif localStateInspection.MissingRequiredTables.Length > 0 then
-                Error $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
+                WorkingTreeScanPrerequisiteSkipped $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
             elif localStateInspection.SchemaVersion
                  <> Some ExpectedLocalStateSchemaVersion then
-                Error $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
+                WorkingTreeScanPrerequisiteSkipped
+                    $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
             else
                 let configuration = inspection.Configuration
 
@@ -759,14 +772,14 @@ module Doctor =
                     |> fun task -> task.GetAwaiter().GetResult()
 
                 match snapshotResult with
-                | Error message -> Error $"Skipped because the read-only local-state snapshot could not be read: {message}"
+                | Error message -> WorkingTreeScanPrerequisiteSkipped $"Skipped because the read-only local-state snapshot could not be read: {message}"
                 | Ok snapshot ->
                     let hasRootDirectoryVersion =
                         snapshot.Index.Values
                         |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
 
                     if not hasRootDirectoryVersion then
-                        Ok(
+                        WorkingTreeScanSummary(
                             "Local-state snapshot is missing the root directory version; doctor did not rebuild it. "
                             + workingTreeScanRemediation
                         )
@@ -777,26 +790,26 @@ module Doctor =
                                 GraceDirectory = configuration.GraceDirectory
                                 GraceStatusFile = configuration.GraceStatusFile
                                 DirectoryIgnoreEntries =
-                                    inspection.Ignore.Entries
+                                    inspection.Ignore.DirectoryEntries
                                     |> Array.map (fun entry -> $"*{entry}")
                                     |> Array.distinct
                                 FileIgnoreEntries = inspection.Ignore.FileEntries
                             }
 
                         let scanResult =
-                            Services.scanWorkingTreeForDifferencesReadOnly scanInput snapshot
+                            workingTreeScanner scanInput snapshot
                             |> fun task -> task.GetAwaiter().GetResult()
 
                         match scanResult with
-                        | Error message -> Error $"Working-tree scan failed without updating local state: {message}"
+                        | Error message -> WorkingTreeScanFailed $"Working-tree scan failed without updating local state: {message}"
                         | Ok differences when differences.Count = 0 ->
-                            Ok "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
+                            WorkingTreeScanSummary "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
                         | Ok differences ->
                             let added = countDifferences Add differences
                             let changed = countDifferences Change differences
                             let deleted = countDifferences Delete differences
 
-                            Ok
+                            WorkingTreeScanSummary
                                 $"Working tree differs from the read-only local-state snapshot: {differences.Count} total, {added} added, {changed} changed, {deleted} deleted. {workingTreeScanRemediation}"
 
     let private oidcSummary (auth: Auth.AuthInspection) =
@@ -1037,9 +1050,10 @@ module Doctor =
                     $"Skipped in the default profile because working-tree drift scanning can hash repository files. Re-run with --full or --check {WorkingTreeScanCheckId}. {workingTreeScanRemediation}"
             else
                 match workingTreeScanSummary context with
-                | Error message -> skipped check message
-                | Ok summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
-                | Ok summary -> warning summary
+                | WorkingTreeScanPrerequisiteSkipped message -> skipped check message
+                | WorkingTreeScanFailed message -> failed message
+                | WorkingTreeScanSummary summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
+                | WorkingTreeScanSummary summary -> warning summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -89,6 +89,9 @@ module Doctor =
     let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
 
     [<Literal>]
+    let private WorkingTreeScanCheckId = "working-tree.scan"
+
+    [<Literal>]
     let private ServerHealthzReachableCheckId = "server.healthz.reachable"
 
     [<Literal>]
@@ -319,6 +322,15 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = WorkingTreeScanCheckId
+                Category = "Working tree"
+                Title = "Working-tree drift scan"
+                Description =
+                    "Skipped by default; --full or an explicit working-tree.scan selection compares the working tree to a read-only local-state snapshot."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -377,6 +389,12 @@ module Doctor =
 
     type private SelectionError = Unknown of string array
 
+    let private categoryMatchesToken (category: string) (token: string) =
+        category.Equals(token, StringComparison.OrdinalIgnoreCase)
+        || category
+            .Replace(" ", "-", StringComparison.OrdinalIgnoreCase)
+            .Equals(token, StringComparison.OrdinalIgnoreCase)
+
     let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
@@ -395,7 +413,7 @@ module Doctor =
                     catalog
                     |> Array.filter (fun check ->
                         check.Id.Equals(token, StringComparison.OrdinalIgnoreCase)
-                        || check.Category.Equals(token, StringComparison.OrdinalIgnoreCase))
+                        || categoryMatchesToken check.Category token)
 
                 if Array.isEmpty matches then
                     unknown.Add(token)
@@ -427,7 +445,9 @@ module Doctor =
 
     type private DoctorInspectionContext =
         {
+            Full: bool
             Offline: bool
+            RequestedTokens: string array
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
@@ -577,7 +597,7 @@ module Doctor =
             }
             |> serverProbeFactory
 
-    let private createInspectionContext offline =
+    let private createInspectionContext full offline requestedTokens =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
@@ -597,7 +617,9 @@ module Doctor =
         let effectiveServerUri = resolveEffectiveServerUri configurationState environmentServerUri
 
         {
+            Full = full
             Offline = offline
+            RequestedTokens = requestedTokens
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
             EnvironmentServerUri = environmentServerUri
@@ -696,6 +718,85 @@ module Doctor =
             match inspection.OpenError with
             | Some message -> $"Skipped because {StateDbReadOnlyOpenCheckId} could not open the database read-only: {message}"
             | None -> $"Skipped because {checkId} requires a read-only local state database inspection."
+
+    let private workingTreeScanExplicitlyRequested (context: DoctorInspectionContext) =
+        context.RequestedTokens
+        |> Array.exists (fun token ->
+            token.Equals(WorkingTreeScanCheckId, StringComparison.OrdinalIgnoreCase)
+            || categoryMatchesToken "Working tree" token)
+
+    let private countDifferences differenceType (differences: List<FileSystemDifference>) =
+        differences
+        |> Seq.filter (fun difference -> difference.DifferenceType = differenceType)
+        |> Seq.length
+
+    let private workingTreeScanRemediation =
+        "Run `grace maintenance scan` to inspect details or `grace maintenance update-index` when you intentionally want local state to match the current working tree."
+
+    let private workingTreeScanSummary (context: DoctorInspectionContext) =
+        match context.ConfigurationState with
+        | ConfigurationMissing _ -> Error $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+        | ConfigurationMalformed _ -> Error $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigurationLoaded inspection ->
+            let localStateInspection = context.LocalStateInspection.Value
+
+            if not localStateInspection.OpenedReadOnly then
+                Error(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
+            elif localStateInspection.MissingRequiredTables.Length > 0 then
+                Error $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
+            elif localStateInspection.SchemaVersion
+                 <> Some ExpectedLocalStateSchemaVersion then
+                Error $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
+            else
+                let configuration = inspection.Configuration
+
+                let snapshotResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+                    |> fun task -> task.GetAwaiter().GetResult()
+
+                match snapshotResult with
+                | Error message -> Error $"Skipped because the read-only local-state snapshot could not be read: {message}"
+                | Ok snapshot ->
+                    let hasRootDirectoryVersion =
+                        snapshot.Index.Values
+                        |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
+
+                    if not hasRootDirectoryVersion then
+                        Ok(
+                            "Local-state snapshot is missing the root directory version; doctor did not rebuild it. "
+                            + workingTreeScanRemediation
+                        )
+                    else
+                        let scanInput: Services.WorkingTreeScanInput =
+                            {
+                                RootDirectory = inspection.RootDirectory
+                                GraceDirectory = configuration.GraceDirectory
+                                GraceStatusFile = configuration.GraceStatusFile
+                                DirectoryIgnoreEntries =
+                                    inspection.Ignore.DirectoryEntries
+                                    |> Array.map (fun entry -> $"*{entry}")
+                                FileIgnoreEntries = inspection.Ignore.FileEntries
+                            }
+
+                        let scanResult =
+                            Services.scanWorkingTreeForDifferencesReadOnly scanInput snapshot
+                            |> fun task -> task.GetAwaiter().GetResult()
+
+                        match scanResult with
+                        | Error message -> Error $"Working-tree scan failed without updating local state: {message}"
+                        | Ok differences when differences.Count = 0 ->
+                            Ok "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
+                        | Ok differences ->
+                            let added = countDifferences Add differences
+                            let changed = countDifferences Change differences
+                            let deleted = countDifferences Delete differences
+
+                            Ok
+                                $"Working tree differs from the read-only local-state snapshot: {differences.Count} total, {added} added, {changed} changed, {deleted} deleted. {workingTreeScanRemediation}"
 
     let private oidcSummary (auth: Auth.AuthInspection) =
         let m2mMissing = missingRequiredFields auth.M2mFields
@@ -925,6 +1026,19 @@ module Doctor =
 
                     failed $"Object-cache metadata is not readable: {objectCacheError}. Doctor did not repair object-cache rows."
                 | None -> skipped check "Object-cache metadata readability was not attempted."
+        | WorkingTreeScanCheckId ->
+            if
+                not context.Full
+                && not (workingTreeScanExplicitlyRequested context)
+            then
+                skipped
+                    check
+                    $"Skipped in the default profile because working-tree drift scanning can hash repository files. Re-run with --full or --check {WorkingTreeScanCheckId}. {workingTreeScanRemediation}"
+            else
+                match workingTreeScanSummary context with
+                | Error message -> skipped check message
+                | Ok summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
+                | Ok summary -> warning summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
@@ -1067,12 +1181,12 @@ module Doctor =
         else
             0
 
-    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+    let private createReportForChecksWithTokens full offline listOnly requestedTokens (checks: LocalOutputDto.DoctorCheckDto array) =
         let results =
             if listOnly then
                 checks |> Array.map listOnlyResultForCheck
             else
-                let context = createInspectionContext offline
+                let context = createInspectionContext full offline requestedTokens
                 checks |> Array.map (resultForCheck context)
 
         let summary = summarize results
@@ -1095,6 +1209,9 @@ module Doctor =
 
         { report with ExitCode = diagnosticExitCode false report }
 
+    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+        createReportForChecksWithTokens full offline listOnly Array.empty checks
+
     let withStatus status (report: LocalOutputDto.DoctorReportDto) =
         let checks =
             if report.Checks.Length = 0 then
@@ -1109,7 +1226,7 @@ module Doctor =
         { updated with ExitCode = diagnosticExitCode updated.Strict updated }
 
     let private createReport full offline strict listOnly requestedTokens checks =
-        let report = createReportForChecks full offline listOnly checks
+        let report = createReportForChecksWithTokens full offline listOnly requestedTokens checks
 
         let report = { report with Strict = strict; RequestedChecks = requestedTokens }
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -275,6 +275,182 @@ module Services =
                 return None
         }
 
+    type WorkingTreeScanInput =
+        {
+            RootDirectory: string
+            GraceDirectory: string
+            GraceStatusFile: string
+            DirectoryIgnoreEntries: string array
+            FileIgnoreEntries: string array
+        }
+
+    let private normalizeFullPath path =
+        Path
+            .GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+    let private isWithinGraceDirectory (scanInput: WorkingTreeScanInput) path =
+        let graceDirectory = normalizeFullPath scanInput.GraceDirectory
+        let candidate = Path.GetFullPath(path)
+
+        candidate.Equals(graceDirectory, StringComparison.OrdinalIgnoreCase)
+        || candidate.StartsWith(
+            graceDirectory
+            + string Path.DirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase
+        )
+        || candidate.StartsWith(
+            graceDirectory
+            + string Path.AltDirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase
+        )
+
+    let private shouldIgnoreFileForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (filePath: FilePath) =
+        let mutable shouldIgnore = false
+
+        if cache.TryGetValue(filePath, &shouldIgnore) then
+            shouldIgnore
+        else
+            let fileInfo = FileInfo(filePath)
+
+            let shouldIgnoreThisFile =
+                isWithinGraceDirectory scanInput filePath
+                || filePath.Equals(scanInput.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.EndsWith(".gracetmp", StringComparison.OrdinalIgnoreCase)
+                || Directory.Exists(filePath)
+                || scanInput.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine)
+                || scanInput.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+                || scanInput.FileIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+
+            cache.TryAdd(filePath, shouldIgnoreThisFile)
+            |> ignore
+
+            shouldIgnoreThisFile
+
+    let private shouldIgnoreDirectoryForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (directoryPath: string) =
+        let mutable shouldIgnore = false
+
+        if cache.TryGetValue(directoryPath, &shouldIgnore) then
+            shouldIgnore
+        else
+            let directoryInfo = DirectoryInfo(directoryPath)
+
+            let shouldIgnoreDirectory =
+                isWithinGraceDirectory scanInput directoryInfo.FullName
+                || scanInput.DirectoryIgnoreEntries.Any(fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory directoryInfo graceIgnoreLine)
+
+            cache.TryAdd(directoryPath, shouldIgnoreDirectory)
+            |> ignore
+
+            shouldIgnoreDirectory
+
+    let private createLocalFileVersionForScan (scanInput: WorkingTreeScanInput) (fileInfo: FileInfo) =
+        task {
+            if fileInfo.Exists then
+                use stream = fileInfo.Open(fileStreamOptionsRead)
+
+                let! isBinary = isBinaryFile stream
+
+                stream.Position <- 0
+                let relativePath = normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName))
+                let! sha256Hash = computeSha256ForFile stream relativePath
+
+                return
+                    Some(
+                        LocalFileVersion.Create
+                            relativePath
+                            sha256Hash
+                            isBinary
+                            fileInfo.Length
+                            (Instant.FromDateTimeUtc(fileInfo.LastWriteTimeUtc))
+                            true
+                            fileInfo.LastWriteTimeUtc
+                    )
+            else
+                return None
+        }
+
+    let private getWorkingDirectoryWriteTimesForScan (scanInput: WorkingTreeScanInput) =
+        let cache = ConcurrentDictionary<FilePath, bool>()
+        let localWriteTimes = Dictionary<FileSystemEntryType * RelativePath, DateTime>()
+
+        let rec collect (directoryInfo: DirectoryInfo) =
+            if not (shouldIgnoreDirectoryForScan scanInput cache directoryInfo.FullName) then
+                let directoryFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, directoryInfo.FullName)))
+
+                localWriteTimes[(FileSystemEntryType.Directory, directoryFullPath)] <- directoryInfo.LastWriteTimeUtc
+
+                directoryInfo
+                    .GetFiles()
+                    .Where(fun file -> not (shouldIgnoreFileForScan scanInput cache file.FullName))
+                |> Seq.iter (fun fileInfo ->
+                    let fileFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName)))
+                    localWriteTimes[(FileSystemEntryType.File, fileFullPath)] <- fileInfo.LastWriteTimeUtc)
+
+                directoryInfo
+                    .GetDirectories()
+                    .Where(fun directory -> not (shouldIgnoreDirectoryForScan scanInput cache directory.FullName))
+                |> Seq.iter collect
+
+        collect (DirectoryInfo(scanInput.RootDirectory))
+        localWriteTimes
+
+    let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
+        task {
+            try
+                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, DateTime * Sha256Hash>()
+
+                for kvp in previousGraceStatus.Index do
+                    let directoryVersion = kvp.Value
+
+                    lookupCache.TryAdd(
+                        (FileSystemEntryType.Directory, directoryVersion.RelativePath),
+                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash)
+                    )
+                    |> ignore
+
+                    for file in directoryVersion.Files do
+                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash))
+                        |> ignore
+
+                let localWriteTimes = getWorkingDirectoryWriteTimesForScan scanInput
+                let differences = List<FileSystemDifference>()
+
+                for kvp in localWriteTimes do
+                    let fileSystemEntryType, relativePath = kvp.Key
+                    let lastWriteTimeUtc = kvp.Value
+
+                    if not (lookupCache.ContainsKey((fileSystemEntryType, relativePath))) then
+                        differences.Add(FileSystemDifference.Create Add fileSystemEntryType relativePath)
+                    elif fileSystemEntryType.IsFile then
+                        let knownLastWriteTimeUtc, existingSha256Hash = lookupCache[(fileSystemEntryType, relativePath)]
+
+                        if lastWriteTimeUtc <> knownLastWriteTimeUtc then
+                            let fileInfo = FileInfo(Path.Combine(scanInput.RootDirectory, relativePath))
+                            let! newFileVersion = createLocalFileVersionForScan scanInput fileInfo
+
+                            match newFileVersion with
+                            | Some fileVersion when fileVersion.Sha256Hash <> existingSha256Hash ->
+                                differences.Add(FileSystemDifference.Create Change fileSystemEntryType relativePath)
+                            | _ -> ()
+
+                for kvp in lookupCache do
+                    let fileSystemEntryType, relativePath = kvp.Key
+
+                    if not (localWriteTimes.ContainsKey((fileSystemEntryType, relativePath))) then
+                        differences.Add(FileSystemDifference.Create Delete fileSystemEntryType relativePath)
+
+                return Ok differences
+            with
+            | ex -> return Error ex.Message
+        }
+
     /// Gets the LocalDirectoryVersion for the root directory of the repository from GraceStatus.
     let getRootDirectoryVersion (graceStatus: GraceStatus) =
         graceStatus.Index.Values.FirstOrDefault(

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -167,7 +167,13 @@ module Services =
             else
                 normalizeFilePath (directoryInfoToCheck.FullName + "/")
 
-        if FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPath, ignoreCase) then
+        let normalizedDirectoryPathWithoutSeparator = Path.TrimEndingDirectorySeparator(normalizedDirectoryPath)
+
+        if
+            FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPath, ignoreCase)
+            || FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPathWithoutSeparator, ignoreCase)
+            || FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, directoryInfoToCheck.Name, ignoreCase)
+        then
             //logToAnsiConsole Colors.Changed $"checkIgnoreLineAgainstDirectory: directory '{normalizedDirectoryPath}' matches ignore entry '{graceIgnoreEntry}'."
             true
         else

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1334,3 +1334,158 @@ module LocalStateDb =
             finally
                 connection.Dispose()
         }
+
+    let readStatusSnapshotReadOnly (dbPath: string) (ownerId: OwnerId) (organizationId: OrganizationId) (repositoryId: RepositoryId) =
+        task {
+            let normalizedPath = Path.GetFullPath(dbPath)
+            let directoryPath = Path.GetDirectoryName(normalizedPath)
+
+            if
+                not (String.IsNullOrWhiteSpace(directoryPath))
+                && not (Directory.Exists(directoryPath))
+            then
+                return Error $"Local state directory was not found for {normalizedPath}."
+            elif Directory.Exists(normalizedPath) then
+                return Error $"Local state database path is a directory: {normalizedPath}."
+            elif not (File.Exists(normalizedPath)) then
+                return Error $"Local state database was not found at {normalizedPath}."
+            else
+                let missingPartialWalSidecars = missingPartialWalSidecars normalizedPath
+
+                if missingPartialWalSidecars.Length > 0 then
+                    let missingNames = String.concat ", " missingPartialWalSidecars
+
+                    return
+                        Error
+                            $"Database has an incomplete WAL sidecar set; missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files or ignoring live WAL content."
+                else
+                    try
+                        let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+                        use connection = openReadOnlyConnection normalizedPath immutableSnapshot
+
+                        match readStatusMetaInternal connection with
+                        | None -> return Error "Local state status_meta row is missing or unreadable."
+                        | Some meta ->
+                            let directories = List<StatusDirectoryRow>()
+                            let files = List<StatusFileRow>()
+
+                            use directoryCommand = connection.CreateCommand()
+
+                            directoryCommand.CommandText <-
+                                "SELECT relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
+
+                            use directoryReader = directoryCommand.ExecuteReader()
+
+                            while directoryReader.Read() do
+                                directories.Add(
+                                    {
+                                        RelativePath = directoryReader.GetString(0)
+                                        ParentPath = directoryReader.GetString(1)
+                                        DirectoryVersionId = Guid.Parse(directoryReader.GetString(2))
+                                        Sha256Hash = directoryReader.GetString(3)
+                                        SizeBytes = directoryReader.GetInt64(4)
+                                        CreatedAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(5))
+                                        LastWriteTimeUtc = DateTime(directoryReader.GetInt64(6), DateTimeKind.Utc)
+                                    }
+                                )
+
+                            use fileCommand = connection.CreateCommand()
+
+                            fileCommand.CommandText <-
+                                "SELECT relative_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+
+                            use fileReader = fileCommand.ExecuteReader()
+
+                            while fileReader.Read() do
+                                files.Add(
+                                    {
+                                        RelativePath = fileReader.GetString(0)
+                                        DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
+                                        Sha256Hash = fileReader.GetString(2)
+                                        IsBinary = fileReader.GetInt64(3) = 1L
+                                        SizeBytes = fileReader.GetInt64(4)
+                                        CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(5))
+                                        UploadedToObjectStorage = fileReader.GetInt64(6) = 1L
+                                        LastWriteTimeUtc = DateTime(fileReader.GetInt64(7), DateTimeKind.Utc)
+                                    }
+                                )
+
+                            let directoriesByParent = Dictionary<string, List<DirectoryVersionId>>()
+                            let filesByDirectory = Dictionary<DirectoryVersionId, List<LocalFileVersion>>()
+
+                            directories
+                            |> Seq.iter (fun directory ->
+                                let mutable existing = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                if directoriesByParent.TryGetValue(directory.ParentPath, &existing) then
+                                    existing.Add(directory.DirectoryVersionId)
+                                else
+                                    directoriesByParent.Add(directory.ParentPath, List<DirectoryVersionId>([ directory.DirectoryVersionId ])))
+
+                            files
+                            |> Seq.iter (fun file ->
+                                let localFile =
+                                    LocalFileVersion.Create
+                                        file.RelativePath
+                                        file.Sha256Hash
+                                        file.IsBinary
+                                        file.SizeBytes
+                                        file.CreatedAt
+                                        file.UploadedToObjectStorage
+                                        file.LastWriteTimeUtc
+
+                                let mutable existing = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                if filesByDirectory.TryGetValue(file.DirectoryVersionId, &existing) then
+                                    existing.Add(localFile)
+                                else
+                                    filesByDirectory.Add(file.DirectoryVersionId, List<LocalFileVersion>([ localFile ])))
+
+                            let index = GraceIndex()
+
+                            directories
+                            |> Seq.iter (fun directory ->
+                                let directoriesForPath =
+                                    let mutable list = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                    if directoriesByParent.TryGetValue(directory.RelativePath, &list) then
+                                        list
+                                    else
+                                        List<DirectoryVersionId>()
+
+                                let filesForPath =
+                                    let mutable list = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                    if filesByDirectory.TryGetValue(directory.DirectoryVersionId, &list) then
+                                        list
+                                    else
+                                        List<LocalFileVersion>()
+
+                                let localDirectory =
+                                    LocalDirectoryVersion.Create
+                                        directory.DirectoryVersionId
+                                        ownerId
+                                        organizationId
+                                        repositoryId
+                                        directory.RelativePath
+                                        directory.Sha256Hash
+                                        directoriesForPath
+                                        filesForPath
+                                        directory.SizeBytes
+                                        directory.LastWriteTimeUtc
+
+                                index.TryAdd(directory.DirectoryVersionId, localDirectory)
+                                |> ignore)
+
+                            return
+                                Ok
+                                    {
+                                        Index = index
+                                        RootDirectoryId = meta.RootDirectoryId
+                                        RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                                        LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
+                                        LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
+                                    }
+                    with
+                    | ex -> return Error ex.Message
+        }

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -165,7 +165,6 @@ module Configuration =
                 else
                     graceIgnoreLine.Substring(0, commentIndex).Trim())
             |> Seq.filter (fun graceIgnoreLine -> (not (String.IsNullOrEmpty(graceIgnoreLine))))
-            |> Seq.map (fun graceIgnoreLine -> Path.TrimEndingDirectorySeparator(graceIgnoreLine))
             |> Seq.toArray
         else
             Array.empty


### PR DESCRIPTION
## Summary

- Adds the `working-tree.scan` doctor check with fast default skip behavior and full/exact scan execution.
- Exposes read-only local-state snapshot access and a pure working-tree scanner so doctor does not initialize or mutate local state.
- Reports working-tree drift as a warning with add/change/delete counts and maintenance remediation, without running maintenance commands.
- Adds focused Doctor CLI coverage for default/full/exact selection, `working-tree` category matching, output cleanliness, ignored/Grace-owned paths, and no-mutation evidence.

## Related Work

Related to #339
Part of #333

## Validation

- `dotnet tool run fantomas src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI/Command/Doctor.CLI.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs` passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Doctor` passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter Maintenance` passed.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` skipped locally because the worker ran the focused cli-command validation gate; PR CI and epic integration gates will cover the broader run.

## Review Status

- 2026-06-10: Implementation committed in `c18b2b4`; initial `full` CI passed; Codex Code Review Bot found P2 comment `3389069077` for directory `.graceignore` pruning.
- 2026-06-10: Fixed comment `3389069077` in `51a0f613b5359f9b5138eaae3d0b639ddd60e574`; validation passed: targeted Fantomas, Release CLI test build, Doctor filter 80/80, Maintenance filter 6/6, and `git diff --check`.
- Prevention: acceptance-criteria / negative-proof gap; no issue template or agent docs update needed for this isolated missed regression because the fix adds a directory-pruning regression test.
- 2026-06-10: New-head Codex review on `51a0f613b5359f9b5138eaae3d0b639ddd60e574` found P2 comments `3389190105` (directory pruning must use directory entries only) and `3389190113` (actual scan errors must fail instead of skip); assigned fresh fix worker `019eb1f7-681a-7402-836f-5e88309ce8bc`.
- 2026-06-10: Fixed comments `3389190105` and `3389190113` in `9500d8006d044ecc28d6340c729038a4d5e35fcd`; validation passed: targeted Fantomas, Release CLI test build, Doctor filter 82/82, Maintenance filter 6/6, and `git diff --check`.
- Prevention `3389190105`: negative-proof gap; current issue now has regression coverage for a file-only ignore entry named like a directory plus directory-entry pruning.
- Prevention `3389190113`: error-classification gap; current issue now has deterministic scanner seam coverage proving execution errors fail strict exact checks.
- 2026-06-10: New-head `full` CI passed on `9500d8006d044ecc28d6340c729038a4d5e35fcd`; Codex Code Review Bot reacted `+1`, with all bot review threads resolved. Ready to merge into `epic/333-grace-doctor`.

## Notes For S6 Docs

- Default `grace doctor` includes `working-tree.scan` as a skipped diagnostic row so users can see why the expensive scan was not run.
- `grace doctor --full` runs the working-tree scan from a read-only local-state snapshot and reports drift as a warning.
- Exact `--check working-tree.scan` and category `--check working-tree` run the scan without requiring `--full`.
- Missing or unreadable local-state snapshots are reported inside the doctor report, not as command-shape `GraceError`s.
- Remediation points users to `grace maintenance scan` or `grace maintenance update-index`; doctor does not invoke either command.