### PR TITLE
I07: Propagate DirectoryVersion BLAKE3 hashes

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -150,6 +150,148 @@ module DirectoryVersion =
         getFilesToValidate newFiles previouslyValidatedFiles
         |> Array.filter isWholeFileContentReference
 
+    let private directoryVersionHashError correlationId (directoryVersion: DirectoryVersion) message =
+        GraceError.Create $"DirectoryVersion '{directoryVersion.RelativePath}' {message}" correlationId
+
+    let private hasMissingHash (value: string) = String.IsNullOrWhiteSpace value
+
+    let normalizeDirectoryVersionForSaveBoundary (directoryVersion: DirectoryVersion) =
+        if directoryVersion.Size
+           <> Constants.InitialDirectorySize then
+            directoryVersion
+        else
+            let normalizedDirectoryVersion = DirectoryVersion()
+            normalizedDirectoryVersion.Class <- directoryVersion.Class
+            normalizedDirectoryVersion.DirectoryVersionId <- directoryVersion.DirectoryVersionId
+            normalizedDirectoryVersion.OwnerId <- directoryVersion.OwnerId
+            normalizedDirectoryVersion.OrganizationId <- directoryVersion.OrganizationId
+            normalizedDirectoryVersion.RepositoryId <- directoryVersion.RepositoryId
+            normalizedDirectoryVersion.RelativePath <- directoryVersion.RelativePath
+            normalizedDirectoryVersion.Sha256Hash <- directoryVersion.Sha256Hash
+            normalizedDirectoryVersion.Blake3Hash <- directoryVersion.Blake3Hash
+            normalizedDirectoryVersion.Directories <- directoryVersion.Directories
+            normalizedDirectoryVersion.Files <- directoryVersion.Files
+            normalizedDirectoryVersion.Size <- getDirectorySize directoryVersion.Files
+            normalizedDirectoryVersion.CreatedAt <- directoryVersion.CreatedAt
+            normalizedDirectoryVersion.HashesValidated <- directoryVersion.HashesValidated
+            normalizedDirectoryVersion
+
+    let computeDirectoryVersionHashesFromChildren (relativePath: RelativePath) (childDirectoryVersions: seq<DirectoryVersion>) (files: seq<FileVersion>) =
+        let directoryEntries =
+            childDirectoryVersions
+            |> Seq.map (fun directoryVersion ->
+                DirectoryVersionPreimageEntry.Directory
+                    directoryVersion.RelativePath
+                    directoryVersion.Size
+                    directoryVersion.Blake3Hash
+                    directoryVersion.Sha256Hash)
+
+        let fileEntries =
+            files
+            |> Seq.map (fun fileVersion ->
+                DirectoryVersionPreimageEntry.File fileVersion.RelativePath fileVersion.Size fileVersion.Blake3Hash fileVersion.Sha256Hash)
+
+        let entries =
+            Seq.append directoryEntries fileEntries
+            |> Seq.toArray
+
+        computeSha256ForDirectoryEntries relativePath entries, computeBlake3ForDirectory relativePath entries
+
+    let validateDirectoryVersionHashesWithChildren correlationId (directoryVersion: DirectoryVersion) (childDirectoryVersions: seq<DirectoryVersion>) =
+        let mutable error: GraceError option = None
+        let childDirectoryVersions = childDirectoryVersions |> Seq.toArray
+
+        if hasMissingHash directoryVersion.Sha256Hash then
+            error <- Some(directoryVersionHashError correlationId directoryVersion "must include DirectoryVersion.Sha256Hash before Save.")
+        elif hasMissingHash directoryVersion.Blake3Hash then
+            error <- Some(directoryVersionHashError correlationId directoryVersion "must include DirectoryVersion.Blake3Hash before Save.")
+        else
+            let mutable childIndex = 0
+
+            while childIndex < childDirectoryVersions.Length
+                  && error.IsNone do
+                let childDirectoryVersion = childDirectoryVersions[childIndex]
+
+                if hasMissingHash childDirectoryVersion.Sha256Hash then
+                    error <-
+                        Some(
+                            directoryVersionHashError
+                                correlationId
+                                directoryVersion
+                                $"has child directory '{childDirectoryVersion.RelativePath}' without Sha256Hash."
+                        )
+                elif hasMissingHash childDirectoryVersion.Blake3Hash then
+                    error <-
+                        Some(
+                            directoryVersionHashError
+                                correlationId
+                                directoryVersion
+                                $"has child directory '{childDirectoryVersion.RelativePath}' without Blake3Hash."
+                        )
+
+                childIndex <- childIndex + 1
+
+            let mutable fileIndex = 0
+
+            while fileIndex < directoryVersion.Files.Count
+                  && error.IsNone do
+                let fileVersion = directoryVersion.Files[fileIndex]
+
+                if hasMissingHash fileVersion.Sha256Hash then
+                    error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Sha256Hash.")
+                elif hasMissingHash fileVersion.Blake3Hash then
+                    error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Blake3Hash.")
+
+                fileIndex <- fileIndex + 1
+
+        match error with
+        | Some error -> Error error
+        | None ->
+            let expectedSha256Hash, expectedBlake3Hash =
+                computeDirectoryVersionHashesFromChildren directoryVersion.RelativePath childDirectoryVersions directoryVersion.Files
+
+            if expectedSha256Hash <> directoryVersion.Sha256Hash then
+                Error(
+                    directoryVersionHashError
+                        correlationId
+                        directoryVersion
+                        $"has mismatched Sha256Hash. Expected {expectedSha256Hash}; received {directoryVersion.Sha256Hash}."
+                )
+            elif expectedBlake3Hash <> directoryVersion.Blake3Hash then
+                Error(
+                    directoryVersionHashError
+                        correlationId
+                        directoryVersion
+                        $"has mismatched Blake3Hash. Expected {expectedBlake3Hash}; received {directoryVersion.Blake3Hash}."
+                )
+            else
+                Ok()
+
+    let private getChildDirectoryVersionsForValidation repositoryId correlationId (directoryVersion: DirectoryVersion) =
+        task {
+            let childDirectoryVersions = ResizeArray<DirectoryVersion>()
+            let mutable error: GraceError option = None
+            let mutable childIndex = 0
+
+            while childIndex < directoryVersion.Directories.Count
+                  && error.IsNone do
+                let childDirectoryId = directoryVersion.Directories[childIndex]
+                let childDirectoryActor = DirectoryVersion.CreateActorProxy childDirectoryId repositoryId correlationId
+                let! exists = childDirectoryActor.Exists correlationId
+
+                if not exists then
+                    error <- Some(directoryVersionHashError correlationId directoryVersion $"references missing child DirectoryVersionId '{childDirectoryId}'.")
+                else
+                    let! childDirectoryDto = childDirectoryActor.Get correlationId
+                    childDirectoryVersions.Add childDirectoryDto.DirectoryVersion
+
+                childIndex <- childIndex + 1
+
+            match error with
+            | Some error -> return Error error
+            | None -> return Ok(childDirectoryVersions.ToArray())
+        }
+
     let private manifestValidationError correlationId (fileVersion: FileVersion) message =
         GraceError.Create $"FileManifest reference for '{fileVersion.RelativePath}' {message}" correlationId
 
@@ -824,7 +966,12 @@ module DirectoryVersion =
                                             metadata.CorrelationId
                                     )
                             else
-                                return Ok command
+                                match! getChildDirectoryVersionsForValidation repositoryDto.RepositoryId metadata.CorrelationId directoryVersion with
+                                | Error graceError -> return Error graceError
+                                | Ok childDirectoryVersions ->
+                                    match validateDirectoryVersionHashesWithChildren metadata.CorrelationId directoryVersion childDirectoryVersions with
+                                    | Error graceError -> return Error graceError
+                                    | Ok () -> return Ok command
 
                         | _ ->
                             if directoryVersionDto.DirectoryVersion.CreatedAt = DirectoryVersion.Default.CreatedAt then
@@ -1093,7 +1240,13 @@ module DirectoryVersion =
                         this.correlationId <- metadata.CorrelationId
                         currentCommand <- getDiscriminatedUnionCaseName command
 
-                        match! isValid command metadata with
+                        let normalizedCommand =
+                            match command with
+                            | DirectoryVersionCommand.Create (directoryVersion, repositoryDto) ->
+                                DirectoryVersionCommand.Create(normalizeDirectoryVersionForSaveBoundary directoryVersion, repositoryDto)
+                            | _ -> command
+
+                        match! isValid normalizedCommand metadata with
                         | Ok command -> return! processCommand command metadata
                         | Error error -> return Error error
                     with

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -165,7 +165,8 @@ module DirectoryVersion =
 
         match contentReference.ReferenceType, contentReference.Manifest with
         | FileContentReferenceType.FileManifest, Some manifest ->
-            not (String.IsNullOrWhiteSpace manifest.FileContentHash)
+            hasMissingHash fileVersion.Blake3Hash
+            && not (String.IsNullOrWhiteSpace manifest.FileContentHash)
             && ContentAddress.isValidAddress manifest.FileContentHash
             && fileVersion.Size = manifest.Size
         | _ -> false
@@ -190,6 +191,13 @@ module DirectoryVersion =
         && previouslyValidatedFiles
            |> Seq.exists (fun previousFile ->
                hasLegacyWholeFileBlake3Gap previousFile
+               && fileIdentity previousFile = fileIdentity fileVersion)
+
+    let private hasUnchangedLegacyManifestBackedFileBlake3Gap (previouslyValidatedFiles: FileVersion seq) (fileVersion: FileVersion) =
+        hasLegacyManifestBackedFileBlake3Gap fileVersion
+        && previouslyValidatedFiles
+           |> Seq.exists (fun previousFile ->
+               hasLegacyManifestBackedFileBlake3Gap previousFile
                && fileIdentity previousFile = fileIdentity fileVersion)
 
     let normalizeDirectoryVersionForSaveBoundary (directoryVersion: DirectoryVersion) =
@@ -287,7 +295,7 @@ module DirectoryVersion =
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Sha256Hash.")
                 elif
                     hasMissingHash fileVersion.Blake3Hash
-                    && not (hasLegacyManifestBackedFileBlake3Gap fileVersion)
+                    && not (hasUnchangedLegacyManifestBackedFileBlake3Gap previouslyValidatedFiles fileVersion)
                     && not (hasUnchangedLegacyWholeFileBlake3Gap previouslyValidatedFiles fileVersion)
                 then
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Blake3Hash.")
@@ -336,7 +344,7 @@ module DirectoryVersion =
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"references missing child DirectoryVersionId '{childDirectoryId}'.")
                 else
                     let! childDirectoryDto = childDirectoryActor.Get correlationId
-                    let childDirectoryVersion = childDirectoryDto.DirectoryVersion
+                    let childDirectoryVersion = normalizeDirectoryVersionForSaveBoundary childDirectoryDto.DirectoryVersion
 
                     if
                         hasMissingHash childDirectoryVersion.Blake3Hash

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -155,6 +155,21 @@ module DirectoryVersion =
 
     let private hasMissingHash (value: string) = String.IsNullOrWhiteSpace value
 
+    let private hasValidatedLegacyDirectoryBlake3Gap (directoryVersion: DirectoryVersion) =
+        hasMissingHash directoryVersion.Blake3Hash
+        && not (hasMissingHash directoryVersion.Sha256Hash)
+        && directoryVersion.HashesValidated
+
+    let private hasLegacyManifestBackedFileBlake3Gap (fileVersion: FileVersion) =
+        let contentReference = normalizeContentReference fileVersion
+
+        match contentReference.ReferenceType, contentReference.Manifest with
+        | FileContentReferenceType.FileManifest, Some manifest ->
+            not (String.IsNullOrWhiteSpace manifest.FileContentHash)
+            && ContentAddress.isValidAddress manifest.FileContentHash
+            && fileVersion.Size = manifest.Size
+        | _ -> false
+
     let normalizeDirectoryVersionForSaveBoundary (directoryVersion: DirectoryVersion) =
         if directoryVersion.Size
            <> Constants.InitialDirectorySize then
