### PR TITLE
Implement grace doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 grace auth whoami
 ```
 
+For a read-only diagnostic report that checks local configuration, authentication environment, local state, selected
+server probes, and machine-readable output shape, run:
+
+```powershell
+grace doctor
+grace --output Json doctor --select Status
+```
+
+See [Grace doctor](./docs/Grace%20doctor.md) for the check catalog, JSON contract, exit-code behavior, redaction notes,
+and repair deferrals.
+
 ### Machine-readable CLI output
 
 Agents, CI jobs, and scripts can request parseable CLI output with `--output Json`. Contracted commands emit exactly
@@ -190,6 +201,7 @@ grace --output Json maintenance stats
 grace maintenance stats --schema
 grace maintenance stats --examples
 grace --output Json maintenance stats --select DirectoryCount
+grace --output Json doctor --select Status
 ```
 
 bash / zsh:
@@ -199,6 +211,7 @@ grace --output Json maintenance stats
 grace maintenance stats --schema
 grace maintenance stats --examples
 grace --output Json maintenance stats --select DirectoryCount
+grace --output Json doctor --select Status
 ```
 
 `--select` is a V1 projection over `ReturnValue` only. Selectors such as `DirectoryCount` or

--- a/README.md
+++ b/README.md
@@ -177,12 +177,20 @@ Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 grace auth whoami
 ```
 
-For a read-only diagnostic report that checks local configuration, authentication environment, local state, selected
-server probes, and machine-readable output shape, run:
+For a read-only diagnostic report that checks local configuration, authentication environment, local state, and
+machine-readable output shape, run:
 
 ```powershell
 grace doctor
 grace --output Json doctor --select Status
+```
+
+Server probes are non-default checks. To run them explicitly, select the `Server` category or a specific `server.*`
+check ID:
+
+```powershell
+grace doctor --check Server
+grace doctor --check server.healthz.reachable
 ```
 
 See [Grace doctor](./docs/Grace%20doctor.md) for the check catalog, JSON contract, exit-code behavior, redaction notes,

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -254,10 +254,11 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 * `grace auth logout`
   Clears the cached interactive token from the secure store.
 
-* `grace doctor --check auth`
+* `grace doctor --check Authentication`
   Produces a read-only diagnostic report for local authentication environment checks. Doctor parses
   `GRACE_TOKEN` shape without printing the token, reports unsupported `GRACE_TOKEN_FILE` configuration, and checks OIDC
-  environment completeness without acquiring, refreshing, storing, or validating credentials with a provider.
+  environment completeness without acquiring, refreshing, storing, or validating credentials with a provider. Use
+  specific `auth.*` check IDs when you want to run only one authentication diagnostic.
 
 ---
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -254,6 +254,11 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 * `grace auth logout`
   Clears the cached interactive token from the secure store.
 
+* `grace doctor --check auth`
+  Produces a read-only diagnostic report for local authentication environment checks. Doctor parses
+  `GRACE_TOKEN` shape without printing the token, reports unsupported `GRACE_TOKEN_FILE` configuration, and checks OIDC
+  environment completeness without acquiring, refreshing, storing, or validating credentials with a provider.
+
 ---
 
 ## Personal Access Tokens (PATs)

--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -1,0 +1,248 @@
+# Grace Doctor
+
+`grace doctor` inspects the local Grace environment and reports diagnostics for people, scripts, and agents. It is a
+read-only command: it does not create configuration, initialize local state, migrate databases, repair object-cache
+rows, acquire credentials, refresh tokens, open a browser, or upload support bundles.
+
+Use it when a Grace checkout, local state database, authentication environment, or server connection looks suspicious and
+you need a structured first look before deciding what to fix.
+
+PowerShell:
+
+```powershell
+grace doctor
+grace --output Json doctor
+grace doctor --list-checks
+grace --output Json doctor --check auth --select Summary
+```
+
+bash / zsh:
+
+```bash
+grace doctor
+grace --output Json doctor
+grace doctor --list-checks
+grace --output Json doctor --check auth --select Summary
+```
+
+## Command Behavior
+
+- Default `grace doctor` runs the default local diagnostics and renders a human table when normal output is enabled.
+- `--output Json` emits one `GraceReturnValue<DoctorReportDto>` JSON document to stdout.
+- `--select` projects from `ReturnValue`, so use paths such as `Status`, `Summary`, or `Checks`, not
+  `ReturnValue.Status`.
+- `--schema` and `--examples` return machine-readable contract metadata for `DoctorReportDto` without running the
+  diagnostics.
+- Unknown `--check` tokens fail before diagnostics run and return the normal `GraceError` envelope in JSON mode.
+
+The report version is `doctor-report-v1`. Consumers should use `ReportVersion` together with stable check IDs when
+parsing or storing doctor evidence.
+
+## Options
+
+| Option | Behavior |
+| --- | --- |
+| `--full` | Includes checks reserved for the full doctor profile. In v1, this enables the working-tree scan. |
+| `--offline` | Skips network probes. Local checks can still run. |
+| `--list-checks` | Lists the catalog and marks each returned check as skipped; diagnostic probes do not run. |
+| `--check <id-or-category>` | Runs only matching check IDs or categories. Repeat the option or separate values with commas. |
+| `--strict` | Returns exit code `1` when the report status is `Warning`; failures already return `1`. |
+
+Check selection is case-insensitive. Category tokens can use spaces or hyphens, so `--check working-tree` matches
+`working-tree.scan`. Exact check IDs can also select non-default or full-profile diagnostics without `--full`.
+
+## Exit Codes
+
+`grace doctor` uses diagnostic exit codes after successful command rendering:
+
+| Report status | Default exit code | With `--strict` |
+| --- | ---: | ---: |
+| `Ok` | `0` | `0` |
+| `Warning` | `0` | `1` |
+| `Failed` | `1` | `1` |
+
+Command-shape errors, including unknown check tokens or invalid `--select` paths, use the existing CLI error behavior.
+In JSON mode they emit a `GraceError` document.
+
+## JSON Contract
+
+Successful JSON output uses the existing Grace result envelope. The `ReturnValue` is a `DoctorReportDto`:
+
+```json
+{
+  "ReturnValue": {
+    "ReportVersion": "doctor-report-v1",
+    "Status": "Warning",
+    "ExitCode": 0,
+    "Full": false,
+    "Offline": false,
+    "Strict": false,
+    "ListOnly": false,
+    "RequestedChecks": [],
+    "Catalog": [
+      {
+        "Id": "cli.catalog",
+        "Category": "CLI",
+        "Title": "CLI command catalog",
+        "Description": "Verifies that the Grace CLI command catalog is available.",
+        "DefaultEnabled": true,
+        "SupportsOffline": true
+      }
+    ],
+    "Checks": [
+      {
+        "Id": "cli.catalog",
+        "Category": "CLI",
+        "Title": "CLI command catalog",
+        "Status": "Ok",
+        "Severity": "Info",
+        "Summary": "Doctor check catalog is available."
+      }
+    ],
+    "Summary": {
+      "Total": 1,
+      "Ok": 1,
+      "Warning": 0,
+      "Failed": 0,
+      "Skipped": 0
+    }
+  },
+  "EventTime": "2026-06-10T00:00:00Z",
+  "CorrelationId": "correlation-id",
+  "Properties": [
+    {
+      "Key": "cli.contractVersion",
+      "Value": "cli-json-v1"
+    }
+  ]
+}
+```
+
+The important DTO fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `ReportVersion` | Stable report contract version. Current value: `doctor-report-v1`. |
+| `Status` | Aggregate report status: `Ok`, `Warning`, or `Failed`. |
+| `ExitCode` | Diagnostic exit code that the command returns after rendering succeeds. |
+| `Full`, `Offline`, `Strict`, `ListOnly` | Echo the execution mode used to produce the report. |
+| `RequestedChecks` | Normalized check tokens from `--check`. |
+| `Catalog` | Catalog entries included in the selected profile. |
+| `Checks` | Diagnostic result rows for selected checks. |
+| `Summary` | Counts by result status. |
+
+Check result statuses are `Ok`, `Warning`, `Failed`, and `Skipped`. Severity is currently `Info`, `Warning`, or
+`Error`.
+
+## Check Catalog
+
+The v1 catalog contains 27 check IDs:
+
+| Check ID | Category | Default | Offline | Summary |
+| --- | --- | --- | --- | --- |
+| `cli.catalog` | CLI | Yes | Yes | Verifies that the doctor check catalog is available. |
+| `config.file.discover` | Configuration | Yes | Yes | Finds `.grace/graceconfig.json` without creating it. |
+| `config.file.parse` | Configuration | Yes | Yes | Reads Grace configuration without rewriting or normalizing it. |
+| `config.repository.identity` | Configuration | Yes | Yes | Checks configured owner, organization, repository, and branch identity. |
+| `config.server-uri.valid` | Configuration | Yes | Yes | Validates the configured server URI without probing the server. |
+| `server-uri.consistency` | Configuration | Yes | Yes | Compares `GRACE_SERVER_URI` with the configured server URI. |
+| `user-config.file.discover` | User configuration | Yes | Yes | Looks for `~/.grace/userconfig.json` without creating it. |
+| `user-config.file.parse` | User configuration | Yes | Yes | Reads user configuration without rewriting it. |
+| `ignore.entries.parse` | Ignore | Yes | Yes | Reads `.graceignore` active entries without creating the file. |
+| `auth.source.detected` | Authentication | Yes | Yes | Classifies likely local authentication source. |
+| `auth.env-token.valid` | Authentication | Yes | Yes | Parses `GRACE_TOKEN` as a Grace PAT without printing or server-validating it. |
+| `auth.token-file.unsupported` | Authentication | Yes | Yes | Reports unsupported `GRACE_TOKEN_FILE` configuration. |
+| `auth.oidc.configuration` | Authentication | Yes | Yes | Checks OIDC environment completeness without token requests. |
+| `state.db.file-present` | Local state | Yes | Yes | Checks the local state database path without creating files. |
+| `state.db.read-only-open` | Local state | Yes | Yes | Opens SQLite local state in read-only mode. |
+| `state.db.schema-version` | Local state | Yes | Yes | Reads the local state `schema_version` metadata. |
+| `state.db.required-tables` | Local state | Yes | Yes | Verifies required local state tables. |
+| `state.db.required-indexes` | Local state | Yes | Yes | Verifies required local state indexes. |
+| `state.db.integrity-check` | Local state | Yes | Yes | Runs SQLite `integrity_check` read-only. |
+| `state.db.foreign-key-check` | Local state | Yes | Yes | Runs SQLite `foreign_key_check` read-only. |
+| `object-cache.index-readable` | Object cache | Yes | Yes | Reads object-cache metadata tables without repairing rows. |
+| `working-tree.scan` | Working tree | Yes | Yes | Skipped by default; runs with `--full` or explicit selection. |
+| `identity.auth-session` | Identity | No | No | Reserved for a later authentication diagnostic. |
+| `server.connectivity` | Server | No | No | Reserved compatibility catalog entry. |
+| `server.healthz.reachable` | Server | No | No | Probes `/healthz` with a short timeout. |
+| `server.lifecycle.headers` | Server | No | No | Surfaces Grace SDK lifecycle response headers from `/healthz`. |
+| `server.auth-principal.available` | Server | No | No | Probes `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present. |
+
+## Working Tree Scan
+
+The working-tree scan is intentionally visible but controlled:
+
+- Default `grace doctor` includes `working-tree.scan` as a skipped row so users can see why the expensive scan did not
+  run.
+- `grace doctor --full` runs the scan from a read-only local-state snapshot and reports drift as a warning.
+- `grace doctor --check working-tree.scan` and category selection with `--check working-tree` run the scan without
+  requiring `--full`.
+- Missing, unreadable, or incomplete local-state snapshots are reported inside the doctor report as skipped diagnostic
+  rows when they are prerequisites, not as command-shape `GraceError`s.
+- Actual scan execution errors are failures, including strict exact-check mode.
+- Directory `.graceignore` entries prune scan traversal. File-only patterns that happen to match directory names do not
+  prune whole directories.
+
+When the scan reports drift, remediation points to `grace maintenance scan` for detailed differences or
+`grace maintenance update-index` when you intentionally want to refresh the local maintenance index. Doctor does not
+invoke either command.
+
+## Authentication And Redaction
+
+Doctor can help explain local authentication setup without exposing secrets:
+
+- `GRACE_TOKEN` is parsed with the pure Grace PAT parser. The raw token is not printed.
+- `Bearer <token>` form is accepted for PAT shape validation, and the raw bearer value is not printed.
+- `GRACE_TOKEN_FILE` is reported as unsupported; set `GRACE_TOKEN` instead.
+- OIDC M2M and CLI environment completeness is checked without token requests, browser/device-code flow, refresh,
+  secure-store reads, or provider validation.
+- `server.auth-principal.available` calls `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present.
+
+Do not paste doctor JSON into public places without reviewing paths and environment names. The report is designed to
+avoid raw secrets, but summaries may include local file paths or configured server URIs.
+
+## Repair Deferral
+
+`grace doctor` does not repair problems in v1. It does not:
+
+- Create `.grace` directories or configuration files.
+- Initialize, migrate, rewrite, move, or back up the local SQLite database.
+- Create missing SQLite tables or indexes.
+- Repair object-cache rows.
+- Acquire, refresh, store, revoke, or rotate credentials.
+- Upload support bundles.
+
+Use the diagnostic result to choose the next command. For example, working-tree drift can be investigated with
+`grace maintenance scan` and intentionally accepted into local state with `grace maintenance update-index`.
+
+## V1 Boundaries
+
+The current v1 command does not document or implement:
+
+- Automatic repair or `--repair`.
+- Full/Aspire/cloud resource probes.
+- Support bundle upload.
+- Browser or device-code authentication flows inside doctor.
+- Token refresh or secure-store mutation inside doctor.
+
+These are explicit deferrals, not hidden current behavior.
+
+## Final Audit
+
+Issue #340 acceptance was audited against `Doctor.CLI.fs`, `CommandOutputContract.CLI.fs`, and the focused CLI tests.
+
+| Acceptance item | Classification | Evidence |
+| --- | --- | --- |
+| Document command semantics, options, exit codes, check catalog, JSON examples, redaction, and repair deferral. | Implemented | This document covers those surfaces. |
+| Keep doctor read-only and avoid command behavior changes. | Implemented | Existing tests cover no config/user-config/local-db/object-cache mutations. |
+| Include stable check IDs, report version, and JSON DTO shape. | Implemented | `doctor-report-v1`, 27 catalog IDs, and `DoctorReportDto` are documented. |
+| Refresh machine-readable CLI inventory evidence. | Implemented | `docs/Machine-readable CLI output.md` keeps registry-backed totals and doctor examples current. |
+| Point README and authentication troubleshooting to doctor where useful. | Implemented | README and `docs/Authentication.md` contain short pointers. |
+| Do not recommend repair or automatic repair commands. | Implemented | Repair is documented as deferred; maintenance commands are manual follow-ups only. |
+| Do not document Full/Aspire/cloud probes as v1 behavior. | Implemented | V1 boundaries explicitly exclude those probes. |
+| Cover docs examples against actual command behavior and JSON contract shape. | Implemented | Examples use `GraceReturnValue<DoctorReportDto>`, `--select` from `ReturnValue`, and current options. |
+| Prove no raw secrets, unsupported cloud probes, stale counts, bad `--select` prefixes, or DB repair claims. | Implemented | Negative guidance is documented and backed by focused Doctor/CommandOutputContract tests. |
+| Use current final validation, not stale sub-issue evidence. | Implemented | Validation for this slice is recorded in the PR handoff. |
+| `--repair`, support bundles, cloud probes, and Aspire diagnostics. | Deferred | Explicit v1 boundaries; no current implementation. |
+| Full production-release candidate review and merge state. | Out of scope | Owned by the orchestrator after this branch is pushed. |
+| Hosted CI and Codex Code Review Bot result on the final epic PR. | Residual risk | Orchestrator-owned after PR creation/update. |

--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -109,14 +109,12 @@ Successful JSON output uses the existing Grace result envelope. The `ReturnValue
   },
   "EventTime": "2026-06-10T00:00:00Z",
   "CorrelationId": "correlation-id",
-  "Properties": [
-    {
-      "Key": "cli.contractVersion",
-      "Value": "cli-json-v1"
-    }
-  ]
+  "Properties": []
 }
 ```
+
+Direct `grace --output Json doctor` output has an empty `Properties` array. The `cli.contractVersion` metadata appears
+in schema and example introspection documents, not in the direct doctor execution envelope.
 
 The important DTO fields are:
 

--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -13,7 +13,7 @@ PowerShell:
 grace doctor
 grace --output Json doctor
 grace doctor --list-checks
-grace --output Json doctor --check auth --select Summary
+grace --output Json doctor --check Authentication --select Summary
 ```
 
 bash / zsh:
@@ -22,7 +22,7 @@ bash / zsh:
 grace doctor
 grace --output Json doctor
 grace doctor --list-checks
-grace --output Json doctor --check auth --select Summary
+grace --output Json doctor --check Authentication --select Summary
 ```
 
 ## Command Behavior
@@ -42,7 +42,7 @@ parsing or storing doctor evidence.
 
 | Option | Behavior |
 | --- | --- |
-| `--full` | Includes checks reserved for the full doctor profile. In v1, this enables the working-tree scan. |
+| `--full` | Includes full-profile checks, including working-tree scan and server probes unless `--offline` is used. |
 | `--offline` | Skips network probes. Local checks can still run. |
 | `--list-checks` | Lists the catalog and marks each returned check as skipped; diagnostic probes do not run. |
 | `--check <id-or-category>` | Runs only matching check IDs or categories. Repeat the option or separate values with commas. |
@@ -50,6 +50,8 @@ parsing or storing doctor evidence.
 
 Check selection is case-insensitive. Category tokens can use spaces or hyphens, so `--check working-tree` matches
 `working-tree.scan`. Exact check IDs can also select non-default or full-profile diagnostics without `--full`.
+Default `grace doctor` does not run server probes. Explicit `--check Server` selection and `--full` can run server
+checks such as `server.healthz.reachable`; `--offline` suppresses checks that do not support offline execution.
 
 ## Exit Codes
 

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -23,6 +23,7 @@ grace --output Json auth logout
 grace auth logout --schema
 grace auth logout --examples
 grace --output Json maintenance stats --select DirectoryCount
+grace --output Json doctor --select Status
 ```
 
 bash / zsh:
@@ -32,6 +33,7 @@ grace --output Json auth logout
 grace auth logout --schema
 grace auth logout --examples
 grace --output Json maintenance stats --select DirectoryCount
+grace --output Json doctor --select Status
 ```
 
 ## Output Envelopes
@@ -125,7 +127,7 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 ## Final Inventory Evidence
 
-The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
+The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
 - Total leaf commands: `203`
 - JSON-ready routed commands: `182`
@@ -169,6 +171,9 @@ The `watch` command is not counted in those V2 routed-success migrations. It is 
 behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of
 starting the watcher.
 
+`doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
+supports `--schema`, `--examples`, and `--select`.
+
 ## Agent Recipes
 
 Use `--schema` first when an agent needs to understand a command contract without changing state:
@@ -192,10 +197,20 @@ $document = $json | ConvertFrom-Json
 $document.ReturnValue.DirectoryCount
 ```
 
+For diagnostics, `doctor` returns a structured report:
+
+```powershell
+$json = grace --output Json doctor --check auth
+$report = $json | ConvertFrom-Json
+$report.ReturnValue.Status
+$report.ReturnValue.Summary.Warning
+```
+
 When using `--select`, request only the `ReturnValue` field path the automation needs:
 
 ```powershell
 grace --output Json maintenance stats --select DirectoryCount
+grace --output Json doctor --select Status
 ```
 
 ## V2 Deferrals

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -200,7 +200,7 @@ $document.ReturnValue.DirectoryCount
 For diagnostics, `doctor` returns a structured report:
 
 ```powershell
-$json = grace --output Json doctor --check auth
+$json = grace --output Json doctor --check Authentication
 $report = $json | ConvertFrom-Json
 $report.ReturnValue.Status
 $report.ReturnValue.Summary.Warning

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -127,8 +127,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory for Epic #274 covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `202`
-- JSON-ready routed commands: `181`
+- Total leaf commands: `203`
+- JSON-ready routed commands: `182`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -212,16 +212,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 202
+        |> should equal 203
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 193
+        |> should equal 194
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 181
+        |> should equal 182
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -262,7 +262,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 181
+        jsonReady |> should equal 182
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -285,7 +285,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 193
+        discovered.Length |> should equal 194
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)
@@ -408,7 +408,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 182
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -425,7 +425,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 181
+        commonEntries.Length |> should equal 182
 
         let parserInvalidEntries =
             commonEntries
@@ -701,6 +701,51 @@ module CommandOutputContractRegistryTests =
             | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
 
     [<Test>]
+    let ``doctor registry entry exposes schema ready local dto metadata`` () =
+        let identity = CommandOutputContract.commandIdentity [] "doctor"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.ReturnValueContract.Status
+            |> should equal SchemaReady
+
+            entry.Features.Schema
+            |> should equal ExistingBehavior
+
+            entry.Features.Examples
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
+            let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+
+            match schemaDocument.Schema with
+            | Some schema ->
+                schema.Status |> should equal "schema-ready"
+
+                schema.ReturnValueContract
+                |> should equal "DoctorReportDto"
+
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                let returnValueSchema =
+                    successSchema
+                        .RootElement
+                        .GetProperty("properties")
+                        .GetProperty("ReturnValue")
+
+                returnValueSchema.GetProperty("title").GetString()
+                |> should equal "DoctorReportDto"
+            | None -> Assert.Fail("Expected schema document for doctor.")
+
+            let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+
+            examplesDocument.Examples[0].Name
+            |> should equal "success-envelope-shape"
+        | None -> Assert.Fail("doctor should have a registry entry.")
+
+    [<Test>]
     let ``metadata incomplete registry entries are explicit`` () =
         let identity = CommandOutputContract.commandIdentity [ "repository" ] "init"
 
@@ -826,26 +871,40 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
+        let docsTrackedEntries =
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.Identity.CommandId <> "doctor")
+
+        let countDocsTracked predicate =
+            docsTrackedEntries
+            |> List.filter predicate
+            |> List.length
+
+        let commandIdsForDocsTracked predicate =
+            docsTrackedEntries
+            |> List.filter predicate
+            |> List.map (fun entry -> entry.Identity.CommandId)
+
         let jsonReady =
-            countEntries (fun entry ->
+            countDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, ExistingGraceResultEnvelope _ -> true
                 | _ -> false)
 
         let intentionallyHumanOnly =
-            countEntries (fun entry ->
+            countDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, JsonModeErrorOnly _ -> true
                 | _ -> false)
 
         let deferredV2 =
-            commandIdsFor (fun entry ->
+            commandIdsForDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | Routed, MigrationRequiredToGraceResultEnvelope _ -> true
                 | _ -> false)
 
         let sourceOnly =
-            commandIdsFor (fun entry ->
+            commandIdsForDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
                 | SourceOnlyUnrouted _, SourceOnlyUnsupported _ -> true
                 | _ -> false)
@@ -853,7 +912,7 @@ module CommandOutputContractRegistryTests =
         let deleted = 0
 
         [
-            $"Total leaf commands: `{CommandOutputContract.entries.Length}`"
+            $"Total leaf commands: `{docsTrackedEntries.Length}`"
             $"JSON-ready routed commands: `{jsonReady}`"
             $"Intentionally human-only commands: `{intentionallyHumanOnly}`"
             $"Deferred routed commands with explicit V2 scope: `{deferredV2.Length}`"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -871,9 +871,7 @@ module CommandOutputContractRegistryTests =
     let ``machine readable cli docs keep final inventory evidence current`` () =
         let markdown = File.ReadAllText(machineReadableDocPath)
 
-        let docsTrackedEntries =
-            CommandOutputContract.entries
-            |> List.filter (fun entry -> entry.Identity.CommandId <> "doctor")
+        let docsTrackedEntries = CommandOutputContract.entries
 
         let countDocsTracked predicate =
             docsTrackedEntries

--- a/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
@@ -7,6 +7,8 @@ open NUnit.Framework
 [<Parallelizable(ParallelScope.All)>]
 module DoctorCliParsingTests =
 
+    let emptyCheckCases: obj array = [| [| "doctor"; "--check" |] :> obj |]
+
     [<Test>]
     let ``doctor command accepts v1 options`` () =
         let parseResult =
@@ -49,6 +51,13 @@ module DoctorCliParsingTests =
     [<Test>]
     let ``doctor command rejects repair option in scaffold slice`` () =
         let parseResult = GraceCommand.rootCommand.Parse([| "doctor"; "--repair" |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
+
+    [<TestCaseSource(nameof emptyCheckCases)>]
+    let ``doctor command rejects check option without value`` (args: string array) =
+        let parseResult = GraceCommand.rootCommand.Parse(args)
 
         parseResult.Errors.Count
         |> should be (greaterThan 0)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Parsing.Tests.fs
@@ -1,0 +1,54 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+
+[<Parallelizable(ParallelScope.All)>]
+module DoctorCliParsingTests =
+
+    [<Test>]
+    let ``doctor command accepts v1 options`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "doctor"
+                    "--full"
+                    "--offline"
+                    "--list-checks"
+                    "--check"
+                    "config"
+                    "--check"
+                    "cli.catalog"
+                    "--strict"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``doctor command accepts global introspection and selection options`` () =
+        let cases =
+            [
+                [| "doctor"; "--schema" |]
+                [| "doctor"; "--examples" |]
+                [|
+                    "--output"
+                    "Json"
+                    "doctor"
+                    "--select"
+                    "Status"
+                |]
+            ]
+
+        for args in cases do
+            let parseResult = GraceCommand.rootCommand.Parse(args)
+
+            parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``doctor command rejects repair option in scaffold slice`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "doctor"; "--repair" |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -113,7 +113,24 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should be (greaterThan 0)
+            |> should equal 4
+
+            returnValue
+                .GetProperty("Catalog")
+                .GetArrayLength()
+            |> should equal 4
+
+            let catalogIds =
+                returnValue
+                    .GetProperty("Catalog")
+                    .EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds
+            |> should contain "identity.auth-session"
+
+            catalogIds |> should contain "server.connectivity"
 
             let firstCheck = returnValue.GetProperty("Checks")[0]
 
@@ -122,6 +139,37 @@ module DoctorCliTests =
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
+
+    [<Test>]
+    let ``doctor list checks offline keeps only offline catalog entries`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--list-checks"
+                                                  "--offline" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let catalogIds =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Catalog")
+                    .EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds.Count |> should equal 2
+
+            catalogIds
+            |> should not' (contain "identity.auth-session")
+
+            catalogIds
+            |> should not' (contain "server.connectivity"))
 
     [<Test>]
     let ``doctor check filter accepts mixed case ids and categories`` () =
@@ -190,6 +238,30 @@ module DoctorCliTests =
 
             rootElement.GetProperty("Error").GetString()
             |> should contain "Unknown doctor check token"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor check followed by option-shaped token emits GraceError`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "--strict" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unknown doctor check token: --strict"
 
             let mutable returnValue = Unchecked.defaultof<JsonElement>
 

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1222,6 +1222,61 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor malformed config from nested directory inspects discovered local-state database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+                File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{ not json")
+
+                let nested = Path.Combine(root, "src", "nested")
+                Directory.CreateDirectory(nested) |> ignore
+                let originalDir = Environment.CurrentDirectory
+
+                try
+                    Environment.CurrentDirectory <- nested
+                    let repoDbPath = localStateDbPath root
+                    let cwdDbPath = Path.Combine(nested, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+                    withLocalStateDbOpenTrace root (fun tracePath ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "state.db.schema-version" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        checks.GetArrayLength() |> should equal 1
+
+                        checks[ 0 ].GetProperty("Status").GetString()
+                        |> should equal "Ok"
+
+                        checks[ 0 ].GetProperty("Summary").GetString()
+                        |> should contain "schema_version is 2"
+
+                        let trace = readTrace tracePath
+                        trace |> should contain repoDbPath
+                        trace |> should not' (contain cwdDbPath)
+
+                        File.Exists(cwdDbPath) |> should equal false
+
+                        Directory.Exists(Path.GetDirectoryName(cwdDbPath))
+                        |> should equal false)
+                finally
+                    Environment.CurrentDirectory <- originalDir))
+
+    [<Test>]
     let ``doctor local-state database path occupied by directory reports failure without mutation`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -11,8 +11,10 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Net
 open System.Text
 open System.Text.Json
+open System.Threading.Tasks
 
 [<NonParallelizable>]
 module DoctorCliTests =
@@ -267,6 +269,46 @@ module DoctorCliTests =
             "object-cache.index-readable"
         |]
 
+    let private serverCheckIds =
+        [|
+            "server.healthz.reachable"
+            "server.lifecycle.headers"
+            "server.auth-principal.available"
+        |]
+
+    let private withDoctorServerProbeFactory factory action =
+        Doctor.setServerProbeFactoryForTests factory
+
+        try
+            action ()
+        finally
+            Doctor.resetServerProbeFactoryForTests ()
+
+    let private successfulProbeWithLifecycle diagnostics =
+        Doctor.ServerProbeSucceeded
+            {
+                StatusCode = HttpStatusCode.OK
+                ReasonPhrase = "OK"
+                LifecycleDiagnostics = diagnostics
+                Body = """{"GraceUserId":"doctor-user","Claims":["repo.read"]}"""
+            }
+
+    let private noLifecycleProbe = successfulProbeWithLifecycle None
+
+    let private lifecycleDiagnostics status unsupportedAfter minimumVersion recommendedVersion updateUrl updateUrlIsHttps unsupportedAfterIsMalformed =
+        let diagnostics: Grace.SDK.ClientIdentity.LifecycleDiagnostics =
+            {
+                Status = status
+                UnsupportedAfter = unsupportedAfter
+                UnsupportedAfterIsMalformed = unsupportedAfterIsMalformed
+                MinimumVersion = minimumVersion
+                RecommendedVersion = recommendedVersion
+                UpdateUrl = updateUrl
+                UpdateUrlIsHttps = updateUrlIsHttps
+            }
+
+        Some diagnostics
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -308,12 +350,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 23
+            |> should equal 26
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 23
+            |> should equal 26
 
             let catalogIds =
                 returnValue
@@ -364,6 +406,9 @@ module DoctorCliTests =
             catalogIds |> should contain "server.connectivity"
             catalogIds |> should contain "config.file.parse"
 
+            for checkId in serverCheckIds do
+                catalogIds |> should contain checkId
+
             catalogIds
             |> should contain "user-config.file.discover"
 
@@ -379,58 +424,633 @@ module DoctorCliTests =
             |> should equal false)
 
     [<Test>]
-    let ``doctor list checks offline keeps only offline catalog entries`` () =
+    let ``doctor list checks offline keeps full catalog without probing`` () =
         withTempDir (fun _ ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
-                                                  "doctor"
-                                                  "--list-checks"
-                                                  "--offline" |]
+            let requestCount = ref 0
 
-            exitCode |> should equal 0
+            withDoctorServerProbeFactory
+                (fun _ ->
+                    incr requestCount
+                    Task.FromResult noLifecycleProbe)
+                (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--list-checks"
+                                                          "--offline" |]
 
-            use document = assertCleanJsonOutput standardOut standardError
+                    exitCode |> should equal 0
 
