### PR TITLE
I08: Carry root hashes through reference and branch events

### DIFF
--- a/src/Grace.Actors/Branch.Actor.fs
+++ b/src/Grace.Actors/Branch.Actor.fs
@@ -159,13 +159,13 @@ module Branch =
 
                     match branchEvent.Event with
                     // Don't save these reference creation events, and don't send them as events; that was done by the Reference actor when the reference was created.
-                    | Assigned (referenceDto, _, _, _)
-                    | Promoted (referenceDto, _, _, _)
-                    | Committed (referenceDto, _, _, _)
-                    | Checkpointed (referenceDto, _, _, _)
-                    | Saved (referenceDto, _, _, _)
-                    | Tagged (referenceDto, _, _, _)
-                    | ExternalCreated (referenceDto, _, _, _) -> branchEvent.Metadata.Properties[ nameof ReferenceId ] <- $"{referenceDto.ReferenceId}"
+                    | Assigned (referenceDto, _, _, _, _)
+                    | Promoted (referenceDto, _, _, _, _)
+                    | Committed (referenceDto, _, _, _, _)
+                    | Checkpointed (referenceDto, _, _, _, _)
+                    | Saved (referenceDto, _, _, _, _)
+                    | Tagged (referenceDto, _, _, _, _)
+                    | ExternalCreated (referenceDto, _, _, _, _) -> branchEvent.Metadata.Properties[ nameof ReferenceId ] <- $"{referenceDto.ReferenceId}"
                     | Rebased referenceId -> branchEvent.Metadata.Properties[ nameof ReferenceId ] <- $"{referenceId}"
                     // Save the rest of the events.
                     | _ ->
@@ -308,7 +308,7 @@ module Branch =
                                 | None -> return Error(GraceError.Create (getErrorMessage BranchError.BranchDoesNotExist) metadata.CorrelationId)
                     }
 