@@ -220,7 +235,10 @@ module DirectoryVersion =
                                 directoryVersion
                                 $"has child directory '{childDirectoryVersion.RelativePath}' without Sha256Hash."
                         )
-                elif hasMissingHash childDirectoryVersion.Blake3Hash then
+                elif
+                    hasMissingHash childDirectoryVersion.Blake3Hash
+                    && not (hasValidatedLegacyDirectoryBlake3Gap childDirectoryVersion)
+                then
                     error <-
                         Some(
                             directoryVersionHashError
@@ -239,7 +257,10 @@ module DirectoryVersion =
 
                 if hasMissingHash fileVersion.Sha256Hash then
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Sha256Hash.")
-                elif hasMissingHash fileVersion.Blake3Hash then
+                elif
+                    hasMissingHash fileVersion.Blake3Hash
+                    && not (hasLegacyManifestBackedFileBlake3Gap fileVersion)
+                then
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Blake3Hash.")
 
                 fileIndex <- fileIndex + 1
@@ -283,7 +304,17 @@ module DirectoryVersion =
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"references missing child DirectoryVersionId '{childDirectoryId}'.")
                 else
                     let! childDirectoryDto = childDirectoryActor.Get correlationId
-                    childDirectoryVersions.Add childDirectoryDto.DirectoryVersion
+                    let childDirectoryVersion = childDirectoryDto.DirectoryVersion
+
+                    if
+                        hasMissingHash childDirectoryVersion.Blake3Hash
+                        && not (hasMissingHash childDirectoryVersion.Sha256Hash)
+                    then
+                        // The child came from an existing actor, so this local DTO can carry the persisted-child marker
+                        // that lets parent saves tolerate immutable SHA-only legacy children without relaxing new creates.
+                        childDirectoryVersion.HashesValidated <- true
+
+                    childDirectoryVersions.Add childDirectoryVersion
 
                 childIndex <- childIndex + 1
 

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -170,6 +170,11 @@ module DirectoryVersion =
             && fileVersion.Size = manifest.Size
         | _ -> false
 
+    let private hasLegacyWholeFileBlake3Gap (fileVersion: FileVersion) =
+        hasMissingHash fileVersion.Blake3Hash
+        && not (hasMissingHash fileVersion.Sha256Hash)
+        && isWholeFileContentReference fileVersion
+
     let normalizeDirectoryVersionForSaveBoundary (directoryVersion: DirectoryVersion) =
         if directoryVersion.Size
            <> Constants.InitialDirectorySize then
@@ -260,6 +265,7 @@ module DirectoryVersion =
                 elif
                     hasMissingHash fileVersion.Blake3Hash
                     && not (hasLegacyManifestBackedFileBlake3Gap fileVersion)
+                    && not (hasLegacyWholeFileBlake3Gap fileVersion)
                 then
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Blake3Hash.")
 

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -175,6 +175,23 @@ module DirectoryVersion =
         && not (hasMissingHash fileVersion.Sha256Hash)
         && isWholeFileContentReference fileVersion
 
+    let private contentReferenceIdentity (fileVersion: FileVersion) =
+        let contentReference = normalizeContentReference fileVersion
+
+        match contentReference.ReferenceType, contentReference.Manifest with
+        | FileContentReferenceType.FileManifest, Some manifest -> $"{contentReference.ReferenceType}:{manifest.ManifestAddress}"
+        | referenceType, _ -> $"{referenceType}"
+
+    let private fileIdentity (fileVersion: FileVersion) =
+        (fileVersion.RelativePath, fileVersion.Size, fileVersion.Sha256Hash, fileVersion.Blake3Hash, contentReferenceIdentity fileVersion)
+
+    let private hasUnchangedLegacyWholeFileBlake3Gap (previouslyValidatedFiles: FileVersion seq) (fileVersion: FileVersion) =
+        hasLegacyWholeFileBlake3Gap fileVersion
+        && previouslyValidatedFiles
+           |> Seq.exists (fun previousFile ->
+               hasLegacyWholeFileBlake3Gap previousFile
+               && fileIdentity previousFile = fileIdentity fileVersion)
+
     let normalizeDirectoryVersionForSaveBoundary (directoryVersion: DirectoryVersion) =
         if directoryVersion.Size
            <> Constants.InitialDirectorySize then
@@ -217,9 +234,15 @@ module DirectoryVersion =
 
         computeSha256ForDirectoryEntries relativePath entries, computeBlake3ForDirectory relativePath entries
 
-    let validateDirectoryVersionHashesWithChildren correlationId (directoryVersion: DirectoryVersion) (childDirectoryVersions: seq<DirectoryVersion>) =
+    let validateDirectoryVersionHashesWithChildrenAndPreviousFiles
+        correlationId
+        (directoryVersion: DirectoryVersion)
+        (childDirectoryVersions: seq<DirectoryVersion>)
+        (previouslyValidatedFiles: FileVersion seq)
+        =
         let mutable error: GraceError option = None
         let childDirectoryVersions = childDirectoryVersions |> Seq.toArray
+        let previouslyValidatedFiles = previouslyValidatedFiles |> Seq.toArray
 
         if hasMissingHash directoryVersion.Sha256Hash then
             error <- Some(directoryVersionHashError correlationId directoryVersion "must include DirectoryVersion.Sha256Hash before Save.")
@@ -265,7 +288,7 @@ module DirectoryVersion =
                 elif
                     hasMissingHash fileVersion.Blake3Hash
                     && not (hasLegacyManifestBackedFileBlake3Gap fileVersion)
-                    && not (hasLegacyWholeFileBlake3Gap fileVersion)
+                    && not (hasUnchangedLegacyWholeFileBlake3Gap previouslyValidatedFiles fileVersion)
                 then
                     error <- Some(directoryVersionHashError correlationId directoryVersion $"has child file '{fileVersion.RelativePath}' without Blake3Hash.")
 
@@ -293,6 +316,9 @@ module DirectoryVersion =
                 )
             else
                 Ok()