-            let catalogIds =
-                document
-                    .RootElement
-                    .GetProperty("ReturnValue")
-                    .GetProperty("Catalog")
-                    .EnumerateArray()
-                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
-                |> Set.ofSeq
+                    use document = assertCleanJsonOutput standardOut standardError
 
-            catalogIds.Count |> should equal 21
+                    let catalogIds =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Catalog")
+                            .EnumerateArray()
+                        |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                        |> Set.ofSeq
 
-            catalogIds |> should contain "config.file.parse"
+                    catalogIds.Count |> should equal 26
 
-            catalogIds
-            |> should contain "ignore.entries.parse"
+                    catalogIds |> should contain "config.file.parse"
 
-            catalogIds
-            |> should contain "auth.source.detected"
+                    catalogIds
+                    |> should contain "ignore.entries.parse"
 
-            catalogIds
-            |> should contain "auth.env-token.valid"
+                    catalogIds
+                    |> should contain "auth.source.detected"
 
-            catalogIds
-            |> should contain "auth.token-file.unsupported"
+                    catalogIds
+                    |> should contain "auth.env-token.valid"
 
-            catalogIds
-            |> should contain "auth.oidc.configuration"
+                    catalogIds
+                    |> should contain "auth.token-file.unsupported"
 
-            catalogIds
-            |> should contain "state.db.file-present"
+                    catalogIds
+                    |> should contain "auth.oidc.configuration"
 
-            catalogIds
-            |> should contain "object-cache.index-readable"
+                    catalogIds
+                    |> should contain "state.db.file-present"
 
-            catalogIds
-            |> should not' (contain "identity.auth-session")
+                    catalogIds
+                    |> should contain "object-cache.index-readable"
 
-            catalogIds
-            |> should not' (contain "server.connectivity"))
+                    catalogIds
+                    |> should contain "identity.auth-session"
+
+                    for checkId in serverCheckIds do
+                        catalogIds |> should contain checkId
+
+                    !requestCount |> should equal 0))
+
+    [<Test>]
+    let ``doctor server healthz reachable passes and lifecycle headers are surfaced`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://configured.example.test/base"
+                |> ignore
+
+                let requests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                let diagnostics =
+                    lifecycleDiagnostics
+                        (Some "deprecated")
+                        (Some "2026-12-01")
+                        (Some "0.1.0")
+                        (Some "0.2.0")
+                        (Some "https://github.com/ScottArbeit/Grace/releases")
+                        (Some true)
+                        false
+
+                withDoctorServerProbeFactory
+                    (fun request ->
+                        requests.Add(request)
+                        Task.FromResult(successfulProbeWithLifecycle diagnostics))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--check"
+                                                              "server.lifecycle.headers" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        (findCheckById checks "server.healthz.reachable")
+                            .GetProperty("Status")
+                            .GetString()
+                        |> should equal "Ok"
+
+                        let lifecycle = findCheckById checks "server.lifecycle.headers"
+
+                        lifecycle.GetProperty("Status").GetString()
+                        |> should equal "Ok"
+
+                        lifecycle.GetProperty("Summary").GetString()
+                        |> should contain "deprecated"
+
+                        requests.Count |> should equal 1
+
+                        requests[0].BaseUri.AbsoluteUri
+                        |> should equal "http://configured.example.test/base"
+
+                        requests[0].RelativePath |> should equal "healthz"
+                        requests[0].BearerToken |> should equal None)))
+
+    [<Test>]
+    let ``doctor server healthz uses GRACE_SERVER_URI over config and reports mismatch separately`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://configured.example.test"
+                |> ignore
+
+                let requests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                withEnv Constants.EnvironmentVariables.GraceServerUri (Some "http://environment.example.test") (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun request ->
+                            requests.Add(request)
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server-uri.consistency"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 0
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let checks =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")
+
+                            (findCheckById checks "server-uri.consistency")
+                                .GetProperty("Status")
+                                .GetString()
+                            |> should equal "Warning"
+
+                            (findCheckById checks "server.healthz.reachable")
+                                .GetProperty("Status")
+                                .GetString()
+                            |> should equal "Ok"
+
+                            requests.Count |> should equal 1
+
+                            requests[0].BaseUri.AbsoluteUri
+                            |> should equal "http://environment.example.test/"))))
+
+    [<Test>]
+    let ``doctor server healthz classifies non-success timeout tls connection and malformed uri findings`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                for probeResult, expectedText in
+                    [
+                        Doctor.ServerProbeSucceeded
+                            { StatusCode = HttpStatusCode.ServiceUnavailable; ReasonPhrase = "Service Unavailable"; LifecycleDiagnostics = None; Body = "" },
+                        "503"
+                        Doctor.ServerProbeTimedOut "Timed out after 1500 ms while probing http://example.test/healthz.", "Timed out"
+                        Doctor.ServerProbeTlsFailed "TLS negotiation failed while probing https://example.test/healthz: certificate error", "TLS"
+                        Doctor.ServerProbeConnectionFailed "Could not connect to http://example.test/healthz: connection refused", "connect"
+                    ] do
+                    writeGraceConfig root "http://example.test"
+                    |> ignore
+
+                    withDoctorServerProbeFactory
+                        (fun _ -> Task.FromResult probeResult)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 1
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Failed"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain expectedText)
+
+                writeGraceConfig root "not-a-uri" |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable" |]
+
+                        exitCode |> should equal 1
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "not an absolute URI"
+
+                        !requestCount |> should equal 0)))
+
+    [<Test>]
+    let ``doctor server lifecycle malformed date and non https update url warn cleanly`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let diagnostics =
+                    lifecycleDiagnostics (Some "unsupported") (Some "not-a-date") (Some "0.1.0") None (Some "http://example.test/update") (Some false) true
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult(successfulProbeWithLifecycle diagnostics))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.lifecycle.headers" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Warning"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "not-a-date"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "http://example.test/update")))
+
+    [<Test>]
+    let ``doctor server explicit checks offline skip without network calls`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--offline"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--check"
+                                                              "server.lifecycle.headers"
+                                                              "--check"
+                                                              "server.auth-principal.available" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let checks =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")
+
+                        checks.GetArrayLength() |> should equal 3
+
+                        for check in checks.EnumerateArray() do
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Skipped"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain "--offline"
+
+                        !requestCount |> should equal 0)))
+
+    [<Test>]
+    let ``doctor server principal skips without valid PAT and runs with non refreshing PAT only`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let requestCount = ref 0
+
+                withDoctorServerProbeFactory
+                    (fun _ ->
+                        incr requestCount
+                        Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.auth-principal.available" |]
+
+                        exitCode |> should equal 0
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Skipped"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "no valid non-refreshing"
+
+                        !requestCount |> should equal 0)
+
+                withEnv Constants.EnvironmentVariables.GraceToken (Some "not-a-pat") (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun _ ->
+                            incr requestCount
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.auth-principal.available" |]
+
+                            exitCode |> should equal 0
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Skipped"
+
+                            !requestCount |> should equal 0))
+
+                let token = validPat ()
+                let principalRequests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                    withDoctorServerProbeFactory
+                        (fun request ->
+                            principalRequests.Add(request)
+                            Task.FromResult noLifecycleProbe)
+                        (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.auth-principal.available" |]
+
+                            exitCode |> should equal 0
+                            assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Ok"
+
+                            principalRequests.Count |> should equal 1
+
+                            principalRequests[0].RelativePath
+                            |> should equal "auth/me"
+
+                            principalRequests[0].BearerToken
+                            |> should equal (Some token)))))
+
+    [<Test>]
+    let ``doctor server output modes and select stay clean`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        for output in [ "Silent"; "Minimal" ] do
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  output
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "server.healthz.reachable" |]
+
+                            exitCode |> should equal 0
+                            standardOut |> should equal String.Empty
+                            standardError |> should equal String.Empty
+
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Verbose"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable"
+                                                              "--select"
+                                                              "Status" |]
+
+                        exitCode |> should equal 0
+                        standardError |> should equal String.Empty
+                        standardOut.Trim() |> should equal "\"Ok\""
+
+                        standardOut
+                        |> should not' (contain "Grace doctor")
+
+                        standardOut |> should not' (contain "healthz"))))
+
+    [<Test>]
+    let ``doctor server selected output is clean for failure warning offline and principal cases`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let assertSelectedStatus expectedExitCode expectedStatus args probeResult token =
+                    let requestCount = ref 0
+
+                    withEnv Constants.EnvironmentVariables.GraceToken token (fun () ->
+                        withDoctorServerProbeFactory
+                            (fun _ ->
+                                incr requestCount
+                                Task.FromResult probeResult)
+                            (fun () ->
+                                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                                exitCode |> should equal expectedExitCode
+                                standardError |> should equal String.Empty
+                                standardOut.Trim() |> should equal expectedStatus
+
+                                standardOut
+                                |> should not' (contain "Grace doctor")
+
+                                standardOut |> should not' (contain "EventTime")
+
+                                if Array.contains "--offline" args then !requestCount |> should equal 0))
+
+                assertSelectedStatus
+                    1
+                    "\"Failed\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.healthz.reachable"
+                        "--select"
+                        "Status"
+                    |]
+                    (Doctor.ServerProbeConnectionFailed "Could not connect to http://example.test/healthz: connection refused")
+                    None
+
+                let warningDiagnostics =
+                    lifecycleDiagnostics (Some "unsupported") (Some "not-a-date") (Some "0.1.0") None (Some "http://example.test/update") (Some false) true
+
+                assertSelectedStatus
+                    0
+                    "\"Warning\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.lifecycle.headers"
+                        "--select"
+                        "Status"
+                    |]
+                    (successfulProbeWithLifecycle warningDiagnostics)
+                    None
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--offline"
+                        "--check"
+                        "server.healthz.reachable"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    None
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.auth-principal.available"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    None
+
+                let token = validPat ()
+
+                assertSelectedStatus
+                    0
+                    "\"Ok\""
+                    [|
+                        "--output"
+                        "Verbose"
+                        "doctor"
+                        "--check"
+                        "server.auth-principal.available"
+                        "--select"
+                        "Status"
+                    |]
+                    noLifecycleProbe
+                    (Some token)))
+
+    [<Test>]
+    let ``doctor server exact check selections are not filtered out`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let assertExactCheck checkId =
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          checkId |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    let actualCheckId = checks[ 0 ].GetProperty("Id").GetString()
+                    actualCheckId |> should equal checkId
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult noLifecycleProbe)
+                    (fun () ->
+                        assertExactCheck "server.healthz.reachable"
+                        assertExactCheck "server.lifecycle.headers"
+                        assertExactCheck "server.auth-principal.available")))
 
     [<Test>]
     let ``doctor check filter accepts mixed case ids and categories`` () =
@@ -1966,7 +2586,7 @@ notes.txt # inline comment
     [<Test>]
     let ``doctor diagnostic exit codes map warning and failure reports`` () =
         let warningReport =
-            Doctor.createReportForChecks false false false Doctor.catalog
+            Doctor.createReportForChecks false true false Doctor.catalog
             |> Doctor.withStatus "Warning"
 
         Doctor.diagnosticExitCode false warningReport

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -487,7 +487,7 @@ module DoctorCliTests =
                     !requestCount |> should equal 0))
 
     [<Test>]
-    let ``doctor server healthz reachable passes and lifecycle headers are surfaced`` () =
+    let ``doctor server healthz reachable warns when lifecycle status is deprecated`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://configured.example.test/base"
@@ -537,7 +537,7 @@ module DoctorCliTests =
                         let lifecycle = findCheckById checks "server.lifecycle.headers"
 
                         lifecycle.GetProperty("Status").GetString()
-                        |> should equal "Ok"
+                        |> should equal "Warning"
 
                         lifecycle.GetProperty("Summary").GetString()
                         |> should contain "deprecated"
@@ -641,6 +641,58 @@ module DoctorCliTests =
                             check.GetProperty("Summary").GetString()
                             |> should contain expectedText)
 
+                let lifecycleRejectionDiagnostics =
+                    lifecycleDiagnostics
+                        (Some "unsupported")
+                        (Some "2026-12-01")
+                        (Some "0.1.0")
+                        (Some "0.2.0")
+                        (Some "https://github.com/ScottArbeit/Grace/releases")
+                        (Some true)
+                        false
+
+                let lifecycleRejection =
+                    Doctor.ServerProbeSucceeded
+                        {
+                            StatusCode = HttpStatusCode.UpgradeRequired
+                            ReasonPhrase = "Upgrade Required"
+                            LifecycleDiagnostics = lifecycleRejectionDiagnostics
+                            Body = ""
+                        }
+
+                withDoctorServerProbeFactory
+                    (fun _ -> Task.FromResult lifecycleRejection)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.healthz.reachable" |]
+
+                        exitCode |> should equal 1
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        let summary = check.GetProperty("Summary").GetString()
+
+                        summary |> should contain "unsupported"
+
+                        summary
+                        |> should contain "Update the Grace CLI/SDK"
+
+                        summary
+                        |> should not' (contain "check server health and GRACE_SERVER_URI"))
+
                 writeGraceConfig root "not-a-uri" |> ignore
 
                 let requestCount = ref 0
@@ -711,8 +763,13 @@ module DoctorCliTests =
                         check.GetProperty("Summary").GetString()
                         |> should contain "not-a-date"
 
-                        check.GetProperty("Summary").GetString()
-                        |> should contain "http://example.test/update")))
+                        let summary = check.GetProperty("Summary").GetString()
+
+                        summary
+                        |> should contain "updateUrl=<suppressed because server value was not HTTPS>"
+
+                        summary
+                        |> should not' (contain "http://example.test/update"))))
 
     [<Test>]
     let ``doctor server explicit checks offline skip without network calls`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -6,10 +6,12 @@ open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client
 open Grace.Types
+open Microsoft.Data.Sqlite
 open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Text
 open System.Text.Json
 
 [<NonParallelizable>]
@@ -137,6 +139,51 @@ module DoctorCliTests =
 
         Path.Combine(graceDir, Constants.GraceConfigFileName)
 
+    let private localStateDbPath root = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+    let private getCorruptBackups root =
+        let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+
+        if Directory.Exists(graceDir) then
+            Directory.GetFiles(graceDir, "grace-local.corrupt.*.db")
+        else
+            Array.empty
+
+    let private ensureValidLocalStateDb root =
+        writeGraceConfig root "http://127.0.0.1:5000"
+        |> ignore
+
+        LocalStateDb
+            .ensureDbInitialized(localStateDbPath root)
+            .GetAwaiter()
+            .GetResult()
+
+    let private openRawConnection (dbPath: string) =
+        let connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+        connection
+
+    let private executeNonQuery (connection: SqliteConnection) (sql: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- sql
+        cmd.ExecuteNonQuery() |> ignore
+
+    let private seedSchemaVersionOnly (dbPath: string) (schemaVersion: string) =
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+        |> ignore
+
+        use connection = openRawConnection dbPath
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+        executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{schemaVersion}');"
+
+    let private snapshotFile (path: string) =
+        if File.Exists(path) then
+            use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+            use reader = new BinaryReader(stream)
+            Some(Convert.ToBase64String(reader.ReadBytes(int stream.Length)), File.GetLastWriteTimeUtc(path))
+        else
+            None
+
     let private snapshotFiles root =
         if Directory.Exists(root) then
             Directory.GetFiles(root, "*", SearchOption.AllDirectories)
@@ -201,6 +248,18 @@ module DoctorCliTests =
 
     let private validPat () = PersonalAccessToken.formatToken "doctor-user" (Guid.NewGuid()) (Array.create 32 7uy)
 
+    let private localStateCheckIds =
+        [|
+            "state.db.file-present"
+            "state.db.read-only-open"
+            "state.db.schema-version"
+            "state.db.required-tables"
+            "state.db.required-indexes"
+            "state.db.integrity-check"
+            "state.db.foreign-key-check"
+            "object-cache.index-readable"
+        |]
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -242,12 +301,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 15
+            |> should equal 23
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 15
+            |> should equal 23
 
             let catalogIds =
                 returnValue
@@ -267,6 +326,30 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration"
+
+            catalogIds
+            |> should contain "state.db.file-present"
+
+            catalogIds
+            |> should contain "state.db.read-only-open"
+
+            catalogIds
+            |> should contain "state.db.schema-version"
+
+            catalogIds
+            |> should contain "state.db.required-tables"
+
+            catalogIds
+            |> should contain "state.db.required-indexes"
+
+            catalogIds
+            |> should contain "state.db.integrity-check"
+
+            catalogIds
+            |> should contain "state.db.foreign-key-check"
+
+            catalogIds
+            |> should contain "object-cache.index-readable"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -311,7 +394,7 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 13
+            catalogIds.Count |> should equal 21
 
             catalogIds |> should contain "config.file.parse"
 
@@ -329,6 +412,12 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration"
+
+            catalogIds
+            |> should contain "state.db.file-present"
+
+            catalogIds
+            |> should contain "object-cache.index-readable"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -869,6 +958,354 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "auth.oidc.configuration")
+
+    [<Test>]
+    let ``doctor list checks includes local-state and object-cache catalog ids`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            for checkId in localStateCheckIds do
+                catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor local-state valid database reports read-only metadata checks`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let args =
+                    [|
+                        yield "--output"
+                        yield "Json"
+                        yield "doctor"
+
+                        for checkId in localStateCheckIds do
+                            yield "--check"
+                            yield checkId
+                    |]
+
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength()
+                |> should equal localStateCheckIds.Length
+
+                for checkId in localStateCheckIds do
+                    let check = findCheckById checks checkId
+
+                    check.GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "schema_version is 2"
+
+                (findCheckById checks "object-cache.index-readable")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "without mutation"))
+
+    [<Test>]
+    let ``doctor missing local-state parent reports check result without creating files`` () =
+        withTempDir (fun root ->
+            let beforeRoot = snapshotFiles root
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "state.db.file-present"
+                                                  "--check"
+                                                  "state.db.read-only-open" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            (findCheckById checks "state.db.file-present")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Warning"
+
+            (findCheckById checks "state.db.read-only-open")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped"
+
+            Directory.Exists(Path.Combine(root, Constants.GraceConfigDirectory))
+            |> should equal false
+
+            snapshotFiles root |> should equal beforeRoot)
+
+    [<Test>]
+    let ``doctor missing local-state database warns without creating database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                File.Exists(dbPath) |> should equal false
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.file-present"
+                                                      "--check"
+                                                      "state.db.schema-version" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.file-present")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Warning"
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Skipped"
+
+                File.Exists(dbPath) |> should equal false
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor local-state database path occupied by directory reports failure without mutation`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                Directory.CreateDirectory(dbPath) |> ignore
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.file-present"
+                                                      "--check"
+                                                      "state.db.read-only-open" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.file-present")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                (findCheckById checks "state.db.read-only-open")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                Directory.Exists(dbPath) |> should equal true
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor corrupt local-state database reports failure without moving bytes or sidecars`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                let bytes = Encoding.UTF8.GetBytes("not a sqlite database")
+                File.WriteAllBytes(dbPath, bytes)
+
+                let oldTime = DateTime.UtcNow.AddDays(-3.0)
+
+                let sidecars =
+                    [| "-journal"; "-wal"; "-shm" |]
+                    |> Array.map (fun suffix -> dbPath + suffix)
+
+                for sidecar in sidecars do
+                    File.WriteAllText(sidecar, "sentinel")
+                    File.SetLastWriteTimeUtc(sidecar, oldTime)
+
+                let dbBefore = snapshotFile dbPath
+                let sidecarsBefore = sidecars |> Array.map snapshotFile
+                let corruptBefore = getCorruptBackups root |> Array.length
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.read-only-open"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 1
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Failed\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut
+                |> should not' (contain "not a sqlite database")
+
+                snapshotFile dbPath |> should equal dbBefore
+
+                sidecars
+                |> Array.map snapshotFile
+                |> should equal sidecarsBefore
+
+                let corruptAfter = getCorruptBackups root |> Array.length
+                corruptAfter |> should equal corruptBefore))
+
+    [<Test>]
+    let ``doctor schema mismatch fails without corrupt backup`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                seedSchemaVersionOnly dbPath "0"
+                let dbBefore = snapshotFile dbPath
+                let corruptBefore = getCorruptBackups root |> Array.length
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.schema-version"
+                                                      "--check"
+                                                      "state.db.required-tables"
+                                                      "--check"
+                                                      "object-cache.index-readable" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "state.db.schema-version")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                (findCheckById checks "state.db.required-tables")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "status_meta"
+
+                (findCheckById checks "object-cache.index-readable")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Failed"
+
+                snapshotFile dbPath |> should equal dbBefore
+
+                let corruptAfter = getCorruptBackups root |> Array.length
+                corruptAfter |> should equal corruptBefore))
+
+    [<Test>]
+    let ``doctor local-state exact check selections are not filtered out`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                for checkId in localStateCheckIds do
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          checkId |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Id").GetString()
+                    |> should equal checkId))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor local-state successful diagnostics emit no output for quiet output modes`` output =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.schema-version" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
 
     [<Test>]
     let ``doctor verbose select returns clean scalar for passing config check`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1,0 +1,256 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.Shared
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+
+[<NonParallelizable>]
+module DoctorCliTests =
+
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
+    let private withTempDir (action: string -> unit) =
+        let tempDir = Path.Combine(Path.GetTempPath(), $"grace-doctor-cli-tests-{Guid.NewGuid():N}")
+        Directory.CreateDirectory(tempDir) |> ignore
+        let originalDir = Environment.CurrentDirectory
+
+        try
+            Environment.CurrentDirectory <- tempDir
+            action tempDir
+        finally
+            Environment.CurrentDirectory <- originalDir
+
+            if Directory.Exists(tempDir) then
+                try
+                    Directory.Delete(tempDir, true)
+                with
+                | _ -> ()
+
+    let private parseJsonOutput (output: string) =
+        output
+            .TrimStart()
+            .StartsWith("{", StringComparison.Ordinal)
+        |> should equal true
+
+        JsonDocument.Parse(output)
+
+    let private assertCleanJsonOutput (standardOut: string) (standardError: string) =
+        standardError |> should equal String.Empty
+        standardOut |> should not' (contain "Elapsed:")
+
+        standardOut
+        |> should not' (contain "Grace Version Control System")
+
+        standardOut
+        |> should not' (contain "Doctor checks")
+
+        parseJsonOutput standardOut
+
+    [<Test>]
+    let ``doctor help works without config and shows v1 options`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--help" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+            standardOut |> should contain "--full"
+            standardOut |> should contain "--offline"
+            standardOut |> should contain "--list-checks"
+            standardOut |> should contain "--check"
+            standardOut |> should contain "--strict"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor list checks emits clean json envelope without config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--list-checks" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty("ReportVersion")
+                .GetString()
+            |> should equal "doctor-report-v1"
+
+            returnValue.GetProperty("Status").GetString()
+            |> should equal "Ok"
+
+            returnValue.GetProperty("Checks").GetArrayLength()
+            |> should be (greaterThan 0)
+
+            let firstCheck = returnValue.GetProperty("Checks")[0]
+
+            firstCheck.GetProperty("Id").GetString()
+            |> should not' (equal String.Empty)
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor check filter accepts mixed case ids and categories`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "CLI.CATALOG"
+                                                  "--check"
+                                                  "configuration" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            checks.GetArrayLength() |> should equal 2)
+
+    [<Test>]
+    let ``doctor invalid check emits GraceError in json mode`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "unknown, configuration, also-unknown" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Error").GetString()
+            |> should contain "Unknown doctor check token"
+
+            let mutable returnValue = Unchecked.defaultof<JsonElement>
+
+            rootElement.TryGetProperty("ReturnValue", &returnValue)
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor schema and examples work without config`` () =
+        withTempDir (fun root ->
+            for args, expectedKind in
+                [
+                    [| "doctor"; "--schema" |], "schema"
+                    [| "doctor"; "--examples" |], "examples"
+                ] do
+                let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+                let rootElement = document.RootElement
+
+                rootElement.GetProperty("Kind").GetString()
+                |> should equal expectedKind
+
+                rootElement
+                    .GetProperty("Command")
+                    .GetProperty("Id")
+                    .GetString()
+                |> should equal "doctor"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select projects return value property without config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--select"
+                                                  "Status" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+            standardOut.Trim() |> should equal "\"Ok\""
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select rejects envelope-qualified path before config`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--select"
+                                                  "ReturnValue.Status" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+
+            document
+                .RootElement
+                .GetProperty("Error")
+                .GetString()
+            |> should contain "cannot project 'ReturnValue'"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor diagnostic exit codes map warning and failure reports`` () =
+        let warningReport =
+            Doctor.createReportForChecks false false false Doctor.catalog
+            |> Doctor.withStatus "Warning"
+
+        Doctor.diagnosticExitCode false warningReport
+        |> should equal 0
+
+        Doctor.diagnosticExitCode true warningReport
+        |> should equal 1
+
+        let failedReport = warningReport |> Doctor.withStatus "Failed"
+
+        Doctor.diagnosticExitCode false failedReport
+        |> should equal 1

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -312,12 +312,13 @@ module DoctorCliTests =
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
 
-    [<Test>]
-    let ``doctor select projects return value property without config`` () =
+    [<TestCase("Json")>]
+    [<TestCase("Verbose")>]
+    let ``doctor select projects return value property without config`` output =
         withTempDir (fun root ->
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
-                                                  "Json"
+                                                  output
                                                   "doctor"
                                                   "--select"
                                                   "Status" |]

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -4,6 +4,7 @@ open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
+open Grace.Shared.Client
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -51,6 +52,85 @@ module DoctorCliTests =
                     Directory.Delete(tempDir, true)
                 with
                 | _ -> ()
+
+    let private withEnv (name: string) (value: string option) (action: unit -> unit) =
+        let original = Environment.GetEnvironmentVariable(name)
+
+        match value with
+        | Some v -> Environment.SetEnvironmentVariable(name, v)
+        | None -> Environment.SetEnvironmentVariable(name, null)
+
+        try
+            action ()
+        finally
+            Environment.SetEnvironmentVariable(name, original)
+
+    let private withIsolatedHome (root: string) (action: string -> unit) =
+        let home = Path.Combine(root, "home")
+        Directory.CreateDirectory(home) |> ignore
+
+        withEnv "USERPROFILE" (Some home) (fun () ->
+            withEnv "HOME" (Some home) (fun () -> withEnv Constants.EnvironmentVariables.GraceServerUri None (fun () -> action home)))
+
+    let private writeGraceConfig root serverUri =
+        let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+        Directory.CreateDirectory(graceDir) |> ignore
+        let ownerId = string (Guid.NewGuid())
+        let organizationId = string (Guid.NewGuid())
+        let repositoryId = string (Guid.NewGuid())
+        let branchId = string (Guid.NewGuid())
+
+        File.WriteAllText(
+            Path.Combine(graceDir, Constants.GraceConfigFileName),
+            sprintf
+                """
+{
+  "ownerId": "%s",
+  "ownerName": "owner",
+  "organizationId": "%s",
+  "organizationName": "org",
+  "repositoryId": "%s",
+  "repositoryName": "repo",
+  "branchId": "%s",
+  "branchName": "main",
+  "serverUri": "%s",
+  "configurationVersion": "0.1",
+  "programVersion": "0.1"
+}
+"""
+                ownerId
+                organizationId
+                repositoryId
+                branchId
+                serverUri
+        )
+
+    let private snapshotFiles root =
+        if Directory.Exists(root) then
+            Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+            |> Array.map (fun path -> Path.GetRelativePath(root, path), File.GetLastWriteTimeUtc(path), FileInfo(path).Length)
+            |> Array.sortBy (fun (relativePath, _, _) -> relativePath)
+        else
+            Array.empty
+
+    let private withUserConfigTemporarilyMissing (action: string -> unit) =
+        let userConfigPath = UserConfiguration.getUserConfigurationPath ()
+        let backupPath = Path.Combine(Path.GetTempPath(), $"grace-userconfig-backup-{Guid.NewGuid():N}.json")
+        let existed = File.Exists(userConfigPath)
+        let userConfigDirectory = Path.GetDirectoryName(userConfigPath)
+
+        try
+            if existed then File.Move(userConfigPath, backupPath)
+
+            action userConfigPath
+        finally
+            if File.Exists(userConfigPath) then File.Delete(userConfigPath)
+
+            if existed then
+                Directory.CreateDirectory(userConfigDirectory)
+                |> ignore
+
+                File.Move(backupPath, userConfigPath)
 
     let private parseJsonOutput (output: string) =
         output
@@ -113,12 +193,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 4
+            |> should equal 11
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 4
+            |> should equal 11
 
             let catalogIds =
                 returnValue
@@ -131,6 +211,13 @@ module DoctorCliTests =
             |> should contain "identity.auth-session"
 
             catalogIds |> should contain "server.connectivity"
+            catalogIds |> should contain "config.file.parse"
+
+            catalogIds
+            |> should contain "user-config.file.discover"
+
+            catalogIds
+            |> should contain "ignore.entries.parse"
 
             let firstCheck = returnValue.GetProperty("Checks")[0]
 
@@ -163,7 +250,12 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 2
+            catalogIds.Count |> should equal 9
+
+            catalogIds |> should contain "config.file.parse"
+
+            catalogIds
+            |> should contain "ignore.entries.parse"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -193,7 +285,8 @@ module DoctorCliTests =
                     .GetProperty("ReturnValue")
                     .GetProperty("Checks")
 
-            checks.GetArrayLength() |> should equal 2)
+            checks.GetArrayLength()
+            |> should be (greaterThanOrEqualTo 5))
 
     [<Test>]
     let ``doctor explicit check includes non-default catalog entry without full`` () =
@@ -219,6 +312,209 @@ module DoctorCliTests =
 
             checks[ 0 ].GetProperty("Id").GetString()
             |> should equal "identity.auth-session")
