### PR TITLE
I06: Propagate file BLAKE3 through save paths

### DIFF
--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -475,6 +475,39 @@ module ContentBlockMetadata =
                 metadataDto <- applyEvents events metadataDto
             }
 
+        member private this.HandleCommand (command: ContentBlockMetadataCommand) (eventMetadata: EventMetadata) =
+            task {
+                this.correlationId <- eventMetadata.CorrelationId
+                RequestContext.Set(Constants.CurrentCommandProperty, commandName command)
+
+                match decideCommand state.State metadataDto command eventMetadata with
+                | Ok decision ->
+                    if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+
+                    let dedupeIndexActor = DedupeIndexActor.CreateActorProxy eventMetadata.CorrelationId
+
+                    do! dedupeIndexActor.WriteAfterAuthoritativeMetadata decision.Metadata eventMetadata.CorrelationId :> Task
+
+                    let returnValue =
+                        (GraceReturnValue.Create decision eventMetadata.CorrelationId)
+                            .enhance(nameof StoragePoolId, decision.Metadata.StoragePoolId)
+                            .enhance(nameof ContentBlockAddress, decision.Metadata.ContentBlockAddress)
+                            .enhance (nameof MetadataVersion, decision.Metadata.MetadataVersion)
+
+                    return Ok returnValue
+                | Error error ->
+                    log.LogWarning(
+                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected ContentBlockMetadata command {Command}. Error: {Error}",
+                        getCurrentInstantExtended (),
+                        getMachineName,
+                        eventMetadata.CorrelationId,
+                        commandName command,
+                        error.Error
+                    )
+
+                    return Error error
+            }
+
         interface IContentBlockMetadataActor with
             member this.Exists correlationId =
                 this.correlationId <- correlationId
@@ -500,35 +533,6 @@ module ContentBlockMetadata =
                 | None -> ContentBlockRangePresence.Absent
                 |> returnTask
 
-            member this.Handle command eventMetadata =
-                task {
-                    this.correlationId <- eventMetadata.CorrelationId
-                    RequestContext.Set(Constants.CurrentCommandProperty, commandName command)
+            member this.Handle command eventMetadata = this.HandleCommand command eventMetadata
 
-                    match decideCommand state.State metadataDto command eventMetadata with
-                    | Ok decision ->
-                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
-
-                        let dedupeIndexActor = DedupeIndexActor.CreateActorProxy eventMetadata.CorrelationId
-
-                        do! dedupeIndexActor.WriteAfterAuthoritativeMetadata decision.Metadata eventMetadata.CorrelationId :> Task
-
-                        let returnValue =
-                            (GraceReturnValue.Create decision eventMetadata.CorrelationId)
-                                .enhance(nameof StoragePoolId, decision.Metadata.StoragePoolId)
-                                .enhance(nameof ContentBlockAddress, decision.Metadata.ContentBlockAddress)
-                                .enhance (nameof MetadataVersion, decision.Metadata.MetadataVersion)
-
-                        return Ok returnValue
-                    | Error error ->
-                        log.LogWarning(
-                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected ContentBlockMetadata command {Command}. Error: {Error}",
-                            getCurrentInstantExtended (),
-                            getMachineName,
-                            eventMetadata.CorrelationId,
-                            commandName command,
-                            error.Error
-                        )
-
-                        return Error error
-                }
+            member this.MergePhysicalRanges merge eventMetadata = this.HandleCommand (ContentBlockMetadataCommand.MergePhysicalRanges merge) eventMetadata

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -20,6 +20,7 @@ open Grace.Types.Reminder
 open Grace.Types.Repository
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
+open Grace.Types.ContentBlockMetadata
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.ObjectPool
 open NodaTime
@@ -42,6 +43,8 @@ open System.Threading
 open Azure.Storage
 
 module DirectoryVersion =
+
+    let private DefaultStoragePoolId = "default"
 
     /// Result of validating a single whole-file content reference.
     type FileValidationResult =
@@ -246,6 +249,55 @@ module DirectoryVersion =
         match error with
         | Some graceError -> Error graceError
         | None -> Ok(manifests.Values |> Seq.toList)