+
+    let validateDirectoryVersionHashesWithChildren correlationId (directoryVersion: DirectoryVersion) (childDirectoryVersions: seq<DirectoryVersion>) =
+        validateDirectoryVersionHashesWithChildrenAndPreviousFiles correlationId directoryVersion childDirectoryVersions Array.empty<FileVersion>
 
     let private getChildDirectoryVersionsForValidation repositoryId correlationId (directoryVersion: DirectoryVersion) =
         task {
@@ -1006,7 +1032,24 @@ module DirectoryVersion =
                                 match! getChildDirectoryVersionsForValidation repositoryDto.RepositoryId metadata.CorrelationId directoryVersion with
                                 | Error graceError -> return Error graceError
                                 | Ok childDirectoryVersions ->
-                                    match validateDirectoryVersionHashesWithChildren metadata.CorrelationId directoryVersion childDirectoryVersions with
+                                    let! mostRecentDirectoryVersion =
+                                        getMostRecentDirectoryVersionByRelativePath
+                                            repositoryDto.RepositoryId
+                                            directoryVersion.RelativePath
+                                            metadata.CorrelationId
+
+                                    let previouslyValidatedFiles =
+                                        match mostRecentDirectoryVersion with
+                                        | Some previousDirectoryVersion -> previousDirectoryVersion.Files :> seq<FileVersion>
+                                        | None -> Seq.empty
+
+                                    match
+                                        validateDirectoryVersionHashesWithChildrenAndPreviousFiles
+                                            metadata.CorrelationId
+                                            directoryVersion
+                                            childDirectoryVersions
+                                            previouslyValidatedFiles
+                                        with
                                     | Error graceError -> return Error graceError
                                     | Ok () -> return Ok command
 

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -635,9 +635,9 @@ module PromotionSet =
                 try
                     let payloadBytes = Encoding.UTF8.GetBytes(textContent)
                     use hashStream = new MemoryStream(payloadBytes)
-                    let! sha256Hash = computeSha256ForFile hashStream filePath
+                    let! sha256Hash, blake3Hash = computeHashesForFile hashStream filePath
 
-                    let fileVersion = FileVersion.Create filePath sha256Hash String.Empty false (int64 payloadBytes.Length)
+                    let fileVersion = FileVersion.CreateWithHashes filePath sha256Hash blake3Hash String.Empty false (int64 payloadBytes.Length)
 
                     let! writeUri = getUriWithWriteSharedAccessSignatureForFileVersion repositoryDto fileVersion metadata.CorrelationId
                     let blobClient = BlobClient(writeUri)

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -44,16 +44,17 @@ module PromotionSet =
 
     type private DirectorySnapshot = { DirectoriesByPath: Dictionary<RelativePath, DirectoryVersion>; FilesByPath: Dictionary<RelativePath, FileVersion> }
 
-    type internal ComputedDirectoryMetadata = { DirectoryVersionId: DirectoryVersionId; Sha256Hash: Sha256Hash; Size: int64 }
+    type internal ComputedDirectoryMetadata = { DirectoryVersionId: DirectoryVersionId; Sha256Hash: Sha256Hash; Blake3Hash: Blake3Hash; Size: int64 }
 
     let internal localDirectoryVersionForPromotionHash ownerId organizationId repositoryId relativePath metadata lastWriteTimeUtc =
-        LocalDirectoryVersion.Create
+        LocalDirectoryVersion.CreateWithHashes
             metadata.DirectoryVersionId
             ownerId
             organizationId
             repositoryId
             relativePath
             metadata.Sha256Hash
+            metadata.Blake3Hash
             (List<DirectoryVersionId>())
             (List<LocalFileVersion>())
             metadata.Size
@@ -966,15 +967,25 @@ module PromotionSet =
                             orderedFileIndex <- orderedFileIndex + 1
 
                     let directorySize = getDirectorySize directoryFiles
-                    let computedSha = computeSha256ForDirectory directoryPath localChildDirectories localDirectoryFiles
+
+                    let preimageEntries =
+                        Seq.append
+                            (localChildDirectories
+                             |> Seq.map (fun directory ->
+                                 DirectoryVersionPreimageEntry.Directory directory.RelativePath directory.Size directory.Blake3Hash directory.Sha256Hash))
+                            (localDirectoryFiles
+                             |> Seq.map (fun file -> DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash))
+                        |> Seq.toArray
+
+                    let computedSha = computeSha256ForDirectoryEntries directoryPath preimageEntries
+                    let computedBlake3 = computeBlake3ForDirectory directoryPath preimageEntries
 
                     let tryReuseDirectoryId (snapshot: DirectorySnapshot) =
                         let mutable existingDirectoryVersion = DirectoryVersion.Default
 
-                        if
-                            snapshot.DirectoriesByPath.TryGetValue(directoryPath, &existingDirectoryVersion)
-                            && existingDirectoryVersion.Sha256Hash = computedSha
-                        then
+                        if snapshot.DirectoriesByPath.TryGetValue(directoryPath, &existingDirectoryVersion)
+                           && existingDirectoryVersion.Sha256Hash = computedSha
+                           && existingDirectoryVersion.Blake3Hash = computedBlake3 then
                             Option.Some existingDirectoryVersion.DirectoryVersionId
                         else
                             Option.None
@@ -993,20 +1004,26 @@ module PromotionSet =
 
                     if reusedDirectoryVersionId.IsNone then
                         let directoryVersion =
-                            DirectoryVersion.Create
+                            DirectoryVersion.CreateWithHashes
                                 directoryVersionId
                                 promotionSetDto.OwnerId
                                 promotionSetDto.OrganizationId
                                 promotionSetDto.RepositoryId
                                 directoryPath
                                 computedSha
+                                computedBlake3
                                 childDirectoryIds
                                 directoryFiles
                                 directorySize
 
                         directoryVersionsToCreate.Add(directoryVersion)
 
-                    computedDirectoryMetadata[directoryPath] <- { DirectoryVersionId = directoryVersionId; Sha256Hash = computedSha; Size = directorySize }
+                    computedDirectoryMetadata[directoryPath] <- {
+                                                                    DirectoryVersionId = directoryVersionId
+                                                                    Sha256Hash = computedSha
+                                                                    Blake3Hash = computedBlake3
+                                                                    Size = directorySize
+                                                                }
 
                     buildIndex <- buildIndex + 1
 

--- a/src/Grace.Actors/Repository.Actor.fs
+++ b/src/Grace.Actors/Repository.Actor.fs
@@ -120,19 +120,22 @@ module Repository =
                                     // Create an empty directory version, and use that for the initial promotion
                                     let emptyDirectoryId = DirectoryVersionId.NewGuid()
 
-                                    let emptySha256Hash = computeSha256ForDirectory RootDirectoryPath (List<LocalDirectoryVersion>()) (List<LocalFileVersion>())
+                                    let emptyDirectoryEntries = Array.Empty<DirectoryVersionPreimageEntry>()
+                                    let emptySha256Hash = computeSha256ForDirectoryEntries RootDirectoryPath emptyDirectoryEntries
+                                    let emptyBlake3Hash = computeBlake3ForDirectory RootDirectoryPath emptyDirectoryEntries
 
                                     let directoryVersionActorProxy =
                                         DirectoryVersion.CreateActorProxy emptyDirectoryId repositoryDto.RepositoryId this.correlationId
 
                                     let emptyDirectoryVersion =
-                                        DirectoryVersion.Create
+                                        DirectoryVersion.CreateWithHashes
                                             emptyDirectoryId
                                             repositoryDto.OwnerId
                                             repositoryDto.OrganizationId
                                             repositoryDto.RepositoryId
                                             RootDirectoryPath
                                             emptySha256Hash
+                                            emptyBlake3Hash
                                             (List<DirectoryVersionId>())
                                             (List<FileVersion>())
                                             0L

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -624,7 +624,10 @@ module CurrentStateCaptureCliTests =
                 (List<FileVersion>([| savedManifestFile |]))
                 unchangedLocalLegacyFile.Size
 
-        let mutable savedDirectoryFiles = List<FileVersion>()
+        let mutable savedDirectoryVersions = List<DirectoryVersion>()
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+        let mutable appliedStatus = GraceStatus.Default
+        let mutable appliedDirectoryVersions = List<LocalDirectoryVersion>()
 
         let differences =
             List<FileSystemDifference>(
@@ -661,9 +664,17 @@ module CurrentStateCaptureCliTests =
                 GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
                 UploadDirectoryVersions =
                     fun directoryVersions ->
-                        savedDirectoryFiles <- directoryVersions[0].Files
+                        savedDirectoryVersions <- directoryVersions
                         Task.FromResult(Ok())
-                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+                ApplyGraceStatusIncremental =
+                    fun status directoryVersions _ ->
+                        appliedStatus <- status
+                        appliedDirectoryVersions <- List<LocalDirectoryVersion>(directoryVersions)
+                        Task.FromResult(())
+                CreateSaveReference =
+                    fun rootDirectoryVersion _ ->
+                        createdSaveRoot <- rootDirectoryVersion
+                        Task.FromResult(Ok(createdSaveId))
             }
 
         let result =
@@ -675,10 +686,15 @@ module CurrentStateCaptureCliTests =
             captured.TargetReferenceId
             |> should equal createdSaveId
 
-            savedDirectoryFiles.Count |> should equal 2
+            savedDirectoryVersions.Count |> should equal 1
+
+            let savedDirectoryVersion = savedDirectoryVersions[0]
+
+            savedDirectoryVersion.Files.Count
+            |> should equal 2
 
             let unchangedSavedFile =
-                savedDirectoryFiles
+                savedDirectoryVersion.Files
                 |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
 
             unchangedSavedFile.Blake3Hash
@@ -686,6 +702,25 @@ module CurrentStateCaptureCliTests =
 
             unchangedSavedFile.ContentReference.ReferenceType
             |> should equal FileContentReferenceType.FileManifest
+
+            createdSaveRoot.Sha256Hash
+            |> should equal savedDirectoryVersion.Sha256Hash
+
+            createdSaveRoot.Blake3Hash
+            |> should equal savedDirectoryVersion.Blake3Hash
+
+            appliedStatus.RootDirectorySha256Hash
+            |> should equal savedDirectoryVersion.Sha256Hash
+
+            let appliedRoot =
+                appliedDirectoryVersions
+                |> Seq.find (fun directoryVersion -> directoryVersion.DirectoryVersionId = updatedRootId)
+
+            appliedRoot.Sha256Hash
+            |> should equal savedDirectoryVersion.Sha256Hash
+
+            appliedRoot.Blake3Hash
+            |> should equal savedDirectoryVersion.Blake3Hash
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -1263,6 +1263,8 @@ module Branch =
                                                 | Ok _ -> ()
                                                 | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
+                                                newGraceStatus <- syncGraceStatusRootDirectoryHash newGraceStatus
+                                                rootDirectoryVersion.Value <- (newGraceStatus.RootDirectoryId, newGraceStatus.RootDirectorySha256Hash)
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
                                             t4.Value <- 100.0
@@ -1363,7 +1365,8 @@ module Branch =
                         | Ok _ -> ()
                         | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
-                        let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                        let newGraceIndex = syncGraceStatusRootDirectoryHash newGraceIndex
+                        let rootDirectoryVersion = getRootDirectoryVersion newGraceIndex
 
                         let sdkParameters =
                             Parameters.Branch.CreateReferenceParameters(

--- a/src/Grace.CLI/Command/Diff.CLI.fs
+++ b/src/Grace.CLI/Command/Diff.CLI.fs
@@ -391,6 +391,8 @@ module Diff =
                                         t5.StartTask()
 
                                         if newDirectoryVersions.Count > 0 then
+                                            let updatedGraceStatus = syncGraceStatusRootDirectoryHash updatedGraceStatus
+
                                             (task {
                                                 match!
                                                     createSaveReference
@@ -712,6 +714,8 @@ module Diff =
                                             t5.StartTask()
 
                                             if newDirectoryVersions.Count > 0 then
+                                                let updatedGraceStatus = syncGraceStatusRootDirectoryHash updatedGraceStatus
+
                                                 (task {
                                                     match!
                                                         createSaveReference

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -740,6 +740,7 @@ module Reference =
                                                 | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
                                                 newGraceStatus <- syncGraceStatusRootDirectoryHash newGraceStatus
+                                                rootDirectoryVersion.Value <- (newGraceStatus.RootDirectoryId, newGraceStatus.RootDirectorySha256Hash)
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
                                             t4.Value <- 100.0

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -739,6 +739,7 @@ module Reference =
                                                 | Ok _ -> ()
                                                 | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
+                                                newGraceStatus <- syncGraceStatusRootDirectoryHash newGraceStatus
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
                                             t4.Value <- 100.0
@@ -858,7 +859,8 @@ module Reference =
                         | Ok _ -> ()
                         | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
-                        let rootDirectoryVersion = getRootDirectoryVersion previousGraceStatus
+                        let newGraceIndex = syncGraceStatusRootDirectoryHash newGraceIndex
+                        let rootDirectoryVersion = getRootDirectoryVersion newGraceIndex
 
                         let sdkParameters =
                             Parameters.Branch.CreateReferenceParameters(

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -499,6 +499,14 @@ module Services =
             LocalDirectoryVersion.Default
         )
 
+    let syncGraceStatusRootDirectoryHash (graceStatus: GraceStatus) =
+        let rootDirectoryVersion = getRootDirectoryVersion graceStatus
+
+        if rootDirectoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
+            graceStatus
+        else
+            { graceStatus with RootDirectoryId = rootDirectoryVersion.DirectoryVersionId; RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash }
+
     let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
 
     /// Gets a dictionary of local paths and their last write times.
@@ -1310,10 +1318,25 @@ module Services =
                 directoryVersions[directoryVersion.DirectoryVersionId] <- directoryVersion
                 directoryVersion
 
-        localDirectoryVersions
-        |> Seq.map buildDirectoryVersion
-        |> Seq.toList
-        |> List<DirectoryVersion>
+        let uploadedDirectoryVersions =
+            localDirectoryVersions
+            |> Seq.map buildDirectoryVersion
+            |> Seq.toList
+
+        for uploadedDirectoryVersion in uploadedDirectoryVersions do
+            let mutable localDirectoryVersion = Unchecked.defaultof<LocalDirectoryVersion>
+
+            if localDirectoryVersionsById.TryGetValue(uploadedDirectoryVersion.DirectoryVersionId, &localDirectoryVersion) then
+                let lastWriteTimeUtc = localDirectoryVersion.LastWriteTimeUtc
+                let uploadedLocalDirectoryVersion = uploadedDirectoryVersion.ToLocalDirectoryVersion lastWriteTimeUtc
+
+                localDirectoryVersion.Sha256Hash <- uploadedLocalDirectoryVersion.Sha256Hash
+                localDirectoryVersion.Blake3Hash <- uploadedLocalDirectoryVersion.Blake3Hash
+                localDirectoryVersion.Directories <- uploadedLocalDirectoryVersion.Directories
+                localDirectoryVersion.Files <- uploadedLocalDirectoryVersion.Files
+                localDirectoryVersion.Size <- uploadedLocalDirectoryVersion.Size
+
+        List<DirectoryVersion>(uploadedDirectoryVersions)
 
     let applyUploadedFileVersionsToDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -96,6 +96,26 @@ module Services =
     let mutable parseResult: ParseResult = null
     let mutable private invocationCorrelationId: CorrelationId option = None
 
+    let private directoryVersionPreimageEntries (directories: seq<LocalDirectoryVersion>) (files: seq<LocalFileVersion>) =
+        let directoryEntries =
+            directories
+            |> Seq.map (fun directory -> DirectoryVersionPreimageEntry.Directory directory.RelativePath directory.Size directory.Blake3Hash directory.Sha256Hash)
+
+        let fileEntries =
+            files
+            |> Seq.map (fun file -> DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash)
+
+        Seq.append directoryEntries fileEntries
+        |> Seq.toArray
+
+    let private computeDirectoryVersionHashes relativeDirectoryPath directories files =
+        let entries = directoryVersionPreimageEntries directories files
+
+        let sha256Hash = computeSha256ForDirectoryEntries relativeDirectoryPath entries
+        let blake3Hash = computeBlake3ForDirectory relativeDirectoryPath entries
+
+        sha256Hash, blake3Hash
+
     let resetInvocationCorrelationId () = invocationCorrelationId <- None
 
     let getCliAssemblyFileVersion () =
@@ -696,7 +716,10 @@ module Services =
                                             let subdirectoryRelativePath = Path.GetRelativePath(Current().RootDirectory, subdirectoryInfo.FullName)
 
 
-                                            let! (subdirectoryVersions: List<LocalDirectoryVersion>, filesInSubdirectory: List<LocalFileVersion>, sha256Hash) =
+                                            let! (subdirectoryVersions: List<LocalDirectoryVersion>,
+                                                  filesInSubdirectory: List<LocalFileVersion>,
+                                                  sha256Hash,
+                                                  blake3Hash) =
                                                 collectDirectoriesAndFiles subdirectoryRelativePath previousDirectoryVersions newGraceStatus parseResult
 
                                             // Check if we already have a LocalDirectoryVersion for this subdirectory.
@@ -713,7 +736,9 @@ module Services =
                                             // If the DirectoryId is Guid.Empty (from LocalDirectoryVersion.Default), or the Sha256Hash doesn't match, create a new LocalDirectoryVersion reflecting the changes.
                                             if existingSubdirectoryVersion.DirectoryVersionId = Guid.Empty
                                                || existingSubdirectoryVersion.Sha256Hash
-                                                  <> sha256Hash then
+                                                  <> sha256Hash
+                                               || existingSubdirectoryVersion.Blake3Hash
+                                                  <> blake3Hash then
                                                 let directoryIds =
                                                     subdirectoryVersions
                                                         .OrderBy(fun d -> d.RelativePath)
@@ -721,13 +746,14 @@ module Services =
                                                         .ToList()
 
                                                 let subdirectoryVersion =
-                                                    LocalDirectoryVersion.Create
+                                                    LocalDirectoryVersion.CreateWithHashes
                                                         (Guid.NewGuid())
                                                         (Current().OwnerId)
                                                         (Current().OrganizationId)
                                                         (Current().RepositoryId)
                                                         (RelativePath(normalizeFilePath subdirectoryRelativePath))
                                                         sha256Hash
+                                                        blake3Hash
                                                         directoryIds
                                                         filesInSubdirectory
                                                         (getLocalDirectorySize filesInSubdirectory)
@@ -774,13 +800,13 @@ module Services =
                 let! (directories, files) = getDirectoryContents previousDirectoryVersions directoryInfo
                 //for file in files do processedThings.Enqueue(file.RelativePath)
 
-                let sha256Hash = computeSha256ForDirectory relativeDirectoryPath directories files
+                let sha256Hash, blake3Hash = computeDirectoryVersionHashes relativeDirectoryPath directories files
 
-                return (directories, files, sha256Hash)
+                return (directories, files, sha256Hash, blake3Hash)
             with
             | ex ->
                 logToAnsiConsole Colors.Error $"Exception in collectDirectoriesAndFiles: {ExceptionResponse.Create ex}"
-                return (List<LocalDirectoryVersion>(), List<LocalFileVersion>(), Sha256Hash.Empty)
+                return (List<LocalDirectoryVersion>(), List<LocalFileVersion>(), Sha256Hash.Empty, Blake3Hash String.Empty)
         }
 
     /// Creates the Grace index file by scanning the repository's working directory.
@@ -801,7 +827,7 @@ module Services =
                     then
                         logToAnsiConsole Colors.Error $"createNewGraceStatusFile: Failed to add {kvp.Value.RelativePath} to previousDirectoryVersions."
 
-                let! (subdirectoriesInRootDirectory, filesInRootDirectory, rootSha256Hash) =
+                let! (subdirectoriesInRootDirectory, filesInRootDirectory, rootSha256Hash, rootBlake3Hash) =
                     collectDirectoriesAndFiles Constants.RootDirectoryPath previousDirectoryVersions newGraceStatus parseResult
 
                 //let getBySha256HashParameters = GetBySha256HashParameters(RepositoryId = $"{Current().RepositoryId}", Sha256Hash = rootSha256Hash)
@@ -817,7 +843,8 @@ module Services =
                             )
                             .Value
 
-                    if previousRootDirectoryVersion.Sha256Hash = rootSha256Hash then
+                    if previousRootDirectoryVersion.Sha256Hash = rootSha256Hash
+                       && previousRootDirectoryVersion.Blake3Hash = rootBlake3Hash then
                         previousRootDirectoryVersion
                     else
                         let subdirectoryIds =
@@ -826,13 +853,14 @@ module Services =
                                 .Select(fun d -> d.DirectoryVersionId)
                                 .ToList()
 
-                        LocalDirectoryVersion.Create
+                        LocalDirectoryVersion.CreateWithHashes
                             (Guid.NewGuid())
                             (Current().OwnerId)
                             (Current().OrganizationId)
                             (Current().RepositoryId)
                             (RelativePath(normalizeFilePath Constants.RootDirectoryPath))
                             (Sha256Hash rootSha256Hash)
+                            rootBlake3Hash
                             subdirectoryIds
                             filesInRootDirectory
                             (getLocalDirectorySize filesInRootDirectory)
@@ -1212,40 +1240,80 @@ module Services =
 
         let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
         let savedManifestBackedByLegacyIdentity = Dictionary<RelativePath * Sha256Hash, FileVersion>()
+        let savedDirectoryVersionsById = Dictionary<DirectoryVersionId, DirectoryVersion>()
 
         for savedDirectoryVersion in savedDirectoryVersions do
+            savedDirectoryVersionsById[savedDirectoryVersion.DirectoryVersionId] <- savedDirectoryVersion
+
             for savedFileVersion in savedDirectoryVersion.Files do
                 if isManifestBackedFileVersion savedFileVersion then
                     savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
                     savedManifestBackedByLegacyIdentity[legacyUploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
-        let directoryVersions = List<DirectoryVersion>()
+        let directoryVersions = Dictionary<DirectoryVersionId, DirectoryVersion>()
+        let localDirectoryVersionsById = Dictionary<DirectoryVersionId, LocalDirectoryVersion>()
 
         for localDirectoryVersion in localDirectoryVersions do
-            let directoryVersion = localDirectoryVersion.ToDirectoryVersion
+            localDirectoryVersionsById[localDirectoryVersion.DirectoryVersionId] <- localDirectoryVersion
 
-            for index in 0 .. directoryVersion.Files.Count - 1 do
-                let fileVersion = directoryVersion.Files[index]
-                let mutable uploadedFileVersion = Unchecked.defaultof<FileVersion>
+        let rec buildDirectoryVersion (localDirectoryVersion: LocalDirectoryVersion) =
+            if directoryVersions.ContainsKey localDirectoryVersion.DirectoryVersionId then
+                directoryVersions[localDirectoryVersion.DirectoryVersionId]
+            else
+                let directoryVersion = localDirectoryVersion.ToDirectoryVersion
 
-                if uploadedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &uploadedFileVersion) then
-                    directoryVersion.Files[ index ] <- uploadedFileVersion
-                else
-                    let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
+                for index in 0 .. directoryVersion.Files.Count - 1 do
+                    let fileVersion = directoryVersion.Files[index]
+                    let mutable uploadedFileVersion = Unchecked.defaultof<FileVersion>
 
-                    if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
-                        directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
-                    elif
-                        savedManifestBackedByLegacyIdentity.TryGetValue(legacyUploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion)
-                        && (hasMissingBlake3Hash fileVersion
-                            || hasMissingBlake3Hash savedManifestBackedFileVersion)
-                    then
-                        directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                    if uploadedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &uploadedFileVersion) then
+                        directoryVersion.Files[ index ] <- uploadedFileVersion
+                    else
+                        let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
 
-            directoryVersions.Add directoryVersion
+                        if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
+                            directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                        elif
+                            savedManifestBackedByLegacyIdentity.TryGetValue(legacyUploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion)
+                            && (hasMissingBlake3Hash fileVersion
+                                || hasMissingBlake3Hash savedManifestBackedFileVersion)
+                        then
+                            directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
 
-        directoryVersions
+                let localChildDirectories = List<LocalDirectoryVersion>()
+
+                for childDirectoryId in directoryVersion.Directories do
+                    let mutable localChildDirectoryVersion = Unchecked.defaultof<LocalDirectoryVersion>
+                    let mutable savedChildDirectoryVersion = Unchecked.defaultof<DirectoryVersion>
+
+                    if localDirectoryVersionsById.TryGetValue(childDirectoryId, &localChildDirectoryVersion) then
+                        let childDirectoryVersion = buildDirectoryVersion localChildDirectoryVersion
+
+                        localChildDirectories.Add(childDirectoryVersion.ToLocalDirectoryVersion localChildDirectoryVersion.LastWriteTimeUtc)
+                    elif savedDirectoryVersionsById.TryGetValue(childDirectoryId, &savedChildDirectoryVersion) then
+                        localChildDirectories.Add(savedChildDirectoryVersion.ToLocalDirectoryVersion localDirectoryVersion.LastWriteTimeUtc)
+                    else
+                        failwith
+                            $"Unable to resolve child DirectoryVersionId '{childDirectoryId}' while recomputing DirectoryVersion '{directoryVersion.RelativePath}'."
+
+                let localFiles =
+                    directoryVersion
+                        .Files
+                        .Select(fun fileVersion -> fileVersion.ToLocalFileVersion localDirectoryVersion.LastWriteTimeUtc)
+                        .ToList()
+
+                let sha256Hash, blake3Hash = computeDirectoryVersionHashes directoryVersion.RelativePath localChildDirectories localFiles
+
+                directoryVersion.Sha256Hash <- sha256Hash
+                directoryVersion.Blake3Hash <- blake3Hash
+                directoryVersions[directoryVersion.DirectoryVersionId] <- directoryVersion
+                directoryVersion
+
+        localDirectoryVersions
+        |> Seq.map buildDirectoryVersion
+        |> Seq.toList
+        |> List<DirectoryVersion>
 
     let applyUploadedFileVersionsToDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
@@ -1287,19 +1355,21 @@ module Services =
                 List<LocalDirectoryVersion>()
 
         // Get the new SHA-256 hash for the updated contents of this directory.
-        let newSha256Hash = computeSha256ForDirectory (previousDirectoryVersion.RelativePath) subdirectoryVersions previousDirectoryVersion.Files
+        let newSha256Hash, newBlake3Hash =
+            computeDirectoryVersionHashes previousDirectoryVersion.RelativePath subdirectoryVersions previousDirectoryVersion.Files
 
         let directoryInfo = DirectoryInfo(Path.Combine(Current().RootDirectory, previousDirectoryVersion.RelativePath))
 
         // Create a new LocalDirectoryVersion that contains a new Id and the updated SHA-256 hash.
         let newDirectoryVersion =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 (Guid.NewGuid())
                 previousDirectoryVersion.OwnerId
                 previousDirectoryVersion.OrganizationId
                 previousDirectoryVersion.RepositoryId
                 previousDirectoryVersion.RelativePath
                 newSha256Hash
+                newBlake3Hash
                 previousDirectoryVersion.Directories
                 previousDirectoryVersion.Files
                 (getLocalDirectorySize previousDirectoryVersion.Files)
@@ -1335,19 +1405,20 @@ module Services =
             Some(processChangedDirectoryVersion newGraceStatus previousDirectoryVersion)
         else
             let directoryInfo = DirectoryInfo(Path.Combine(Current().RootDirectory, difference.RelativePath))
-            let sha256Hash = computeSha256ForDirectory difference.RelativePath (List()) (List())
+            let sha256Hash, blake3Hash = computeDirectoryVersionHashes difference.RelativePath (List()) (List())
 
             Some(
-                LocalDirectoryVersion.Create
+                LocalDirectoryVersion.CreateWithHashes
                     (Guid.NewGuid())
                     previousRootVersion.OwnerId
                     previousRootVersion.OrganizationId
                     previousRootVersion.RepositoryId
                     difference.RelativePath
                     sha256Hash
+                    blake3Hash
                     (List())
                     (List())
-                    Constants.InitialDirectorySize
+                    0L
                     directoryInfo.LastWriteTimeUtc
             )
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2189,6 +2189,48 @@ module Services =
             CreatedSaveMessage = createdSaveMessage
         }
 
+    let private syncGraceStatusWithUploadedDirectoryVersions
+        (updatedGraceStatus: GraceStatus)
+        (newDirectoryVersions: List<LocalDirectoryVersion>)
+        (uploadedDirectoryVersions: List<DirectoryVersion>)
+        =
+        let localDirectoryVersionsById = Dictionary<DirectoryVersionId, LocalDirectoryVersion>()
+
+        for localDirectoryVersion in newDirectoryVersions do
+            localDirectoryVersionsById[localDirectoryVersion.DirectoryVersionId] <- localDirectoryVersion
+
+        let syncedDirectoryVersions =
+            uploadedDirectoryVersions
+            |> Seq.map (fun uploadedDirectoryVersion ->
+                let mutable localDirectoryVersion = Unchecked.defaultof<LocalDirectoryVersion>
+
+                let lastWriteTimeUtc =
+                    if localDirectoryVersionsById.TryGetValue(uploadedDirectoryVersion.DirectoryVersionId, &localDirectoryVersion) then
+                        localDirectoryVersion.LastWriteTimeUtc
+                    else
+                        DateTime.UtcNow
+
+                uploadedDirectoryVersion.ToLocalDirectoryVersion lastWriteTimeUtc)
+            |> Seq.toList
+
+        let syncedIndex = GraceIndex()
+
+        for kvp in updatedGraceStatus.Index do
+            syncedIndex.TryAdd(kvp.Key, kvp.Value) |> ignore
+
+        for localDirectoryVersion in syncedDirectoryVersions do
+            syncedIndex[localDirectoryVersion.DirectoryVersionId] <- localDirectoryVersion
+
+        let mutable syncedRootDirectoryVersion = Unchecked.defaultof<LocalDirectoryVersion>
+
+        let rootDirectorySha256Hash =
+            if syncedIndex.TryGetValue(updatedGraceStatus.RootDirectoryId, &syncedRootDirectoryVersion) then
+                syncedRootDirectoryVersion.Sha256Hash
+            else
+                updatedGraceStatus.RootDirectorySha256Hash
+
+        { updatedGraceStatus with Index = syncedIndex; RootDirectorySha256Hash = rootDirectorySha256Hash }, List<LocalDirectoryVersion>(syncedDirectoryVersions)
+
     let private createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion =
         task {
             if not branchDto.SaveEnabled then
@@ -2287,6 +2329,9 @@ module Services =
                                     match! operations.UploadDirectoryVersions uploadedDirectoryVersions with
                                     | Error error -> return Error error
                                     | Ok () ->
+                                        let updatedGraceStatus, newDirectoryVersions =
+                                            syncGraceStatusWithUploadedDirectoryVersions updatedGraceStatus newDirectoryVersions uploadedDirectoryVersions
+
                                         let updatedGraceStatus =
                                             { updatedGraceStatus with
                                                 LastSuccessfulFileUpload = getCurrentInstant ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -364,6 +364,8 @@ module Watch =
 
                 match result with
                 | Ok returnValue ->
+                    let newGraceStatus = syncGraceStatusRootDirectoryHash newGraceStatus
+
                     do! updateObjectCacheFile newDirectoryVersions
 
                     let fileDifferences =

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -5,6 +5,7 @@ open Azure.Storage.Blobs.Specialized
 open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Shared.Services
 open Grace.Shared.Utilities
 open Grace.Shared.Validation
 open Grace.Shared.Validation.Errors
@@ -182,6 +183,29 @@ module BranchServerTestHelpers =
         SHA256.HashData(bytes)
         |> fun hash -> byteArrayToString (hash.AsSpan())
 
+    let private blake3Hex (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
+
+    let private createRootDirectoryVersion (repositoryId: string) (fileVersion: FileVersion) =
+        let entries =
+            [|
+                DirectoryVersionPreimageEntry.File fileVersion.RelativePath fileVersion.Size fileVersion.Blake3Hash fileVersion.Sha256Hash
+            |]
+
+        let sha256Hash = computeSha256ForDirectoryEntries (RelativePath "/") entries
+        let blake3Hash = computeBlake3ForDirectory (RelativePath "/") entries
+
+        Grace.Types.Common.DirectoryVersion.CreateWithHashes
+            (Guid.NewGuid())
+            (Guid.Parse ownerId)
+            (Guid.Parse organizationId)
+            (Guid.Parse repositoryId)
+            "/"
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>())
+            (List<FileVersion>([ fileVersion ]))
+            fileVersion.Size
+
     let private gzipBytes (bytes: byte array) =
         use compressed = new MemoryStream()
         use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
@@ -248,7 +272,10 @@ module BranchServerTestHelpers =
             let relativePath = $"annotate/{Guid.NewGuid():N}/sample.fs"
             let content = $"let value = 42{Environment.NewLine}let other = value + 1{Environment.NewLine}"
             let contentBytes = Encoding.UTF8.GetBytes(content)
-            let fileVersion = FileVersion.Create relativePath (sha256Hex contentBytes) String.Empty false (int64 contentBytes.Length)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes relativePath (sha256Hex contentBytes) (blake3Hex contentBytes) String.Empty false (int64 contentBytes.Length)
+
             let tempRoot = Path.Combine(Path.GetTempPath(), "grace-annotate-tests", Guid.NewGuid().ToString("N"))
             let filePath = Path.Combine(tempRoot, relativePath.Replace('/', Path.DirectorySeparatorChar))
 
@@ -260,17 +287,7 @@ module BranchServerTestHelpers =
             try
                 do! uploadFileToObjectStorageAsync repositoryId contentBytes fileVersion
 
-                let directoryVersion =
-                    Grace.Types.Common.DirectoryVersion.Create
-                        (Guid.NewGuid())
-                        (Guid.Parse ownerId)
-                        (Guid.Parse organizationId)
-                        (Guid.Parse repositoryId)
-                        "/"
-                        (sha256Hex (Encoding.UTF8.GetBytes($"directory-{Guid.NewGuid():N}")))
-                        (List<DirectoryVersionId>())
-                        (List<FileVersion>([ fileVersion ]))
-                        (int64 contentBytes.Length)
+                let directoryVersion = createRootDirectoryVersion repositoryId fileVersion
 
                 do! saveDirectoryVersionAsync repositoryId directoryVersion
                 do! saveBranchReferenceAsync repositoryId branch directoryVersion
@@ -284,21 +301,13 @@ module BranchServerTestHelpers =
     let createAnnotatableReferenceWithContentAsync repositoryId (branch: Branch.BranchDto) relativePath (content: string) =
         task {
             let contentBytes = Encoding.UTF8.GetBytes(content)
-            let fileVersion = FileVersion.Create relativePath (sha256Hex contentBytes) String.Empty false (int64 contentBytes.Length)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes relativePath (sha256Hex contentBytes) (blake3Hex contentBytes) String.Empty false (int64 contentBytes.Length)
 
             do! uploadFileToObjectStorageAsync repositoryId contentBytes fileVersion
 
-            let directoryVersion =
-                Grace.Types.Common.DirectoryVersion.Create
-                    (Guid.NewGuid())
-                    (Guid.Parse ownerId)
-                    (Guid.Parse organizationId)
-                    (Guid.Parse repositoryId)
-                    "/"
-                    (sha256Hex (Encoding.UTF8.GetBytes($"directory-{Guid.NewGuid():N}")))
-                    (List<DirectoryVersionId>())
-                    (List<FileVersion>([ fileVersion ]))
-                    (int64 contentBytes.Length)
+            let directoryVersion = createRootDirectoryVersion repositoryId fileVersion
 
             do! saveDirectoryVersionAsync repositoryId directoryVersion
             do! saveBranchReferenceAsync repositoryId branch directoryVersion

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -2,6 +2,7 @@ namespace Grace.Server.Tests
 
 open Grace.Server.Tests.Services
 open Grace.Shared
+open Grace.Shared.Services
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types
@@ -16,23 +17,40 @@ open System.Net.Http
 module DirectoryVersionServerTestHelpers =
     type DirectoryVersionModel = Grace.Types.Common.DirectoryVersion
 
-    let private sha256 (index: int) = Convert.ToString(index, 16).PadLeft(64, '0')
-
     let createDirectoryVersion
         (directoryVersionId: DirectoryVersionId)
         (repositoryId: string)
         (relativePath: RelativePath)
-        (hashIndex: int)
-        (childDirectoryIds: DirectoryVersionId seq)
+        (childDirectoryVersions: DirectoryVersionModel seq)
         : DirectoryVersionModel
         =
-        DirectoryVersionModel.Create
+        let childDirectoryVersions = childDirectoryVersions |> Seq.toArray
+
+        let childDirectoryIds =
+            childDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+
+        let entries =
+            childDirectoryVersions
+            |> Seq.map (fun directoryVersion ->
+                DirectoryVersionPreimageEntry.Directory
+                    directoryVersion.RelativePath
+                    directoryVersion.Size
+                    directoryVersion.Blake3Hash
+                    directoryVersion.Sha256Hash)
+            |> Seq.toArray
+
+        let sha256Hash = computeSha256ForDirectoryEntries relativePath entries
+        let blake3Hash = computeBlake3ForDirectory relativePath entries
+
+        DirectoryVersionModel.CreateWithHashes
             directoryVersionId
             (Guid.Parse ownerId)
             (Guid.Parse organizationId)
             (Guid.Parse repositoryId)
             relativePath
-            (sha256 hashIndex)
+            sha256Hash
+            blake3Hash
             (List<DirectoryVersionId>(childDirectoryIds))
             (List<FileVersion>())
             0L
@@ -118,6 +136,7 @@ module DirectoryVersionServerTestHelpers =
         Assert.That(actual.DirectoryVersion.RepositoryId, Is.EqualTo(expected.RepositoryId))
         Assert.That(actual.DirectoryVersion.RelativePath, Is.EqualTo(expected.RelativePath))
         Assert.That(actual.DirectoryVersion.Sha256Hash, Is.EqualTo(expected.Sha256Hash))
+        Assert.That(actual.DirectoryVersion.Blake3Hash, Is.EqualTo(expected.Blake3Hash))
         Assert.That(actual.DirectoryVersion.HashesValidated, Is.True)
 
     let assertDirectoryVersion (expected: DirectoryVersionModel) (actual: DirectoryVersionModel) =
@@ -127,6 +146,7 @@ module DirectoryVersionServerTestHelpers =
         Assert.That(actual.RepositoryId, Is.EqualTo(expected.RepositoryId))
         Assert.That(actual.RelativePath, Is.EqualTo(expected.RelativePath))
         Assert.That(actual.Sha256Hash, Is.EqualTo(expected.Sha256Hash))
+        Assert.That(actual.Blake3Hash, Is.EqualTo(expected.Blake3Hash))
         Assert.That(actual.HashesValidated, Is.True)
 
 [<NonParallelizable>]
@@ -139,9 +159,9 @@ type DirectoryVersionServer() =
             let childId = Guid.NewGuid()
             let rootId = Guid.NewGuid()
 
-            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/src/" 0x101 []
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/src/" []
 
-            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" 0x102 [ childId ]
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" [ child ]
 
             do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync child
             do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync root
@@ -193,9 +213,9 @@ type DirectoryVersionServer() =
             let childId = Guid.NewGuid()
             let rootId = Guid.NewGuid()
 
-            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/docs/" 0x201 []
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "/docs/" []
 
-            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" 0x202 [ childId ]
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" [ child ]
 
             let! saveResponse =
                 Client.PostAsync(

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -53,7 +53,7 @@ module DirectoryVersionServerTestHelpers =
             blake3Hash
             (List<DirectoryVersionId>(childDirectoryIds))
             (List<FileVersion>())
-            0L
+            Constants.InitialDirectorySize
 
     let createParameters (directoryVersion: DirectoryVersionModel) =
         let parameters = Parameters.DirectoryVersion.CreateParameters()

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -17,6 +17,12 @@ open System.Net.Http
 module DirectoryVersionServerTestHelpers =
     type DirectoryVersionModel = Grace.Types.Common.DirectoryVersion
 
+    let normalizedDirectorySizeForHash (directoryVersion: DirectoryVersionModel) =
+        if directoryVersion.Size = Constants.InitialDirectorySize then
+            0L
+        else
+            directoryVersion.Size
+
     let createDirectoryVersion
         (directoryVersionId: DirectoryVersionId)
         (repositoryId: string)
@@ -35,7 +41,7 @@ module DirectoryVersionServerTestHelpers =
             |> Seq.map (fun directoryVersion ->
                 DirectoryVersionPreimageEntry.Directory
                     directoryVersion.RelativePath
-                    directoryVersion.Size
+                    (normalizedDirectorySizeForHash directoryVersion)
                     directoryVersion.Blake3Hash
                     directoryVersion.Sha256Hash)
             |> Seq.toArray
@@ -244,4 +250,34 @@ type DirectoryVersionServer() =
                 DirectoryVersionServerTestHelpers.assertBadRequestGraceError
                     (DirectoryVersionError.getErrorMessage DirectoryVersionError.DirectoryDoesNotExist)
                     missingResponse
+        }
+
+    [<Test>]
+    member _.SaveDirectoryVersionsOrdersDotRootAfterDirectChildrenWhenInputIsRootFirst() =
+        task {
+            let repositoryId = repositoryIds[2]
+            let childId = Guid.NewGuid()
+            let rootId = Guid.NewGuid()
+
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "src" []
+
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "." [ child ]
+
+            let! saveResponse =
+                Client.PostAsync(
+                    "/directory/saveDirectoryVersions",
+                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ root; child ])
+                )
+
+            do! DirectoryVersionServerTestHelpers.assertOk saveResponse
+            let! saveReturnValue = deserializeContent<GraceReturnValue<string>> saveResponse
+            Assert.That(saveReturnValue.ReturnValue, Is.EqualTo("Uploaded new directory versions."))
+
+            let! fetchedRoot = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
+            DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetchedRoot
+            Assert.That(fetchedRoot.DirectoryVersion.Directories, Has.Count.EqualTo(1))
+            Assert.That(fetchedRoot.DirectoryVersion.Directories, Does.Contain(childId))
+
+            let! fetchedChild = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId childId
+            DirectoryVersionServerTestHelpers.assertDirectoryVersionDto child fetchedChild
         }

--- a/src/Grace.Server.Unit.Tests/PromotionSet.DirectoryHash.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/PromotionSet.DirectoryHash.Tests.fs
@@ -19,18 +19,31 @@ type PromotionSetDirectoryHashTests() =
     let lastWriteTimeUtc = DateTime(2026, 6, 10, 12, 0, 0, DateTimeKind.Utc)
 
     let childSha256 = "27a1f6b711aa88117824253726920929081e2bc06e66b40bdd62f75c12d1c809"
+    let childBlake3 = "6f2f7d3de9b92f1f2df7fddf7e7b7b48ab92a0b4e40bb87c13ebac932f8b9e4a"
     let rootFileSha256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    let rootFileBlake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adcd1e8c76d9a8885f16a39f"
 
-    let rootFile = LocalFileVersion.Create (RelativePath "README.md") rootFileSha256 false 12L (Instant.FromUtc(2026, 6, 10, 12, 0)) true lastWriteTimeUtc
+    let rootFile =
+        LocalFileVersion.CreateWithHashes
+            (RelativePath "README.md")
+            rootFileSha256
+            rootFileBlake3
+            false
+            12L
+            (Instant.FromUtc(2026, 6, 10, 12, 0))
+            true
+            lastWriteTimeUtc
 
     [<Test>]
-    member _.PromotionHashChildDirectoryPreservesComputedSizeInParentSha256Preimage() =
-        let childMetadata: PromotionSet.ComputedDirectoryMetadata = { DirectoryVersionId = childDirectoryId; Sha256Hash = childSha256; Size = 27L }
+    member _.PromotionHashChildDirectoryPreservesComputedSizeAndBothHashesInParentPreimage() =
+        let childMetadata: PromotionSet.ComputedDirectoryMetadata =
+            { DirectoryVersionId = childDirectoryId; Sha256Hash = childSha256; Blake3Hash = childBlake3; Size = 27L }
 
         let childDirectory =
             PromotionSet.localDirectoryVersionForPromotionHash ownerId organizationId repositoryId (RelativePath "src") childMetadata lastWriteTimeUtc
 
         Assert.That(childDirectory.Size, Is.EqualTo(27L))
+        Assert.That(childDirectory.Blake3Hash, Is.EqualTo(childBlake3))
 
         let actualChildDirectories = List<LocalDirectoryVersion>()
         actualChildDirectories.Add(childDirectory)
@@ -38,23 +51,36 @@ type PromotionSetDirectoryHashTests() =
         let rootFiles = List<LocalFileVersion>()
         rootFiles.Add(rootFile)
 
-        let actual = Services.computeSha256ForDirectory (RelativePath ".") actualChildDirectories rootFiles
+        let actualEntries =
+            [
+                Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 27L childBlake3 childSha256
+                Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L rootFileBlake3 rootFileSha256
+            ]
 
-        let expected =
+        let actualSha256 = Services.computeSha256ForDirectoryEntries (RelativePath ".") actualEntries
+        let actualBlake3 = Services.computeBlake3ForDirectory (RelativePath ".") actualEntries
+
+        let expected = Services.computeSha256ForDirectoryEntries (RelativePath ".") actualEntries
+
+        let expectedBlake3 = Services.computeBlake3ForDirectory (RelativePath ".") actualEntries
+
+        let zeroSizeRegression =
             Services.computeSha256ForDirectoryEntries
+                (RelativePath ".")
+                [
+                    Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 0L childBlake3 childSha256
+                    Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L rootFileBlake3 rootFileSha256
+                ]
+
+        let shaOnlyBlake3Regression =
+            Services.computeBlake3ForDirectory
                 (RelativePath ".")
                 [
                     Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 27L String.Empty childSha256
                     Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L String.Empty rootFileSha256
                 ]
 
-        let zeroSizeRegression =
-            Services.computeSha256ForDirectoryEntries
-                (RelativePath ".")
-                [
-                    Services.DirectoryVersionPreimageEntry.Directory (RelativePath "src") 0L String.Empty childSha256
-                    Services.DirectoryVersionPreimageEntry.File (RelativePath "README.md") 12L String.Empty rootFileSha256
-                ]
-
-        Assert.That(actual, Is.EqualTo(expected))
-        Assert.That(actual, Is.Not.EqualTo(zeroSizeRegression))
+        Assert.That(actualSha256, Is.EqualTo(expected))
+        Assert.That(actualBlake3, Is.EqualTo(expectedBlake3))
+        Assert.That(actualSha256, Is.Not.EqualTo(zeroSizeRegression))
+        Assert.That(actualBlake3, Is.Not.EqualTo(shaOnlyBlake3Regression))

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -70,6 +70,9 @@ type SaveBoundaryActorTests() =
 
     let wholeFile () = FileVersion.Create "/small.txt" "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd" String.Empty false 42L
 
+    let fileWithHashes (relativePath: string) (sha256Hash: string) (blake3Hash: string) size =
+        FileVersion.CreateWithHashes (RelativePath relativePath) (Sha256Hash sha256Hash) (Blake3Hash blake3Hash) String.Empty false size
+
     let referenceDto referenceType =
         { Grace.Types.Reference.ReferenceDto.Default with
             ReferenceId = referenceId
@@ -92,6 +95,32 @@ type SaveBoundaryActorTests() =
             fileList
             (fileList
              |> Seq.sumBy (fun fileVersion -> fileVersion.Size))
+
+    let hashedDirectory directoryId relativePath (childDirectories: DirectoryVersion seq) (files: FileVersion seq) =
+        let childDirectories = childDirectories |> Seq.toArray
+        let files = List<FileVersion>(files)
+        let sha256Hash, blake3Hash = DirectoryVersionActor.computeDirectoryVersionHashesFromChildren relativePath childDirectories files
+
+        Grace.Types.Common.DirectoryVersion.CreateWithHashes
+            directoryId
+            ownerId
+            organizationId
+            repositoryId
+            relativePath
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>(
+                childDirectories
+                |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+            ))
+            files
+            (files
+             |> Seq.sumBy (fun fileVersion -> fileVersion.Size))
+
+    let assertDirectoryHashesValid directoryVersion childDirectories =
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-directory-hash" directoryVersion childDirectories with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected DirectoryVersion hashes to validate, got {error.Error}.")
 
     let expectPlan result =
         match result with
@@ -141,6 +170,144 @@ type SaveBoundaryActorTests() =
         match DirectoryVersionActor.validateManifestBackedFileForSaveBoundary "corr-manifest-empty-blake3" fileVersion manifest with
         | Ok () -> ()
         | Error error -> Assert.Fail($"Expected legacy empty BLAKE3 to be accepted, got {error.Error}.")
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRequiresDirectoryBlake3BeforeSave() =
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] []
+        directoryVersion.Blake3Hash <- Blake3Hash String.Empty
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-missing-directory-blake3" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected missing DirectoryVersion.Blake3Hash to reject before Save.")
+        | Error error -> Assert.That(error.Error, Does.Contain("DirectoryVersion.Blake3Hash"))
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRejectsMismatchedDirectoryBlake3BeforeSave() =
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] []
+        directoryVersion.Blake3Hash <- Blake3Hash "0000000000000000000000000000000000000000000000000000000000000000"
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-mismatched-directory-blake3" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected mismatched DirectoryVersion.Blake3Hash to reject before Save.")
+        | Error error -> Assert.That(error.Error, Does.Contain("mismatched Blake3Hash"))
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRejectsMismatchedDirectorySha256BeforeSave() =
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] []
+        directoryVersion.Sha256Hash <- Sha256Hash "0000000000000000000000000000000000000000000000000000000000000000"
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-mismatched-directory-sha" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected mismatched DirectoryVersion.Sha256Hash to reject before Save.")
+        | Error error -> Assert.That(error.Error, Does.Contain("mismatched Sha256Hash"))
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationNormalizesJsonOmittedZeroSizeBeforeSave() =
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/empty/") [] []
+        directoryVersion.Size <- Constants.InitialDirectorySize
+
+        let normalizedDirectoryVersion = DirectoryVersionActor.normalizeDirectoryVersionForSaveBoundary directoryVersion
+
+        Assert.That(normalizedDirectoryVersion.Size, Is.EqualTo(0L))
+        assertDirectoryHashesValid normalizedDirectoryVersion []
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRejectsMissingChildDirectoryBlake3() =
+        let child = hashedDirectory (Guid.NewGuid()) (RelativePath "/src/") [] []
+        child.Blake3Hash <- Blake3Hash String.Empty
+        let parent = hashedDirectory directoryVersionId (RelativePath "/") [ child ] []
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-missing-child-directory-blake3" parent [ child ] with
+        | Ok () -> Assert.Fail("Expected missing child DirectoryVersion.Blake3Hash to reject before Save.")
+        | Error error ->
+            Assert.That(
+                error.Error,
+                Does
+                    .Contain("child directory")
+                    .And.Contain("Blake3Hash")
+            )
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRejectsMissingChildFileBlake3() =
+        let fileVersion =
+            fileWithHashes
+                "/a.txt"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                1L
+
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-missing-child-file-blake3" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected missing child file Blake3Hash to reject before Save.")
+        | Error error ->
+            Assert.That(
+                error.Error,
+                Does
+                    .Contain("child file")
+                    .And.Contain("Blake3Hash")
+            )
+
+    [<Test>]
+    member _.DirectoryVersionHashesAreStableForReorderedChildren() =
+        let fileA =
+            fileWithHashes
+                "/a.txt"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                1L
+
+        let fileB =
+            fileWithHashes
+                "/b.txt"
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                1L
+
+        let first = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileA; fileB ]
+        let second = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileB; fileA ]
+
+        Assert.That(second.Sha256Hash, Is.EqualTo(first.Sha256Hash))
+        Assert.That(second.Blake3Hash, Is.EqualTo(first.Blake3Hash))
+        assertDirectoryHashesValid first []
+
+    [<Test>]
+    member _.DirectoryVersionHashesIncludeChildNamesAndMovedDirectoryPath() =
+        let sameSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let sameBlake = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        let fileA = fileWithHashes "/a.txt" sameSha sameBlake 10L
+        let fileB = fileWithHashes "/b.txt" sameSha sameBlake 10L
+
+        let namedA = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileA ]
+        let namedB = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileB ]
+        let movedA = hashedDirectory directoryVersionId (RelativePath "/moved/") [] [ fileA ]
+
+        Assert.That(namedB.Sha256Hash, Is.Not.EqualTo(namedA.Sha256Hash))
+        Assert.That(namedB.Blake3Hash, Is.Not.EqualTo(namedA.Blake3Hash))
+        Assert.That(movedA.Sha256Hash, Is.Not.EqualTo(namedA.Sha256Hash))
+        Assert.That(movedA.Blake3Hash, Is.Not.EqualTo(namedA.Blake3Hash))
+
+    [<Test>]
+    member _.DirectoryVersionHashesPreserveManifestBackedSiblingHashData() =
+        let manifest = finalizedManifest ()
+        let manifestBackedFile = manifestFile manifest
+        manifestBackedFile.Blake3Hash <- Blake3Hash manifest.FileContentHash
+
+        let changedFile =
+            fileWithHashes
+                "/changed.txt"
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                12L
+
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ manifestBackedFile; changedFile ]
+
+        assertDirectoryHashesValid directoryVersion []
+
+        Assert.That(
+            directoryVersion.Files[0]
+                .ContentReference
+                .ReferenceType,
+            Is.EqualTo(FileContentReferenceType.FileManifest)
+        )
 
     [<Test>]
     member _.ManifestSaveBoundaryRejectsAbsentContentBlockMetadataRanges() =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -172,15 +172,40 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected legacy empty BLAKE3 to be accepted, got {error.Error}.")
 
     [<Test>]