+
+    [<Test>]
+    let ``doctor explicit config check is not filtered out without full`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 1
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"))
+
+    [<Test>]
+    let ``doctor verbose select returns clean scalar for passing config check`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Ok\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut |> should not' (contain "EventTime")))
+
+    [<Test>]
+    let ``doctor reports config server uri mismatch and ignore counts without mutating files`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+
+                File.WriteAllText(
+                    Path.Combine(root, Constants.GraceIgnoreFileName),
+                    """
+# comment
+bin/
+obj/
+*.tmp
+
+notes.txt # inline comment
+"""
+                )
+
+                let beforeRoot = snapshotFiles root
+                let beforeHome = snapshotFiles home
+
+                withEnv Constants.EnvironmentVariables.GraceServerUri (Some "http://127.0.0.1:6000") (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "config.file.parse"
+                                                          "--check"
+                                                          "server-uri.consistency"
+                                                          "--check"
+                                                          "ignore.entries.parse" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 3
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    checks[ 1 ].GetProperty("Status").GetString()
+                    |> should equal "Warning"
+
+                    checks[ 2 ].GetProperty("Summary").GetString()
+                    |> should contain "4 active entries"
+
+                    snapshotFiles root |> should equal beforeRoot
+                    snapshotFiles home |> should equal beforeHome
+
+                    File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
+                    |> should equal false)))
+
+    [<Test>]
+    let ``doctor malformed config fails parse and selected skipped dependent output stays clean`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+                Directory.CreateDirectory(graceDir) |> ignore
+                File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{ not json")
+
+                let beforeRoot = snapshotFiles root
+                let beforeHome = snapshotFiles home
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--check"
+                                                      "ignore.entries.parse"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 1
+                standardError |> should equal String.Empty
+
+                standardOut
+                    .TrimStart()
+                    .StartsWith("[", StringComparison.Ordinal)
+                |> should equal true
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut |> should not' (contain "EventTime")
+
+                use document = JsonDocument.Parse(standardOut)
+                let checks = document.RootElement
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                snapshotFiles root |> should equal beforeRoot
+                snapshotFiles home |> should equal beforeHome))
+
+    [<Test>]
+    let ``doctor missing user config reports warning without creating user grace directory`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun home ->
+                withUserConfigTemporarilyMissing (fun userConfigPath ->
+                    let beforeHome = snapshotFiles home
+                    let beforeUserConfigExists = File.Exists(userConfigPath)
+
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "user-config.file.discover" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let check =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")[0]
+
+                    check.GetProperty("Status").GetString()
+                    |> should equal "Warning"
+
+                    check.GetProperty("Summary").GetString()
+                    |> should contain "no file was created"
+
+                    snapshotFiles home |> should equal beforeHome
+
+                    File.Exists(userConfigPath)
+                    |> should equal beforeUserConfigExists
+
+                    Directory.Exists(Path.Combine(home, Constants.GraceConfigDirectory))
+                    |> should equal false)))
 
     [<Test>]
     let ``doctor invalid check emits GraceError in json mode`` () =
@@ -300,17 +596,22 @@ module DoctorCliTests =
     [<TestCase("Minimal")>]
     let ``doctor suppresses successful human output for quiet output modes`` output =
         withTempDir (fun root ->
-            let exitCode, standardOut, standardError =
-                runWithCapturedStdoutAndStderr [| "--output"
-                                                  output
-                                                  "doctor" |]
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
 
-            exitCode |> should equal 0
-            standardOut |> should equal String.Empty
-            standardError |> should equal String.Empty
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse" |]
 
-            Directory.Exists(Path.Combine(root, ".grace"))
-            |> should equal false)
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty
+
+                File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
+                |> should equal false))
 
     [<TestCase("Json")>]
     [<TestCase("Verbose")>]
@@ -325,7 +626,7 @@ module DoctorCliTests =
 
             exitCode |> should equal 0
             standardError |> should equal String.Empty
-            standardOut.Trim() |> should equal "\"Ok\""
+            standardOut.Trim() |> should equal "\"Warning\""
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1912,6 +1912,59 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor working-tree scan prunes trailing-slash ignored directories`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, [| "bin/"; "obj/"; "home/cache/" |]))
+
+                seedWorkingTreeSnapshot root |> ignore
+
+                let ignoredPaths =
+                    [|
+                        Path.Combine(root, "bin", "added-from-bin.txt")
+                        Path.Combine(root, "obj", "Debug", "generated.txt")
+                        Path.Combine(root, "home", "cache", "generated.txt")
+                    |]
+
+                for ignoredPath in ignoredPaths do
+                    Directory.CreateDirectory(Path.GetDirectoryName(ignoredPath))
+                    |> ignore
+
+                    File.WriteAllText(ignoredPath, "ignored generated content")
+
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should contain "1 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
     let ``doctor working-tree category selector runs scan`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -673,6 +673,59 @@ module DoctorCliTests =
                         requests[0].BearerToken |> should equal None)))
 
     [<Test>]
+    let ``doctor exact lifecycle headers fails when healthz returns non-success without lifecycle headers`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://example.test"
+                |> ignore
+
+                let requests = ResizeArray<Doctor.ServerProbeRequest>()
+
+                let failedProbe =
+                    Doctor.ServerProbeSucceeded
+                        { StatusCode = HttpStatusCode.InternalServerError; ReasonPhrase = "Internal Server Error"; LifecycleDiagnostics = None; Body = "" }
+
+                withDoctorServerProbeFactory
+                    (fun request ->
+                        requests.Add(request)
+                        Task.FromResult failedProbe)
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "server.lifecycle.headers" |]
+
+                        exitCode |> should equal 1
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+                        returnValue.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        let checks = returnValue.GetProperty("Checks")
+
+                        checks.GetArrayLength() |> should equal 1
+
+                        let lifecycle = checks[0]
+
+                        lifecycle.GetProperty("Id").GetString()
+                        |> should equal "server.lifecycle.headers"
+
+                        lifecycle.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        lifecycle.GetProperty("Summary").GetString()
+                        |> should contain "HTTP 500 Internal Server Error"
+
+                        requests.Count |> should equal 1
+
+                        requests[0].RelativePath |> should equal "healthz")))
+
+    [<Test>]
     let ``doctor server healthz uses GRACE_SERVER_URI over config and reports mismatch separately`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -105,6 +105,8 @@ module DoctorCliTests =
                 serverUri
         )
 
+        Path.Combine(graceDir, Constants.GraceConfigFileName)
+
     let private snapshotFiles root =
         if Directory.Exists(root) then
             Directory.GetFiles(root, "*", SearchOption.AllDirectories)
@@ -112,6 +114,8 @@ module DoctorCliTests =
             |> Array.sortBy (fun (relativePath, _, _) -> relativePath)
         else
             Array.empty
+
+    let private openExclusiveReadLock path = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None)
 
     let private withUserConfigTemporarilyMissing (action: string -> unit) =
         let userConfigPath = UserConfiguration.getUserConfigurationPath ()
@@ -318,6 +322,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
@@ -349,6 +354,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
@@ -373,6 +379,7 @@ module DoctorCliTests =
         withTempDir (fun root ->
             withIsolatedHome root (fun home ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 File.WriteAllText(
                     Path.Combine(root, Constants.GraceIgnoreFileName),
@@ -476,6 +483,101 @@ notes.txt # inline comment
 
                 snapshotFiles root |> should equal beforeRoot
                 snapshotFiles home |> should equal beforeHome))
+
+    [<Test>]
+    let ``doctor treats unreadable config file as parse failure instead of missing config`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                let configPath = writeGraceConfig root "http://127.0.0.1:5000"
+
+                use _lock = openExclusiveReadLock configPath
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.discover"
+                                                      "--check"
+                                                      "config.file.parse" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.discover"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                checks[ 0 ].GetProperty("Summary").GetString()
+                |> should contain "parsing is reported"
+
+                checks[ 1 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Summary").GetString()
+                |> should contain "Could not parse"))
+
+    [<Test>]
+    let ``doctor carries unreadable graceignore into ignore parse result without affecting config parse`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+                File.WriteAllText(graceIgnorePath, "bin/")
+
+                use _lock = openExclusiveReadLock graceIgnorePath
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "config.file.parse"
+                                                      "--check"
+                                                      "ignore.entries.parse" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal "config.file.parse"
+
+                checks[ 0 ].GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                checks[ 1 ].GetProperty("Id").GetString()
+                |> should equal "ignore.entries.parse"
+
+                checks[ 1 ].GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                checks[ 1 ].GetProperty("Summary").GetString()
+                |> should contain "Could not parse"))
 
     [<Test>]
     let ``doctor missing user config reports warning without creating user grace directory`` () =
@@ -598,6 +700,7 @@ notes.txt # inline comment
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
                 writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
 
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -97,6 +97,13 @@ module DoctorCliTests =
         finally
             Environment.SetEnvironmentVariable(name, original)
 
+    let private withLocalStateDbOpenTrace root (action: string -> unit) =
+        let tracePath = Path.Combine(root, "local-state-open-trace.log")
+
+        withEnv "GRACE_LOCALSTATE_DB_TRACE_PATH" (Some tracePath) (fun () -> withEnv "GRACE_LOCALSTATE_DB_TRACE_OPEN" (Some "1") (fun () -> action tracePath))
+
+    let private readTrace tracePath = if File.Exists(tracePath) then File.ReadAllText(tracePath) else String.Empty
+
     let private withIsolatedHome (root: string) (action: string -> unit) =
         let home = Path.Combine(root, "home")
         Directory.CreateDirectory(home) |> ignore
@@ -980,6 +987,109 @@ module DoctorCliTests =
 
             for checkId in localStateCheckIds do
                 catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor selected non-local check does not open local-state database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+                File.WriteAllText(dbPath, "not a sqlite database")
+                let dbBefore = snapshotFile dbPath
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "config.file.parse" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Id").GetString()
+                    |> should equal "config.file.parse"
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    readTrace tracePath |> should equal String.Empty
+                    snapshotFile dbPath |> should equal dbBefore)))
+
+    [<Test>]
+    let ``doctor selected local-state check opens local-state database read-only`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "state.db.schema-version" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    checks.GetArrayLength() |> should equal 1
+
+                    checks[ 0 ].GetProperty("Status").GetString()
+                    |> should equal "Ok"
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting")))
+
+    [<Test>]
+    let ``doctor default run opens local-state database and includes local-state checks`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    for checkId in localStateCheckIds do
+                        (findCheckById checks checkId)
+                            .GetProperty("Id")
+                            .GetString()
+                        |> should equal checkId
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting")))
 
     [<Test>]
     let ``doctor local-state valid database reports read-only metadata checks`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -12,9 +12,11 @@ open Spectre.Console
 open System
 open System.IO
 open System.Net
+open System.Security.Cryptography
 open System.Text
 open System.Text.Json
 open System.Threading.Tasks
+open Grace.Types.Common
 
 [<NonParallelizable>]
 module DoctorCliTests =
@@ -166,6 +168,116 @@ module DoctorCliTests =
             .ensureDbInitialized(localStateDbPath root)
             .GetAwaiter()
             .GetResult()
+
+    let private sha256Hex (text: string) =
+        use sha256 = SHA256.Create()
+
+        Encoding.UTF8.GetBytes(text)
+        |> sha256.ComputeHash
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let private createSnapshotFile relativePath content lastWriteTime =
+        LocalFileVersion.Create
+            relativePath
+            (sha256Hex content)
+            false
+            (int64 (Encoding.UTF8.GetByteCount(content)))
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            lastWriteTime
+
+    let private seedWorkingTreeSnapshot root =
+        writeGraceConfig root "http://127.0.0.1:5000"
+        |> ignore
+
+        let dbPath = localStateDbPath root
+
+        LocalStateDb.ensureDbInitialized (dbPath)
+        |> fun task -> task.GetAwaiter().GetResult()
+
+        let ownerId = Guid.NewGuid()
+        let organizationId = Guid.NewGuid()
+        let repositoryId = Guid.NewGuid()
+        let rootDirectoryId = Guid.NewGuid()
+        let homeDirectoryId = Guid.NewGuid()
+        let indexedWriteTime = DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        let changedPath = Path.Combine(root, "changed.txt")
+        let unchangedPath = Path.Combine(root, "mtime-only.txt")
+        let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+
+        File.WriteAllText(changedPath, "old content")
+        File.SetLastWriteTimeUtc(changedPath, indexedWriteTime)
+        File.WriteAllText(unchangedPath, "same content")
+        File.SetLastWriteTimeUtc(unchangedPath, indexedWriteTime)
+
+        let files =
+            ResizeArray(
+                [|
+                    createSnapshotFile "changed.txt" "old content" indexedWriteTime
+                    createSnapshotFile "deleted.txt" "deleted content" indexedWriteTime
+                    createSnapshotFile "mtime-only.txt" "same content" indexedWriteTime
+                |]
+            )
+
+        if File.Exists(graceIgnorePath) then
+            files.Add(createSnapshotFile Constants.GraceIgnoreFileName (File.ReadAllText(graceIgnorePath)) (File.GetLastWriteTimeUtc(graceIgnorePath)))
+
+        let homeDirectory =
+            LocalDirectoryVersion.Create
+                homeDirectoryId
+                ownerId
+                organizationId
+                repositoryId
+                "home"
+                "home-snapshot-hash"
+                (System.Collections.Generic.List<DirectoryVersionId>())
+                (System.Collections.Generic.List<LocalFileVersion>())
+                0L
+                indexedWriteTime
+
+        let rootChildDirectories =
+            if Directory.Exists(Path.Combine(root, "home")) then
+                System.Collections.Generic.List<DirectoryVersionId>([| homeDirectoryId |])
+            else
+                System.Collections.Generic.List<DirectoryVersionId>()
+
+        let rootFiles = files |> Seq.toArray
+
+        let rootDirectory =
+            LocalDirectoryVersion.Create
+                rootDirectoryId
+                ownerId
+                organizationId
+                repositoryId
+                Constants.RootDirectoryPath
+                "root-snapshot-hash"
+                rootChildDirectories
+                (System.Collections.Generic.List<LocalFileVersion>(rootFiles))
+                (rootFiles |> Array.sumBy (fun file -> file.Size))
+                indexedWriteTime
+
+        let indexEntries =
+            [|
+                System.Collections.Generic.KeyValuePair(rootDirectoryId, rootDirectory)
+
+                if Directory.Exists(Path.Combine(root, "home")) then
+                    System.Collections.Generic.KeyValuePair(homeDirectoryId, homeDirectory)
+            |]
+
+        let status =
+            { GraceStatus.Default with Index = GraceIndex(indexEntries); RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = "root-snapshot-hash" }
+
+        LocalStateDb.replaceStatusSnapshot dbPath status
+        |> fun task -> task.GetAwaiter().GetResult()
+
+        File.WriteAllText(changedPath, "new content")
+        File.SetLastWriteTimeUtc(changedPath, indexedWriteTime.AddMinutes(5.0))
+        File.WriteAllText(Path.Combine(root, "added.txt"), "added content")
+        File.WriteAllText(unchangedPath, "same content")
+        File.SetLastWriteTimeUtc(unchangedPath, indexedWriteTime.AddMinutes(10.0))
+
+        dbPath
 
     let private openRawConnection (dbPath: string) =
         let connection = new SqliteConnection($"Data Source={dbPath}")
@@ -350,12 +462,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 26
+            |> should equal 27
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 26
+            |> should equal 27
 
             let catalogIds =
                 returnValue
@@ -399,6 +511,8 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "object-cache.index-readable"
+
+            catalogIds |> should contain "working-tree.scan"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -453,7 +567,7 @@ module DoctorCliTests =
                         |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                         |> Set.ofSeq
 
-                    catalogIds.Count |> should equal 26
+                    catalogIds.Count |> should equal 27
 
                     catalogIds |> should contain "config.file.parse"
 
@@ -1664,6 +1778,255 @@ module DoctorCliTests =
 
             for checkId in localStateCheckIds do
                 catalogIds |> should contain checkId)
+
+    [<Test>]
+    let ``doctor list checks includes working-tree scan catalog id`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds |> should contain "working-tree.scan")
+
+    [<Test>]
+    let ``doctor default working-tree scan is skipped without traversing changed files`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                let dbPath = seedWorkingTreeSnapshot root
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let checks = document.RootElement
+                let workingTree = findCheckById checks "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should contain "Skipped in the default profile"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should not' (contain "differs")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor full working-tree scan reports drift warning without mutation`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--full"
+                                                      "--offline"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should contain "1 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+                summary |> should contain "grace maintenance scan"
+
+                summary
+                |> should contain "grace maintenance update-index"
+
+                summary |> should not' (contain "mtime-only.txt")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor exact working-tree scan runs without full and excludes ignored and grace-owned paths`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "ignored.txt")
+                seedWorkingTreeSnapshot root |> ignore
+                File.WriteAllText(Path.Combine(root, "ignored.txt"), "ignored content")
+                File.WriteAllText(Path.Combine(root, Constants.GraceConfigDirectory, "grace-local.db-wal.extra"), "sidecar-ish content")
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "3 total"
+                summary |> should not' (contain "ignored.txt")
+                summary |> should not' (contain ".grace")
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor working-tree category selector runs scan`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor working-tree default quiet modes emit no successful diagnostic output`` output =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+                let indexedWriteTime = DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                File.WriteAllText(Path.Combine(root, "changed.txt"), "old content")
+                File.SetLastWriteTimeUtc(Path.Combine(root, "changed.txt"), indexedWriteTime)
+                File.WriteAllText(Path.Combine(root, "deleted.txt"), "deleted content")
+                File.SetLastWriteTimeUtc(Path.Combine(root, "deleted.txt"), indexedWriteTime)
+                File.Delete(Path.Combine(root, "added.txt"))
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
+
+    [<Test>]
+    let ``doctor working-tree verbose select emits clean scalar without progress text`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "doctor"
+                                                      "--full"
+                                                      "--offline"
+                                                      "--select"
+                                                      "Status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut.Trim() |> should equal "\"Warning\""
+
+                standardOut
+                |> should not' (contain "Grace doctor")
+
+                standardOut
+                |> should not' (contain "scanForDifferences")
+
+                standardOut
+                |> should not' (contain "Working tree differs")))
+
+    [<Test>]
+    let ``doctor working-tree scan skips unreadable snapshot inside report without creating database`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                writeGraceConfig root "http://127.0.0.1:5000"
+                |> ignore
+
+                let dbPath = localStateDbPath root
+
+                Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+                |> ignore
+
+                File.WriteAllText(dbPath, "not a sqlite database")
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Skipped"
+
+                workingTree.GetProperty("Summary").GetString()
+                |> should contain "Skipped because"
+
+                snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
     let ``doctor selected non-local check does not open local-state database`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client
+open Grace.Types
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -36,6 +37,35 @@ module DoctorCliTests =
             Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
 
+    let private authEnvNames =
+        [|
+            Constants.EnvironmentVariables.GraceToken
+            Constants.EnvironmentVariables.GraceTokenFile
+            Constants.EnvironmentVariables.GraceAuthOidcAuthority
+            Constants.EnvironmentVariables.GraceAuthOidcAudience
+            Constants.EnvironmentVariables.GraceAuthOidcCliClientId
+            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort
+            Constants.EnvironmentVariables.GraceAuthOidcCliScopes
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret
+            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes
+            Constants.EnvironmentVariables.GraceServerUri
+        |]
+
+    let private withClearedAuthEnv (action: unit -> unit) =
+        let originalValues =
+            authEnvNames
+            |> Array.map (fun name -> name, Environment.GetEnvironmentVariable(name))
+
+        try
+            authEnvNames
+            |> Array.iter (fun name -> Environment.SetEnvironmentVariable(name, null))
+
+            action ()
+        finally
+            originalValues
+            |> Array.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value))
+
     let private withTempDir (action: string -> unit) =
         let tempDir = Path.Combine(Path.GetTempPath(), $"grace-doctor-cli-tests-{Guid.NewGuid():N}")
         Directory.CreateDirectory(tempDir) |> ignore
@@ -43,7 +73,7 @@ module DoctorCliTests =
 
         try
             Environment.CurrentDirectory <- tempDir
-            action tempDir
+            withClearedAuthEnv (fun () -> action tempDir)
         finally
             Environment.CurrentDirectory <- originalDir
 
@@ -156,6 +186,21 @@ module DoctorCliTests =
 
         parseJsonOutput standardOut
 
+    let private findCheckById (checks: JsonElement) checkId =
+        checks.EnumerateArray()
+        |> Seq.find (fun check ->
+            check
+                .GetProperty("Id")
+                .GetString()
+                .Equals(checkId, StringComparison.Ordinal))
+
+    let private assertDoesNotContainSecrets (secrets: string list) (standardOut: string) (standardError: string) =
+        for secret in secrets do
+            standardOut |> should not' (contain secret)
+            standardError |> should not' (contain secret)
+
+    let private validPat () = PersonalAccessToken.formatToken "doctor-user" (Guid.NewGuid()) (Array.create 32 7uy)
+
     [<Test>]
     let ``doctor help works without config and shows v1 options`` () =
         withTempDir (fun root ->
@@ -197,12 +242,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 11
+            |> should equal 15
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 11
+            |> should equal 15
 
             let catalogIds =
                 returnValue
@@ -210,6 +255,18 @@ module DoctorCliTests =
                     .EnumerateArray()
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration"
 
             catalogIds
             |> should contain "identity.auth-session"
@@ -254,12 +311,24 @@ module DoctorCliTests =
                 |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                 |> Set.ofSeq
 
-            catalogIds.Count |> should equal 9
+            catalogIds.Count |> should equal 13
 
             catalogIds |> should contain "config.file.parse"
 
             catalogIds
             |> should contain "ignore.entries.parse"
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration"
 
             catalogIds
             |> should not' (contain "identity.auth-session")
@@ -348,6 +417,292 @@ module DoctorCliTests =
 
                 checks[ 0 ].GetProperty("Status").GetString()
                 |> should equal "Ok"))
+
+    [<Test>]
+    let ``doctor auth detects valid GRACE_TOKEN without printing raw value`` () =
+        withTempDir (fun _ ->
+            let token = validPat ()
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.source.detected"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 2
+
+                (findCheckById checks "auth.source.detected")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "GRACE_TOKEN PAT"
+
+                (findCheckById checks "auth.env-token.valid")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
+
+    [<TestCase("not-a-pat")>]
+    [<TestCase("Bearer not-a-pat")>]
+    [<TestCase("")>]
+    let ``doctor auth rejects invalid GRACE_TOKEN safely`` token =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 1
+
+                if not (String.IsNullOrEmpty token) then
+                    assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN"))
+
+    [<Test>]
+    let ``doctor auth reports unsupported GRACE_TOKEN_FILE with GRACE_TOKEN remediation`` () =
+        withTempDir (fun _ ->
+            let tokenFilePath = "C:\\secret\\grace-token.txt"
+
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFilePath) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.token-file.unsupported" |]
+
+                exitCode |> should equal 1
+                assertDoesNotContainSecrets [ tokenFilePath ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN"))
+
+    [<Test>]
+    let ``doctor auth missing environment warns and skips token validation`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "auth.source.detected"
+                                                  "--check"
+                                                  "auth.env-token.valid"
+                                                  "--check"
+                                                  "auth.oidc.configuration" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            (findCheckById checks "auth.source.detected")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Warning"
+
+            (findCheckById checks "auth.env-token.valid")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped"
+
+            (findCheckById checks "auth.oidc.configuration")
+                .GetProperty("Status")
+                .GetString()
+            |> should equal "Skipped")
+
+    [<Test>]
+    let ``doctor auth reports partial OIDC M2M and CLI configuration without secret values`` () =
+        withTempDir (fun _ ->
+            let authority = "https://tenant.example.invalid/very-secret-authority"
+            let m2mSecret = "m2m-client-secret-value"
+            let cliClientId = "cli-client-secret-looking-id"
+
+            withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some authority) (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some m2mSecret) (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcCliClientId (Some cliClientId) (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "auth.oidc.configuration" |]
+
+                        exitCode |> should equal 0
+                        assertDoesNotContainSecrets [ authority; m2mSecret; cliClientId ] standardOut standardError
+
+                        use document = assertCleanJsonOutput standardOut standardError
+
+                        let check =
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Checks")[0]
+
+                        check.GetProperty("Status").GetString()
+                        |> should equal "Warning"
+
+                        check.GetProperty("Summary").GetString()
+                        |> should contain "partial"))))
+
+    [<Test>]
+    let ``doctor auth exact check selections are not filtered out`` () =
+        withTempDir (fun _ ->
+            for checkId in
+                [
+                    "auth.env-token.valid"
+                    "auth.token-file.unsupported"
+                    "auth.oidc.configuration"
+                ] do
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      checkId |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                checks.GetArrayLength() |> should equal 1
+
+                checks[ 0 ].GetProperty("Id").GetString()
+                |> should equal checkId)
+
+    [<TestCase("Json")>]
+    [<TestCase("Verbose")>]
+    let ``doctor auth select output is clean for valid and invalid auth states`` output =
+        withTempDir (fun _ ->
+            for token, expectedStatus in
+                [
+                    validPat (), "\"Ok\""
+                    "not-a-pat", "\"Failed\""
+                ] do
+                withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          output
+                                                          "doctor"
+                                                          "--check"
+                                                          "auth.env-token.valid"
+                                                          "--select"
+                                                          "Status" |]
+
+                    if expectedStatus = "\"Ok\"" then
+                        exitCode |> should equal 0
+                    else
+                        exitCode |> should equal 1
+
+                    standardError |> should equal String.Empty
+                    standardOut.Trim() |> should equal expectedStatus
+                    assertDoesNotContainSecrets [ token ] standardOut standardError
+
+                    standardOut
+                    |> should not' (contain "Grace doctor")
+
+                    standardOut |> should not' (contain "EventTime")))
+
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor auth successful diagnostics emit no output for quiet output modes`` output =
+        withTempDir (fun _ ->
+            let token = validPat ()
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      output
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                standardOut |> should equal String.Empty
+                standardError |> should equal String.Empty))
+
+    [<Test>]
+    let ``doctor auth list checks includes S2 auth catalog ids`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--list-checks"
+                                                  "--select"
+                                                  "Catalog" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = JsonDocument.Parse(standardOut)
+
+            let catalogIds =
+                document.RootElement.EnumerateArray()
+                |> Seq.map (fun check -> check.GetProperty("Id").GetString())
+                |> Set.ofSeq
+
+            catalogIds
+            |> should contain "auth.source.detected"
+
+            catalogIds
+            |> should contain "auth.env-token.valid"
+
+            catalogIds
+            |> should contain "auth.token-file.unsupported"
+
+            catalogIds
+            |> should contain "auth.oidc.configuration")
 
     [<Test>]
     let ``doctor verbose select returns clean scalar for passing config check`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -396,6 +396,14 @@ module DoctorCliTests =
         finally
             Doctor.resetServerProbeFactoryForTests ()
 
+    let private withWorkingTreeScanner scanner action =
+        Doctor.setWorkingTreeScannerForTests scanner
+
+        try
+            action ()
+        finally
+            Doctor.resetWorkingTreeScannerForTests ()
+
     let private successfulProbeWithLifecycle diagnostics =
         Doctor.ServerProbeSucceeded
             {
@@ -1965,6 +1973,90 @@ module DoctorCliTests =
                 snapshotFiles root |> should equal beforeRoot))
 
     [<Test>]
+    let ``doctor working-tree scan does not prune directories from file-only ignore entries`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "build")
+
+                seedWorkingTreeSnapshot root |> ignore
+
+                let buildOutput = Path.Combine(root, "build", "generated.txt")
+
+                Directory.CreateDirectory(Path.GetDirectoryName(buildOutput))
+                |> ignore
+
+                File.WriteAllText(buildOutput, "generated content that should be detected")
+
+                let beforeRoot = snapshotFiles root
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "working-tree.scan"
+                                                      "--select"
+                                                      "Checks" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                use document = JsonDocument.Parse(standardOut)
+
+                document.RootElement.GetArrayLength()
+                |> should equal 1
+
+                let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                workingTree.GetProperty("Status").GetString()
+                |> should equal "Warning"
+
+                let summary = workingTree.GetProperty("Summary").GetString()
+
+                summary |> should contain "5 total"
+                summary |> should contain "3 added"
+                summary |> should contain "1 changed"
+                summary |> should contain "1 deleted"
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    [<Test>]
+    let ``doctor strict exact working-tree scan fails when read-only scan execution fails`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                seedWorkingTreeSnapshot root |> ignore
+
+                withWorkingTreeScanner
+                    (fun _ _ -> Task.FromResult(Error "simulated read-only scan failure"))
+                    (fun () ->
+                        let exitCode, standardOut, standardError =
+                            runWithCapturedStdoutAndStderr [| "--output"
+                                                              "Json"
+                                                              "doctor"
+                                                              "--check"
+                                                              "working-tree.scan"
+                                                              "--strict"
+                                                              "--select"
+                                                              "Checks" |]
+
+                        exitCode |> should equal 1
+                        standardError |> should equal String.Empty
+                        use document = JsonDocument.Parse(standardOut)
+
+                        document.RootElement.GetArrayLength()
+                        |> should equal 1
+
+                        let workingTree = findCheckById document.RootElement "working-tree.scan"
+
+                        workingTree.GetProperty("Status").GetString()
+                        |> should equal "Failed"
+
+                        workingTree.GetProperty("Severity").GetString()
+                        |> should equal "Error"
+
+                        workingTree.GetProperty("Summary").GetString()
+                        |> should contain "Working-tree scan failed without updating local state: simulated read-only scan failure")))
+
+    [<Test>]
     let ``doctor working-tree category selector runs scan`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->
@@ -2706,6 +2798,9 @@ notes.txt # inline comment
 
                     checks[ 2 ].GetProperty("Summary").GetString()
                     |> should contain "4 active entries"
+
+                    checks[ 2 ].GetProperty("Summary").GetString()
+                    |> should contain "2 file patterns and 2 directory patterns"
 
                     snapshotFiles root |> should equal beforeRoot
                     snapshotFiles home |> should equal beforeHome

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -148,6 +148,31 @@ module DoctorCliTests =
             checks.GetArrayLength() |> should equal 2)
 
     [<Test>]
+    let ``doctor explicit check includes non-default catalog entry without full`` () =
+        withTempDir (fun _ ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "doctor"
+                                                  "--check"
+                                                  "identity.auth-session" |]
+
+            exitCode |> should equal 0
+
+            use document = assertCleanJsonOutput standardOut standardError
+
+            let checks =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Checks")
+
+            checks.GetArrayLength() |> should equal 1
+
+            checks[ 0 ].GetProperty("Id").GetString()
+            |> should equal "identity.auth-session")
+
+    [<Test>]
     let ``doctor invalid check emits GraceError in json mode`` () =
         withTempDir (fun _ ->
             let exitCode, standardOut, standardError =
@@ -199,6 +224,22 @@ module DoctorCliTests =
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
 
+    [<TestCase("Silent")>]
+    [<TestCase("Minimal")>]
+    let ``doctor suppresses successful human output for quiet output modes`` output =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  output
+                                                  "doctor" |]
+
+            exitCode |> should equal 0
+            standardOut |> should equal String.Empty
+            standardError |> should equal String.Empty
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
     [<Test>]
     let ``doctor select projects return value property without config`` () =
         withTempDir (fun root ->
@@ -212,6 +253,28 @@ module DoctorCliTests =
             exitCode |> should equal 0
             standardError |> should equal String.Empty
             standardOut.Trim() |> should equal "\"Ok\""
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    [<Test>]
+    let ``doctor select missing property returns projection failure exit code`` () =
+        withTempDir (fun root ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--select"
+                                                  "NoSuchProperty" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+
+            document
+                .RootElement
+                .GetProperty("Error")
+                .GetString()
+            |> should contain "NoSuchProperty"
 
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1061,6 +1061,68 @@ module DoctorCliTests =
                     |> should contain "openReadOnlyConnection starting")))
 
     [<Test>]
