### PR TITLE
Preserve manifest refs for unchanged siblings with legacy BLAKE3

### DIFF
--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -516,6 +516,127 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``local changes preserve saved manifest references when unchanged sibling has legacy local Blake3`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/changed.txt"
+        let unchangedPath = RelativePath "src/unchanged-legacy-large.bin"
+        let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with legacy local state")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash changedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex changedPayload))
+                false
+                (int64 changedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let unchangedLocalLegacyFile =
+            LocalFileVersion.Create
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let savedManifestLocalFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex unchangedPayload))
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let savedManifestFile = savedManifestLocalFile.ToFileVersion
+        savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
+
+        let savedRoot =
+            DirectoryVersion.Create
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| savedManifestFile |]))
+                unchangedLocalLegacyFile.Size
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.Create
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>(
+                    [|
+                        changedFile
+                        unchangedLocalLegacyFile
+                    |]
+                ))
+                (changedFile.Size + unchangedLocalLegacyFile.Size)
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| changedFile.ToFileVersion |])
+                GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            savedDirectoryFiles.Count |> should equal 2
+
+            let unchangedSavedFile =
+                savedDirectoryFiles
+                |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
+
+            unchangedSavedFile.Blake3Hash
+            |> should equal savedManifestFile.Blake3Hash
+
+            unchangedSavedFile.ContentReference.ReferenceType
+            |> should equal FileContentReferenceType.FileManifest
+        | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
     let ``local changes do not apply local status when save reference creation fails`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1192,9 +1192,13 @@ module Services =
 
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
+    let private legacyUploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash)
+
     let private isManifestBackedFileVersion (fileVersion: FileVersion) =
         not (isNull (box fileVersion.ContentReference))
         && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
+
+    let private hasMissingBlake3Hash (fileVersion: FileVersion) = String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash)
 
     let applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
@@ -1207,11 +1211,14 @@ module Services =
             uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
 
         let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+        let savedManifestBackedByLegacyIdentity = Dictionary<RelativePath * Sha256Hash, FileVersion>()
 
         for savedDirectoryVersion in savedDirectoryVersions do
             for savedFileVersion in savedDirectoryVersion.Files do
                 if isManifestBackedFileVersion savedFileVersion then
                     savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
+
+                    savedManifestBackedByLegacyIdentity[legacyUploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
         let directoryVersions = List<DirectoryVersion>()
 
@@ -1228,6 +1235,12 @@ module Services =
                     let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
 
                     if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
+                        directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                    elif
+                        savedManifestBackedByLegacyIdentity.TryGetValue(legacyUploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion)
+                        && (hasMissingBlake3Hash fileVersion
+                            || hasMissingBlake3Hash savedManifestBackedFileVersion)
+                    then
                         directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
 
             directoryVersions.Add directoryVersion


### PR DESCRIPTION
### Motivation

- Fix a high-priority save-overlay bug where unchanged manifest-backed sibling files could lose their `ContentReference` when a directory change caused local file versions to be rebuilt without BLAKE3, causing save failures or loss of manifest-backed semantics.
- Ensure save overlays prefer exact `(RelativePath, Sha256Hash, Blake3Hash)` matches but fall back to preserving prior manifest-backed references when local state still has legacy/empty `Blake3Hash`.

### Description

- Update `src/Grace.CLI/Command/Services.CLI.fs` to add `legacyUploadedFileVersionIdentity`, `hasMissingBlake3Hash`, and a legacy-index `savedManifestBackedByLegacyIdentity`, and to use that legacy mapping when appropriate during directory save overlays.
- Change `applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions` to prefer exact uploaded/current identity matches and otherwise preserve saved manifest-backed `FileVersion` entries using the legacy identity when either side lacks a BLAKE3 hash.
- Add a focused unit test `local changes preserve saved manifest references when unchanged sibling has legacy local Blake3` in `src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs` to cover a changed file with an unchanged manifest-backed sibling that has legacy local state.

### Testing

- Ran formatting with `dotnet tool run fantomas -- src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs` which completed successfully.
- Built the CLI tests with `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` which succeeded.
- Ran the focused CLI test filter with `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~CurrentStateCaptureCliTests"` and the `CurrentStateCaptureCliTests` suite passed (14 passed, 0 failed).
- Ran `git diff --check` (no whitespace errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a0151587483238c0ec7f67bad2fc7)