+
+    let validateManifestReferencesForSaveBoundaryWithResolver
+        (getRangePresence: ContentBlockAddress -> ContentBlockRangeQuery -> Task<ContentBlockRangePresence>)
+        correlationId
+        (manifests: FileManifest seq)
+        =
+        task {
+            let manifestArray = manifests |> Seq.toArray
+            let mutable manifestIndex = 0
+            let mutable error: GraceError option = None
+
+            while manifestIndex < manifestArray.Length
+                  && error.IsNone do
+                let manifest = manifestArray[manifestIndex]
+                let mutable blockIndex = 0
+
+                while blockIndex < manifest.Blocks.Count && error.IsNone do
+                    let block = manifest.Blocks[blockIndex]
+                    let query: ContentBlockRangeQuery = { OrdinalStart = blockIndex; OrdinalCount = 1 }
+                    let! presence = getRangePresence block.Address query
+
+                    if presence = ContentBlockRangePresence.Absent then
+                        error <-
+                            Some(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' references ContentBlock '{block.Address}' at ordinal {blockIndex}, but no finalized ContentBlock metadata range exists."
+                                    correlationId
+                            )
+
+                    blockIndex <- blockIndex + 1
+
+                manifestIndex <- manifestIndex + 1
+
+            return
+                match error with
+                | Some graceError -> Error graceError
+                | None -> Ok()
+        }
+
+    let private validateManifestReferencesForSaveBoundary correlationId manifests =
+        let getRangePresence contentBlockAddress query =
+            let storagePoolId = StoragePoolId DefaultStoragePoolId
+            let actorKey = $"{storagePoolId}|{contentBlockAddress}"
+
+            let metadataActor = orleansClient.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(actorKey, correlationId)
+
+            metadataActor.GetRangePresence query correlationId
+
+        validateManifestReferencesForSaveBoundaryWithResolver getRangePresence correlationId manifests
 
     type DirectoryVersionActor
         (
@@ -788,205 +840,214 @@ module DirectoryVersion =
                                     | Create (directoryVersion, repositoryDto) ->
                                         match getManifestReferencesForSaveBoundary directoryVersion metadata.CorrelationId with
                                         | Error graceError -> return Error graceError
-                                        | Ok _ ->
-                                            // Determine which whole-file entries need validation using incremental validation logic.
-                                            // Manifest-backed files were already accepted by UploadSession finalization; WholeFileContent remains unchanged.
-                                            let! mostRecentDirectoryVersion =
-                                                getMostRecentDirectoryVersionByRelativePath
-                                                    repositoryDto.RepositoryId
-                                                    directoryVersion.RelativePath
-                                                    metadata.CorrelationId
+                                        | Ok manifests ->
+                                            match! validateManifestReferencesForSaveBoundary metadata.CorrelationId manifests with
+                                            | Error graceError -> return Error graceError
+                                            | Ok () ->
 
-                                            let filesToValidate =
-                                                match mostRecentDirectoryVersion with
-                                                | Some previousDirectoryVersion ->
-                                                    getFilesToValidateForSaveBoundary directoryVersion.Files previousDirectoryVersion.Files
-                                                | None -> getFilesToValidateForSaveBoundary directoryVersion.Files (List<FileVersion>())
+                                                // Determine which whole-file entries need validation using incremental validation logic.
+                                                // Manifest-backed files are accepted only after their ContentBlock metadata ranges exist.
+                                                let! mostRecentDirectoryVersion =
+                                                    getMostRecentDirectoryVersionByRelativePath
+                                                        repositoryDto.RepositoryId
+                                                        directoryVersion.RelativePath
+                                                        metadata.CorrelationId
 
-                                            log.LogDebug(
-                                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting SHA-256 validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
-                                                getCurrentInstantExtended (),
-                                                getMachineName,
-                                                metadata.CorrelationId,
-                                                directoryVersion.DirectoryVersionId,
-                                                directoryVersion.RelativePath,
-                                                directoryVersion.Files.Count,
-                                                filesToValidate.Length
-                                            )
+                                                let filesToValidate =
+                                                    match mostRecentDirectoryVersion with
+                                                    | Some previousDirectoryVersion ->
+                                                        getFilesToValidateForSaveBoundary directoryVersion.Files previousDirectoryVersion.Files
+                                                    | None -> getFilesToValidateForSaveBoundary directoryVersion.Files (List<FileVersion>())
 
-                                            let validationResults = ConcurrentQueue<FileValidationResult>()
-
-                                            // Validate files in parallel
-                                            do!
-                                                Parallel.ForEachAsync(
-                                                    filesToValidate,
-                                                    Constants.ParallelOptions,
-                                                    (fun fileVersion ct ->
-                                                        ValueTask(
-                                                            task {
-                                                                let! result = validateFileSha256 repositoryDto fileVersion metadata.CorrelationId
-                                                                validationResults.Enqueue result
-                                                            }
-                                                        ))
-                                                )
-
-                                            let validationResults = validationResults.ToArray()
-
-                                            // Collect failures
-                                            let failures =
-                                                validationResults
-                                                |> Array.filter (fun result ->
-                                                    match result with
-                                                    | Valid _ -> false
-                                                    | _ -> true)
-                                                |> Array.toList
-
-                                            let validCount =
-                                                validationResults
-                                                |> Array.filter (fun result ->
-                                                    match result with
-                                                    | Valid _ -> true
-                                                    | _ -> false)
-                                                |> Array.length
-
-                                            let totalElapsedMs =
-                                                validationResults
-                                                |> Array.sumBy (fun result ->
-                                                    match result with
-                                                    | Valid (_, _, _, ms) -> ms
-                                                    | HashMismatch (_, _, _, _, _, ms) -> ms
-                                                    | MissingInStorage (_, ms) -> ms
-                                                    | ValidationError (_, _, ms) -> ms)
-
-                                            // Log validation results
-                                            for result in validationResults do
-                                                match result with
-                                                | Valid (fv, computedSha256Hash, computedBlake3Hash, elapsedMs) ->
-                                                    log.LogDebug(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash validation passed; File: {RelativePath}; Sha256Hash: {Sha256Hash}; Blake3Hash: {Blake3Hash}; ElapsedMs: {ElapsedMs}.",
-                                                        getCurrentInstantExtended (),
-                                                        getMachineName,
-                                                        metadata.CorrelationId,
-                                                        fv.RelativePath,
-                                                        computedSha256Hash,
-                                                        computedBlake3Hash,
-                                                        elapsedMs
-                                                    )
-                                                | HashMismatch (fv, expectedSha256Hash, computedSha256Hash, expectedBlake3Hash, computedBlake3Hash, elapsedMs) ->
-                                                    log.LogWarning(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash mismatch; File: {RelativePath}; ExpectedSha256Hash: {ExpectedSha256Hash}; ComputedSha256Hash: {ComputedSha256Hash}; ExpectedBlake3Hash: {ExpectedBlake3Hash}; ComputedBlake3Hash: {ComputedBlake3Hash}; ElapsedMs: {ElapsedMs}.",
-                                                        getCurrentInstantExtended (),
-                                                        getMachineName,
-                                                        metadata.CorrelationId,
-                                                        fv.RelativePath,
-                                                        expectedSha256Hash,
-                                                        computedSha256Hash,
-                                                        expectedBlake3Hash,
-                                                        computedBlake3Hash,
-                                                        elapsedMs
-                                                    )
-                                                | MissingInStorage (fv, elapsedMs) ->
-                                                    log.LogWarning(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; File not found in object storage; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ElapsedMs: {ElapsedMs}.",
-                                                        getCurrentInstantExtended (),
-                                                        getMachineName,
-                                                        metadata.CorrelationId,
-                                                        fv.RelativePath,
-                                                        fv.Sha256Hash,
-                                                        elapsedMs
-                                                    )
-                                                | ValidationError (fv, errorMessage, elapsedMs) ->
-                                                    log.LogError(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation error; File: {RelativePath}; Error: {ErrorMessage}; ElapsedMs: {ElapsedMs}.",
-                                                        getCurrentInstantExtended (),
-                                                        getMachineName,
-                                                        metadata.CorrelationId,
-                                                        fv.RelativePath,
-                                                        errorMessage,
-                                                        elapsedMs
-                                                    )
-
-                                            // Check if any validation failed
-                                            if failures.Length > 0 then
-                                                // Build error message with details about failures
-                                                let errorDetails =
-                                                    failures
-                                                    |> List.map (fun failure ->
-                                                        match failure with
-                                                        | HashMismatch (fv, expectedSha256, computedSha256, expectedBlake3, computedBlake3, _) ->
-                                                            $"File '{fv.RelativePath}': hash mismatch (expected SHA-256: {expectedSha256}, computed SHA-256: {computedSha256}, expected BLAKE3: {expectedBlake3}, computed BLAKE3: {computedBlake3})"
-                                                        | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
-                                                        | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
-                                                        | _ -> "Unknown error")
-                                                    |> String.concat "; "
-
-                                                log.LogWarning(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                log.LogDebug(
+                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Starting SHA-256 validation for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FileCount: {FileCount}; FilesToValidate: {FilesToValidate}.",
                                                     getCurrentInstantExtended (),
                                                     getMachineName,
                                                     metadata.CorrelationId,
                                                     directoryVersion.DirectoryVersionId,
                                                     directoryVersion.RelativePath,
-                                                    failures.Length,
-                                                    validCount,
-                                                    totalElapsedMs
+                                                    directoryVersion.Files.Count,
+                                                    filesToValidate.Length
                                                 )
 
-                                                // Determine the appropriate error type
-                                                let hasHashMismatch =
-                                                    failures
-                                                    |> List.exists (fun f ->
-                                                        match f with
-                                                        | HashMismatch _ -> true
+                                                let validationResults = ConcurrentQueue<FileValidationResult>()
+
+                                                // Validate files in parallel
+                                                do!
+                                                    Parallel.ForEachAsync(
+                                                        filesToValidate,
+                                                        Constants.ParallelOptions,
+                                                        (fun fileVersion ct ->
+                                                            ValueTask(
+                                                                task {
+                                                                    let! result = validateFileSha256 repositoryDto fileVersion metadata.CorrelationId
+                                                                    validationResults.Enqueue result
+                                                                }
+                                                            ))
+                                                    )
+
+                                                let validationResults = validationResults.ToArray()
+
+                                                // Collect failures
+                                                let failures =
+                                                    validationResults
+                                                    |> Array.filter (fun result ->
+                                                        match result with
+                                                        | Valid _ -> false
+                                                        | _ -> true)
+                                                    |> Array.toList
+
+                                                let validCount =
+                                                    validationResults
+                                                    |> Array.filter (fun result ->
+                                                        match result with
+                                                        | Valid _ -> true
                                                         | _ -> false)
+                                                    |> Array.length
 
-                                                let hasMissing =
-                                                    failures
-                                                    |> List.exists (fun f ->
-                                                        match f with
-                                                        | MissingInStorage _ -> true
-                                                        | _ -> false)
+                                                let totalElapsedMs =
+                                                    validationResults
+                                                    |> Array.sumBy (fun result ->
+                                                        match result with
+                                                        | Valid (_, _, _, ms) -> ms
+                                                        | HashMismatch (_, _, _, _, _, ms) -> ms
+                                                        | MissingInStorage (_, ms) -> ms
+                                                        | ValidationError (_, _, ms) -> ms)
 
-                                                let errorMessage =
-                                                    if hasMissing then
-                                                        DirectoryVersionError.getErrorMessage DirectoryVersionError.FileNotFoundInObjectStorage
-                                                        + " "
-                                                        + errorDetails
-                                                    elif hasHashMismatch then
-                                                        DirectoryVersionError.getErrorMessage DirectoryVersionError.FileSha256HashDoesNotMatch
-                                                        + " "
-                                                        + errorDetails
-                                                    else
-                                                        $"File integrity check failed: {errorDetails}"
+                                                // Log validation results
+                                                for result in validationResults do
+                                                    match result with
+                                                    | Valid (fv, computedSha256Hash, computedBlake3Hash, elapsedMs) ->
+                                                        log.LogDebug(
+                                                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash validation passed; File: {RelativePath}; Sha256Hash: {Sha256Hash}; Blake3Hash: {Blake3Hash}; ElapsedMs: {ElapsedMs}.",
+                                                            getCurrentInstantExtended (),
+                                                            getMachineName,
+                                                            metadata.CorrelationId,
+                                                            fv.RelativePath,
+                                                            computedSha256Hash,
+                                                            computedBlake3Hash,
+                                                            elapsedMs
+                                                        )
+                                                    | HashMismatch (fv,
+                                                                    expectedSha256Hash,
+                                                                    computedSha256Hash,
+                                                                    expectedBlake3Hash,
+                                                                    computedBlake3Hash,
+                                                                    elapsedMs) ->
+                                                        log.LogWarning(
+                                                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash mismatch; File: {RelativePath}; ExpectedSha256Hash: {ExpectedSha256Hash}; ComputedSha256Hash: {ComputedSha256Hash}; ExpectedBlake3Hash: {ExpectedBlake3Hash}; ComputedBlake3Hash: {ComputedBlake3Hash}; ElapsedMs: {ElapsedMs}.",
+                                                            getCurrentInstantExtended (),
+                                                            getMachineName,
+                                                            metadata.CorrelationId,
+                                                            fv.RelativePath,
+                                                            expectedSha256Hash,
+                                                            computedSha256Hash,
+                                                            expectedBlake3Hash,
+                                                            computedBlake3Hash,
+                                                            elapsedMs
+                                                        )
+                                                    | MissingInStorage (fv, elapsedMs) ->
+                                                        log.LogWarning(
+                                                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; File not found in object storage; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ElapsedMs: {ElapsedMs}.",
+                                                            getCurrentInstantExtended (),
+                                                            getMachineName,
+                                                            metadata.CorrelationId,
+                                                            fv.RelativePath,
+                                                            fv.Sha256Hash,
+                                                            elapsedMs
+                                                        )
+                                                    | ValidationError (fv, errorMessage, elapsedMs) ->
+                                                        log.LogError(
+                                                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation error; File: {RelativePath}; Error: {ErrorMessage}; ElapsedMs: {ElapsedMs}.",
+                                                            getCurrentInstantExtended (),
+                                                            getMachineName,
+                                                            metadata.CorrelationId,
+                                                            fv.RelativePath,
+                                                            errorMessage,
+                                                            elapsedMs
+                                                        )
 
-                                                return Error(GraceError.Create errorMessage metadata.CorrelationId)
-                                            else
-                                                log.LogInformation(
-                                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
-                                                    getCurrentInstantExtended (),
-                                                    getMachineName,
-                                                    metadata.CorrelationId,
-                                                    directoryVersion.DirectoryVersionId,
-                                                    directoryVersion.RelativePath,
-                                                    validCount,
-                                                    totalElapsedMs
-                                                )
+                                                // Check if any validation failed
+                                                if failures.Length > 0 then
+                                                    // Build error message with details about failures
+                                                    let errorDetails =
+                                                        failures
+                                                        |> List.map (fun failure ->
+                                                            match failure with
+                                                            | HashMismatch (fv, expectedSha256, computedSha256, expectedBlake3, computedBlake3, _) ->
+                                                                $"File '{fv.RelativePath}': hash mismatch (expected SHA-256: {expectedSha256}, computed SHA-256: {computedSha256}, expected BLAKE3: {expectedBlake3}, computed BLAKE3: {computedBlake3})"
+                                                            | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
+                                                            | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
+                                                            | _ -> "Unknown error")
+                                                        |> String.concat "; "
 
-                                                let newDirectoryVersion = DirectoryVersion()
-                                                newDirectoryVersion.Class <- directoryVersion.Class
-                                                newDirectoryVersion.DirectoryVersionId <- directoryVersion.DirectoryVersionId
-                                                newDirectoryVersion.OwnerId <- directoryVersion.OwnerId
-                                                newDirectoryVersion.OrganizationId <- directoryVersion.OrganizationId
-                                                newDirectoryVersion.RepositoryId <- directoryVersion.RepositoryId
-                                                newDirectoryVersion.RelativePath <- directoryVersion.RelativePath
-                                                newDirectoryVersion.Sha256Hash <- directoryVersion.Sha256Hash
-                                                newDirectoryVersion.Blake3Hash <- directoryVersion.Blake3Hash
-                                                newDirectoryVersion.Directories <- directoryVersion.Directories
-                                                newDirectoryVersion.Files <- directoryVersion.Files
-                                                newDirectoryVersion.Size <- directoryVersion.Size
-                                                newDirectoryVersion.CreatedAt <- directoryVersion.CreatedAt
-                                                newDirectoryVersion.HashesValidated <- true
-                                                return Ok(Created newDirectoryVersion)
+                                                    log.LogWarning(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation failed for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; FailedCount: {FailedCount}; ValidCount: {ValidCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        directoryVersion.DirectoryVersionId,
+                                                        directoryVersion.RelativePath,
+                                                        failures.Length,
+                                                        validCount,
+                                                        totalElapsedMs
+                                                    )
+
+                                                    // Determine the appropriate error type
+                                                    let hasHashMismatch =
+                                                        failures
+                                                        |> List.exists (fun f ->
+                                                            match f with
+                                                            | HashMismatch _ -> true
+                                                            | _ -> false)
+
+                                                    let hasMissing =
+                                                        failures
+                                                        |> List.exists (fun f ->
+                                                            match f with
+                                                            | MissingInStorage _ -> true
+                                                            | _ -> false)
+
+                                                    let errorMessage =
+                                                        if hasMissing then
+                                                            DirectoryVersionError.getErrorMessage DirectoryVersionError.FileNotFoundInObjectStorage
+                                                            + " "
+                                                            + errorDetails
+                                                        elif hasHashMismatch then
+                                                            DirectoryVersionError.getErrorMessage DirectoryVersionError.FileSha256HashDoesNotMatch
+                                                            + " "
+                                                            + errorDetails
+                                                        else
+                                                            $"File integrity check failed: {errorDetails}"
+
+                                                    return Error(GraceError.Create errorMessage metadata.CorrelationId)
+                                                else
+                                                    log.LogInformation(
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation succeeded for DirectoryVersion; DirectoryVersionId: {DirectoryVersionId}; RelativePath: {RelativePath}; ValidatedCount: {ValidatedCount}; TotalElapsedMs: {TotalElapsedMs}.",
+                                                        getCurrentInstantExtended (),
+                                                        getMachineName,
+                                                        metadata.CorrelationId,
+                                                        directoryVersion.DirectoryVersionId,
+                                                        directoryVersion.RelativePath,
+                                                        validCount,
+                                                        totalElapsedMs
+                                                    )
+
+                                                    let newDirectoryVersion = DirectoryVersion()
+                                                    newDirectoryVersion.Class <- directoryVersion.Class
+                                                    newDirectoryVersion.DirectoryVersionId <- directoryVersion.DirectoryVersionId
+                                                    newDirectoryVersion.OwnerId <- directoryVersion.OwnerId
+                                                    newDirectoryVersion.OrganizationId <- directoryVersion.OrganizationId
+                                                    newDirectoryVersion.RepositoryId <- directoryVersion.RepositoryId
+                                                    newDirectoryVersion.RelativePath <- directoryVersion.RelativePath
+                                                    newDirectoryVersion.Sha256Hash <- directoryVersion.Sha256Hash
+                                                    newDirectoryVersion.Blake3Hash <- directoryVersion.Blake3Hash
+                                                    newDirectoryVersion.Directories <- directoryVersion.Directories
+                                                    newDirectoryVersion.Files <- directoryVersion.Files
+                                                    newDirectoryVersion.Size <- directoryVersion.Size
+                                                    newDirectoryVersion.CreatedAt <- directoryVersion.CreatedAt
+                                                    newDirectoryVersion.HashesValidated <- true
+                                                    return Ok(Created newDirectoryVersion)
                                     | SetRecursiveSize recursiveSize -> return Ok(RecursiveSizeSet recursiveSize)
                                     | DeleteLogical deleteReason ->
                                         let repositoryActorProxy =

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -43,14 +43,20 @@ open Azure.Storage
 
 module DirectoryVersion =
 
-    /// Result of validating a single file's SHA-256 hash.
+    /// Result of validating a single whole-file content reference.
     type FileValidationResult =
-        | Valid of fileVersion: FileVersion * computedHash: Sha256Hash * elapsedMs: float
-        | HashMismatch of fileVersion: FileVersion * expectedHash: Sha256Hash * computedHash: Sha256Hash * elapsedMs: float
+        | Valid of fileVersion: FileVersion * computedSha256Hash: Sha256Hash * computedBlake3Hash: Blake3Hash * elapsedMs: float
+        | HashMismatch of
+            fileVersion: FileVersion *
+            expectedSha256Hash: Sha256Hash *
+            computedSha256Hash: Sha256Hash *
+            expectedBlake3Hash: Blake3Hash *
+            computedBlake3Hash: Blake3Hash *
+            elapsedMs: float
         | MissingInStorage of fileVersion: FileVersion * elapsedMs: float
         | ValidationError of fileVersion: FileVersion * errorMessage: string * elapsedMs: float
 
-    /// Validates a single file's SHA-256 hash by downloading from storage and computing.
+    /// Validates a single file's version hashes by downloading from storage and computing.
     /// Note: Non-binary files are stored as GZip-compressed streams, so we need to decompress them first.
     let validateFileSha256 (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
         task {
@@ -64,54 +70,78 @@ module DirectoryVersion =
                     stopwatch.Stop()
                     return MissingInStorage(fileVersion, stopwatch.Elapsed.TotalMilliseconds)
                 else
-                    // Download the stream from blob storage
-                    use! blobStream = blobClient.OpenReadAsync(position = 0, bufferSize = (64 * 1024))
+                    let computeHashFromBlob computeHash =
+                        task {
+                            use! blobStream = blobClient.OpenReadAsync(position = 0, bufferSize = (64 * 1024))
 
-                    // Compute SHA-256 hash using the server-specific validation function.
-                    // Text files are stored as GZip streams and need decompression.
-                    let! computedHash =
-                        if fileVersion.IsBinary then
-                            computeSha256ForFile blobStream fileVersion.RelativePath
-                        else
-                            task {
+                            if fileVersion.IsBinary then
+                                return! computeHash blobStream
+                            else
                                 use gzStream = new GZipStream(stream = blobStream, mode = CompressionMode.Decompress, leaveOpen = false)
-                                return! computeSha256ForFile gzStream fileVersion.RelativePath
-                            }
+                                return! computeHash gzStream
+                        }
+
+                    let! computedSha256Hash = computeHashFromBlob (fun stream -> computeSha256ForFile stream fileVersion.RelativePath)
+
+                    let! computedBlake3Hash = computeHashFromBlob (fun stream -> computeBlake3ForFile stream)
+
+                    let computedBlake3Hash = Blake3Hash $"{computedBlake3Hash}"
 
                     stopwatch.Stop()
 
-                    if computedHash = fileVersion.Sha256Hash then
-                        return Valid(fileVersion, computedHash, stopwatch.Elapsed.TotalMilliseconds)
+                    if computedSha256Hash = fileVersion.Sha256Hash
+                       && (String.IsNullOrWhiteSpace fileVersion.Blake3Hash
+                           || computedBlake3Hash = fileVersion.Blake3Hash) then
+                        return Valid(fileVersion, computedSha256Hash, computedBlake3Hash, stopwatch.Elapsed.TotalMilliseconds)
                     else
-                        return HashMismatch(fileVersion, fileVersion.Sha256Hash, computedHash, stopwatch.Elapsed.TotalMilliseconds)
+                        return
+                            HashMismatch(
+                                fileVersion,
+                                fileVersion.Sha256Hash,
+                                computedSha256Hash,
+                                fileVersion.Blake3Hash,
+                                computedBlake3Hash,
+                                stopwatch.Elapsed.TotalMilliseconds
+                            )
             with
             | ex ->
                 stopwatch.Stop()
                 return ValidationError(fileVersion, ex.Message, stopwatch.Elapsed.TotalMilliseconds)
         }
 
-    /// Determines which files need validation by comparing with a previously validated DirectoryVersion.
-    /// Returns the list of files that need to be validated.
-    let getFilesToValidate (newFiles: List<FileVersion>) (previouslyValidatedFiles: List<FileVersion>) : FileVersion array =
-        if previouslyValidatedFiles.Count > 0 then
-            // Create a set of (RelativePath, Sha256Hash) pairs from the old files
-            let previousFilesLookup = Dictionary<RelativePath, Sha256Hash>()
-
-            previouslyValidatedFiles
-            |> Seq.iter (fun previousFile -> previousFilesLookup.Add(previousFile.RelativePath, previousFile.Sha256Hash))
-
-            // Return files that are not in the old set (new or changed)
-            newFiles
-                .Where(fun f -> not (previousFilesLookup.Contains(KeyValuePair(f.RelativePath, f.Sha256Hash))))
-                .ToArray()
-        else
-            newFiles.ToArray()
-
     let private normalizeContentReference (fileVersion: FileVersion) =
         if isNull (box fileVersion.ContentReference) then
             FileContentReference.WholeFileContent
         else
             fileVersion.ContentReference
+
+    /// Determines which files need validation by comparing with a previously validated DirectoryVersion.
+    /// Returns the list of files that need to be validated.
+    let getFilesToValidate (newFiles: List<FileVersion>) (previouslyValidatedFiles: List<FileVersion>) : FileVersion array =
+        if previouslyValidatedFiles.Count > 0 then
+            let contentReferenceIdentity (fileVersion: FileVersion) =
+                let contentReference = normalizeContentReference fileVersion
+
+                match contentReference.ReferenceType, contentReference.Manifest with
+                | FileContentReferenceType.FileManifest, Some manifest -> $"{contentReference.ReferenceType}:{manifest.ManifestAddress}"
+                | referenceType, _ -> $"{referenceType}"
+
+            let fileIdentity (fileVersion: FileVersion) =
+                (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash, contentReferenceIdentity fileVersion)
+
+            let previousFilesLookup = HashSet<RelativePath * Sha256Hash * Blake3Hash * string>()
+
+            previouslyValidatedFiles
+            |> Seq.iter (fun previousFile ->
+                previousFilesLookup.Add(fileIdentity previousFile)
+                |> ignore)
+
+            // Return files that are not in the old set (new or changed)
+            newFiles
+                .Where(fun f -> not (previousFilesLookup.Contains(fileIdentity f)))
+                .ToArray()
+        else
+            newFiles.ToArray()
 
     let private isWholeFileContentReference (fileVersion: FileVersion) =
         (normalizeContentReference fileVersion)
@@ -169,6 +199,11 @@ module DirectoryVersion =
                 Error(manifestValidationError correlationId fileVersion "must include a ChunkingSuiteId before Save.")
             elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
                 Error(manifestValidationError correlationId fileVersion "has an invalid FileContentHash before Save.")
+            elif
+                not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+                && fileVersion.Blake3Hash <> manifest.FileContentHash
+            then
+                Error(manifestValidationError correlationId fileVersion "must match FileVersion.Blake3Hash before Save.")
             elif manifest.Size <= 0L then
                 Error(manifestValidationError correlationId fileVersion "must have a positive size before Save.")
             elif fileVersion.Size <> manifest.Size then
@@ -822,33 +857,36 @@ module DirectoryVersion =
                                                 validationResults
                                                 |> Array.sumBy (fun result ->
                                                     match result with
-                                                    | Valid (_, _, ms) -> ms
-                                                    | HashMismatch (_, _, _, ms) -> ms
+                                                    | Valid (_, _, _, ms) -> ms
+                                                    | HashMismatch (_, _, _, _, _, ms) -> ms
                                                     | MissingInStorage (_, ms) -> ms
                                                     | ValidationError (_, _, ms) -> ms)
 
                                             // Log validation results
                                             for result in validationResults do
                                                 match result with
-                                                | Valid (fv, computedHash, elapsedMs) ->
+                                                | Valid (fv, computedSha256Hash, computedBlake3Hash, elapsedMs) ->
                                                     log.LogDebug(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 validation passed; File: {RelativePath}; Hash: {Hash}; ElapsedMs: {ElapsedMs}.",
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash validation passed; File: {RelativePath}; Sha256Hash: {Sha256Hash}; Blake3Hash: {Blake3Hash}; ElapsedMs: {ElapsedMs}.",
                                                         getCurrentInstantExtended (),
                                                         getMachineName,
                                                         metadata.CorrelationId,
                                                         fv.RelativePath,
-                                                        computedHash,
+                                                        computedSha256Hash,
+                                                        computedBlake3Hash,
                                                         elapsedMs
                                                     )
-                                                | HashMismatch (fv, expectedHash, computedHash, elapsedMs) ->
+                                                | HashMismatch (fv, expectedSha256Hash, computedSha256Hash, expectedBlake3Hash, computedBlake3Hash, elapsedMs) ->
                                                     log.LogWarning(
-                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; SHA-256 hash mismatch; File: {RelativePath}; ExpectedHash: {ExpectedHash}; ComputedHash: {ComputedHash}; ElapsedMs: {ElapsedMs}.",
+                                                        "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; file version hash mismatch; File: {RelativePath}; ExpectedSha256Hash: {ExpectedSha256Hash}; ComputedSha256Hash: {ComputedSha256Hash}; ExpectedBlake3Hash: {ExpectedBlake3Hash}; ComputedBlake3Hash: {ComputedBlake3Hash}; ElapsedMs: {ElapsedMs}.",
                                                         getCurrentInstantExtended (),
                                                         getMachineName,
                                                         metadata.CorrelationId,
                                                         fv.RelativePath,
-                                                        expectedHash,
-                                                        computedHash,
+                                                        expectedSha256Hash,
+                                                        computedSha256Hash,
+                                                        expectedBlake3Hash,
+                                                        computedBlake3Hash,
                                                         elapsedMs
                                                     )
                                                 | MissingInStorage (fv, elapsedMs) ->
@@ -879,8 +917,8 @@ module DirectoryVersion =
                                                     failures
                                                     |> List.map (fun failure ->
                                                         match failure with
-                                                        | HashMismatch (fv, expected, computed, _) ->
-                                                            $"File '{fv.RelativePath}': hash mismatch (expected: {expected}, computed: {computed})"
+                                                        | HashMismatch (fv, expectedSha256, computedSha256, expectedBlake3, computedBlake3, _) ->
+                                                            $"File '{fv.RelativePath}': hash mismatch (expected SHA-256: {expectedSha256}, computed SHA-256: {computedSha256}, expected BLAKE3: {expectedBlake3}, computed BLAKE3: {computedBlake3})"
                                                         | MissingInStorage (fv, _) -> $"File '{fv.RelativePath}': not found in object storage"
                                                         | ValidationError (fv, msg, _) -> $"File '{fv.RelativePath}': validation error ({msg})"
                                                         | _ -> "Unknown error")

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -70,22 +70,18 @@ module DirectoryVersion =
                     stopwatch.Stop()
                     return MissingInStorage(fileVersion, stopwatch.Elapsed.TotalMilliseconds)
                 else
-                    let computeHashFromBlob computeHash =
+                    let computeHashesFromBlob () =
                         task {
                             use! blobStream = blobClient.OpenReadAsync(position = 0, bufferSize = (64 * 1024))
 
                             if fileVersion.IsBinary then
-                                return! computeHash blobStream
+                                return! computeHashesForFile blobStream fileVersion.RelativePath
                             else
                                 use gzStream = new GZipStream(stream = blobStream, mode = CompressionMode.Decompress, leaveOpen = false)
-                                return! computeHash gzStream
+                                return! computeHashesForFile gzStream fileVersion.RelativePath
                         }
 
-                    let! computedSha256Hash = computeHashFromBlob (fun stream -> computeSha256ForFile stream fileVersion.RelativePath)
-
-                    let! computedBlake3Hash = computeHashFromBlob (fun stream -> computeBlake3ForFile stream)
-
-                    let computedBlake3Hash = Blake3Hash $"{computedBlake3Hash}"
+                    let! computedSha256Hash, computedBlake3Hash = computeHashesFromBlob ()
 
                     stopwatch.Stop()
 

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -250,6 +250,10 @@ module DirectoryVersion =
         | Some graceError -> Error graceError
         | None -> Ok(manifests.Values |> Seq.toList)
 
+    let contentBlockMetadataActorKeyForSaveBoundary repositoryId contentBlockAddress =
+        let storagePoolId = DedupeIndex.storagePoolIdForRepositoryId repositoryId
+        $"{storagePoolId}|{contentBlockAddress}"
+
     let validateManifestReferencesForSaveBoundaryWithResolver
         (getRangePresence: ContentBlockAddress -> ContentBlockRangeQuery -> Task<ContentBlockRangePresence>)
         correlationId
@@ -267,14 +271,14 @@ module DirectoryVersion =
 
                 while blockIndex < manifest.Blocks.Count && error.IsNone do
                     let block = manifest.Blocks[blockIndex]
-                    let query: ContentBlockRangeQuery = { OrdinalStart = blockIndex; OrdinalCount = 1 }
+                    let query: ContentBlockRangeQuery = { OrdinalStart = 0; OrdinalCount = 1 }
                     let! presence = getRangePresence block.Address query
 
                     if presence = ContentBlockRangePresence.Absent then
                         error <-
                             Some(
                                 GraceError.Create
-                                    $"FileManifest '{manifest.ManifestAddress}' references ContentBlock '{block.Address}' at ordinal {blockIndex}, but no finalized ContentBlock metadata range exists."
+                                    $"FileManifest '{manifest.ManifestAddress}' references ContentBlock '{block.Address}' at manifest block index {blockIndex}, but no finalized ContentBlock metadata range exists at content-block ordinal 0."
                                     correlationId
                             )
 
@@ -288,11 +292,9 @@ module DirectoryVersion =
                 | None -> Ok()
         }
 
-    let private validateManifestReferencesForSaveBoundary correlationId manifests =
+    let private validateManifestReferencesForSaveBoundary repositoryId correlationId manifests =
         let getRangePresence contentBlockAddress query =
-            let storagePoolId = StoragePoolId DefaultStoragePoolId
-            let actorKey = $"{storagePoolId}|{contentBlockAddress}"
-
+            let actorKey = contentBlockMetadataActorKeyForSaveBoundary repositoryId contentBlockAddress
             let metadataActor = orleansClient.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(actorKey, correlationId)
 
             metadataActor.GetRangePresence query correlationId
@@ -841,7 +843,7 @@ module DirectoryVersion =
                                         match getManifestReferencesForSaveBoundary directoryVersion metadata.CorrelationId with
                                         | Error graceError -> return Error graceError
                                         | Ok manifests ->
-                                            match! validateManifestReferencesForSaveBoundary metadata.CorrelationId manifests with
+                                            match! validateManifestReferencesForSaveBoundary repositoryDto.RepositoryId metadata.CorrelationId manifests with
                                             | Error graceError -> return Error graceError
                                             | Ok () ->
 

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -603,6 +603,10 @@ module Interfaces =
         /// Validates whole-record metadata updates and converts them to persisted events.
         abstract member Handle: command: ContentBlockMetadataCommand -> eventMetadata: EventMetadata -> Task<GraceResult<ContentBlockMetadataDecision>>
 
+        /// Validates merged physical ranges and converts them to persisted events.
+        abstract member MergePhysicalRanges:
+            merge: MergeContentBlockPhysicalRanges -> eventMetadata: EventMetadata -> Task<GraceResult<ContentBlockMetadataDecision>>
+
     /// Defines the operations for the cluster-scoped dedupe discovery index actor.
     [<Interface>]
     type IDedupeIndexActor =

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -29,9 +29,6 @@ open System.Threading.Tasks
 
 module Reference =
 
-    [<Literal>]
-    let private DefaultStoragePoolId = "default"
-
     type ManifestSaveContributionPlan =
         {
             RepositoryId: RepositoryId
@@ -58,14 +55,17 @@ module Reference =
         | ManifestContributionDirection.Increment -> ManifestContributionWorkflowOperationId $"save:{referenceId:N}:{manifestAddress}:fanout"
         | ManifestContributionDirection.Decrement -> ManifestContributionWorkflowOperationId $"save-expiry:{referenceId:N}:{manifestAddress}:fanout"
 
-    let private workflowRangesForManifest (manifest: FileManifest) =
+    let private workflowRangesForManifest repositoryId (manifest: FileManifest) =
+        let storagePoolId = DedupeIndex.storagePoolIdForRepositoryId repositoryId
+        let seenContentBlocks = HashSet<ContentBlockAddress>()
         let ranges = ResizeArray<ManifestContributionWorkflowRange>()
         let mutable index = 0
 
         while index < manifest.Blocks.Count do
             let block = manifest.Blocks[index]
 
-            ranges.Add({ StoragePoolId = StoragePoolId DefaultStoragePoolId; ContentBlockAddress = block.Address; OrdinalStart = index; OrdinalCount = 1 })
+            if seenContentBlocks.Add block.Address then
+                ranges.Add({ StoragePoolId = storagePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = 1 })
 
             index <- index + 1
 
@@ -96,7 +96,7 @@ module Reference =
                     ReferenceId = referenceId
                     Manifest = manifest
                     CounterCommand = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, manifest.ManifestAddress)
-                    WorkflowRanges = workflowRangesForManifest manifest
+                    WorkflowRanges = workflowRangesForManifest repositoryId manifest
                 })
             |> Ok
 

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -849,7 +849,7 @@ module UploadSession =
                                     let metadataActor =
                                         orleansClient.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(actorKey, metadata.CorrelationId)
 
-                                    let! metadataResult = metadataActor.Handle metadataCommands[metadataIndex] metadata
+                                    let! metadataResult = metadataActor.MergePhysicalRanges merge metadata
 
                                     match metadataResult with
                                     | Ok _ -> ()

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -2,6 +2,7 @@ namespace Grace.Actors
 
 open Grace.Actors.Constants
 open Grace.Actors.Context
+open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Shared
@@ -315,6 +316,40 @@ module UploadSession =
     let private decodedLogicalLength (decodedBlock: ContentBlockFormat.DecodedContentBlock) =
         decodedBlock.Chunks
         |> Array.sumBy (fun chunk -> int64 chunk.Length)
+
+    let private manifestBlockAddresses (manifest: FileManifest) =
+        let addresses = HashSet<ContentBlockAddress>()
+
+        if
+            not (isNull (box manifest))
+            && not (isNull manifest.Blocks)
+        then
+            for block in manifest.Blocks do
+                if not (isNull (box block)) then addresses.Add(block.Address) |> ignore
+
+        addresses
+
+    let createContentBlockMetadataMergeCommandsForFinalizedUploads storagePoolId finalizeOperationId (session: UploadSessionDto) (manifest: FileManifest) =
+        let manifestAddresses = manifestBlockAddresses manifest
+        let commands = ResizeArray<ContentBlockMetadataCommand>()
+        let seen = HashSet<ContentBlockAddress>()
+
+        for confirmedBlock in session.ConfirmedBlockUploads do
+            if manifestAddresses.Contains confirmedBlock.ContentBlockAddress
+               && seen.Add confirmedBlock.ContentBlockAddress then
+                commands.Add(
+                    ContentBlockMetadataCommand.MergePhysicalRanges
+                        {
+                            OperationId = $"{finalizeOperationId}:content-block-metadata:{confirmedBlock.ContentBlockAddress}"
+                            StoragePoolId = storagePoolId
+                            ContentBlockAddress = confirmedBlock.ContentBlockAddress
+                            BlockFormatVersion = 1s
+                            StoragePlacement = confirmedBlock.StoragePlacement
+                            Ranges = confirmedBlock.Ranges
+                        }
+                )
+
+        commands.ToArray()
 
     let private manifestValidationErrorMessage error =
         match error with
@@ -755,6 +790,8 @@ module UploadSession =
                     | Ok decision ->
                         if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
 
+                        let mutable sideEffectError: GraceError option = None
+
                         match command with
                         | UploadSessionCommand.Abandon operationId when not decision.WasIdempotentReplay ->
                             let reminderState =
@@ -795,31 +832,63 @@ module UploadSession =
                                         (ReminderState.UploadSessionPhysicalDeletion reminderState)
                                         metadata.CorrelationId
 
-                            let dedupeIndexActor = DedupeIndexActor.CreateActorProxy metadata.CorrelationId
+                            let storagePoolId = DedupeIndex.storagePoolIdForRepositoryId decision.Session.RepositoryId
 
-                            do!
-                                dedupeIndexActor.RegisterFinalizedManifest
-                                    {
-                                        StoragePoolId = DedupeIndex.storagePoolIdForRepositoryId decision.Session.RepositoryId
-                                        Session = decision.Session
-                                        Manifest = finalize.Manifest
-                                        BlockPayloads = finalize.BlockPayloads
-                                    }
-                                    metadata.CorrelationId
-                                :> Task
+                            let metadataCommands =
+                                createContentBlockMetadataMergeCommandsForFinalizedUploads storagePoolId finalize.OperationId decision.Session finalize.Manifest
+
+                            let mutable metadataIndex = 0
+                            let mutable metadataError = None
+
+                            while metadataIndex < metadataCommands.Length
+                                  && metadataError.IsNone do
+                                match metadataCommands[metadataIndex] with
+                                | ContentBlockMetadataCommand.MergePhysicalRanges merge ->
+                                    let actorKey = ContentBlockMetadataActorKey.Create merge.StoragePoolId merge.ContentBlockAddress
+
+                                    let metadataActor =
+                                        orleansClient.CreateActorProxyWithCorrelationId<IContentBlockMetadataActor>(actorKey, metadata.CorrelationId)
+
+                                    let! metadataResult = metadataActor.Handle metadataCommands[metadataIndex] metadata
+
+                                    match metadataResult with
+                                    | Ok _ -> ()
+                                    | Error error -> metadataError <- Some error
+                                | _ -> ()
+
+                                metadataIndex <- metadataIndex + 1
+
+                            match metadataError with
+                            | Some error -> sideEffectError <- Some error
+                            | None ->
+                                let dedupeIndexActor = DedupeIndexActor.CreateActorProxy metadata.CorrelationId
+
+                                do!
+                                    dedupeIndexActor.RegisterFinalizedManifest
+                                        {
+                                            StoragePoolId = storagePoolId
+                                            Session = decision.Session
+                                            Manifest = finalize.Manifest
+                                            BlockPayloads = finalize.BlockPayloads
+                                        }
+                                        metadata.CorrelationId
+                                    :> Task
                         | UploadSessionCommand.DeletePhysicalState _ ->
                             do! this.CompactPhysicalStateEvents()
                             this.DeactivateOnIdle()
                         | _ -> ()
 
-                        let returnValue =
-                            (GraceReturnValue.Create decision metadata.CorrelationId)
-                                .enhance(nameof RepositoryId, decision.Session.RepositoryId)
-                                .enhance(nameof UploadSessionId, decision.Session.UploadSessionId)
-                                .enhance(nameof UploadSessionOperationId, decision.OperationId)
-                                .enhance (nameof UploadSessionLifecycleState, decision.Session.LifecycleState)
+                        match sideEffectError with
+                        | Some error -> return Error error
+                        | None ->
+                            let returnValue =
+                                (GraceReturnValue.Create decision metadata.CorrelationId)
+                                    .enhance(nameof RepositoryId, decision.Session.RepositoryId)
+                                    .enhance(nameof UploadSessionId, decision.Session.UploadSessionId)
+                                    .enhance(nameof UploadSessionOperationId, decision.OperationId)
+                                    .enhance (nameof UploadSessionLifecycleState, decision.Session.LifecycleState)
 
-                        return Ok returnValue
+                            return Ok returnValue
                     | Error error ->
                         log.LogWarning(
                             "{CurrentInstant}: Node: {HostName}; CorrelationId: {CorrelationId}; Rejected UploadSession command {Command}. Error: {Error}",

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -839,6 +839,7 @@ module UploadSession =
 
                             let mutable metadataIndex = 0
                             let mutable metadataError = None
+                            let mergedMetadata = ResizeArray<ContentBlockMetadata>()
 
                             while metadataIndex < metadataCommands.Length
                                   && metadataError.IsNone do
@@ -852,7 +853,7 @@ module UploadSession =
                                     let! metadataResult = metadataActor.MergePhysicalRanges merge metadata
 
                                     match metadataResult with
-                                    | Ok _ -> ()
+                                    | Ok returnValue -> mergedMetadata.Add(returnValue.ReturnValue.Metadata)
                                     | Error error -> metadataError <- Some error
                                 | _ -> ()
 
@@ -873,6 +874,9 @@ module UploadSession =
                                         }
                                         metadata.CorrelationId
                                     :> Task
+
+                                for authoritativeMetadata in mergedMetadata do
+                                    do! dedupeIndexActor.WriteAfterAuthoritativeMetadata authoritativeMetadata metadata.CorrelationId :> Task
                         | UploadSessionCommand.DeletePhysicalState _ ->
                             do! this.CompactPhysicalStateEvents()
                             this.DeactivateOnIdle()

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -12,6 +12,8 @@ open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.IO
+open System.Security.Cryptography
+open System.Text
 open System.Threading.Tasks
 
 [<NonParallelizable>]
@@ -55,6 +57,27 @@ module CurrentStateCaptureCliTests =
     let private branch saveEnabled latestReference =
         { BranchDto.Default with BranchId = currentBranchId; SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
 
+    let private sha256Hash (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+    let private manifestReferenceFor bytes =
+        let blockAddress = ContentBlockAddress(ContentAddress.computeBlake3Hex bytes)
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex bytes),
+                int64 bytes.Length,
+                [
+                    ContentBlock.Create(blockAddress, 0L, int64 bytes.Length)
+                ]
+            )
+
+        FileContentReference.FileManifest { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
     let private defaultOperations branchDto =
         {
             GetBranch = fun () -> Task.FromResult(Ok(GraceReturnValue.Create branchDto correlationId))
@@ -63,7 +86,7 @@ module CurrentStateCaptureCliTests =
             ScanForDifferences = fun _ -> Task.FromResult(List<FileSystemDifference>())
             CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
             BuildUpdatedGraceStatus = fun status _ -> Task.FromResult(status, List<LocalDirectoryVersion>())
-            UploadFileVersions = fun _ -> Task.FromResult(Ok())
+            UploadFileVersions = fun _ -> Task.FromResult(Ok Array.empty<FileVersion>)
             UploadDirectoryVersions = fun _ -> Task.FromResult(Ok())
             ApplyGraceStatusIncremental = fun _ _ _ -> Task.FromResult(())
             CreateSaveReference = fun _ _ -> Task.FromResult(Ok(Guid.NewGuid()))
@@ -279,7 +302,14 @@ module CurrentStateCaptureCliTests =
                 UploadFileVersions =
                     fun fileVersions ->
                         uploadedFiles <- List<LocalFileVersion>(fileVersions)
-                        Task.FromResult(Ok())
+
+                        Task.FromResult(
+                            Ok(
+                                fileVersions
+                                |> Seq.map (fun fileVersion -> fileVersion.ToFileVersion)
+                                |> Seq.toArray
+                            )
+                        )
                 CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
             }
 
@@ -300,6 +330,197 @@ module CurrentStateCaptureCliTests =
             uploadedFiles[0].Sha256Hash
             |> should equal changedFile.Sha256Hash
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes save directory versions with enriched uploaded file versions`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/large.bin"
+        let payload = Encoding.UTF8.GetBytes("large manifest-backed payload")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash payload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex payload))
+                true
+                (int64 payload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let uploadedFile = changedFile.ToFileVersion
+        uploadedFile.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex payload)
+        uploadedFile.ContentReference <- manifestReferenceFor payload
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile |]))
+                changedFile.Size
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| uploadedFile |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            savedDirectoryFiles.Count |> should equal 1
+
+            savedDirectoryFiles[0].Blake3Hash
+            |> should equal uploadedFile.Blake3Hash
+
+            savedDirectoryFiles[0]
+                .ContentReference
+                .ReferenceType
+            |> should equal FileContentReferenceType.FileManifest
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes do not apply local status when save reference creation fails`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let mutable appliedStatus = false
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "new-folder")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                ApplyGraceStatusIncremental =
+                    fun _ _ _ ->
+                        appliedStatus <- true
+                        Task.FromResult(())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Error(GraceError.Create "save reference failed" correlationId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured -> Assert.Fail($"Expected save-reference failure, got: {captured}")
+        | Error error ->
+            error.Error
+            |> should contain "save reference failed"
+
+            appliedStatus |> should equal false
+
+    [<Test>]
+    let ``read-only current-state scan detects changed BLAKE3 when SHA-256 still matches`` () =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-scan-{Guid.NewGuid():N}")
+        let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
+        let filePath = Path.Combine(root, "same-sha-different-blake3.txt")
+        let relativePath = RelativePath "same-sha-different-blake3.txt"
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+
+            Directory.CreateDirectory(graceDirectory)
+            |> ignore
+
+            let payload = Encoding.UTF8.GetBytes("same sha, different blake3")
+            File.WriteAllBytes(filePath, payload)
+
+            let fileInfo = FileInfo(filePath)
+
+            let priorFile =
+                LocalFileVersion.CreateWithHashes
+                    relativePath
+                    (sha256Hash payload)
+                    (Blake3Hash "legacy-or-wrong-blake3")
+                    false
+                    fileInfo.Length
+                    (Grace.Shared.Utilities.getCurrentInstant ())
+                    true
+                    (fileInfo.LastWriteTimeUtc.AddSeconds(-10.0))
+
+            let previousRoot =
+                LocalDirectoryVersion.Create
+                    rootDirectoryId
+                    OwnerId.Empty
+                    OrganizationId.Empty
+                    RepositoryId.Empty
+                    Constants.RootDirectoryPath
+                    rootSha
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>([| priorFile |]))
+                    priorFile.Size
+                    DateTime.UtcNow
+
+            let index = GraceIndex()
+
+            index.TryAdd(rootDirectoryId, previousRoot)
+            |> ignore
+
+            let previousStatus = { GraceStatus.Default with Index = index; RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = rootSha }
+
+            let scanInput =
+                {
+                    RootDirectory = root
+                    GraceDirectory = graceDirectory
+                    GraceStatusFile = Path.Combine(graceDirectory, Constants.GraceLocalStateDbFileName)
+                    DirectoryIgnoreEntries = Array.empty
+                    FileIgnoreEntries = Array.empty
+                }
+
+            match (scanWorkingTreeForDifferencesReadOnly scanInput previousStatus)
+                .Result
+                with
+            | Error error -> Assert.Fail($"Expected scan success, got: {error}")
+            | Ok differences ->
+                differences.Count |> should equal 1
+
+                differences[0].DifferenceType
+                |> should equal DifferenceType.Change
+
+                differences[0].RelativePath
+                |> should equal relativePath
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
 
     [<Test>]
     let ``created save reference id is parsed from response properties`` () =
@@ -330,7 +551,7 @@ module CurrentStateCaptureCliTests =
                 UploadFileVersions =
                     fun _ ->
                         uploadedFiles <- true
-                        Task.FromResult(Ok())
+                        Task.FromResult(Ok Array.empty<FileVersion>)
                 CreateSaveReference =
                     fun _ _ ->
                         createdSave <- true

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -87,6 +87,7 @@ module CurrentStateCaptureCliTests =
             CopyUpdatedFilesToObjectCache = fun _ -> Task.FromResult(Seq.empty<LocalFileVersion>)
             BuildUpdatedGraceStatus = fun status _ -> Task.FromResult(status, List<LocalDirectoryVersion>())
             UploadFileVersions = fun _ -> Task.FromResult(Ok Array.empty<FileVersion>)
+            GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok Array.empty<DirectoryVersion>)
             UploadDirectoryVersions = fun _ -> Task.FromResult(Ok())
             ApplyGraceStatusIncremental = fun _ _ _ -> Task.FromResult(())
             CreateSaveReference = fun _ _ -> Task.FromResult(Ok(Guid.NewGuid()))
@@ -411,6 +412,110 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``local changes preserve saved manifest references for unchanged sibling files`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/changed.txt"
+        let unchangedPath = RelativePath "src/unchanged-large.bin"
+        let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash changedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex changedPayload))
+                false
+                (int64 changedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let unchangedFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex unchangedPayload))
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let uploadedChangedFile = changedFile.ToFileVersion
+        let savedManifestFile = unchangedFile.ToFileVersion
+        savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
+
+        let savedRoot =
+            DirectoryVersion.Create
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| savedManifestFile |]))
+                unchangedFile.Size
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile; unchangedFile |]))
+                (changedFile.Size + unchangedFile.Size)
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| uploadedChangedFile |])
+                GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            savedDirectoryFiles.Count |> should equal 2
+
+            let unchangedSavedFile =
+                savedDirectoryFiles
+                |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
+
+            unchangedSavedFile.ContentReference.ReferenceType
+            |> should equal FileContentReferenceType.FileManifest
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
     let ``local changes do not apply local status when save reference creation fails`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"
@@ -519,6 +624,72 @@ module CurrentStateCaptureCliTests =
 
                 differences[0].RelativePath
                 |> should equal relativePath
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    [<Test>]
+    let ``read-only current-state scan treats empty stored BLAKE3 as unknown when SHA-256 still matches`` () =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-scan-{Guid.NewGuid():N}")
+        let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
+        let filePath = Path.Combine(root, "legacy-empty-blake3.txt")
+        let relativePath = RelativePath "legacy-empty-blake3.txt"
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+
+            Directory.CreateDirectory(graceDirectory)
+            |> ignore
+
+            let payload = Encoding.UTF8.GetBytes("same sha, legacy empty blake3")
+            File.WriteAllBytes(filePath, payload)
+
+            let fileInfo = FileInfo(filePath)
+
+            let priorFile =
+                LocalFileVersion.CreateWithHashes
+                    relativePath
+                    (sha256Hash payload)
+                    (Blake3Hash String.Empty)
+                    false
+                    fileInfo.Length
+                    (Grace.Shared.Utilities.getCurrentInstant ())
+                    true
+                    (fileInfo.LastWriteTimeUtc.AddSeconds(-10.0))
+
+            let previousRoot =
+                LocalDirectoryVersion.Create
+                    rootDirectoryId
+                    OwnerId.Empty
+                    OrganizationId.Empty
+                    RepositoryId.Empty
+                    Constants.RootDirectoryPath
+                    rootSha
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>([| priorFile |]))
+                    priorFile.Size
+                    DateTime.UtcNow
+
+            let index = GraceIndex()
+
+            index.TryAdd(rootDirectoryId, previousRoot)
+            |> ignore
+
+            let previousStatus = { GraceStatus.Default with Index = index; RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = rootSha }
+
+            let scanInput =
+                {
+                    RootDirectory = root
+                    GraceDirectory = graceDirectory
+                    GraceStatusFile = Path.Combine(graceDirectory, Constants.GraceLocalStateDbFileName)
+                    DirectoryIgnoreEntries = Array.empty
+                    FileIgnoreEntries = Array.empty
+                }
+
+            match (scanWorkingTreeForDifferencesReadOnly scanInput previousStatus)
+                .Result
+                with
+            | Error error -> Assert.Fail($"Expected scan success, got: {error}")
+            | Ok differences -> differences.Count |> should equal 0
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
 

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -262,6 +262,58 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``changed file upload selection comes from updated directory versions`` () =
+        let changedPath = RelativePath "src/cached-large.bin"
+        let unchangedPath = RelativePath "src/unchanged-large.bin"
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (Sha256Hash "changed-file-sha")
+                (Blake3Hash "changed-file-blake3")
+                true
+                42L
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let unchangedFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (Sha256Hash "unchanged-file-sha")
+                (Blake3Hash "unchanged-file-blake3")
+                true
+                43L
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "src/new-folder")
+                |]
+            )
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile; unchangedFile |]))
+                (changedFile.Size + unchangedFile.Size)
+                DateTime.UtcNow
+
+        let selected = getChangedFileVersionsReferencedByUpdatedDirectories differences (List<LocalDirectoryVersion>([| updatedRoot |]))
+
+        selected |> should equal [ changedFile ]
+
+    [<Test>]
     let ``local changes upload changed file versions already present in object cache`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -516,6 +516,127 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``local changes preserve saved manifest references when unchanged sibling has legacy local Blake3`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/changed.txt"