+    let ``doctor local-state checks inspect checkpointed wal database without creating missing sidecars`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+                SqliteConnection.ClearAllPools()
+
+                let dbPath = localStateDbPath root
+                let walPath = dbPath + "-wal"
+                let shmPath = dbPath + "-shm"
+
+                for sidecar in [| walPath; shmPath |] do
+                    if File.Exists(sidecar) then File.Delete(sidecar)
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+
+                let dbBefore = snapshotFile dbPath
+
+                withLocalStateDbOpenTrace root (fun tracePath ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--check"
+                                                          "state.db.read-only-open"
+                                                          "--check"
+                                                          "state.db.schema-version"
+                                                          "--check"
+                                                          "state.db.integrity-check"
+                                                          "--check"
+                                                          "object-cache.index-readable" |]
+
+                    exitCode |> should equal 0
+
+                    use document = assertCleanJsonOutput standardOut standardError
+
+                    let checks =
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Checks")
+
+                    for checkId in
+                        [|
+                            "state.db.read-only-open"
+                            "state.db.schema-version"
+                            "state.db.integrity-check"
+                            "object-cache.index-readable"
+                        |] do
+                        (findCheckById checks checkId)
+                            .GetProperty("Status")
+                            .GetString()
+                        |> should equal "Ok"
+
+                    readTrace tracePath
+                    |> should contain "openReadOnlyConnection starting"
+
+                    snapshotFile dbPath |> should equal dbBefore
+                    File.Exists(walPath) |> should equal false
+                    File.Exists(shmPath) |> should equal false)))
+
+    [<Test>]
     let ``doctor default run opens local-state database and includes local-state checks`` () =
         withTempDir (fun root ->
             withIsolatedHome root (fun _ ->

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -456,9 +456,45 @@ module DoctorCliTests =
                     .GetString()
                 |> should equal "Ok"))
 
+    [<Test>]
+    let ``doctor auth accepts bearer GRACE_TOKEN without printing raw value`` () =
+        withTempDir (fun _ ->
+            let token = validPat ()
+            let bearerToken = $"  Bearer {token}  "
+
+            withEnv Constants.EnvironmentVariables.GraceToken (Some bearerToken) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.source.detected"
+                                                      "--check"
+                                                      "auth.env-token.valid" |]
+
+                exitCode |> should equal 0
+                assertDoesNotContainSecrets [ token; bearerToken ] standardOut standardError
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "auth.source.detected")
+                    .GetProperty("Summary")
+                    .GetString()
+                |> should contain "GRACE_TOKEN PAT"
+
+                (findCheckById checks "auth.env-token.valid")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
+
     [<TestCase("not-a-pat")>]
     [<TestCase("Bearer not-a-pat")>]
-    [<TestCase("")>]
     let ``doctor auth rejects invalid GRACE_TOKEN safely`` token =
         withTempDir (fun _ ->
             withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
@@ -487,6 +523,52 @@ module DoctorCliTests =
 
                 check.GetProperty("Summary").GetString()
                 |> should contain "GRACE_TOKEN"))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN as unset and continues OIDC inspection`` token =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some "https://tenant.example.invalid/") (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience (Some "https://api.example.invalid/") (fun () ->
+                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId (Some "m2m-client-id") (fun () ->
+                            withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some "m2m-client-secret") (fun () ->
+                                let exitCode, standardOut, standardError =
+                                    runWithCapturedStdoutAndStderr [| "--output"
+                                                                      "Json"
+                                                                      "doctor"
+                                                                      "--check"
+                                                                      "auth.source.detected"
+                                                                      "--check"
+                                                                      "auth.env-token.valid"
+                                                                      "--check"
+                                                                      "auth.oidc.configuration" |]
+
+                                exitCode |> should equal 0
+                                assertDoesNotContainSecrets [ "m2m-client-secret" ] standardOut standardError
+
+                                use document = assertCleanJsonOutput standardOut standardError
+
+                                let checks =
+                                    document
+                                        .RootElement
+                                        .GetProperty("ReturnValue")
+                                        .GetProperty("Checks")
+
+                                (findCheckById checks "auth.source.detected")
+                                    .GetProperty("Summary")
+                                    .GetString()
+                                |> should contain "OIDC M2M environment"
+
+                                (findCheckById checks "auth.env-token.valid")
+                                    .GetProperty("Status")
+                                    .GetString()
+                                |> should equal "Skipped"
+
+                                (findCheckById checks "auth.oidc.configuration")
+                                    .GetProperty("Status")
+                                    .GetString()
+                                |> should equal "Ok"))))))
 
     [<Test>]
     let ``doctor auth reports unsupported GRACE_TOKEN_FILE with GRACE_TOKEN remediation`` () =
@@ -517,6 +599,59 @@ module DoctorCliTests =
 
                 check.GetProperty("Summary").GetString()
                 |> should contain "GRACE_TOKEN"))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN_FILE as unset for explicit checks`` tokenFileValue =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFileValue) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "auth.token-file.unsupported" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Ok"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "GRACE_TOKEN_FILE is not set."))
+
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    let ``doctor auth treats blank GRACE_TOKEN_FILE as unset in default checks`` tokenFileValue =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceTokenFile (Some tokenFileValue) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor" |]
+
+                exitCode |> should equal 0
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let checks =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")
+
+                (findCheckById checks "auth.token-file.unsupported")
+                    .GetProperty("Status")
+                    .GetString()
+                |> should equal "Ok"))
 
     [<Test>]
     let ``doctor auth missing environment warns and skips token validation`` () =
@@ -590,6 +725,37 @@ module DoctorCliTests =
 
                         check.GetProperty("Summary").GetString()
                         |> should contain "partial"))))
+
+    [<Test>]
+    let ``doctor auth treats blank OIDC required values as missing`` () =
+        withTempDir (fun _ ->
+            withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some "   ") (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience (Some "https://api.example.invalid/") (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId (Some "m2m-client-id") (fun () ->
+                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some "m2m-client-secret") (fun () ->
+                            let exitCode, standardOut, standardError =
+                                runWithCapturedStdoutAndStderr [| "--output"
+                                                                  "Json"
+                                                                  "doctor"
+                                                                  "--check"
+                                                                  "auth.oidc.configuration" |]
+
+                            exitCode |> should equal 0
+                            assertDoesNotContainSecrets [ "m2m-client-secret" ] standardOut standardError
+
+                            use document = assertCleanJsonOutput standardOut standardError
+
+                            let check =
+                                document
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("Checks")[0]
+
+                            check.GetProperty("Status").GetString()
+                            |> should equal "Warning"
+
+                            check.GetProperty("Summary").GetString()
+                            |> should contain Constants.EnvironmentVariables.GraceAuthOidcAuthority)))))
 
     [<Test>]
     let ``doctor auth exact check selections are not filtered out`` () =

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -40,6 +40,8 @@
     <Compile Include="WebhookApproval.CLI.Tests.fs" />
     <Compile Include="PromotionSet.CLI.Tests.fs" />
     <Compile Include="Maintenance.CLI.Tests.fs" />
+    <Compile Include="Doctor.CLI.Parsing.Tests.fs" />
+    <Compile Include="Doctor.CLI.Tests.fs" />
     <Compile Include="CommandOutputContract.CLI.Tests.fs" />
     <Compile Include="CurrentStateCapture.CLI.Tests.fs" />
     <Compile Include="Watch.Tests.fs" />

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -141,6 +141,14 @@ module LocalStateDbTests =
         else
             Directory.GetFiles(directoryPath, "grace-local.corrupt.*.db")
 
+    let private snapshotFile (path: string) =
+        if File.Exists(path) then
+            use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+            use reader = new BinaryReader(stream)
+            Some(reader.ReadBytes(int stream.Length), File.GetLastWriteTimeUtc(path))
+        else
+            None
+
     let private seedSchemaVersionOnly (dbPath: string) (schemaVersion: string) =
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
         |> ignore
@@ -520,6 +528,162 @@ module LocalStateDbTests =
                 if File.Exists(shmPath) then
                     File.GetLastWriteTimeUtc(shmPath)
                     |> should be (greaterThan oldTime)
+            })
+
+    [<Test>]
+    let ``read-only inspection reports valid database metadata`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+                inspection.OpenError |> should equal None
+
+                inspection.SchemaVersion
+                |> should equal (Some "2")
+
+                inspection.MissingRequiredTables
+                |> should equal Array.empty<string>
+
+                inspection.MissingRequiredIndexes
+                |> should equal Array.empty<string>
+
+                inspection.IntegrityCheckRows
+                |> should equal [| "ok" |]
+
+                inspection.ForeignKeyViolations
+                |> should equal Array.empty<string>
+
+                inspection.ObjectCacheReadable
+                |> should equal (Some true)
+
+                inspection.ObjectCacheError |> should equal None
+            })
+
+    [<Test>]
+    let ``read-only inspection does not create missing parent or database`` () =
+        withTempDir (fun root _ ->
+            task {
+                let missingDbPath = Path.Combine(root, "missing-grace", Constants.GraceLocalStateDbFileName)
+
+                let inspection = LocalStateDb.inspectReadOnly missingDbPath
+
+                inspection.ParentDirectoryExists
+                |> should equal false
+
+                inspection.DbFileExists |> should equal false
+                inspection.OpenedReadOnly |> should equal false
+
+                Directory.Exists(Path.GetDirectoryName(missingDbPath))
+                |> should equal false
+
+                File.Exists(missingDbPath) |> should equal false
+            })
+
+    [<Test>]
+    let ``read-only inspection preserves corrupt bytes sidecars and backups`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                Directory.CreateDirectory(Path.GetDirectoryName(configuration.GraceStatusFile))
+                |> ignore
+
+                let corruptBytes = Encoding.UTF8.GetBytes("this is not a sqlite database")
+                File.WriteAllBytes(configuration.GraceStatusFile, corruptBytes)
+
+                let oldTime = DateTime.UtcNow.AddDays(-2.0)
+
+                let sidecars =
+                    [| "-journal"; "-wal"; "-shm" |]
+                    |> Array.map (fun suffix -> configuration.GraceStatusFile + suffix)
+
+                for sidecar in sidecars do
+                    File.WriteAllText(sidecar, $"sentinel-{Path.GetFileName(sidecar)}")
+                    File.SetLastWriteTimeUtc(sidecar, oldTime)
+
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+                let sidecarsBefore = sidecars |> Array.map snapshotFile
+
+                let backupsBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal false
+                inspection.OpenError.IsSome |> should equal true
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                sidecars
+                |> Array.map snapshotFile
+                |> should equal sidecarsBefore
+
+                let backupsAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                backupsAfter |> should equal backupsBefore
+            })
+
+    [<Test>]
+    let ``read-only inspection reports schema mismatch without corrupt backup`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                seedSchemaVersionOnly configuration.GraceStatusFile "0"
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+
+                let backupsBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.SchemaVersion
+                |> should equal (Some "0")
+
+                inspection.MissingRequiredTables
+                |> should contain "status_meta"
+
+                inspection.MissingRequiredIndexes
+                |> should contain "ix_object_cache_files_path_hash"
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                let backupsAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                backupsAfter |> should equal backupsBefore
+            })
+
+    [<Test>]
+    let ``read-only inspection reports foreign-key inconsistency without repair`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery connection "PRAGMA foreign_keys = OFF;"
+
+                executeNonQuery
+                    connection
+                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('00000000-0000-0000-0000-000000000111', 'orphan.txt', 'hash', 0, 1, 0, 0, 0);"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.ForeignKeyViolations.Length
+                |> should be (greaterThan 0)
+
+                let orphanCount = executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directory_files WHERE relative_path = 'orphan.txt';"
+                orphanCount |> should equal 1
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -563,7 +563,7 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``read-only inspection does not create missing wal sidecars`` () =
+    let ``read-only inspection opens checkpointed wal database without creating missing sidecars`` () =
         withTempDir (fun _ configuration ->
             task {
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
@@ -582,11 +582,17 @@ module LocalStateDbTests =
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
 
-                inspection.OpenedReadOnly |> should equal false
+                inspection.OpenedReadOnly |> should equal true
+                inspection.OpenError |> should equal None
 
-                inspection.OpenError
-                |> Option.defaultValue String.Empty
-                |> should contain "required sidecar files are missing"
+                inspection.SchemaVersion
+                |> should equal (Some "2")
+
+                inspection.IntegrityCheckRows
+                |> should equal [| "ok" |]
+
+                inspection.ObjectCacheReadable
+                |> should equal (Some true)
 
                 snapshotFile configuration.GraceStatusFile
                 |> should equal dbBefore

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -563,6 +563,39 @@ module LocalStateDbTests =
             })
 
     [<Test>]
+    let ``read-only inspection does not create missing wal sidecars`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                SqliteConnection.ClearAllPools()
+
+                let walPath = configuration.GraceStatusFile + "-wal"
+                let shmPath = configuration.GraceStatusFile + "-shm"
+
+                for sidecar in [| walPath; shmPath |] do
+                    if File.Exists(sidecar) then File.Delete(sidecar)
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal false
+
+                inspection.OpenError
+                |> Option.defaultValue String.Empty
+                |> should contain "required sidecar files are missing"
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                File.Exists(walPath) |> should equal false
+                File.Exists(shmPath) |> should equal false
+            })
+
+    [<Test>]
     let ``read-only inspection does not create missing parent or database`` () =
         withTempDir (fun root _ ->
             task {

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -68,15 +68,122 @@ module Auth =
 
     type TokenStore = { Helper: MsalCacheHelper; StorageProperties: StorageCreationProperties; LockFilePath: string; InProcessLock: SemaphoreSlim }
 
+    type AuthEnvironmentFieldStatus = { Name: string; IsSet: bool; Required: bool }
+
+    type AuthInspection =
+        {
+            GraceTokenPresent: bool
+            GraceTokenValid: bool
+            GraceTokenError: string option
+            GraceTokenFilePresent: bool
+            M2mFields: AuthEnvironmentFieldStatus array
+            CliFields: AuthEnvironmentFieldStatus array
+            M2mComplete: bool
+            CliComplete: bool
+            HasPartialM2m: bool
+            HasPartialCli: bool
+            ActiveSource: string
+            HasUsableCredentialSource: bool
+        }
+
     let private tryGetEnv name =
         let value = Environment.GetEnvironmentVariable(name)
         if String.IsNullOrWhiteSpace value then None else Some value
+
+    let private isEnvSet name =
+        isNull (Environment.GetEnvironmentVariable(name))
+        |> not
 
     let private normalizeBearerToken (token: string) =
         if token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
             token.Substring("Bearer ".Length).Trim()
         else
             token.Trim()
+
+    let private authField required name = { Name = name; IsSet = isEnvSet name; Required = required }
+
+    let private requiredFieldsComplete fields =
+        fields
+        |> Array.filter (fun field -> field.Required)
+        |> Array.forall (fun field -> field.IsSet)
+
+    let private anyFieldsSet fields = fields |> Array.exists (fun field -> field.IsSet)
+
+    let private hasPartialRequiredFields fields =
+        anyFieldsSet fields
+        && not (requiredFieldsComplete fields)
+
+    let inspectAuthEnvironment () =
+        let tokenValue = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+        let graceTokenPresent = not (isNull tokenValue)
+
+        let graceTokenValid, graceTokenError =
+            if not graceTokenPresent then
+                false, None
+            elif String.IsNullOrWhiteSpace tokenValue then
+                false, Some $"GRACE_TOKEN is set but empty. Provide a Grace PAT or unset {Constants.EnvironmentVariables.GraceToken}."
+            else
+                let trimmed = tokenValue.Trim()
+
+                match Grace.Types.PersonalAccessToken.tryParseToken trimmed with
+                | Some _ -> true, None
+                | None ->
+                    false,
+                    Some
+                        $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens and bearer prefixes are not valid here."
+
+        let m2mFields =
+            [|
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAuthority
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAudience
+                authField true Constants.EnvironmentVariables.GraceAuthOidcM2mClientId
+                authField true Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret
+                authField false Constants.EnvironmentVariables.GraceAuthOidcM2mScopes
+            |]
+
+        let cliFields =
+            [|
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAuthority
+                authField true Constants.EnvironmentVariables.GraceAuthOidcAudience
+                authField true Constants.EnvironmentVariables.GraceAuthOidcCliClientId
+                authField false Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort
+                authField false Constants.EnvironmentVariables.GraceAuthOidcCliScopes
+            |]
+
+        let m2mComplete = requiredFieldsComplete m2mFields
+        let cliComplete = requiredFieldsComplete cliFields
+        let hasPartialM2m = hasPartialRequiredFields m2mFields
+        let hasPartialCli = hasPartialRequiredFields cliFields
+        let graceTokenFilePresent = isEnvSet Constants.EnvironmentVariables.GraceTokenFile
+
+        let activeSource, hasUsableCredentialSource =
+            if graceTokenValid then
+                $"{Constants.EnvironmentVariables.GraceToken} PAT", true
+            elif graceTokenError.IsSome then
+                $"{Constants.EnvironmentVariables.GraceToken} invalid", false
+            elif graceTokenFilePresent then
+                $"{Constants.EnvironmentVariables.GraceTokenFile} unsupported", false
+            elif m2mComplete then
+                "OIDC M2M environment", true
+            elif cliComplete then
+                "OIDC CLI environment", true
+            else
+                "None", false
+
+        {
+            GraceTokenPresent = graceTokenPresent
+            GraceTokenValid = graceTokenValid
+            GraceTokenError = graceTokenError
+            GraceTokenFilePresent = graceTokenFilePresent
+            M2mFields = m2mFields
+            CliFields = cliFields
+            M2mComplete = m2mComplete
+            CliComplete = cliComplete
+            HasPartialM2m = hasPartialM2m
+            HasPartialCli = hasPartialCli
+            ActiveSource = activeSource
+            HasUsableCredentialSource = hasUsableCredentialSource
+        }
 
     let private normalizeAuthority (authority: string) =
         let trimmed = authority.Trim()

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -90,15 +90,15 @@ module Auth =
         let value = Environment.GetEnvironmentVariable(name)
         if String.IsNullOrWhiteSpace value then None else Some value
 
-    let private isEnvSet name =
-        isNull (Environment.GetEnvironmentVariable(name))
-        |> not
+    let private isEnvSet name = tryGetEnv name |> Option.isSome
 
     let private normalizeBearerToken (token: string) =
-        if token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
-            token.Substring("Bearer ".Length).Trim()
+        let trimmed = token.Trim()
+
+        if trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
+            trimmed.Substring("Bearer ".Length).Trim()
         else
-            token.Trim()
+            trimmed
 
     let private authField required name = { Name = name; IsSet = isEnvSet name; Required = required }
 
@@ -114,23 +114,20 @@ module Auth =
         && not (requiredFieldsComplete fields)
 
     let inspectAuthEnvironment () =
-        let tokenValue = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
-        let graceTokenPresent = not (isNull tokenValue)
+        let tokenValue = tryGetEnv Constants.EnvironmentVariables.GraceToken
+        let graceTokenPresent = tokenValue.IsSome
 
         let graceTokenValid, graceTokenError =
-            if not graceTokenPresent then
-                false, None
-            elif String.IsNullOrWhiteSpace tokenValue then
-                false, Some $"GRACE_TOKEN is set but empty. Provide a Grace PAT or unset {Constants.EnvironmentVariables.GraceToken}."
-            else
-                let trimmed = tokenValue.Trim()
+            match tokenValue with
+            | None -> false, None
+            | Some value ->
+                let normalized = normalizeBearerToken value
 
-                match Grace.Types.PersonalAccessToken.tryParseToken trimmed with
+                match Grace.Types.PersonalAccessToken.tryParseToken normalized with
                 | Some _ -> true, None
                 | None ->
                     false,
-                    Some
-                        $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens and bearer prefixes are not valid here."
+                    Some $"GRACE_TOKEN accepts Grace PATs only (prefix {Grace.Types.PersonalAccessToken.TokenPrefix}). Auth0 access tokens are not valid here."
 
         let m2mFields =
             [|

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -118,6 +118,27 @@ module Common =
                 NewDirectoryVersions: MaintenanceScanDirectoryVersionDto array
             }
 
+        type DoctorCheckDto = { Id: string; Category: string; Title: string; Description: string; DefaultEnabled: bool; SupportsOffline: bool }
+
+        type DoctorCheckResultDto = { Id: string; Category: string; Title: string; Status: string; Severity: string; Summary: string }
+
+        type DoctorSummaryDto = { Total: int; Ok: int; Warning: int; Failed: int; Skipped: int }
+
+        type DoctorReportDto =
+            {
+                ReportVersion: string
+                Status: string
+                ExitCode: int
+                Full: bool
+                Offline: bool
+                Strict: bool
+                ListOnly: bool
+                RequestedChecks: string array
+                Catalog: DoctorCheckDto array
+                Checks: DoctorCheckResultDto array
+                Summary: DoctorSummaryDto
+            }
+
         type WatchResultDto = { Started: bool; Completed: bool; Message: string; RootDirectory: string; ServerUri: string; RepositoryId: Guid; BranchId: Guid }
 
     /// The output format for the command.

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -697,6 +697,8 @@ module Doctor =
         |> Option.map (fun diagnostics ->
             $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}, and Grace SDK lifecycle headers reported client status requiring action: {lifecycleSummary diagnostics}. Update the Grace CLI/SDK or otherwise address the lifecycle status before retrying.")
 
+    let private isSuccessfulHttpStatus (statusCode: HttpStatusCode) = int statusCode >= 200 && int statusCode <= 299
+
     let private probeFailureSummary inspection =
         match inspection with
         | ServerProbeSkipped message -> message
@@ -882,10 +884,7 @@ module Doctor =
         | ServerHealthzReachableCheckId ->
             match context.ServerHealthzInspection.Value with
             | ServerProbeSkipped message -> skipped check message
-            | ServerProbeSucceeded response when
-                int response.StatusCode >= 200
-                && int response.StatusCode <= 299
-                ->
+            | ServerProbeSucceeded response when isSuccessfulHttpStatus response.StatusCode ->
                 ok $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}; timeout was {DoctorServerProbeTimeoutMilliseconds} ms."
             | ServerProbeSucceeded response ->
                 match healthzLifecycleRejectionSummary response with
@@ -903,6 +902,12 @@ module Doctor =
         | ServerLifecycleHeadersCheckId ->
             match context.ServerHealthzInspection.Value with
             | ServerProbeSkipped message -> skipped check message
+            | ServerProbeSucceeded response when not (isSuccessfulHttpStatus response.StatusCode) ->
+                match healthzLifecycleRejectionSummary response with
+                | Some summary -> failed summary
+                | None ->
+                    failed
+                        $"Could not inspect lifecycle headers because /healthz returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
             | ServerProbeSucceeded response ->
                 match response.LifecycleDiagnostics with
                 | None -> ok "No Grace SDK lifecycle headers were returned by /healthz."
@@ -926,10 +931,7 @@ module Doctor =
                     match probeServer "auth/me" (Some token) effectiveServerUri
                           |> fun task -> task.GetAwaiter().GetResult()
                         with
-                    | ServerProbeSucceeded response when
-                        int response.StatusCode >= 200
-                        && int response.StatusCode <= 299
-                        ->
+                    | ServerProbeSucceeded response when isSuccessfulHttpStatus response.StatusCode ->
                         ok
                             $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
                     | ServerProbeSucceeded response ->

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -397,7 +397,7 @@ module Doctor =
     type private ConfigurationInspectionState =
         | ConfigurationLoaded of Configuration.GraceConfigurationInspection
         | ConfigurationMissing of string
-        | ConfigurationMalformed of string
+        | ConfigurationMalformed of path: string * message: string
 
     type private DoctorInspectionContext =
         {
@@ -415,13 +415,13 @@ module Doctor =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
             | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
-            | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
+            | Error (Configuration.ConfigurationFileMalformed (path, message)) -> ConfigurationMalformed(path, message)
 
         let localStateDbPath =
             match configurationState with
             | ConfigurationLoaded inspection -> inspection.Configuration.GraceStatusFile
-            | ConfigurationMissing _
-            | ConfigurationMalformed _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+            | ConfigurationMalformed (path, _) -> Path.Combine(Path.GetDirectoryName(path), Constants.GraceLocalStateDbFileName)
+            | ConfigurationMissing _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
 
         {
             ConfigurationState = configurationState
@@ -632,12 +632,12 @@ module Doctor =
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
             | ConfigurationMissing message -> warning $"{message} No configuration file was created."
-            | ConfigurationMalformed _ -> ok $"Found {Constants.GraceConfigFileName}, but parsing is reported by {ConfigFileParseCheckId}."
+            | ConfigurationMalformed (path, _) -> ok $"Found {Constants.GraceConfigFileName} at {path}, but parsing is reported by {ConfigFileParseCheckId}."
         | ConfigFileParseCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Parsed {inspection.Path} without rewriting it."
             | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
-            | ConfigurationMalformed message -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
+            | ConfigurationMalformed (_, message) -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
         | ConfigRepositoryIdentityCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection ->

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -51,7 +51,7 @@ module Doctor =
                 OptionName.Check,
                 Required = false,
                 Description = "Filter the scaffolded doctor report by check ID or category. Repeat or separate values with commas.",
-                Arity = ArgumentArity.ZeroOrMore
+                Arity = ArgumentArity.OneOrMore
             )
 
         let strict =
@@ -117,11 +117,11 @@ module Doctor =
         | Unknown of string array
         | OfflineExcluded of string array
 
-    let private selectedCatalogEntries full offline requestedTokens =
+    let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
             |> Array.filter (fun check ->
-                (full || check.DefaultEnabled)
+                (full || listOnly || check.DefaultEnabled)
                 && (not offline || check.SupportsOffline))
 
         if Array.isEmpty requestedTokens then
@@ -159,8 +159,8 @@ module Doctor =
             else
                 Ok(selected |> Seq.toArray)
 
-    let private validateChecks parseResult full offline requestedTokens =
-        match selectedCatalogEntries full offline requestedTokens with
+    let private validateChecks parseResult full offline listOnly requestedTokens =
+        match selectedCatalogEntries full offline listOnly requestedTokens with
         | Ok checks -> Ok checks
         | Error (OfflineExcluded tokens) ->
             let tokens = String.Join(", ", tokens)
@@ -286,7 +286,7 @@ module Doctor =
                 parseResult.GetValue(Options.check)
                 |> tokenizeChecks
 
-            match validateChecks parseResult full offline requestedTokens with
+            match validateChecks parseResult full offline listChecks requestedTokens with
             | Error error -> renderOutput parseResult (Error error)
             | Ok checks ->
                 let report = createReport full offline strict listChecks requestedTokens checks

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1,5 +1,6 @@
 namespace Grace.CLI.Command
 
+open Grace.CLI
 open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
@@ -11,6 +12,7 @@ open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
+open System.IO
 open System.Threading
 open System.Threading.Tasks
 
@@ -57,6 +59,33 @@ module Doctor =
 
     [<Literal>]
     let private AuthOidcConfigurationCheckId = "auth.oidc.configuration"
+
+    [<Literal>]
+    let private StateDbFilePresentCheckId = "state.db.file-present"
+
+    [<Literal>]
+    let private StateDbReadOnlyOpenCheckId = "state.db.read-only-open"
+
+    [<Literal>]
+    let private StateDbSchemaVersionCheckId = "state.db.schema-version"
+
+    [<Literal>]
+    let private StateDbRequiredTablesCheckId = "state.db.required-tables"
+
+    [<Literal>]
+    let private StateDbRequiredIndexesCheckId = "state.db.required-indexes"
+
+    [<Literal>]
+    let private StateDbIntegrityCheckId = "state.db.integrity-check"
+
+    [<Literal>]
+    let private StateDbForeignKeyCheckId = "state.db.foreign-key-check"
+
+    [<Literal>]
+    let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
+
+    [<Literal>]
+    let private ExpectedLocalStateSchemaVersion = "2"
 
     module private Options =
         let full =
@@ -210,6 +239,70 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = StateDbFilePresentCheckId
+                Category = "Local state"
+                Title = "Local state database file"
+                Description = "Checks the configured .grace/grace-local.db path without creating directories or files."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbReadOnlyOpenCheckId
+                Category = "Local state"
+                Title = "Local state read-only open"
+                Description = "Opens the local state SQLite database in read-only mode without initialization, migration, or repair."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbSchemaVersionCheckId
+                Category = "Local state"
+                Title = "Local state schema version"
+                Description = "Reads the local state schema_version metadata without writing defaults."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbRequiredTablesCheckId
+                Category = "Local state"
+                Title = "Local state required tables"
+                Description = "Verifies required local state tables from sqlite_master without creating schema objects."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbRequiredIndexesCheckId
+                Category = "Local state"
+                Title = "Local state required indexes"
+                Description = "Verifies required local state indexes from sqlite_master without creating schema objects."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbIntegrityCheckId
+                Category = "Local state"
+                Title = "SQLite integrity check"
+                Description = "Runs SQLite integrity_check read-only and reports the result without repair."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbForeignKeyCheckId
+                Category = "Local state"
+                Title = "SQLite foreign-key check"
+                Description = "Runs SQLite foreign_key_check read-only and reports violations without mutation."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ObjectCacheIndexReadableCheckId
+                Category = "Object cache"
+                Title = "Object-cache index readability"
+                Description = "Reads object-cache metadata tables from the local state database without repairing rows."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -312,6 +405,7 @@ module Doctor =
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
+            LocalStateInspection: LocalStateDb.ReadOnlyLocalStateInspection
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -323,6 +417,12 @@ module Doctor =
             | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
             | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
 
+        let localStateDbPath =
+            match configurationState with
+            | ConfigurationLoaded inspection -> inspection.Configuration.GraceStatusFile
+            | ConfigurationMissing _
+            | ConfigurationMalformed _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
         {
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
@@ -330,6 +430,7 @@ module Doctor =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
             AuthInspection = Auth.inspectAuthEnvironment ()
+            LocalStateInspection = LocalStateDb.inspectReadOnly localStateDbPath
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -348,6 +449,20 @@ module Doctor =
         |> Array.map (fun field -> field.Name)
 
     let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
+
+    let private formatListOrNone (values: string array) = if Array.isEmpty values then "none" else String.Join(", ", values)
+
+    let private localStateUnavailableSummary checkId (inspection: LocalStateDb.ReadOnlyLocalStateInspection) =
+        if not inspection.ParentDirectoryExists then
+            $"Skipped because {StateDbFilePresentCheckId} did not find the local .grace directory for {inspection.DbPath}; doctor did not create it."
+        elif inspection.DbPathIsDirectory then
+            $"Skipped because {StateDbFilePresentCheckId} found a directory at the database path {inspection.DbPath}."
+        elif not inspection.DbFileExists then
+            $"Skipped because {StateDbFilePresentCheckId} did not find {inspection.DbPath}; doctor did not create it."
+        else
+            match inspection.OpenError with
+            | Some message -> $"Skipped because {StateDbReadOnlyOpenCheckId} could not open the database read-only: {message}"
+            | None -> $"Skipped because {checkId} requires a read-only local state database inspection."
 
     let private oidcSummary (auth: Auth.AuthInspection) =
         let m2mMissing = missingRequiredFields auth.M2mFields
@@ -416,6 +531,103 @@ module Doctor =
             if auth.M2mComplete || auth.CliComplete then ok summary
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
+        | StateDbFilePresentCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.ParentDirectoryExists then
+                warning
+                    $"Local state directory was not found for {inspection.DbPath}; doctor did not create it. Run a Grace command that initializes local state when you are ready to create evidence."
+            elif inspection.DbPathIsDirectory then
+                failed
+                    $"Local state database path is a directory: {inspection.DbPath}. Move the directory aside or restore a valid {Constants.GraceLocalStateDbFileName} file."
+            elif not inspection.DbFileExists then
+                warning
+                    $"Local state database was not found at {inspection.DbPath}; doctor did not create it. Run a Grace command that initializes local state when local status is expected."
+            else
+                ok $"Local state database file exists at {inspection.DbPath}."
+        | StateDbReadOnlyOpenCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if inspection.OpenedReadOnly then
+                ok "Opened the local state database with SQLite read-only mode. No initialization, migration, WAL change, or repair was attempted."
+            elif inspection.DbPathIsDirectory then
+                failed $"Could not open local state read-only because the DB path is a directory: {inspection.DbPath}."
+            elif inspection.ParentDirectoryExists
+                 && inspection.DbFileExists then
+                let openError =
+                    inspection.OpenError
+                    |> Option.defaultValue "unknown SQLite error"
+
+                failed $"Could not open local state read-only: {openError}"
+            else
+                skipped check (localStateUnavailableSummary StateDbReadOnlyOpenCheckId inspection)
+        | StateDbSchemaVersionCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbSchemaVersionCheckId inspection)
+            else
+                match inspection.SchemaVersion with
+                | Some version when version = ExpectedLocalStateSchemaVersion -> ok $"Local state schema_version is {ExpectedLocalStateSchemaVersion}."
+                | Some version ->
+                    failed
+                        $"Local state schema_version is {version}; expected {ExpectedLocalStateSchemaVersion}. Doctor did not migrate, recreate, or move corrupt database files."
+                | None -> failed "Local state schema_version metadata is missing or unreadable. Doctor did not write default metadata."
+        | StateDbRequiredTablesCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbRequiredTablesCheckId inspection)
+            elif Array.isEmpty inspection.MissingRequiredTables then
+                ok "All required local state tables are present."
+            else
+                failed $"Missing required local state tables: {formatListOrNone inspection.MissingRequiredTables}. Doctor did not create schema objects."
+        | StateDbRequiredIndexesCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbRequiredIndexesCheckId inspection)
+            elif Array.isEmpty inspection.MissingRequiredIndexes then
+                ok "All required local state indexes are present."
+            else
+                failed $"Missing required local state indexes: {formatListOrNone inspection.MissingRequiredIndexes}. Doctor did not create schema objects."
+        | StateDbIntegrityCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbIntegrityCheckId inspection)
+            elif inspection.IntegrityCheckRows.Length = 1
+                 && inspection
+                     .IntegrityCheckRows[ 0 ]
+                     .Equals("ok", StringComparison.OrdinalIgnoreCase) then
+                ok "SQLite integrity_check returned ok."
+            else
+                failed $"SQLite integrity_check reported: {formatListOrNone inspection.IntegrityCheckRows}. Doctor did not repair or rewrite the database."
+        | StateDbForeignKeyCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbForeignKeyCheckId inspection)
+            elif Array.isEmpty inspection.ForeignKeyViolations then
+                ok "SQLite foreign_key_check returned no violations."
+            else
+                failed
+                    $"SQLite foreign_key_check reported violations: {formatListOrNone inspection.ForeignKeyViolations}. Doctor did not repair object-cache rows."
+        | ObjectCacheIndexReadableCheckId ->
+            let inspection = context.LocalStateInspection
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary ObjectCacheIndexReadableCheckId inspection)
+            else
+                match inspection.ObjectCacheReadable with
+                | Some true -> ok "Object-cache metadata tables are readable from the local state database without mutation."
+                | Some false ->
+                    let objectCacheError =
+                        inspection.ObjectCacheError
+                        |> Option.defaultValue "unknown SQLite error"
+
+                    failed $"Object-cache metadata is not readable: {objectCacheError}. Doctor did not repair object-cache rows."
+                | None -> skipped check "Object-cache metadata readability was not attempted."
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -113,6 +113,10 @@ module Doctor =
             |> Array.filter (String.IsNullOrWhiteSpace >> not)
             |> Array.distinctBy (fun value -> value.ToUpperInvariant())
 