-    member _.DirectoryVersionHashValidationAllowsLegacyManifestBackedFileBlake3Gap() =
+    member _.DirectoryVersionHashValidationRejectsNewManifestBackedFileBlake3Gap() =
         let manifest = finalizedManifest ()
         let fileVersion = manifestFile manifest
         fileVersion.Blake3Hash <- Blake3Hash String.Empty
         let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
 
         match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-legacy-manifest-file-blake3" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected new manifest-backed FileVersion without BLAKE3 to reject before Save.")
+        | Error error ->
+            Assert.That(
+                error.Error,
+                Does
+                    .Contain("child file")
+                    .And.Contain("Blake3Hash")
+            )
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationAllowsUnchangedLegacyManifestBackedFileBlake3Gap() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let previousFileVersion = manifestFile manifest
+        previousFileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
+
+        match
+            DirectoryVersionActor.validateDirectoryVersionHashesWithChildrenAndPreviousFiles
+                "corr-legacy-manifest-file-blake3"
+                directoryVersion
+                []
+                [ previousFileVersion ]
+            with
         | Ok () -> ()
-        | Error error -> Assert.Fail($"Expected legacy manifest-backed FileVersion without BLAKE3 to validate, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected unchanged legacy manifest-backed FileVersion without BLAKE3 to validate, got {error.Error}.")
 
     [<Test>]
     member _.DirectoryVersionHashValidationRequiresDirectoryBlake3BeforeSave() =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -247,7 +247,7 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected validated legacy child DirectoryVersion without BLAKE3 to validate, got {error.Error}.")
 
     [<Test>]