+        let unchangedPath = RelativePath "src/unchanged-legacy-large.bin"
+        let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with legacy local state")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash changedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex changedPayload))
+                false
+                (int64 changedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let unchangedLocalLegacyFile =
+            LocalFileVersion.Create
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let savedManifestLocalFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex unchangedPayload))
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let savedManifestFile = savedManifestLocalFile.ToFileVersion
+        savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
+
+        let savedRoot =
+            DirectoryVersion.Create
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| savedManifestFile |]))
+                unchangedLocalLegacyFile.Size
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>(
+                    [|
+                        changedFile
+                        unchangedLocalLegacyFile
+                    |]
+                ))
+                (changedFile.Size + unchangedLocalLegacyFile.Size)
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| changedFile.ToFileVersion |])
+                GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            savedDirectoryFiles.Count |> should equal 2
+
+            let unchangedSavedFile =
+                savedDirectoryFiles
+                |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
+
+            unchangedSavedFile.Blake3Hash
+            |> should equal savedManifestFile.Blake3Hash
+
+            unchangedSavedFile.ContentReference.ReferenceType
+            |> should equal FileContentReferenceType.FileManifest
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
     let ``local changes do not apply local status when save reference creation fails`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2442,7 +2442,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 3"
+                |> should contain "schema_version is 2"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2573,7 +2573,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 3"
+                        |> should contain "schema_version is 2"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2442,7 +2442,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 2"
+                |> should contain "schema_version is 3"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2573,7 +2573,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 2"
+                        |> should contain "schema_version is 3"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -177,12 +177,22 @@ module DoctorCliTests =
         |> Convert.ToHexString
         |> fun value -> value.ToLowerInvariant()
 
-    let private createSnapshotFile relativePath content lastWriteTime =
-        LocalFileVersion.Create
+    let private createSnapshotFile (relativePath: RelativePath) (content: string) (lastWriteTime: DateTime) =
+        let bytes = Encoding.UTF8.GetBytes(content)
+        use stream = new MemoryStream(bytes)
+
+        let blake3Hash =
+            Services
+                .computeBlake3ForFile(stream)
+                .GetAwaiter()
+                .GetResult()
+
+        LocalFileVersion.CreateWithHashes
             relativePath
             (sha256Hex content)
+            (Blake3Hash $"{blake3Hash}")
             false
-            (int64 (Encoding.UTF8.GetByteCount(content)))
+            (int64 bytes.Length)
             (Grace.Shared.Utilities.getCurrentInstant ())
             true
             lastWriteTime
@@ -2432,7 +2442,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 2"
+                |> should contain "schema_version is 3"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2563,7 +2573,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 2"
+                        |> should contain "schema_version is 3"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -160,6 +160,56 @@ module LocalStateDbTests =
         executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
         executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{schemaVersion}');"
 
+    let private seedCurrentSchemaWithStatusMeta (dbPath: string) (rootId: Guid) rootHash ticks =
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+        |> ignore
+
+        use connection = openRawConnection dbPath
+        executeNonQuery connection "PRAGMA journal_mode = WAL;"
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_directories_parent ON status_directories(parent_path);"
+        executeNonQuery connection "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
+
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_directory_version_id ON status_files(directory_version_id);"
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_sha256 ON status_files(sha256_hash);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS object_cache_directories (directory_version_id TEXT PRIMARY KEY, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_object_cache_directories_relative_path ON object_cache_directories(relative_path);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS object_cache_directory_children (parent_directory_version_id TEXT NOT NULL, child_directory_version_id TEXT NOT NULL, ordinal INTEGER NOT NULL, PRIMARY KEY (parent_directory_version_id, child_directory_version_id), FOREIGN KEY (parent_directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE, FOREIGN KEY (child_directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE RESTRICT);"
+
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
+
+        executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3');"
+
+        executeNonQuery
+            connection
+            $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootHash}', {ticks}, {ticks});"
+
     let private createTestStatus (rootId: Guid) (rootHash: string) (ticks: int64) =
         { GraceStatus.Default with
             RootDirectoryId = rootId
@@ -216,7 +266,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -478,7 +528,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -505,7 +555,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -558,7 +608,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "2")
+                |> should equal (Some "3")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -602,7 +652,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "2")
+                |> should equal (Some "3")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -803,7 +853,7 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``ensureDbInitialized preserves existing schema v2 status_meta row`` () =
+    let ``ensureDbInitialized recreates legacy schema v2 database without blake3 columns`` () =
         withTempDir (fun _ configuration ->
             task {
                 Directory.CreateDirectory(Path.GetDirectoryName(configuration.GraceStatusFile))
@@ -813,19 +863,20 @@ module LocalStateDbTests =
                 let rootHash = "custom-root-hash"
                 let ticks = 1234567890L
 
-                use connection = openRawConnection configuration.GraceStatusFile
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
 
-                executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+                    executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
 
-                executeNonQuery
-                    connection
-                    "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
 
-                executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '2');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '2');"
 
-                executeNonQuery
-                    connection
-                    $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootHash}', {ticks}, {ticks});"
+                    executeNonQuery
+                        connection
+                        $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootHash}', {ticks}, {ticks});"
 
                 let corruptBefore =
                     getCorruptBackups configuration.GraceStatusFile
@@ -837,9 +888,56 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
+
+                readRootId
+                |> should not' (equal (rootId.ToString()))
+
+                readRootHash |> should not' (equal rootHash)
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    [<Test>]
+    let ``ensureDbInitialized preserves existing schema v3 current schema status_meta row`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let rootHash = "custom-root-hash"
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash ticks
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
+                let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
+                schemaVersion |> should equal "3"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
+
+                let blake3Columns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('status_files') WHERE name = 'blake3_hash';"
+
+                blake3Columns |> should equal 1
+
+                let replacementStatus = createTestStatus (Guid.NewGuid()) "replacement-root-hash" (ticks + 1L)
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile replacementStatus
+
+                let updatedRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
+
+                updatedRootHash
+                |> should equal "replacement-root-hash"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1025,7 +1123,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -1051,7 +1149,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "2"
+                schemaVersion |> should equal "3"
             })
 
     [<Test>]
@@ -1866,7 +1964,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "2"
+                    schemaVersion |> should equal "3"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -216,7 +216,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "2"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -478,7 +478,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "2"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -505,7 +505,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "2"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -558,7 +558,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "3")
+                |> should equal (Some "2")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -602,7 +602,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "3")
+                |> should equal (Some "2")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -803,7 +803,7 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``ensureDbInitialized does not overwrite existing status_meta row`` () =
+    let ``ensureDbInitialized preserves existing schema v2 status_meta row`` () =
         withTempDir (fun _ configuration ->
             task {
                 Directory.CreateDirectory(Path.GetDirectoryName(configuration.GraceStatusFile))
@@ -821,19 +821,31 @@ module LocalStateDbTests =
                     connection
                     "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
 
-                executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3');"
+                executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '2');"
 
                 executeNonQuery
                     connection
                     $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootHash}', {ticks}, {ticks});"
 
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
 
                 use connection2 = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
+                schemaVersion |> should equal "2"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal corruptBefore
             })
 
     [<Test>]
@@ -1013,7 +1025,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "2"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -1039,7 +1051,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "2"
             })
 
     [<Test>]
@@ -1854,7 +1866,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "3"
+                    schemaVersion |> should equal "2"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -398,7 +398,8 @@ module LocalStateDbTests =
                     srcRead.Files
                     |> Seq.find (fun file -> file.RelativePath = "src/file.txt")
 
-                changedRead.Blake3Hash |> should equal "src-blake3-2"
+                changedRead.Blake3Hash
+                |> should equal "src-blake3-2"
 
                 readBack.Index.Values
                 |> Seq.collect (fun dv -> dv.Files)
@@ -557,7 +558,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "2")
+                |> should equal (Some "3")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -601,7 +602,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "2")
+                |> should equal (Some "3")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -727,7 +728,7 @@ module LocalStateDbTests =
 
                 executeNonQuery
                     connection
-                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('00000000-0000-0000-0000-000000000111', 'orphan.txt', 'hash', 0, 1, 0, 0, 0);"
+                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ('00000000-0000-0000-0000-000000000111', 'orphan.txt', 'hash', '', 0, 1, 0, 0, 0);"
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
 
@@ -1240,6 +1241,51 @@ module LocalStateDbTests =
 
                 fileRead.LastWriteTimeUtc.Kind
                 |> should equal DateTimeKind.Utc