+    type private SelectionError =
+        | Unknown of string array
+        | OfflineExcluded of string array
+
     let private selectedCatalogEntries full offline requestedTokens =
         let profileEntries =
             catalog
@@ -125,6 +129,7 @@ module Doctor =
         else
             let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
             let unknown = ResizeArray<string>()
+            let excludedOffline = ResizeArray<string>()
 
             for token in requestedTokens do
                 let matches =
@@ -137,17 +142,36 @@ module Doctor =
                     unknown.Add(token)
                 else
                     for check in matches do
-                        if
-                            (full || check.DefaultEnabled)
-                            && (not offline || check.SupportsOffline)
-                            && not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase)))
-                        then
+                        if offline && not check.SupportsOffline then
+                            excludedOffline.Add(check.Id)
+                        elif not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
                             selected.Add(check)
 
             if unknown.Count > 0 then
-                Error(unknown |> Seq.toArray)
+                Error(Unknown(unknown |> Seq.toArray))
+            elif excludedOffline.Count > 0 then
+                let tokens =
+                    excludedOffline
+                    |> Seq.distinctBy (fun value -> value.ToUpperInvariant())
+                    |> Seq.toArray
+
+                Error(OfflineExcluded tokens)
             else
                 Ok(selected |> Seq.toArray)
+
+    let private validateChecks parseResult full offline requestedTokens =
+        match selectedCatalogEntries full offline requestedTokens with
+        | Ok checks -> Ok checks
+        | Error (OfflineExcluded tokens) ->
+            let tokens = String.Join(", ", tokens)
+            Error(GraceError.Create $"Doctor check token is not available in offline mode: {tokens}." (getCorrelationId parseResult))
+        | Error (Unknown unknown) ->
+            let tokens = String.Join(", ", unknown)
+            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
+
+    let private shouldRenderHumanReport parseResult =
+        not (parseResult |> json)
+        && (parseResult |> hasOutput)
 
     let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         {
@@ -247,13 +271,6 @@ module Doctor =
 
         AnsiConsole.Write(table)
 
-    let private validateChecks parseResult full offline requestedTokens =
-        match selectedCatalogEntries full offline requestedTokens with
-        | Ok checks -> Ok checks
-        | Error unknown ->
-            let tokens = String.Join(", ", unknown)
-            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
-
     type Invoke() =
         inherit SynchronousCommandLineAction()
 
@@ -273,14 +290,13 @@ module Doctor =
             | Error error -> renderOutput parseResult (Error error)
             | Ok checks ->
                 let report = createReport full offline strict listChecks requestedTokens checks
+                let renderResult = renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
 
-                if parseResult |> json then
-                    renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
-                    |> ignore
-                else
+                if renderResult = 0
+                   && shouldRenderHumanReport parseResult then
                     renderHumanReport report
 
-                diagnosticExitCode strict report
+                if renderResult <> 0 then renderResult else diagnosticExitCode strict report
 
     let Build =
         let doctorCommand =

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -46,6 +46,18 @@ module Doctor =
     [<Literal>]
     let private IgnoreEntriesParseCheckId = "ignore.entries.parse"
 
+    [<Literal>]
+    let private AuthSourceDetectedCheckId = "auth.source.detected"
+
+    [<Literal>]
+    let private AuthEnvTokenValidCheckId = "auth.env-token.valid"
+
+    [<Literal>]
+    let private AuthTokenFileUnsupportedCheckId = "auth.token-file.unsupported"
+
+    [<Literal>]
+    let private AuthOidcConfigurationCheckId = "auth.oidc.configuration"
+
     module private Options =
         let full =
             new Option<bool>(
@@ -166,6 +178,38 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = AuthSourceDetectedCheckId
+                Category = "Authentication"
+                Title = "Authentication source"
+                Description = "Classifies the likely local authentication source from environment configuration without acquiring credentials."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthEnvTokenValidCheckId
+                Category = "Authentication"
+                Title = "GRACE_TOKEN PAT shape"
+                Description = "Validates GRACE_TOKEN with the pure Grace PAT parser without printing or verifying the token."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthTokenFileUnsupportedCheckId
+                Category = "Authentication"
+                Title = "GRACE_TOKEN_FILE unsupported"
+                Description = "Reports unsupported token-file configuration and recommends GRACE_TOKEN."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = AuthOidcConfigurationCheckId
+                Category = "Authentication"
+                Title = "OIDC environment configuration"
+                Description = "Checks OIDC M2M and CLI environment completeness without token requests or secure-store reads."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -267,6 +311,7 @@ module Doctor =
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
+            AuthInspection: Auth.AuthInspection
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -284,12 +329,42 @@ module Doctor =
             EnvironmentServerUri =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
+            AuthInspection = Auth.inspectAuthEnvironment ()
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
         { Id = checkId; Category = category; Title = title; Status = status; Severity = severity; Summary = summary }
 
     let private skipped (check: LocalOutputDto.DoctorCheckDto) summary = checkResult check.Id check.Category check.Title "Skipped" "Info" summary
+
+    let private missingRequiredFields (fields: Auth.AuthEnvironmentFieldStatus array) =
+        fields
+        |> Array.filter (fun field -> field.Required && not field.IsSet)
+        |> Array.map (fun field -> field.Name)
+
+    let private presentFieldNames (fields: Auth.AuthEnvironmentFieldStatus array) =
+        fields
+        |> Array.filter (fun field -> field.IsSet)
+        |> Array.map (fun field -> field.Name)
+
+    let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
+
+    let private oidcSummary (auth: Auth.AuthInspection) =
+        let m2mMissing = missingRequiredFields auth.M2mFields
+        let cliMissing = missingRequiredFields auth.CliFields
+        let m2mPresent = presentFieldNames auth.M2mFields
+        let cliPresent = presentFieldNames auth.CliFields
+
+        if auth.M2mComplete && auth.CliComplete then
+            "OIDC M2M and CLI environment configuration are complete. No token was requested and no secure token storage was read."
+        elif auth.M2mComplete then
+            $"OIDC M2M environment configuration is complete; CLI OIDC is incomplete with missing required keys: {formatFieldNames cliMissing}. No token was requested."
+        elif auth.CliComplete then
+            $"OIDC CLI environment configuration is complete; M2M OIDC is incomplete with missing required keys: {formatFieldNames m2mMissing}. No browser, device-code flow, or secure token storage was used."
+        elif auth.HasPartialM2m || auth.HasPartialCli then
+            $"OIDC environment configuration is partial. M2M present keys: {formatFieldNames m2mPresent}; M2M missing required keys: {formatFieldNames m2mMissing}. CLI present keys: {formatFieldNames cliPresent}; CLI missing required keys: {formatFieldNames cliMissing}."
+        else
+            "No OIDC environment configuration was detected. Set the OIDC M2M or CLI environment keys, or provide GRACE_TOKEN."
 
     let private resultForCheck (context: DoctorInspectionContext) (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         let ok summary = checkResult check.Id check.Category check.Title "Ok" "Info" summary
@@ -298,6 +373,49 @@ module Doctor =
 
         match check.Id with
         | CliCatalogCheckId -> ok "Doctor check catalog is available."
+        | AuthSourceDetectedCheckId ->
+            let auth = context.AuthInspection
+
+            if auth.HasUsableCredentialSource then
+                ok $"Likely authentication source: {auth.ActiveSource}. Doctor did not acquire, refresh, store, or validate credentials with a provider."
+            elif auth.GraceTokenError.IsSome then
+                warning $"Likely authentication source: {auth.ActiveSource}. {auth.GraceTokenError.Value}"
+            elif auth.GraceTokenFilePresent then
+                warning
+                    $"Likely authentication source: {auth.ActiveSource}. Local token files are unsupported; unset {Constants.EnvironmentVariables.GraceTokenFile} and set {Constants.EnvironmentVariables.GraceToken}."
+            elif auth.HasPartialM2m || auth.HasPartialCli then
+                warning $"No complete authentication source was detected. {oidcSummary auth}"
+            else
+                warning $"No authentication source was detected. Set {Constants.EnvironmentVariables.GraceToken}, OIDC M2M variables, or OIDC CLI variables."
+        | AuthEnvTokenValidCheckId ->
+            let auth = context.AuthInspection
+
+            if not auth.GraceTokenPresent then
+                skipped check $"{Constants.EnvironmentVariables.GraceToken} is not set; no environment PAT was validated."
+            elif auth.GraceTokenValid then
+                ok
+                    $"{Constants.EnvironmentVariables.GraceToken} is set and has a valid Grace PAT shape. The token value was not printed or verified against the server."
+            else
+                failed (
+                    auth.GraceTokenError
+                    |> Option.defaultValue
+                        $"{Constants.EnvironmentVariables.GraceToken} is not a valid Grace PAT. Set a token with prefix {Grace.Types.PersonalAccessToken.TokenPrefix}."
+                )
+        | AuthTokenFileUnsupportedCheckId ->
+            let auth = context.AuthInspection
+
+            if auth.GraceTokenFilePresent then
+                failed
+                    $"Local token files are unsupported. Unset {Constants.EnvironmentVariables.GraceTokenFile} and set {Constants.EnvironmentVariables.GraceToken} to a Grace PAT."
+            else
+                ok $"{Constants.EnvironmentVariables.GraceTokenFile} is not set."
+        | AuthOidcConfigurationCheckId ->
+            let auth = context.AuthInspection
+            let summary = oidcSummary auth
+
+            if auth.M2mComplete || auth.CliComplete then ok summary
+            elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
+            else skipped check summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -5,6 +5,7 @@ open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Client
+open Grace.SDK
 open Grace.Types.Common
 open Spectre.Console
 open System
@@ -13,6 +14,9 @@ open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
 open System.IO
+open System.Net
+open System.Net.Http
+open System.Net.Http.Headers
 open System.Threading
 open System.Threading.Tasks
 
@@ -85,7 +89,19 @@ module Doctor =
     let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
 
     [<Literal>]
+    let private ServerHealthzReachableCheckId = "server.healthz.reachable"
+
+    [<Literal>]
+    let private ServerLifecycleHeadersCheckId = "server.lifecycle.headers"
+
+    [<Literal>]
+    let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
+
+    [<Literal>]
     let private ExpectedLocalStateSchemaVersion = "2"
+
+    [<Literal>]
+    let private DoctorServerProbeTimeoutMilliseconds = 1500
 
     module private Options =
         let full =
@@ -314,7 +330,32 @@ module Doctor =
                 Id = "server.connectivity"
                 Category = "Server"
                 Title = "Grace server connectivity"
-                Description = "Reserved for a later server connectivity diagnostic. Scaffold only; no network probe is executed."
+                Description =
+                    "Reserved compatibility catalog entry. Use the specific server.healthz, server.lifecycle, or server.auth-principal checks for active probes."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerHealthzReachableCheckId
+                Category = "Server"
+                Title = "Grace server /healthz reachability"
+                Description = "Resolves the effective Grace server URI and probes /healthz with a short timeout."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerLifecycleHeadersCheckId
+                Category = "Server"
+                Title = "Grace server lifecycle headers"
+                Description = "Surfaces Grace SDK lifecycle response headers from the anonymous /healthz probe."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = ServerAuthPrincipalAvailableCheckId
+                Category = "Server"
+                Title = "Grace authenticated principal"
+                Description = "Optionally probes /auth/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
                 DefaultEnabled = false
                 SupportsOffline = false
             }
@@ -334,23 +375,20 @@ module Doctor =
             |> Array.filter (String.IsNullOrWhiteSpace >> not)
             |> Array.distinctBy (fun value -> value.ToUpperInvariant())
 
-    type private SelectionError =
-        | Unknown of string array
-        | OfflineExcluded of string array
+    type private SelectionError = Unknown of string array
 
     let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
             |> Array.filter (fun check ->
                 (full || listOnly || check.DefaultEnabled)
-                && (not offline || check.SupportsOffline))
+                && (listOnly || not offline || check.SupportsOffline))
 
         if Array.isEmpty requestedTokens then
             Ok(profileEntries)
         else
             let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
             let unknown = ResizeArray<string>()
-            let excludedOffline = ResizeArray<string>()
 
             for token in requestedTokens do
                 let matches =
@@ -363,29 +401,17 @@ module Doctor =
                     unknown.Add(token)
                 else
                     for check in matches do
-                        if offline && not check.SupportsOffline then
-                            excludedOffline.Add(check.Id)
-                        elif not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
+                        if not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase))) then
                             selected.Add(check)
 
             if unknown.Count > 0 then
                 Error(Unknown(unknown |> Seq.toArray))
-            elif excludedOffline.Count > 0 then
-                let tokens =
-                    excludedOffline
-                    |> Seq.distinctBy (fun value -> value.ToUpperInvariant())
-                    |> Seq.toArray
-
-                Error(OfflineExcluded tokens)
             else
                 Ok(selected |> Seq.toArray)
 
     let private validateChecks parseResult full offline listOnly requestedTokens =
         match selectedCatalogEntries full offline listOnly requestedTokens with
         | Ok checks -> Ok checks
-        | Error (OfflineExcluded tokens) ->
-            let tokens = String.Join(", ", tokens)
-            Error(GraceError.Create $"Doctor check token is not available in offline mode: {tokens}." (getCorrelationId parseResult))
         | Error (Unknown unknown) ->
             let tokens = String.Join(", ", unknown)
             Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
@@ -401,16 +427,157 @@ module Doctor =
 
     type private DoctorInspectionContext =
         {
+            Offline: bool
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
             LocalStateInspection: Lazy<LocalStateDb.ReadOnlyLocalStateInspection>
+            ServerHealthzInspection: Lazy<ServerProbeInspection>
         }
+
+    and private EffectiveServerUri =
+        | EffectiveServerUriResolved of Uri * string
+        | EffectiveServerUriUnavailable of string
+
+    and ServerProbeResponse =
+        {
+            StatusCode: HttpStatusCode
+            ReasonPhrase: string
+            LifecycleDiagnostics: ClientIdentity.LifecycleDiagnostics option
+            Body: string
+        }
+
+    and ServerProbeInspection =
+        | ServerProbeSucceeded of ServerProbeResponse
+        | ServerProbeSkipped of string
+        | ServerProbeInvalidUri of string
+        | ServerProbeTimedOut of string
+        | ServerProbeTlsFailed of string
+        | ServerProbeConnectionFailed of string
+        | ServerProbeFailed of string
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
 
-    let private createInspectionContext () =
+    type ServerProbeRequest = { BaseUri: Uri; RelativePath: string; BearerToken: string option; Timeout: TimeSpan }
+
+    let private normalizeBearerToken (token: string) =
+        let trimmed = token.Trim()
+
+        if trimmed.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) then
+            trimmed.Substring("Bearer ".Length).Trim()
+        else
+            trimmed
+
+    let private buildProbeUri (baseUri: Uri) (relativePath: string) =
+        if not baseUri.IsAbsoluteUri then
+            Error "Effective server URI is not absolute."
+        elif
+            not (baseUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            && not (baseUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        then
+            Error $"Effective server URI uses unsupported scheme '{baseUri.Scheme}'."
+        else
+            let baseText = baseUri.AbsoluteUri.TrimEnd('/')
+            let pathText = relativePath.TrimStart('/')
+            Ok(Uri($"{baseText}/{pathText}"))
+
+    let private defaultServerProbe (request: ServerProbeRequest) =
+        task {
+            match buildProbeUri request.BaseUri request.RelativePath with
+            | Error message -> return ServerProbeInvalidUri message
+            | Ok requestUri ->
+                use cancellationSource = new CancellationTokenSource(request.Timeout)
+                use httpClient = new HttpClient()
+                httpClient.Timeout <- Timeout.InfiniteTimeSpan
+                ClientIdentity.applyHeaders httpClient |> ignore
+
+                use httpRequest = new HttpRequestMessage(HttpMethod.Get, requestUri)
+
+                match request.BearerToken with
+                | Some token -> httpRequest.Headers.Authorization <- AuthenticationHeaderValue("Bearer", token)
+                | None -> ()
+
+                try
+                    use! response = httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationSource.Token)
+                    let! body = response.Content.ReadAsStringAsync(cancellationSource.Token)
+
+                    return
+                        ServerProbeSucceeded
+                            {
+                                StatusCode = response.StatusCode
+                                ReasonPhrase =
+                                    response.ReasonPhrase
+                                    |> Option.ofObj
+                                    |> Option.defaultValue String.Empty
+                                LifecycleDiagnostics = ClientIdentity.parseLifecycleDiagnostics response
+                                Body = body
+                            }
+                with
+                | :? OperationCanceledException when cancellationSource.IsCancellationRequested ->
+                    return ServerProbeTimedOut $"Timed out after {int request.Timeout.TotalMilliseconds} ms while probing {requestUri}."
+                | :? HttpRequestException as ex when
+                    not (isNull ex.InnerException)
+                    && ex
+                        .InnerException
+                        .GetType()
+                        .Name.Contains("Authentication", StringComparison.OrdinalIgnoreCase)
+                    ->
+                    return ServerProbeTlsFailed $"TLS negotiation failed while probing {requestUri}: {ex.Message}"
+                | :? HttpRequestException as ex -> return ServerProbeConnectionFailed $"Could not connect to {requestUri}: {ex.Message}"
+                | ex -> return ServerProbeFailed $"Unexpected server probe failure for {requestUri}: {ex.Message}"
+        }
+
+    let mutable private serverProbeFactory: ServerProbeRequest -> Task<ServerProbeInspection> = defaultServerProbe
+
+    let setServerProbeFactoryForTests factory = serverProbeFactory <- factory
+
+    let resetServerProbeFactoryForTests () = serverProbeFactory <- defaultServerProbe
+
+    let private resolveEffectiveServerUri (configurationState: ConfigurationInspectionState) environmentServerUri =
+        let tryResolve source value =
+            match Uri.TryCreate(value, UriKind.Absolute) with
+            | true, uri when
+                uri.Scheme = Uri.UriSchemeHttp
+                || uri.Scheme = Uri.UriSchemeHttps
+                ->
+                EffectiveServerUriResolved(uri, source)
+            | true, uri -> EffectiveServerUriUnavailable $"Effective server URI from {source} uses unsupported scheme '{uri.Scheme}'."
+            | false, _ -> EffectiveServerUriUnavailable $"Effective server URI from {source} is not an absolute URI: {value}."
+
+        match environmentServerUri with
+        | Some value -> tryResolve Constants.EnvironmentVariables.GraceServerUri value
+        | None ->
+            match configurationState with
+            | ConfigurationLoaded inspection -> tryResolve Constants.GraceConfigFileName inspection.Configuration.ServerUri
+            | ConfigurationMissing _ ->
+                EffectiveServerUriUnavailable
+                    $"No effective server URI was available because {Constants.GraceConfigFileName} was not found and {Constants.EnvironmentVariables.GraceServerUri} is not set."
+            | ConfigurationMalformed _ ->
+                EffectiveServerUriUnavailable
+                    $"No effective server URI was available because {ConfigFileParseCheckId} failed and {Constants.EnvironmentVariables.GraceServerUri} is not set."
+
+    let private validEnvironmentPat (authInspection: Auth.AuthInspection) =
+        if authInspection.GraceTokenValid then
+            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+            |> normalizeOptionalText
+            |> Option.map normalizeBearerToken
+        else
+            None
+
+    let private probeServer relativePath bearerToken effectiveServerUri =
+        match effectiveServerUri with
+        | EffectiveServerUriUnavailable message -> Task.FromResult(ServerProbeInvalidUri message)
+        | EffectiveServerUriResolved (uri, _) ->
+            {
+                BaseUri = uri
+                RelativePath = relativePath
+                BearerToken = bearerToken
+                Timeout = TimeSpan.FromMilliseconds(float DoctorServerProbeTimeoutMilliseconds)
+            }
+            |> serverProbeFactory
+
+    let private createInspectionContext offline =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
@@ -423,14 +590,26 @@ module Doctor =
             | ConfigurationMalformed (path, _) -> Path.Combine(Path.GetDirectoryName(path), Constants.GraceLocalStateDbFileName)
             | ConfigurationMissing _ -> Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
 
+        let environmentServerUri =
+            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+            |> normalizeOptionalText
+
+        let effectiveServerUri = resolveEffectiveServerUri configurationState environmentServerUri
+
         {
+            Offline = offline
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
-            EnvironmentServerUri =
-                Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
-                |> normalizeOptionalText
+            EnvironmentServerUri = environmentServerUri
             AuthInspection = Auth.inspectAuthEnvironment ()
             LocalStateInspection = lazy (LocalStateDb.inspectReadOnly localStateDbPath)
+            ServerHealthzInspection =
+                lazy
+                    (if offline then
+                         ServerProbeSkipped "Skipped because --offline is set; doctor did not perform any server network probe."
+                     else
+                         probeServer "healthz" None effectiveServerUri
+                         |> fun task -> task.GetAwaiter().GetResult())
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -451,6 +630,45 @@ module Doctor =
     let private formatFieldNames (names: string array) = if Array.isEmpty names then "none" else String.Join(", ", names)
 
     let private formatListOrNone (values: string array) = if Array.isEmpty values then "none" else String.Join(", ", values)
+
+    let private lifecycleSummary (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        let details = ResizeArray<string>()
+
+        match diagnostics.Status with
+        | Some status -> details.Add($"status={status}")
+        | None -> ()
+
+        match diagnostics.UnsupportedAfter with
+        | Some unsupportedAfter -> details.Add($"unsupportedAfter={unsupportedAfter}")
+        | None -> ()
+
+        match diagnostics.MinimumVersion with
+        | Some minimumVersion -> details.Add($"minimumVersion={minimumVersion}")
+        | None -> ()
+
+        match diagnostics.RecommendedVersion with
+        | Some recommendedVersion -> details.Add($"recommendedVersion={recommendedVersion}")
+        | None -> ()
+
+        match diagnostics.UpdateUrl with
+        | Some updateUrl -> details.Add($"updateUrl={updateUrl}")
+        | None -> ()
+
+        String.Join("; ", details)
+
+    let private lifecycleHasWarning (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        diagnostics.UnsupportedAfterIsMalformed
+        || diagnostics.UpdateUrlIsHttps = Some false
+
+    let private probeFailureSummary inspection =
+        match inspection with
+        | ServerProbeSkipped message -> message
+        | ServerProbeInvalidUri message -> message
+        | ServerProbeTimedOut message -> message
+        | ServerProbeTlsFailed message -> message
+        | ServerProbeConnectionFailed message -> message
+        | ServerProbeFailed message -> message
+        | ServerProbeSucceeded response -> $"Server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}."
 
     let private localStateUnavailableSummary checkId (inspection: LocalStateDb.ReadOnlyLocalStateInspection) =
         if not inspection.ParentDirectoryExists then
@@ -531,6 +749,67 @@ module Doctor =
             if auth.M2mComplete || auth.CliComplete then ok summary
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
+        | ServerHealthzReachableCheckId ->
+            match context.ServerHealthzInspection.Value with
+            | ServerProbeSkipped message -> skipped check message
+            | ServerProbeSucceeded response when
+                int response.StatusCode >= 200
+                && int response.StatusCode <= 299
+                ->
+                ok $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}; timeout was {DoctorServerProbeTimeoutMilliseconds} ms."
+            | ServerProbeSucceeded response ->
+                failed
+                    $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
+            | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
+            | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
+            | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."
+            | ServerProbeInvalidUri message ->
+                failed
+                    $"{message} Set {Constants.EnvironmentVariables.GraceServerUri} or {Constants.GraceConfigFileName} serverUri to an absolute http/https URI."
+            | ServerProbeFailed message -> failed message
+        | ServerLifecycleHeadersCheckId ->
+            match context.ServerHealthzInspection.Value with
+            | ServerProbeSkipped message -> skipped check message
+            | ServerProbeSucceeded response ->
+                match response.LifecycleDiagnostics with
+                | None -> ok "No Grace SDK lifecycle headers were returned by /healthz."
+                | Some diagnostics when lifecycleHasWarning diagnostics ->
+                    warning
+                        $"Lifecycle headers were returned by /healthz with advisory warnings: {lifecycleSummary diagnostics}. Malformed unsupported-after dates or non-HTTPS update URLs should be corrected server-side."
+                | Some diagnostics -> ok $"Lifecycle headers were returned by /healthz: {lifecycleSummary diagnostics}."
+            | failure -> failed $"Could not inspect lifecycle headers because /healthz did not produce a response: {probeFailureSummary failure}"
+        | ServerAuthPrincipalAvailableCheckId ->
+            if context.Offline then
+                skipped check "Skipped because --offline is set; doctor did not perform the authenticated principal probe."
+            else
+                match validEnvironmentPat context.AuthInspection with
+                | None ->
+                    skipped
+                        check
+                        $"Skipped because no valid non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT is available. Doctor did not use OIDC, token refresh, secure storage, browser, device-code, or SDK auth provider paths."
+                | Some token ->
+                    let effectiveServerUri = resolveEffectiveServerUri context.ConfigurationState context.EnvironmentServerUri
+
+                    match probeServer "auth/me" (Some token) effectiveServerUri
+                          |> fun task -> task.GetAwaiter().GetResult()
+                        with
+                    | ServerProbeSucceeded response when
+                        int response.StatusCode >= 200
+                        && int response.StatusCode <= 299
+                        ->
+                        ok
+                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
+                    | ServerProbeSucceeded response ->
+                        failed
+                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
+                    | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
+                    | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
+                    | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."
+                    | ServerProbeInvalidUri message ->
+                        failed
+                            $"{message} Set {Constants.EnvironmentVariables.GraceServerUri} or {Constants.GraceConfigFileName} serverUri to an absolute http/https URI."
+                    | ServerProbeSkipped message -> skipped check message
+                    | ServerProbeFailed message -> failed message
         | StateDbFilePresentCheckId ->
             let inspection = context.LocalStateInspection.Value
 
@@ -775,7 +1054,7 @@ module Doctor =
             if listOnly then
                 checks |> Array.map listOnlyResultForCheck
             else
-                let context = createInspectionContext ()
+                let context = createInspectionContext offline
                 checks |> Array.map (resultForCheck context)
 
         let summary = summarize results

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -405,7 +405,7 @@ module Doctor =
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
             AuthInspection: Auth.AuthInspection
-            LocalStateInspection: LocalStateDb.ReadOnlyLocalStateInspection
+            LocalStateInspection: Lazy<LocalStateDb.ReadOnlyLocalStateInspection>
         }
 
     let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
@@ -430,7 +430,7 @@ module Doctor =
                 Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
                 |> normalizeOptionalText
             AuthInspection = Auth.inspectAuthEnvironment ()
-            LocalStateInspection = LocalStateDb.inspectReadOnly localStateDbPath
+            LocalStateInspection = lazy (LocalStateDb.inspectReadOnly localStateDbPath)
         }
 
     let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
@@ -532,7 +532,7 @@ module Doctor =
             elif auth.HasPartialM2m || auth.HasPartialCli then warning summary
             else skipped check summary
         | StateDbFilePresentCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.ParentDirectoryExists then
                 warning
@@ -546,7 +546,7 @@ module Doctor =
             else
                 ok $"Local state database file exists at {inspection.DbPath}."
         | StateDbReadOnlyOpenCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if inspection.OpenedReadOnly then
                 ok "Opened the local state database with SQLite read-only mode. No initialization, migration, WAL change, or repair was attempted."
@@ -562,7 +562,7 @@ module Doctor =
             else
                 skipped check (localStateUnavailableSummary StateDbReadOnlyOpenCheckId inspection)
         | StateDbSchemaVersionCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbSchemaVersionCheckId inspection)
@@ -574,7 +574,7 @@ module Doctor =
                         $"Local state schema_version is {version}; expected {ExpectedLocalStateSchemaVersion}. Doctor did not migrate, recreate, or move corrupt database files."
                 | None -> failed "Local state schema_version metadata is missing or unreadable. Doctor did not write default metadata."
         | StateDbRequiredTablesCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbRequiredTablesCheckId inspection)
@@ -583,7 +583,7 @@ module Doctor =
             else
                 failed $"Missing required local state tables: {formatListOrNone inspection.MissingRequiredTables}. Doctor did not create schema objects."
         | StateDbRequiredIndexesCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbRequiredIndexesCheckId inspection)
@@ -592,7 +592,7 @@ module Doctor =
             else
                 failed $"Missing required local state indexes: {formatListOrNone inspection.MissingRequiredIndexes}. Doctor did not create schema objects."
         | StateDbIntegrityCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbIntegrityCheckId inspection)