-    member _.DirectoryVersionHashValidationRejectsMissingChildFileBlake3() =
+    member _.DirectoryVersionHashValidationAllowsLegacyWholeFileBlake3Gap() =
         let fileVersion =
             fileWithHashes
                 "/a.txt"
@@ -255,8 +255,26 @@ type SaveBoundaryActorTests() =
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 1L
 
-        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
         fileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-legacy-whole-file-blake3" directoryVersion [] with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected legacy whole-file FileVersion without BLAKE3 to validate, got {error.Error}.")
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationRejectsMissingManifestChildFileBlake3() =
+        let fileVersion =
+            fileWithHashes
+                "/a.txt"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                1L
+
+        fileVersion.ContentReference <- { Class = "FileContentReference"; ReferenceType = FileContentReferenceType.FileManifest; Manifest = None }
+
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
 
         match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-missing-child-file-blake3" directoryVersion [] with
         | Ok () -> Assert.Fail("Expected missing child file Blake3Hash to reject before Save.")

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -247,7 +247,7 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected validated legacy child DirectoryVersion without BLAKE3 to validate, got {error.Error}.")
 
     [<Test>]
-    member _.DirectoryVersionHashValidationAllowsLegacyWholeFileBlake3Gap() =
+    member _.DirectoryVersionHashValidationRejectsNewWholeFileBlake3Gap() =
         let fileVersion =
             fileWithHashes
                 "/a.txt"