+            })
+
+    [<Test>]
+    let ``readStatusSnapshotReadOnly preserves persisted file blake3 hashes`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(999L)
+                let lastWrite = DateTime(2021, 10, 11, 12, 13, 14, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+                let blake3Hash = "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+                let file = createFileVersionWithHashes "root.txt" "sha256-hash" blake3Hash false 10L now lastWrite
+                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [||] [| file |] file.Size lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, rootDir) |> ignore
+
+                let status =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootDir.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile status
+
+                let! readOnlyResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+
+                match readOnlyResult with
+                | Ok readBack ->
+                    let rootRead = readBack.Index[rootId]
+
+                    let fileRead =
+                        rootRead.Files
+                        |> Seq.find (fun f -> f.RelativePath = "root.txt")
+
+                    fileRead.Blake3Hash
+                    |> should equal (Blake3Hash blake3Hash)
+                | Error error -> Assert.Fail($"Expected read-only snapshot to load, but got: {error}")
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -211,6 +211,7 @@ type ManifestUploadSdkTests() =
                     Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(uploadedBlocks.Count))
                     Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.FileManifest))
                     Assert.That(uploadResult.Manifest, Is.EqualTo(finalizedManifest))
+                    Assert.That(uploadResult.FileVersion.Blake3Hash, Is.EqualTo(Blake3Hash(ContentAddress.computeBlake3Hex payload)))
                     Assert.That(sessionIds |> Seq.distinct |> Seq.length, Is.EqualTo(1))
                     Assert.That(calls[0], Is.EqualTo("start"))
                     Assert.That(calls[calls.Count - 1], Is.EqualTo("finalize"))
@@ -256,6 +257,7 @@ type ManifestUploadSdkTests() =
                     let uploadResult = returnValue.ReturnValue
                     Assert.That(uploadResult.UsedManifestUpload, Is.False)
                     Assert.That(uploadResult.UploadedBlockCount, Is.EqualTo(0))
+                    Assert.That(uploadResult.FileVersion.Blake3Hash, Is.EqualTo(fileVersion.Blake3Hash))
                     Assert.That(uploadResult.FileVersion.ContentReference.ReferenceType, Is.EqualTo(FileContentReferenceType.WholeFileContent))
                     Assert.That(uploadResult.Manifest, Is.EqualTo(None))
                     Assert.That(uploadResult.UploadSessionId, Is.EqualTo(None))
@@ -343,7 +345,7 @@ type ManifestUploadSdkTests() =
             let wholeFileUpload (parameters: GetUploadMetadataForFilesParameters) =
                 task {
                     wholeFileFallbacks.Add(parameters.FileVersions)
-                    return Ok(GraceReturnValue.Create true correlationId)
+                    return Ok(GraceReturnValue.Create parameters.FileVersions correlationId)
                 }
 
             let parameters = ManifestUploadSdkTests.UploadParameters correlationId [| manifestFile; ineligibleFile |]
@@ -353,7 +355,7 @@ type ManifestUploadSdkTests() =
             match result with
             | Error error -> Assert.Fail($"{error.Error}{Environment.NewLine}{serialize error.Properties}")
             | Ok returnValue ->
-                Assert.That(returnValue.ReturnValue, Is.True)
+                Assert.That(returnValue.ReturnValue, Is.EquivalentTo([| manifestFile; ineligibleFile |]))
 
                 Assert.That(
                     manifestAttempts,

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
 open Grace.Types.Common
 open NodaTime
@@ -470,6 +471,33 @@ module WatchTests =
 
                 readFileIfExists ipcFileName
                 |> should equal originalContents))
+
+    [<Test>]
+    let ``watch cached file changes remain processable when object already exists`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "cached-file.txt")
+            File.WriteAllText(filePath, "cached file payload")
+
+            match (Services.copyToObjectDirectory (FilePath filePath))
+                .Result
+                with
+            | Some _ -> ()
+            | None -> Assert.Fail("Expected first object-cache copy to create the object.")
+
+            let parameters =
+                GetUploadMetadataForFilesParameters(
+                    OwnerId = $"{OwnerId.Empty}",
+                    OrganizationId = $"{OrganizationId.Empty}",
+                    RepositoryId = $"{RepositoryId.Empty}",
+                    CorrelationId = "watch-cache-hit-test"
+                )
+
+            Assert.DoesNotThrow(
+                Action (fun () ->
+                    (Watch.copyFileToObjectDirectoryAndUploadToStorage parameters (FilePath filePath))
+                        .GetAwaiter()
+                        .GetResult())
+            ))
 
     [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -475,7 +475,12 @@ module WatchTests =
     [<Test>]
     let ``watch cached file changes remain processable when object already exists`` () =
         withTempRepo (fun root ->
-            let filePath = Path.Combine(root, "cached-file.txt")
+            let nestedDirectory = Path.Combine(root, "dir")
+
+            Directory.CreateDirectory(nestedDirectory)
+            |> ignore
+
+            let filePath = Path.Combine(nestedDirectory, "cached-file.txt")
             File.WriteAllText(filePath, "cached file payload")
 
             match (Services.copyToObjectDirectory (FilePath filePath))

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -505,6 +505,37 @@ module WatchTests =
             ))
 
     [<Test>]
+    let ``object-cache copies preserve scanner Blake3 identity`` () =
+        withTempRepo (fun root ->
+            let nestedDirectory = Path.Combine(root, "dir")
+
+            Directory.CreateDirectory(nestedDirectory)
+            |> ignore
+
+            let filePath = Path.Combine(nestedDirectory, "whole-file.txt")
+            File.WriteAllText(filePath, "whole-file watch upload payload")
+
+            let localFileVersion =
+                match (Services.createLocalFileVersion (FileInfo filePath))
+                    .Result
+                    with
+                | Some fileVersion -> fileVersion
+                | None -> failwith "Expected scanner file version."
+
+            let copiedFileVersion =
+                match (Services.copyToObjectDirectory (FilePath filePath))
+                    .Result
+                    with
+                | Some fileVersion -> fileVersion
+                | None -> failwith "Expected object-cache copy to create the object."
+
+            String.IsNullOrWhiteSpace(string copiedFileVersion.Blake3Hash)
+            |> should equal false
+
+            copiedFileVersion.Blake3Hash
+            |> should equal localFileVersion.Blake3Hash)
+
+    [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -473,36 +473,39 @@ module WatchTests =
                 |> should equal originalContents))
 
     [<Test>]
-    let ``watch cached file changes remain processable when object already exists`` () =
-        withTempRepo (fun root ->
-            let nestedDirectory = Path.Combine(root, "dir")
+    let ``watch cached file changes upload cached object for save enrichment`` () =
+        let filePath = FilePath @"C:\repo\dir\cached-file.txt"
 
-            Directory.CreateDirectory(nestedDirectory)
-            |> ignore
+        let cachedFileVersion =
+            FileVersion.Create "dir/cached-file.txt" (Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") String.Empty true 12L
 
-            let filePath = Path.Combine(nestedDirectory, "cached-file.txt")
-            File.WriteAllText(filePath, "cached file payload")
+        let mutable uploadedFileVersions = Array.empty<FileVersion>
 
-            match (Services.copyToObjectDirectory (FilePath filePath))
-                .Result
-                with
-            | Some _ -> ()
-            | None -> Assert.Fail("Expected first object-cache copy to create the object.")
+        let copyFileToObjectCache _ = Task.FromResult<FileVersion option> None
 
-            let parameters =
-                GetUploadMetadataForFilesParameters(
-                    OwnerId = $"{OwnerId.Empty}",
-                    OrganizationId = $"{OrganizationId.Empty}",
-                    RepositoryId = $"{RepositoryId.Empty}",
-                    CorrelationId = "watch-cache-hit-test"
-                )
+        let getCachedFileVersion _ = Task.FromResult(Some cachedFileVersion)
 
-            Assert.DoesNotThrow(
-                Action (fun () ->
-                    (Watch.copyFileToObjectDirectoryAndUploadToStorage parameters (FilePath filePath))
-                        .GetAwaiter()
-                        .GetResult())
-            ))
+        let uploadFileVersions (parameters: GetUploadMetadataForFilesParameters) =
+            uploadedFileVersions <- parameters.FileVersions
+            Task.FromResult(Ok(GraceReturnValue.Create parameters.FileVersions parameters.CorrelationId))
+
+        let parameters =
+            GetUploadMetadataForFilesParameters(
+                OwnerId = $"{OwnerId.Empty}",
+                OrganizationId = $"{OrganizationId.Empty}",
+                RepositoryId = $"{RepositoryId.Empty}",
+                CorrelationId = "watch-cache-hit-test"
+            )
+
+        (Watch.copyFileToObjectDirectoryAndUploadToStorageWithClients copyFileToObjectCache getCachedFileVersion uploadFileVersions parameters filePath)
+            .GetAwaiter()
+            .GetResult()
+
+        uploadedFileVersions
+        |> should equal [| cachedFileVersion |]
+
+        parameters.FileVersions
+        |> should equal [| cachedFileVersion |]
 
     [<Test>]
     let ``object-cache copies preserve scanner Blake3 identity`` () =

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2946,7 +2946,19 @@ module Branch =
                                 saveParameters.RepositoryName <- graceIds.RepositoryName
                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                                let! savedDirectoryVersionsResult =
+                                    getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId (getCorrelationId parseResult)
+
+                                let savedDirectoryVersions =
+                                    match savedDirectoryVersionsResult with
+                                    | Ok returnValue -> returnValue
+                                    | Error error -> raise (InvalidOperationException($"Error retrieving saved directory versions: {error.Error}"))
+
+                                saveParameters.DirectoryVersions <-
+                                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                        uploadedFileVersions
+                                        savedDirectoryVersions
+                                        newDirectoryVersions
 
                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                 | Ok returnValue ->

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1199,29 +1199,12 @@ module Branch =
 
                                             t3.StartTask() // Upload to object storage.
 
-                                            let updatedRelativePaths =
-                                                differences
-                                                    .Select(fun difference ->
-                                                        match difference.DifferenceType with
-                                                        | Add ->
-                                                            match difference.FileSystemEntryType with
-                                                            | FileSystemEntryType.File -> Some difference.RelativePath
-                                                            | FileSystemEntryType.Directory -> None
-                                                        | Change ->
-                                                            match difference.FileSystemEntryType with
-                                                            | FileSystemEntryType.File -> Some difference.RelativePath
-                                                            | FileSystemEntryType.Directory -> None
-                                                        | Delete -> None)
-                                                    .Where(fun relativePathOption -> relativePathOption.IsSome)
-                                                    .Select(fun relativePath -> relativePath.Value)
-
-                                            // let newFileVersions = updatedRelativePaths.Select(fun relativePath ->
-                                            //     newDirectoryVersions.First(fun dv -> dv.Files.Exists(fun file -> file.RelativePath = relativePath)).Files.First(fun file -> file.RelativePath = relativePath))
+                                            let fileVersionsToUpload = getChangedFileVersionsReferencedByUpdatedDirectories differences newDirectoryVersions
 
                                             let mutable lastFileUploadInstant = newGraceStatus.LastSuccessfulFileUpload
                                             let mutable uploadedFileVersions = Array.empty<FileVersion>
 
-                                            if newFileVersions.Count() > 0 then
+                                            if fileVersionsToUpload.Count() > 0 then
                                                 let getUploadMetadataForFilesParameters =
                                                     Storage.GetUploadMetadataForFilesParameters(
                                                         OwnerId = graceIds.OwnerIdString,
@@ -1232,7 +1215,7 @@ module Branch =
                                                         RepositoryName = graceIds.RepositoryName,
                                                         CorrelationId = getCorrelationId parseResult,
                                                         FileVersions =
-                                                            (newFileVersions
+                                                            (fileVersionsToUpload
                                                              |> Seq.map (fun localFileVersion -> localFileVersion.ToFileVersion)
                                                              |> Seq.toArray)
                                                     )
@@ -1329,27 +1312,7 @@ module Branch =
 
                         let! (newGraceIndex, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
 
-                        let updatedRelativePaths =
-                            differences
-                                .Select(fun difference ->
-                                    match difference.DifferenceType with
-                                    | Add ->
-                                        match difference.FileSystemEntryType with
-                                        | FileSystemEntryType.File -> Some difference.RelativePath
-                                        | FileSystemEntryType.Directory -> None
-                                    | Change ->
-                                        match difference.FileSystemEntryType with
-                                        | FileSystemEntryType.File -> Some difference.RelativePath
-                                        | FileSystemEntryType.Directory -> None
-                                    | Delete -> None)
-                                .Where(fun relativePathOption -> relativePathOption.IsSome)
-                                .Select(fun relativePath -> relativePath.Value)
-
-                        let newFileVersions =
-                            updatedRelativePaths.Select (fun relativePath ->
-                                newDirectoryVersions
-                                    .First(fun dv -> dv.Files.Exists(fun file -> file.RelativePath = relativePath))
-                                    .Files.First(fun file -> file.RelativePath = relativePath))
+                        let newFileVersions = getChangedFileVersionsReferencedByUpdatedDirectories differences newDirectoryVersions
 
                         let getUploadMetadataForFilesParameters =
                             Storage.GetUploadMetadataForFilesParameters(
@@ -2869,27 +2832,7 @@ module Branch =
 
                             if currentBranch.SaveEnabled
                                && newDirectoryVersions.Any() then
-                                let updatedRelativePaths =
-                                    differences
-                                        .Select(fun difference ->
-                                            match difference.DifferenceType with
-                                            | Add ->
-                                                match difference.FileSystemEntryType with
-                                                | FileSystemEntryType.File -> Some difference.RelativePath
-                                                | FileSystemEntryType.Directory -> None
-                                            | Change ->
-                                                match difference.FileSystemEntryType with
-                                                | FileSystemEntryType.File -> Some difference.RelativePath
-                                                | FileSystemEntryType.Directory -> None
-                                            | Delete -> None)
-                                        .Where(fun relativePathOption -> relativePathOption.IsSome)
-                                        .Select(fun relativePath -> relativePath.Value)
-
-                                let newFileVersions =
-                                    updatedRelativePaths.Select (fun relativePath ->
-                                        newDirectoryVersions
-                                            .First(fun dv -> dv.Files.Exists(fun file -> file.RelativePath = relativePath))
-                                            .Files.First(fun file -> file.RelativePath = relativePath))
+                                let newFileVersions = getChangedFileVersionsReferencedByUpdatedDirectories differences newDirectoryVersions
 
                                 logToAnsiConsole
                                     Colors.Verbose

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1259,8 +1259,20 @@ module Branch =
                                                 saveParameters.RepositoryName <- graceIds.RepositoryName
                                                 saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
+                                                let! savedDirectoryVersionsResult =
+                                                    getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId (getCorrelationId parseResult)
+
+                                                let savedDirectoryVersions =
+                                                    match savedDirectoryVersionsResult with
+                                                    | Ok returnValue -> returnValue
+                                                    | Error error ->
+                                                        raise (InvalidOperationException($"Error retrieving saved directory versions: {error.Error}"))
+
                                                 saveParameters.DirectoryVersions <-
-                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                                                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                                        uploadedFileVersions
+                                                        savedDirectoryVersions
+                                                        newDirectoryVersions
 
                                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
@@ -1370,7 +1382,19 @@ module Branch =
                         saveParameters.RepositoryName <- graceIds.RepositoryName
                         saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                        saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                        let! savedDirectoryVersionsResult =
+                            getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId (getCorrelationId parseResult)
+
+                        let savedDirectoryVersions =
+                            match savedDirectoryVersionsResult with
+                            | Ok returnValue -> returnValue
+                            | Error error -> raise (InvalidOperationException($"Error retrieving saved directory versions: {error.Error}"))
+
+                        saveParameters.DirectoryVersions <-
+                            applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                uploadedFileVersions
+                                savedDirectoryVersions
+                                newDirectoryVersions
 
                         match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                         | Ok _ -> ()

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1162,6 +1162,7 @@ module Branch =
                                         //let mutable rootDirectoryId = DirectoryId.Empty
                                         //let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
                                         let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty)
+                                        let mutable applyLocalStatusAfterReferenceSave = fun () -> Task.FromResult(())
 
                                         match! getGraceWatchStatus () with
                                         | Some graceWatchStatus ->
@@ -1218,6 +1219,7 @@ module Branch =
                                             //     newDirectoryVersions.First(fun dv -> dv.Files.Exists(fun file -> file.RelativePath = relativePath)).Files.First(fun file -> file.RelativePath = relativePath))
 
                                             let mutable lastFileUploadInstant = newGraceStatus.LastSuccessfulFileUpload
+                                            let mutable uploadedFileVersions = Array.empty<FileVersion>
 
                                             if newFileVersions.Count() > 0 then
                                                 let getUploadMetadataForFilesParameters =
@@ -1236,8 +1238,8 @@ module Branch =
                                                     )
 
                                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                                | Ok returnValue -> () //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
-                                                | Error error -> logToAnsiConsole Colors.Error $"Error uploading files to object storage: {error.Error}"
+                                                | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
+                                                | Error error -> raise (InvalidOperationException($"Error uploading files to object storage: {error.Error}"))
 
                                                 lastFileUploadInstant <- getCurrentInstant ()
 
@@ -1258,13 +1260,13 @@ module Branch =
                                                 saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
                                                 saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
-                                                        .ToList()
+                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
                                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                                                match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                | Ok _ -> ()
+                                                | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
@@ -1276,7 +1278,8 @@ module Branch =
                                                     LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
                                                 }
 
-                                            do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
+                                            applyLocalStatusAfterReferenceSave <-
+                                                fun () -> applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
 
                                         t5.StartTask() // Create new reference.
 
@@ -1299,6 +1302,11 @@ module Branch =
                                             )
 
                                         let! result = command sdkParameters
+
+                                        match result with
+                                        | Ok _ -> do! applyLocalStatusAfterReferenceSave ()
+                                        | Error _ -> ()
+
                                         t5.Value <- 100.0
 
                                         return result
@@ -1347,6 +1355,12 @@ module Branch =
                             )
 
                         let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                        let uploadedFileVersions =
+                            match uploadResult with
+                            | Ok returnValue -> returnValue.ReturnValue
+                            | Error error -> raise (InvalidOperationException($"Error uploading files to object storage: {error.Error}"))
+
                         let saveParameters = SaveDirectoryVersionsParameters()
                         saveParameters.OwnerId <- graceIds.OwnerIdString
                         saveParameters.OwnerName <- graceIds.OwnerName
@@ -1356,12 +1370,12 @@ module Branch =
                         saveParameters.RepositoryName <- graceIds.RepositoryName
                         saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                        saveParameters.DirectoryVersions <-
-                            newDirectoryVersions
-                                .Select(fun dv -> dv.ToDirectoryVersion)
-                                .ToList()
+                        saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
-                        let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                        match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                        | Ok _ -> ()
+                        | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
+
                         let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
                         let sdkParameters =
@@ -2875,13 +2889,13 @@ module Branch =
                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
                                 | Ok returnValue ->
                                     t |> setProgressTaskValue showOutput 100.0
-                                    return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions)
+                                    return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions, returnValue.ReturnValue)
                                 | Error error ->
                                     t |> setProgressTaskValue showOutput 50.0
                                     return Error error
                             else
                                 t |> setProgressTaskValue showOutput 100.0
-                                return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions)
+                                return Ok(showOutput, parseResult, parameters, currentBranch, newDirectoryVersions, Array.empty<FileVersion>)
                         }
 
                     // 5. Upload new directory versions.
@@ -2891,7 +2905,8 @@ module Branch =
                          parseResult: ParseResult,
                          parameters: SwitchParameters,
                          currentBranch: BranchDto,
-                         newDirectoryVersions: List<LocalDirectoryVersion>)
+                         newDirectoryVersions: List<LocalDirectoryVersion>,
+                         uploadedFileVersions: FileVersion array)
                         =
                         task {
                             t |> startProgressTask showOutput
@@ -2907,12 +2922,7 @@ module Branch =
                                 saveParameters.RepositoryName <- graceIds.RepositoryName
                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
-                                saveParameters.DirectoryVersions <-
-                                    newDirectoryVersions
-                                        .Select(fun dv -> dv.ToDirectoryVersion)
-                                        .ToList()
-
-                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                                saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                 | Ok returnValue ->

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -365,8 +365,20 @@ module Diff =
                                                 saveParameters.RepositoryName <- graceIds.RepositoryName
                                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
+                                                let! savedDirectoryVersionsResult =
+                                                    getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId (getCorrelationId parseResult)
+
+                                                let savedDirectoryVersions =
+                                                    match savedDirectoryVersionsResult with
+                                                    | Ok returnValue -> returnValue
+                                                    | Error error ->
+                                                        raise (InvalidOperationException($"Failed to retrieve saved directory versions. {error.Error}"))
+
                                                 saveParameters.DirectoryVersions <-
-                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                                                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                                        uploadedFileVersions
+                                                        savedDirectoryVersions
+                                                        newDirectoryVersions
 
                                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                 | Ok returnValue -> ()
@@ -671,8 +683,22 @@ module Diff =
                                                     saveParameters.RepositoryName <- graceIds.RepositoryName
                                                     saveParameters.CorrelationId <- getCorrelationId parseResult
 
+                                                    let! savedDirectoryVersionsResult =
+                                                        getSavedDirectoryVersionsForRootDirectory
+                                                            previousGraceStatus.RootDirectoryId
+                                                            (getCorrelationId parseResult)
+
+                                                    let savedDirectoryVersions =
+                                                        match savedDirectoryVersionsResult with
+                                                        | Ok returnValue -> returnValue
+                                                        | Error error ->
+                                                            raise (InvalidOperationException($"Failed to retrieve saved directory versions. {error.Error}"))
+
                                                     saveParameters.DirectoryVersions <-
-                                                        applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                                                        applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                                            uploadedFileVersions
+                                                            savedDirectoryVersions
+                                                            newDirectoryVersions
 
                                                     match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                     | Ok returnValue -> ()

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -320,7 +320,6 @@ module Diff =
 
                                         let! (updatedGraceStatus, newDirectoryVersions) = getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
 
-                                        do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
                                         rootDirectoryId <- updatedGraceStatus.RootDirectoryId
                                         rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
                                         previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
@@ -343,9 +342,13 @@ module Diff =
                                                      |> Seq.toArray)
                                             )
 
-                                        match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                        | Ok returnValue -> ()
-                                        | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
+                                        let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                                        let uploadedFileVersions =
+                                            match uploadResult with
+                                            | Ok returnValue -> returnValue.ReturnValue
+                                            | Error error ->
+                                                raise (InvalidOperationException($"Failed to upload changed files to object storage. {error.Error}"))
 
                                         t3.Value <- 100.0
 
@@ -363,13 +366,11 @@ module Diff =
                                                 saveParameters.CorrelationId <- getCorrelationId parseResult
 
                                                 saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
-                                                        .ToList()
+                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
                                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                 | Ok returnValue -> ()
-                                                | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                | Error error -> raise (InvalidOperationException($"Failed to upload new directory versions. {error.Error}"))
                                             })
                                                 .Wait()
 
@@ -387,9 +388,11 @@ module Diff =
                                                         (getCorrelationId parseResult)
                                                     with
                                                 | Ok saveReference -> ()
-                                                | Error error -> logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
+                                                | Error error -> raise (InvalidOperationException($"Failed to create a save reference. {error.Error}"))
                                             })
                                                 .Wait()
+
+                                            do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
 
                                         t5.Value <- 100.0
 
@@ -623,7 +626,6 @@ module Diff =
                                             let! (updatedGraceStatus, newDirectoryVersions) =
                                                 getNewGraceStatusAndDirectoryVersions previousGraceStatus differences
 
-                                            do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
                                             rootDirectoryId <- updatedGraceStatus.RootDirectoryId
                                             rootDirectorySha256Hash <- updatedGraceStatus.RootDirectorySha256Hash
                                             previousDirectoryIds <- updatedGraceStatus.Index.Keys.ToHashSet()
@@ -646,9 +648,13 @@ module Diff =
                                                          |> Seq.toArray)
                                                 )
 
-                                            match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                            | Ok returnValue -> ()
-                                            | Error error -> logToAnsiConsole Colors.Error $"Failed to upload changed files to object storage. {error}"
+                                            let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                                            let uploadedFileVersions =
+                                                match uploadResult with
+                                                | Ok returnValue -> returnValue.ReturnValue
+                                                | Error error ->
+                                                    raise (InvalidOperationException($"Failed to upload changed files to object storage. {error.Error}"))
 
                                             t3.Value <- 100.0
 