@@ -604,7 +604,7 @@ module Doctor =
             else
                 failed $"SQLite integrity_check reported: {formatListOrNone inspection.IntegrityCheckRows}. Doctor did not repair or rewrite the database."
         | StateDbForeignKeyCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary StateDbForeignKeyCheckId inspection)
@@ -614,7 +614,7 @@ module Doctor =
                 failed
                     $"SQLite foreign_key_check reported violations: {formatListOrNone inspection.ForeignKeyViolations}. Doctor did not repair object-cache rows."
         | ObjectCacheIndexReadableCheckId ->
-            let inspection = context.LocalStateInspection
+            let inspection = context.LocalStateInspection.Value
 
             if not inspection.OpenedReadOnly then
                 skipped check (localStateUnavailableSummary ObjectCacheIndexReadableCheckId inspection)

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -777,8 +777,9 @@ module Doctor =
                                 GraceDirectory = configuration.GraceDirectory
                                 GraceStatusFile = configuration.GraceStatusFile
                                 DirectoryIgnoreEntries =
-                                    inspection.Ignore.DirectoryEntries
+                                    inspection.Ignore.Entries
                                     |> Array.map (fun entry -> $"*{entry}")
+                                    |> Array.distinct
                                 FileIgnoreEntries = inspection.Ignore.FileEntries
                             }
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -275,7 +275,11 @@ module Doctor =
         inherit SynchronousCommandLineAction()
 
         override _.Invoke(parseResult: ParseResult) : int =
-            if parseResult |> verbose then printParseResult parseResult
+            if
+                (parseResult |> verbose)
+                && not (parseResult |> hasSelect)
+            then
+                printParseResult parseResult
 
             let full = parseResult.GetValue(Options.full)
             let offline = parseResult.GetValue(Options.offline)

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1,0 +1,295 @@
+namespace Grace.CLI.Command
+
+open Grace.CLI.Common
+open Grace.CLI.Text
+open Grace.Shared
+open Grace.Types.Common
+open Spectre.Console
+open System
+open System.Collections.Generic
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Threading
+open System.Threading.Tasks
+
+module Doctor =
+
+    [<Literal>]
+    let ReportVersion = "doctor-report-v1"
+
+    module private Options =
+        let full =
+            new Option<bool>(
+                OptionName.Full,
+                Required = false,
+                Description = "Include checks reserved for the full doctor profile.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let offline =
+            new Option<bool>(
+                OptionName.Offline,
+                Required = false,
+                Description = "Limit the scaffolded report to checks that can run without network access.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let listChecks =
+            new Option<bool>(
+                OptionName.ListChecks,
+                Required = false,
+                Description = "List the inert doctor check catalog without running diagnostics.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let check =
+            new Option<string []>(
+                OptionName.Check,
+                Required = false,
+                Description = "Filter the scaffolded doctor report by check ID or category. Repeat or separate values with commas.",
+                Arity = ArgumentArity.ZeroOrMore
+            )
+
+        let strict =
+            new Option<bool>(
+                OptionName.Strict,
+                Required = false,
+                Description = "Return a failing exit code when the doctor report status is Warning.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+    let catalog: LocalOutputDto.DoctorCheckDto array =
+        [|
+            {
+                Id = "cli.catalog"
+                Category = "CLI"
+                Title = "CLI command catalog"
+                Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = "configuration.config-file"
+                Category = "Configuration"
+                Title = "Grace configuration file"
+                Description = "Reserved for a later configuration-file diagnostic. Scaffold only; no file is read in this slice."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = "identity.auth-session"
+                Category = "Identity"
+                Title = "Authentication session"
+                Description = "Reserved for a later authentication diagnostic. Scaffold only; no auth state is read in this slice."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+            {
+                Id = "server.connectivity"
+                Category = "Server"
+                Title = "Grace server connectivity"
+                Description = "Reserved for a later server connectivity diagnostic. Scaffold only; no network probe is executed."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+        |]
+
+    let private tokenizeChecks (values: string array) =
+        if isNull values then
+            Array.empty
+        else
+            values
+            |> Array.collect (fun value ->
+                value.Split(
+                    ',',
+                    StringSplitOptions.RemoveEmptyEntries
+                    ||| StringSplitOptions.TrimEntries
+                ))
+            |> Array.filter (String.IsNullOrWhiteSpace >> not)
+            |> Array.distinctBy (fun value -> value.ToUpperInvariant())
+
+    let private selectedCatalogEntries full offline requestedTokens =
+        let profileEntries =
+            catalog
+            |> Array.filter (fun check ->
+                (full || check.DefaultEnabled)
+                && (not offline || check.SupportsOffline))
+
+        if Array.isEmpty requestedTokens then
+            Ok(profileEntries)
+        else
+            let selected = ResizeArray<LocalOutputDto.DoctorCheckDto>()
+            let unknown = ResizeArray<string>()
+
+            for token in requestedTokens do
+                let matches =
+                    catalog
+                    |> Array.filter (fun check ->
+                        check.Id.Equals(token, StringComparison.OrdinalIgnoreCase)
+                        || check.Category.Equals(token, StringComparison.OrdinalIgnoreCase))
+
+                if Array.isEmpty matches then
+                    unknown.Add(token)
+                else
+                    for check in matches do
+                        if
+                            (full || check.DefaultEnabled)
+                            && (not offline || check.SupportsOffline)
+                            && not (selected.Exists(fun existing -> existing.Id.Equals(check.Id, StringComparison.OrdinalIgnoreCase)))
+                        then
+                            selected.Add(check)
+
+            if unknown.Count > 0 then
+                Error(unknown |> Seq.toArray)
+            else
+                Ok(selected |> Seq.toArray)
+
+    let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+        {
+            Id = check.Id
+            Category = check.Category
+            Title = check.Title
+            Status = "Ok"
+            Severity = "Info"
+            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+        }
+
+    let private summarize (checks: LocalOutputDto.DoctorCheckResultDto array) =
+        let count status =
+            checks
+            |> Array.filter (fun check -> check.Status.Equals(status, StringComparison.OrdinalIgnoreCase))
+            |> Array.length
+
+        {
+            LocalOutputDto.DoctorSummaryDto.Total = checks.Length
+            LocalOutputDto.DoctorSummaryDto.Ok = count "Ok"
+            LocalOutputDto.DoctorSummaryDto.Warning = count "Warning"
+            LocalOutputDto.DoctorSummaryDto.Failed = count "Failed"
+            LocalOutputDto.DoctorSummaryDto.Skipped = count "Skipped"
+        }
+
+    let private reportStatus (summary: LocalOutputDto.DoctorSummaryDto) =
+        if summary.Failed > 0 then "Failed"
+        elif summary.Warning > 0 then "Warning"
+        else "Ok"
+
+    let diagnosticExitCode strict (report: LocalOutputDto.DoctorReportDto) =
+        if report.Status.Equals("Failed", StringComparison.OrdinalIgnoreCase) then
+            1
+        elif
+            strict
+            && report.Status.Equals("Warning", StringComparison.OrdinalIgnoreCase)
+        then
+            1
+        else
+            0
+
+    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+        let results = checks |> Array.map resultForCheck
+        let summary = summarize results
+        let status = reportStatus summary
+
+        let report: LocalOutputDto.DoctorReportDto =
+            {
+                ReportVersion = ReportVersion
+                Status = status
+                ExitCode = 0
+                Full = full
+                Offline = offline
+                Strict = false
+                ListOnly = listOnly
+                RequestedChecks = Array.empty
+                Catalog = checks
+                Checks = results
+                Summary = summary
+            }
+
+        { report with ExitCode = diagnosticExitCode false report }
+
+    let withStatus status (report: LocalOutputDto.DoctorReportDto) =
+        let checks =
+            if report.Checks.Length = 0 then
+                report.Checks
+            else
+                report.Checks
+                |> Array.mapi (fun index check -> if index = 0 then { check with Status = status } else check)
+
+        let summary = summarize checks
+        let normalizedStatus = reportStatus summary
+        let updated = { report with Status = normalizedStatus; Checks = checks; Summary = summary }
+        { updated with ExitCode = diagnosticExitCode updated.Strict updated }
+
+    let private createReport full offline strict listOnly requestedTokens checks =
+        let report = createReportForChecks full offline listOnly checks
+
+        let report = { report with Strict = strict; RequestedChecks = requestedTokens }
+
+        { report with ExitCode = diagnosticExitCode strict report }
+
+    let private renderHumanReport (report: LocalOutputDto.DoctorReportDto) =
+        AnsiConsole.MarkupLine("[bold]Grace doctor[/]")
+        AnsiConsole.MarkupLine($"Status: {report.Status}; checks: {report.Summary.Total}; exit code: {report.ExitCode}")
+
+        let table = Table(Border = TableBorder.Rounded)
+        table.AddColumn("Check") |> ignore
+        table.AddColumn("Category") |> ignore
+        table.AddColumn("Status") |> ignore
+        table.AddColumn("Summary") |> ignore
+
+        for check in report.Checks do
+            table.AddRow(Markup.Escape(check.Id), Markup.Escape(check.Category), Markup.Escape(check.Status), Markup.Escape(check.Summary))
+            |> ignore
+
+        AnsiConsole.Write(table)
+
+    let private validateChecks parseResult full offline requestedTokens =
+        match selectedCatalogEntries full offline requestedTokens with
+        | Ok checks -> Ok checks
+        | Error unknown ->
+            let tokens = String.Join(", ", unknown)
+            Error(GraceError.Create $"Unknown doctor check token: {tokens}." (getCorrelationId parseResult))
+
+    type Invoke() =
+        inherit SynchronousCommandLineAction()
+
+        override _.Invoke(parseResult: ParseResult) : int =
+            if parseResult |> verbose then printParseResult parseResult
+
+            let full = parseResult.GetValue(Options.full)
+            let offline = parseResult.GetValue(Options.offline)
+            let strict = parseResult.GetValue(Options.strict)
+            let listChecks = parseResult.GetValue(Options.listChecks)
+
+            let requestedTokens =
+                parseResult.GetValue(Options.check)
+                |> tokenizeChecks
+
+            match validateChecks parseResult full offline requestedTokens with
+            | Error error -> renderOutput parseResult (Error error)
+            | Ok checks ->
+                let report = createReport full offline strict listChecks requestedTokens checks
+
+                if parseResult |> json then
+                    renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
+                    |> ignore
+                else
+                    renderHumanReport report
+
+                diagnosticExitCode strict report
+
+    let Build =
+        let doctorCommand =
+            new Command("doctor", Description = "Inspect the local Grace environment with inert scaffolded diagnostics.")
+            |> addOption Options.full
+            |> addOption Options.offline
+            |> addOption Options.listChecks
+            |> addOption Options.check
+            |> addOption Options.strict
+
+        doctorCommand.Action <- Invoke()
+        doctorCommand

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -733,20 +733,33 @@ module Doctor =
     let private workingTreeScanRemediation =
         "Run `grace maintenance scan` to inspect details or `grace maintenance update-index` when you intentionally want local state to match the current working tree."
 
+    type private WorkingTreeScanSummaryResult =
+        | WorkingTreeScanPrerequisiteSkipped of string
+        | WorkingTreeScanFailed of string
+        | WorkingTreeScanSummary of string
+
+    let mutable private workingTreeScanner = Services.scanWorkingTreeForDifferencesReadOnly
+
+    let setWorkingTreeScannerForTests scanner = workingTreeScanner <- scanner
+
+    let resetWorkingTreeScannerForTests () = workingTreeScanner <- Services.scanWorkingTreeForDifferencesReadOnly
+
     let private workingTreeScanSummary (context: DoctorInspectionContext) =
         match context.ConfigurationState with
-        | ConfigurationMissing _ -> Error $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
-        | ConfigurationMalformed _ -> Error $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigurationMissing _ ->
+            WorkingTreeScanPrerequisiteSkipped $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+        | ConfigurationMalformed _ -> WorkingTreeScanPrerequisiteSkipped $"Skipped because {ConfigFileParseCheckId} failed."
         | ConfigurationLoaded inspection ->
             let localStateInspection = context.LocalStateInspection.Value
 
             if not localStateInspection.OpenedReadOnly then
-                Error(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
+                WorkingTreeScanPrerequisiteSkipped(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
             elif localStateInspection.MissingRequiredTables.Length > 0 then
-                Error $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
+                WorkingTreeScanPrerequisiteSkipped $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
             elif localStateInspection.SchemaVersion
                  <> Some ExpectedLocalStateSchemaVersion then
-                Error $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
+                WorkingTreeScanPrerequisiteSkipped
+                    $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
             else
                 let configuration = inspection.Configuration
 
@@ -759,14 +772,14 @@ module Doctor =
                     |> fun task -> task.GetAwaiter().GetResult()
 
                 match snapshotResult with
-                | Error message -> Error $"Skipped because the read-only local-state snapshot could not be read: {message}"
+                | Error message -> WorkingTreeScanPrerequisiteSkipped $"Skipped because the read-only local-state snapshot could not be read: {message}"
                 | Ok snapshot ->
                     let hasRootDirectoryVersion =
                         snapshot.Index.Values
                         |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
 
                     if not hasRootDirectoryVersion then
-                        Ok(
+                        WorkingTreeScanSummary(
                             "Local-state snapshot is missing the root directory version; doctor did not rebuild it. "
                             + workingTreeScanRemediation
                         )
@@ -777,26 +790,26 @@ module Doctor =
                                 GraceDirectory = configuration.GraceDirectory
                                 GraceStatusFile = configuration.GraceStatusFile
                                 DirectoryIgnoreEntries =
-                                    inspection.Ignore.Entries
+                                    inspection.Ignore.DirectoryEntries
                                     |> Array.map (fun entry -> $"*{entry}")
                                     |> Array.distinct
                                 FileIgnoreEntries = inspection.Ignore.FileEntries
                             }
 
                         let scanResult =
-                            Services.scanWorkingTreeForDifferencesReadOnly scanInput snapshot
+                            workingTreeScanner scanInput snapshot
                             |> fun task -> task.GetAwaiter().GetResult()
 
                         match scanResult with
-                        | Error message -> Error $"Working-tree scan failed without updating local state: {message}"
+                        | Error message -> WorkingTreeScanFailed $"Working-tree scan failed without updating local state: {message}"
                         | Ok differences when differences.Count = 0 ->
-                            Ok "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
+                            WorkingTreeScanSummary "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
                         | Ok differences ->
                             let added = countDifferences Add differences
                             let changed = countDifferences Change differences
                             let deleted = countDifferences Delete differences
 
-                            Ok
+                            WorkingTreeScanSummary
                                 $"Working tree differs from the read-only local-state snapshot: {differences.Count} total, {added} added, {changed} changed, {deleted} deleted. {workingTreeScanRemediation}"
 
     let private oidcSummary (auth: Auth.AuthInspection) =
@@ -1037,9 +1050,10 @@ module Doctor =
                     $"Skipped in the default profile because working-tree drift scanning can hash repository files. Re-run with --full or --check {WorkingTreeScanCheckId}. {workingTreeScanRemediation}"
             else
                 match workingTreeScanSummary context with
-                | Error message -> skipped check message
-                | Ok summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
-                | Ok summary -> warning summary
+                | WorkingTreeScanPrerequisiteSkipped message -> skipped check message
+                | WorkingTreeScanFailed message -> failed message
+                | WorkingTreeScanSummary summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
+                | WorkingTreeScanSummary summary -> warning summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -3,6 +3,7 @@ namespace Grace.CLI.Command
 open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
+open Grace.Shared.Client
 open Grace.Types.Common
 open Spectre.Console
 open System
@@ -17,6 +18,33 @@ module Doctor =
 
     [<Literal>]
     let ReportVersion = "doctor-report-v1"
+
+    [<Literal>]
+    let private CliCatalogCheckId = "cli.catalog"
+
+    [<Literal>]
+    let private ConfigFileDiscoverCheckId = "config.file.discover"
+
+    [<Literal>]
+    let private ConfigFileParseCheckId = "config.file.parse"
+
+    [<Literal>]
+    let private ConfigRepositoryIdentityCheckId = "config.repository.identity"
+
+    [<Literal>]
+    let private ConfigServerUriCheckId = "config.server-uri.valid"
+
+    [<Literal>]
+    let private ServerUriConsistencyCheckId = "server-uri.consistency"
+
+    [<Literal>]
+    let private UserConfigDiscoverCheckId = "user-config.file.discover"
+
+    [<Literal>]
+    let private UserConfigParseCheckId = "user-config.file.parse"
+
+    [<Literal>]
+    let private IgnoreEntriesParseCheckId = "ignore.entries.parse"
 
     module private Options =
         let full =
@@ -66,18 +94,74 @@ module Doctor =
     let catalog: LocalOutputDto.DoctorCheckDto array =
         [|
             {
-                Id = "cli.catalog"
+                Id = CliCatalogCheckId
                 Category = "CLI"
                 Title = "CLI command catalog"
-                Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                Description = "Verifies that the Grace CLI command catalog is available."
                 DefaultEnabled = true
                 SupportsOffline = true
             }
             {
-                Id = "configuration.config-file"
+                Id = ConfigFileDiscoverCheckId
                 Category = "Configuration"
-                Title = "Grace configuration file"
-                Description = "Reserved for a later configuration-file diagnostic. Scaffold only; no file is read in this slice."
+                Title = "Grace configuration discovery"
+                Description = "Finds .grace/graceconfig.json by walking upward from the current directory without creating it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigFileParseCheckId
+                Category = "Configuration"
+                Title = "Grace configuration parse"
+                Description = "Reads .grace/graceconfig.json without rewriting or normalizing it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigRepositoryIdentityCheckId
+                Category = "Configuration"
+                Title = "Repository identity"
+                Description = "Reports whether the repository configuration includes owner, organization, repository, and branch identity values."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ConfigServerUriCheckId
+                Category = "Configuration"
+                Title = "Configured server URI"
+                Description = "Validates the server URI stored in .grace/graceconfig.json without probing the server."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = ServerUriConsistencyCheckId
+                Category = "Configuration"
+                Title = "Server URI consistency"
+                Description = "Compares the configured server URI with GRACE_SERVER_URI when both are present."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = UserConfigDiscoverCheckId
+                Category = "User configuration"
+                Title = "User configuration discovery"
+                Description = "Checks whether ~/.grace/userconfig.json exists without creating it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = UserConfigParseCheckId
+                Category = "User configuration"
+                Title = "User configuration parse"
+                Description = "Reads ~/.grace/userconfig.json without creating or rewriting it."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = IgnoreEntriesParseCheckId
+                Category = "Ignore"
+                Title = ".graceignore entries"
+                Description = "Reads .graceignore entries, ignoring comments and blank lines, without creating the file."
                 DefaultEnabled = true
                 SupportsOffline = true
             }
@@ -173,14 +257,156 @@ module Doctor =
         not (parseResult |> json)
         && (parseResult |> hasOutput)
 
-    let private resultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+    type private ConfigurationInspectionState =
+        | ConfigurationLoaded of Configuration.GraceConfigurationInspection
+        | ConfigurationMissing of string
+        | ConfigurationMalformed of string
+
+    type private DoctorInspectionContext =
+        {
+            ConfigurationState: ConfigurationInspectionState
+            UserConfiguration: UserConfiguration.UserConfigurationInspection
+            EnvironmentServerUri: string option
+        }
+
+    let private normalizeOptionalText value = if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim())
+
+    let private createInspectionContext () =
+        let configurationState =
+            match Configuration.tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection -> ConfigurationLoaded inspection
+            | Error message when message.Contains(Constants.GraceConfigFileName, StringComparison.OrdinalIgnoreCase) -> ConfigurationMissing message
+            | Error message -> ConfigurationMalformed message
+
+        {
+            ConfigurationState = configurationState
+            UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
+            EnvironmentServerUri =
+                Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+                |> normalizeOptionalText
+        }
+
+    let private checkResult checkId category title status severity summary : LocalOutputDto.DoctorCheckResultDto =
+        { Id = checkId; Category = category; Title = title; Status = status; Severity = severity; Summary = summary }
+
+    let private skipped (check: LocalOutputDto.DoctorCheckDto) summary = checkResult check.Id check.Category check.Title "Skipped" "Info" summary
+
+    let private resultForCheck (context: DoctorInspectionContext) (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
+        let ok summary = checkResult check.Id check.Category check.Title "Ok" "Info" summary
+        let warning summary = checkResult check.Id check.Category check.Title "Warning" "Warning" summary
+        let failed summary = checkResult check.Id check.Category check.Title "Failed" "Error" summary
+
+        match check.Id with
+        | CliCatalogCheckId -> ok "Doctor check catalog is available."
+        | ConfigFileDiscoverCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
+            | ConfigurationMissing message -> warning $"{message} No configuration file was created."
+            | ConfigurationMalformed _ -> ok $"Found {Constants.GraceConfigFileName}, but parsing is reported by {ConfigFileParseCheckId}."
+        | ConfigFileParseCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection -> ok $"Parsed {inspection.Path} without rewriting it."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed message -> failed $"Could not parse {Constants.GraceConfigFileName}: {message}"
+        | ConfigRepositoryIdentityCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                let configuration = inspection.Configuration
+
+                let missing =
+                    [|
+                        if configuration.OwnerId = OwnerId.Empty then "ownerId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.OwnerName) then "ownerName"
+
+                        if configuration.OrganizationId = OrganizationId.Empty then "organizationId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.OrganizationName) then
+                            "organizationName"
+
+                        if configuration.RepositoryId = RepositoryId.Empty then "repositoryId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.RepositoryName) then
+                            "repositoryName"
+
+                        if configuration.BranchId = BranchId.Empty then "branchId"
+
+                        if String.IsNullOrWhiteSpace(string configuration.BranchName) then "branchName"
+                    |]
+
+                if Array.isEmpty missing then
+                    ok $"Repository identity is populated for root {inspection.RootDirectory}."
+                else
+                    let missingText = String.Join(", ", missing)
+                    warning $"Repository identity has blank or empty values: {missingText}."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigServerUriCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                match Uri.TryCreate(inspection.Configuration.ServerUri, UriKind.Absolute) with
+                | true, uri when
+                    uri.Scheme = Uri.UriSchemeHttp
+                    || uri.Scheme = Uri.UriSchemeHttps
+                    ->
+                    let normalizedUri = uri.AbsoluteUri.TrimEnd('/')
+                    ok $"Configured server URI is {normalizedUri}."
+                | true, uri -> warning $"Configured server URI uses unsupported scheme '{uri.Scheme}'."
+                | false, _ -> failed $"Configured server URI is not an absolute URI: {inspection.Configuration.ServerUri}."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | ServerUriConsistencyCheckId ->
+            match context.ConfigurationState, context.EnvironmentServerUri with
+            | ConfigurationLoaded inspection, Some environmentServerUri ->
+                match Uri.TryCreate(inspection.Configuration.ServerUri, UriKind.Absolute), Uri.TryCreate(environmentServerUri, UriKind.Absolute) with
+                | (true, configured), (true, environmentValue) ->
+                    let configuredValue = configured.AbsoluteUri.TrimEnd('/')
+                    let environmentValue = environmentValue.AbsoluteUri.TrimEnd('/')
+
+                    if configuredValue.Equals(environmentValue, StringComparison.OrdinalIgnoreCase) then
+                        ok $"Configured server URI and {Constants.EnvironmentVariables.GraceServerUri} match."
+                    else
+                        warning $"Configured server URI '{configuredValue}' differs from {Constants.EnvironmentVariables.GraceServerUri} '{environmentValue}'."
+                | _, (false, _) -> warning $"{Constants.EnvironmentVariables.GraceServerUri} is not an absolute URI: {environmentServerUri}."
+                | (false, _), _ -> skipped check $"Skipped because {ConfigServerUriCheckId} did not produce a valid configured URI."
+            | ConfigurationLoaded _, None ->
+                ok $"{Constants.EnvironmentVariables.GraceServerUri} is not set; configuration server URI is the active local value."
+            | ConfigurationMissing _, _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _, _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | UserConfigDiscoverCheckId ->
+            if context.UserConfiguration.Exists then
+                ok $"Found user configuration at {context.UserConfiguration.Path}."
+            else
+                warning $"User configuration file was not found at {context.UserConfiguration.Path}; no file was created."
+        | UserConfigParseCheckId ->
+            if not context.UserConfiguration.Exists then
+                skipped check $"Skipped because {UserConfigDiscoverCheckId} did not find userconfig.json."
+            else
+                match context.UserConfiguration.ErrorMessage with
+                | Some message -> failed $"Could not parse user configuration: {message}"
+                | None -> ok $"Parsed user configuration at {context.UserConfiguration.Path} without rewriting it."
+        | IgnoreEntriesParseCheckId ->
+            match context.ConfigurationState with
+            | ConfigurationLoaded inspection ->
+                let ignore = inspection.Ignore
+
+                if ignore.Exists then
+                    ok
+                        $".graceignore has {ignore.Entries.Length} active entries: {ignore.FileEntries.Length} file patterns and {ignore.DirectoryEntries.Length} directory patterns."
+                else
+                    warning $".graceignore was not found at {ignore.Path}; no file was created."
+            | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+            | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
+        | _ -> skipped check "No diagnostic implementation is registered for this check."
+
+    let private listOnlyResultForCheck (check: LocalOutputDto.DoctorCheckDto) : LocalOutputDto.DoctorCheckResultDto =
         {
             Id = check.Id
             Category = check.Category
             Title = check.Title
-            Status = "Ok"
+            Status = "Skipped"
             Severity = "Info"
-            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+            Summary = "Catalog discovery only; diagnostic probes were not run."
         }
 
     let private summarize (checks: LocalOutputDto.DoctorCheckResultDto array) =
@@ -214,7 +440,13 @@ module Doctor =
             0
 
     let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
-        let results = checks |> Array.map resultForCheck
+        let results =
+            if listOnly then
+                checks |> Array.map listOnlyResultForCheck
+            else
+                let context = createInspectionContext ()
+                checks |> Array.map (resultForCheck context)
+
         let summary = summarize results
         let status = reportStatus summary
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -89,6 +89,9 @@ module Doctor =
     let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
 
     [<Literal>]
+    let private WorkingTreeScanCheckId = "working-tree.scan"
+
+    [<Literal>]
     let private ServerHealthzReachableCheckId = "server.healthz.reachable"
 
     [<Literal>]
@@ -319,6 +322,15 @@ module Doctor =
                 SupportsOffline = true
             }
             {
+                Id = WorkingTreeScanCheckId
+                Category = "Working tree"
+                Title = "Working-tree drift scan"
+                Description =
+                    "Skipped by default; --full or an explicit working-tree.scan selection compares the working tree to a read-only local-state snapshot."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
                 Id = "identity.auth-session"
                 Category = "Identity"
                 Title = "Authentication session"
@@ -377,6 +389,12 @@ module Doctor =
 
     type private SelectionError = Unknown of string array
 
+    let private categoryMatchesToken (category: string) (token: string) =
+        category.Equals(token, StringComparison.OrdinalIgnoreCase)
+        || category
+            .Replace(" ", "-", StringComparison.OrdinalIgnoreCase)
+            .Equals(token, StringComparison.OrdinalIgnoreCase)
+
     let private selectedCatalogEntries full offline listOnly requestedTokens =
         let profileEntries =
             catalog
@@ -395,7 +413,7 @@ module Doctor =
                     catalog
                     |> Array.filter (fun check ->
                         check.Id.Equals(token, StringComparison.OrdinalIgnoreCase)
-                        || check.Category.Equals(token, StringComparison.OrdinalIgnoreCase))
+                        || categoryMatchesToken check.Category token)
 
                 if Array.isEmpty matches then
                     unknown.Add(token)
@@ -427,7 +445,9 @@ module Doctor =
 
     type private DoctorInspectionContext =
         {
+            Full: bool
             Offline: bool
+            RequestedTokens: string array
             ConfigurationState: ConfigurationInspectionState
             UserConfiguration: UserConfiguration.UserConfigurationInspection
             EnvironmentServerUri: string option
@@ -577,7 +597,7 @@ module Doctor =
             }
             |> serverProbeFactory
 
-    let private createInspectionContext offline =
+    let private createInspectionContext full offline requestedTokens =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
@@ -597,7 +617,9 @@ module Doctor =
         let effectiveServerUri = resolveEffectiveServerUri configurationState environmentServerUri
 
         {
+            Full = full
             Offline = offline
+            RequestedTokens = requestedTokens
             ConfigurationState = configurationState
             UserConfiguration = UserConfiguration.tryInspectUserConfiguration ()
             EnvironmentServerUri = environmentServerUri
@@ -696,6 +718,85 @@ module Doctor =
             match inspection.OpenError with
             | Some message -> $"Skipped because {StateDbReadOnlyOpenCheckId} could not open the database read-only: {message}"
             | None -> $"Skipped because {checkId} requires a read-only local state database inspection."
+
+    let private workingTreeScanExplicitlyRequested (context: DoctorInspectionContext) =
+        context.RequestedTokens
+        |> Array.exists (fun token ->
+            token.Equals(WorkingTreeScanCheckId, StringComparison.OrdinalIgnoreCase)
+            || categoryMatchesToken "Working tree" token)
+
+    let private countDifferences differenceType (differences: List<FileSystemDifference>) =
+        differences
+        |> Seq.filter (fun difference -> difference.DifferenceType = differenceType)
+        |> Seq.length
+
+    let private workingTreeScanRemediation =
+        "Run `grace maintenance scan` to inspect details or `grace maintenance update-index` when you intentionally want local state to match the current working tree."
+
+    let private workingTreeScanSummary (context: DoctorInspectionContext) =
+        match context.ConfigurationState with
+        | ConfigurationMissing _ -> Error $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
+        | ConfigurationMalformed _ -> Error $"Skipped because {ConfigFileParseCheckId} failed."
+        | ConfigurationLoaded inspection ->
+            let localStateInspection = context.LocalStateInspection.Value
+
+            if not localStateInspection.OpenedReadOnly then
+                Error(localStateUnavailableSummary WorkingTreeScanCheckId localStateInspection)
+            elif localStateInspection.MissingRequiredTables.Length > 0 then
+                Error $"Skipped because {StateDbRequiredTablesCheckId} did not find all required local-state tables."
+            elif localStateInspection.SchemaVersion
+                 <> Some ExpectedLocalStateSchemaVersion then
+                Error $"Skipped because {StateDbSchemaVersionCheckId} did not find schema_version {ExpectedLocalStateSchemaVersion}."
+            else
+                let configuration = inspection.Configuration
+
+                let snapshotResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+                    |> fun task -> task.GetAwaiter().GetResult()
+
+                match snapshotResult with
+                | Error message -> Error $"Skipped because the read-only local-state snapshot could not be read: {message}"
+                | Ok snapshot ->
+                    let hasRootDirectoryVersion =
+                        snapshot.Index.Values
+                        |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
+
+                    if not hasRootDirectoryVersion then
+                        Ok(
+                            "Local-state snapshot is missing the root directory version; doctor did not rebuild it. "
+                            + workingTreeScanRemediation
+                        )
+                    else
+                        let scanInput: Services.WorkingTreeScanInput =
+                            {
+                                RootDirectory = inspection.RootDirectory
+                                GraceDirectory = configuration.GraceDirectory
+                                GraceStatusFile = configuration.GraceStatusFile
+                                DirectoryIgnoreEntries =
+                                    inspection.Ignore.DirectoryEntries
+                                    |> Array.map (fun entry -> $"*{entry}")
+                                FileIgnoreEntries = inspection.Ignore.FileEntries
+                            }
+
+                        let scanResult =
+                            Services.scanWorkingTreeForDifferencesReadOnly scanInput snapshot
+                            |> fun task -> task.GetAwaiter().GetResult()
+
+                        match scanResult with
+                        | Error message -> Error $"Working-tree scan failed without updating local state: {message}"
+                        | Ok differences when differences.Count = 0 ->
+                            Ok "Working tree matches the read-only local-state snapshot. Doctor did not update the maintenance index."
+                        | Ok differences ->
+                            let added = countDifferences Add differences
+                            let changed = countDifferences Change differences
+                            let deleted = countDifferences Delete differences
+
+                            Ok
+                                $"Working tree differs from the read-only local-state snapshot: {differences.Count} total, {added} added, {changed} changed, {deleted} deleted. {workingTreeScanRemediation}"
 
     let private oidcSummary (auth: Auth.AuthInspection) =
         let m2mMissing = missingRequiredFields auth.M2mFields
@@ -925,6 +1026,19 @@ module Doctor =
 
                     failed $"Object-cache metadata is not readable: {objectCacheError}. Doctor did not repair object-cache rows."
                 | None -> skipped check "Object-cache metadata readability was not attempted."
+        | WorkingTreeScanCheckId ->
+            if
+                not context.Full
+                && not (workingTreeScanExplicitlyRequested context)
+            then
+                skipped
+                    check
+                    $"Skipped in the default profile because working-tree drift scanning can hash repository files. Re-run with --full or --check {WorkingTreeScanCheckId}. {workingTreeScanRemediation}"
+            else
+                match workingTreeScanSummary context with
+                | Error message -> skipped check message
+                | Ok summary when summary.StartsWith("Working tree matches", StringComparison.Ordinal) -> ok summary
+                | Ok summary -> warning summary
         | ConfigFileDiscoverCheckId ->
             match context.ConfigurationState with
             | ConfigurationLoaded inspection -> ok $"Found {Constants.GraceConfigFileName} at {inspection.Path}; repository root {inspection.RootDirectory}."
@@ -1067,12 +1181,12 @@ module Doctor =
         else
             0
 
-    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+    let private createReportForChecksWithTokens full offline listOnly requestedTokens (checks: LocalOutputDto.DoctorCheckDto array) =
         let results =
             if listOnly then
                 checks |> Array.map listOnlyResultForCheck
             else
-                let context = createInspectionContext offline
+                let context = createInspectionContext full offline requestedTokens
                 checks |> Array.map (resultForCheck context)
 
         let summary = summarize results
@@ -1095,6 +1209,9 @@ module Doctor =
 
         { report with ExitCode = diagnosticExitCode false report }
 
+    let createReportForChecks full offline listOnly (checks: LocalOutputDto.DoctorCheckDto array) =
+        createReportForChecksWithTokens full offline listOnly Array.empty checks
+
     let withStatus status (report: LocalOutputDto.DoctorReportDto) =
         let checks =
             if report.Checks.Length = 0 then
@@ -1109,7 +1226,7 @@ module Doctor =
         { updated with ExitCode = diagnosticExitCode updated.Strict updated }
 
     let private createReport full offline strict listOnly requestedTokens checks =
-        let report = createReportForChecks full offline listOnly checks
+        let report = createReportForChecksWithTokens full offline listOnly requestedTokens checks
 
         let report = { report with Strict = strict; RequestedChecks = requestedTokens }
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -275,8 +275,8 @@ module Doctor =
         let configurationState =
             match Configuration.tryInspectCurrentDirectoryConfiguration () with
             | Ok inspection -> ConfigurationLoaded inspection
-            | Error message when message.Contains(Constants.GraceConfigFileName, StringComparison.OrdinalIgnoreCase) -> ConfigurationMissing message
-            | Error message -> ConfigurationMalformed message
+            | Error (Configuration.ConfigurationFileNotFound message) -> ConfigurationMissing message
+            | Error (Configuration.ConfigurationFileMalformed message) -> ConfigurationMalformed message
 
         {
             ConfigurationState = configurationState
@@ -390,11 +390,12 @@ module Doctor =
             | ConfigurationLoaded inspection ->
                 let ignore = inspection.Ignore
 
-                if ignore.Exists then
+                match ignore.ErrorMessage with
+                | Some message -> failed $"Could not parse {Constants.GraceIgnoreFileName}: {message}"
+                | None when ignore.Exists ->
                     ok
                         $".graceignore has {ignore.Entries.Length} active entries: {ignore.FileEntries.Length} file patterns and {ignore.DirectoryEntries.Length} directory patterns."
-                else
-                    warning $".graceignore was not found at {ignore.Path}; no file was created."
+                | None -> warning $".graceignore was not found at {ignore.Path}; no file was created."
             | ConfigurationMissing _ -> skipped check $"Skipped because {ConfigFileDiscoverCheckId} did not find {Constants.GraceConfigFileName}."
             | ConfigurationMalformed _ -> skipped check $"Skipped because {ConfigFileParseCheckId} failed."
         | _ -> skipped check "No diagnostic implementation is registered for this check."

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -650,15 +650,30 @@ module Doctor =
         | Some recommendedVersion -> details.Add($"recommendedVersion={recommendedVersion}")
         | None -> ()
 
-        match diagnostics.UpdateUrl with
-        | Some updateUrl -> details.Add($"updateUrl={updateUrl}")
-        | None -> ()
+        match diagnostics.UpdateUrl, diagnostics.UpdateUrlIsHttps with
+        | Some updateUrl, Some true -> details.Add($"updateUrl={updateUrl}")
+        | Some _, Some false -> details.Add("updateUrl=<suppressed because server value was not HTTPS>")
+        | Some updateUrl, _ -> details.Add($"updateUrl={updateUrl}")
+        | None, _ -> ()
 
         String.Join("; ", details)
 
+    let private lifecycleStatusNeedsUserAction (diagnostics: ClientIdentity.LifecycleDiagnostics) =
+        match diagnostics.Status with
+        | Some status when status.Equals("deprecated", StringComparison.OrdinalIgnoreCase) -> true
+        | Some status when status.Equals("unsupported", StringComparison.OrdinalIgnoreCase) -> true
+        | _ -> false
+
     let private lifecycleHasWarning (diagnostics: ClientIdentity.LifecycleDiagnostics) =
-        diagnostics.UnsupportedAfterIsMalformed
+        lifecycleStatusNeedsUserAction diagnostics
+        || diagnostics.UnsupportedAfterIsMalformed
         || diagnostics.UpdateUrlIsHttps = Some false
+
+    let private healthzLifecycleRejectionSummary (response: ServerProbeResponse) =
+        response.LifecycleDiagnostics
+        |> Option.filter lifecycleStatusNeedsUserAction
+        |> Option.map (fun diagnostics ->
+            $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}, and Grace SDK lifecycle headers reported client status requiring action: {lifecycleSummary diagnostics}. Update the Grace CLI/SDK or otherwise address the lifecycle status before retrying.")
 
     let private probeFailureSummary inspection =
         match inspection with
@@ -758,8 +773,11 @@ module Doctor =
                 ->
                 ok $"Reached /healthz with HTTP {(int response.StatusCode)} {response.ReasonPhrase}; timeout was {DoctorServerProbeTimeoutMilliseconds} ms."
             | ServerProbeSucceeded response ->
-                failed
-                    $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
+                match healthzLifecycleRejectionSummary response with
+                | Some summary -> failed summary
+                | None ->
+                    failed
+                        $"Reached /healthz but the server returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; check server health and GRACE_SERVER_URI."
             | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
             | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
             | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -275,6 +275,182 @@ module Services =
                 return None
         }
 
+    type WorkingTreeScanInput =
+        {
+            RootDirectory: string
+            GraceDirectory: string
+            GraceStatusFile: string
+            DirectoryIgnoreEntries: string array
+            FileIgnoreEntries: string array
+        }
+
+    let private normalizeFullPath path =
+        Path
+            .GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+    let private isWithinGraceDirectory (scanInput: WorkingTreeScanInput) path =
+        let graceDirectory = normalizeFullPath scanInput.GraceDirectory
+        let candidate = Path.GetFullPath(path)
+
+        candidate.Equals(graceDirectory, StringComparison.OrdinalIgnoreCase)
+        || candidate.StartsWith(
+            graceDirectory
+            + string Path.DirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase
+        )
+        || candidate.StartsWith(
+            graceDirectory
+            + string Path.AltDirectorySeparatorChar,
+            StringComparison.OrdinalIgnoreCase
+        )
+
+    let private shouldIgnoreFileForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (filePath: FilePath) =
+        let mutable shouldIgnore = false
+
+        if cache.TryGetValue(filePath, &shouldIgnore) then
+            shouldIgnore
+        else
+            let fileInfo = FileInfo(filePath)
+
+            let shouldIgnoreThisFile =
+                isWithinGraceDirectory scanInput filePath
+                || filePath.Equals(scanInput.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.Equals(scanInput.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
+                || filePath.EndsWith(".gracetmp", StringComparison.OrdinalIgnoreCase)
+                || Directory.Exists(filePath)
+                || scanInput.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine)
+                || scanInput.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+                || scanInput.FileIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+
+            cache.TryAdd(filePath, shouldIgnoreThisFile)
+            |> ignore
+
+            shouldIgnoreThisFile
+
+    let private shouldIgnoreDirectoryForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (directoryPath: string) =
+        let mutable shouldIgnore = false
+
+        if cache.TryGetValue(directoryPath, &shouldIgnore) then
+            shouldIgnore
+        else
+            let directoryInfo = DirectoryInfo(directoryPath)
+
+            let shouldIgnoreDirectory =
+                isWithinGraceDirectory scanInput directoryInfo.FullName
+                || scanInput.DirectoryIgnoreEntries.Any(fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory directoryInfo graceIgnoreLine)
+
+            cache.TryAdd(directoryPath, shouldIgnoreDirectory)
+            |> ignore
+
+            shouldIgnoreDirectory
+
+    let private createLocalFileVersionForScan (scanInput: WorkingTreeScanInput) (fileInfo: FileInfo) =
+        task {
+            if fileInfo.Exists then
+                use stream = fileInfo.Open(fileStreamOptionsRead)
+
+                let! isBinary = isBinaryFile stream
+
+                stream.Position <- 0
+                let relativePath = normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName))
+                let! sha256Hash = computeSha256ForFile stream relativePath
+
+                return
+                    Some(
+                        LocalFileVersion.Create
+                            relativePath
+                            sha256Hash
+                            isBinary
+                            fileInfo.Length
+                            (Instant.FromDateTimeUtc(fileInfo.LastWriteTimeUtc))
+                            true
+                            fileInfo.LastWriteTimeUtc
+                    )
+            else
+                return None
+        }
+
+    let private getWorkingDirectoryWriteTimesForScan (scanInput: WorkingTreeScanInput) =
+        let cache = ConcurrentDictionary<FilePath, bool>()
+        let localWriteTimes = Dictionary<FileSystemEntryType * RelativePath, DateTime>()
+
+        let rec collect (directoryInfo: DirectoryInfo) =
+            if not (shouldIgnoreDirectoryForScan scanInput cache directoryInfo.FullName) then
+                let directoryFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, directoryInfo.FullName)))
+
+                localWriteTimes[(FileSystemEntryType.Directory, directoryFullPath)] <- directoryInfo.LastWriteTimeUtc
+
+                directoryInfo
+                    .GetFiles()
+                    .Where(fun file -> not (shouldIgnoreFileForScan scanInput cache file.FullName))
+                |> Seq.iter (fun fileInfo ->
+                    let fileFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName)))
+                    localWriteTimes[(FileSystemEntryType.File, fileFullPath)] <- fileInfo.LastWriteTimeUtc)
+
+                directoryInfo
+                    .GetDirectories()
+                    .Where(fun directory -> not (shouldIgnoreDirectoryForScan scanInput cache directory.FullName))
+                |> Seq.iter collect
+
+        collect (DirectoryInfo(scanInput.RootDirectory))
+        localWriteTimes
+
+    let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
+        task {
+            try
+                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, DateTime * Sha256Hash>()
+
+                for kvp in previousGraceStatus.Index do
+                    let directoryVersion = kvp.Value
+
+                    lookupCache.TryAdd(
+                        (FileSystemEntryType.Directory, directoryVersion.RelativePath),
+                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash)
+                    )
+                    |> ignore
+
+                    for file in directoryVersion.Files do
+                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash))
+                        |> ignore
+
+                let localWriteTimes = getWorkingDirectoryWriteTimesForScan scanInput
+                let differences = List<FileSystemDifference>()
+
+                for kvp in localWriteTimes do
+                    let fileSystemEntryType, relativePath = kvp.Key
+                    let lastWriteTimeUtc = kvp.Value
+
+                    if not (lookupCache.ContainsKey((fileSystemEntryType, relativePath))) then
+                        differences.Add(FileSystemDifference.Create Add fileSystemEntryType relativePath)
+                    elif fileSystemEntryType.IsFile then
+                        let knownLastWriteTimeUtc, existingSha256Hash = lookupCache[(fileSystemEntryType, relativePath)]
+
+                        if lastWriteTimeUtc <> knownLastWriteTimeUtc then
+                            let fileInfo = FileInfo(Path.Combine(scanInput.RootDirectory, relativePath))
+                            let! newFileVersion = createLocalFileVersionForScan scanInput fileInfo
+
+                            match newFileVersion with
+                            | Some fileVersion when fileVersion.Sha256Hash <> existingSha256Hash ->
+                                differences.Add(FileSystemDifference.Create Change fileSystemEntryType relativePath)
+                            | _ -> ()
+
+                for kvp in lookupCache do
+                    let fileSystemEntryType, relativePath = kvp.Key
+
+                    if not (localWriteTimes.ContainsKey((fileSystemEntryType, relativePath))) then
+                        differences.Add(FileSystemDifference.Create Delete fileSystemEntryType relativePath)
+
+                return Ok differences
+            with
+            | ex -> return Error ex.Message
+        }
+
     /// Gets the LocalDirectoryVersion for the root directory of the repository from GraceStatus.
     let getRootDirectoryVersion (graceStatus: GraceStatus) =
         graceStatus.Index.Values.FirstOrDefault(

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -167,7 +167,13 @@ module Services =
             else
                 normalizeFilePath (directoryInfoToCheck.FullName + "/")
 
-        if FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPath, ignoreCase) then
+        let normalizedDirectoryPathWithoutSeparator = Path.TrimEndingDirectorySeparator(normalizedDirectoryPath)
+
+        if
+            FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPath, ignoreCase)
+            || FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, normalizedDirectoryPathWithoutSeparator, ignoreCase)
+            || FileSystemName.MatchesSimpleExpression(graceIgnoreEntry, directoryInfoToCheck.Name, ignoreCase)
+        then
             //logToAnsiConsole Colors.Changed $"checkIgnoreLineAgainstDirectory: directory '{normalizedDirectoryPath}' matches ignore entry '{graceIgnoreEntry}'."
             true
         else

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -374,6 +374,130 @@ module CommandOutputContract =
                     |]
             |}
 