@@ -259,8 +259,45 @@ type SaveBoundaryActorTests() =
         let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
 
         match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-legacy-whole-file-blake3" directoryVersion [] with
+        | Ok () -> Assert.Fail("Expected new whole-file FileVersion without BLAKE3 to reject before Save.")
+        | Error error ->
+            Assert.That(
+                error.Error,
+                Does
+                    .Contain("child file")
+                    .And.Contain("Blake3Hash")
+            )
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationAllowsUnchangedLegacyWholeFileBlake3Gap() =
+        let fileVersion =
+            fileWithHashes
+                "/a.txt"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                1L
+
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+
+        let previousFileVersion =
+            fileWithHashes
+                "/a.txt"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                1L
+
+        previousFileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
+
+        match
+            DirectoryVersionActor.validateDirectoryVersionHashesWithChildrenAndPreviousFiles
+                "corr-legacy-whole-file-blake3"
+                directoryVersion
+                []
+                [ previousFileVersion ]
+            with
         | Ok () -> ()
-        | Error error -> Assert.Fail($"Expected legacy whole-file FileVersion without BLAKE3 to validate, got {error.Error}.")
+        | Error error -> Assert.Fail($"Expected unchanged legacy whole-file FileVersion without BLAKE3 to validate, got {error.Error}.")
 
     [<Test>]
     member _.DirectoryVersionHashValidationRejectsMissingManifestChildFileBlake3() =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -172,6 +172,17 @@ type SaveBoundaryActorTests() =
         | Error error -> Assert.Fail($"Expected legacy empty BLAKE3 to be accepted, got {error.Error}.")
 
     [<Test>]