-                let addReference ownerId organizationId repositoryId branchId directoryId sha256Hash referenceText referenceType links =
+                let addReference ownerId organizationId repositoryId branchId directoryId sha256Hash blake3Hash referenceText referenceType links =
                     task {
                         let referenceId: ReferenceId = ReferenceId.NewGuid()
                         let referenceActor = Reference.CreateActorProxy referenceId repositoryId this.correlationId
@@ -322,6 +322,7 @@ module Branch =
                                 branchId,
                                 directoryId,
                                 sha256Hash,
+                                blake3Hash,
                                 referenceType,
                                 referenceText,
                                 links
@@ -345,7 +346,7 @@ module Branch =
                                     | Create (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions) ->
                                         // Add an initial Rebase reference to this branch that points to the BasedOn reference, unless we're creating `main`.
                                         if branchName <> InitialBranchName then
-                                            // We need to get the reference that we're rebasing on, so we can get the DirectoryId and Sha256Hash.
+                                            // We need to get the reference that we're rebasing on, so we can get the DirectoryId and root hashes.
                                             let referenceActorProxy = Reference.CreateActorProxy basedOn repositoryId this.correlationId
                                             let! promotionDto = referenceActorProxy.Get this.correlationId
 
@@ -357,6 +358,7 @@ module Branch =
                                                     branchId
                                                     promotionDto.DirectoryId
                                                     promotionDto.Sha256Hash
+                                                    promotionDto.Blake3Hash
                                                     promotionDto.ReferenceText
                                                     ReferenceType.Rebase
                                                     [
@@ -381,7 +383,7 @@ module Branch =
                                         metadata.Properties[ nameof BranchId ] <- $"{this.GetGrainId().GetGuidKey()}"
                                         metadata.Properties[ nameof BranchName ] <- $"{branchDto.BranchName}"
 
-                                        // We need to get the reference that we're rebasing on, so we can get the directoryId and sha256Hash.
+                                        // We need to get the reference that we're rebasing on, so we can get the directoryId and root hashes.
                                         let referenceActorProxy = Reference.CreateActorProxy referenceId branchDto.RepositoryId this.correlationId
                                         let! promotionDto = referenceActorProxy.Get metadata.CorrelationId
 
@@ -390,6 +392,7 @@ module Branch =
                                             addReferenceToCurrentBranch
                                                 promotionDto.DirectoryId
                                                 promotionDto.Sha256Hash
+                                                promotionDto.Blake3Hash
                                                 promotionDto.ReferenceText
                                                 ReferenceType.Rebase
                                                 [
@@ -420,33 +423,69 @@ module Branch =
                                     | EnableAutoRebase enabled -> return Ok(EnabledAutoRebase enabled)
                                     | SetPromotionMode promotionMode -> return Ok(PromotionModeSet promotionMode)
                                     | UpdateParentBranch newParentBranchId -> return Ok(ParentBranchUpdated newParentBranchId)
-                                    | BranchCommand.Assign (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Promotion List.empty with
-                                        | Ok returnValue -> return Ok(Assigned(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Assign (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match!
+                                            addReferenceToCurrentBranch
+                                                directoryVersionId
+                                                sha256Hash
+                                                blake3Hash
+                                                referenceText
+                                                ReferenceType.Promotion
+                                                List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(Assigned(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.Promote (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Promotion List.empty with
-                                        | Ok returnValue -> return Ok(Promoted(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Promote (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match!
+                                            addReferenceToCurrentBranch
+                                                directoryVersionId
+                                                sha256Hash
+                                                blake3Hash
+                                                referenceText
+                                                ReferenceType.Promotion
+                                                List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(Promoted(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.Commit (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Commit List.empty with
-                                        | Ok returnValue -> return Ok(Committed(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Commit (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match!
+                                            addReferenceToCurrentBranch directoryVersionId sha256Hash blake3Hash referenceText ReferenceType.Commit List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(Committed(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.Checkpoint (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Checkpoint List.empty with
-                                        | Ok returnValue -> return Ok(Checkpointed(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Checkpoint (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match!
+                                            addReferenceToCurrentBranch
+                                                directoryVersionId
+                                                sha256Hash
+                                                blake3Hash
+                                                referenceText
+                                                ReferenceType.Checkpoint
+                                                List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(Checkpointed(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.Save (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Save List.empty with
-                                        | Ok returnValue -> return Ok(Saved(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Save (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash blake3Hash referenceText ReferenceType.Save List.empty
+                                            with
+                                        | Ok returnValue -> return Ok(Saved(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.Tag (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.Tag List.empty with
-                                        | Ok returnValue -> return Ok(Tagged(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.Tag (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash blake3Hash referenceText ReferenceType.Tag List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(Tagged(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
-                                    | BranchCommand.CreateExternal (directoryVersionId, sha256Hash, referenceText) ->
-                                        match! addReferenceToCurrentBranch directoryVersionId sha256Hash referenceText ReferenceType.External List.empty with
-                                        | Ok returnValue -> return Ok(ExternalCreated(returnValue.ReturnValue, directoryVersionId, sha256Hash, referenceText))
+                                    | BranchCommand.CreateExternal (directoryVersionId, sha256Hash, blake3Hash, referenceText) ->
+                                        match!
+                                            addReferenceToCurrentBranch directoryVersionId sha256Hash blake3Hash referenceText ReferenceType.External List.empty
+                                            with
+                                        | Ok returnValue ->
+                                            return Ok(ExternalCreated(returnValue.ReturnValue, directoryVersionId, sha256Hash, blake3Hash, referenceText))
                                         | Error error -> return Error error
                                     | RemoveReference referenceId -> return Ok(ReferenceRemoved referenceId)
                                     | DeleteLogical (force, deleteReason, reassignChildBranches, newParentBranchId) ->

--- a/src/Grace.Actors/PromotionSet.Actor.fs
+++ b/src/Grace.Actors/PromotionSet.Actor.fs
@@ -1810,6 +1810,7 @@ module PromotionSet =
                             promotionSetDto.TargetBranchId,
                             step.AppliedDirectoryVersionId,
                             directoryVersionDto.DirectoryVersion.Sha256Hash,
+                            directoryVersionDto.DirectoryVersion.Blake3Hash,
                             ReferenceType.Promotion,
                             referenceText,
                             links

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -113,6 +113,42 @@ module Reference =
         referenceDto.ReferenceId <> ReferenceId.Empty
         && referenceDto.ReferenceType = ReferenceType.Save
 
+    let validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryId sha256Hash blake3Hash (directoryVersion: DirectoryVersion) =
+        if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
+            Error(
+                (GraceError.Create "Reference root DirectoryVersion does not exist." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance (nameof DirectoryVersionId, directoryId)
+            )
+        elif String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash) then
+            Error(
+                (GraceError.Create "Reference root DirectoryVersion must include Blake3Hash before reference creation." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance (nameof DirectoryVersionId, directoryId)
+            )
+        elif String.IsNullOrWhiteSpace(string blake3Hash) then
+            Error(
+                (GraceError.Create "Reference command must include the root DirectoryVersion Blake3Hash." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance (nameof DirectoryVersionId, directoryId)
+            )
+        elif directoryVersion.Sha256Hash <> sha256Hash then
+            Error(
+                (GraceError.Create "Reference command Sha256Hash does not match the root DirectoryVersion Sha256Hash." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance(nameof DirectoryVersionId, directoryId)
+                    .enhance (nameof Sha256Hash, sha256Hash)
+            )
+        elif directoryVersion.Blake3Hash <> blake3Hash then
+            Error(
+                (GraceError.Create "Reference command Blake3Hash does not match the root DirectoryVersion Blake3Hash." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance(nameof DirectoryVersionId, directoryId)
+                    .enhance (nameof Blake3Hash, blake3Hash)
+            )
+        else
+            Ok()
+
     let tryCreateManifestContributionStart plan intent =
         match intent with
         | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, manifestAddress) when
@@ -369,7 +405,17 @@ module Reference =
 
                     // If this is a Save or Checkpoint reference, schedule a physical deletion based on the default delays from the repository.
                     match referenceEvent.Event with
-                    | Created (referenceId, ownerId, organizationId, repositoryId, branchId, directoryId, sha256Hash, referenceType, referenceText, links) ->
+                    | Created (referenceId,
+                               ownerId,
+                               organizationId,
+                               repositoryId,
+                               branchId,
+                               directoryId,
+                               sha256Hash,
+                               blake3Hash,
+                               referenceType,
+                               referenceText,
+                               links) ->
                         do!
                             match referenceDto.ReferenceType with
                             | ReferenceType.Save ->
@@ -383,6 +429,7 @@ module Reference =
                                             BranchId = referenceDto.BranchId
                                             DirectoryVersionId = referenceDto.DirectoryId
                                             Sha256Hash = referenceDto.Sha256Hash
+                                            Blake3Hash = referenceDto.Blake3Hash
                                             DeleteReason = $"Save: automatic deletion after {repositoryDto.SaveDays} days"
                                             CorrelationId = correlationId
                                         }
@@ -406,6 +453,7 @@ module Reference =
                                             BranchId = referenceDto.BranchId
                                             DirectoryVersionId = referenceDto.DirectoryId
                                             Sha256Hash = referenceDto.Sha256Hash
+                                            Blake3Hash = referenceDto.Blake3Hash
                                             DeleteReason = $"Checkpoint: automatic deletion after {repositoryDto.CheckpointDays} days"
                                             CorrelationId = correlationId
                                         }
@@ -489,7 +537,17 @@ module Reference =
                             return Error(GraceError.Create (getErrorMessage ReferenceError.DuplicateCorrelationId) metadata.CorrelationId)
                         else
                             match command with
-                            | Create (referenceId, ownerId, organizationId, repositoryId, branchId, directoryId, sha256Hash, referenceType, referenceText, links) ->
+                            | Create (referenceId,
+                                      ownerId,
+                                      organizationId,
+                                      repositoryId,
+                                      branchId,
+                                      directoryId,
+                                      sha256Hash,
+                                      blake3Hash,
+                                      referenceType,
+                                      referenceText,
+                                      links) ->
                                 match referenceDto.UpdatedAt with
                                 | Some _ -> return Error(GraceError.Create (getErrorMessage ReferenceError.ReferenceAlreadyExists) metadata.CorrelationId)
                                 | None -> return Ok command
@@ -526,6 +584,21 @@ module Reference =
                                 | Ok plans -> return! applyManifestContributionBoundary plans metadata
                         }
 
+                    let validateRootDirectoryVersionHashes repositoryId directoryId sha256Hash blake3Hash =
+                        task {
+                            let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
+                            let! directoryVersionDto = directoryVersionActorProxy.Get metadata.CorrelationId
+
+                            return
+                                validateReferenceRootDirectoryVersionHashes
+                                    metadata.CorrelationId
+                                    repositoryId
+                                    directoryId
+                                    sha256Hash
+                                    blake3Hash
+                                    directoryVersionDto.DirectoryVersion
+                        }
+
                     task {
                         let! (referenceEventTypeResult: Result<ReferenceEventType, GraceError>) =
                             task {
@@ -537,26 +610,31 @@ module Reference =
                                           branchId,
                                           directoryId,
                                           sha256Hash,
+                                          blake3Hash,
                                           referenceType,
                                           referenceText,
                                           links) ->
-                                    match! applySaveManifestBoundary referenceId repositoryId directoryId referenceType with
+                                    match! validateRootDirectoryVersionHashes repositoryId directoryId sha256Hash blake3Hash with
                                     | Ok () ->
-                                        return
-                                            Ok(
-                                                Created(
-                                                    referenceId,
-                                                    ownerId,
-                                                    organizationId,
-                                                    repositoryId,
-                                                    branchId,
-                                                    directoryId,
-                                                    sha256Hash,
-                                                    referenceType,
-                                                    referenceText,
-                                                    links
+                                        match! applySaveManifestBoundary referenceId repositoryId directoryId referenceType with
+                                        | Ok () ->
+                                            return
+                                                Ok(
+                                                    Created(
+                                                        referenceId,
+                                                        ownerId,
+                                                        organizationId,
+                                                        repositoryId,
+                                                        branchId,
+                                                        directoryId,
+                                                        sha256Hash,
+                                                        blake3Hash,
+                                                        referenceType,
+                                                        referenceText,
+                                                        links
+                                                    )
                                                 )
-                                            )
+                                        | Error graceError -> return Error graceError
                                     | Error graceError -> return Error graceError
                                 | AddLink link -> return Ok(LinkAdded link)
                                 | RemoveLink link -> return Ok(LinkRemoved link)
@@ -590,6 +668,7 @@ module Reference =
                                             BranchId = referenceDto.BranchId
                                             DirectoryVersionId = referenceDto.DirectoryId
                                             Sha256Hash = referenceDto.Sha256Hash
+                                            Blake3Hash = referenceDto.Blake3Hash
                                             DeleteReason = deleteReason
                                             CorrelationId = metadata.CorrelationId
                                         }

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -149,6 +149,45 @@ module Reference =
         else
             Ok()
 
+    let internal repairLegacyCreatedEventBlake3
+        (getDirectoryVersion: RepositoryId -> DirectoryVersionId -> CorrelationId -> Task<DirectoryVersion>)
+        (referenceEvent: ReferenceEvent)
+        =
+        task {
+            match referenceEvent.Event with
+            | Created (referenceId, ownerId, organizationId, repositoryId, branchId, directoryId, sha256Hash, blake3Hash, referenceType, referenceText, links) when
+                String.IsNullOrWhiteSpace(string blake3Hash)
+                ->
+                let! directoryVersion = getDirectoryVersion repositoryId directoryId referenceEvent.Metadata.CorrelationId
+
+                if
+                    directoryVersion.DirectoryVersionId = directoryId
+                    && directoryVersion.Sha256Hash = sha256Hash
+                    && not (String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash))
+                then
+                    return
+                        { referenceEvent with
+                            Event =
+                                Created(
+                                    referenceId,
+                                    ownerId,
+                                    organizationId,
+                                    repositoryId,
+                                    branchId,
+                                    directoryId,
+                                    sha256Hash,
+                                    directoryVersion.Blake3Hash,
+                                    referenceType,
+                                    referenceText,
+                                    links
+                                )
+                        },
+                        true
+                else
+                    return referenceEvent, false
+            | _ -> return referenceEvent, false
+        }
+
     let tryCreateManifestContributionStart plan intent =
         match intent with
         | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, manifestAddress) when
@@ -279,15 +318,38 @@ module Reference =
         member val private correlationId: CorrelationId = String.Empty with get, set
 
         override this.OnActivateAsync(ct) =
-            let activateStartTime = getCurrentInstant ()
+            task {
+                let activateStartTime = getCurrentInstant ()
 
-            logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
+                logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
 
-            referenceDto <-
-                state.State
-                |> Seq.fold (fun referenceDto event -> ReferenceDto.UpdateDto event referenceDto) referenceDto
+                let getDirectoryVersion repositoryId directoryId correlationId =
+                    task {
+                        let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId correlationId
+                        let! directoryVersionDto = directoryVersionActorProxy.Get correlationId
+                        return directoryVersionDto.DirectoryVersion
+                    }
 
-            Task.CompletedTask
+                let! repairResults =
+                    state.State
+                    |> Seq.map (fun referenceEvent -> task { return! repairLegacyCreatedEventBlake3 getDirectoryVersion referenceEvent })
+                    |> Task.WhenAll
+
+                let repairedLegacyCreatedEvent =
+                    repairResults
+                    |> Array.exists (fun (_, wasRepaired) -> wasRepaired)
+
+                if repairedLegacyCreatedEvent then
+                    state.State.Clear()
+                    state.State.AddRange(repairResults |> Array.map fst)
+                    do! state.WriteStateAsync()
+
+                referenceDto <-
+                    repairResults
+                    |> Array.map fst
+                    |> Seq.fold (fun referenceDto event -> ReferenceDto.UpdateDto event referenceDto) referenceDto
+            }
+            :> Task
 
         interface IGraceReminderWithGuidKey with
             /// Schedules a Grace reminder.

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -114,19 +114,37 @@ module Reference =
         && referenceDto.ReferenceType = ReferenceType.Save
 
     let validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryId sha256Hash blake3Hash (directoryVersion: DirectoryVersion) =
+        let directoryVersionBlake3IsEmpty = String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash)
+        let commandBlake3IsEmpty = String.IsNullOrWhiteSpace(string blake3Hash)
+
+        let isLegacyEmptyBlake3Root =
+            directoryVersion.RelativePath = Constants.RootDirectoryPath
+            && directoryVersionBlake3IsEmpty
+            && commandBlake3IsEmpty
+
         if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
             Error(
                 (GraceError.Create "Reference root DirectoryVersion does not exist." correlationId)
                     .enhance(nameof RepositoryId, repositoryId)
                     .enhance (nameof DirectoryVersionId, directoryId)
             )
-        elif String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash) then
+        elif directoryVersion.RelativePath
+             <> Constants.RootDirectoryPath then
+            Error(
+                (GraceError.Create "Reference root DirectoryVersion must use the repository root path." correlationId)
+                    .enhance(nameof RepositoryId, repositoryId)
+                    .enhance(nameof DirectoryVersionId, directoryId)
+                    .enhance (nameof RelativePath, directoryVersion.RelativePath)
+            )
+        elif directoryVersionBlake3IsEmpty
+             && not commandBlake3IsEmpty then
             Error(
                 (GraceError.Create "Reference root DirectoryVersion must include Blake3Hash before reference creation." correlationId)
                     .enhance(nameof RepositoryId, repositoryId)
                     .enhance (nameof DirectoryVersionId, directoryId)
             )
-        elif String.IsNullOrWhiteSpace(string blake3Hash) then
+        elif commandBlake3IsEmpty
+             && not isLegacyEmptyBlake3Root then
             Error(
                 (GraceError.Create "Reference command must include the root DirectoryVersion Blake3Hash." correlationId)
                     .enhance(nameof RepositoryId, repositoryId)
@@ -139,7 +157,8 @@ module Reference =
                     .enhance(nameof DirectoryVersionId, directoryId)
                     .enhance (nameof Sha256Hash, sha256Hash)
             )
-        elif directoryVersion.Blake3Hash <> blake3Hash then
+        elif directoryVersion.Blake3Hash <> blake3Hash
+             && not isLegacyEmptyBlake3Root then
             Error(
                 (GraceError.Create "Reference command Blake3Hash does not match the root DirectoryVersion Blake3Hash." correlationId)
                     .enhance(nameof RepositoryId, repositoryId)

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -114,11 +114,17 @@ module Reference =
         && referenceDto.ReferenceType = ReferenceType.Save
 
     let validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryId sha256Hash blake3Hash (directoryVersion: DirectoryVersion) =
+        let rootRelativePath = directoryVersion.RelativePath
+
+        let isRootDirectoryRelativePath =
+            rootRelativePath = Constants.RootDirectoryPath
+            || rootRelativePath = "/"
+
         let directoryVersionBlake3IsEmpty = String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash)
         let commandBlake3IsEmpty = String.IsNullOrWhiteSpace(string blake3Hash)
 
         let isLegacyEmptyBlake3Root =
-            directoryVersion.RelativePath = Constants.RootDirectoryPath
+            isRootDirectoryRelativePath
             && directoryVersionBlake3IsEmpty
             && commandBlake3IsEmpty
 
@@ -128,8 +134,7 @@ module Reference =
                     .enhance(nameof RepositoryId, repositoryId)
                     .enhance (nameof DirectoryVersionId, directoryId)
             )
-        elif directoryVersion.RelativePath
-             <> Constants.RootDirectoryPath then
+        elif not isRootDirectoryRelativePath then
             Error(
                 (GraceError.Create "Reference root DirectoryVersion must use the repository root path." correlationId)
                     .enhance(nameof RepositoryId, repositoryId)

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -184,11 +184,8 @@ module Reference =
                 ->
                 let! directoryVersion = getDirectoryVersion repositoryId directoryId referenceEvent.Metadata.CorrelationId
 
-                if
-                    directoryVersion.DirectoryVersionId = directoryId
-                    && directoryVersion.Sha256Hash = sha256Hash
-                    && not (String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash))
-                then
+                match ReferenceDto.TryGetLegacyRootDirectoryHashRepair directoryId sha256Hash blake3Hash directoryVersion with
+                | Some (repairedSha256Hash, repairedBlake3Hash) ->
                     return
                         { referenceEvent with
                             Event =
@@ -199,16 +196,15 @@ module Reference =
                                     repositoryId,
                                     branchId,
                                     directoryId,
-                                    sha256Hash,
-                                    directoryVersion.Blake3Hash,
+                                    repairedSha256Hash,
+                                    repairedBlake3Hash,
                                     referenceType,
                                     referenceText,
                                     links
                                 )
                         },
                         true
-                else
-                    return referenceEvent, false
+                | None -> return referenceEvent, false
             | _ -> return referenceEvent, false
         }
 

--- a/src/Grace.Actors/Repository.Actor.fs
+++ b/src/Grace.Actors/Repository.Actor.fs
@@ -152,6 +152,7 @@ module Repository =
                                             (BranchCommand.Promote(
                                                 emptyDirectoryId,
                                                 emptySha256Hash,
+                                                emptyBlake3Hash,
                                                 (getLocalizedString StringResourceName.InitialPromotionMessage)
                                             ))
                                             repositoryEvent.Metadata

--- a/src/Grace.Actors/Services.Actor.fs
+++ b/src/Grace.Actors/Services.Actor.fs
@@ -1303,6 +1303,113 @@ module Services =
             isNotDeletedReference referenceDto
             && hasPromotionSetTerminalLink referenceDto)
 
+    let internal getRootDirectoryVersionByDirectoryVersionId (repositoryId: RepositoryId) (directoryVersionId: DirectoryVersionId) correlationId =
+        task {
+            let mutable directoryVersion = DirectoryVersion.Default
+
+            match actorStateStorageProvider with
+            | Unknown -> ()
+            | AzureCosmosDb ->
+                let indexMetrics = stringBuilderPool.Get()
+                let requestCharge = stringBuilderPool.Get()
+
+                try
+                    let queryDefinition =
+                        QueryDefinition(
+                            """
+                            SELECT TOP 1 c.State
+                            FROM c
+                            WHERE STRINGEQUALS(c.State[0].Event.created.DirectoryVersionId, @directoryVersionId, true)
+                                AND (
+                                    STRINGEQUALS(c.State[0].Event.created.RelativePath, @rootRelativePath, true)
+                                    OR STRINGEQUALS(c.State[0].Event.created.RelativePath, @slashRootRelativePath, true)
+                                )
+                                AND c.GrainType = @grainType
+                                AND c.PartitionKey = @partitionKey
+                            ORDER BY c.State[0].Event.created.CreatedAt DESC
+                            """
+                        )
+                            .WithParameter("@directoryVersionId", $"{directoryVersionId}")
+                            .WithParameter("@rootRelativePath", Constants.RootDirectoryPath)
+                            .WithParameter("@slashRootRelativePath", RelativePath "/")
+                            .WithParameter("@grainType", StateName.DirectoryVersion)
+                            .WithParameter("@partitionKey", repositoryId)
+
+                    let iterator = cosmosContainer.GetItemQueryIterator<DirectoryVersionEventValue>(queryDefinition, requestOptions = queryRequestOptions)
+
+                    while iterator.HasMoreResults
+                          && directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty do
+                        let! results = DefaultAsyncRetryPolicy.ExecuteAsync(fun () -> iterator.ReadNextAsync())
+
+                        indexMetrics.Append($"{results.IndexMetrics}, ")
+                        |> ignore
+
+                        requestCharge.Append($"{results.RequestCharge:F3}, ")
+                        |> ignore
+
+                        let eventsForAllDirectories = results.Resource |> Seq.toArray
+                        let mutable index = 0
+
+                        while index < eventsForAllDirectories.Length
+                              && directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty do
+                            let directoryVersionDto =
+                                eventsForAllDirectories[index].State
+                                |> Array.fold
+                                    (fun directoryVersionDto directoryEvent ->
+                                        directoryVersionDto
+                                        |> DirectoryVersionDto.UpdateDto directoryEvent)
+                                    DirectoryVersionDto.Default
+
+                            directoryVersion <- directoryVersionDto.DirectoryVersion
+                            index <- index + 1
+
+                    if (indexMetrics.Length >= 2)
+                       && (requestCharge.Length >= 2)
+                       && Activity.Current <> null then
+                        Activity
+                            .Current
+                            .SetTag("indexMetrics", $"{indexMetrics.Remove(indexMetrics.Length - 2, 2)}")
+                            .SetTag("requestCharge", $"{requestCharge.Remove(requestCharge.Length - 2, 2)}")
+                        |> ignore
+                finally
+                    stringBuilderPool.Return(indexMetrics)
+                    stringBuilderPool.Return(requestCharge)
+            | MongoDB -> ()
+
+            if directoryVersion.DirectoryVersionId
+               <> DirectoryVersionId.Empty then
+                return Some directoryVersion
+            else
+                return None
+        }
+
+    let internal hydrateLegacyReferenceProjectionBlake3
+        (getDirectoryVersion: RepositoryId -> DirectoryVersionId -> CorrelationId -> Task<DirectoryVersion option>)
+        correlationId
+        (referenceDto: ReferenceDto)
+        =
+        task {
+            if String.IsNullOrWhiteSpace(string referenceDto.Blake3Hash) then
+                let! directoryVersion = getDirectoryVersion referenceDto.RepositoryId referenceDto.DirectoryId correlationId
+
+                match directoryVersion with
+                | Some rootDirectoryVersion ->
+                    let hydratedReferenceDto, _ = ReferenceDto.HydrateLegacyRootDirectoryHash rootDirectoryVersion referenceDto
+                    return hydratedReferenceDto
+                | None -> return referenceDto
+            else
+                return referenceDto
+        }
+
+    let internal projectReferenceEventsWithLegacyBlake3Hydration getDirectoryVersion correlationId referenceEvents =
+        task {
+            let referenceDto =
+                referenceEvents
+                |> Array.fold (fun current referenceEvent -> current |> ReferenceDto.UpdateDto referenceEvent) ReferenceDto.Default
+
+            return! hydrateLegacyReferenceProjectionBlake3 getDirectoryVersion correlationId referenceDto
+        }
+
     /// Gets a list of references that match a provided SHA-256 hash.
     let getReferencesBySha256Hash (repositoryId: RepositoryId) (branchId: BranchId) (sha256Hash: Sha256Hash) (maxCount: int) =
         task {
@@ -1344,19 +1451,19 @@ module Services =
                         requestCharge.Append($"{results.RequestCharge:F3}, ")
                         |> ignore
 
-                        let eventsForAllReferences = results.Resource
+                        let eventsForAllReferences = results.Resource |> Seq.toArray
+                        let mutable index = 0
 
-                        eventsForAllReferences
-                        |> Seq.iter (fun eventsForOneReference ->
-                            let referenceDto =
-                                eventsForOneReference.State
-                                |> Array.fold
-                                    (fun referenceDto referenceEvent ->
-                                        referenceDto
-                                        |> ReferenceDto.UpdateDto referenceEvent)
-                                    ReferenceDto.Default
+                        while index < eventsForAllReferences.Length do
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    "getReferencesBySha256Hash"
+                                    eventsForAllReferences[index].State
 
-                            if isNotDeletedReference referenceDto then references.Add(referenceDto))
+                            if isNotDeletedReference referenceDto then references.Add(referenceDto)
+
+                            index <- index + 1
 
                     if (indexMetrics.Length >= 2)
                        && (requestCharge.Length >= 2)
@@ -1424,19 +1531,19 @@ module Services =
                         requestCharge.Append($"{results.RequestCharge:F3}, ")
                         |> ignore
 
-                        let eventsForAllReferences = results.Resource
+                        let eventsForAllReferences = results.Resource |> Seq.toArray
+                        let mutable index = 0
 
-                        eventsForAllReferences
-                        |> Seq.iter (fun eventsForOneReference ->
-                            let referenceDto =
-                                eventsForOneReference.State
-                                |> Array.fold
-                                    (fun referenceDto referenceEvent ->
-                                        referenceDto
-                                        |> ReferenceDto.UpdateDto referenceEvent)
-                                    ReferenceDto.Default
+                        while index < eventsForAllReferences.Length do
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    correlationId
+                                    eventsForAllReferences[index].State
 
-                            references.Add(referenceDto))
+                            references.Add(referenceDto)
+
+                            index <- index + 1
 
                     //logToConsole
                     //    $"In Services.Actor.getReferences: BranchId: {branchId}; RepositoryId: {repositoryId}; Retrieved {references.Count} references.{Environment.NewLine}{printQueryDefinition queryDefinition}{Environment.NewLine}{serialize references}"
@@ -1613,19 +1720,19 @@ module Services =
                         requestCharge.Append($"{results.RequestCharge:F3}, ")
                         |> ignore
 
-                        let eventsForAllReferences = results.Resource
+                        let eventsForAllReferences = results.Resource |> Seq.toArray
+                        let mutable index = 0
 
-                        eventsForAllReferences
-                        |> Seq.iter (fun eventsForOneReference ->
-                            let referenceDto =
-                                eventsForOneReference.State
-                                |> Array.fold
-                                    (fun referenceDto referenceEvent ->
-                                        referenceDto
-                                        |> ReferenceDto.UpdateDto referenceEvent)
-                                    ReferenceDto.Default
+                        while index < eventsForAllReferences.Length do
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    correlationId
+                                    eventsForAllReferences[index].State
 
-                            references.Add(referenceDto))
+                            references.Add(referenceDto)
+
+                            index <- index + 1
 
                     if indexMetrics.Length >= 2
                        && requestCharge.Length >= 2
@@ -1697,9 +1804,11 @@ module Services =
 
                         while index < eventsForAllReferences.Length
                               && latestReference.IsNone do
-                            let referenceDto =
-                                eventsForAllReferences[index].State
-                                |> Array.fold (fun current referenceEvent -> current |> ReferenceDto.UpdateDto referenceEvent) ReferenceDto.Default
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    "getLatestReference"
+                                    eventsForAllReferences[index].State
 
                             if isNotDeletedReference referenceDto then latestReference <- Some referenceDto
 
@@ -1776,11 +1885,11 @@ module Services =
 
                                             while index < eventsForAllReferences.Length
                                                   && not foundForType do
-                                                let referenceDto =
-                                                    eventsForAllReferences[index].State
-                                                    |> Array.fold
-                                                        (fun current referenceEvent -> current |> ReferenceDto.UpdateDto referenceEvent)
-                                                        ReferenceDto.Default
+                                                let! referenceDto =
+                                                    projectReferenceEventsWithLegacyBlake3Hydration
+                                                        getRootDirectoryVersionByDirectoryVersionId
+                                                        "getLatestReferenceByReferenceTypes"
+                                                        eventsForAllReferences[index].State
 
                                                 if isNotDeletedReference referenceDto then
                                                     referenceDtos.TryAdd(referenceType, referenceDto)
@@ -1868,9 +1977,11 @@ module Services =
 
                         while index < eventsForAllReferences.Length
                               && latestReference.IsNone do
-                            let referenceDto =
-                                eventsForAllReferences[index].State
-                                |> Array.fold (fun current referenceEvent -> current |> ReferenceDto.UpdateDto referenceEvent) ReferenceDto.Default
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    "getLatestReferenceByType"
+                                    eventsForAllReferences[index].State
 
                             if isNotDeletedReference referenceDto then latestReference <- Some referenceDto
 
@@ -1938,9 +2049,11 @@ module Services =
 
                         while index < eventsForAllReferences.Length
                               && latestPromotion.IsNone do
-                            let referenceDto =
-                                eventsForAllReferences[index].State
-                                |> Array.fold (fun current referenceEvent -> current |> ReferenceDto.UpdateDto referenceEvent) ReferenceDto.Default
+                            let! referenceDto =
+                                projectReferenceEventsWithLegacyBlake3Hydration
+                                    getRootDirectoryVersionByDirectoryVersionId
+                                    "getLatestPromotion"
+                                    eventsForAllReferences[index].State
 
                             if isNotDeletedReference referenceDto
                                && hasPromotionSetTerminalLink referenceDto then
@@ -2452,19 +2565,18 @@ module Services =
                                 clientElapsedTime
                                 + results.Diagnostics.GetClientElapsedTime()
 
-                            let eventsForAllReferences = results.Resource
+                            let eventsForAllReferences = results.Resource |> Seq.toArray
+                            let mutable index = 0
 
-                            eventsForAllReferences
-                            |> Seq.iter (fun eventsForOneReference ->
-                                let referenceDto =
-                                    eventsForOneReference.State
-                                    |> Array.fold
-                                        (fun referenceDto referenceEvent ->
-                                            referenceDto
-                                            |> ReferenceDto.UpdateDto referenceEvent)
-                                        ReferenceDto.Default
+                            while index < eventsForAllReferences.Length do
+                                let! referenceDto =
+                                    projectReferenceEventsWithLegacyBlake3Hydration
+                                        getRootDirectoryVersionByDirectoryVersionId
+                                        correlationId
+                                        eventsForAllReferences[index].State
 
-                                queryResults.Add(referenceDto.ReferenceId, referenceDto))
+                                queryResults.Add(referenceDto.ReferenceId, referenceDto)
+                                index <- index + 1
 
                         // Add the results to the list in the same order as the supplied referenceIds.
                         referenceIds

--- a/src/Grace.Actors/Services.Actor.fs
+++ b/src/Grace.Actors/Services.Actor.fs
@@ -2248,14 +2248,18 @@ module Services =
                             SELECT TOP 1 c.State
                             FROM c
                             WHERE STARTSWITH(c.State[0].Event.created.Sha256Hash, @sha256Hash, true)
-                                AND STRINGEQUALS(c.State[0].Event.created.RelativePath, @relativePath, true)
+                                AND (
+                                    STRINGEQUALS(c.State[0].Event.created.RelativePath, @rootRelativePath, true)
+                                    OR STRINGEQUALS(c.State[0].Event.created.RelativePath, @slashRootRelativePath, true)
+                                )
                                 AND c.GrainType = @grainType
                                 AND c.PartitionKey = @partitionKey
                             ORDER BY c.State[0].Event.created.CreatedAt DESC
                             """
                         )
                             .WithParameter("@sha256Hash", sha256Hash)
-                            .WithParameter("@relativePath", Constants.RootDirectoryPath)
+                            .WithParameter("@rootRelativePath", Constants.RootDirectoryPath)
+                            .WithParameter("@slashRootRelativePath", RelativePath "/")
                             .WithParameter("@grainType", StateName.DirectoryVersion)
                             .WithParameter("@partitionKey", repositoryId)
 

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -206,6 +206,49 @@ module BranchServerTestHelpers =
             (List<FileVersion>([ fileVersion ]))
             fileVersion.Size
 
+    let private normalizedDirectorySizeForHash (directoryVersion: Grace.Types.Common.DirectoryVersion) =
+        if directoryVersion.Size = Constants.InitialDirectorySize then
+            0L
+        else
+            directoryVersion.Size
+
+    let private createDirectoryVersion
+        (directoryVersionId: DirectoryVersionId)
+        (repositoryId: string)
+        (relativePath: RelativePath)
+        (childDirectoryVersions: Grace.Types.Common.DirectoryVersion seq)
+        =
+        let childDirectoryVersions = childDirectoryVersions |> Seq.toArray
+
+        let childDirectoryIds =
+            childDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+
+        let entries =
+            childDirectoryVersions
+            |> Seq.map (fun directoryVersion ->
+                DirectoryVersionPreimageEntry.Directory
+                    directoryVersion.RelativePath
+                    (normalizedDirectorySizeForHash directoryVersion)
+                    directoryVersion.Blake3Hash
+                    directoryVersion.Sha256Hash)
+            |> Seq.toArray
+
+        let sha256Hash = computeSha256ForDirectoryEntries relativePath entries
+        let blake3Hash = computeBlake3ForDirectory relativePath entries
+
+        Grace.Types.Common.DirectoryVersion.CreateWithHashes
+            directoryVersionId
+            (Guid.Parse ownerId)
+            (Guid.Parse organizationId)
+            (Guid.Parse repositoryId)
+            relativePath
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>(childDirectoryIds))
+            (List<FileVersion>())
+            Constants.InitialDirectorySize
+
     let private gzipBytes (bytes: byte array) =
         use compressed = new MemoryStream()
         use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
@@ -248,6 +291,36 @@ module BranchServerTestHelpers =
 
             let! response = Client.PostAsync("/directory/saveDirectoryVersions", createJsonContent parameters)
             do! assertOk response
+        }
+
+    let saveDirectoryVersionsAsync repositoryId (directoryVersions: Grace.Types.Common.DirectoryVersion seq) =
+        task {
+            let parameters = Parameters.DirectoryVersion.SaveDirectoryVersionsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            for directoryVersion in directoryVersions do
+                parameters.DirectoryVersions.Add(directoryVersion)
+
+            let! response = Client.PostAsync("/directory/saveDirectoryVersions", createJsonContent parameters)
+            do! assertOk response
+        }
+
+    let saveReferenceResponseAsync repositoryId (branch: Branch.BranchDto) directoryVersionId sha256Hash =
+        task {
+            let parameters = Parameters.Branch.CreateReferenceParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.DirectoryVersionId <- directoryVersionId
+            parameters.Sha256Hash <- sha256Hash
+            parameters.Message <- "Root hash hydration route proof save"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! Client.PostAsync("/branch/save", createJsonContent parameters)
         }
 
     let private saveBranchReferenceAsync repositoryId (branch: Branch.BranchDto) (directoryVersion: Grace.Types.Common.DirectoryVersion) =
@@ -297,6 +370,22 @@ module BranchServerTestHelpers =
             finally
                 if Directory.Exists(tempRoot) then Directory.Delete(tempRoot, true)
         }
+
+    let createDotRootWithChildDirectoryVersions repositoryId childRelativePath =
+        let child = createDirectoryVersion (Guid.NewGuid()) repositoryId childRelativePath []
+        let root = createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath [ child ]
+        child, root
+
+    let shortestUniquePrefix (selected: Sha256Hash) (other: Sha256Hash) =
+        let selectedHash = string selected
+        let otherHash = string other
+        let mutable prefixLength = 2
+
+        while prefixLength < selectedHash.Length
+              && otherHash.StartsWith(selectedHash.Substring(0, prefixLength), StringComparison.OrdinalIgnoreCase) do
+            prefixLength <- prefixLength + 1
+
+        selectedHash.Substring(0, prefixLength)
 
     let createAnnotatableReferenceWithContentAsync repositoryId (branch: Branch.BranchDto) relativePath (content: string) =
         task {
@@ -509,6 +598,46 @@ type BranchServer() =
 
             do! BranchServerTestHelpers.assertMissingRepositoryAsync ()
             do! BranchServerTestHelpers.assertMissingBranchAsync repositoryId
+        }
+
+    [<Test>]
+    member _.SaveWithDirectoryVersionIdAndShaPrefixHydratesFullRootHashes() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"RootPrefix{Guid.NewGuid():N}"
+            let child, root = BranchServerTestHelpers.createDotRootWithChildDirectoryVersions repositoryId $"prefix/{Guid.NewGuid():N}"
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ child; root ]
+
+            let rootShaPrefix = (string root.Sha256Hash).Substring(0, 8)
+            let! response = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch root.DirectoryVersionId (Sha256Hash rootShaPrefix)
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseBody)
+
+            let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
+            Assert.That(savedBranch.LatestSave.DirectoryId, Is.EqualTo(root.DirectoryVersionId))
+            Assert.That(savedBranch.LatestSave.Sha256Hash, Is.EqualTo(root.Sha256Hash))
+            Assert.That(savedBranch.LatestSave.Blake3Hash, Is.EqualTo(root.Blake3Hash))
+        }
+
+    [<Test>]
+    member _.SaveWithShaOnlyChildDirectoryPrefixDoesNotCreateRootReference() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"ChildPrefix{Guid.NewGuid():N}"
+            let child, root = BranchServerTestHelpers.createDotRootWithChildDirectoryVersions repositoryId $"child-prefix/{Guid.NewGuid():N}"
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ child; root ]
+
+            let childOnlyPrefix = BranchServerTestHelpers.shortestUniquePrefix child.Sha256Hash root.Sha256Hash
+            let! response = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch DirectoryVersionId.Empty (Sha256Hash childOnlyPrefix)
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseBody)
+            Assert.That(responseBody, Does.Contain("Reference root DirectoryVersion does not exist."))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -185,7 +185,7 @@ module BranchServerTestHelpers =
 
     let private blake3Hex (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
 
-    let private createRootDirectoryVersion (repositoryId: string) (fileVersion: FileVersion) =
+    let createRootDirectoryVersion (repositoryId: string) (fileVersion: FileVersion) =
         let entries =
             [|
                 DirectoryVersionPreimageEntry.File fileVersion.RelativePath fileVersion.Size fileVersion.Blake3Hash fileVersion.Sha256Hash
@@ -323,6 +323,35 @@ module BranchServerTestHelpers =
             return! Client.PostAsync("/branch/save", createJsonContent parameters)
         }
 
+    let assignReferenceResponseAsync repositoryId (branch: Branch.BranchDto) directoryVersionId sha256Hash =
+        task {
+            let parameters = Parameters.Branch.AssignParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.DirectoryVersionId <- directoryVersionId
+            parameters.Sha256Hash <- sha256Hash
+            parameters.Message <- "Root hash hydration route proof assign"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! Client.PostAsync("/branch/assign", createJsonContent parameters)
+        }
+
+    let enableAssignAsync repositoryId (branch: Branch.BranchDto) =
+        task {
+            let parameters = Parameters.Branch.EnableFeatureParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.Enabled <- true
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/branch/enableAssign", createJsonContent parameters)
+            do! assertOk response
+        }
+
     let private saveBranchReferenceAsync repositoryId (branch: Branch.BranchDto) (directoryVersion: Grace.Types.Common.DirectoryVersion) =
         task {
             let parameters = Parameters.Branch.CreateReferenceParameters()
@@ -375,6 +404,40 @@ module BranchServerTestHelpers =
         let child = createDirectoryVersion (Guid.NewGuid()) repositoryId childRelativePath []
         let root = createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath [ child ]
         child, root
+
+    let createSlashRootDirectoryVersion repositoryId = createDirectoryVersion (Guid.NewGuid()) repositoryId (RelativePath "/") []
+
+    let createDotRootWithChildShaPrefixCollision repositoryId childBasePath excludedRootHashes =
+        let mutable collision = None
+        let mutable attempt = 0
+        let prefixLength = 3
+
+        while collision.IsNone && attempt < 32768 do
+            let child, root = createDotRootWithChildDirectoryVersions repositoryId $"{childBasePath}/{attempt}"
+
+            let rootPrefix =
+                (string root.Sha256Hash)
+                    .Substring(0, prefixLength)
+
+            let excludedRootMatches =
+                excludedRootHashes
+                |> Seq.exists (fun excludedHash ->
+                    (string excludedHash)
+                        .StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+
+            if not excludedRootMatches
+               && (string child.Sha256Hash)
+                   .StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase) then
+                child.CreatedAt <- getCurrentInstant ()
+                collision <- Some(child, root, rootPrefix)
+
+            attempt <- attempt + 1
+
+        match collision with
+        | Some collision -> collision
+        | None ->
+            Assert.Fail("Could not generate a root/child SHA prefix collision for the assign regression test.")
+            Unchecked.defaultof<Grace.Types.Common.DirectoryVersion * Grace.Types.Common.DirectoryVersion * string>
 
     let shortestUniquePrefix (selected: Sha256Hash) (other: Sha256Hash) =
         let selectedHash = string selected
@@ -620,6 +683,55 @@ type BranchServer() =
             Assert.That(savedBranch.LatestSave.DirectoryId, Is.EqualTo(root.DirectoryVersionId))
             Assert.That(savedBranch.LatestSave.Sha256Hash, Is.EqualTo(root.Sha256Hash))
             Assert.That(savedBranch.LatestSave.Blake3Hash, Is.EqualTo(root.Blake3Hash))
+        }
+
+    [<Test>]
+    member _.SaveWithShaOnlySlashRootHydratesFullRootHashes() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"SlashRoot{Guid.NewGuid():N}"
+
+            let root = BranchServerTestHelpers.createSlashRootDirectoryVersion repositoryId
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ root ]
+
+            let! response = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch DirectoryVersionId.Empty root.Sha256Hash
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseBody)
+
+            let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
+            Assert.That(savedBranch.LatestSave.DirectoryId, Is.EqualTo(root.DirectoryVersionId))
+            Assert.That(savedBranch.LatestSave.Sha256Hash, Is.EqualTo(root.Sha256Hash))
+            Assert.That(savedBranch.LatestSave.Blake3Hash, Is.EqualTo(root.Blake3Hash))
+        }
+
+    [<Test>]
+    member _.AssignWithShaOnlyRootPrefixIgnoresNewerChildDirectoryMatch() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"AssignRootPrefix{Guid.NewGuid():N}"
+
+            let child, root, sharedPrefix =
+                BranchServerTestHelpers.createDotRootWithChildShaPrefixCollision
+                    repositoryId
+                    $"assign-prefix/{Guid.NewGuid():N}"
+                    [ parentBranch.BasedOn.Sha256Hash ]
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ root; child ]
+            do! BranchServerTestHelpers.enableAssignAsync repositoryId branch
+
+            let! response = BranchServerTestHelpers.assignReferenceResponseAsync repositoryId branch DirectoryVersionId.Empty (Sha256Hash sharedPrefix)
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseBody)
+
+            let! assignedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
+            Assert.That(assignedBranch.LatestPromotion.DirectoryId, Is.EqualTo(root.DirectoryVersionId))
+            Assert.That(assignedBranch.LatestPromotion.Sha256Hash, Is.EqualTo(root.Sha256Hash))
+            Assert.That(assignedBranch.LatestPromotion.Blake3Hash, Is.EqualTo(root.Blake3Hash))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -641,6 +641,24 @@ type BranchServer() =
         }
 
     [<Test>]
+    member _.SaveWithChildDirectoryVersionIdAndShaPrefixDoesNotCreateRootReference() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"ChildIdPrefix{Guid.NewGuid():N}"
+            let child, root = BranchServerTestHelpers.createDotRootWithChildDirectoryVersions repositoryId $"child-id-prefix/{Guid.NewGuid():N}"
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ child; root ]
+
+            let childShaPrefix = (string child.Sha256Hash).Substring(0, 8)
+            let! response = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch child.DirectoryVersionId (Sha256Hash childShaPrefix)
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseBody)
+            Assert.That(responseBody, Does.Contain("Reference root DirectoryVersion must use the repository root path."))
+        }
+
+    [<Test>]
     member _.AnnotateRouteAndSdkReturnEnvelopeForServerKnownReference() =
         task {
             let repositoryId = repositoryIds[0]

--- a/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
@@ -137,6 +137,7 @@ module private EventingIntegrationHelpers =
                         branchId,
                         Guid.NewGuid(),
                         Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
                         referenceType,
                         $"{referenceType}-reference",
                         Seq.empty

--- a/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
@@ -48,6 +48,7 @@ type AutomationEventingTests() =
                         branchId,
                         Guid.NewGuid(),
                         Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
                         ReferenceType.Promotion,
                         "promotion",
                         [
@@ -104,6 +105,7 @@ type AutomationEventingTests() =
                         Guid.NewGuid(),
                         Guid.NewGuid(),
                         Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
                         ReferenceType.Promotion,
                         "promotion",
                         [

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
+    <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -153,3 +153,93 @@ type ReferenceActorHashValidationTests() =
             Assert.That(repairedDto.Sha256Hash, Is.EqualTo(sha256Hash))
             Assert.That(repairedDto.Blake3Hash, Is.EqualTo(blake3Hash))
         }
+
+    [<Test>]
+    member _.LegacyCreatedEventWithEmptyBlake3HydratesFromRootShaPrefix() =
+        task {
+            let referenceId = Guid.Parse("77777777-bbbb-4444-8888-777777777777")
+            let branchId = Guid.Parse("88888888-bbbb-4444-8888-888888888888")
+            let fullSha256Hash = Sha256Hash "abcdef0123456789"
+            let prefixSha256Hash = Sha256Hash "abcdef"
+            let directoryVersion = directoryVersionWithHashes fullSha256Hash blake3Hash
+
+            let legacyCreatedEvent =
+                {
+                    Event =
+                        ReferenceEventType.Created(
+                            referenceId,
+                            ownerId,
+                            organizationId,
+                            repositoryId,
+                            branchId,
+                            directoryVersionId,
+                            prefixSha256Hash,
+                            Blake3Hash String.Empty,
+                            ReferenceType.Commit,
+                            ReferenceText "legacy prefix commit",
+                            Seq.empty
+                        )
+                    Metadata =
+                        {
+                            Timestamp = getCurrentInstant ()
+                            CorrelationId = correlationId
+                            Principal = "legacy-prefix-replay-test"
+                            ClientType = None
+                            Properties = Dictionary<string, string>()
+                        }
+                }
+
+            let getDirectoryVersion _ _ _ = Task.FromResult directoryVersion
+
+            let! repairedEvent, wasRepaired = repairLegacyCreatedEventBlake3 getDirectoryVersion legacyCreatedEvent
+            Assert.That(wasRepaired, Is.True)
+
+            let repairedDto = ReferenceDto.UpdateDto repairedEvent ReferenceDto.Default
+            Assert.That(repairedDto.Sha256Hash, Is.EqualTo(fullSha256Hash))
+            Assert.That(repairedDto.Blake3Hash, Is.EqualTo(blake3Hash))
+        }
+
+    [<Test>]
+    member _.LegacyCreatedEventWithEmptyBlake3DoesNotHydrateFromNonRootOrWrongShaPrefix() =
+        task {
+            let referenceId = Guid.Parse("99999999-bbbb-4444-8888-999999999999")
+            let branchId = Guid.Parse("aaaaaaaa-bbbb-4444-8888-aaaaaaaaaaaa")
+            let fullSha256Hash = Sha256Hash "abcdef0123456789"
+
+            let createEvent storedSha256Hash =
+                {
+                    Event =
+                        ReferenceEventType.Created(
+                            referenceId,
+                            ownerId,
+                            organizationId,
+                            repositoryId,
+                            branchId,
+                            directoryVersionId,
+                            storedSha256Hash,
+                            Blake3Hash String.Empty,
+                            ReferenceType.Commit,
+                            ReferenceText "legacy mismatch commit",
+                            Seq.empty
+                        )
+                    Metadata =
+                        {
+                            Timestamp = getCurrentInstant ()
+                            CorrelationId = correlationId
+                            Principal = "legacy-mismatch-replay-test"
+                            ClientType = None
+                            Properties = Dictionary<string, string>()
+                        }
+                }
+
+            let nonRootDirectoryVersion = childDirectoryVersionWithHashes fullSha256Hash blake3Hash
+            let getNonRootDirectoryVersion _ _ _ = Task.FromResult nonRootDirectoryVersion
+            let! _, nonRootWasRepaired = repairLegacyCreatedEventBlake3 getNonRootDirectoryVersion (createEvent (Sha256Hash "abcdef"))
+
+            let rootDirectoryVersion = directoryVersionWithHashes fullSha256Hash blake3Hash
+            let getRootDirectoryVersion _ _ _ = Task.FromResult rootDirectoryVersion
+            let! _, wrongPrefixWasRepaired = repairLegacyCreatedEventBlake3 getRootDirectoryVersion (createEvent (Sha256Hash "123456"))
+
+            Assert.That(nonRootWasRepaired, Is.False)
+            Assert.That(wrongPrefixWasRepaired, Is.False)
+        }

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -2,10 +2,13 @@ namespace Grace.Server.Unit.Tests
 
 open Grace.Actors.Reference
 open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.Common
+open Grace.Types.Reference
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Threading.Tasks
 
 [<Parallelizable(ParallelScope.All)>]
 type ReferenceActorHashValidationTests() =
@@ -69,3 +72,50 @@ type ReferenceActorHashValidationTests() =
             Assert.That(shaError.Error, Does.Contain("Sha256Hash does not match"))
             Assert.That(blakeError.Error, Does.Contain("Blake3Hash does not match"))
         | _ -> Assert.Fail("Expected both mismatched hash validations to fail.")
+
+    [<Test>]
+    member _.LegacyCreatedEventWithEmptyBlake3HydratesFromMatchingRootDirectoryVersion() =
+        task {
+            let referenceId = Guid.Parse("55555555-bbbb-4444-8888-555555555555")
+            let branchId = Guid.Parse("66666666-bbbb-4444-8888-666666666666")
+            let directoryVersion = directoryVersionWithHashes sha256Hash blake3Hash
+
+            let legacyCreatedEvent =
+                {
+                    Event =
+                        ReferenceEventType.Created(
+                            referenceId,
+                            ownerId,
+                            organizationId,
+                            repositoryId,
+                            branchId,
+                            directoryVersionId,
+                            sha256Hash,
+                            Blake3Hash String.Empty,
+                            ReferenceType.Commit,
+                            ReferenceText "legacy commit",
+                            Seq.empty
+                        )
+                    Metadata =
+                        {
+                            Timestamp = getCurrentInstant ()
+                            CorrelationId = correlationId
+                            Principal = "legacy-replay-test"
+                            ClientType = None
+                            Properties = Dictionary<string, string>()
+                        }
+                }
+
+            let getDirectoryVersion (requestedRepositoryId: RepositoryId) (requestedDirectoryId: DirectoryVersionId) (requestedCorrelationId: CorrelationId) =
+                Assert.That(requestedRepositoryId, Is.EqualTo(repositoryId))
+                Assert.That(requestedDirectoryId, Is.EqualTo(directoryVersionId))
+                Assert.That(requestedCorrelationId, Is.EqualTo(correlationId))
+                Task.FromResult directoryVersion
+
+            let! repairedEvent, wasRepaired = repairLegacyCreatedEventBlake3 getDirectoryVersion legacyCreatedEvent
+            Assert.That(wasRepaired, Is.True)
+
+            let repairedDto = ReferenceDto.UpdateDto repairedEvent ReferenceDto.Default
+            Assert.That(repairedDto.Sha256Hash, Is.EqualTo(sha256Hash))
+            Assert.That(repairedDto.Blake3Hash, Is.EqualTo(blake3Hash))
+        }

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -34,6 +34,19 @@ type ReferenceActorHashValidationTests() =
             (List<FileVersion>())
             0L
 
+    let childDirectoryVersionWithHashes sha blake3 =
+        DirectoryVersion.CreateWithHashes
+            directoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            (RelativePath $"child/{Guid.NewGuid():N}")
+            sha
+            blake3
+            (List<DirectoryVersionId>())
+            (List<FileVersion>())
+            0L
+
     [<Test>]
     member _.MissingRootBlake3FailsBeforeReferenceCreation() =
         let directoryVersion = directoryVersionWithHashes sha256Hash (Blake3Hash String.Empty)
@@ -56,6 +69,27 @@ type ReferenceActorHashValidationTests() =
         match result with
         | Ok _ -> Assert.Fail("Expected empty command Blake3Hash to fail.")
         | Error error -> Assert.That(error.Error, Does.Contain("command must include"))
+
+    [<Test>]
+    member _.LegacyRootDirectoryVersionWithEmptyBlake3AllowsEmptyCommandBlake3() =
+        let directoryVersion = directoryVersionWithHashes sha256Hash (Blake3Hash String.Empty)
+
+        let result =
+            validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId sha256Hash (Blake3Hash String.Empty) directoryVersion
+
+        match result with
+        | Ok _ -> ()
+        | Error error -> Assert.Fail($"Expected legacy empty Blake3Hash root to be tolerated, but got {error.Error}.")
+
+    [<Test>]
+    member _.NonRootDirectoryVersionFailsBeforeReferenceCreation() =
+        let directoryVersion = childDirectoryVersionWithHashes sha256Hash blake3Hash
+
+        let result = validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId sha256Hash blake3Hash directoryVersion
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected non-root DirectoryVersion to fail.")
+        | Error error -> Assert.That(error.Error, Does.Contain("repository root path"))
 
     [<Test>]
     member _.MismatchedRootHashesFailBeforeReferenceCreation() =

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -1,0 +1,71 @@
+namespace Grace.Server.Unit.Tests
+
+open Grace.Actors.Reference
+open Grace.Shared
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+[<Parallelizable(ParallelScope.All)>]
+type ReferenceActorHashValidationTests() =
+
+    let correlationId = "reference-root-hash-validation-tests"
+    let ownerId = Guid.Parse("11111111-bbbb-4444-8888-111111111111")
+    let organizationId = Guid.Parse("22222222-bbbb-4444-8888-222222222222")
+    let repositoryId = Guid.Parse("33333333-bbbb-4444-8888-333333333333")
+    let directoryVersionId = Guid.Parse("44444444-bbbb-4444-8888-444444444444")
+    let sha256Hash = Sha256Hash "root-sha256"
+    let blake3Hash = Blake3Hash "root-blake3"
+
+    let directoryVersionWithHashes sha blake3 =
+        DirectoryVersion.CreateWithHashes
+            directoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            (RelativePath ".")
+            sha
+            blake3
+            (List<DirectoryVersionId>())
+            (List<FileVersion>())
+            0L
+
+    [<Test>]
+    member _.MissingRootBlake3FailsBeforeReferenceCreation() =
+        let directoryVersion = directoryVersionWithHashes sha256Hash (Blake3Hash String.Empty)
+
+        let result = validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId sha256Hash blake3Hash directoryVersion
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected missing root Blake3Hash to fail.")
+        | Error error ->
+            Assert.That(error.Error, Does.Contain("must include Blake3Hash"))
+            Assert.That(error.Properties[nameof DirectoryVersionId], Is.EqualTo(string directoryVersionId))
+
+    [<Test>]
+    member _.EmptyCommandBlake3FailsBeforeReferenceCreation() =
+        let directoryVersion = directoryVersionWithHashes sha256Hash blake3Hash
+
+        let result =
+            validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId sha256Hash (Blake3Hash String.Empty) directoryVersion
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected empty command Blake3Hash to fail.")
+        | Error error -> Assert.That(error.Error, Does.Contain("command must include"))
+
+    [<Test>]
+    member _.MismatchedRootHashesFailBeforeReferenceCreation() =
+        let directoryVersion = directoryVersionWithHashes sha256Hash blake3Hash
+
+        let shaResult =
+            validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId (Sha256Hash "wrong-sha") blake3Hash directoryVersion
+
+        let blakeResult =
+            validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryVersionId sha256Hash (Blake3Hash "wrong-blake3") directoryVersion
+
+        match shaResult, blakeResult with
+        | Error shaError, Error blakeError ->
+            Assert.That(shaError.Error, Does.Contain("Sha256Hash does not match"))
+            Assert.That(blakeError.Error, Does.Contain("Blake3Hash does not match"))
+        | _ -> Assert.Fail("Expected both mismatched hash validations to fail.")

--- a/src/Grace.Server.Unit.Tests/Services.EffectivePromotion.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Services.EffectivePromotion.Tests.fs
@@ -1,11 +1,15 @@
 namespace Grace.Server.Tests
 
 open Grace.Actors
+open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.Reference
 open Grace.Types.Common
 open NodaTime
 open NUnit.Framework
 open System
+open System.Collections.Generic
+open System.Threading.Tasks
 
 [<Parallelizable(ParallelScope.All)>]
 type ServicesEffectivePromotionTests() =
@@ -29,6 +33,69 @@ type ServicesEffectivePromotionTests() =
             CreatedAt = createdAt
             Links = links
             DeletedAt = if isDeleted then Some(createdAt + Duration.FromMinutes(1.0)) else Option.None
+        }
+
+    let ownerId = Guid.Parse("11111111-cccc-4444-8888-111111111111")
+    let organizationId = Guid.Parse("22222222-cccc-4444-8888-222222222222")
+    let repositoryId = Guid.Parse("33333333-cccc-4444-8888-333333333333")
+    let branchId = Guid.Parse("44444444-cccc-4444-8888-444444444444")
+    let directoryVersionId = Guid.Parse("55555555-cccc-4444-8888-555555555555")
+    let referenceId = Guid.Parse("66666666-cccc-4444-8888-666666666666")
+    let fullSha256Hash = Sha256Hash "abcdef0123456789"
+    let prefixSha256Hash = Sha256Hash "abcdef"
+    let blake3Hash = Blake3Hash "root-blake3"
+    let correlationId = "services-reference-projection-tests"
+
+    let rootDirectoryVersionWithHashes sha256Hash blake3Hash =
+        DirectoryVersion.CreateWithHashes
+            directoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            (RelativePath ".")
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>())
+            (List<FileVersion>())
+            0L
+
+    let childDirectoryVersionWithHashes sha256Hash blake3Hash =
+        DirectoryVersion.CreateWithHashes
+            directoryVersionId
+            ownerId
+            organizationId
+            repositoryId
+            (RelativePath "child")
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>())
+            (List<FileVersion>())
+            0L
+
+    let legacyCreatedReferenceEvent storedSha256Hash =
+        {
+            Event =
+                ReferenceEventType.Created(
+                    referenceId,
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    branchId,
+                    directoryVersionId,
+                    storedSha256Hash,
+                    Blake3Hash String.Empty,
+                    ReferenceType.Commit,
+                    ReferenceText "legacy projection commit",
+                    Seq.empty
+                )
+            Metadata =
+                {
+                    Timestamp = Instant.FromUtc(2026, 6, 11, 9, 0)
+                    CorrelationId = correlationId
+                    Principal = "services-projection-test"
+                    ClientType = Option.None
+                    Properties = Dictionary<string, string>()
+                }
         }
 
     [<Test>]
@@ -68,3 +135,57 @@ type ServicesEffectivePromotionTests() =
         let selected = Services.tryGetLatestNotDeletedReference ([ deletedLatest; previousActive ])
 
         Assert.That(selected, Is.EqualTo(Some previousActive))
+
+    [<Test>]
+    member _.DirectReferenceProjectionHydratesLegacyEmptyBlake3FromRootShaPrefix() =
+        task {
+            let rootDirectoryVersion = rootDirectoryVersionWithHashes fullSha256Hash blake3Hash
+
+            let getDirectoryVersion
+                (requestedRepositoryId: RepositoryId)
+                (requestedDirectoryVersionId: DirectoryVersionId)
+                (requestedCorrelationId: CorrelationId)
+                =
+                Assert.That(requestedRepositoryId, Is.EqualTo(repositoryId))
+                Assert.That(requestedDirectoryVersionId, Is.EqualTo(directoryVersionId))
+                Assert.That(requestedCorrelationId, Is.EqualTo(correlationId))
+                Task.FromResult(Some rootDirectoryVersion)
+
+            let! referenceDto =
+                Services.projectReferenceEventsWithLegacyBlake3Hydration
+                    getDirectoryVersion
+                    correlationId
+                    [|
+                        legacyCreatedReferenceEvent prefixSha256Hash
+                    |]
+
+            Assert.That(referenceDto.Sha256Hash, Is.EqualTo(fullSha256Hash))
+            Assert.That(referenceDto.Blake3Hash, Is.EqualTo(blake3Hash))
+        }
+
+    [<Test>]
+    member _.DirectReferenceProjectionLeavesLegacyEmptyBlake3ForNonRootOrWrongShaPrefix() =
+        task {
+            let getChildDirectoryVersion _ _ _ = Task.FromResult(Some(childDirectoryVersionWithHashes fullSha256Hash blake3Hash))
+
+            let! nonRootReferenceDto =
+                Services.projectReferenceEventsWithLegacyBlake3Hydration
+                    getChildDirectoryVersion
+                    correlationId
+                    [|
+                        legacyCreatedReferenceEvent prefixSha256Hash
+                    |]
+
+            let getRootDirectoryVersion _ _ _ = Task.FromResult(Some(rootDirectoryVersionWithHashes fullSha256Hash blake3Hash))
+
+            let! wrongPrefixReferenceDto =
+                Services.projectReferenceEventsWithLegacyBlake3Hydration
+                    getRootDirectoryVersion
+                    correlationId
+                    [|
+                        legacyCreatedReferenceEvent (Sha256Hash "123456")
+                    |]
+
+            Assert.That(nonRootReferenceDto.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+            Assert.That(wrongPrefixReferenceDto.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
+        }

--- a/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
@@ -289,6 +289,7 @@ type WebhookDispatchUnitTests() =
                             otherBranchId,
                             Guid.NewGuid(),
                             Sha256Hash String.Empty,
+                            Blake3Hash String.Empty,
                             ReferenceType.Promotion,
                             "promotion",
                             [

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -578,7 +578,8 @@ module Branch =
                 if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
                     return None
                 elif directoryVersion.RelativePath
-                     <> Constants.RootDirectoryPath then
+                     <> Constants.RootDirectoryPath
+                     && directoryVersion.RelativePath <> "/" then
                     return None
                 elif
                     not (String.IsNullOrEmpty requestedSha256Hash)

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -577,6 +577,9 @@ module Branch =
 
                 if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
                     return None
+                elif directoryVersion.RelativePath
+                     <> Constants.RootDirectoryPath then
+                    return None
                 elif
                     not (String.IsNullOrEmpty requestedSha256Hash)
                     && not (

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -830,7 +830,8 @@ module Branch =
                                     )
                                 )
                         elif not <| String.IsNullOrEmpty(parameters.Sha256Hash) then
-                            match! getDirectoryVersionBySha256Hash (Guid.Parse(graceIds.RepositoryIdString)) parameters.Sha256Hash parameters.CorrelationId with
+                            match! getRootDirectoryVersionBySha256Hash (Guid.Parse(graceIds.RepositoryIdString)) parameters.Sha256Hash parameters.CorrelationId
+                                with
                             | Some directoryVersion ->
                                 return
                                     Some(

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -573,18 +573,22 @@ module Branch =
                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
                 let! directoryVersionDto = directoryVersionActorProxy.Get correlationId
                 let directoryVersion = directoryVersionDto.DirectoryVersion
+                let requestedSha256Hash = string sha256Hash
 
                 if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
                     return None
                 elif
-                    not (String.IsNullOrEmpty(string sha256Hash))
-                    && directoryVersion.Sha256Hash <> sha256Hash
+                    not (String.IsNullOrEmpty requestedSha256Hash)
+                    && not (
+                        (string directoryVersion.Sha256Hash)
+                            .StartsWith(requestedSha256Hash, StringComparison.OrdinalIgnoreCase)
+                    )
                 then
                     return None
                 else
                     return Some directoryVersion
             elif not (String.IsNullOrEmpty(string sha256Hash)) then
-                return! getDirectoryVersionBySha256Hash repositoryId sha256Hash correlationId
+                return! getRootDirectoryVersionBySha256Hash repositoryId sha256Hash correlationId
             else
                 return None
         }

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -567,6 +567,43 @@ module Branch =
                 return! context |> result500ServerError graceError
         }
 
+    let private tryResolveRootDirectoryVersionForReferenceCommand repositoryId directoryVersionId sha256Hash correlationId =
+        task {
+            if directoryVersionId <> DirectoryVersionId.Empty then
+                let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
+                let! directoryVersionDto = directoryVersionActorProxy.Get correlationId
+                let directoryVersion = directoryVersionDto.DirectoryVersion
+
+                if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
+                    return None
+                elif
+                    not (String.IsNullOrEmpty(string sha256Hash))
+                    && directoryVersion.Sha256Hash <> sha256Hash
+                then
+                    return None
+                else
+                    return Some directoryVersion
+            elif not (String.IsNullOrEmpty(string sha256Hash)) then
+                return! getDirectoryVersionBySha256Hash repositoryId sha256Hash correlationId
+            else
+                return None
+        }
+
+    let private referenceCommandFromRoot
+        (createCommand: DirectoryVersionId * Sha256Hash * Blake3Hash * ReferenceText -> BranchCommand)
+        repositoryId
+        directoryVersionId
+        sha256Hash
+        referenceText
+        correlationId
+        =
+        task {
+            match! tryResolveRootDirectoryVersionForReferenceCommand repositoryId directoryVersionId sha256Hash correlationId with
+            | Some directoryVersion ->
+                return createCommand (directoryVersion.DirectoryVersionId, directoryVersion.Sha256Hash, directoryVersion.Blake3Hash, referenceText)
+            | None -> return createCommand (directoryVersionId, sha256Hash, Blake3Hash String.Empty, referenceText)
+        }
+
     let processQuery<'T, 'U when 'T :> BranchParameters>
         (context: HttpContext)
         (parameters: 'T)
@@ -776,11 +813,26 @@ module Branch =
                             let! directoryVersionDto = directoryVersionActorProxy.Get(parameters.CorrelationId)
 
                             return
-                                Some(Assign(parameters.DirectoryVersionId, directoryVersionDto.DirectoryVersion.Sha256Hash, ReferenceText parameters.Message))
+                                Some(
+                                    Assign(
+                                        parameters.DirectoryVersionId,
+                                        directoryVersionDto.DirectoryVersion.Sha256Hash,
+                                        directoryVersionDto.DirectoryVersion.Blake3Hash,
+                                        ReferenceText parameters.Message
+                                    )
+                                )
                         elif not <| String.IsNullOrEmpty(parameters.Sha256Hash) then
                             match! getDirectoryVersionBySha256Hash (Guid.Parse(graceIds.RepositoryIdString)) parameters.Sha256Hash parameters.CorrelationId with
                             | Some directoryVersion ->
-                                return Some(Assign(directoryVersion.DirectoryVersionId, directoryVersion.Sha256Hash, ReferenceText parameters.Message))
+                                return
+                                    Some(
+                                        Assign(
+                                            directoryVersion.DirectoryVersionId,
+                                            directoryVersion.Sha256Hash,
+                                            directoryVersion.Blake3Hash,
+                                            ReferenceText parameters.Message
+                                        )
+                                    )
                             | None -> return None
                         else
                             return None
@@ -826,8 +878,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    Promote(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        Promote
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Promote)
                 return! processCommand context validations command
@@ -856,8 +914,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    BranchCommand.Commit(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        BranchCommand.Commit
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Commit)
                 return! processCommand context validations command
@@ -885,8 +949,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    BranchCommand.Checkpoint(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        BranchCommand.Checkpoint
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Checkpoint)
                 return! processCommand context validations command
@@ -916,8 +986,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    BranchCommand.Save(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        BranchCommand.Save
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Save)
                 return! processCommand context validations command
@@ -945,8 +1021,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    BranchCommand.Tag(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        BranchCommand.Tag
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Tag)
                 return! processCommand context validations command
@@ -974,8 +1056,14 @@ module Branch =
                     |]
 
                 let command (parameters: CreateReferenceParameters) =
-                    BranchCommand.CreateExternal(parameters.DirectoryVersionId, parameters.Sha256Hash, ReferenceText parameters.Message)
-                    |> returnValueTask
+                    referenceCommandFromRoot
+                        BranchCommand.CreateExternal
+                        graceIds.RepositoryId
+                        parameters.DirectoryVersionId
+                        parameters.Sha256Hash
+                        (ReferenceText parameters.Message)
+                        parameters.CorrelationId
+                    |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof CreateExternal)
                 return! processCommand context validations command

--- a/src/Grace.Server/DerivedComputation.Server.fs
+++ b/src/Grace.Server/DerivedComputation.Server.fs
@@ -37,6 +37,7 @@ module DerivedComputation =
                                           branchId,
                                           directoryId,
                                           sha256Hash,
+                                          blake3Hash,
                                           referenceType,
                                           referenceText,
                                           links) ->

--- a/src/Grace.Server/Eventing.Server.fs
+++ b/src/Grace.Server/Eventing.Server.fs
@@ -179,7 +179,7 @@ module EventingPublisher =
             |> Some
         | ReferenceEvent referenceEvent ->
             match referenceEvent.Event with
-            | ReferenceEventType.Created (referenceId, ownerId, organizationId, repositoryId, branchId, _, _, referenceType, _, links) ->
+            | ReferenceEventType.Created (referenceId, ownerId, organizationId, repositoryId, branchId, _, _, _, referenceType, _, links) ->
                 if referenceType = ReferenceType.Promotion then
                     match tryGetTerminalPromotionSetId links with
                     | Some promotionSetId ->

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -469,7 +469,9 @@ module Notification =
                     | _ -> return None
                 | ReferenceEvent referenceEvent ->
                     match referenceEvent.Event with
-                    | ReferenceEventType.Created (_, _, _, repositoryId, branchId, _, _, referenceType, _, links) when referenceType = ReferenceType.Promotion ->
+                    | ReferenceEventType.Created (_, _, _, repositoryId, branchId, _, _, _, referenceType, _, links) when
+                        referenceType = ReferenceType.Promotion
+                        ->
                         match tryGetTerminalPromotionSetId links with
                         | Some promotionSetId ->
                             let! branchDto = getBranchDto branchId repositoryId correlationId
@@ -675,6 +677,7 @@ module Notification =
                                                   branchId,
                                                   directoryId,
                                                   sha256Hash,
+                                                  blake3Hash,
                                                   referenceType,
                                                   referenceText,
                                                   links) ->

--- a/src/Grace.Types.Tests/Branch.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Branch.Types.Tests.fs
@@ -1,0 +1,127 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared
+open Grace.Types.Branch
+open Grace.Types.Common
+open Grace.Types.Reference
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+[<Parallelizable(ParallelScope.All)>]
+type BranchDtoHashTests() =
+
+    let timestamp = Instant.FromUtc(2026, 6, 11, 9, 0)
+    let branchId = Guid.Parse("11111111-aaaa-4444-8888-111111111111")
+    let directoryVersionId = Guid.Parse("22222222-aaaa-4444-8888-222222222222")
+    let referenceId = Guid.Parse("33333333-aaaa-4444-8888-333333333333")
+    let sha256Hash = Sha256Hash "root-sha256"
+    let blake3Hash = Blake3Hash "root-blake3"
+    let referenceText = ReferenceText "root reference"
+
+    let metadata =
+        {
+            Timestamp = timestamp
+            CorrelationId = "branch-root-hash-tests"
+            Principal = "alice@example.test"
+            ClientType = Option.None
+            Properties = Dictionary<string, string>()
+        }
+
+    let referenceDto referenceType =
+        { ReferenceDto.Default with
+            ReferenceId = referenceId
+            BranchId = branchId
+            DirectoryId = directoryVersionId
+            Sha256Hash = sha256Hash
+            Blake3Hash = blake3Hash
+            ReferenceType = referenceType
+            ReferenceText = referenceText
+            CreatedAt = timestamp
+        }
+
+    let branchEvent (eventType: BranchEventType) : BranchEvent = { Event = eventType; Metadata = metadata }
+
+    [<Test>]
+    member _.ReferenceProducingCommandsCarryBothRootHashes() =
+        let commands =
+            [
+                BranchCommand.Assign(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.Promote(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.Commit(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.Checkpoint(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.Save(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.Tag(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchCommand.CreateExternal(directoryVersionId, sha256Hash, blake3Hash, referenceText)
+            ]
+
+        for command in commands do
+            match command with
+            | BranchCommand.Assign (directoryId, sha, blake3, text)
+            | BranchCommand.Promote (directoryId, sha, blake3, text)
+            | BranchCommand.Commit (directoryId, sha, blake3, text)
+            | BranchCommand.Checkpoint (directoryId, sha, blake3, text)
+            | BranchCommand.Save (directoryId, sha, blake3, text)
+            | BranchCommand.Tag (directoryId, sha, blake3, text)
+            | BranchCommand.CreateExternal (directoryId, sha, blake3, text) ->
+                Assert.That(directoryId, Is.EqualTo(directoryVersionId))
+                Assert.That(sha, Is.EqualTo(sha256Hash))
+                Assert.That(blake3, Is.EqualTo(blake3Hash))
+                Assert.That(text, Is.EqualTo(referenceText))
+            | _ -> Assert.Fail($"Unexpected command case: {command}")
+
+    [<Test>]
+    member _.ReferenceProducingEventsCarryBothRootHashes() =
+        let promotionReference = referenceDto ReferenceType.Promotion
+        let commitReference = referenceDto ReferenceType.Commit
+        let checkpointReference = referenceDto ReferenceType.Checkpoint
+        let saveReference = referenceDto ReferenceType.Save
+        let tagReference = referenceDto ReferenceType.Tag
+        let externalReference = referenceDto ReferenceType.External
+
+        let events =
+            [
+                BranchEventType.Assigned(promotionReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.Promoted(promotionReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.Committed(commitReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.Checkpointed(checkpointReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.Saved(saveReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.Tagged(tagReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+                BranchEventType.ExternalCreated(externalReference, directoryVersionId, sha256Hash, blake3Hash, referenceText)
+            ]
+
+        for event in events do
+            match event with
+            | BranchEventType.Assigned (reference, directoryId, sha, blake3, text)
+            | BranchEventType.Promoted (reference, directoryId, sha, blake3, text)
+            | BranchEventType.Committed (reference, directoryId, sha, blake3, text)
+            | BranchEventType.Checkpointed (reference, directoryId, sha, blake3, text)
+            | BranchEventType.Saved (reference, directoryId, sha, blake3, text)
+            | BranchEventType.Tagged (reference, directoryId, sha, blake3, text)
+            | BranchEventType.ExternalCreated (reference, directoryId, sha, blake3, text) ->
+                Assert.That(reference.Sha256Hash, Is.EqualTo(sha256Hash))
+                Assert.That(reference.Blake3Hash, Is.EqualTo(blake3Hash))
+                Assert.That(directoryId, Is.EqualTo(directoryVersionId))
+                Assert.That(sha, Is.EqualTo(sha256Hash))
+                Assert.That(blake3, Is.EqualTo(blake3Hash))
+                Assert.That(text, Is.EqualTo(referenceText))
+            | _ -> Assert.Fail($"Unexpected event case: {event}")
+
+    [<Test>]
+    member _.ReplayProjectionKeepsLatestReferencesWithBothRootHashes() =
+        let committed =
+            BranchDto.UpdateDto
+                (branchEvent (BranchEventType.Committed(referenceDto ReferenceType.Commit, directoryVersionId, sha256Hash, blake3Hash, referenceText)))
+                BranchDto.Default
+
+        let saved =
+            BranchDto.UpdateDto
+                (branchEvent (BranchEventType.Saved(referenceDto ReferenceType.Save, directoryVersionId, sha256Hash, blake3Hash, referenceText)))
+                committed
+
+        Assert.That(committed.LatestCommit.Sha256Hash, Is.EqualTo(sha256Hash))
+        Assert.That(committed.LatestCommit.Blake3Hash, Is.EqualTo(blake3Hash))
+        Assert.That(saved.LatestSave.Sha256Hash, Is.EqualTo(sha256Hash))
+        Assert.That(saved.LatestSave.Blake3Hash, Is.EqualTo(blake3Hash))
+        Assert.That(saved.LatestCommit.Blake3Hash, Is.EqualTo(blake3Hash))

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="EventMetadata.Types.Tests.fs" />
     <Compile Include="Automation.Types.Tests.fs" />
     <Compile Include="Reference.Types.Tests.fs" />
+    <Compile Include="Branch.Types.Tests.fs" />
     <Compile Include="Annotation.Types.Tests.fs" />
     <Compile Include="PromotionSet.ConflictModel.Types.Tests.fs" />
     <Compile Include="PromotionSet.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/Reference.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Reference.Types.Tests.fs
@@ -20,6 +20,8 @@ type ReferenceDtoTests() =
     let branchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
     let directoryId = Guid.Parse("66666666-6666-6666-6666-666666666666")
     let promotionSetId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+    let rootSha256Hash = Sha256Hash "root-sha256"
+    let rootBlake3Hash = Blake3Hash "root-blake3"
 
     let createMetadata principal timestamp =
         {
@@ -40,7 +42,8 @@ type ReferenceDtoTests() =
                     repositoryId,
                     branchId,
                     directoryId,
-                    Sha256Hash "abc123",
+                    rootSha256Hash,
+                    rootBlake3Hash,
                     ReferenceType.Commit,
                     ReferenceText "commit reference",
                     Seq.empty
@@ -52,8 +55,16 @@ type ReferenceDtoTests() =
     member _.CreatedEventWithPrincipalPopulatesCreatedBy() =
         let updated = ReferenceDto.UpdateDto (createdEvent "alice@example.test") ReferenceDto.Default
 
+        Assert.That(updated.Sha256Hash, Is.EqualTo(rootSha256Hash))
+        Assert.That(updated.Blake3Hash, Is.EqualTo(rootBlake3Hash))
+        Assert.That(updated.DirectoryId, Is.EqualTo(directoryId))
         Assert.That(updated.CreatedBy, Is.EqualTo(Some "alice@example.test"))
         Assert.That(updated.CreatedAt, Is.EqualTo(timestamp))
+
+    [<Test>]
+    member _.DefaultReferenceDtoUsesExplicitEmptyBlake3ForLegacyReplayBoundary() =
+        Assert.That(ReferenceDto.Default.Sha256Hash, Is.EqualTo(Sha256Hash String.Empty))
+        Assert.That(ReferenceDto.Default.Blake3Hash, Is.EqualTo(Blake3Hash String.Empty))
 
     [<Test>]
     member _.DefaultAndBlankCreatedPrincipalKeepCreatedByMissing() =

--- a/src/Grace.Types/Branch.Types.fs
+++ b/src/Grace.Types/Branch.Types.fs
@@ -38,13 +38,13 @@ module Branch =
             initialPermissions: ReferenceType seq
         | Rebase of basedOn: ReferenceId
         | SetName of newName: BranchName
-        | Assign of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Promote of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Commit of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Checkpoint of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Save of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Tag of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | CreateExternal of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
+        | Assign of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | Promote of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | Commit of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | Checkpoint of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | Save of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | Tag of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
+        | CreateExternal of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
         | EnableAssign of enabled: bool
         | EnablePromotion of enabled: bool
         | EnableCommit of enabled: bool
@@ -76,13 +76,48 @@ module Branch =
             initialPermissions: ReferenceType seq
         | Rebased of basedOn: ReferenceId
         | NameSet of newName: BranchName
-        | Assigned of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Promoted of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Committed of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Checkpointed of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Saved of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | Tagged of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
-        | ExternalCreated of referenceDto: ReferenceDto * directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * referenceText: ReferenceText
+        | Assigned of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | Promoted of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | Committed of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | Checkpointed of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | Saved of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | Tagged of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
+        | ExternalCreated of
+            referenceDto: ReferenceDto *
+            directoryVersionId: DirectoryVersionId *
+            sha256Hash: Sha256Hash *
+            blake3Hash: Blake3Hash *
+            referenceText: ReferenceText
         | EnabledAssign of enabled: bool
         | EnabledPromotion of enabled: bool
         | EnabledCommit of enabled: bool
@@ -223,23 +258,24 @@ module Branch =
 
                     { currentBranchDto with BasedOn = basedOnReferenceDto }
                 | NameSet branchName -> { currentBranchDto with BranchName = branchName }
-                | Assigned (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Assigned (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with LatestPromotion = referenceDto; BasedOn = referenceDto; ShouldRecomputeLatestReferences = true }
 
-                | Promoted (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Promoted (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with LatestPromotion = referenceDto; BasedOn = referenceDto; ShouldRecomputeLatestReferences = true }
 
-                | Committed (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Committed (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with LatestCommit = referenceDto; ShouldRecomputeLatestReferences = true }
 
-                | Checkpointed (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Checkpointed (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with LatestCheckpoint = referenceDto; ShouldRecomputeLatestReferences = true }
 
-                | Saved (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Saved (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with LatestSave = referenceDto; ShouldRecomputeLatestReferences = true }
 
-                | Tagged (referenceDto, directoryVersion, sha256Hash, referenceText) -> { currentBranchDto with ShouldRecomputeLatestReferences = true }
-                | ExternalCreated (referenceDto, directoryVersion, sha256Hash, referenceText) ->
+                | Tagged (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
+                    { currentBranchDto with ShouldRecomputeLatestReferences = true }
+                | ExternalCreated (referenceDto, directoryVersion, sha256Hash, blake3Hash, referenceText) ->
                     { currentBranchDto with ShouldRecomputeLatestReferences = true }
                 | EnabledAssign enabled -> { currentBranchDto with AssignEnabled = enabled }
                 | EnabledPromotion enabled -> { currentBranchDto with PromotionEnabled = enabled }

--- a/src/Grace.Types/Reference.Types.fs
+++ b/src/Grace.Types/Reference.Types.fs
@@ -18,6 +18,7 @@ module Reference =
             BranchId: BranchId
             DirectoryVersionId: DirectoryVersionId
             Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
             DeleteReason: DeleteReason
             CorrelationId: CorrelationId
         }
@@ -32,6 +33,7 @@ module Reference =
             BranchId: BranchId *
             DirectoryId: DirectoryVersionId *
             Sha256Hash: Sha256Hash *
+            Blake3Hash: Blake3Hash *
             ReferenceType: ReferenceType *
             ReferenceText: ReferenceText *
             Links: ReferenceLinkType seq
@@ -54,6 +56,7 @@ module Reference =
             BranchId: BranchId *
             DirectoryId: DirectoryVersionId *
             Sha256Hash: Sha256Hash *
+            Blake3Hash: Blake3Hash *
             ReferenceType: ReferenceType *
             ReferenceText: ReferenceText *
             Links: ReferenceLinkType seq
@@ -85,6 +88,7 @@ module Reference =
             BranchId: BranchId
             DirectoryId: DirectoryVersionId
             Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
             ReferenceType: ReferenceType
             ReferenceText: ReferenceText
             Links: ReferenceLinkType seq
@@ -105,6 +109,7 @@ module Reference =
                 BranchId = BranchId.Empty
                 DirectoryId = DirectoryVersionId.Empty
                 Sha256Hash = Sha256Hash String.Empty
+                Blake3Hash = Blake3Hash String.Empty
                 ReferenceType = Save
                 ReferenceText = ReferenceText String.Empty
                 Links = Seq.empty
@@ -119,7 +124,17 @@ module Reference =
         static member UpdateDto referenceEvent currentReferenceDto =
             let newReferenceDto =
                 match referenceEvent.Event with
-                | Created (referenceId, ownerId, organizationId, repositoryId, branchId, directoryId, sha256Hash, referenceType, referenceText, links) ->
+                | Created (referenceId,
+                           ownerId,
+                           organizationId,
+                           repositoryId,
+                           branchId,
+                           directoryId,
+                           sha256Hash,
+                           blake3Hash,
+                           referenceType,
+                           referenceText,
+                           links) ->
                     { currentReferenceDto with
                         ReferenceId = referenceId
                         OwnerId = ownerId
@@ -128,6 +143,7 @@ module Reference =
                         BranchId = branchId
                         DirectoryId = directoryId
                         Sha256Hash = sha256Hash
+                        Blake3Hash = blake3Hash
                         ReferenceType = referenceType
                         ReferenceText = referenceText
                         Links = links

--- a/src/Grace.Types/Reference.Types.fs
+++ b/src/Grace.Types/Reference.Types.fs
@@ -120,6 +120,37 @@ module Reference =
                 DeleteReason = String.Empty
             }
 
+        static member TryGetLegacyRootDirectoryHashRepair directoryId sha256Hash blake3Hash (directoryVersion: DirectoryVersion) =
+            let rootRelativePath = directoryVersion.RelativePath
+
+            let isRootDirectoryRelativePath =
+                rootRelativePath = Constants.RootDirectoryPath
+                || rootRelativePath = RelativePath "/"
+
+            let referenceSha256Hash = string sha256Hash
+            let rootSha256Hash = string directoryVersion.Sha256Hash
+
+            let referenceSha256MatchesRoot =
+                not (String.IsNullOrWhiteSpace referenceSha256Hash)
+                && rootSha256Hash.StartsWith(referenceSha256Hash, StringComparison.OrdinalIgnoreCase)
+
+            if
+                String.IsNullOrWhiteSpace(string blake3Hash)
+                && directoryVersion.DirectoryVersionId = directoryId
+                && isRootDirectoryRelativePath
+                && referenceSha256MatchesRoot
+                && not (String.IsNullOrWhiteSpace(string directoryVersion.Blake3Hash))
+            then
+                Some(directoryVersion.Sha256Hash, directoryVersion.Blake3Hash)
+            else
+                None
+
+        static member HydrateLegacyRootDirectoryHash directoryVersion referenceDto =
+            match ReferenceDto.TryGetLegacyRootDirectoryHashRepair referenceDto.DirectoryId referenceDto.Sha256Hash referenceDto.Blake3Hash directoryVersion
+                with
+            | Some (fullSha256Hash, blake3Hash) -> { referenceDto with Sha256Hash = fullSha256Hash; Blake3Hash = blake3Hash }, true
+            | None -> referenceDto, false
+
         /// Updates the ReferenceDto based on the ReferenceEvent.
         static member UpdateDto referenceEvent currentReferenceDto =
             let newReferenceDto =

--- a/src/OpenAPI/Branch.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Branch.Components.OpenAPI.yaml
@@ -257,6 +257,8 @@
           example: 33a4e36b-828f-4fae-9343-50b6560dc842
         Sha256Hash:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Blake3Hash'
         ReferenceType:
           $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType'
         ReferenceText:
@@ -414,6 +416,7 @@
           BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
           DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
           Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
           ReferenceType: Commit
           ReferenceText: Capture release candidate.
           CreatedAt: '2026-06-04T18:15:00Z'
@@ -445,6 +448,7 @@
             BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
             DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
             Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
             ReferenceType: Commit
             ReferenceText: Capture release candidate.
             CreatedAt: '2026-06-04T18:15:00Z'

--- a/src/OpenAPI/Dto.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Dto.Components.OpenAPI.yaml
@@ -150,6 +150,8 @@
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/DirectoryId
         Sha256Hash:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash
+        Blake3Hash:
+          $ref: Shared.Components.OpenAPI.yaml#/components/schemas/Blake3Hash
         ReferenceType:
           $ref: Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceType
         ReferenceText:

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -3805,6 +3805,8 @@ components:
           $ref: '#/components/schemas/DirectoryId'
         Sha256Hash:
           $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         ReferenceType:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
@@ -4603,6 +4605,9 @@ components:
     Sha256Hash:
       type: string
       example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+    Blake3Hash:
+      type: string
+      example: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
     StorageAccountName:
       type: string
     StorageConnectionString:
@@ -5295,6 +5300,8 @@ components:
           example: 33a4e36b-828f-4fae-9343-50b6560dc842
         Sha256Hash:
           $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         ReferenceType:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
@@ -5460,6 +5467,7 @@ components:
           BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
           DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
           Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
           ReferenceType: Commit
           ReferenceText: Capture release candidate.
           CreatedAt: '2026-06-04T18:15:00Z'
@@ -5509,6 +5517,7 @@ components:
             BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
             DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
             Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
             ReferenceType: Commit
             ReferenceText: Capture release candidate.
             CreatedAt: '2026-06-04T18:15:00Z'
@@ -6872,6 +6881,7 @@ components:
                   BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
                   DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
                   Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
                   ReferenceType: Commit
                   ReferenceText: Capture release candidate.
                   CreatedAt: '2026-06-04T18:15:00Z'

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -3805,6 +3805,8 @@ components:
           $ref: '#/components/schemas/DirectoryId'
         Sha256Hash:
           $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         ReferenceType:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
@@ -4603,6 +4605,9 @@ components:
     Sha256Hash:
       type: string
       example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+    Blake3Hash:
+      type: string
+      example: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
     StorageAccountName:
       type: string
     StorageConnectionString:
@@ -5295,6 +5300,8 @@ components:
           example: 33a4e36b-828f-4fae-9343-50b6560dc842
         Sha256Hash:
           $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         ReferenceType:
           $ref: '#/components/schemas/ReferenceType'
         ReferenceText:
@@ -5460,6 +5467,7 @@ components:
           BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
           DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
           Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+          Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
           ReferenceType: Commit
           ReferenceText: Capture release candidate.
           CreatedAt: '2026-06-04T18:15:00Z'
@@ -5509,6 +5517,7 @@ components:
             BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
             DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
             Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+            Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
             ReferenceType: Commit
             ReferenceText: Capture release candidate.
             CreatedAt: '2026-06-04T18:15:00Z'
@@ -6872,6 +6881,7 @@ components:
                   BranchId: de7bf47d-23ae-4599-af68-68a317ea390d
                   DirectoryId: 33a4e36b-828f-4fae-9343-50b6560dc842
                   Sha256Hash: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+                  Blake3Hash: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
                   ReferenceType: Commit
                   ReferenceText: Capture release candidate.
                   CreatedAt: '2026-06-04T18:15:00Z'

--- a/src/OpenAPI/Main.OpenAPI.yaml
+++ b/src/OpenAPI/Main.OpenAPI.yaml
@@ -567,6 +567,8 @@ components:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
     Sha256Hash:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+    Blake3Hash:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Blake3Hash'
     StorageAccountName:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/StorageAccountName'
     StorageConnectionString:

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "Branch.Components.OpenAPI.yaml",
-      "sha256": "b938bb8cc8c42859a357799578bfed6edf72a11bb507dddf35b918a775cad988"
+      "sha256": "13efeae2820c627de2895acbe2a72ae3a3ab869b19f503b0b8d8a721db8d65a0"
     },
     {
       "path": "Branch.Paths.OpenAPI.yaml",
@@ -37,11 +37,11 @@
     },
     {
       "path": "Dto.Components.OpenAPI.yaml",
-      "sha256": "72acc5bea675e60a851d6631738cdfe558b903a66ff2976be413f51ec5cda7fd"
+      "sha256": "1c86d504ad9e983b8ecd0d6806f0b25211683a2a0632e73186be06f21615344f"
     },
     {
       "path": "Main.OpenAPI.yaml",
-      "sha256": "51c97d3576c44494f4aef575e862ea0282d3c60e07611c717d02a4c1036c8ad4"
+      "sha256": "4b425c20901e431c1f277480b50c14bff09f18c951bf760db6872782408b1548"
     },
     {
       "path": "Organization.Components.OpenAPI.yaml",
@@ -77,7 +77,7 @@
     },
     {
       "path": "Shared.Components.OpenAPI.yaml",
-      "sha256": "314fb2dbc050a12adee8f0c36e79ac26bc4bb3f98fca7ea76eee275e04791c53"
+      "sha256": "ee3d7204a358396465cde8e7e4fcd01be5e49612a6374fa805322e06230f41a8"
     },
     {
       "path": "Shared2.Components.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "b4c2f628aef754d113fc2fe91f2b2eb010e77c94aaeb8a01233fcbcb8f75cbf7",
+      "sourceDigest": "ebc970fd5747185c18e974b052003b4c9c8637ea22411c21eaa8989af3854dc6",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "ddbf4e7def1f60da2fa7f29924121a15ed945d273e5683c9c0ab43c6311ef857"
+      "sha256": "797904f42ad7625a784a2699c5bef6f48b07926fe5c0685e25d37c605c7c427d"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "b4c2f628aef754d113fc2fe91f2b2eb010e77c94aaeb8a01233fcbcb8f75cbf7",
+      "sourceDigest": "ebc970fd5747185c18e974b052003b4c9c8637ea22411c21eaa8989af3854dc6",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "8827d0b15ab38c79d672c8c4f30a7446b9d7014967ada09f993528ce5ae9a995"
+      "sha256": "ce35358671648f3b9fafbf32ecb97e239ada4b0d70579447c10d473d96af49c9"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "b4c2f628aef754d113fc2fe91f2b2eb010e77c94aaeb8a01233fcbcb8f75cbf7",
+      "sourceDigest": "ebc970fd5747185c18e974b052003b4c9c8637ea22411c21eaa8989af3854dc6",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/Shared.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Shared.Components.OpenAPI.yaml
@@ -82,6 +82,9 @@ components:
     Sha256Hash:
       type: string
       example: 805331A98813206270E35564769E8BB59EEA02AEB7B27C7D6C63E625E1857243
+    Blake3Hash:
+      type: string
+      example: 9A35D91B2F631BE9025DE753139B88F7B1E71385C412BC3986FF2F38F230841D
     StorageAccountName:
       type: string
     StorageConnectionString:


### PR DESCRIPTION
Related to #351
Part of #343

## Summary

- Carries root `DirectoryVersion` BLAKE3 alongside SHA-256 through Reference and Branch command/event contracts, DTO replay, branch reference-producing paths, reminder state, event consumers, and focused tests.
- Adds root hash validation before reference event append, save-boundary mutation, state write, event publication, branch latest-reference mutation, reminder scheduling, or caller success output.
- Keeps public request DTO shapes unchanged for this slice: server/actor paths resolve root BLAKE3 from the referenced `DirectoryVersion`.
- Exposes `Blake3Hash` alongside `Sha256Hash` in the checked-in OpenAPI `ReferenceDto` / `ReferenceApiDto` response schemas and examples.
- Repairs legacy empty-BLAKE3 reference replay and direct service projections from matching root `DirectoryVersion` hashes, including SHA-prefix legacy events.
- Preserves SHA-256 across DTOs, commands, events, reminders, event consumers, and tests during the transition.

## Scope Notes

- Public request DTO input shapes, SDK facade behavior, CLI JSON output, and docs updates are intentionally deferred to later public-surface issues.
- Response DTO OpenAPI schema coverage is included here because `ReferenceDto` now returns `Blake3Hash`.
- Legacy full migration/reset is out of scope; this slice adds compatible replay/projection repair for legacy Created events and legacy direct projections where the root `DirectoryVersion` proves the missing BLAKE3.
- The implementation expands beyond the original owned path list only where the preflight inventory or review findings found compile-required or live command/query callers:
  - `src/Grace.Server/Branch.Server.fs`
  - `src/Grace.Actors/PromotionSet.Actor.fs`
  - `src/Grace.Actors/Repository.Actor.fs`
  - `src/Grace.Actors/Services.Actor.fs`
  - server event consumers and tests that construct or pattern-match `ReferenceEventType.Created`
  - checked-in OpenAPI response schema/projection artifacts for `ReferenceDto` / `ReferenceApiDto`
  - shared root directory SHA lookup and focused tests for slash-root, assign-prefix, legacy replay, and direct projection repairs

## Proof Matrix

| Requirement | Proof |
| --- | --- |
| `ReferenceDto` replay carries both root hashes | `ReferenceDtoTests.CreatedEventWithPrincipalPopulatesCreatedBy` asserts SHA-256 and BLAKE3 replay. |
| Legacy actor replay boundary is explicit | `ReferenceActorHashValidationTests` covers legacy Created-event repair, including SHA-prefix legacy events. |
| Direct service projections hydrate legacy BLAKE3 | `ServicesEffectivePromotionTests` covers direct projection repair without reference actor activation. |
| Branch commands/events carry both root hashes | `BranchDtoHashTests.ReferenceProducingCommandsCarryBothRootHashes` and `ReferenceProducingEventsCarryBothRootHashes`. |
| Branch replay projections retain both hashes | `BranchDtoHashTests.ReplayProjectionKeepsLatestReferencesWithBothRootHashes`. |
| Invalid root hash data fails before reference write | `ReferenceActorHashValidationTests` covers missing root BLAKE3, empty command BLAKE3, mismatched SHA-256/BLAKE3, and legacy Created-event repair. |
| Slash root compatibility is preserved | `BranchServer` focused integration tests pass after accepting `/` as a root spelling while preserving child-directory rejection. |
| Assign SHA-only hydration is root-scoped | `Grace.Server.Tests.BranchServer` focused integration tests cover assign SHA-prefix root scoping when a newer child directory also matches the prefix. |
| OpenAPI response schemas expose root BLAKE3 | `ReferenceDto` / `ReferenceApiDto` schemas and examples include `Blake3Hash`; OpenAPI projections were regenerated. |
| Forbidden shapes absent | BLAKE3 comes from root `DirectoryVersion.Blake3Hash`, not `ReferenceId`, SHA-256, file content hash, or reference-object hash; SHA-prefix hydration uses the resolved root DirectoryVersion, SHA-only lookup is root-scoped, directory-id hydration rejects non-root records, and only `.` / `/` are accepted as root path spellings. |

## Validation

Passed:

- Targeted Fantomas on touched F# files.
- `dotnet test C:\Source\Grace-gh-351\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ReferenceDtoTests|FullyQualifiedName~BranchDtoHashTests" --logger "console;verbosity=normal"`, `8/8`.
- `dotnet test C:\Source\Grace-gh-351\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ReferenceActorHashValidationTests" --logger "console;verbosity=normal"`, `3/3`.
- `dotnet test C:\Source\Grace-gh-351\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter "Name~LegacyCreatedEventWithEmptyBlake3HydratesFromMatchingRootDirectoryVersion"`, `1/1` after `fc54ee42fa5142daa9fb906ca0fa923efcd9f44f`.
- `dotnet test C:\Source\Grace-gh-351\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "Name~SaveWithDirectoryVersionIdAndShaPrefixHydratesFullRootHashes|Name~SaveWithShaOnlyChildDirectoryPrefixDoesNotCreateRootReference"`, `2/2` after `fc54ee42fa5142daa9fb906ca0fa923efcd9f44f`.
- `dotnet test --configuration Release C:\Source\Grace-gh-351\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~ReferenceActorHashValidationTests"`, `6/6` after `5f0022fb6755b9979852fefe0ada1698a42e692c`.
- `dotnet test --configuration Release C:\Source\Grace-gh-351\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~SaveWithDirectoryVersionIdAndShaPrefixHydratesFullRootHashes|FullyQualifiedName~SaveWithShaOnlyChildDirectoryPrefixDoesNotCreateRootReference|FullyQualifiedName~SaveWithChildDirectoryVersionIdAndShaPrefixDoesNotCreateRootReference"`, `3/3` after `5f0022fb6755b9979852fefe0ada1698a42e692c`.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`, passed after `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`.
- `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~BranchServer"`, `11/11` after `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`, covering the hosted full annotate failures and child-directory rejection guard.
- `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~Grace.Server.Tests.BranchServer"`, `13/13` after `459ff7cd26b272730ac9a8d20eac049f7f881cf7`, covering slash-root SHA-only save hydration, assign SHA-prefix root scoping, and child-directory rejection.
- `dotnet build --configuration Release C:\Source\Grace-gh-351\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`, passed after `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`.
- `dotnet test --configuration Release --no-build C:\Source\Grace-gh-351\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~ReferenceActorHashValidationTests|FullyQualifiedName~ServicesEffectivePromotionTests"`, `13/13` after `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`.
- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`, passed after `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`, passed freshness/projection checks after `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`; generated-client matrix remains an existing pending proof gate outside this slice.
- `pwsh ./scripts/validate.ps1 -Fast`, passed before and after `fc54ee42fa5142daa9fb906ca0fa923efcd9f44f`, after `5f0022fb6755b9979852fefe0ada1698a42e692c`, after `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`, after `459ff7cd26b272730ac9a8d20eac049f7f881cf7`, and after `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`.
- `git diff --check`
- `git diff --cached --check`

## Review Status

- Worker bot-prevention self-review: completed before each push.
- High-risk pre-PR review waiver: this slice touches event serialization, actors, branch/reference contracts, service query projections, server event consumers, and OpenAPI response schemas, but the user explicitly prohibited manual Codex review requests. This PR relies on the repository's automatic Codex Code Review Bot after PR updates.
- Automatic Codex Code Review Bot:
  - `0844b60eaa155ad94507bd1462e6ead59746be1a`: findings fixed in `fc54ee42fa5142daa9fb906ca0fa923efcd9f44f`; inline threads resolved.
  - `fc54ee42fa5142daa9fb906ca0fa923efcd9f44f`: findings fixed in `5f0022fb6755b9979852fefe0ada1698a42e692c`; inline threads resolved.
  - `5f0022fb6755b9979852fefe0ada1698a42e692c`: top-level findings and hosted full slash-root failure fixed in `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`.
  - `3cdb3dc37dd56c65155b3dd4ab726d33dfedde23`: inline findings fixed in `459ff7cd26b272730ac9a8d20eac049f7f881cf7`; threads resolved.
  - `459ff7cd26b272730ac9a8d20eac049f7f881cf7`: inline findings fixed in `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`; threads resolved.
  - `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`: automatic bot gave thumbs-up at 2026-06-11T11:57:05Z; no unresolved review threads remain.
- Hosted validation: `Validate / full` passed on `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`.
- Prevention line: reference and branch events now carry root DirectoryVersion BLAKE3 beside SHA-256, branch/reference write paths resolve BLAKE3 from root DirectoryVersions rather than deriving it from identifiers or SHA-256, legacy actor replay and direct service projections repair empty BLAKE3 only when a root DirectoryVersion proves the stored full SHA or prefix, shared SHA-only root lookup is root-scoped and accepts both `.` and `/`, `/branch/assign` uses the same root-scoped resolver as other reference-producing routes, non-root child directory versions remain rejected, invalid or empty new root BLAKE3 fails before durable mutation/publication, reminder state retains both root hashes, OpenAPI response schemas expose `Blake3Hash`, and public request/SDK/CLI JSON surfaces remain deferred to their owning issues.

## Residual Risk

- The negative before-append proof is via the pure validation helper used by `Reference.Actor` immediately before save-boundary work and `ApplyEvent`, not a full Orleans persistence-failure harness.
- Legacy direct projection repair adds root DirectoryVersion lookups only for legacy projected references with empty BLAKE3; this is expected to affect old records only.
- Public request surfaces still accept existing inputs and resolve BLAKE3 server-side; later public/SDK/CLI issues may expose BLAKE3 directly where appropriate.
- Local `prove-openapi.ps1 -Check All -AllowPending` still reports existing generated-client matrix pending proof gates; the freshness/projection checks for this schema update passed.
- Ready to merge: hosted validation passed, automatic Codex Code Review Bot gave thumbs-up, and all review threads are resolved on `b741f5d43faca41bbda2b1f896b7212ee0dfee0f`.