+    let private doctorCheckSchema =
+        schemaObject
+            "DoctorCheckDto"
+            [
+                "Id", scalarSchema "string"
+                "Category", scalarSchema "string"
+                "Title", scalarSchema "string"
+                "Description", scalarSchema "string"
+                "DefaultEnabled", scalarSchema "boolean"
+                "SupportsOffline", scalarSchema "boolean"
+            ]
+            [|
+                "Id"
+                "Category"
+                "Title"
+                "Description"
+                "DefaultEnabled"
+                "SupportsOffline"
+            |]
+
+    let private doctorCheckResultSchema =
+        schemaObject
+            "DoctorCheckResultDto"
+            [
+                "Id", scalarSchema "string"
+                "Category", scalarSchema "string"
+                "Title", scalarSchema "string"
+                "Status", scalarSchema "string"
+                "Severity", scalarSchema "string"
+                "Summary", scalarSchema "string"
+            ]
+            [|
+                "Id"
+                "Category"
+                "Title"
+                "Status"
+                "Severity"
+                "Summary"
+            |]
+
+    let private doctorSummarySchema =
+        schemaObject
+            "DoctorSummaryDto"
+            [
+                "Total", scalarSchema "integer"
+                "Ok", scalarSchema "integer"
+                "Warning", scalarSchema "integer"
+                "Failed", scalarSchema "integer"
+                "Skipped", scalarSchema "integer"
+            ]
+            [|
+                "Total"
+                "Ok"
+                "Warning"
+                "Failed"
+                "Skipped"
+            |]
+
+    let private doctorReportSchema =
+        schemaObject
+            "DoctorReportDto"
+            [
+                "ReportVersion", scalarSchema "string"
+                "Status", scalarSchema "string"
+                "ExitCode", scalarSchema "integer"
+                "Full", scalarSchema "boolean"
+                "Offline", scalarSchema "boolean"
+                "Strict", scalarSchema "boolean"
+                "ListOnly", scalarSchema "boolean"
+                "RequestedChecks", arraySchema (scalarSchema "string") "Requested check IDs or categories after token normalization."
+                "Catalog", arraySchema doctorCheckSchema "Inert doctor check catalog entries included in the report."
+                "Checks", arraySchema doctorCheckResultSchema "Scaffolded check results; no real diagnostics run in this slice."
+                "Summary", doctorSummarySchema
+            ]
+            [|
+                "ReportVersion"
+                "Status"
+                "ExitCode"
+                "Full"
+                "Offline"
+                "Strict"
+                "ListOnly"
+                "RequestedChecks"
+                "Catalog"
+                "Checks"
+                "Summary"
+            |]
+
+    let private doctorReportExample =
+        box
+            {|
+                ReportVersion = "doctor-report-v1"
+                Status = "Ok"
+                ExitCode = 0
+                Full = false
+                Offline = false
+                Strict = false
+                ListOnly = true
+                RequestedChecks = [| "cli.catalog" |]
+                Catalog =
+                    [|
+                        {|
+                            Id = "cli.catalog"
+                            Category = "CLI"
+                            Title = "CLI command catalog"
+                            Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
+                            DefaultEnabled = true
+                            SupportsOffline = true
+                        |}
+                    |]
+                Checks =
+                    [|
+                        {|
+                            Id = "cli.catalog"
+                            Category = "CLI"
+                            Title = "CLI command catalog"
+                            Status = "Ok"
+                            Severity = "Info"
+                            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
+                        |}
+                    |]
+                Summary = {| Total = 1; Ok = 1; Warning = 0; Failed = 0; Skipped = 0 |}
+            |}
+
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
 
@@ -468,6 +592,16 @@ module CommandOutputContract =
                 maintenanceStatsExample
                 [
                     "Command-specific CLI DTO emitted by maintenance update-index in the common Grace result envelope after the local index is updated."
+                ]
+        | "doctor", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "DoctorReportDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                doctorReportSchema
+                doctorReportExample
+                [
+                    "Command-specific CLI DTO emitted by grace doctor in the common Grace result envelope."
+                    "Doctor schema and examples are intentionally available in the S0 scaffold because later slices add real diagnostics behind the stable DTO."
                 ]
         | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
@@ -719,7 +853,11 @@ module CommandOutputContract =
             ExecutionScope = executionScope
             Mutating = mutating
             EnvelopeContract = envelopeContract
-            Features = featuresFor behavior
+            Features =
+                if identity.CommandId.Equals("doctor", StringComparison.Ordinal) then
+                    { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
+                else
+                    featuresFor behavior
             ReturnValueContract = returnValueContractFor identity envelopeContract
         }
 
@@ -849,6 +987,7 @@ module CommandOutputContract =
             row [ "history" ] "run" true true human_proc_only fire_and_forget_progress local_client RequiresCliDto
             row [ "history" ] "search" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [] "doctor" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "check-ignore-entries" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "list-contents" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "scan" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -41,6 +41,7 @@
 		<Compile Include="Command\DirectoryVersion.CLI.fs" />
 		<Compile Include="Command\Watch.CLI.fs" />
 		<Compile Include="Command\Maintenance.CLI.fs" />
+		<Compile Include="Command\Doctor.CLI.fs" />
                 
                 <Compile Include="Command\WorkItem.CLI.fs" />
                 <Compile Include="Command\Review.CLI.fs" />

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -5,6 +5,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.IO
+open System.Text
 open System.Threading
 open System.Threading.Tasks
 open Grace.Shared.Client.Configuration
@@ -254,6 +255,32 @@ module LocalStateDb =
 
             raise ex
 
+    let private sqliteHeaderMagic = Encoding.ASCII.GetBytes("SQLite format 3" + string (char 0))
+
+    let private isWalModeHeader (dbPath: string) =
+        try
+            use stream = new FileStream(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+
+            if stream.Length < 20L then
+                false
+            else
+                let header = Array.zeroCreate<byte> 20
+                let bytesRead = stream.Read(header, 0, header.Length)
+
+                bytesRead = header.Length
+                && header[0..15] = sqliteHeaderMagic
+                && header[18] = 2uy
+                && header[19] = 2uy
+        with
+        | _ -> false
+
+    let private missingWalSidecars (dbPath: string) =
+        if isWalModeHeader dbPath then
+            [| dbPath + "-wal"; dbPath + "-shm" |]
+            |> Array.filter (File.Exists >> not)
+        else
+            Array.empty
+
     let private readTextRows (connection: SqliteConnection) (sql: string) =
         use cmd = connection.CreateCommand()
         cmd.CommandText <- sql
@@ -337,56 +364,73 @@ module LocalStateDb =
            || dbPathIsDirectory then
             emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
         else
-            try
-                use connection = openReadOnlyConnection normalizedPath
-                let tableNames = readObjectNames connection "table"
-                let indexNames = readObjectNames connection "index"
+            let missingWalSidecars = missingWalSidecars normalizedPath
 
-                let missingRequiredTables =
-                    requiredTableNames
-                    |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
+            if missingWalSidecars.Length > 0 then
+                let missingNames =
+                    missingWalSidecars
+                    |> Array.map Path.GetFileName
+                    |> String.concat ", "
 
-                let missingRequiredIndexes =
-                    requiredIndexNames
-                    |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
+                emptyReadOnlyInspection
+                    normalizedPath
+                    parentDirectoryExists
+                    dbFileExists
+                    dbPathIsDirectory
+                    false
+                    (Some
+                        $"Database is in WAL mode but required sidecar files are missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files.")
+            else
+                try
+                    use connection = openReadOnlyConnection normalizedPath
+                    let tableNames = readObjectNames connection "table"
+                    let indexNames = readObjectNames connection "index"
 
-                let schemaVersion =
-                    try
-                        readSchemaVersionReadOnly connection
-                    with
-                    | _ -> None
+                    let missingRequiredTables =
+                        requiredTableNames
+                        |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
 
-                let integrityRows =
-                    try
-                        readTextRows connection "PRAGMA integrity_check;"
-                    with
-                    | ex -> [| ex.Message |]
+                    let missingRequiredIndexes =
+                        requiredIndexNames
+                        |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
 
-                let foreignKeyViolations =
-                    try
-                        readForeignKeyViolations connection
-                    with
-                    | ex -> [| ex.Message |]
+                    let schemaVersion =
+                        try
+                            readSchemaVersionReadOnly connection
+                        with
+                        | _ -> None
 
-                let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+                    let integrityRows =
+                        try
+                            readTextRows connection "PRAGMA integrity_check;"
+                        with
+                        | ex -> [| ex.Message |]
 
-                {
-                    DbPath = normalizedPath
-                    ParentDirectoryExists = parentDirectoryExists
-                    DbFileExists = dbFileExists
-                    DbPathIsDirectory = dbPathIsDirectory
-                    OpenedReadOnly = true
-                    OpenError = None
-                    SchemaVersion = schemaVersion
-                    MissingRequiredTables = missingRequiredTables
-                    MissingRequiredIndexes = missingRequiredIndexes
-                    IntegrityCheckRows = integrityRows
-                    ForeignKeyViolations = foreignKeyViolations
-                    ObjectCacheReadable = objectCacheReadable
-                    ObjectCacheError = objectCacheError
-                }
-            with
-            | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
+                    let foreignKeyViolations =
+                        try
+                            readForeignKeyViolations connection
+                        with
+                        | ex -> [| ex.Message |]
+
+                    let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+
+                    {
+                        DbPath = normalizedPath
+                        ParentDirectoryExists = parentDirectoryExists
+                        DbFileExists = dbFileExists
+                        DbPathIsDirectory = dbPathIsDirectory
+                        OpenedReadOnly = true
+                        OpenError = None
+                        SchemaVersion = schemaVersion
+                        MissingRequiredTables = missingRequiredTables
+                        MissingRequiredIndexes = missingRequiredIndexes
+                        IntegrityCheckRows = integrityRows
+                        ForeignKeyViolations = foreignKeyViolations
+                        ObjectCacheReadable = objectCacheReadable
+                        ObjectCacheError = objectCacheError
+                    }
+                with
+                | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
 
     let private tryGetMetaValue (connection: SqliteConnection) (key: string) =
         use cmd = connection.CreateCommand()

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -159,6 +159,224 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
         |]
 
+    let private requiredTableNames =
+        [|
+            "meta"
+            "status_meta"
+            "status_directories"
+            "status_files"
+            "object_cache_directories"
+            "object_cache_directory_children"
+            "object_cache_directory_files"
+        |]
+
+    let private requiredIndexNames =
+        [|
+            "ix_status_directories_parent"
+            "ix_status_directories_directory_version_id"
+            "ix_status_files_directory_path"
+            "ix_status_files_directory_version_id"
+            "ix_status_files_sha256"
+            "ix_object_cache_directories_relative_path"
+            "ix_object_cache_children_parent"
+            "ix_object_cache_files_path_hash"
+        |]
+
+    type ReadOnlyLocalStateInspection =
+        {
+            DbPath: string
+            ParentDirectoryExists: bool
+            DbFileExists: bool
+            DbPathIsDirectory: bool
+            OpenedReadOnly: bool
+            OpenError: string option
+            SchemaVersion: string option
+            MissingRequiredTables: string array
+            MissingRequiredIndexes: string array
+            IntegrityCheckRows: string array
+            ForeignKeyViolations: string array
+            ObjectCacheReadable: bool option
+            ObjectCacheError: string option
+        }
+
+    let private emptyReadOnlyInspection dbPath parentDirectoryExists dbFileExists dbPathIsDirectory openedReadOnly openError =
+        {
+            DbPath = dbPath
+            ParentDirectoryExists = parentDirectoryExists
+            DbFileExists = dbFileExists
+            DbPathIsDirectory = dbPathIsDirectory
+            OpenedReadOnly = openedReadOnly
+            OpenError = openError
+            SchemaVersion = None
+            MissingRequiredTables = requiredTableNames
+            MissingRequiredIndexes = requiredIndexNames
+            IntegrityCheckRows = Array.empty
+            ForeignKeyViolations = Array.empty
+            ObjectCacheReadable = None
+            ObjectCacheError = None
+        }
+
+    let private openReadOnlyConnection (dbPath: string) =
+        sqliteInitialized.Value |> ignore
+
+        let connectionString =
+            let builder = SqliteConnectionStringBuilder()
+            builder.DataSource <- dbPath
+            builder.Mode <- SqliteOpenMode.ReadOnly
+            builder.Pooling <- false
+            builder.DefaultTimeout <- BusyTimeoutMs / 1000
+            builder.ToString()
+
+        let connection = new SqliteConnection(connectionString)
+
+        try
+            connection.Open()
+            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
+            executePragma connection "PRAGMA query_only = ON;"
+            connection
+        with
+        | ex ->
+            try
+                connection.Dispose()
+            with
+            | _ -> ()
+
+            raise ex
+
+    let private readTextRows (connection: SqliteConnection) (sql: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- sql
+        use reader = cmd.ExecuteReader()
+        let rows = ResizeArray<string>()
+
+        while reader.Read() do
+            rows.Add(reader.GetString(0))
+
+        rows |> Seq.toArray
+
+    let private readObjectNames (connection: SqliteConnection) objectType =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT name FROM sqlite_master WHERE type = $type;"
+
+        cmd.Parameters.AddWithValue("$type", objectType)
+        |> ignore
+
+        use reader = cmd.ExecuteReader()
+        let names = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+
+        while reader.Read() do
+            names.Add(reader.GetString(0)) |> ignore
+
+        names
+
+    let private readSchemaVersionReadOnly (connection: SqliteConnection) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version' LIMIT 1;"
+        let value = cmd.ExecuteScalar()
+
+        if isNull value || value = DBNull.Value then
+            None
+        else
+            Some(Convert.ToString(value))
+
+    let private readForeignKeyViolations (connection: SqliteConnection) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "PRAGMA foreign_key_check;"
+        use reader = cmd.ExecuteReader()
+        let violations = ResizeArray<string>()
+
+        while reader.Read() do
+            let tableName = reader.GetString(0)
+            let rowId = reader.GetInt64(1)
+            let parent = reader.GetString(2)
+            let foreignKeyId = reader.GetInt32(3)
+            violations.Add($"{tableName}:{rowId}->{parent}#{foreignKeyId}")
+
+        violations |> Seq.toArray
+
+    let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
+        try
+            for tableName in
+                [|
+                    "object_cache_directories"
+                    "object_cache_directory_children"
+                    "object_cache_directory_files"
+                |] do
+                use cmd = connection.CreateCommand()
+                cmd.CommandText <- $"SELECT COUNT(*) FROM {tableName};"
+                cmd.ExecuteScalar() |> ignore
+
+            Some true, None
+        with
+        | ex -> Some false, Some ex.Message
+
+    let inspectReadOnly (dbPath: string) =
+        let normalizedPath = Path.GetFullPath(dbPath)
+        let directoryPath = Path.GetDirectoryName(normalizedPath)
+
+        let parentDirectoryExists =
+            String.IsNullOrWhiteSpace(directoryPath)
+            || Directory.Exists(directoryPath)
+
+        let dbFileExists = File.Exists(normalizedPath)
+        let dbPathIsDirectory = Directory.Exists(normalizedPath)
+
+        if not parentDirectoryExists
+           || (not dbFileExists && not dbPathIsDirectory)
+           || dbPathIsDirectory then
+            emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
+        else
+            try
+                use connection = openReadOnlyConnection normalizedPath
+                let tableNames = readObjectNames connection "table"
+                let indexNames = readObjectNames connection "index"
+
+                let missingRequiredTables =
+                    requiredTableNames
+                    |> Array.filter (fun tableName -> not (tableNames.Contains(tableName)))
+
+                let missingRequiredIndexes =
+                    requiredIndexNames
+                    |> Array.filter (fun indexName -> not (indexNames.Contains(indexName)))
+
+                let schemaVersion =
+                    try
+                        readSchemaVersionReadOnly connection
+                    with
+                    | _ -> None
+
+                let integrityRows =
+                    try
+                        readTextRows connection "PRAGMA integrity_check;"
+                    with
+                    | ex -> [| ex.Message |]
+
+                let foreignKeyViolations =
+                    try
+                        readForeignKeyViolations connection
+                    with
+                    | ex -> [| ex.Message |]
+
+                let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+
+                {
+                    DbPath = normalizedPath
+                    ParentDirectoryExists = parentDirectoryExists
+                    DbFileExists = dbFileExists
+                    DbPathIsDirectory = dbPathIsDirectory
+                    OpenedReadOnly = true
+                    OpenError = None
+                    SchemaVersion = schemaVersion
+                    MissingRequiredTables = missingRequiredTables
+                    MissingRequiredIndexes = missingRequiredIndexes
+                    IntegrityCheckRows = integrityRows
+                    ForeignKeyViolations = foreignKeyViolations
+                    ObjectCacheReadable = objectCacheReadable
+                    ObjectCacheError = objectCacheError
+                }
+            with
+            | ex -> emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false (Some ex.Message)
+
     let private tryGetMetaValue (connection: SqliteConnection) (key: string) =
         use cmd = connection.CreateCommand()
         cmd.CommandText <- "SELECT value FROM meta WHERE key = $key LIMIT 1;"

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1334,3 +1334,158 @@ module LocalStateDb =
             finally
                 connection.Dispose()
         }