@@ -666,13 +672,12 @@ module Diff =
                                                     saveParameters.CorrelationId <- getCorrelationId parseResult
 
                                                     saveParameters.DirectoryVersions <-
-                                                        newDirectoryVersions
-                                                            .Select(fun dv -> dv.ToDirectoryVersion)
-                                                            .ToList()
+                                                        applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
                                                     match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                     | Ok returnValue -> ()
-                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to upload new directory versions. {error}"
+                                                    | Error error ->
+                                                        raise (InvalidOperationException($"Failed to upload new directory versions. {error.Error}"))
                                                 })
                                                     .Wait()
 
@@ -689,9 +694,11 @@ module Diff =
                                                             (getCorrelationId parseResult)
                                                         with
                                                     | Ok saveReference -> ()
-                                                    | Error error -> logToAnsiConsole Colors.Error $"Failed to create a save reference. {error}"
+                                                    | Error error -> raise (InvalidOperationException($"Failed to create a save reference. {error.Error}"))
                                                 })
                                                     .Wait()
+
+                                                do! applyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
 
                                             t5.Value <- 100.0
 

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -101,7 +101,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "2"
+    let private ExpectedLocalStateSchemaVersion = "3"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -101,7 +101,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "3"
+    let private ExpectedLocalStateSchemaVersion = "2"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -720,8 +720,20 @@ module Reference =
                                                 saveParameters.CorrelationId <- graceIds.CorrelationId
                                                 saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
+                                                let! savedDirectoryVersionsResult =
+                                                    getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId graceIds.CorrelationId
+
+                                                let savedDirectoryVersions =
+                                                    match savedDirectoryVersionsResult with
+                                                    | Ok returnValue -> returnValue
+                                                    | Error error ->
+                                                        raise (InvalidOperationException($"Error retrieving saved directory versions: {error.Error}"))
+
                                                 saveParameters.DirectoryVersions <-
-                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                                                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                                        uploadedFileVersions
+                                                        savedDirectoryVersions
+                                                        newDirectoryVersions
 
                                                 match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                                                 | Ok _ -> ()
@@ -829,7 +841,18 @@ module Reference =
                         saveParameters.RepositoryName <- graceIds.RepositoryName
                         saveParameters.CorrelationId <- graceIds.CorrelationId
 
-                        saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+                        let! savedDirectoryVersionsResult = getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId graceIds.CorrelationId
+
+                        let savedDirectoryVersions =
+                            match savedDirectoryVersionsResult with
+                            | Ok returnValue -> returnValue
+                            | Error error -> raise (InvalidOperationException($"Error retrieving saved directory versions: {error.Error}"))
+
+                        saveParameters.DirectoryVersions <-
+                            applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                uploadedFileVersions
+                                savedDirectoryVersions
+                                newDirectoryVersions
 
                         match! DirectoryVersion.SaveDirectoryVersions saveParameters with
                         | Ok _ -> ()

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -622,6 +622,7 @@ module Reference =
                                         //let mutable rootDirectoryId = DirectoryId.Empty
                                         //let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
                                         let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty)
+                                        let mutable applyLocalStatusAfterReferenceSave = fun () -> Task.FromResult(())
 
                                         match! getGraceWatchStatus () with
                                         | Some graceWatchStatus ->
@@ -678,6 +679,7 @@ module Reference =
                                             //     newDirectoryVersions.First(fun dv -> dv.Files.Exists(fun file -> file.RelativePath = relativePath)).Files.First(fun file -> file.RelativePath = relativePath))
 
                                             let mutable lastFileUploadInstant = newGraceStatus.LastSuccessfulFileUpload
+                                            let mutable uploadedFileVersions = Array.empty<FileVersion>
 
                                             if newFileVersions.Count() > 0 then
                                                 let getUploadMetadataForFilesParameters =
@@ -696,8 +698,8 @@ module Reference =
                                                     )
 
                                                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                                                | Ok returnValue -> () //logToAnsiConsole Colors.Verbose $"Uploaded all files to object storage."
-                                                | Error error -> logToAnsiConsole Colors.Error $"Error uploading files to object storage: {error.Error}"
+                                                | Ok returnValue -> uploadedFileVersions <- returnValue.ReturnValue
+                                                | Error error -> raise (InvalidOperationException($"Error uploading files to object storage: {error.Error}"))
 
                                                 lastFileUploadInstant <- getCurrentInstant ()
 
@@ -719,11 +721,11 @@ module Reference =
                                                 saveParameters.DirectoryVersionId <- $"{newGraceStatus.RootDirectoryId}"
 
                                                 saveParameters.DirectoryVersions <-
-                                                    newDirectoryVersions
-                                                        .Select(fun dv -> dv.ToDirectoryVersion)
-                                                        .ToList()
+                                                    applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
-                                                let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                                                match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                                                | Ok _ -> ()
+                                                | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
@@ -735,7 +737,8 @@ module Reference =
                                                     LastSuccessfulDirectoryVersionUpload = lastDirectoryVersionUpload
                                                 }
 
-                                            do! applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
+                                            applyLocalStatusAfterReferenceSave <-
+                                                fun () -> applyGraceStatusIncremental newGraceStatus newDirectoryVersions differences
 
                                         t5.StartTask() // Create new reference.
 
@@ -758,6 +761,11 @@ module Reference =
                                             )
 
                                         let! result = command sdkParameters
+
+                                        match result with
+                                        | Ok _ -> do! applyLocalStatusAfterReferenceSave ()
+                                        | Error _ -> ()
+
                                         t5.Value <- 100.0
 
                                         return result
@@ -806,6 +814,12 @@ module Reference =
                             )
 
                         let! uploadResult = uploadFilesToObjectStorage getUploadMetadataForFilesParameters
+
+                        let uploadedFileVersions =
+                            match uploadResult with
+                            | Ok returnValue -> returnValue.ReturnValue
+                            | Error error -> raise (InvalidOperationException($"Error uploading files to object storage: {error.Error}"))
+
                         let saveParameters = SaveDirectoryVersionsParameters()
                         saveParameters.OwnerId <- graceIds.OwnerIdString
                         saveParameters.OwnerName <- graceIds.OwnerName
@@ -815,12 +829,12 @@ module Reference =
                         saveParameters.RepositoryName <- graceIds.RepositoryName
                         saveParameters.CorrelationId <- graceIds.CorrelationId
 
-                        saveParameters.DirectoryVersions <-
-                            newDirectoryVersions
-                                .Select(fun dv -> dv.ToDirectoryVersion)
-                                .ToList()
+                        saveParameters.DirectoryVersions <- applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
 
-                        let! uploadDirectoryVersions = DirectoryVersion.SaveDirectoryVersions saveParameters
+                        match! DirectoryVersion.SaveDirectoryVersions saveParameters with
+                        | Ok _ -> ()
+                        | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
+
                         let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
 
                         let sdkParameters =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -261,10 +261,15 @@ module Services =
                     stream.Position <- 0
                     let! sha256Hash = computeSha256ForFile stream relativePath
 
+                    stream.Position <- 0
+                    let! fileContentHash = computeBlake3ForFile stream
+                    let blake3Hash = Blake3Hash $"{fileContentHash}"
+
                     let returnValue =
-                        LocalFileVersion.Create
+                        LocalFileVersion.CreateWithHashes
                             relativePath
                             sha256Hash
+                            blake3Hash
                             isBinary
                             fileInfo.Length
                             (Instant.FromDateTimeUtc(fileInfo.LastWriteTimeUtc))
@@ -367,11 +372,16 @@ module Services =
                 let relativePath = normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName))
                 let! sha256Hash = computeSha256ForFile stream relativePath
 
+                stream.Position <- 0
+                let! fileContentHash = computeBlake3ForFile stream
+                let blake3Hash = Blake3Hash $"{fileContentHash}"
+
                 return
                     Some(
-                        LocalFileVersion.Create
+                        LocalFileVersion.CreateWithHashes
                             relativePath
                             sha256Hash
+                            blake3Hash
                             isBinary
                             fileInfo.Length
                             (Instant.FromDateTimeUtc(fileInfo.LastWriteTimeUtc))
@@ -410,19 +420,19 @@ module Services =
     let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
         task {
             try
-                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, DateTime * Sha256Hash>()
+                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, DateTime * Sha256Hash * Blake3Hash>()
 
                 for kvp in previousGraceStatus.Index do
                     let directoryVersion = kvp.Value
 
                     lookupCache.TryAdd(
                         (FileSystemEntryType.Directory, directoryVersion.RelativePath),
-                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash)
+                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash, Blake3Hash String.Empty)
                     )
                     |> ignore
 
                     for file in directoryVersion.Files do
-                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash))
+                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash, file.Blake3Hash))
                         |> ignore
 
                 let localWriteTimes = getWorkingDirectoryWriteTimesForScan scanInput
@@ -435,14 +445,17 @@ module Services =
                     if not (lookupCache.ContainsKey((fileSystemEntryType, relativePath))) then
                         differences.Add(FileSystemDifference.Create Add fileSystemEntryType relativePath)
                     elif fileSystemEntryType.IsFile then
-                        let knownLastWriteTimeUtc, existingSha256Hash = lookupCache[(fileSystemEntryType, relativePath)]
+                        let knownLastWriteTimeUtc, existingSha256Hash, existingBlake3Hash = lookupCache[(fileSystemEntryType, relativePath)]
 
                         if lastWriteTimeUtc <> knownLastWriteTimeUtc then
                             let fileInfo = FileInfo(Path.Combine(scanInput.RootDirectory, relativePath))
                             let! newFileVersion = createLocalFileVersionForScan scanInput fileInfo
 
                             match newFileVersion with
-                            | Some fileVersion when fileVersion.Sha256Hash <> existingSha256Hash ->
+                            | Some fileVersion when
+                                fileVersion.Sha256Hash <> existingSha256Hash
+                                || fileVersion.Blake3Hash <> existingBlake3Hash
+                                ->
                                 differences.Add(FileSystemDifference.Create Change fileSystemEntryType relativePath)
                             | _ -> ()
 
@@ -541,7 +554,7 @@ module Services =
     let scanForDifferences (previousGraceStatus: GraceStatus) =
         task {
             try
-                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, (DateTime * Sha256Hash)>()
+                let lookupCache = Dictionary<FileSystemEntryType * RelativePath, (DateTime * Sha256Hash * Blake3Hash)>()
 
                 let differences = ConcurrentStack<FileSystemDifference>()
 
@@ -552,14 +565,14 @@ module Services =
 
                     lookupCache.TryAdd(
                         (FileSystemEntryType.Directory, directoryVersion.RelativePath),
-                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash)
+                        (directoryVersion.LastWriteTimeUtc, directoryVersion.Sha256Hash, Blake3Hash String.Empty)
                     )
                     |> ignore
 
                     for file in directoryVersion.Files do
                         fileCount <- fileCount + 1
 
-                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash))
+                        lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash, file.Blake3Hash))
                         |> ignore
 
                 if parseResult |> isOutputFormat "Verbose" then
@@ -583,7 +596,7 @@ module Services =
 
                     // Check for changes
                     if lookupCache.ContainsKey((fileSystemEntryType, relativePath)) then
-                        let (knownLastWriteTimeUtc, existingSha256Hash) = lookupCache[(fileSystemEntryType, relativePath)]
+                        let (knownLastWriteTimeUtc, existingSha256Hash, existingBlake3Hash) = lookupCache[(fileSystemEntryType, relativePath)]
                         // Has the LastWriteTimeUtc changed from the one in GraceStatus?
                         if fileSystemEntryType.IsFile
                            && lastWriteTimeUtc <> knownLastWriteTimeUtc then
@@ -593,19 +606,20 @@ module Services =
 
                             match! createLocalFileVersion fileInfo with
                             | Some newFileVersion ->
-                                if newFileVersion.Sha256Hash <> existingSha256Hash then
+                                if newFileVersion.Sha256Hash <> existingSha256Hash
+                                   || newFileVersion.Blake3Hash <> existingBlake3Hash then
                                     differences.Push(FileSystemDifference.Create Change fileSystemEntryType relativePath)
 
                                     if parseResult |> isOutputFormat "Verbose" then
                                         logToAnsiConsole
                                             Colors.Verbose
-                                            $"scanForDifferences: Found change in file: {relativePath}; existing Sha256Hash: {getShortSha256Hash existingSha256Hash}; new Sha256Hash: {getShortSha256Hash newFileVersion.Sha256Hash}."
+                                            $"scanForDifferences: Found change in file: {relativePath}; existing Sha256Hash: {getShortSha256Hash existingSha256Hash}; new Sha256Hash: {getShortSha256Hash newFileVersion.Sha256Hash}; existing Blake3Hash: {existingBlake3Hash}; new Blake3Hash: {newFileVersion.Blake3Hash}."
                             | None -> ()
 
                 // Check for deletions
                 for keyValuePair in lookupCache do
                     let (fileSystemEntryType, relativePath) = keyValuePair.Key
-                    let (knownLastWriteTimeUtc, existingSha256Hash) = keyValuePair.Value
+                    let (knownLastWriteTimeUtc, existingSha256Hash, existingBlake3Hash) = keyValuePair.Value
 
                     if
                         not
@@ -1047,7 +1061,9 @@ module Services =
                                     ValueTask(
                                         task {
                                             let fileVersion =
-                                                (parameters.FileVersions.First(fun fileVersion -> fileVersion.Sha256Hash = uploadMetadata.Sha256Hash))
+                                                parameters.FileVersions.First (fun fileVersion ->
+                                                    fileVersion.RelativePath = uploadMetadata.RelativePath
+                                                    && fileVersion.Sha256Hash = uploadMetadata.Sha256Hash)
                                             //logToAnsiConsole Colors.Verbose $"In Services.uploadFilesToObjectStorage(): Uploading {fileVersion.GetObjectFileName} to object storage."
                                             match!
                                                 Storage.SaveFileToObjectStorage
@@ -1068,7 +1084,7 @@ module Services =
                             )
 
                         if errors |> Seq.isEmpty then
-                            return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                            return Ok(GraceReturnValue.Create parameters.FileVersions parameters.CorrelationId)
                         else
                             // use Seq.fold to create a single error message from the ConcurrentQueue<GraceError>
                             let errorMessage =
@@ -1080,7 +1096,7 @@ module Services =
                             return Error graceError |> enhance "Errors" errorMessage
                     | Error error -> return Error error
                 else
-                    return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                    return Ok(GraceReturnValue.Create parameters.FileVersions parameters.CorrelationId)
             | AWSS3 -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
             | GoogleCloudStorage -> return Error(GraceError.Create (getErrorMessage StorageError.NotImplemented) parameters.CorrelationId)
         }
@@ -1122,14 +1138,15 @@ module Services =
 
     let internal uploadFilesToObjectStorageWithClients
         (manifestUpload: FileVersion -> Task<GraceResult<ManifestUpload.ManifestUploadResult>>)
-        (wholeFileUpload: GetUploadMetadataForFilesParameters -> Task<GraceResult<bool>>)
+        (wholeFileUpload: GetUploadMetadataForFilesParameters -> Task<GraceResult<FileVersion array>>)
         (parameters: GetUploadMetadataForFilesParameters)
         =
         task {
             if parameters.FileVersions.Count() = 0 then
-                return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                return Ok(GraceReturnValue.Create Array.empty<FileVersion> parameters.CorrelationId)
             else
                 let fallbackFileVersions = ConcurrentQueue<FileVersion>()
+                let uploadedFileVersions = ConcurrentQueue<FileVersion>()
                 let errors = ConcurrentQueue<GraceError>()
                 let mutable fileVersionIndex = 0
 
@@ -1138,7 +1155,7 @@ module Services =
 
                     match! manifestUpload fileVersion with
                     | Ok result when not result.ReturnValue.UsedManifestUpload -> fallbackFileVersions.Enqueue(fileVersion)
-                    | Ok _ -> ()
+                    | Ok result -> uploadedFileVersions.Enqueue(result.ReturnValue.FileVersion)
                     | Error error -> errors.Enqueue(error)
 
                     fileVersionIndex <- fileVersionIndex + 1
@@ -1154,9 +1171,15 @@ module Services =
                     let fallback = fallbackFileVersions.ToArray()
 
                     if fallback.Length = 0 then
-                        return Ok(GraceReturnValue.Create true parameters.CorrelationId)
+                        return Ok(GraceReturnValue.Create (uploadedFileVersions.ToArray()) parameters.CorrelationId)
                     else
-                        return! wholeFileUpload (copyStorageParameters parameters fallback)
+                        match! wholeFileUpload (copyStorageParameters parameters fallback) with
+                        | Error error -> return Error error
+                        | Ok fallbackResult ->
+                            for fileVersion in fallbackResult.ReturnValue do
+                                uploadedFileVersions.Enqueue(fileVersion)
+
+                            return Ok(GraceReturnValue.Create (uploadedFileVersions.ToArray()) parameters.CorrelationId)
         }
 
     /// Uploads all new or changed files from a directory to object storage.
@@ -1165,6 +1188,33 @@ module Services =
             (fun fileVersion -> ManifestUpload.uploadFile (createManifestUploadRequest parameters fileVersion))
             uploadWholeFilesToObjectStorage
             parameters
+
+    let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
+
+    let applyUploadedFileVersionsToDirectoryVersions
+        (uploadedFileVersions: IEnumerable<FileVersion>)
+        (localDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
+        =
+        let uploadedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+
+        for uploadedFileVersion in uploadedFileVersions do
+            uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
+
+        let directoryVersions = List<DirectoryVersion>()
+
+        for localDirectoryVersion in localDirectoryVersions do
+            let directoryVersion = localDirectoryVersion.ToDirectoryVersion
+
+            for index in 0 .. directoryVersion.Files.Count - 1 do
+                let fileVersion = directoryVersion.Files[index]
+                let mutable uploadedFileVersion = Unchecked.defaultof<FileVersion>
+
+                if uploadedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &uploadedFileVersion) then
+                    directoryVersion.Files[ index ] <- uploadedFileVersion
+
+            directoryVersions.Add directoryVersion
+
+        directoryVersions
 
     /// Creates an updated LocalDirectoryVersion instance, with a new DirectoryId, based on changes to an existing one.
     ///
@@ -1320,7 +1370,9 @@ module Services =
             match! createLocalFileVersion fileInfo with
             | Some fileVersion ->
                 if fileVersion.Sha256Hash
-                    <> existingFileVersion.Sha256Hash then
+                   <> existingFileVersion.Sha256Hash
+                   || fileVersion.Blake3Hash
+                      <> existingFileVersion.Blake3Hash then
                     directoryVersion.Files.RemoveAt(existingFileIndex)
                     directoryVersion.Files.Add(fileVersion)
                     directoryVersion.Size <- directoryVersion.Files.Sum(fun file -> int64 (file.Size))
@@ -1498,12 +1550,7 @@ module Services =
 
     /// Ensures that the provided directory versions are uploaded to Grace Server.
     /// This will add new directory versions, and ignore existing directory versions, as they are immutable.
-    let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
-        let directoryVersions =
-            localDirectoryVersions
-                .Select(fun ldv -> ldv.ToDirectoryVersion)
-                .ToList()
-
+    let saveDirectoryVersions (directoryVersions: IEnumerable<DirectoryVersion>) correlationId =
         let saveParameters = SaveDirectoryVersionsParameters()
         saveParameters.OwnerId <- $"{Current().OwnerId}"
         saveParameters.OwnerName <- Current().OwnerName
@@ -1512,9 +1559,12 @@ module Services =
         saveParameters.RepositoryId <- $"{Current().RepositoryId}"
         saveParameters.RepositoryName <- Current().RepositoryName
         saveParameters.CorrelationId <- correlationId
-        saveParameters.DirectoryVersions <- directoryVersions
+        saveParameters.DirectoryVersions <- directoryVersions.ToList()
 
         DirectoryVersion.SaveDirectoryVersions saveParameters
+
+    let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
+        saveDirectoryVersions (localDirectoryVersions.Select(fun ldv -> ldv.ToDirectoryVersion)) correlationId
 
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
@@ -1944,8 +1994,8 @@ module Services =
             ScanForDifferences: GraceStatus -> Task<List<FileSystemDifference>>
             CopyUpdatedFilesToObjectCache: List<FileSystemDifference> -> Task<seq<LocalFileVersion>>
             BuildUpdatedGraceStatus: GraceStatus -> List<FileSystemDifference> -> Task<GraceStatus * List<LocalDirectoryVersion>>
-            UploadFileVersions: seq<LocalFileVersion> -> Task<Result<unit, GraceError>>
-            UploadDirectoryVersions: List<LocalDirectoryVersion> -> Task<Result<unit, GraceError>>
+            UploadFileVersions: seq<LocalFileVersion> -> Task<Result<FileVersion array, GraceError>>
+            UploadDirectoryVersions: List<DirectoryVersion> -> Task<Result<unit, GraceError>>
             ApplyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
         }
@@ -1985,7 +2035,7 @@ module Services =
         directoryVersions
         |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
         |> Seq.filter (fun fileVersion -> changedFilePaths.Contains fileVersion.RelativePath)
-        |> Seq.distinctBy (fun fileVersion -> fileVersion.RelativePath, fileVersion.Sha256Hash)
+        |> Seq.distinctBy (fun fileVersion -> fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
         |> Seq.toList
 
     let private saveDisabledError correlationId =
@@ -2085,8 +2135,10 @@ module Services =
 
                             match! operations.UploadFileVersions fileVersionsToUpload with
                             | Error error -> return Error error
-                            | Ok () ->
-                                match! operations.UploadDirectoryVersions newDirectoryVersions with
+                            | Ok uploadedFileVersions ->
+                                let uploadedDirectoryVersions = applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
+
+                                match! operations.UploadDirectoryVersions uploadedDirectoryVersions with
                                 | Error error -> return Error error
                                 | Ok () ->
                                     let updatedGraceStatus =
@@ -2095,9 +2147,13 @@ module Services =
                                             LastSuccessfulDirectoryVersionUpload = getCurrentInstant ()
                                         }
 
-                                    do! operations.ApplyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
                                     let rootDirectoryVersion = getRootDirectoryVersion updatedGraceStatus
-                                    return! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion
+
+                                    match! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion with
+                                    | Error error -> return Error error
+                                    | Ok captured ->
+                                        do! operations.ApplyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
+                                        return Ok captured
         }
 
     let parseCreatedReferenceId correlationId (returnValue: GraceReturnValue<string>) =
@@ -2282,13 +2338,13 @@ module Services =
                     )
 
                 match! uploadFilesToObjectStorage parameters with
-                | Ok _ -> return Ok()
+                | Ok returnValue -> return Ok returnValue.ReturnValue
                 | Error error -> return Error error
             }
 
         let uploadDirectoryVersionsForCapture directoryVersions =
             task {
-                match! uploadDirectoryVersions directoryVersions correlationId with
+                match! saveDirectoryVersions directoryVersions correlationId with
                 | Ok _ -> return Ok()
                 | Error error -> return Error error
             }

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2084,7 +2084,7 @@ module Services =
         ]
         |> Seq.tryFind (referenceHasRootOnBranch branchDto.BranchId rootDirectoryId rootDirectorySha256Hash)
 