+    member _.DirectoryVersionHashValidationAllowsLegacyManifestBackedFileBlake3Gap() =
+        let manifest = finalizedManifest ()
+        let fileVersion = manifestFile manifest
+        fileVersion.Blake3Hash <- Blake3Hash String.Empty
+        let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] [ fileVersion ]
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-legacy-manifest-file-blake3" directoryVersion [] with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected legacy manifest-backed FileVersion without BLAKE3 to validate, got {error.Error}.")
+
+    [<Test>]
     member _.DirectoryVersionHashValidationRequiresDirectoryBlake3BeforeSave() =
         let directoryVersion = hashedDirectory directoryVersionId (RelativePath "/") [] []
         directoryVersion.Blake3Hash <- Blake3Hash String.Empty
@@ -223,6 +234,17 @@ type SaveBoundaryActorTests() =
                     .Contain("child directory")
                     .And.Contain("Blake3Hash")
             )
+
+    [<Test>]
+    member _.DirectoryVersionHashValidationAllowsValidatedLegacyChildDirectoryBlake3Gap() =
+        let child = hashedDirectory (Guid.NewGuid()) (RelativePath "/src/") [] []
+        child.HashesValidated <- true
+        child.Blake3Hash <- Blake3Hash String.Empty
+        let parent = hashedDirectory directoryVersionId (RelativePath "/") [ child ] []
+
+        match DirectoryVersionActor.validateDirectoryVersionHashesWithChildren "corr-legacy-child-directory-blake3" parent [ child ] with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected validated legacy child DirectoryVersion without BLAKE3 to validate, got {error.Error}.")
 
     [<Test>]
     member _.DirectoryVersionHashValidationRejectsMissingChildFileBlake3() =

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -367,18 +367,6 @@ module DirectoryVersion =
                         let repositoryActorProxy = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
                         let! repositoryDto = repositoryActorProxy.Get(correlationId)
 
-                        let routeHashError =
-                            parameters.DirectoryVersions
-                            |> Seq.tryPick (fun directoryVersion ->
-                                if String.IsNullOrWhiteSpace $"{directoryVersion.Blake3Hash}" then
-                                    Some(
-                                        GraceError.Create
-                                            $"DirectoryVersion '{directoryVersion.RelativePath}' must include DirectoryVersion.Blake3Hash before Save."
-                                            correlationId
-                                    )
-                                else
-                                    None)
-
                         let orderedDirectoryVersions =
                             parameters.DirectoryVersions
                             |> Seq.sortByDescending (fun directoryVersion ->
@@ -393,31 +381,37 @@ module DirectoryVersion =
                                     .Length)
                             |> Seq.toArray
 
-                        match routeHashError with
-                        | Some graceError -> results.Enqueue(Error graceError)
-                        | None ->
-                            for directoryVersion in orderedDirectoryVersions do
-                                try
-                                    // Check if the directory version exists. If it doesn't, create it.
-                                    let directoryVersionActor = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
+                        for directoryVersion in orderedDirectoryVersions do
+                            try
+                                // Check if the directory version exists. If it doesn't, create it.
+                                let directoryVersionActor = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
 
-                                    let! exists = directoryVersionActor.Exists parameters.CorrelationId
-                                    //logToConsole $"In SaveDirectoryVersions: {dv.DirectoryId} exists: {exists}"
-                                    if not <| exists then
+                                let! exists = directoryVersionActor.Exists parameters.CorrelationId
+                                //logToConsole $"In SaveDirectoryVersions: {dv.DirectoryId} exists: {exists}"
+                                if not <| exists then
+                                    if String.IsNullOrWhiteSpace $"{directoryVersion.Blake3Hash}" then
+                                        results.Enqueue(
+                                            Error(
+                                                GraceError.Create
+                                                    $"DirectoryVersion '{directoryVersion.RelativePath}' must include DirectoryVersion.Blake3Hash before Save."
+                                                    correlationId
+                                            )
+                                        )
+                                    else
                                         let! createResult =
                                             directoryVersionActor.Handle
                                                 (DirectoryVersionCommand.Create(directoryVersion, repositoryDto))
                                                 (createMetadata context)
 
                                         results.Enqueue(createResult)
-                                with
-                                | ex ->
-                                    let exceptionResponse = Utilities.ExceptionResponse.Create ex
+                            with
+                            | ex ->
+                                let exceptionResponse = Utilities.ExceptionResponse.Create ex
 
-                                    logToConsole
-                                        $"****Error in SaveDirectoryVersions: directoryVersion.Directories.Count: {directoryVersion.Directories.Count}; directoryVersion.Files.Count: {directoryVersion.Files.Count}."
+                                logToConsole
+                                    $"****Error in SaveDirectoryVersions: directoryVersion.Directories.Count: {directoryVersion.Directories.Count}; directoryVersion.Files.Count: {directoryVersion.Files.Count}."
 