+
+    let readStatusSnapshotReadOnly (dbPath: string) (ownerId: OwnerId) (organizationId: OrganizationId) (repositoryId: RepositoryId) =
+        task {
+            let normalizedPath = Path.GetFullPath(dbPath)
+            let directoryPath = Path.GetDirectoryName(normalizedPath)
+
+            if
+                not (String.IsNullOrWhiteSpace(directoryPath))
+                && not (Directory.Exists(directoryPath))
+            then
+                return Error $"Local state directory was not found for {normalizedPath}."
+            elif Directory.Exists(normalizedPath) then
+                return Error $"Local state database path is a directory: {normalizedPath}."
+            elif not (File.Exists(normalizedPath)) then
+                return Error $"Local state database was not found at {normalizedPath}."
+            else
+                let missingPartialWalSidecars = missingPartialWalSidecars normalizedPath
+
+                if missingPartialWalSidecars.Length > 0 then
+                    let missingNames = String.concat ", " missingPartialWalSidecars
+
+                    return
+                        Error
+                            $"Database has an incomplete WAL sidecar set; missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files or ignoring live WAL content."
+                else
+                    try
+                        let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+                        use connection = openReadOnlyConnection normalizedPath immutableSnapshot
+
+                        match readStatusMetaInternal connection with
+                        | None -> return Error "Local state status_meta row is missing or unreadable."
+                        | Some meta ->
+                            let directories = List<StatusDirectoryRow>()
+                            let files = List<StatusFileRow>()
+
+                            use directoryCommand = connection.CreateCommand()
+
+                            directoryCommand.CommandText <-
+                                "SELECT relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
+
+                            use directoryReader = directoryCommand.ExecuteReader()
+
+                            while directoryReader.Read() do
+                                directories.Add(
+                                    {
+                                        RelativePath = directoryReader.GetString(0)
+                                        ParentPath = directoryReader.GetString(1)
+                                        DirectoryVersionId = Guid.Parse(directoryReader.GetString(2))
+                                        Sha256Hash = directoryReader.GetString(3)
+                                        SizeBytes = directoryReader.GetInt64(4)
+                                        CreatedAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(5))
+                                        LastWriteTimeUtc = DateTime(directoryReader.GetInt64(6), DateTimeKind.Utc)
+                                    }
+                                )
+
+                            use fileCommand = connection.CreateCommand()
+
+                            fileCommand.CommandText <-
+                                "SELECT relative_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+
+                            use fileReader = fileCommand.ExecuteReader()
+
+                            while fileReader.Read() do
+                                files.Add(
+                                    {
+                                        RelativePath = fileReader.GetString(0)
+                                        DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
+                                        Sha256Hash = fileReader.GetString(2)
+                                        IsBinary = fileReader.GetInt64(3) = 1L
+                                        SizeBytes = fileReader.GetInt64(4)
+                                        CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(5))
+                                        UploadedToObjectStorage = fileReader.GetInt64(6) = 1L
+                                        LastWriteTimeUtc = DateTime(fileReader.GetInt64(7), DateTimeKind.Utc)
+                                    }
+                                )
+
+                            let directoriesByParent = Dictionary<string, List<DirectoryVersionId>>()
+                            let filesByDirectory = Dictionary<DirectoryVersionId, List<LocalFileVersion>>()
+
+                            directories
+                            |> Seq.iter (fun directory ->
+                                let mutable existing = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                if directoriesByParent.TryGetValue(directory.ParentPath, &existing) then
+                                    existing.Add(directory.DirectoryVersionId)
+                                else
+                                    directoriesByParent.Add(directory.ParentPath, List<DirectoryVersionId>([ directory.DirectoryVersionId ])))
+
+                            files
+                            |> Seq.iter (fun file ->
+                                let localFile =
+                                    LocalFileVersion.Create
+                                        file.RelativePath
+                                        file.Sha256Hash
+                                        file.IsBinary
+                                        file.SizeBytes
+                                        file.CreatedAt
+                                        file.UploadedToObjectStorage
+                                        file.LastWriteTimeUtc
+
+                                let mutable existing = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                if filesByDirectory.TryGetValue(file.DirectoryVersionId, &existing) then
+                                    existing.Add(localFile)
+                                else
+                                    filesByDirectory.Add(file.DirectoryVersionId, List<LocalFileVersion>([ localFile ])))
+
+                            let index = GraceIndex()
+
+                            directories
+                            |> Seq.iter (fun directory ->
+                                let directoriesForPath =
+                                    let mutable list = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                    if directoriesByParent.TryGetValue(directory.RelativePath, &list) then
+                                        list
+                                    else
+                                        List<DirectoryVersionId>()
+
+                                let filesForPath =
+                                    let mutable list = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                    if filesByDirectory.TryGetValue(directory.DirectoryVersionId, &list) then
+                                        list
+                                    else
+                                        List<LocalFileVersion>()
+
+                                let localDirectory =
+                                    LocalDirectoryVersion.Create
+                                        directory.DirectoryVersionId
+                                        ownerId
+                                        organizationId
+                                        repositoryId
+                                        directory.RelativePath
+                                        directory.Sha256Hash
+                                        directoriesForPath
+                                        filesForPath
+                                        directory.SizeBytes
+                                        directory.LastWriteTimeUtc
+
+                                index.TryAdd(directory.DirectoryVersionId, localDirectory)
+                                |> ignore)
+
+                            return
+                                Ok
+                                    {
+                                        Index = index
+                                        RootDirectoryId = meta.RootDirectoryId
+                                        RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                                        LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
+                                        LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
+                                    }
+                    with
+                    | ex -> return Error ex.Message
+        }

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -26,8 +26,8 @@ module LocalStateDb =
     let mutable private verboseEnabled = false
 
     let setVerbose enabled = verboseEnabled <- enabled
-    let private traceFilePath = Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_PATH")
-    let private traceOpenConnections = not (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_OPEN")))
+    let private getTraceFilePath () = Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_PATH")
+    let private shouldTraceOpenConnections () = not (String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GRACE_LOCALSTATE_DB_TRACE_OPEN")))
     let private initLocks = ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase)
     let private initializedDbs = ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
 
@@ -39,6 +39,8 @@ module LocalStateDb =
     let private logVerbose message = if verboseEnabled then Log.LogVerbose message
 
     let private logTrace message =
+        let traceFilePath = getTraceFilePath ()
+
         if not (String.IsNullOrWhiteSpace(traceFilePath)) then
             try
                 File.AppendAllText(traceFilePath, $"{DateTime.UtcNow:O} {message}{Environment.NewLine}")
@@ -100,6 +102,7 @@ module LocalStateDb =
     let private openConnection (dbPath: string) =
         sqliteInitialized.Value |> ignore
         let directoryPath = Path.GetDirectoryName(dbPath)
+        let traceOpenConnections = shouldTraceOpenConnections ()
         logVerbose $"LocalStateDb.openConnection starting. dbPath={dbPath} dir={directoryPath}"
 
         if traceOpenConnections then
@@ -218,6 +221,10 @@ module LocalStateDb =
 
     let private openReadOnlyConnection (dbPath: string) =
         sqliteInitialized.Value |> ignore
+        let traceOpenConnections = shouldTraceOpenConnections ()
+
+        if traceOpenConnections then
+            logTrace $"openReadOnlyConnection starting. dbPath={dbPath}"
 
         let connectionString =
             let builder = SqliteConnectionStringBuilder()
@@ -233,6 +240,10 @@ module LocalStateDb =
             connection.Open()
             executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
             executePragma connection "PRAGMA query_only = ON;"
+
+            if traceOpenConnections then
+                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath}"
+
             connection
         with
         | ex ->

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -220,41 +220,6 @@ module LocalStateDb =
             ObjectCacheError = None
         }
 
-    let private openReadOnlyConnection (dbPath: string) =
-        sqliteInitialized.Value |> ignore
-        let traceOpenConnections = shouldTraceOpenConnections ()
-
-        if traceOpenConnections then
-            logTrace $"openReadOnlyConnection starting. dbPath={dbPath}"
-
-        let connectionString =
-            let builder = SqliteConnectionStringBuilder()
-            builder.DataSource <- dbPath
-            builder.Mode <- SqliteOpenMode.ReadOnly
-            builder.Pooling <- false
-            builder.DefaultTimeout <- BusyTimeoutMs / 1000
-            builder.ToString()
-
-        let connection = new SqliteConnection(connectionString)
-
-        try
-            connection.Open()
-            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
-            executePragma connection "PRAGMA query_only = ON;"
-
-            if traceOpenConnections then
-                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath}"
-
-            connection
-        with
-        | ex ->
-            try
-                connection.Dispose()
-            with
-            | _ -> ()
-
-            raise ex
-
     let private sqliteHeaderMagic = Encoding.ASCII.GetBytes("SQLite format 3" + string (char 0))
 
     let private isWalModeHeader (dbPath: string) =
@@ -274,12 +239,65 @@ module LocalStateDb =
         with
         | _ -> false
 
-    let private missingWalSidecars (dbPath: string) =
-        if isWalModeHeader dbPath then
-            [| dbPath + "-wal"; dbPath + "-shm" |]
-            |> Array.filter (File.Exists >> not)
-        else
+    let private walSidecarPaths (dbPath: string) = dbPath + "-wal", dbPath + "-shm"
+
+    let private missingPartialWalSidecars (dbPath: string) =
+        let walPath, shmPath = walSidecarPaths dbPath
+        let walExists = File.Exists(walPath)
+        let shmExists = File.Exists(shmPath)
+
+        if walExists = shmExists then
             Array.empty
+        else
+            [|
+                if not walExists then Path.GetFileName(walPath)
+
+                if not shmExists then Path.GetFileName(shmPath)
+            |]
+
+    let private shouldUseImmutableReadOnlySnapshot (dbPath: string) =
+        let walPath, shmPath = walSidecarPaths dbPath
+
+        isWalModeHeader dbPath
+        && not (File.Exists(walPath))
+        && not (File.Exists(shmPath))
+
+    let private openReadOnlyConnection (dbPath: string) immutableSnapshot =
+        sqliteInitialized.Value |> ignore
+        let traceOpenConnections = shouldTraceOpenConnections ()
+
+        if traceOpenConnections then
+            logTrace $"openReadOnlyConnection starting. dbPath={dbPath} immutableSnapshot={immutableSnapshot}"
+
+        let connectionString =
+            let builder = SqliteConnectionStringBuilder()
+
+            builder.DataSource <- if immutableSnapshot then $"{Uri(dbPath).AbsoluteUri}?immutable=1" else dbPath
+
+            builder.Mode <- SqliteOpenMode.ReadOnly
+            builder.Pooling <- false
+            builder.DefaultTimeout <- BusyTimeoutMs / 1000
+            builder.ToString()
+
+        let connection = new SqliteConnection(connectionString)
+
+        try
+            connection.Open()
+            executePragma connection $"PRAGMA busy_timeout = {BusyTimeoutMs};"
+            executePragma connection "PRAGMA query_only = ON;"
+
+            if traceOpenConnections then
+                logTrace $"openReadOnlyConnection opened connection. dbPath={dbPath} immutableSnapshot={immutableSnapshot}"
+
+            connection
+        with
+        | ex ->
+            try
+                connection.Dispose()
+            with
+            | _ -> ()
+
+            raise ex
 
     let private readTextRows (connection: SqliteConnection) (sql: string) =
         use cmd = connection.CreateCommand()
@@ -364,13 +382,10 @@ module LocalStateDb =
            || dbPathIsDirectory then
             emptyReadOnlyInspection normalizedPath parentDirectoryExists dbFileExists dbPathIsDirectory false None
         else
-            let missingWalSidecars = missingWalSidecars normalizedPath
+            let missingPartialWalSidecars = missingPartialWalSidecars normalizedPath
 
-            if missingWalSidecars.Length > 0 then
-                let missingNames =
-                    missingWalSidecars
-                    |> Array.map Path.GetFileName
-                    |> String.concat ", "
+            if missingPartialWalSidecars.Length > 0 then
+                let missingNames = String.concat ", " missingPartialWalSidecars
 
                 emptyReadOnlyInspection
                     normalizedPath
@@ -379,10 +394,11 @@ module LocalStateDb =
                     dbPathIsDirectory
                     false
                     (Some
-                        $"Database is in WAL mode but required sidecar files are missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files.")
+                        $"Database has an incomplete WAL sidecar set; missing: {missingNames}. Doctor did not open the database to avoid creating sidecar files or ignoring live WAL content.")
             else
                 try
-                    use connection = openReadOnlyConnection normalizedPath
+                    let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+                    use connection = openReadOnlyConnection normalizedPath immutableSnapshot
                     let tableNames = readObjectNames connection "table"
                     let indexNames = readObjectNames connection "index"
 

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -509,7 +509,16 @@ module GraceCommand =
                         "admin"
                     ]
             }
-            { Heading = "Local utilities"; CommandNames = [ "history"; "maintenance"; "alias" ] }
+            {
+                Heading = "Local utilities"
+                CommandNames =
+                    [
+                        "doctor"
+                        "history"
+                        "maintenance"
+                        "alias"
+                    ]
+            }
         ]
 
     let private repositoryHelpSections =
@@ -830,6 +839,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(History.Build)
         rootCommand.Subcommands.Add(Auth.Build)
         rootCommand.Subcommands.Add(Maintenance.Build)
+        rootCommand.Subcommands.Add(Doctor.Build)
         rootCommand.Subcommands.Add(WorkItemCommand.Build)
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
@@ -945,6 +955,14 @@ module GraceCommand =
 
     /// Checks if the command is a `grace watch` command.
     let isGraceWatch (parseResult: ParseResult) = if (parseResult.CommandResult.Command.Name = "watch") then true else false
+
+    /// Checks if the command is a `grace doctor` command.
+    let isGraceDoctor (parseResult: ParseResult) =
+        if isNull parseResult then
+            false
+        else
+            Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
+            |> Seq.exists (fun command -> command.Name.Equals("doctor", StringComparison.OrdinalIgnoreCase))
 
     /// Checks if the command is a foreground `grace watch` command.
     let isGraceWatchForeground (parseResult: ParseResult) =
@@ -1094,7 +1112,8 @@ module GraceCommand =
                                 raise (IntrospectionExit returnValue)
                             | None -> ()
 
-                        LocalStateDb.setVerbose (parseResult |> verbose)
+                        if not (parseResult |> isGraceDoctor) then
+                            LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
                         match parseResult.Action with
@@ -1264,6 +1283,9 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
+                    else if parseResult |> isGraceDoctor then
+                        let invokedReturnValue = parseResult.Invoke()
+                        returnValue <- invokedReturnValue
                     else if configurationFileExists () then
                         match tryGetJsonConfigurationError parseResult with
                         | Some error ->
@@ -1349,6 +1371,7 @@ module GraceCommand =
                                 "auth"
                                 "connect"
                                 "alias"
+                                "doctor"
                             ]
 
                         let isAllowed =
@@ -1410,7 +1433,10 @@ module GraceCommand =
                     (finishTime - startTime).TotalMilliseconds
                     |> int64
 
-                if not isIntrospection then
+                if
+                    not isIntrospection
+                    && not (parseResult |> isGraceDoctor)
+                then
                     HistoryStorage.tryRecordInvocation
                         {
                             argvOriginal = argvOriginal

--- a/src/Grace.CLI/Text.CLI.fs
+++ b/src/Grace.CLI/Text.CLI.fs
@@ -73,6 +73,9 @@ module Text =
         let ForceRecompute = "--force-recompute"
 
         [<Literal>]
+        let Full = "--full"
+
+        [<Literal>]
         let FullSha = "--full-sha"
 
         [<Literal>]
@@ -94,6 +97,9 @@ module Text =
         let ListFiles = "--list-files"
 
         [<Literal>]
+        let ListChecks = "--list-checks"
+
+        [<Literal>]
         let LogicalDeleteDays = "--logical-delete-days"
 
         [<Literal>]
@@ -110,6 +116,9 @@ module Text =
 
         [<Literal>]
         let NewName = "--new-name"
+
+        [<Literal>]
+        let Offline = "--offline"
 
         [<Literal>]
         let OrganizationId = "--organization-id"
@@ -248,6 +257,9 @@ module Text =
 
         [<Literal>]
         let Since = "--since"
+
+        [<Literal>]
+        let Strict = "--strict"
 
         [<Literal>]
         let Status = "--status"

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -165,7 +165,6 @@ module Configuration =
                 else
                     graceIgnoreLine.Substring(0, commentIndex).Trim())
             |> Seq.filter (fun graceIgnoreLine -> (not (String.IsNullOrEmpty(graceIgnoreLine))))
-            |> Seq.map (fun graceIgnoreLine -> Path.TrimEndingDirectorySeparator(graceIgnoreLine))
             |> Seq.toArray
         else
             Array.empty

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -147,7 +147,10 @@ module Configuration =
             // Deserialize the JSON configuration file into a GraceConfiguration object
             let graceConfiguration = JsonSerializer.Deserialize<GraceConfiguration>(buffer, Constants.JsonSerializerOptions)
 
-            Ok graceConfiguration
+            if obj.ReferenceEquals(graceConfiguration, null) then
+                Error "Configuration file is empty or invalid JSON."
+            else
+                Ok graceConfiguration
         with
         | ex -> Error $"Exception: {ex.Message}{Environment.NewLine}Stack trace: {ex.StackTrace}"
 
@@ -201,6 +204,43 @@ module Configuration =
 
         graceConfiguration.IsPopulated <- true
         graceConfiguration
+
+    type GraceIgnoreInspection = { Path: string; Exists: bool; Entries: string array; FileEntries: string array; DirectoryEntries: string array }
+
+    type GraceConfigurationInspection = { Path: string; RootDirectory: string; Configuration: GraceConfiguration; Ignore: GraceIgnoreInspection }
+
+    let inspectGraceIgnore rootDirectory =
+        let graceIgnorePath = Path.Combine(rootDirectory, Constants.GraceIgnoreFileName)
+        let entries = getGraceIgnoreEntries graceIgnorePath
+
+        {
+            Path = graceIgnorePath
+            Exists = File.Exists(graceIgnorePath)
+            Entries = entries
+            FileEntries =
+                entries
+                |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
+            DirectoryEntries =
+                entries
+                |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+        }
+
+    let tryInspectCurrentDirectoryConfiguration () =
+        match findGraceConfigurationFile () with
+        | Error errorMessage -> Error errorMessage
+        | Ok graceConfigurationFilePath ->
+            match parseConfigurationFile graceConfigurationFilePath with
+            | Error errorMessage -> Error errorMessage
+            | Ok graceConfigurationFromFile ->
+                let configuration = populateDerivedFields graceConfigurationFilePath graceConfigurationFromFile
+
+                Ok
+                    {
+                        Path = graceConfigurationFilePath
+                        RootDirectory = configuration.RootDirectory
+                        Configuration = configuration
+                        Ignore = inspectGraceIgnore configuration.RootDirectory
+                    }
 
     let private createDefaultConfigurationFile () =
         let graceConfigurationFilePath = Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -226,7 +226,7 @@ module Configuration =
 
     type GraceConfigurationInspectionError =
         | ConfigurationFileNotFound of string
-        | ConfigurationFileMalformed of string
+        | ConfigurationFileMalformed of path: string * message: string
 
     let private tryGetGraceIgnoreEntries graceIgnorePath =
         try
@@ -261,7 +261,7 @@ module Configuration =
         | Error errorMessage -> Error(ConfigurationFileNotFound errorMessage)
         | Ok graceConfigurationFilePath ->
             match parseConfigurationFile graceConfigurationFilePath with
-            | Error errorMessage -> Error(ConfigurationFileMalformed errorMessage)
+            | Error errorMessage -> Error(ConfigurationFileMalformed(graceConfigurationFilePath, errorMessage))
             | Ok graceConfigurationFromFile ->
                 let configuration = populateConfigurationPaths graceConfigurationFilePath graceConfigurationFromFile
                 let ignore = inspectGraceIgnore configuration.RootDirectory

--- a/src/Grace.Shared/Client/Configuration.Shared.fs
+++ b/src/Grace.Shared/Client/Configuration.Shared.fs
@@ -170,7 +170,19 @@ module Configuration =
         else
             Array.empty
 
-    let private populateDerivedFields (graceConfigurationFilePath: string) (graceConfiguration: GraceConfiguration) =
+    let private populateGraceIgnoreFields (graceConfiguration: GraceConfiguration) graceIgnoreEntries =
+        graceConfiguration.GraceIgnoreEntries <- graceIgnoreEntries
+
+        graceConfiguration.GraceFileIgnoreEntries <-
+            graceIgnoreEntries
+            |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
+
+        graceConfiguration.GraceDirectoryIgnoreEntries <-
+            graceIgnoreEntries
+            |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+            |> Array.map (fun graceIgnoreLine -> $"*{graceIgnoreLine}")
+
+    let private populateConfigurationPaths (graceConfigurationFilePath: string) (graceConfiguration: GraceConfiguration) =
         let graceConfigurationDirectory = Path.GetDirectoryName(graceConfigurationFilePath)
 
         graceConfiguration.RootDirectory <- Path.GetFullPath(Path.Combine(graceConfigurationDirectory, ".."))
@@ -187,35 +199,53 @@ module Configuration =
 
         graceConfiguration.ConfigurationDirectory <- FileInfo(graceConfigurationFilePath).DirectoryName
 
+        graceConfiguration
+
+    let private populateDerivedFields graceConfigurationFilePath graceConfiguration =
+        let graceConfiguration = populateConfigurationPaths graceConfigurationFilePath graceConfiguration
         let graceIgnoreFullPath = (Path.Combine(graceConfiguration.RootDirectory, Constants.GraceIgnoreFileName))
 
         let graceIgnoreEntries = getGraceIgnoreEntries graceIgnoreFullPath
 
-        graceConfiguration.GraceIgnoreEntries <- graceIgnoreEntries
-
-        graceConfiguration.GraceFileIgnoreEntries <-
-            graceIgnoreEntries
-            |> Array.where (fun graceIgnoreLine -> not <| pathContainsSeparator graceIgnoreLine)
-
-        graceConfiguration.GraceDirectoryIgnoreEntries <-
-            graceIgnoreEntries
-            |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
-            |> Array.map (fun graceIgnoreLine -> $"*{graceIgnoreLine}")
+        populateGraceIgnoreFields graceConfiguration graceIgnoreEntries
 
         graceConfiguration.IsPopulated <- true
         graceConfiguration
 
-    type GraceIgnoreInspection = { Path: string; Exists: bool; Entries: string array; FileEntries: string array; DirectoryEntries: string array }
+    type GraceIgnoreInspection =
+        {
+            Path: string
+            Exists: bool
+            Entries: string array
+            FileEntries: string array
+            DirectoryEntries: string array
+            ErrorMessage: string option
+        }
 
     type GraceConfigurationInspection = { Path: string; RootDirectory: string; Configuration: GraceConfiguration; Ignore: GraceIgnoreInspection }
 
+    type GraceConfigurationInspectionError =
+        | ConfigurationFileNotFound of string
+        | ConfigurationFileMalformed of string
+
+    let private tryGetGraceIgnoreEntries graceIgnorePath =
+        try
+            Ok(getGraceIgnoreEntries graceIgnorePath)
+        with
+        | ex -> Error $"Exception: {ex.Message}{Environment.NewLine}Stack trace: {ex.StackTrace}"
+
     let inspectGraceIgnore rootDirectory =
         let graceIgnorePath = Path.Combine(rootDirectory, Constants.GraceIgnoreFileName)
-        let entries = getGraceIgnoreEntries graceIgnorePath
+        let exists = File.Exists(graceIgnorePath)
+
+        let entries, errorMessage =
+            match tryGetGraceIgnoreEntries graceIgnorePath with
+            | Ok entries -> entries, None
+            | Error errorMessage -> Array.empty, Some errorMessage
 
         {
             Path = graceIgnorePath
-            Exists = File.Exists(graceIgnorePath)
+            Exists = exists
             Entries = entries
             FileEntries =
                 entries
@@ -223,24 +253,22 @@ module Configuration =
             DirectoryEntries =
                 entries
                 |> Array.where (fun graceIgnoreLine -> pathContainsSeparator graceIgnoreLine)
+            ErrorMessage = errorMessage
         }
 
     let tryInspectCurrentDirectoryConfiguration () =
         match findGraceConfigurationFile () with
-        | Error errorMessage -> Error errorMessage
+        | Error errorMessage -> Error(ConfigurationFileNotFound errorMessage)
         | Ok graceConfigurationFilePath ->
             match parseConfigurationFile graceConfigurationFilePath with
-            | Error errorMessage -> Error errorMessage
+            | Error errorMessage -> Error(ConfigurationFileMalformed errorMessage)
             | Ok graceConfigurationFromFile ->
-                let configuration = populateDerivedFields graceConfigurationFilePath graceConfigurationFromFile
+                let configuration = populateConfigurationPaths graceConfigurationFilePath graceConfigurationFromFile
+                let ignore = inspectGraceIgnore configuration.RootDirectory
+                populateGraceIgnoreFields configuration ignore.Entries
+                configuration.IsPopulated <- true
 
-                Ok
-                    {
-                        Path = graceConfigurationFilePath
-                        RootDirectory = configuration.RootDirectory
-                        Configuration = configuration
-                        Ignore = inspectGraceIgnore configuration.RootDirectory
-                    }
+                Ok { Path = graceConfigurationFilePath; RootDirectory = configuration.RootDirectory; Configuration = configuration; Ignore = ignore }
 
     let private createDefaultConfigurationFile () =
         let graceConfigurationFilePath = Path.Combine(Environment.CurrentDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)

--- a/src/Grace.Shared/Client/UserConfiguration.Shared.fs
+++ b/src/Grace.Shared/Client/UserConfiguration.Shared.fs
@@ -62,6 +62,8 @@ module UserConfiguration =
 
     type UserConfigurationLoadResult = { Configuration: UserConfiguration; WasCorrupt: bool; ErrorMessage: string option; CreatedNew: bool }
 
+    type UserConfigurationInspection = { Path: string; Exists: bool; Configuration: UserConfiguration option; ErrorMessage: string option }
+
     let private normalizeHistory (history: HistoryConfiguration) =
         let normalized = if obj.ReferenceEquals(history, null) then HistoryConfiguration() else history
 
@@ -163,3 +165,20 @@ module UserConfiguration =
                 ErrorMessage = Some $"Failed to read user configuration: {ex.Message}"
                 CreatedNew = false
             }
+
+    let tryInspectUserConfiguration () =
+        let path = getUserConfigurationPath ()
+
+        if not <| File.Exists(path) then
+            { Path = path; Exists = false; Configuration = None; ErrorMessage = None }
+        else
+            try
+                let json = File.ReadAllText(path)
+                let configuration = JsonSerializer.Deserialize<UserConfiguration>(json, Constants.JsonSerializerOptions)
+
+                if obj.ReferenceEquals(configuration, null) then
+                    { Path = path; Exists = true; Configuration = None; ErrorMessage = Some "User configuration file is empty or invalid JSON." }
+                else
+                    { Path = path; Exists = true; Configuration = Some(normalizeConfiguration configuration); ErrorMessage = None }
+            with
+            | ex -> { Path = path; Exists = true; Configuration = None; ErrorMessage = Some $"Failed to read user configuration: {ex.Message}" }


### PR DESCRIPTION
Closes #333

## Summary
- Add root-level `grace doctor` as a read-only diagnostic command with human and JSON output.
- Add diagnostics for configuration, user configuration, ignore rules, authentication, local state, object cache, server health/lifecycle, and full-mode working-tree drift.
- Document `grace doctor`, refresh machine-readable CLI output inventory/examples, and add README/auth troubleshooting pointers.

## Review Status
- 2026-06-10: Epic branch `epic/333-grace-doctor` is current with `origin/main` (`0` behind, `28` ahead) at `6b4a859244949ea9ac1f398f6b0f0d3df5a79ffd`.
- 2026-06-10: Final local validation before opening the PR passed: `pwsh ./scripts/validate.ps1 -Fast` and `git diff --check`.
- 2026-06-10: Codex Code Review Bot found P2 `server.lifecycle.headers` exact-check behavior could report `Ok` on non-2xx `/healthz` without lifecycle headers (comment #4672021644 on `455cf4ab2b23c456d60a9869b9aac601d0da8a90`).
- 2026-06-10: Fixed in `6b4a859244949ea9ac1f398f6b0f0d3df5a79ffd`; exact lifecycle-header checks now fail on non-2xx `/healthz`, with regression coverage for HTTP 500/no lifecycle headers.
- 2026-06-10: Fix validation passed: Fantomas, focused Doctor CLI tests (79 tests), `pwsh ./scripts/validate.ps1 -Fast`, and `git diff --check`.
- 2026-06-10: Prevention: acceptance-criteria / negative-proof gap; current PR now includes an exact-check non-2xx `/healthz` regression test, no sibling issue/template/agent-doc update needed.
- 2026-06-10: Codex Code Review Bot clean signal present on current head via bot `+1` reaction.
- 2026-06-10: Hosted `full` validation passed on `6b4a859244949ea9ac1f398f6b0f0d3df5a79ffd` (Validate run #675).

## Validation
- Final epic validation before opening PR #376: `pwsh ./scripts/validate.ps1 -Fast` passed on `epic/333-grace-doctor` at `455cf4ab2b23c456d60a9869b9aac601d0da8a90`.
  - Format step: skipped by current repo setting.
  - Build: succeeded, 0 warnings, 0 errors.
  - Fast selected test suites: passed.
- Final PR fix validation on `6b4a859244949ea9ac1f398f6b0f0d3df5a79ffd`:
  - `dotnet tool run fantomas -- src/Grace.CLI/Command/Doctor.CLI.fs src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`: passed.
  - `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~DoctorCliTests"`: passed, 79 tests.
  - `pwsh ./scripts/validate.ps1 -Fast`: passed, build 0 warnings/errors and Fast test gate passed.
  - `git diff --check`: passed.
- Hosted `full` validation passed on `6b4a859244949ea9ac1f398f6b0f0d3df5a79ffd` (Validate run #675).
- Sub-issue PRs recorded focused validation, hosted `full` checks where applicable, and Codex Code Review Bot review loops.

## Full Validation
Skipped locally. The epic did not change Aspire orchestration, deployment/runtime behavior, storage/service-bus/cosmos/redis integration, or cross-service integration behavior that requires `validate -Full`; `validate -Fast`, focused slice tests, hosted `full` checks for sub-issue PRs, and Codex Code Review Bot gates cover this release candidate.

## Release Notes
- `grace doctor` is read-only in v1 and does not repair, initialize, migrate, refresh credentials, upload bundles, or mutate local/server state.
- `--output Json`, `--select`, `--schema`, and `--examples` are documented for automation consumers.
- `--full` can run full-profile checks including server probes unless `--offline` suppresses non-offline checks.
- Repair/support-bundle/cloud/Aspire diagnostics remain deferred or out of scope for v1.