-    let private getChangedFileVersionsReferencedByUpdatedDirectories
+    let internal getChangedFileVersionsReferencedByUpdatedDirectories
         (differences: List<FileSystemDifference>)
         (directoryVersions: List<LocalDirectoryVersion>)
         =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1192,9 +1192,13 @@ module Services =
 
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
+    let private legacyUploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash)
+
     let private isManifestBackedFileVersion (fileVersion: FileVersion) =
         not (isNull (box fileVersion.ContentReference))
         && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
+
+    let private hasMissingBlake3Hash (fileVersion: FileVersion) = String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash)
 
     let applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
@@ -1207,11 +1211,14 @@ module Services =
             uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
 
         let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+        let savedManifestBackedByLegacyIdentity = Dictionary<RelativePath * Sha256Hash, FileVersion>()
 
         for savedDirectoryVersion in savedDirectoryVersions do
             for savedFileVersion in savedDirectoryVersion.Files do
                 if isManifestBackedFileVersion savedFileVersion then
                     savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
+
+                    savedManifestBackedByLegacyIdentity[legacyUploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
         let directoryVersions = List<DirectoryVersion>()
 
@@ -1228,6 +1235,12 @@ module Services =
                     let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
 
                     if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
+                        directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                    elif
+                        savedManifestBackedByLegacyIdentity.TryGetValue(legacyUploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion)
+                        && (hasMissingBlake3Hash fileVersion
+                            || hasMissingBlake3Hash savedManifestBackedFileVersion)
+                    then
                         directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
 
             directoryVersions.Add directoryVersion

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2271,6 +2271,9 @@ module Services =
                     let! isBinary = isBinaryFile tempFileStream
                     tempFileStream.Position <- 0
                     let! sha256Hash = computeSha256ForFile tempFileStream relativeFilePath
+                    tempFileStream.Position <- 0
+                    let! fileContentHash = computeBlake3ForFile tempFileStream
+                    let blake3Hash = Blake3Hash $"{fileContentHash}"
                     //logToConsole $"filePath: {filePath}; tempFilePath: {tempFilePath}; SHA256: {sha256Hash}"
 
                     // I'm going to rename the temp file below, using the SHA-256 hash, so I'll close the file and dispose the stream first.
@@ -2300,7 +2303,16 @@ module Services =
                         //logToConsole $"Finished copyToObjectDirectory for {filePath}; isBinary: {isBinary}; moved temp file to object directory."
                         let relativePath = Path.GetRelativePath(Current().RootDirectory, filePath)
 
-                        return Some(FileVersion.Create (RelativePath relativePath) (Sha256Hash $"{sha256Hash}") ("") isBinary (objectFilePathInfo.Length))
+                        return
+                            Some(
+                                FileVersion.CreateWithHashes
+                                    (RelativePath relativePath)
+                                    (Sha256Hash $"{sha256Hash}")
+                                    blake3Hash
+                                    String.Empty
+                                    isBinary
+                                    objectFilePathInfo.Length
+                            )
                     else
                         // If we do already have this exact version of the file, just delete the temp file.
                         File.Delete(tempFilePath)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -417,6 +417,11 @@ module Services =
         collect (DirectoryInfo(scanInput.RootDirectory))
         localWriteTimes
 
+    let private hasFileContentChanged existingSha256Hash existingBlake3Hash (newFileVersion: LocalFileVersion) =
+        newFileVersion.Sha256Hash <> existingSha256Hash
+        || (existingBlake3Hash <> Blake3Hash String.Empty
+            && newFileVersion.Blake3Hash <> existingBlake3Hash)
+
     let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
         task {
             try
@@ -452,10 +457,7 @@ module Services =
                             let! newFileVersion = createLocalFileVersionForScan scanInput fileInfo
 
                             match newFileVersion with
-                            | Some fileVersion when
-                                fileVersion.Sha256Hash <> existingSha256Hash
-                                || fileVersion.Blake3Hash <> existingBlake3Hash
-                                ->
+                            | Some fileVersion when hasFileContentChanged existingSha256Hash existingBlake3Hash fileVersion ->
                                 differences.Add(FileSystemDifference.Create Change fileSystemEntryType relativePath)
                             | _ -> ()
 
@@ -606,8 +608,7 @@ module Services =
 
                             match! createLocalFileVersion fileInfo with
                             | Some newFileVersion ->
-                                if newFileVersion.Sha256Hash <> existingSha256Hash
-                                   || newFileVersion.Blake3Hash <> existingBlake3Hash then
+                                if hasFileContentChanged existingSha256Hash existingBlake3Hash newFileVersion then
                                     differences.Push(FileSystemDifference.Create Change fileSystemEntryType relativePath)
 
                                     if parseResult |> isOutputFormat "Verbose" then
@@ -1191,14 +1192,26 @@ module Services =
 
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
-    let applyUploadedFileVersionsToDirectoryVersions
+    let private isManifestBackedFileVersion (fileVersion: FileVersion) =
+        not (isNull (box fileVersion.ContentReference))
+        && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
+
+    let applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
+        (savedDirectoryVersions: IEnumerable<DirectoryVersion>)
         (localDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
         =
         let uploadedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
 
         for uploadedFileVersion in uploadedFileVersions do
             uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
+
+        let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+
+        for savedDirectoryVersion in savedDirectoryVersions do
+            for savedFileVersion in savedDirectoryVersion.Files do
+                if isManifestBackedFileVersion savedFileVersion then
+                    savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
         let directoryVersions = List<DirectoryVersion>()
 
@@ -1211,10 +1224,21 @@ module Services =
 
                 if uploadedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &uploadedFileVersion) then
                     directoryVersion.Files[ index ] <- uploadedFileVersion
+                else
+                    let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
+
+                    if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
+                        directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
 
             directoryVersions.Add directoryVersion
 
         directoryVersions
+
+    let applyUploadedFileVersionsToDirectoryVersions
+        (uploadedFileVersions: IEnumerable<FileVersion>)
+        (localDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
+        =
+        applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions uploadedFileVersions Array.empty localDirectoryVersions
 
     /// Creates an updated LocalDirectoryVersion instance, with a new DirectoryId, based on changes to an existing one.
     ///
@@ -1565,6 +1589,36 @@ module Services =
 
     let uploadDirectoryVersions (localDirectoryVersions: List<LocalDirectoryVersion>) correlationId =
         saveDirectoryVersions (localDirectoryVersions.Select(fun ldv -> ldv.ToDirectoryVersion)) correlationId
+
+    let getSavedDirectoryVersionsForRootDirectory (rootDirectoryId: DirectoryVersionId) (correlationId: CorrelationId) =
+        task {
+            if rootDirectoryId = DirectoryVersionId.Empty then
+                return Ok Array.empty
+            else
+                let current = Current()
+
+                let parameters =
+                    GetParameters(
+                        OwnerId = $"{current.OwnerId}",
+                        OwnerName = current.OwnerName,
+                        OrganizationId = $"{current.OrganizationId}",
+                        OrganizationName = current.OrganizationName,
+                        RepositoryId = $"{current.RepositoryId}",
+                        RepositoryName = current.RepositoryName,
+                        DirectoryVersionId = $"{rootDirectoryId}",
+                        CorrelationId = correlationId
+                    )
+
+                match! DirectoryVersion.GetDirectoryVersionsRecursive parameters with
+                | Ok returnValue ->
+                    return
+                        Ok(
+                            returnValue.ReturnValue
+                            |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
+                            |> Seq.toArray
+                        )
+                | Error error -> return Error error
+        }
 
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
@@ -1995,6 +2049,7 @@ module Services =
             CopyUpdatedFilesToObjectCache: List<FileSystemDifference> -> Task<seq<LocalFileVersion>>
             BuildUpdatedGraceStatus: GraceStatus -> List<FileSystemDifference> -> Task<GraceStatus * List<LocalDirectoryVersion>>
             UploadFileVersions: seq<LocalFileVersion> -> Task<Result<FileVersion array, GraceError>>
+            GetSavedDirectoryVersions: GraceStatus -> Task<Result<DirectoryVersion array, GraceError>>
             UploadDirectoryVersions: List<DirectoryVersion> -> Task<Result<unit, GraceError>>
             ApplyGraceStatusIncremental: GraceStatus -> IEnumerable<LocalDirectoryVersion> -> IEnumerable<FileSystemDifference> -> Task<unit>
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
@@ -2136,24 +2191,31 @@ module Services =
                             match! operations.UploadFileVersions fileVersionsToUpload with
                             | Error error -> return Error error
                             | Ok uploadedFileVersions ->
-                                let uploadedDirectoryVersions = applyUploadedFileVersionsToDirectoryVersions uploadedFileVersions newDirectoryVersions
-
-                                match! operations.UploadDirectoryVersions uploadedDirectoryVersions with
+                                match! operations.GetSavedDirectoryVersions previousGraceStatus with
                                 | Error error -> return Error error
-                                | Ok () ->
-                                    let updatedGraceStatus =
-                                        { updatedGraceStatus with
-                                            LastSuccessfulFileUpload = getCurrentInstant ()
-                                            LastSuccessfulDirectoryVersionUpload = getCurrentInstant ()
-                                        }
+                                | Ok savedDirectoryVersions ->
+                                    let uploadedDirectoryVersions =
+                                        applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                                            uploadedFileVersions
+                                            savedDirectoryVersions
+                                            newDirectoryVersions
 
-                                    let rootDirectoryVersion = getRootDirectoryVersion updatedGraceStatus
-
-                                    match! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion with
+                                    match! operations.UploadDirectoryVersions uploadedDirectoryVersions with
                                     | Error error -> return Error error
-                                    | Ok captured ->
-                                        do! operations.ApplyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
-                                        return Ok captured
+                                    | Ok () ->
+                                        let updatedGraceStatus =
+                                            { updatedGraceStatus with
+                                                LastSuccessfulFileUpload = getCurrentInstant ()
+                                                LastSuccessfulDirectoryVersionUpload = getCurrentInstant ()
+                                            }
+
+                                        let rootDirectoryVersion = getRootDirectoryVersion updatedGraceStatus
+
+                                        match! createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion with
+                                        | Error error -> return Error error
+                                        | Ok captured ->
+                                            do! operations.ApplyGraceStatusIncremental updatedGraceStatus newDirectoryVersions differences
+                                            return Ok captured
         }
 
     let parseCreatedReferenceId correlationId (returnValue: GraceReturnValue<string>) =
@@ -2369,6 +2431,7 @@ module Services =
                     }
             BuildUpdatedGraceStatus = getNewGraceStatusAndDirectoryVersions
             UploadFileVersions = uploadFileVersions
+            GetSavedDirectoryVersions = fun previousGraceStatus -> getSavedDirectoryVersionsForRootDirectory previousGraceStatus.RootDirectoryId correlationId
             UploadDirectoryVersions = uploadDirectoryVersionsForCapture
             ApplyGraceStatusIncremental = applyGraceStatusIncremental
             CreateSaveReference = createSaveReferenceForCapture

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -441,27 +441,48 @@ module Watch =
             | _ -> return None
         }
 
-    /// Copies a file from the working directory to the object directory, with its SHA-256 hash, and then uploads it to storage.
-    let copyFileToObjectDirectoryAndUploadToStorage (getUploadMetadataForFilesParameters: GetUploadMetadataForFilesParameters) fullPath =
+    let internal uploadFileVersionToStorage
+        (uploadFileVersions: GetUploadMetadataForFilesParameters -> Task<GraceResult<FileVersion array>>)
+        (getUploadMetadataForFilesParameters: GetUploadMetadataForFilesParameters)
+        (fileVersion: FileVersion)
+        =
+        task {
+            getUploadMetadataForFilesParameters.FileVersions <- [| fileVersion |]
+
+            match! uploadFileVersions getUploadMetadataForFilesParameters with
+            | Ok returnValue ->
+                for uploadedFileVersion in returnValue.ReturnValue do
+                    uploadedFileVersions[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
+
+                logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
+            | Error error -> raise (InvalidOperationException($"Failed to upload {fileVersion.GetObjectFileName} to storage: {error.Error}"))
+        }
+
+    let internal copyFileToObjectDirectoryAndUploadToStorageWithClients
+        (copyFileToObjectCache: FilePath -> Task<FileVersion option>)
+        (getCachedFileVersion: FilePath -> Task<FileVersion option>)
+        (uploadFileVersions: GetUploadMetadataForFilesParameters -> Task<GraceResult<FileVersion array>>)
+        (getUploadMetadataForFilesParameters: GetUploadMetadataForFilesParameters)
+        fullPath
+        =
         task {
             //logToConsole $"*In fileChanged for {fullPath}."
-            match! copyToObjectDirectory fullPath with
-            | Some fileVersion ->
-                getUploadMetadataForFilesParameters.FileVersions <- [| fileVersion |]
-
-                match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                | Ok returnValue ->
-                    for uploadedFileVersion in returnValue.ReturnValue do
-                        uploadedFileVersions[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
-
-                    logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
-                | Error error -> raise (InvalidOperationException($"Failed to upload {fileVersion.GetObjectFileName} to storage: {error.Error}"))
+            match! copyFileToObjectCache fullPath with
+            | Some fileVersion -> do! uploadFileVersionToStorage uploadFileVersions getUploadMetadataForFilesParameters fileVersion
             | None ->
-                match! getCachedFileVersionForUploadSkip fullPath with
-                | Some fileVersion ->
-                    logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} already exists in the object cache; skipping upload."
+                match! getCachedFileVersion fullPath with
+                | Some fileVersion -> do! uploadFileVersionToStorage uploadFileVersions getUploadMetadataForFilesParameters fileVersion
                 | None -> raise (InvalidOperationException($"Failed to copy {fullPath} to the object cache before upload."))
         }
+
+    /// Copies a file from the working directory to the object directory, with its SHA-256 hash, and then uploads it to storage.
+    let copyFileToObjectDirectoryAndUploadToStorage (getUploadMetadataForFilesParameters: GetUploadMetadataForFilesParameters) fullPath =
+        copyFileToObjectDirectoryAndUploadToStorageWithClients
+            copyToObjectDirectory
+            getCachedFileVersionForUploadSkip
+            uploadFilesToObjectStorage
+            getUploadMetadataForFilesParameters
+            fullPath
 
     /// Decompresses the GraceStatus information from the memory stream.
     let retrieveGraceStatusFromMemoryStream () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -430,7 +430,14 @@ module Watch =
             let fileInfo = FileInfo(fullPath)
 
             match! createLocalFileVersion fileInfo with
-            | Some localFileVersion when File.Exists(localFileVersion.FullObjectPath) -> return Some localFileVersion.ToFileVersion
+            | Some localFileVersion ->
+                let relativeDirectoryPath = getLocalRelativeDirectory fullPath (Current().RootDirectory)
+                let objectFilePath = Path.Combine(Current().ObjectDirectory, relativeDirectoryPath, localFileVersion.GetObjectFileName)
+
+                if File.Exists(objectFilePath) then
+                    return Some localFileVersion.ToFileVersion
+                else
+                    return None
             | _ -> return None
         }
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -44,6 +44,9 @@ open Grace.Types.Automation
 module Watch =
     exception private WatchCommandExit of int
 
+    let private uploadedFileVersions = ConcurrentDictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+
+    let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
     module private Options =
         let ownerId =
@@ -332,8 +335,21 @@ module Watch =
                     Colors.Verbose
                     $"new Sha256Hash: {dv.Sha256Hash.Substring(0, 8)}; DirectoryId: {dv.DirectoryVersionId.ToString().Substring(0, 9)}...; RelativePath: {dv.RelativePath}"
 
+            let directoryUploadedFileVersions =
+                let fileIdentities =
+                    newDirectoryVersions
+                    |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+                    |> Seq.map (fun fileVersion -> (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash))
+                    |> HashSet
+
+                uploadedFileVersions.Values
+                |> Seq.filter (fun fileVersion -> fileIdentities.Contains(uploadedFileVersionIdentity fileVersion))
+                |> Seq.toArray
+
             // Upload the new directory versions.
-            let! result = uploadDirectoryVersions newDirectoryVersions correlationId
+            let directoryVersionsToSave = applyUploadedFileVersionsToDirectoryVersions directoryUploadedFileVersions newDirectoryVersions
+
+            let! result = saveDirectoryVersions directoryVersionsToSave correlationId
 
             match result with
             | Ok returnValue ->
@@ -376,6 +392,13 @@ module Watch =
                         let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
                         // Apply incremental changes to the Grace Status DB.
                         do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+
+                        for fileVersion in directoryUploadedFileVersions do
+                            let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                            uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
+                            |> ignore
+
                         //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
                         graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
                         return Some newGraceStatusWithUpdatedTime
@@ -400,9 +423,13 @@ module Watch =
                 getUploadMetadataForFilesParameters.FileVersions <- [| fileVersion |]
 
                 match! uploadFilesToObjectStorage getUploadMetadataForFilesParameters with
-                | Ok returnValue -> logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
-                | Error error -> logToAnsiConsole Colors.Error $"**Failed to upload {fileVersion.GetObjectFileName} to storage."
-            | None -> ()
+                | Ok returnValue ->
+                    for uploadedFileVersion in returnValue.ReturnValue do
+                        uploadedFileVersions[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
+
+                    logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
+                | Error error -> raise (InvalidOperationException($"Failed to upload {fileVersion.GetObjectFileName} to storage: {error.Error}"))
+            | None -> raise (InvalidOperationException($"Failed to copy {fullPath} to the object cache before upload."))
         }
 
     /// Decompresses the GraceStatus information from the memory stream.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -346,72 +346,92 @@ module Watch =
                 |> Seq.filter (fun fileVersion -> fileIdentities.Contains(uploadedFileVersionIdentity fileVersion))
                 |> Seq.toArray
 
-            // Upload the new directory versions.
-            let directoryVersionsToSave = applyUploadedFileVersionsToDirectoryVersions directoryUploadedFileVersions newDirectoryVersions
+            let! savedDirectoryVersionsResult = getSavedDirectoryVersionsForRootDirectory graceStatus.RootDirectoryId correlationId
 
-            let! result = saveDirectoryVersions directoryVersionsToSave correlationId
-
-            match result with
-            | Ok returnValue ->
-                do! updateObjectCacheFile newDirectoryVersions
-
-                let fileDifferences =
-                    differences
-                        .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
-                        .ToList()
-
-                let message =
-                    if fileDifferences |> Seq.isEmpty then
-                        String.Empty
-                    else
-                        let sb = stringBuilderPool.Get()
-
-                        try
-                            for fileDifference in fileDifferences do
-                                //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
-                                match fileDifference.DifferenceType with
-                                | Change ->
-                                    sb.AppendLine($"{fileDifference.RelativePath}")
-                                    |> ignore
-                                | Add ->
-                                    sb.AppendLine($"Add {fileDifference.RelativePath}")
-                                    |> ignore
-                                | Delete ->
-                                    sb.AppendLine($"Delete {fileDifference.RelativePath}")
-                                    |> ignore
-
-                            let saveMessage = sb.ToString()
-                            saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
-                        finally
-                            stringBuilderPool.Return(sb)
-
-                // If there are changes either to files or just to directories, create a save reference.
-                if (differences.Count > 0) then
-                    match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
-                    | Ok returnValue ->
-                        let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
-                        // Apply incremental changes to the Grace Status DB.
-                        do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
-
-                        for fileVersion in directoryUploadedFileVersions do
-                            let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
-
-                            uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
-                            |> ignore
-
-                        //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
-                        graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
-                        return Some newGraceStatusWithUpdatedTime
-                    | Error error ->
-                        logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
-                        return None
-                else
-                    // There were no changes to process, so just return the existing GraceStatus.
-                    //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
-                    return Some graceStatus
+            match savedDirectoryVersionsResult with
             | Error error ->
                 logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
                 return None
+            | Ok savedDirectoryVersions ->
+                // Upload the new directory versions.
+                let directoryVersionsToSave =
+                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                        directoryUploadedFileVersions
+                        savedDirectoryVersions
+                        newDirectoryVersions
+
+                let! result = saveDirectoryVersions directoryVersionsToSave correlationId
+
+                match result with
+                | Ok returnValue ->
+                    do! updateObjectCacheFile newDirectoryVersions
+
+                    let fileDifferences =
+                        differences
+                            .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
+                            .ToList()
+
+                    let message =
+                        if fileDifferences |> Seq.isEmpty then
+                            String.Empty
+                        else
+                            let sb = stringBuilderPool.Get()
+
+                            try
+                                for fileDifference in fileDifferences do
+                                    //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
+                                    match fileDifference.DifferenceType with
+                                    | Change ->
+                                        sb.AppendLine($"{fileDifference.RelativePath}")
+                                        |> ignore
+                                    | Add ->
+                                        sb.AppendLine($"Add {fileDifference.RelativePath}")
+                                        |> ignore
+                                    | Delete ->
+                                        sb.AppendLine($"Delete {fileDifference.RelativePath}")
+                                        |> ignore
+
+                                let saveMessage = sb.ToString()
+                                saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
+                            finally
+                                stringBuilderPool.Return(sb)
+
+                    // If there are changes either to files or just to directories, create a save reference.
+                    if (differences.Count > 0) then
+                        match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
+                        | Ok returnValue ->
+                            let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
+                            // Apply incremental changes to the Grace Status DB.
+                            do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+
+                            for fileVersion in directoryUploadedFileVersions do
+                                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
+                                |> ignore
+
+                            //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
+                            graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
+                            return Some newGraceStatusWithUpdatedTime
+                        | Error error ->
+                            logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
+                            return None
+                    else
+                        // There were no changes to process, so just return the existing GraceStatus.
+                        //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
+                        return Some graceStatus
+                | Error error ->
+                    logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
+                    return None
+        }
+
+    let private getCachedFileVersionForUploadSkip (fullPath: FilePath) =
+        task {
+            let fileInfo = FileInfo(fullPath)
+
+            match! createLocalFileVersion fileInfo with
+            | Some localFileVersion when File.Exists(localFileVersion.FullObjectPath) -> return Some localFileVersion.ToFileVersion
+            | _ -> return None
         }
 
     /// Copies a file from the working directory to the object directory, with its SHA-256 hash, and then uploads it to storage.
@@ -429,7 +449,11 @@ module Watch =
 
                     logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} has been uploaded to storage."
                 | Error error -> raise (InvalidOperationException($"Failed to upload {fileVersion.GetObjectFileName} to storage: {error.Error}"))
-            | None -> raise (InvalidOperationException($"Failed to copy {fullPath} to the object cache before upload."))
+            | None ->
+                match! getCachedFileVersionForUploadSkip fullPath with
+                | Some fileVersion ->
+                    logToAnsiConsole Colors.Verbose $"File {fileVersion.GetObjectFileName} already exists in the object cache; skipping upload."
+                | None -> raise (InvalidOperationException($"Failed to copy {fullPath} to the object cache before upload."))
         }
 
     /// Decompresses the GraceStatus information from the memory stream.

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1415,6 +1415,7 @@ module LocalStateDb =
                                         ParentPath = directoryReader.GetString(1)
                                         DirectoryVersionId = Guid.Parse(directoryReader.GetString(2))
                                         Sha256Hash = directoryReader.GetString(3)
+                                        Blake3Hash = String.Empty
                                         SizeBytes = directoryReader.GetInt64(4)
                                         CreatedAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(5))
                                         LastWriteTimeUtc = DateTime(directoryReader.GetInt64(6), DateTimeKind.Utc)
@@ -1434,6 +1435,7 @@ module LocalStateDb =
                                         RelativePath = fileReader.GetString(0)
                                         DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
                                         Sha256Hash = fileReader.GetString(2)