-                                    logToConsole $"{exceptionResponse}"
+                                logToConsole $"{exceptionResponse}"
 
                         let firstError =
                             results

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -367,38 +367,57 @@ module DirectoryVersion =
                         let repositoryActorProxy = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
                         let! repositoryDto = repositoryActorProxy.Get(correlationId)
 
-                        do!
-                            Parallel.ForEachAsync(
-                                parameters.DirectoryVersions,
-                                Constants.ParallelOptions,
-                                (fun directoryVersion ct ->
-                                    ValueTask(
-                                        task {
-                                            try
-                                                // Check if the directory version exists. If it doesn't, create it.
-                                                let directoryVersionActor =
-                                                    DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
+                        let routeHashError =
+                            parameters.DirectoryVersions
+                            |> Seq.tryPick (fun directoryVersion ->
+                                if String.IsNullOrWhiteSpace $"{directoryVersion.Blake3Hash}" then
+                                    Some(
+                                        GraceError.Create
+                                            $"DirectoryVersion '{directoryVersion.RelativePath}' must include DirectoryVersion.Blake3Hash before Save."
+                                            correlationId
+                                    )
+                                else
+                                    None)
 
-                                                let! exists = directoryVersionActor.Exists parameters.CorrelationId
-                                                //logToConsole $"In SaveDirectoryVersions: {dv.DirectoryId} exists: {exists}"
-                                                if not <| exists then
-                                                    let! createResult =
-                                                        directoryVersionActor.Handle
-                                                            (DirectoryVersionCommand.Create(directoryVersion, repositoryDto))
-                                                            (createMetadata context)
+                        let orderedDirectoryVersions =
+                            parameters.DirectoryVersions
+                            |> Seq.sortByDescending (fun directoryVersion ->
+                                $"{directoryVersion.RelativePath}".TrimEnd(
+                                    '/',
+                                    '\\'
+                                )
+                                    .Split(
+                                    [| '/'; '\\' |],
+                                    StringSplitOptions.RemoveEmptyEntries
+                                )
+                                    .Length)
+                            |> Seq.toArray
 
-                                                    results.Enqueue(createResult)
-                                            with
-                                            | ex ->
-                                                let exceptionResponse = Utilities.ExceptionResponse.Create ex
+                        match routeHashError with
+                        | Some graceError -> results.Enqueue(Error graceError)
+                        | None ->
+                            for directoryVersion in orderedDirectoryVersions do
+                                try
+                                    // Check if the directory version exists. If it doesn't, create it.
+                                    let directoryVersionActor = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
 
-                                                logToConsole
-                                                    $"****Error in SaveDirectoryVersions: directoryVersion.Directories.Count: {directoryVersion.Directories.Count}; directoryVersion.Files.Count: {directoryVersion.Files.Count}."
+                                    let! exists = directoryVersionActor.Exists parameters.CorrelationId
+                                    //logToConsole $"In SaveDirectoryVersions: {dv.DirectoryId} exists: {exists}"
+                                    if not <| exists then
+                                        let! createResult =
+                                            directoryVersionActor.Handle
+                                                (DirectoryVersionCommand.Create(directoryVersion, repositoryDto))
+                                                (createMetadata context)
 
-                                                logToConsole $"{exceptionResponse}"
-                                        }
-                                    ))
-                            )
+                                        results.Enqueue(createResult)
+                                with
+                                | ex ->
+                                    let exceptionResponse = Utilities.ExceptionResponse.Create ex
+
+                                    logToConsole
+                                        $"****Error in SaveDirectoryVersions: directoryVersion.Directories.Count: {directoryVersion.Directories.Count}; directoryVersion.Files.Count: {directoryVersion.Files.Count}."
+
+                                    logToConsole $"{exceptionResponse}"
 
                         let firstError =
                             results

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -35,6 +35,20 @@ module DirectoryVersion =
 
     let activitySource = new ActivitySource("Branch")
 
+    let private directorySaveDepth (relativePath: RelativePath) =
+        let trimmedPath = $"{relativePath}".Trim().TrimEnd('/', '\\')
+
+        if String.IsNullOrWhiteSpace trimmedPath
+           || trimmedPath = "." then
+            0
+        else
+            trimmedPath
+                .Split(
+                    [| '/'; '\\' |],
+                    StringSplitOptions.RemoveEmptyEntries
+                )
+                .Length
+
     let processCommand<'T when 'T :> DirectoryVersionParameters>
         (context: HttpContext)
         (validations: Validations<'T>)
@@ -369,16 +383,7 @@ module DirectoryVersion =
 
                         let orderedDirectoryVersions =
                             parameters.DirectoryVersions
-                            |> Seq.sortByDescending (fun directoryVersion ->
-                                $"{directoryVersion.RelativePath}".TrimEnd(
-                                    '/',
-                                    '\\'
-                                )
-                                    .Split(
-                                    [| '/'; '\\' |],
-                                    StringSplitOptions.RemoveEmptyEntries
-                                )
-                                    .Length)
+                            |> Seq.sortByDescending (fun directoryVersion -> directorySaveDepth directoryVersion.RelativePath)
                             |> Seq.toArray
 
                         for directoryVersion in orderedDirectoryVersions do


### PR DESCRIPTION
Related to #350
Part of #343

## Summary

- Propagates DirectoryVersion BLAKE3 and the updated SHA-256 preimage through CLI local recompute, save overlays, repository empty-root creation, promotion recompute, server save ordering, and actor validation.
- Rejects missing or mismatched DirectoryVersion SHA-256/BLAKE3 and missing child file/directory hashes before persistence, event publication, or follow-on state mutation.
- Normalizes the JSON-ingress empty-directory size sentinel before hash validation/persistence so omitted `Size = 0` values do not produce mismatched parent hashes.
- Keeps manifest-backed sibling preservation in the CLI overlay path and fails unresolved child directory metadata before hashing a partial parent.

## Scope Notes

- Public BLAKE3 lookup routes remain owned by #354 through #357.
- Local SQLite schema/migration/reset behavior remains owned by #352.
- OpenAPI, SDK, CLI JSON, and docs are unchanged because this slice uses DTO fields scaffolded by #348 and behavior owned by this issue's actor/server/CLI save paths.

## Proof Matrix

| Requirement | Proof |
| --- | --- |
| Root and nested directories carry both hashes | `DirectoryVersion.Server.Tests.fs` helpers compute/assert both SHA-256 and BLAKE3; actor tests validate computed hashes. |
| Missing/mismatched directory hashes fail before save | `SaveBoundary.Actor.Tests.fs` covers missing BLAKE3, mismatched BLAKE3, mismatched SHA-256, missing child directory BLAKE3, missing child file BLAKE3, and narrow legacy persisted-child tolerances. |
| Manifest-backed sibling preservation remains intact | CLI overlay path preserves `FileManifest` hash/reference data; save-boundary tests now tolerate legacy manifest-backed files with empty file BLAKE3 only after manifest validation. |
| Boundary/adversarial cases | Tests cover empty directory JSON normalization, reordered children, duplicate-content children with different names, moved directory path, child size in promotion preimage, SHA-only BLAKE3 rejection, unchanged legacy child directories, local status/root hash sync after recompute, CLI save-caller sync, promotion text override BLAKE3, existing-directory skip behavior, stale reference-root refresh, narrowed legacy whole-file tolerance, narrowed manifest-backed legacy gaps, dot-root batch ordering, and normalized child sizes in parent hashes. |
| Forbidden shapes absent | Directory hashes use `DirectoryVersionPreimageEntry` with child kind/name/path/size and same-algorithm child hashes; the diff does not fill BLAKE3 from SHA-256 or hash child IDs. |

## Validation

Passed:

- Targeted Fantomas on touched F# files.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "FullyQualifiedName~SaveBoundaryActorTests|FullyQualifiedName~PromotionSetDirectoryHashTests" --logger "console;verbosity=normal"`, `28/28` before review fixes.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "SaveBoundaryActorTests"`, passed twice after review fixes, `29/29`.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "CurrentStateCaptureCliTests"`, passed after review fixes, `15/15`.
- `dotnet build C:\Source\Grace-gh-350\src\Grace.slnx --configuration Release --no-restore`, passed after hosted full/test-helper fix, `0` warnings and `0` errors.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --no-build --no-restore --filter "FullyQualifiedName~SaveBoundaryActorTests"`, passed after hosted full/test-helper fix, `30` tests.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --no-build --no-restore --filter "FullyQualifiedName~PromotionSet"`, passed after hosted full/test-helper fix, `34` tests.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "FullyQualifiedName~SaveBoundaryActorTests"`, passed after `d6c6b5c726308867c9d2e2ae40dc01ac0c839e66`, `31/31`.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~CurrentStateCaptureCliTests"`, passed after `d6c6b5c726308867c9d2e2ae40dc01ac0c839e66`, `15/15`.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~DirectoryVersionServer"`, reproduced the hosted failures first, then passed after `d6c6b5c726308867c9d2e2ae40dc01ac0c839e66`, `2/2`.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "FullyQualifiedName~SaveBoundaryActorTests"`, passed after `70572c156d6fa428750c990b576f8c21412b614a`, `32/32`.
- `dotnet test C:\Source\Grace-gh-350\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~DirectoryVersionServer"`, passed after `70572c156d6fa428750c990b576f8c21412b614a`, `3/3`.
- `pwsh ./scripts/validate.ps1 -Fast`, passed after initial implementation, twice after review fixes, after hosted full/test-helper fixes, after `d6c6b5c726308867c9d2e2ae40dc01ac0c839e66`, and again after `70572c156d6fa428750c990b576f8c21412b614a`:
  - Authorization `39`
  - Types `115`
  - Server.Unit `526`
  - CLI `510 passed / 1 skipped`
  - Server.Tests fast profile reported no matching tests for its selected filter in that assembly.
- `git diff --check`

Attempted but not completed:

- Focused `Grace.Server.Tests` DirectoryVersion integration rerun was attempted twice after the initial fix, but both runs stopped during Aspire/Azurite fixture startup before tests executed. Earlier, that focused path reached the tests and exposed the `Size = -1` parent-hash mismatch; the mismatch now has a direct unit regression.
- Focused Aspire-backed `Grace.Server.Tests` filter for the five hosted failures on `f0b79b0b39e33ea697dd5c2307135ef4bf2fe6c6` was attempted after `e51281a3cc03e95de0d3b4a7c712cc8d5f9f6e89`, but local OneTimeSetUp failed before test bodies because Azurite failed to start.

## Review Status

- Worker bot-prevention self-review: completed before push.
- High-risk pre-PR review waiver: this slice touches actor/server/CLI save-boundary surfaces, but the user explicitly prohibited manual Codex review requests. This PR relies on the repository's automatic Codex Code Review Bot after PR creation.
- Automatic Codex Code Review Bot: pending.
- Hosted validation: pending.
- Prevention line: Directory hashes are computed only after authoritative I06 file overlays, saved DirectoryVersions are rejected when either algorithm or child hash data is missing/mismatched, server batch saves process children before parents, empty-directory JSON size omission is normalized before hash validation, unresolved child directory metadata fails fast, manifest-backed siblings keep their file-manifest references, and public lookup/local-state migration surfaces remain deferred to their owning issues.

## Residual Risk

- Earlier Aspire-backed focused server integration reruns could not be completed locally because Azurite fixture startup failed before test execution. The latest focused `DirectoryVersionServer` run reproduced the two hosted failures and then passed locally after `d6c6b5c726308867c9d2e2ae40dc01ac0c839e66`; hosted `Validate / full` remains the confirmation gate for the complete Aspire-backed server test group.
- No merge blocker remains: hosted `Validate / full` passed, Codex Code Review Bot gave thumbs-up, and all review threads are resolved on `70572c156d6fa428750c990b576f8c21412b614a`.