+                                        Blake3Hash = String.Empty
                                         IsBinary = fileReader.GetInt64(3) = 1L
                                         SizeBytes = fileReader.GetInt64(4)
                                         CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(5))

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1398,8 +1398,21 @@ module LocalStateDb =
                         match readStatusMetaInternal connection with
                         | None -> return Error "Local state status_meta row is missing or unreadable."
                         | Some meta ->
+                            let columnExists tableName columnName =
+                                use command = connection.CreateCommand()
+                                command.CommandText <- $"PRAGMA table_info({tableName});"
+                                use reader = command.ExecuteReader()
+                                let mutable found = false
+
+                                while reader.Read() do
+                                    if StringComparer.OrdinalIgnoreCase.Equals(reader.GetString(1), columnName) then
+                                        found <- true
+
+                                found
+
                             let directories = List<StatusDirectoryRow>()
                             let files = List<StatusFileRow>()
+                            let hasStatusFilesBlake3Hash = columnExists "status_files" "blake3_hash"
 
                             use directoryCommand = connection.CreateCommand()
 
@@ -1424,8 +1437,10 @@ module LocalStateDb =
 
                             use fileCommand = connection.CreateCommand()
 
+                            let fileBlake3Projection = if hasStatusFilesBlake3Hash then "blake3_hash" else "''"
+
                             fileCommand.CommandText <-
-                                "SELECT relative_path, directory_version_id, sha256_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+                                $"SELECT relative_path, directory_version_id, sha256_hash, {fileBlake3Projection}, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
 
                             use fileReader = fileCommand.ExecuteReader()
 
@@ -1435,12 +1450,12 @@ module LocalStateDb =
                                         RelativePath = fileReader.GetString(0)
                                         DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
                                         Sha256Hash = fileReader.GetString(2)
-                                        Blake3Hash = String.Empty
-                                        IsBinary = fileReader.GetInt64(3) = 1L
-                                        SizeBytes = fileReader.GetInt64(4)
-                                        CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(5))
-                                        UploadedToObjectStorage = fileReader.GetInt64(6) = 1L
-                                        LastWriteTimeUtc = DateTime(fileReader.GetInt64(7), DateTimeKind.Utc)
+                                        Blake3Hash = fileReader.GetString(3)
+                                        IsBinary = fileReader.GetInt64(4) = 1L
+                                        SizeBytes = fileReader.GetInt64(5)
+                                        CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
+                                        UploadedToObjectStorage = fileReader.GetInt64(7) = 1L
+                                        LastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
                                     }
                                 )
 
@@ -1459,9 +1474,10 @@ module LocalStateDb =
                             files
                             |> Seq.iter (fun file ->
                                 let localFile =
-                                    LocalFileVersion.Create
+                                    LocalFileVersion.CreateWithHashes
                                         file.RelativePath
                                         file.Sha256Hash
+                                        file.Blake3Hash
                                         file.IsBinary
                                         file.SizeBytes
                                         file.CreatedAt

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -17,7 +17,7 @@ open SQLitePCL
 
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "3"
+    let private SchemaVersion = "2"
 
     [<Literal>]
     let private BusyTimeoutMs = 30000

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -17,7 +17,7 @@ open SQLitePCL
 
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "2"
+    let private SchemaVersion = "3"
 
     [<Literal>]
     let private BusyTimeoutMs = 30000

--- a/src/Grace.SDK/ManifestUpload.SDK.fs
+++ b/src/Grace.SDK/ManifestUpload.SDK.fs
@@ -169,8 +169,16 @@ module ManifestUpload =
         parameters.Manifest <- manifest
         parameters
 
-    let private manifestFileVersion (fileVersion: FileVersion) manifest =
-        let manifestVersion = FileVersion.Create fileVersion.RelativePath fileVersion.Sha256Hash fileVersion.BlobUri fileVersion.IsBinary fileVersion.Size
+    let private manifestFileVersion (fileVersion: FileVersion) (manifest: FileManifest) =
+        let manifestVersion =
+            FileVersion.CreateWithHashes
+                fileVersion.RelativePath
+                fileVersion.Sha256Hash
+                (Blake3Hash $"{manifest.FileContentHash}")
+                fileVersion.BlobUri
+                fileVersion.IsBinary
+                fileVersion.Size
+
         manifestVersion.CreatedAt <- fileVersion.CreatedAt
         manifestVersion.ContentReference <- FileContentReference.FileManifest manifest
         manifestVersion

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -211,6 +211,7 @@ module Storage =
                 metadata[nameof RepositoryName] <- $"{Current().RepositoryName}"
                 metadata[nameof RepositoryId] <- $"{Current().RepositoryId}"
                 metadata[nameof Sha256Hash] <- fileVersion.Sha256Hash
+                metadata[nameof Blake3Hash] <- fileVersion.Blake3Hash
                 metadata["UncompressedSize"] <- $"{fileInfo.Length}"
 
                 match Current().ObjectStorageProvider with
@@ -300,6 +301,7 @@ module Storage =
                             let returnValue = GraceReturnValue.Create "File successfully saved to object storage." correlationId
 
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue
@@ -308,6 +310,7 @@ module Storage =
                             let returnValue = GraceReturnValue.Create "File already exists in object storage." correlationId
 
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue
@@ -320,6 +323,7 @@ module Storage =
                             // If the file already exists in Blob Storage, we don't need to do anything.
                             let returnValue = GraceReturnValue.Create "File already exists in object storage." correlationId
                             returnValue.Properties.Add(nameof Sha256Hash, fileVersion.Sha256Hash)
+                            returnValue.Properties.Add(nameof Blake3Hash, fileVersion.Blake3Hash)
                             returnValue.Properties.Add(nameof RelativePath, fileVersion.RelativePath)
                             returnValue.Properties.Add(nameof RepositoryId, repositoryId)
                             return Ok returnValue

--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -121,6 +121,7 @@ type AnnotationMaterializationServerTests() =
     member _.ManifestBackedContentMaterializesExactUtf8Text() =
         let bytes = textBytes "manifest line one\nmanifest line two\n"
         let target, block = manifestFile "/src/Large.fs" bytes
+        target.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex bytes)
         let objects = Dictionary<string, byte array>()
         objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
 
@@ -130,6 +131,31 @@ type AnnotationMaterializationServerTests() =
 
         Assert.That(result.Text, Is.EqualTo("manifest line one\nmanifest line two\n"))
         Assert.That(result.Bytes = bytes, Is.True)
+
+    [<Test>]
+    member _.MaterializationRejectsMismatchedFileBlake3WhenPresent() =
+        let bytes = textBytes "manifest blake3 payload"
+        let target, block = manifestFile "/src/Large.fs" bytes
+        target.Blake3Hash <- Blake3Hash "wrong-blake3"
+        let objects = Dictionary<string, byte array>()
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+
+        materialize (readerFrom objects) target
+        |> expectErrorContains "FileVersion.Blake3Hash"
+
+    [<Test>]
+    member _.MaterializationAllowsLegacyEmptyFileBlake3() =
+        let bytes = textBytes "legacy manifest payload"
+        let target, block = manifestFile "/src/LegacyLarge.fs" bytes
+        target.Blake3Hash <- Blake3Hash String.Empty
+        let objects = Dictionary<string, byte array>()
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+
+        let result =
+            materialize (readerFrom objects) target
+            |> expectOk
+
+        Assert.That(result.Text, Is.EqualTo("legacy manifest payload"))
 
     [<Test>]
     member _.BinaryTargetIsRejectedBeforeStorageRead() =

--- a/src/Grace.Server.Unit.Tests/OrleansFilters.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OrleansFilters.Server.Tests.fs
@@ -31,3 +31,11 @@ type OrleansPartitionKeyProviderTests() =
         let sourceText = File.ReadAllText(filePath)
 
         Assert.That(sourceText, Does.Contain("| StateName.WorkItemNumberCounter -> repositoryId ()"))
+
+    [<Test>]
+    member _.ContentBlockMetadataMapsToFirstGrainKeySegment() =
+        let filePath = tryResolveSourcePath ()
+        let sourceText = File.ReadAllText(filePath)
+
+        Assert.That(sourceText, Does.Contain("let firstGrainKeySegment () = $\"{grainId.Key}\".Split('|')[0]"))
+        Assert.That(sourceText, Does.Contain("| StateName.ContentBlockMetadata -> firstGrainKeySegment ()"))

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -167,6 +167,37 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected existing ContentBlock metadata to be accepted before Save, got {error.Error}.")
 
     [<Test>]
+    member _.ManifestSaveBoundaryChecksEachContentBlockAtOrdinalZero() =
+        let manifest = finalizedManifestWithBlockCopies 2
+        let queries = ResizeArray<ContentBlockRangeQuery>()
+
+        let getRangePresence _ query =
+            queries.Add(query)
+            Task.FromResult ContentBlockRangePresence.Reclaimable
+
+        match (DirectoryVersionActor.validateManifestReferencesForSaveBoundaryWithResolver getRangePresence "corr-ordinal-zero" [ manifest ])
+            .Result
+            with
+        | Ok () ->
+            Assert.That(queries, Has.Count.EqualTo(2))
+
+            Assert.That(
+                queries
+                |> Seq.forall (fun query -> query.OrdinalStart = 0 && query.OrdinalCount = 1),
+                Is.True
+            )
+        | Error error -> Assert.Fail($"Expected multi-block manifest metadata checks to use content-block ordinal zero, got {error.Error}.")
+
+    [<Test>]
+    member _.ManifestSaveBoundaryUsesRepositoryDerivedContentBlockMetadataPool() =
+        let contentBlockAddress = ContentBlockAddress "block-address"
+        let expected = $"{DedupeIndex.storagePoolIdForRepositoryId repositoryId}|{contentBlockAddress}"
+
+        let actual = DirectoryVersionActor.contentBlockMetadataActorKeyForSaveBoundary repositoryId contentBlockAddress
+
+        Assert.That(actual, Is.EqualTo(expected))
+
+    [<Test>]
     member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =
         let manifest = finalizedManifest ()
         let directoryVersion = directoryWith [ manifestFile manifest ]

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -284,14 +284,22 @@ type SaveBoundaryActorTests() =
     member _.SaveBoundaryStartsContributionWorkflowForRepeatedManifestBlockOccurrences() =
         let manifest = finalizedManifestWithBlockCopies 2
         let directoryVersion = directoryWith [ manifestFile manifest ]
+        let expectedStoragePoolId = DedupeIndex.storagePoolIdForRepositoryId repositoryId
 
         let plan =
             ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-repeated-block"
             |> expectPlan
 
-        Assert.That(plan.WorkflowRanges, Has.Length.EqualTo(2))
-        Assert.That(plan.WorkflowRanges[0].ContentBlockAddress, Is.EqualTo(plan.WorkflowRanges[1].ContentBlockAddress))
-        Assert.That(plan.WorkflowRanges[0].OrdinalStart, Is.Not.EqualTo(plan.WorkflowRanges[1].OrdinalStart))
+        Assert.That(plan.WorkflowRanges, Has.Length.EqualTo(1))
+
+        Assert.That(
+            plan.WorkflowRanges
+            |> Seq.forall (fun range ->
+                range.StoragePoolId = expectedStoragePoolId
+                && range.OrdinalStart = 0
+                && range.OrdinalCount = 1),
+            Is.True
+        )
 
         let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, manifest.ManifestAddress)
 
@@ -301,7 +309,7 @@ type SaveBoundaryActorTests() =
                 ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-repeated-workflow")
 
             match workflowDecision with
-            | Ok decision -> Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(2))
+            | Ok decision -> Assert.That(ManifestContributionWorkflowActor.pendingRanges decision.Workflow, Has.Length.EqualTo(1))
             | Error error -> Assert.Fail($"Expected repeated block occurrences to start contribution workflow, got {error.Error}.")
         | None -> Assert.Fail("Expected increment intent to start manifest contribution workflow fan-out.")
 

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -121,6 +121,26 @@ type SaveBoundaryActorTests() =
         Assert.That(filesToValidate[0].RelativePath, Is.EqualTo(wholeFile.RelativePath))
 
     [<Test>]
+    member _.ManifestSaveBoundaryRejectsMismatchedFileBlake3WhenPresent() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash "wrong-blake3"
+
+        match DirectoryVersionActor.validateManifestBackedFileForSaveBoundary "corr-manifest-blake3-mismatch" fileVersion manifest with
+        | Ok () -> Assert.Fail("Expected manifest-backed FileVersion BLAKE3 mismatch to be rejected.")
+        | Error error -> Assert.That(error.Error, Does.Contain("FileVersion.Blake3Hash"))
+
+    [<Test>]
+    member _.ManifestSaveBoundaryAllowsLegacyEmptyFileBlake3() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+
+        match DirectoryVersionActor.validateManifestBackedFileForSaveBoundary "corr-manifest-empty-blake3" fileVersion manifest with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected legacy empty BLAKE3 to be accepted, got {error.Error}.")
+
+    [<Test>]
     member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =
         let manifest = finalizedManifest ()
         let directoryVersion = directoryWith [ manifestFile manifest ]

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Shared
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.RepositoryContentCounter
 open Grace.Types.Common
@@ -9,6 +10,7 @@ open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.Text
+open System.Threading.Tasks
 
 module DirectoryVersionActor = Grace.Actors.DirectoryVersion
 module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
@@ -139,6 +141,30 @@ type SaveBoundaryActorTests() =
         match DirectoryVersionActor.validateManifestBackedFileForSaveBoundary "corr-manifest-empty-blake3" fileVersion manifest with
         | Ok () -> ()
         | Error error -> Assert.Fail($"Expected legacy empty BLAKE3 to be accepted, got {error.Error}.")
+
+    [<Test>]
+    member _.ManifestSaveBoundaryRejectsAbsentContentBlockMetadataRanges() =
+        let manifest = finalizedManifest ()
+
+        let getRangePresence _ _ = Task.FromResult ContentBlockRangePresence.Absent
+
+        match (DirectoryVersionActor.validateManifestReferencesForSaveBoundaryWithResolver getRangePresence "corr-absent-block" [ manifest ])
+            .Result
+            with
+        | Ok () -> Assert.Fail("Expected manifest-backed save to reject absent ContentBlock metadata before Save.")
+        | Error error -> Assert.That(error.Error, Does.Contain("no finalized ContentBlock metadata range exists"))
+
+    [<Test>]
+    member _.ManifestSaveBoundaryAcceptsExistingReclaimableContentBlockMetadataRanges() =
+        let manifest = finalizedManifest ()
+
+        let getRangePresence _ _ = Task.FromResult ContentBlockRangePresence.Reclaimable
+
+        match (DirectoryVersionActor.validateManifestReferencesForSaveBoundaryWithResolver getRangePresence "corr-reclaimable-block" [ manifest ])
+            .Result
+            with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected existing ContentBlock metadata to be accepted before Save, got {error.Error}.")
 
     [<Test>]
     member _.SaveBoundaryAcceptsFinalizedManifestAfterDurableIncrementIntent() =

--- a/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
@@ -682,6 +682,75 @@ type UploadSessionActorTests() =
         | Error error -> Assert.Fail($"Expected finalize to succeed, got {error.Error}.")
 
     [<Test>]
+    member _.FinalizeManifestCreatesRepositoryPoolMetadataForUploadedBlocks() =
+        let firstBytes = Text.Encoding.UTF8.GetBytes("hello first")
+        let secondBytes = Text.Encoding.UTF8.GetBytes("hello second")
+        let fileBytes = Array.concat [ firstBytes; secondBytes ]
+        let firstBlock = encodedBlock firstBytes
+        let secondBlock = encodedBlock secondBytes
+        let manifest = manifestFor fileBytes [| firstBlock; secondBlock |]
+
+        let session =
+            { UploadSessionDto.Default with
+                ConfirmedBlockUploads =
+                    [|
+                        {
+                            ContentBlockAddress = firstBlock.Address
+                            PayloadLength = firstBlock.Payload.LongLength
+                            StoragePlacement = { ObjectKey = $"cas/content-blocks/{firstBlock.Address}"; ETag = Some "etag-first" }
+                            Ranges =
+                                [|
+                                    {
+                                        OrdinalStart = 0
+                                        OrdinalCount = 1
+                                        ActiveManifestCount = 0
+                                        PhysicalOffset = 0L
+                                        PhysicalLength = int64 firstBytes.Length
+                                    }
+                                |]
+                            ConfirmedAt = timestamp
+                        }
+                        {
+                            ContentBlockAddress = secondBlock.Address
+                            PayloadLength = secondBlock.Payload.LongLength
+                            StoragePlacement = { ObjectKey = $"cas/content-blocks/{secondBlock.Address}"; ETag = Some "etag-second" }
+                            Ranges =
+                                [|
+                                    {
+                                        OrdinalStart = 0
+                                        OrdinalCount = 1
+                                        ActiveManifestCount = 0
+                                        PhysicalOffset = 0L
+                                        PhysicalLength = int64 secondBytes.Length
+                                    }
+                                |]
+                            ConfirmedAt = timestamp
+                        }
+                    |]
+            }
+
+        let expectedStoragePoolId = DedupeIndex.storagePoolIdForRepositoryId repositoryId
+
+        let commands = UploadSessionActor.createContentBlockMetadataMergeCommandsForFinalizedUploads expectedStoragePoolId "op-finalize" session manifest
+
+        Assert.That(commands, Has.Length.EqualTo(2))
+
+        let assertMerge command (expectedAddress: ContentBlockAddress) (expectedObjectKey: string) =
+            match command with
+            | ContentBlockMetadataCommand.MergePhysicalRanges merge ->
+                Assert.That(merge.OperationId, Is.EqualTo($"op-finalize:content-block-metadata:{expectedAddress}"))
+                Assert.That(merge.StoragePoolId, Is.EqualTo(expectedStoragePoolId))
+                Assert.That(merge.ContentBlockAddress, Is.EqualTo(expectedAddress))
+                Assert.That(merge.StoragePlacement.ObjectKey, Is.EqualTo(expectedObjectKey))
+                Assert.That(merge.Ranges, Has.Length.EqualTo(1))
+                Assert.That(merge.Ranges[0].OrdinalStart, Is.EqualTo(0))
+                Assert.That(merge.Ranges[0].OrdinalCount, Is.EqualTo(1))
+            | _ -> Assert.Fail("Expected uploaded block finalization to create ContentBlockMetadata MergePhysicalRanges commands.")
+
+        assertMerge commands[0] firstBlock.Address $"cas/content-blocks/{firstBlock.Address}"
+        assertMerge commands[1] secondBlock.Address $"cas/content-blocks/{secondBlock.Address}"
+
+    [<Test>]
     member _.FinalizeManifestFromClaimedReuseRangeValidatesReconstructionAndFinalizes() =
         let fileBytes = Text.Encoding.UTF8.GetBytes("reuse range bytes")
         let block = encodedBlock fileBytes

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -38,6 +38,8 @@ module internal AnnotationMaterialization =
         |> Convert.ToHexString
         |> fun value -> value.ToLowerInvariant()
 
+    let private blake3Hex (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
+
     let private validateFileVersionShape (fileVersion: FileVersion) correlationId =
         if isNull (box fileVersion) then
             Error(error correlationId "Annotation target FileVersion is required.")
@@ -70,6 +72,11 @@ module internal AnnotationMaterialization =
             && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
         then
             Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+            && not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase))
+        then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
         else
             Ok(copyBytes bytes)
 

--- a/src/Grace.Server/OrleansFilters.Server.fs
+++ b/src/Grace.Server/OrleansFilters.Server.fs
@@ -44,6 +44,7 @@ module Orleans =
 
                         let organizationId () = $"{orleansContext[nameof OrganizationId]}"
                         let repositoryId () = $"{orleansContext[nameof RepositoryId]}"
+                        let firstGrainKeySegment () = $"{grainId.Key}".Split('|')[0]
 
                         let partitionKey =
                             match grainType with
@@ -66,6 +67,7 @@ module Orleans =
                             | StateName.Artifact -> repositoryId ()
                             | StateName.ApprovalRequest -> repositoryId ()
                             | StateName.ApprovalRequestIndex -> repositoryId ()
+                            | StateName.ContentBlockMetadata -> firstGrainKeySegment ()
                             | StateName.Reference -> repositoryId ()
                             | StateName.Reminder -> StateName.Reminder
                             | StateName.Repository -> organizationId ()

--- a/src/Grace.Shared/Services.Shared.fs
+++ b/src/Grace.Shared/Services.Shared.fs
@@ -24,10 +24,10 @@ module Services =
 
             match result with
             | Ok result ->
-                result.Properties[key] <- safeValue
+                result.Properties[ key ] <- safeValue
                 Ok result
             | Error error ->
-                error.Properties[key] <- safeValue
+                error.Properties[ key ] <- safeValue
                 Error error
         else
             result
@@ -45,7 +45,9 @@ module Services =
                 true // Indicates that the object is okay to be returned to the pool
 
     /// An ObjectPool for IncrementalHash instances.
-    let incrementalHashPool = DefaultObjectPoolProvider().Create(IncrementalHashPolicy())
+    let incrementalHashPool =
+        DefaultObjectPoolProvider()
+            .Create(IncrementalHashPolicy())
 
     /// Computes the BLAKE3 value for a given file, presented as a stream.
     ///
@@ -57,7 +59,7 @@ module Services =
             // I did some informal perf testing on large files. This size was best, larger didn't help, and 64K keeps it on the small object heap.
             let bufferLength = 64 * 1024
 
-            let buffer = ArrayPool<byte>.Shared.Rent(bufferLength)
+            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
             let mutable hasher = Hasher.New()
 
             try
@@ -77,7 +79,7 @@ module Services =
                 return FileContentHash(byteArrayToString blake3Bytes)
             finally
                 if not <| isNull buffer then
-                    ArrayPool<byte>.Shared.Return(buffer, clearArray = true)
+                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
 
                 hasher.Dispose()
         }
@@ -101,7 +103,7 @@ module Services =
                     int (stream.Length)
 
             // Get a buffer to hold the part of the file we're going to check.
-            let startingBytes = ArrayPool<byte>.Shared.Rent(bytesToCheck)
+            let startingBytes = ArrayPool<byte>.Shared.Rent (bytesToCheck)
             //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Rented byte array of length {bytesToCheck}."
 
             try
@@ -113,13 +115,18 @@ module Services =
                     //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Finished reading stream."
 
                     // Search for a 0x00 character.
-                    return startingBytes.Take(bytesRead).Any(fun b -> char (b) = nulChar)
-                with ex ->
+                    return
+                        startingBytes
+                            .Take(bytesRead)
+                            .Any(fun b -> char (b) = nulChar)
+                with
+                | ex ->
                     //logToConsole $"In isBinaryFile: stream.Length: {stream.Length}. Caught exception: {ExceptionResponse.Create ex}."
                     return false
             finally
                 // Return the rented buffer to the pool, even if an exception is thrown.
-                if not <| isNull startingBytes then ArrayPool<byte>.Shared.Return(startingBytes)
+                if not <| isNull startingBytes then
+                    ArrayPool<byte>.Shared.Return (startingBytes)
         }
 
     /// Computes the SHA-256 value for a given file, presented as a stream.
@@ -131,7 +138,7 @@ module Services =
             let bufferLength = 64 * 1024
 
             // Using object pooling for both of these.
-            let buffer = ArrayPool<byte>.Shared.Rent(bufferLength)
+            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
             let hasher = incrementalHashPool.Get()
 
             try
@@ -158,9 +165,51 @@ module Services =
                 return Sha256Hash sha256Hash
             finally
                 if not <| isNull buffer then
-                    ArrayPool<byte>.Shared.Return(buffer, clearArray = true)
+                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
 
                 if not <| isNull hasher then incrementalHashPool.Return(hasher)
+        }
+
+    /// Computes both file content hashes from a single pass over a stream.
+    let computeHashesForFile (stream: Stream) (relativeFilePath: RelativePath) =
+        task {
+            if isNull stream then nullArg (nameof stream)
+
+            // I did some informal perf testing on large files. This size was best, larger didn't help, and 64K keeps it on the small object heap.
+            let bufferLength = 64 * 1024
+
+            let buffer = ArrayPool<byte>.Shared.Rent (bufferLength)
+            let sha256Hasher = incrementalHashPool.Get()
+            let mutable blake3Hasher = Hasher.New()
+
+            try
+                let mutable moreToRead = true
+
+                while moreToRead do
+                    let! bytesRead = stream.ReadAsync(buffer, 0, bufferLength)
+
+                    if bytesRead > 0 then
+                        sha256Hasher.AppendData(buffer, 0, bytesRead)
+                        blake3Hasher.Update(buffer.AsSpan(0, bytesRead))
+                    else
+                        moreToRead <- false
+
+                let sha256Bytes = stackalloc<byte> SHA256.HashSizeInBytes
+
+                sha256Hasher.GetHashAndReset(sha256Bytes)
+                |> ignore
+
+                let blake3Bytes = stackalloc<byte> Hash.Size
+                blake3Hasher.Finalize(blake3Bytes)
+
+                return Sha256Hash(byteArrayToString sha256Bytes), Blake3Hash(byteArrayToString blake3Bytes)
+            finally
+                if not <| isNull buffer then
+                    ArrayPool<byte>.Shared.Return (buffer, clearArray = true)
+
+                if not <| isNull sha256Hasher then incrementalHashPool.Return(sha256Hasher)
+
+                blake3Hasher.Dispose()
         }
 
     /// The hash algorithm to use for a DirectoryVersion preimage.
@@ -175,11 +224,13 @@ module Services =
 
     /// A child entry included in a DirectoryVersion preimage.
     type DirectoryVersionPreimageEntry =
-        { Kind: DirectoryVersionPreimageEntryKind
-          RelativePath: RelativePath
-          Size: int64
-          Blake3Hash: Blake3Hash
-          Sha256Hash: Sha256Hash }
+        {
+            Kind: DirectoryVersionPreimageEntryKind
+            RelativePath: RelativePath
+            Size: int64
+            Blake3Hash: Blake3Hash
+            Sha256Hash: Sha256Hash
+        }
 
         static member Create kind relativePath size blake3Hash sha256Hash =
             { Kind = kind; RelativePath = RelativePath(normalizeFilePath $"{relativePath}"); Size = size; Blake3Hash = blake3Hash; Sha256Hash = sha256Hash }
@@ -205,7 +256,10 @@ module Services =
         | DirectoryVersionHashAlgorithm.Blake3 -> entry.Blake3Hash
         | DirectoryVersionHashAlgorithm.Sha256 -> entry.Sha256Hash
 
-    let private encodeDirectoryVersionPath (path: RelativePath) = normalizeFilePath $"{path}" |> Encoding.UTF8.GetBytes |> Convert.ToBase64String
+    let private encodeDirectoryVersionPath (path: RelativePath) =
+        normalizeFilePath $"{path}"
+        |> Encoding.UTF8.GetBytes
+        |> Convert.ToBase64String
 
     /// Builds the versioned DirectoryVersion preimage used by both BLAKE3 and SHA-256 directory hashes.
     let directoryVersionPreimage algorithm (relativeDirectoryPath: RelativePath) (entries: seq<DirectoryVersionPreimageEntry>) =
@@ -269,10 +323,14 @@ module Services =
         computeSha256ForDirectoryEntries relativeDirectoryPath (Seq.append directoryEntries fileEntries)
 
     /// Gets the total size of the files contained within this specific directory. This does not include the size of any subdirectories.
-    let getDirectorySize (files: IList<FileVersion>) = files |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
+    let getDirectorySize (files: IList<FileVersion>) =
+        files
+        |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
 
     /// Gets the total size of the files contained within this specific directory. This does not include the size of any subdirectories.
-    let getLocalDirectorySize (files: IList<LocalFileVersion>) = files |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
+    let getLocalDirectorySize (files: IList<LocalFileVersion>) =
+        files
+        |> Seq.fold (fun (size: int64) file -> size + file.Size) 0L
 
     /// Gets the number of path segments for the longest relative path in GraceIndex.
     ///

--- a/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
@@ -67,6 +67,42 @@ type ContentAddressTypesTests() =
             Assert.That(sha256Hash, Is.EqualTo(Sha256Hash expectedSha256), $"SHA-256 vector failed for {name}.")
 
     [<Test>]
+    member _.CombinedFileHashesMatchKnownVectors() =
+        let vectors =
+            [
+                "empty",
+                Array.empty,
+                "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                "abc",
+                Encoding.UTF8.GetBytes("abc"),
+                "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                "binary",
+                [|
+                    0uy
+                    1uy
+                    2uy
+                    3uy
+                    4uy
+                    255uy
+                    128uy
+                    64uy
+                    10uy
+                    13uy
+                |],
+                "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
+                "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2"
+            ]
+
+        for name, bytes, expectedBlake3, expectedSha256 in vectors do
+            use stream = new ChunkedReadStream(bytes, 3)
+            let sha256Hash, blake3Hash = runTask (Services.computeHashesForFile stream (RelativePath $"vectors/{name}.bin"))
+
+            Assert.That(blake3Hash, Is.EqualTo(Blake3Hash expectedBlake3), $"BLAKE3 vector failed for {name}.")
+            Assert.That(sha256Hash, Is.EqualTo(Sha256Hash expectedSha256), $"SHA-256 vector failed for {name}.")
+
+    [<Test>]
     member _.FileHashesIgnoreRelativePath() =
         let bytes = Encoding.UTF8.GetBytes("same file bytes, different paths")
 

--- a/src/Grace.Types.Tests/ContentBlockMetadata.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentBlockMetadata.Types.Tests.fs
@@ -1,0 +1,35 @@
+namespace Grace.Types.Tests
+
+open Grace.Types.ContentBlockMetadata
+open Microsoft.FSharp.Reflection
+open NUnit.Framework
+open Orleans
+
+[<TestFixture>]
+type ContentBlockMetadataTypesTests() =
+
+    [<Test>]
+    member _.ContentBlockMetadataCommandCasesHaveStableSerializerIds() =
+        let actual =
+            FSharpType.GetUnionCases(typeof<ContentBlockMetadataCommand>)
+            |> Array.map (fun unionCase ->
+                let serializerId =
+                    unionCase.GetCustomAttributes()
+                    |> Seq.choose (function
+                        | :? IdAttribute as attribute -> Some attribute
+                        | _ -> None)
+                    |> Seq.exactlyOne
+
+                unionCase.Name, serializerId.Id)
+
+        Assert.That(
+            actual,
+            Is.EquivalentTo(
+                [|
+                    "ReplaceWholeRecord", 0u
+                    "MergePhysicalRanges", 1u
+                    "CompactPhysicalRanges", 2u
+                    "SetCompactionChurnState", 3u
+                |]
+            )
+        )

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Webhooks.Types.Tests.fs" />
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Common.Types.Tests.fs" />
+    <Compile Include="ContentBlockMetadata.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />
     <Compile Include="DirectoryVersionPreimage.Shared.Tests.fs" />

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -14,17 +14,37 @@ module ContentBlockMetadata =
     [<CLIMutable; GenerateSerializer>]
     type ContentBlockStoragePlacement =
         {
+            [<Id(0u)>]
             ObjectKey: string
+            [<Id(1u)>]
             ETag: string option
         }
 
         static member Empty = { ObjectKey = String.Empty; ETag = None }
 
     [<CLIMutable; GenerateSerializer>]
-    type ContentBlockMetadataRange = { OrdinalStart: int; OrdinalCount: int; ActiveManifestCount: int; PhysicalOffset: int64; PhysicalLength: int64 }
+    type ContentBlockMetadataRange =
+        {
+            [<Id(0u)>]
+            OrdinalStart: int
+            [<Id(1u)>]
+            OrdinalCount: int
+            [<Id(2u)>]
+            ActiveManifestCount: int
+            [<Id(3u)>]
+            PhysicalOffset: int64
+            [<Id(4u)>]
+            PhysicalLength: int64
+        }
 
     [<CLIMutable; GenerateSerializer>]
-    type ContentBlockRangeQuery = { OrdinalStart: int; OrdinalCount: int }
+    type ContentBlockRangeQuery =
+        {
+            [<Id(0u)>]
+            OrdinalStart: int
+            [<Id(1u)>]
+            OrdinalCount: int
+        }
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockRangePresence =
@@ -45,7 +65,15 @@ module ContentBlockMetadata =
         static member GetKnownTypes() = GetKnownTypes<ContentBlockRangeGcSafety>()
 
     [<CLIMutable; GenerateSerializer>]
-    type ContentBlockRangeGcSafetyContext = { Presence: ContentBlockRangePresence; HasPendingContributionWorkflow: bool; HasActiveReuseClaim: bool }
+    type ContentBlockRangeGcSafetyContext =
+        {
+            [<Id(0u)>]
+            Presence: ContentBlockRangePresence
+            [<Id(1u)>]
+            HasPendingContributionWorkflow: bool
+            [<Id(2u)>]
+            HasActiveReuseClaim: bool
+        }
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockCompactionSelection =
@@ -60,20 +88,30 @@ module ContentBlockMetadata =
     [<CLIMutable; GenerateSerializer>]
     type ContentBlockCompactionCandidateContext =
         {
+            [<Id(0u)>]
             Now: Instant
+            [<Id(1u)>]
             ExpectedMetadataVersion: MetadataVersion
+            [<Id(2u)>]
             HasActiveUpload: bool
+            [<Id(3u)>]
             HasActiveFinalization: bool
+            [<Id(4u)>]
             HasActiveRangeClaim: bool
+            [<Id(5u)>]
             HasActiveCompaction: bool
         }
 
     [<CLIMutable; GenerateSerializer>]
     type ContentBlockCompactionChurnState =
         {
+            [<Id(0u)>]
             HasActiveUpload: bool
+            [<Id(1u)>]
             HasActiveFinalization: bool
+            [<Id(2u)>]
             HasActiveRangeClaim: bool
+            [<Id(3u)>]
             HasActiveCompaction: bool
         }
 
@@ -82,15 +120,25 @@ module ContentBlockMetadata =
     [<CLIMutable; GenerateSerializer>]
     type ContentBlockMetadata =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             StoragePoolId: StoragePoolId
+            [<Id(2u)>]
             ContentBlockAddress: ContentBlockAddress
+            [<Id(3u)>]
             BlockFormatVersion: int16
+            [<Id(4u)>]
             StoragePlacement: ContentBlockStoragePlacement
+            [<Id(5u)>]
             Ranges: ContentBlockMetadataRange array
+            [<Id(6u)>]
             TotalPhysicalBytes: int64
+            [<Id(7u)>]
             ActivePhysicalBytes: int64
+            [<Id(8u)>]
             MetadataVersion: MetadataVersion
+            [<Id(9u)>]
             UpdatedAt: Instant
         }
 
@@ -109,38 +157,63 @@ module ContentBlockMetadata =
             }
 
     [<GenerateSerializer>]
-    type ReplaceContentBlockMetadata = { OperationId: string; ExpectedMetadataVersion: MetadataVersion option; Metadata: ContentBlockMetadata }
+    type ReplaceContentBlockMetadata =
+        {
+            [<Id(0u)>]
+            OperationId: string
+            [<Id(1u)>]
+            ExpectedMetadataVersion: MetadataVersion option
+            [<Id(2u)>]
+            Metadata: ContentBlockMetadata
+        }
 
     [<GenerateSerializer>]
     type MergeContentBlockPhysicalRanges =
         {
+            [<Id(0u)>]
             OperationId: string
+            [<Id(1u)>]
             StoragePoolId: StoragePoolId
+            [<Id(2u)>]
             ContentBlockAddress: ContentBlockAddress
+            [<Id(3u)>]
             BlockFormatVersion: int16
+            [<Id(4u)>]
             StoragePlacement: ContentBlockStoragePlacement
+            [<Id(5u)>]
             Ranges: ContentBlockMetadataRange array
         }
 
     [<GenerateSerializer>]
     type CompactContentBlockPhysicalRanges =
         {
+            [<Id(0u)>]
             OperationId: string
+            [<Id(1u)>]
             ExpectedMetadataVersion: MetadataVersion
+            [<Id(2u)>]
             StoragePlacement: ContentBlockStoragePlacement
+            [<Id(3u)>]
             Ranges: ContentBlockMetadataRange array
+            [<Id(4u)>]
             CandidateContext: ContentBlockCompactionCandidateContext
         }
 
     [<GenerateSerializer>]
-    type SetContentBlockCompactionChurnState = { OperationId: string; ChurnState: ContentBlockCompactionChurnState }
+    type SetContentBlockCompactionChurnState =
+        {
+            [<Id(0u)>]
+            OperationId: string
+            [<Id(1u)>]
+            ChurnState: ContentBlockCompactionChurnState
+        }
 
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockMetadataCommand =
-        | ReplaceWholeRecord of replace: ReplaceContentBlockMetadata
-        | MergePhysicalRanges of merge: MergeContentBlockPhysicalRanges
-        | CompactPhysicalRanges of compact: CompactContentBlockPhysicalRanges
-        | SetCompactionChurnState of setChurnState: SetContentBlockCompactionChurnState
+        | [<Id(0u)>] ReplaceWholeRecord of replace: ReplaceContentBlockMetadata
+        | [<Id(1u)>] MergePhysicalRanges of merge: MergeContentBlockPhysicalRanges
+        | [<Id(2u)>] CompactPhysicalRanges of compact: CompactContentBlockPhysicalRanges
+        | [<Id(3u)>] SetCompactionChurnState of setChurnState: SetContentBlockCompactionChurnState
 
         static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataCommand>()
 


### PR DESCRIPTION
Related to #349
Part of #343

## Summary

- Propagates complete-file `Blake3Hash` through file scan, upload planning, whole-file fallback, manifest upload, directory-save overlays, materialization checks, and implicit save callers.
- Uses returned enriched `FileVersion`s from manifest and whole-file upload paths instead of continuing with stale input versions.
- Preserves prior manifest-backed references for unchanged siblings and treats `(RelativePath, Sha256Hash, Blake3Hash)` as the overlay/change identity.
- Defers local status updates until upload, directory save, and save-reference creation succeed in the touched save paths.
- Keeps non-version SHA-256 protections unchanged, including protected dedupe labels.
- Fixes automatic review findings by streaming whole-file validation once for both hashes, preserving persisted BLAKE3 in read-only doctor snapshots, preserving unchanged manifest-backed sibling references, keeping cached watch changes processable, and treating legacy empty stored BLAKE3 as unknown.

## Scope Notes

- This PR intentionally does not implement DirectoryVersion BLAKE3/SHA-256 preimage propagation; that remains #350 / I07.
- This PR intentionally does not implement Local SQLite schema/migration/reset dual-hash behavior; that remains #352 / I09.
- `src/Grace.CLI/LocalStateDb.CLI.fs` is included for read-only materializer/projection compatibility so existing `Blake3Hash` row fields compile and read with legacy-compatible defaults.
- `src/Grace.CLI/Command/Doctor.CLI.fs` and focused doctor/local-state fixtures are included only to preserve persisted BLAKE3 in read-only doctor snapshots and align tests with the branch's existing schema version 3. This PR does not add schema migrations, reset policy, or I09 dual-hash state behavior.
- `src/Grace.Shared/Services.Shared.fs` and `ContentAddress.Types.Tests.fs` are included to add and prove the one-pass SHA-256 plus BLAKE3 stream helper needed by save-boundary validation.

## Caller Matrix

- Current-state capture path: updated.
- `grace branch` implicit save path: updated.
- `grace diff` implicit save path: updated.
- `grace reference` implicit save path: updated.
- `grace watch` save path, including multiple batches: updated.
- Manifest-eligible large file upload: updated; manifest upload returns enriched `FileVersion` with `Blake3Hash = FileManifest.FileContentHash`.
- Manifest-ineligible small or whole-file fallback upload: updated; fallback returns resulting `FileVersion`s and preserves BLAKE3.
- Changed file whose content already exists in local object cache: covered by current-state capture upload selection and focused tests.
- Changed directory containing unchanged manifest-backed sibling file: reviewed and covered by save-boundary preservation behavior.
- Legacy whole-file `FileVersion` with empty `Blake3Hash`: supported.
- Legacy manifest-backed `FileVersion` with empty `Blake3Hash`: supported.

## Validation

Passed:

- `dotnet tool run fantomas -- <touched F# files>`
- Focused CLI Release build
- Focused Server.Unit Release build
- Focused CLI tests, `24/24`
  - `CurrentStateCaptureCliTests`
  - `ManifestUploadSdkTests`
- Focused Server.Unit tests, `24/24`
  - `AnnotationMaterializationServerTests`
  - `SaveBoundaryActorTests`
- `dotnet test C:\Source\Grace-gh-349\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ContentAddressTypesTests"`, `8/8`
- `dotnet test C:\Source\Grace-gh-349\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~DoctorCliTests"`, `119/119` before the final local-state schema fix and `120/120` after `75534cac3ee0a7abc90b8b4e9bbd46bc0545556e`
- `pwsh ./scripts/validate.ps1 -Fast`, passed after fix commit `1774ccdf15e28754765df97749e200e4d60000e1` and again after `75534cac3ee0a7abc90b8b4e9bbd46bc0545556e`
  - Types `114`, Authorization `39`, Server.Unit `511`, CLI `504`; Server.Tests had no Fast filter matches in this run.
- `git diff --check`

Hosted validation:

- `Validate / full` failed on the initial head `8f680614e2d4609ad5880b887f4bd7c384c7421b` with the same LocalStateDb/doctor failures fixed by `1774ccdf15e28754765df97749e200e4d60000e1`.
- `Validate / full` passed on `1774ccdf15e28754765df97749e200e4d60000e1`.
- `Validate / full` passed on `81a4db8983548f99edbab6439004679abcde16e7`.
- `Validate / full` passed on `75534cac3ee0a7abc90b8b4e9bbd46bc0545556e`.

## Review Status

- Worker bot-prevention self-review: completed before initial push and before each fix push.
- High-risk pre-PR review waiver: recorded by orchestrator because the user explicitly prohibited manual Codex review requests; this PR relies on the repository's automatic Codex Code Review Bot after PR creation.
- Automatic Codex Code Review Bot on `8f680614e2d4609ad5880b887f4bd7c384c7421b`: two P2 findings, fixed by `1774ccdf15e28754765df97749e200e4d60000e1`, answered, and resolved.
- Automatic Codex Code Review Bot on `1774ccdf15e28754765df97749e200e4d60000e1`: three findings, fixed by `3a0e0fcb477c3d166fabadbfb7ff6b3d3a0c7e5c`, answered, and resolved.
- Codex Cloud follow-up `0ee307aff4ea8a702192e933b723b44cfdf53f1f` was merged into this branch as `00186b7dc1e4dae65270934ffbb72512f69bdfd6`.
- Automatic Codex Code Review Bot on `00186b7dc1e4dae65270934ffbb72512f69bdfd6`: one P2 finding, fixed by `07bfc02293f18155ad30730ed64dfc60e7e6400f`, answered, and resolved.
- Automatic Codex Code Review Bot on `07bfc02293f18155ad30730ed64dfc60e7e6400f`: one P1 finding and one P2 finding, fixed by `f04e5ce9269f0eccf27b7feb5d53740b091ff3ef`, answered, and resolved.
- Automatic Codex Code Review Bot on `f04e5ce9269f0eccf27b7feb5d53740b091ff3ef`: one P1 branch-switch finding and one top-level P2 local-state schema finding, fixed by `ef2842acef4bcf7ca86ea052b91df8e0d3986eb8` and `97d90dcd6b18885f5dbf9fd05ef8e8977a37c23b`, answered, and resolved or recorded in PR comments.
- Automatic Codex Code Review Bot on `ef2842acef4bcf7ca86ea052b91df8e0d3986eb8` / `97d90dcd6b18885f5dbf9fd05ef8e8977a37c23b`: manifest-finalization and watch cached-hit upload findings, fixed by `757b2574f515750574637d2f3c1a9f0e3b8739df`, answered, and resolved or recorded in PR comments.
- Automatic Codex Code Review Bot on `757b2574f515750574637d2f3c1a9f0e3b8739df`: three P1 content-block metadata validation findings, fixed by `23e666825975ab1a0f452d86af5290f14795a497`, answered, and resolved.
- Hosted `Validate / full` on `23e666825975ab1a0f452d86af5290f14795a497`: failed because ContentBlockMetadata had no Cosmos partition-key mapping and then exposed hosted serialization issues; fixed by `dda185bd7cd7a5577da65f212322fce13776d2ff`, hosted full passed on that head, and the fix was recorded in PR comments.
- Automatic Codex Code Review Bot on `23e666825975ab1a0f452d86af5290f14795a497`: two findings about Reference contribution workflow pool/ordinal alignment and branch cached upload enrichment, fixed by `6cc56eb3fe8ace93442719327259b52dba4261d5`, answered, and resolved.
- Automatic Codex Code Review Bot on `6cc56eb3fe8ace93442719327259b52dba4261d5`: one P2 dedupe metadata publication finding, fixed by `81a4db8983548f99edbab6439004679abcde16e7`, answered, and resolved.
- Automatic Codex Code Review Bot and hosted `Validate / full` on `81a4db8983548f99edbab6439004679abcde16e7`: pending automatic signals.
- Prevention line: The latest fixes preserve unchanged manifest-backed sibling refs across watch and implicit Branch/Diff/Reference/branch-switch saves, keep cached watch and branch changes in the processing and upload-enrichment pipeline for nested cache paths, preserve whole-file watch upload BLAKE3 identity for cleanup, align Reference contribution workflows with repository-pool content-block metadata and per-block ordinal-zero ranges, verify manifest-backed save references against repository-pool content-block metadata before skipping whole-file blob validation, persist content-block metadata during manifest finalization before dedupe registration, publish merged authoritative metadata to dedupe discovery, add hosted Cosmos partition-key and serializer coverage for ContentBlockMetadata, avoid legacy-empty-BLAKE3 false changes, preserve duplicate-blob-streaming and read-only-doctor-BLAKE3 protections, restore local-state schema version 3 for the BLAKE3-column write schema while preserving read-only legacy projections until I09 owns full migration/reset policy, and keep stale-upload-result, SHA-256-only-identity, early-local-status, hidden-save-failure, legacy-compatibility, and non-version-SHA-256 protections in place.
## Residual Risk

- No local Fast blocker remains after `81a4db8983548f99edbab6439004679abcde16e7`.
- Merge remains blocked until hosted `Validate / full` passes and the automatic Codex Code Review Bot reports no issues on `81a4db8983548f99edbab6439004679abcde16e7`.


