### PR TITLE
I09: Persist local SQLite dual-hash state

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -66,7 +66,7 @@ module DirectoryVersion =
             let stopwatch = Stopwatch.StartNew()
 
             try
-                let! blobClient = getAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
+                let! blobClient = getReadableAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
                 let! existsResponse = blobClient.ExistsAsync()
 
                 if not existsResponse.Value then
@@ -1433,7 +1433,7 @@ module DirectoryVersion =
                             // Step 4: Process the files in the current directory.
                             for fileVersion in fileVersions do
 
-                                let! fileBlobClient = getAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
+                                let! fileBlobClient = getReadableAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
                                 let! existsResult = fileBlobClient.ExistsAsync()
 
                                 if existsResult.Value = true then

--- a/src/Grace.Actors/Services.Actor.fs
+++ b/src/Grace.Actors/Services.Actor.fs
@@ -306,7 +306,33 @@ module Services =
 
     let getAzureBlobClientForFileVersion (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
         task {
-            let blobName = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+            let blobName = StorageKeys.wholeFileContentObjectKey fileVersion
+            return! getAzureBlobClient repositoryDto blobName correlationId
+        }
+
+    let private getReadableWholeFileContentObjectKey (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
+        task {
+            let currentBlobName = StorageKeys.wholeFileContentObjectKey fileVersion
+            let! currentBlobClient = getAzureBlobClient repositoryDto currentBlobName correlationId
+
+            if StorageKeys.hasBlake3SpecificWholeFileContentObjectKey fileVersion then
+                let! currentExists = currentBlobClient.ExistsAsync()
+
+                if currentExists.Value then
+                    return currentBlobName
+                else
+                    let legacyBlobName = StorageKeys.legacyWholeFileContentObjectKey fileVersion
+                    let! legacyBlobClient = getAzureBlobClient repositoryDto legacyBlobName correlationId
+                    let! legacyExists = legacyBlobClient.ExistsAsync()
+
+                    if legacyExists.Value then return legacyBlobName else return currentBlobName
+            else
+                return currentBlobName
+        }
+
+    let getReadableAzureBlobClientForFileVersion (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
+        task {
+            let! blobName = getReadableWholeFileContentObjectKey repositoryDto fileVersion correlationId
             return! getAzureBlobClient repositoryDto blobName correlationId
         }
 
@@ -398,7 +424,7 @@ module Services =
     /// Gets a full Uri, including shared access signature, for reading from the object storage provider.
     let getUriWithReadSharedAccessSignatureForFileVersion (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
         task {
-            let blobName = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+            let! blobName = getReadableWholeFileContentObjectKey repositoryDto fileVersion correlationId
             return! getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
         }
 
@@ -440,7 +466,7 @@ module Services =
     /// Gets a full Uri, including shared access signature, for writing from the object storage provider.
     let getUriWithWriteSharedAccessSignatureForFileVersion (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
         task {
-            let blobName = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+            let blobName = StorageKeys.wholeFileContentObjectKey fileVersion
             return! getUriWithWriteSharedAccessSignature repositoryDto blobName correlationId
         }
 

--- a/src/Grace.CLI.LocalStateDb.Worker/Program.fs
+++ b/src/Grace.CLI.LocalStateDb.Worker/Program.fs
@@ -7,7 +7,7 @@ open Grace.Types.Common
 open NodaTime
 
 module Program =
-    let private run (dbPath: string) (rootId: Guid) (rootHash: string) (iterations: int) =
+    let private run (dbPath: string) (rootId: Guid) (rootSha256Hash: string) (rootBlake3Hash: string) (iterations: int) =
         task {
             let baseTicks =
                 SystemClock
@@ -20,10 +20,28 @@ module Program =
             while index < iterations do
                 let ticks = baseTicks + int64 index
 
+                let rootDirectory =
+                    LocalDirectoryVersion.CreateWithHashes
+                        rootId
+                        Guid.Empty
+                        Guid.Empty
+                        Guid.Empty
+                        "."
+                        rootSha256Hash
+                        rootBlake3Hash
+                        (System.Collections.Generic.List<DirectoryVersionId>())
+                        (System.Collections.Generic.List<LocalFileVersion>())
+                        0L
+                        DateTime.UtcNow
+
+                let graceIndex = GraceIndex()
+                graceIndex.TryAdd(rootId, rootDirectory) |> ignore
+
                 let status =
                     { GraceStatus.Default with
+                        Index = graceIndex
                         RootDirectoryId = rootId
-                        RootDirectorySha256Hash = rootHash
+                        RootDirectorySha256Hash = rootSha256Hash
                         LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(ticks)
                         LastSuccessfulDirectoryVersionUpload = Instant.FromUnixTimeTicks(ticks)
                     }
@@ -35,16 +53,17 @@ module Program =
     [<EntryPoint>]
     let main argv =
         try
-            if argv.Length < 4 then
-                Console.Error.WriteLine("Usage: <dbPath> <rootId> <rootHash> <iterations>")
+            if argv.Length < 5 then
+                Console.Error.WriteLine("Usage: <dbPath> <rootId> <rootSha256Hash> <rootBlake3Hash> <iterations>")
                 2
             else
                 let dbPath = argv[0]
                 let rootId = Guid.Parse(argv[1])
-                let rootHash = argv[2]
-                let iterations = Int32.Parse(argv[3])
+                let rootSha256Hash = argv[2]
+                let rootBlake3Hash = argv[3]
+                let iterations = Int32.Parse(argv[4])
 
-                run dbPath rootId rootHash iterations
+                run dbPath rootId rootSha256Hash rootBlake3Hash iterations
                 |> fun task -> task.GetAwaiter().GetResult()
 
                 0

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -2,6 +2,8 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Command
+open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -54,3 +56,27 @@ module ConnectTests =
 
             File.Exists(getGraceConfigPath root)
             |> should equal true)
+
+    [<Test>]
+    let ``connect skip decision requires matching blake3 when remote has one`` () =
+        let remoteFile =
+            FileVersion.CreateWithHashes
+                (RelativePath "same-sha-different-blake3.txt")
+                (Sha256Hash "shared-sha")
+                (Blake3Hash "remote-blake3")
+                String.Empty
+                false
+                10L
+
+        Connect.existingFileMatchesRemoteVersion (Sha256Hash "shared-sha") (Blake3Hash "local-blake3") remoteFile
+        |> should equal false
+
+        Connect.existingFileMatchesRemoteVersion (Sha256Hash "shared-sha") (Blake3Hash "remote-blake3") remoteFile
+        |> should equal true
+
+    [<Test>]
+    let ``connect skip decision keeps legacy empty blake3 remote compatible`` () =
+        let remoteFile = FileVersion.Create (RelativePath "legacy-sha-only.txt") (Sha256Hash "legacy-sha") String.Empty false 10L
+
+        Connect.existingFileMatchesRemoteVersion (Sha256Hash "legacy-sha") (Blake3Hash "different-local-blake3") remoteFile
+        |> should equal true

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -3,9 +3,11 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.Services
+open Grace.Shared.Client.Configuration
 open Grace.Shared
 open Grace.Shared.Constants
 open Grace.Types.Branch
+open Grace.Types.DirectoryVersion
 open Grace.Types.Common
 open Grace.Types.Reference
 open NUnit.Framework
@@ -77,6 +79,41 @@ module CurrentStateCaptureCliTests =
             )
 
         FileContentReference.FileManifest { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let private configureForRoot (root: string) =
+        let configuration = GraceConfiguration()
+        configuration.OwnerId <- Guid.NewGuid()
+        configuration.OrganizationId <- Guid.NewGuid()
+        configuration.RepositoryId <- Guid.NewGuid()
+        configuration.RootDirectory <- root
+        configuration.StandardizedRootDirectory <- Grace.Shared.Utilities.normalizeFilePath root
+        configuration.GraceDirectory <- Path.Combine(root, Constants.GraceConfigDirectory)
+        configuration.ObjectDirectory <- Path.Combine(configuration.GraceDirectory, Constants.GraceObjectsDirectory)
+        configuration.GraceStatusFile <- Path.Combine(configuration.GraceDirectory, Constants.GraceLocalStateDbFileName)
+        configuration.GraceObjectCacheFile <- configuration.GraceStatusFile
+        configuration.ConfigurationDirectory <- configuration.GraceDirectory
+        configuration.IsPopulated <- true
+        updateConfiguration configuration
+        configuration
+
+    let private withTempRepo (action: string -> GraceConfiguration -> unit) =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-{Guid.NewGuid():N}")
+        let previousDirectory = Environment.CurrentDirectory
+        let previousConfiguration = if configurationFileExists () then Some(Current()) else None
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+            Environment.CurrentDirectory <- root
+            let configuration = configureForRoot root
+            action root configuration
+        finally
+            Environment.CurrentDirectory <- previousDirectory
+
+            match previousConfiguration with
+            | Some configuration -> updateConfiguration configuration
+            | None -> resetConfiguration ()
+
+            if Directory.Exists(root) then Directory.Delete(root, true)
 
     let private defaultOperations branchDto =
         {
@@ -834,6 +871,83 @@ module CurrentStateCaptureCliTests =
                 |> should equal relativePath
         finally
             if Directory.Exists(root) then Directory.Delete(root, true)
+
+    [<Test>]
+    let ``updateWorkingDirectory replaces same-sha file when blake3 changes`` () =
+        withTempRepo (fun root configuration ->
+            let relativePath = RelativePath "collision.txt"
+            let sharedSha256Hash = Sha256Hash "same-sha256"
+            let previousBlake3Hash = Blake3Hash "previous-blake3"
+            let updatedBlake3Hash = Blake3Hash "updated-blake3"
+            let previousBytes = Encoding.UTF8.GetBytes("old-bytes")
+            let updatedBytes = Encoding.UTF8.GetBytes("new-bytes")
+            let workingFilePath = Path.Combine(root, string relativePath)
+
+            File.WriteAllBytes(workingFilePath, previousBytes)
+
+            let previousFile =
+                LocalFileVersion.CreateWithHashes
+                    relativePath
+                    sharedSha256Hash
+                    previousBlake3Hash
+                    false
+                    (int64 previousBytes.Length)
+                    (Grace.Shared.Utilities.getCurrentInstant ())
+                    true
+                    DateTime.UtcNow
+
+            let previousRoot =
+                LocalDirectoryVersion.CreateWithHashes
+                    rootDirectoryId
+                    configuration.OwnerId
+                    configuration.OrganizationId
+                    configuration.RepositoryId
+                    Constants.RootDirectoryPath
+                    rootSha
+                    (Blake3Hash "previous-root-blake3")
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>([| previousFile |]))
+                    (int64 previousBytes.Length)
+                    DateTime.UtcNow
+
+            let previousIndex = GraceIndex()
+
+            previousIndex.TryAdd(rootDirectoryId, previousRoot)
+            |> ignore
+
+            let previousStatus = { GraceStatus.Default with Index = previousIndex; RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = rootSha }
+
+            let updatedFile = FileVersion.CreateWithHashes relativePath sharedSha256Hash updatedBlake3Hash String.Empty false (int64 updatedBytes.Length)
+
+            let updatedRoot =
+                DirectoryVersion.CreateWithHashes
+                    (Guid.NewGuid())
+                    configuration.OwnerId
+                    configuration.OrganizationId
+                    configuration.RepositoryId
+                    Constants.RootDirectoryPath
+                    (Sha256Hash "updated-root-sha")
+                    (Blake3Hash "updated-root-blake3")
+                    (List<DirectoryVersionId>())
+                    (List<FileVersion>([| updatedFile |]))
+                    (int64 updatedBytes.Length)
+
+            let updatedDto = { DirectoryVersionDto.Default with DirectoryVersion = updatedRoot; RecursiveSize = int64 updatedBytes.Length }
+
+            let updatedLocalFile = updatedFile.ToLocalFileVersion DateTime.UtcNow
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updatedLocalFile.FullObjectPath))
+            |> ignore
+
+            File.WriteAllBytes(updatedLocalFile.FullObjectPath, updatedBytes)
+
+            let updatedStatus = graceStatus updatedRoot.DirectoryVersionId updatedRoot.Sha256Hash
+
+            updateWorkingDirectory previousStatus updatedStatus [| updatedDto |] correlationId
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            File.ReadAllBytes(workingFilePath)
+            |> should equal updatedBytes)
 
     [<Test>]
     let ``read-only current-state scan treats empty stored BLAKE3 as unknown when SHA-256 still matches`` () =

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -936,6 +936,17 @@ module CurrentStateCaptureCliTests =
 
             let updatedLocalFile = updatedFile.ToLocalFileVersion DateTime.UtcNow
 
+            let previousObjectPath = previousFile.FullObjectPath
+            let updatedObjectPath = updatedLocalFile.FullObjectPath
+
+            previousObjectPath
+            |> should not' (equal updatedObjectPath)
+
+            Directory.CreateDirectory(Path.GetDirectoryName(previousObjectPath))
+            |> ignore
+
+            File.WriteAllBytes(previousObjectPath, previousBytes)
+
             Directory.CreateDirectory(Path.GetDirectoryName(updatedLocalFile.FullObjectPath))
             |> ignore
 

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -234,13 +234,14 @@ module DoctorCliTests =
             files.Add(createSnapshotFile Constants.GraceIgnoreFileName (File.ReadAllText(graceIgnorePath)) (File.GetLastWriteTimeUtc(graceIgnorePath)))
 
         let homeDirectory =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 homeDirectoryId
                 ownerId
                 organizationId
                 repositoryId
                 "home"
                 "home-snapshot-hash"
+                (Blake3Hash "home-snapshot-blake3")
                 (System.Collections.Generic.List<DirectoryVersionId>())
                 (System.Collections.Generic.List<LocalFileVersion>())
                 0L
@@ -255,13 +256,14 @@ module DoctorCliTests =
         let rootFiles = files |> Seq.toArray
 
         let rootDirectory =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 rootDirectoryId
                 ownerId
                 organizationId
                 repositoryId
                 Constants.RootDirectoryPath
                 "root-snapshot-hash"
+                (Blake3Hash "root-snapshot-blake3")
                 rootChildDirectories
                 (System.Collections.Generic.List<LocalFileVersion>(rootFiles))
                 (rootFiles |> Array.sumBy (fun file -> file.Size))
@@ -2442,7 +2444,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 3"
+                |> should contain "schema_version is 4"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2573,7 +2575,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 3"
+                        |> should contain "schema_version is 4"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -99,13 +99,14 @@ module LocalStateDbTests =
         sizeBytes
         lastWriteTimeUtc
         =
-        LocalDirectoryVersion.Create
+        LocalDirectoryVersion.CreateWithHashes
             directoryVersionId
             configuration.OwnerId
             configuration.OrganizationId
             configuration.RepositoryId
             relativePath
             sha256Hash
+            (Blake3Hash $"{sha256Hash}-blake3")
             (List<DirectoryVersionId>(directoryIds))
             (List<LocalFileVersion>(files))
             sizeBytes
@@ -160,7 +161,7 @@ module LocalStateDbTests =
         executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
         executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{schemaVersion}');"
 
-    let private seedCurrentSchemaWithStatusMeta (dbPath: string) (rootId: Guid) rootHash ticks =
+    let private seedCurrentSchemaWithStatusMeta (dbPath: string) (rootId: Guid) rootSha256Hash rootBlake3Hash ticks =
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
         |> ignore
 
@@ -170,7 +171,7 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
 
         executeNonQuery
             connection
@@ -204,11 +205,11 @@ module LocalStateDbTests =
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
 
         executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3');"
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '4');"
 
         executeNonQuery
             connection
-            $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootHash}', {ticks}, {ticks});"
+            $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootSha256Hash}', '{rootBlake3Hash}', {ticks}, {ticks});"
 
     let private createTestStatus (rootId: Guid) (rootHash: string) (ticks: int64) =
         { GraceStatus.Default with
@@ -266,7 +267,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -318,6 +319,12 @@ module LocalStateDbTests =
 
                 readBack.RootDirectorySha256Hash
                 |> should equal rootDirectory.Sha256Hash
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let persistedRootBlake3 = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
+
+                persistedRootBlake3
+                |> should equal (string rootDirectory.Blake3Hash)
 
                 readBack.Index.Count |> should equal 2
 
@@ -528,7 +535,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -555,7 +562,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -608,7 +615,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "3")
+                |> should equal (Some "4")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -652,7 +659,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "3")
+                |> should equal (Some "4")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -888,7 +895,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -903,14 +910,15 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``ensureDbInitialized preserves existing schema v3 current schema status_meta row`` () =
+    let ``ensureDbInitialized preserves existing schema v4 current schema status_meta row`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
                 let rootHash = "custom-root-hash"
                 let ticks = 1234567890L
 
-                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash ticks
+                let rootBlake3Hash = "custom-root-blake3"
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash rootBlake3Hash ticks
 
                 let corruptBefore =
                     getCorruptBackups configuration.GraceStatusFile
@@ -922,13 +930,19 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "3"
+                let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
+                schemaVersion |> should equal "4"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
+                readRootBlake3Hash |> should equal rootBlake3Hash
 
                 let blake3Columns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('status_files') WHERE name = 'blake3_hash';"
 
+                let rootBlake3Columns =
+                    executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('status_meta') WHERE name = 'root_directory_blake3_hash';"
+
                 blake3Columns |> should equal 1
+                rootBlake3Columns |> should equal 1
 
                 let replacementStatus = createTestStatus (Guid.NewGuid()) "replacement-root-hash" (ticks + 1L)
 
@@ -1123,7 +1137,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -1149,7 +1163,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "3"
+                schemaVersion |> should equal "4"
             })
 
     [<Test>]
@@ -1395,7 +1409,98 @@ module LocalStateDbTests =
 
                     fileRead.Blake3Hash
                     |> should equal (Blake3Hash blake3Hash)
+
+                    rootRead.Blake3Hash
+                    |> should equal rootDir.Blake3Hash
                 | Error error -> Assert.Fail($"Expected read-only snapshot to load, but got: {error}")
+            })
+
+    [<Test>]
+    let ``readStatusSnapshotReadOnly rejects legacy sha-only schema with reset guidance`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3');"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', 'root-sha', {ticks}, {ticks});"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+                let! readOnlyResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+
+                match readOnlyResult with
+                | Ok _ -> Assert.Fail("Expected legacy SHA-only local state to be rejected.")
+                | Error error ->
+                    error
+                    |> should contain "schema version is incompatible"
+
+                    error
+                    |> should contain "reset the local state database"
+            })
+
+    [<Test>]
+    let ``readStatusSnapshotReadOnly rejects empty persisted blake3 values with reset guidance`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(1001L)
+                let lastWrite = DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+                let file = createFileVersionWithHashes "root.txt" "sha256-hash" "file-blake3" false 10L now lastWrite
+                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [||] [| file |] file.Size lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, rootDir) |> ignore
+
+                let status =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootDir.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile status
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery connection "UPDATE status_directories SET blake3_hash = '' WHERE relative_path = '.';"
+
+                let! readOnlyResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+
+                match readOnlyResult with
+                | Ok _ -> Assert.Fail("Expected empty BLAKE3 local state to be rejected.")
+                | Error error ->
+                    error |> should contain "empty BLAKE3 values"
+
+                    error
+                    |> should contain "reset the local state database"
             })
 
     [<Test>]
@@ -1920,7 +2025,9 @@ module LocalStateDbTests =
                             let startInfo = ProcessStartInfo()
                             startInfo.FileName <- worker.FileName
 
-                            startInfo.Arguments <- $"{worker.ArgumentsPrefix} \"{dbPath}\" {rootId} {rootHash} {iterationsPerProcess}"
+                            let rootBlake3Hash = "root-blake3"
+
+                            startInfo.Arguments <- $"{worker.ArgumentsPrefix} \"{dbPath}\" {rootId} {rootHash} {rootBlake3Hash} {iterationsPerProcess}"
 
                             startInfo.RedirectStandardOutput <- true
                             startInfo.RedirectStandardError <- true
@@ -1964,7 +2071,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "3"
+                    schemaVersion |> should equal "4"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -1554,6 +1554,62 @@ module LocalStateDbTests =
             })
 
     [<Test>]
+    let ``readStatusSnapshotReadOnly rejects partial v4 object-cache schema missing blake3 columns`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '4');"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', 'root-sha', 'root-blake3', {ticks}, {ticks});"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS object_cache_directories (directory_version_id TEXT PRIMARY KEY, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path));"
+
+                let! readOnlyResult =
+                    LocalStateDb.readStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+
+                match readOnlyResult with
+                | Ok _ -> Assert.Fail("Expected partial object-cache BLAKE3 schema to be rejected.")
+                | Error error ->
+                    error
+                    |> should contain "object_cache_directories.blake3_hash"
+
+                    error
+                    |> should contain "object_cache_directory_files.blake3_hash"
+
+                    error
+                    |> should contain "reset the local state database"
+            })
+
+    [<Test>]
     let ``readStatusSnapshotReadOnly rejects empty persisted blake3 values with reset guidance`` () =
         withTempDir (fun _ configuration ->
             task {

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -1014,6 +1014,46 @@ module LocalStateDbTests =
             })
 
     [<Test>]
+    let ``ensureDbInitialized recreates current schema database with empty status blake3 rows`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let rootHash = "partial-empty-blake3-root-hash"
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash "root-blake3" ticks
+
+                use seedConnection = openRawConnection configuration.GraceStatusFile
+
+                executeNonQuery
+                    seedConnection
+                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ('.', '', '00000000-0000-0000-0000-000000000001', 'root-sha', '', 0, 0, 0);"
+
+                seedConnection.Dispose()
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
+                let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
+
+                schemaVersion |> should equal "4"
+                statusDirectoryCount |> should equal 0
+                statusMetaCount |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    [<Test>]
     let ``journal mode is WAL after initialization`` () =
         withTempDir (fun _ configuration ->
             task {
@@ -1749,6 +1789,56 @@ module LocalStateDbTests =
 
                 meta.LastSuccessfulFileUpload
                 |> should equal metaOnlyStatus.LastSuccessfulFileUpload
+            })
+
+    [<Test>]
+    let ``applyStatusIncremental does not preserve root blake3 metadata for different root identity`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(5350L)
+                let lastWrite = DateTime(2022, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+                let originalRootId = Guid.NewGuid()
+                let replacementRootId = Guid.NewGuid()
+
+                let originalRoot = createDirectoryVersion configuration originalRootId Constants.RootDirectoryPath "original-root-hash" [||] [||] 0L lastWrite
+
+                let index = GraceIndex()
+
+                index.TryAdd(originalRootId, originalRoot)
+                |> ignore
+
+                let statusWithRoot =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = originalRootId
+                        RootDirectorySha256Hash = originalRoot.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusWithRoot
+
+                let metaOnlyDifferentRootStatus =
+                    { statusWithRoot with
+                        Index = GraceIndex()
+                        RootDirectoryId = replacementRootId
+                        RootDirectorySha256Hash = Sha256Hash "replacement-root-hash"
+                        LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(5360L)
+                        LastSuccessfulDirectoryVersionUpload = Instant.FromUnixTimeTicks(5360L)
+                    }
+
+                do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile metaOnlyDifferentRootStatus [] []
+
+                let! meta = LocalStateDb.readStatusMeta configuration.GraceStatusFile
+
+                meta.RootDirectoryId
+                |> should equal replacementRootId
+
+                meta.RootDirectorySha256Hash
+                |> should equal (Sha256Hash "replacement-root-hash")
+
+                meta.RootDirectoryBlake3Hash
+                |> should equal (Blake3Hash String.Empty)
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -211,6 +211,24 @@ module LocalStateDbTests =
             connection
             $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootSha256Hash}', '{rootBlake3Hash}', {ticks}, {ticks});"
 
+    let private seedPartialV4WithoutRootBlake3Column (dbPath: string) (rootId: Guid) rootSha256Hash ticks =
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
+        |> ignore
+
+        use connection = openRawConnection dbPath
+        executeNonQuery connection "PRAGMA journal_mode = WAL;"
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '4');"
+
+        executeNonQuery
+            connection
+            $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootSha256Hash}', {ticks}, {ticks});"
+
     let private createTestStatus (rootId: Guid) (rootHash: string) (ticks: int64) =
         { GraceStatus.Default with
             RootDirectoryId = rootId
@@ -961,6 +979,41 @@ module LocalStateDbTests =
             })
 
     [<Test>]
+    let ``ensureDbInitialized recreates partial schema v4 database missing root blake3 column`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let rootHash = "partial-v4-root-hash"
+                let ticks = 1234567890L
+
+                seedPartialV4WithoutRootBlake3Column configuration.GraceStatusFile rootId rootHash ticks
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+
+                let rootBlake3Columns =
+                    executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('status_meta') WHERE name = 'root_directory_blake3_hash';"
+
+                let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
+
+                schemaVersion |> should equal "4"
+                rootBlake3Columns |> should equal 1
+                statusMetaCount |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    [<Test>]
     let ``journal mode is WAL after initialization`` () =
         withTempDir (fun _ configuration ->
             task {
@@ -1654,6 +1707,82 @@ module LocalStateDbTests =
 
                 fileRead2.LastWriteTimeUtc.Ticks
                 |> should equal lastWrite2.Ticks
+            })
+
+    [<Test>]
+    let ``applyStatusIncremental preserves root blake3 metadata for meta-only status updates`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(5300L)
+                let lastWrite = DateTime(2022, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+
+                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [||] [||] 0L lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, rootDir) |> ignore
+
+                let statusWithRoot =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootDir.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusWithRoot
+
+                let metaOnlyStatus =
+                    { statusWithRoot with
+                        Index = GraceIndex()
+                        LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(5400L)
+                        LastSuccessfulDirectoryVersionUpload = Instant.FromUnixTimeTicks(5400L)
+                    }
+
+                do! LocalStateDb.applyStatusIncremental configuration.GraceStatusFile metaOnlyStatus [] []
+
+                let! meta = LocalStateDb.readStatusMeta configuration.GraceStatusFile
+
+                meta.RootDirectoryBlake3Hash
+                |> should equal rootDir.Blake3Hash
+
+                meta.LastSuccessfulFileUpload
+                |> should equal metaOnlyStatus.LastSuccessfulFileUpload
+            })
+
+    [<Test>]
+    let ``replaceStatusSnapshot writes empty root blake3 for default status`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(5450L)
+                let lastWrite = DateTime(2022, 2, 4, 5, 6, 7, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+
+                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [||] [||] 0L lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, rootDir) |> ignore
+
+                let statusWithRoot =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootDir.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusWithRoot
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile GraceStatus.Default
+
+                let! meta = LocalStateDb.readStatusMeta configuration.GraceStatusFile
+
+                meta.RootDirectoryId
+                |> should equal DirectoryVersionId.Empty
+
+                meta.RootDirectoryBlake3Hash
+                |> should equal (Blake3Hash String.Empty)
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -132,6 +132,26 @@ type ManifestUploadSdkTests() =
         Assert.That(Storage.isExistingContentBlockUploadConflict forbidden, Is.False)
 
     [<Test>]
+    member _.WholeFileLocalObjectCacheNameIncludesBlake3WithoutChangingRemoteObjectName() =
+        let fileVersion =
+            FileVersion.CreateWithHashes
+                (RelativePath "src/cache/whole-file.txt")
+                (Sha256Hash "sha256-value")
+                (Blake3Hash "blake3-value")
+                String.Empty
+                false
+                10L
+
+        Assert.That(fileVersion.GetObjectFileName, Is.EqualTo("whole-file_sha256-value.txt"))
+        Assert.That(Storage.getLocalObjectCacheFileName fileVersion, Is.EqualTo("whole-file_sha256-value_blake3-value.txt"))
+
+    [<Test>]
+    member _.WholeFileLocalObjectCacheNameKeepsLegacyShaOnlyNameWithoutBlake3() =
+        let fileVersion = FileVersion.Create (RelativePath "src/cache/legacy-file.txt") (Sha256Hash "sha256-value") String.Empty false 10L
+
+        Assert.That(Storage.getLocalObjectCacheFileName fileVersion, Is.EqualTo(fileVersion.GetObjectFileName))
+
+    [<Test>]
     member _.ManifestUploadFlowStartsUploadsConfirmsAndFinalizesNewBlocksOnly() =
         task {
             let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -132,7 +132,7 @@ type ManifestUploadSdkTests() =
         Assert.That(Storage.isExistingContentBlockUploadConflict forbidden, Is.False)
 
     [<Test>]
-    member _.WholeFileLocalObjectCacheNameIncludesBlake3WithoutChangingRemoteObjectName() =
+    member _.WholeFileLocalObjectCacheNameIncludesBlake3() =
         let fileVersion =
             FileVersion.CreateWithHashes
                 (RelativePath "src/cache/whole-file.txt")
@@ -144,6 +144,14 @@ type ManifestUploadSdkTests() =
 
         Assert.That(fileVersion.GetObjectFileName, Is.EqualTo("whole-file_sha256-value.txt"))
         Assert.That(Storage.getLocalObjectCacheFileName fileVersion, Is.EqualTo("whole-file_sha256-value_blake3-value.txt"))
+
+    [<Test>]
+    member _.WholeFileLocalObjectCacheNameIncludesBlake3ForExtensionlessFiles() =
+        let fileVersion =
+            FileVersion.CreateWithHashes (RelativePath "Dockerfile") (Sha256Hash "sha256-value") (Blake3Hash "blake3-value") String.Empty false 10L
+
+        Assert.That(fileVersion.GetObjectFileName, Is.EqualTo("Dockerfile_sha256-value"))
+        Assert.That(Storage.getLocalObjectCacheFileName fileVersion, Is.EqualTo("Dockerfile_sha256-value_blake3-value"))
 
     [<Test>]
     member _.WholeFileLocalObjectCacheNameKeepsLegacyShaOnlyNameWithoutBlake3() =

--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -160,6 +160,33 @@ type ManifestUploadSdkTests() =
         Assert.That(Storage.getLocalObjectCacheFileName fileVersion, Is.EqualTo(fileVersion.GetObjectFileName))
 
     [<Test>]
+    member _.UploadMetadataMatchingIncludesBlake3WhenPathAndShaCollide() =
+        let firstFileVersion =
+            FileVersion.CreateWithHashes (RelativePath "src/cache/collision.txt") (Sha256Hash "same-sha256") (Blake3Hash "first-blake3") String.Empty false 10L
+
+        let secondFileVersion =
+            FileVersion.CreateWithHashes (RelativePath "src/cache/collision.txt") (Sha256Hash "same-sha256") (Blake3Hash "second-blake3") String.Empty false 10L
+
+        let uploadMetadata: Parameters.Storage.UploadMetadata =
+            {
+                RelativePath = secondFileVersion.RelativePath
+                BlobUriWithSasToken = Uri("https://example.test/upload")
+                Sha256Hash = secondFileVersion.Sha256Hash
+                Blake3Hash = secondFileVersion.Blake3Hash
+                ContentReference = FileContentReference.WholeFileContent
+            }
+
+        let matchedFileVersion =
+            Services.findFileVersionForUploadMetadata
+                [|
+                    firstFileVersion
+                    secondFileVersion
+                |]
+                uploadMetadata
+
+        Assert.That(matchedFileVersion, Is.EqualTo(secondFileVersion))
+
+    [<Test>]
     member _.ManifestUploadFlowStartsUploadsConfirmsAndFinalizesNewBlocksOnly() =
         task {
             let payload = ManifestUploadSdkTests.PseudoRandomBytes 220000

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -539,6 +539,40 @@ module WatchTests =
             |> should equal localFileVersion.Blake3Hash)
 
     [<Test>]
+    let ``object-cache copy returns file version when object already exists`` () =
+        withTempRepo (fun root ->
+            let nestedDirectory = Path.Combine(root, "dir")
+
+            Directory.CreateDirectory(nestedDirectory)
+            |> ignore
+
+            let filePath = Path.Combine(nestedDirectory, "cached-file.txt")
+            File.WriteAllText(filePath, "already cached object payload")
+
+            let firstCopy =
+                match (Services.copyToObjectDirectory (FilePath filePath))
+                    .Result
+                    with
+                | Some fileVersion -> fileVersion
+                | None -> failwith "Expected the first object-cache copy to create the object."
+
+            let secondCopy =
+                match (Services.copyToObjectDirectory (FilePath filePath))
+                    .Result
+                    with
+                | Some fileVersion -> fileVersion
+                | None -> failwith "Expected the cache-hit copy to return the existing object version."
+
+            secondCopy.Sha256Hash
+            |> should equal firstCopy.Sha256Hash
+
+            secondCopy.Blake3Hash
+            |> should equal firstCopy.Blake3Hash
+
+            secondCopy.RelativePath
+            |> should equal firstCopy.RelativePath)
+
+    [<Test>]
     let ``watch json auth failure emits one clean error envelope`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -628,11 +628,7 @@ module Connect =
 
                 match fileVersionsByRelativePath.TryGetValue(entryRelativePath) with
                 | true, fileVersion ->
-                    let objectFileName =
-                        if String.IsNullOrWhiteSpace(entry.Comment) then
-                            fileVersion.GetObjectFileName
-                        else
-                            entry.Comment
+                    let objectFileName = getLocalObjectCacheFileName fileVersion.RelativePath fileVersion.Sha256Hash fileVersion.Blake3Hash
 
                     let fileInfo = FileInfo(Path.Combine(Current().RootDirectory, fileVersion.RelativePath))
 

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -403,6 +403,11 @@ module Connect =
                 | None -> return Error(GraceError.Create "No downloadable version found for this branch." graceIds.CorrelationId)
         }
 
+    let internal existingFileMatchesRemoteVersion localSha256Hash localBlake3Hash (fileVersion: FileVersion) =
+        localSha256Hash = fileVersion.Sha256Hash
+        && (String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash)
+            || localBlake3Hash = fileVersion.Blake3Hash)
+
     let private collectFileConflicts (fileVersions: FileVersion array) (force: bool) =
         let conflicts = ResizeArray<string>()
         let filesToSkip = HashSet<RelativePath>()
@@ -421,7 +426,20 @@ module Connect =
 
                             let! localHash = Grace.Shared.Services.computeSha256ForFile stream fileVersion.RelativePath
 
-                            if localHash = fileVersion.Sha256Hash then
+                            let! localBlake3Hash =
+                                task {
+                                    if
+                                        localHash = fileVersion.Sha256Hash
+                                        && not (String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash))
+                                    then
+                                        stream.Position <- 0L
+                                        let! localFileContentHash = Grace.Shared.Services.computeBlake3ForFile stream
+                                        return Blake3Hash $"{localFileContentHash}"
+                                    else
+                                        return Blake3Hash String.Empty
+                                }
+
+                            if existingFileMatchesRemoteVersion localHash localBlake3Hash fileVersion then
                                 filesToSkip.Add(fileVersion.RelativePath)
                                 |> ignore
                             elif not force then

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -101,7 +101,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "3"
+    let private ExpectedLocalStateSchemaVersion = "4"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2428,6 +2428,15 @@ module Services =
                     let objectFilePath = Path.Combine(objectDirectoryPath, objectFileName)
                     //logToConsole $"relativeDirectoryPath: {relativeDirectoryPath}; objectFileName: {objectFileName}; objectFilePath: {objectFilePath}"
 
+                    let createFileVersion (objectFilePathInfo: FileInfo) =
+                        FileVersion.CreateWithHashes
+                            (RelativePath relativeFilePath)
+                            (Sha256Hash $"{sha256Hash}")
+                            blake3Hash
+                            String.Empty
+                            isBinary
+                            objectFilePathInfo.Length
+
                     // If we don't already have this file, with this exact SHA256, make sure the directory exists,
                     //   and rename the temp file to the proper SHA256-enhanced name of the file.
                     if not (File.Exists(objectFilePath)) then
@@ -2440,23 +2449,23 @@ module Services =
                         let objectFilePathInfo = FileInfo(objectFilePath)
                         //logToConsole $"After creating FileInfo; Exists: {objectFilePathInfo.Exists}; FullName = {objectFilePathInfo.FullName}..."
                         //logToConsole $"Finished copyToObjectDirectory for {filePath}; isBinary: {isBinary}; moved temp file to object directory."
-                        let relativePath = Path.GetRelativePath(Current().RootDirectory, filePath)
-
-                        return
-                            Some(
-                                FileVersion.CreateWithHashes
-                                    (RelativePath relativePath)
-                                    (Sha256Hash $"{sha256Hash}")
-                                    blake3Hash
-                                    String.Empty
-                                    isBinary
-                                    objectFilePathInfo.Length
-                            )
+                        return Some(createFileVersion objectFilePathInfo)
                     else
-                        // If we do already have this exact version of the file, just delete the temp file.
-                        File.Delete(tempFilePath)
-                        //logToConsole $"Finished copyToObjectDirectory for {filePath}; object file already exists; deleted temp file."
-                        return None
+                        use objectFileStream = File.Open(objectFilePath, fileStreamOptionsRead)
+                        let! existingFileContentHash = computeBlake3ForFile objectFileStream
+                        let existingBlake3Hash = Blake3Hash $"{existingFileContentHash}"
+                        do! objectFileStream.DisposeAsync()
+
+                        if existingBlake3Hash <> blake3Hash then
+                            File.Move(tempFilePath, objectFilePath, true)
+                            let objectFilePathInfo = FileInfo(objectFilePath)
+                            return Some(createFileVersion objectFilePathInfo)
+                        else
+                            // The object already exists with matching SHA-256 and BLAKE3. Keep returning a version so
+                            // cache-hit changed files remain available to manifest upload/overlay callers.
+                            File.Delete(tempFilePath)
+                            let objectFilePathInfo = FileInfo(objectFilePath)
+                            return Some(createFileVersion objectFilePathInfo)
                 //return result
                 else
                     logToAnsiConsole Colors.Error $"File {filePath} does not exist."

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2039,11 +2039,16 @@ module Services =
 
                         if findFileVersionFromPreviousGraceStatus.Count() > 0 then
                             let fileVersionFromPreviousGraceStatus = findFileVersionFromPreviousGraceStatus.First()
-                            // If the length is different, or the Sha256Hash is changing in the new version, we'll delete the
+                            // If the length or content identity changes in the new version, we'll delete the
                             //   file in the working directory, and copy the version from the object cache to replace it.
                             if existingFileOnDisk.Length <> fileVersion.Size
                                || fileVersionFromPreviousGraceStatus.Sha256Hash
-                                  <> fileVersion.Sha256Hash then
+                                  <> fileVersion.Sha256Hash
+                               || (fileVersionFromPreviousGraceStatus.Blake3Hash
+                                   <> Blake3Hash String.Empty
+                                   && fileVersion.Blake3Hash <> Blake3Hash String.Empty
+                                   && fileVersionFromPreviousGraceStatus.Blake3Hash
+                                      <> fileVersion.Blake3Hash) then
                                 //logToAnsiConsole
                                 //    Colors.Verbose
                                 //    $"Replacing {fileVersion.FullName}; previous length: {fileVersionFromPreviousGraceStatus.Size}; new length: {fileVersion.Size}."

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1097,6 +1097,12 @@ module Services =
             downloadFiles
             correlationId
 
+    let internal findFileVersionForUploadMetadata (fileVersions: IEnumerable<FileVersion>) (uploadMetadata: UploadMetadata) =
+        fileVersions.First (fun fileVersion ->
+            fileVersion.RelativePath = uploadMetadata.RelativePath
+            && fileVersion.Sha256Hash = uploadMetadata.Sha256Hash
+            && fileVersion.Blake3Hash = uploadMetadata.Blake3Hash)
+
     let private uploadWholeFilesToObjectStorage (parameters: GetUploadMetadataForFilesParameters) =
         task {
             match Current().ObjectStorageProvider with
@@ -1117,10 +1123,7 @@ module Services =
                                 (fun uploadMetadata ct ->
                                     ValueTask(
                                         task {
-                                            let fileVersion =
-                                                parameters.FileVersions.First (fun fileVersion ->
-                                                    fileVersion.RelativePath = uploadMetadata.RelativePath
-                                                    && fileVersion.Sha256Hash = uploadMetadata.Sha256Hash)
+                                            let fileVersion = findFileVersionForUploadMetadata parameters.FileVersions uploadMetadata
                                             //logToAnsiConsole Colors.Verbose $"In Services.uploadFilesToObjectStorage(): Uploading {fileVersion.GetObjectFileName} to object storage."
                                             match!
                                                 Storage.SaveFileToObjectStorage

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -152,6 +152,14 @@ module Services =
         /// Gets a DirectoryInfo instance for the parent directory of this local file.
         member this.DirectoryInfo = DirectoryInfo(this.FullName)
 
+    /// Gets the local object-cache file name. Legacy rows without BLAKE3 keep the SHA-only name; dual-hash rows
+    /// include BLAKE3 so same-path SHA-256 collisions do not overwrite or reuse the wrong local bytes.
+    let getLocalObjectCacheFileName (relativePath: RelativePath) (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) =
+        if String.IsNullOrWhiteSpace(string blake3Hash) then
+            getObjectFileName relativePath sha256Hash
+        else
+            getObjectFileName relativePath (Sha256Hash $"{sha256Hash}_{blake3Hash}")
+
     // Extension methods for dealing with local files.
     type LocalFileVersion with
         /// Gets the full path for this file in the working directory.
@@ -166,7 +174,19 @@ module Services =
         member this.RelativeDirectory = Path.GetRelativePath(Current().RootDirectory, this.FileInfo.DirectoryName)
 
         /// Gets the full name of the object file for this LocalFileVersion.
-        member this.FullObjectPath = getNativeFilePath (Path.Combine(Current().ObjectDirectory, this.RelativePath, this.GetObjectFileName))
+        member this.FullObjectPath =
+            getNativeFilePath (
+                Path.Combine(Current().ObjectDirectory, this.RelativePath, getLocalObjectCacheFileName this.RelativePath this.Sha256Hash this.Blake3Hash)
+            )
+
+    let getLocalObjectCachePathForFileVersion (fileVersion: FileVersion) =
+        getNativeFilePath (
+            Path.Combine(
+                Current().ObjectDirectory,
+                fileVersion.RelativePath,
+                getLocalObjectCacheFileName fileVersion.RelativePath fileVersion.Sha256Hash fileVersion.Blake3Hash
+            )
+        )
 
     /// Flag to determine if we should do case-insensitive file name processing on the current platform.
     let ignoreCase = runningOnWindows
@@ -904,7 +924,7 @@ module Services =
             if not exists then
                 let allFilesExist =
                     localDirectoryVersion.Files
-                    |> Seq.forall (fun file -> File.Exists(Path.Combine(Current().ObjectDirectory, file.RelativeDirectory, file.GetObjectFileName)))
+                    |> Seq.forall (fun file -> File.Exists(file.FullObjectPath))
 
                 if allFilesExist then
                     do! upsertObjectCache [ localDirectoryVersion ]
@@ -1166,7 +1186,7 @@ module Services =
                 RepositoryName = parameters.RepositoryName
                 AuthorizedScope = fileVersion.RelativePath
                 FileVersion = fileVersion
-                LocalFilePath = Path.Combine(current.ObjectDirectory, fileVersion.RelativePath, fileVersion.GetObjectFileName)
+                LocalFilePath = getLocalObjectCachePathForFileVersion fileVersion
                 CorrelationId = parameters.CorrelationId
                 PlannerOptions = LocalPlanner.Options.Default
             }
@@ -1859,14 +1879,7 @@ module Services =
         }
 
     /// Checks if a file already exists in the object cache.
-    let isFileInObjectCache (fileVersion: LocalFileVersion) =
-        task {
-            let objectFileName = fileVersion.GetObjectFileName
-
-            let objectFilePath = Path.Combine(Current().ObjectDirectory, fileVersion.RelativeDirectory, objectFileName)
-
-            return File.Exists(objectFilePath)
-        }
+    let isFileInObjectCache (fileVersion: LocalFileVersion) = task { return File.Exists(fileVersion.FullObjectPath) }
 
     /// Updates the Grace Status index with new directory versions after getting them from the server.
     let updateGraceStatusWithNewDirectoryVersionsFromServer
@@ -2426,7 +2439,7 @@ module Services =
                     // Get the new name for this version of the file, including the SHA-256 hash.
                     let relativeDirectoryPath = getLocalRelativeDirectory filePath (Current().RootDirectory)
 
-                    let objectFileName = getObjectFileName filePath sha256Hash
+                    let objectFileName = getLocalObjectCacheFileName (RelativePath relativeFilePath) (Sha256Hash $"{sha256Hash}") blake3Hash
 
                     let objectDirectoryPath = Path.Combine(Current().ObjectDirectory, relativeDirectoryPath)
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -434,7 +434,13 @@ module Watch =
             match! createLocalFileVersion fileInfo with
             | Some localFileVersion ->
                 let relativeDirectoryPath = getLocalRelativeDirectory fullPath (Current().RootDirectory)
-                let objectFilePath = Path.Combine(Current().ObjectDirectory, relativeDirectoryPath, localFileVersion.GetObjectFileName)
+
+                let objectFilePath =
+                    Path.Combine(
+                        Current().ObjectDirectory,
+                        relativeDirectoryPath,
+                        getLocalObjectCacheFileName localFileVersion.RelativePath localFileVersion.Sha256Hash localFileVersion.Blake3Hash
+                    )
 
                 if File.Exists(objectFilePath) then
                     return Some localFileVersion.ToFileVersion

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -17,7 +17,7 @@ open SQLitePCL
 
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "3"
+    let private SchemaVersion = "4"
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
@@ -147,7 +147,7 @@ module LocalStateDb =
     let private schemaStatements =
         [|
             "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS status_meta (id INTEGER PRIMARY KEY CHECK (id = 1), root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, last_successful_file_upload_unix_ticks INTEGER NOT NULL, last_successful_directory_version_upload_unix_ticks INTEGER NOT NULL);"
             "CREATE TABLE IF NOT EXISTS status_directories (relative_path TEXT PRIMARY KEY, parent_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL);"
             "CREATE INDEX IF NOT EXISTS ix_status_directories_parent ON status_directories(parent_path);"
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
@@ -350,6 +350,18 @@ module LocalStateDb =
 
         violations |> Seq.toArray
 
+    let private columnExists (connection: SqliteConnection) tableName columnName =
+        use command = connection.CreateCommand()
+        command.CommandText <- $"PRAGMA table_info({tableName});"
+        use reader = command.ExecuteReader()
+        let mutable found = false
+
+        while reader.Read() do
+            if StringComparer.OrdinalIgnoreCase.Equals(reader.GetString(1), columnName) then
+                found <- true
+
+        found
+
     let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
         try
             for tableName in
@@ -465,12 +477,15 @@ module LocalStateDb =
 
         executeNonQueryWithParams
             connection
-            "INSERT OR IGNORE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, $root_id, $root_hash, $last_file, $last_dir);"
+            "INSERT OR IGNORE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, $root_id, $root_sha256_hash, $root_blake3_hash, $last_file, $last_dir);"
             (fun parameters ->
                 parameters.AddWithValue("$root_id", defaultStatus.RootDirectoryId.ToString())
                 |> ignore
 
-                parameters.AddWithValue("$root_hash", defaultStatus.RootDirectorySha256Hash)
+                parameters.AddWithValue("$root_sha256_hash", defaultStatus.RootDirectorySha256Hash)
+                |> ignore
+
+                parameters.AddWithValue("$root_blake3_hash", Blake3Hash String.Empty)
                 |> ignore
 
                 parameters.AddWithValue("$last_file", defaultStatus.LastSuccessfulFileUpload.ToUnixTimeTicks())
@@ -594,6 +609,7 @@ module LocalStateDb =
         {
             RootDirectoryId: DirectoryVersionId
             RootDirectorySha256Hash: Sha256Hash
+            RootDirectoryBlake3Hash: Blake3Hash
             LastSuccessfulFileUpload: Instant
             LastSuccessfulDirectoryVersionUpload: Instant
         }
@@ -602,19 +618,21 @@ module LocalStateDb =
         use cmd = connection.CreateCommand()
 
         cmd.CommandText <-
-            "SELECT root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks FROM status_meta WHERE id = 1;"
+            "SELECT root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks FROM status_meta WHERE id = 1;"
 
         use reader = cmd.ExecuteReader()
 
         if reader.Read() then
             let rootId = Guid.Parse(reader.GetString(0))
-            let rootHash = reader.GetString(1)
-            let lastFile = Instant.FromUnixTimeTicks(reader.GetInt64(2))
-            let lastDir = Instant.FromUnixTimeTicks(reader.GetInt64(3))
+            let rootSha256Hash = reader.GetString(1)
+            let rootBlake3Hash = reader.GetString(2)
+            let lastFile = Instant.FromUnixTimeTicks(reader.GetInt64(3))
+            let lastDir = Instant.FromUnixTimeTicks(reader.GetInt64(4))
 
             {
                 RootDirectoryId = rootId
-                RootDirectorySha256Hash = rootHash
+                RootDirectorySha256Hash = rootSha256Hash
+                RootDirectoryBlake3Hash = rootBlake3Hash
                 LastSuccessfulFileUpload = lastFile
                 LastSuccessfulDirectoryVersionUpload = lastDir
             }
@@ -637,6 +655,7 @@ module LocalStateDb =
                         {
                             RootDirectoryId = defaultStatus.RootDirectoryId
                             RootDirectorySha256Hash = defaultStatus.RootDirectorySha256Hash
+                            RootDirectoryBlake3Hash = Blake3Hash String.Empty
                             LastSuccessfulFileUpload = defaultStatus.LastSuccessfulFileUpload
                             LastSuccessfulDirectoryVersionUpload = defaultStatus.LastSuccessfulDirectoryVersionUpload
                         }
@@ -644,15 +663,31 @@ module LocalStateDb =
                 connection.Dispose()
         }
 
+    let private getRootDirectoryBlake3Hash (graceStatus: GraceStatus) =
+        let mutable rootDirectory = Unchecked.defaultof<LocalDirectoryVersion>
+
+        if
+            not (isNull graceStatus.Index)
+            && graceStatus.Index.TryGetValue(graceStatus.RootDirectoryId, &rootDirectory)
+        then
+            rootDirectory.Blake3Hash
+        else
+            Blake3Hash String.Empty
+
     let private setStatusMeta (connection: SqliteConnection) (graceStatus: GraceStatus) =
+        let rootDirectoryBlake3Hash = getRootDirectoryBlake3Hash graceStatus
+
         executeNonQueryWithParams
             connection
-            "INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, $root_id, $root_hash, $last_file, $last_dir);"
+            "INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, $root_id, $root_sha256_hash, $root_blake3_hash, $last_file, $last_dir);"
             (fun parameters ->
                 parameters.AddWithValue("$root_id", graceStatus.RootDirectoryId.ToString())
                 |> ignore
 
-                parameters.AddWithValue("$root_hash", graceStatus.RootDirectorySha256Hash)
+                parameters.AddWithValue("$root_sha256_hash", graceStatus.RootDirectorySha256Hash)
+                |> ignore
+
+                parameters.AddWithValue("$root_blake3_hash", rootDirectoryBlake3Hash)
                 |> ignore
 
                 parameters.AddWithValue("$last_file", graceStatus.LastSuccessfulFileUpload.ToUnixTimeTicks())
@@ -1216,6 +1251,7 @@ module LocalStateDb =
                         {
                             RootDirectoryId = defaultStatus.RootDirectoryId
                             RootDirectorySha256Hash = defaultStatus.RootDirectorySha256Hash
+                            RootDirectoryBlake3Hash = Blake3Hash String.Empty
                             LastSuccessfulFileUpload = defaultStatus.LastSuccessfulFileUpload
                             LastSuccessfulDirectoryVersionUpload = defaultStatus.LastSuccessfulDirectoryVersionUpload
                         }
@@ -1394,148 +1430,181 @@ module LocalStateDb =
                     try
                         let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
                         use connection = openReadOnlyConnection normalizedPath immutableSnapshot
+                        let schemaVersion = readSchemaVersionReadOnly connection
 
-                        match readStatusMetaInternal connection with
-                        | None -> return Error "Local state status_meta row is missing or unreadable."
-                        | Some meta ->
-                            let columnExists tableName columnName =
-                                use command = connection.CreateCommand()
-                                command.CommandText <- $"PRAGMA table_info({tableName});"
-                                use reader = command.ExecuteReader()
-                                let mutable found = false
+                        let missingBlake3Columns =
+                            [|
+                                if not (columnExists connection "status_meta" "root_directory_blake3_hash") then
+                                    "status_meta.root_directory_blake3_hash"
 
-                                while reader.Read() do
-                                    if StringComparer.OrdinalIgnoreCase.Equals(reader.GetString(1), columnName) then
-                                        found <- true
+                                if not (columnExists connection "status_directories" "blake3_hash") then
+                                    "status_directories.blake3_hash"
 
-                                found
+                                if not (columnExists connection "status_files" "blake3_hash") then
+                                    "status_files.blake3_hash"
+                            |]
 
-                            let directories = List<StatusDirectoryRow>()
-                            let files = List<StatusFileRow>()
-                            let hasStatusFilesBlake3Hash = columnExists "status_files" "blake3_hash"
-
-                            use directoryCommand = connection.CreateCommand()
-
-                            directoryCommand.CommandText <-
-                                "SELECT relative_path, parent_path, directory_version_id, sha256_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
-
-                            use directoryReader = directoryCommand.ExecuteReader()
-
-                            while directoryReader.Read() do
-                                directories.Add(
-                                    {
-                                        RelativePath = directoryReader.GetString(0)
-                                        ParentPath = directoryReader.GetString(1)
-                                        DirectoryVersionId = Guid.Parse(directoryReader.GetString(2))
-                                        Sha256Hash = directoryReader.GetString(3)
-                                        Blake3Hash = String.Empty
-                                        SizeBytes = directoryReader.GetInt64(4)
-                                        CreatedAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(5))
-                                        LastWriteTimeUtc = DateTime(directoryReader.GetInt64(6), DateTimeKind.Utc)
-                                    }
-                                )
-
-                            use fileCommand = connection.CreateCommand()
-
-                            let fileBlake3Projection = if hasStatusFilesBlake3Hash then "blake3_hash" else "''"
-
-                            fileCommand.CommandText <-
-                                $"SELECT relative_path, directory_version_id, sha256_hash, {fileBlake3Projection}, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
-
-                            use fileReader = fileCommand.ExecuteReader()
-
-                            while fileReader.Read() do
-                                files.Add(
-                                    {
-                                        RelativePath = fileReader.GetString(0)
-                                        DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
-                                        Sha256Hash = fileReader.GetString(2)
-                                        Blake3Hash = fileReader.GetString(3)
-                                        IsBinary = fileReader.GetInt64(4) = 1L
-                                        SizeBytes = fileReader.GetInt64(5)
-                                        CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
-                                        UploadedToObjectStorage = fileReader.GetInt64(7) = 1L
-                                        LastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
-                                    }
-                                )
-
-                            let directoriesByParent = Dictionary<string, List<DirectoryVersionId>>()
-                            let filesByDirectory = Dictionary<DirectoryVersionId, List<LocalFileVersion>>()
-
-                            directories
-                            |> Seq.iter (fun directory ->
-                                let mutable existing = Unchecked.defaultof<List<DirectoryVersionId>>
-
-                                if directoriesByParent.TryGetValue(directory.ParentPath, &existing) then
-                                    existing.Add(directory.DirectoryVersionId)
-                                else
-                                    directoriesByParent.Add(directory.ParentPath, List<DirectoryVersionId>([ directory.DirectoryVersionId ])))
-
-                            files
-                            |> Seq.iter (fun file ->
-                                let localFile =
-                                    LocalFileVersion.CreateWithHashes
-                                        file.RelativePath
-                                        file.Sha256Hash
-                                        file.Blake3Hash
-                                        file.IsBinary
-                                        file.SizeBytes
-                                        file.CreatedAt
-                                        file.UploadedToObjectStorage
-                                        file.LastWriteTimeUtc
-
-                                let mutable existing = Unchecked.defaultof<List<LocalFileVersion>>
-
-                                if filesByDirectory.TryGetValue(file.DirectoryVersionId, &existing) then
-                                    existing.Add(localFile)
-                                else
-                                    filesByDirectory.Add(file.DirectoryVersionId, List<LocalFileVersion>([ localFile ])))
-
-                            let index = GraceIndex()
-
-                            directories
-                            |> Seq.iter (fun directory ->
-                                let directoriesForPath =
-                                    let mutable list = Unchecked.defaultof<List<DirectoryVersionId>>
-
-                                    if directoriesByParent.TryGetValue(directory.RelativePath, &list) then
-                                        list
-                                    else
-                                        List<DirectoryVersionId>()
-
-                                let filesForPath =
-                                    let mutable list = Unchecked.defaultof<List<LocalFileVersion>>
-
-                                    if filesByDirectory.TryGetValue(directory.DirectoryVersionId, &list) then
-                                        list
-                                    else
-                                        List<LocalFileVersion>()
-
-                                let localDirectory =
-                                    LocalDirectoryVersion.Create
-                                        directory.DirectoryVersionId
-                                        ownerId
-                                        organizationId
-                                        repositoryId
-                                        directory.RelativePath
-                                        directory.Sha256Hash
-                                        directoriesForPath
-                                        filesForPath
-                                        directory.SizeBytes
-                                        directory.LastWriteTimeUtc
-
-                                index.TryAdd(directory.DirectoryVersionId, localDirectory)
-                                |> ignore)
+                        if schemaVersion <> Some SchemaVersion then
+                            let foundSchemaVersion = defaultArg schemaVersion "<missing>"
 
                             return
-                                Ok
-                                    {
-                                        Index = index
-                                        RootDirectoryId = meta.RootDirectoryId
-                                        RootDirectorySha256Hash = meta.RootDirectorySha256Hash
-                                        LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
-                                        LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
+                                Error
+                                    $"Local state database schema version is incompatible with this Grace CLI. Expected {SchemaVersion}, found {foundSchemaVersion}. Run a normal Grace command to reset the local state database, or move the local state database aside and retry."
+                        elif missingBlake3Columns.Length > 0 then
+                            let missingColumns = String.concat ", " missingBlake3Columns
+
+                            return
+                                Error
+                                    $"Local state database is missing required BLAKE3 columns: {missingColumns}. Run a normal Grace command to reset the local state database, or move the local state database aside and retry."
+                        else
+                            match readStatusMetaInternal connection with
+                            | None -> return Error "Local state status_meta row is missing or unreadable."
+                            | Some meta ->
+                                let directories = List<StatusDirectoryRow>()
+                                let files = List<StatusFileRow>()
+
+                                use directoryCommand = connection.CreateCommand()
+
+                                directoryCommand.CommandText <-
+                                    "SELECT relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks FROM status_directories;"
+
+                                use directoryReader = directoryCommand.ExecuteReader()
+
+                                while directoryReader.Read() do
+                                    directories.Add(
+                                        {
+                                            RelativePath = directoryReader.GetString(0)
+                                            ParentPath = directoryReader.GetString(1)
+                                            DirectoryVersionId = Guid.Parse(directoryReader.GetString(2))
+                                            Sha256Hash = directoryReader.GetString(3)
+                                            Blake3Hash = directoryReader.GetString(4)
+                                            SizeBytes = directoryReader.GetInt64(5)
+                                            CreatedAt = Instant.FromUnixTimeTicks(directoryReader.GetInt64(6))
+                                            LastWriteTimeUtc = DateTime(directoryReader.GetInt64(7), DateTimeKind.Utc)
+                                        }
+                                    )
+
+                                use fileCommand = connection.CreateCommand()
+
+                                fileCommand.CommandText <-
+                                    "SELECT relative_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+
+                                use fileReader = fileCommand.ExecuteReader()
+
+                                while fileReader.Read() do
+                                    files.Add(
+                                        {
+                                            RelativePath = fileReader.GetString(0)
+                                            DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
+                                            Sha256Hash = fileReader.GetString(2)
+                                            Blake3Hash = fileReader.GetString(3)
+                                            IsBinary = fileReader.GetInt64(4) = 1L
+                                            SizeBytes = fileReader.GetInt64(5)
+                                            CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
+                                            UploadedToObjectStorage = fileReader.GetInt64(7) = 1L
+                                            LastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
+                                        }
+                                    )
+
+                                let emptyBlake3Rows =
+                                    seq {
+                                        yield!
+                                            directories
+                                            |> Seq.filter (fun directory -> String.IsNullOrWhiteSpace(string directory.Blake3Hash))
+                                            |> Seq.map (fun directory -> $"directory:{directory.RelativePath}")
+
+                                        yield!
+                                            files
+                                            |> Seq.filter (fun file -> String.IsNullOrWhiteSpace(string file.Blake3Hash))
+                                            |> Seq.map (fun file -> $"file:{file.RelativePath}")
                                     }
+                                    |> Seq.toArray
+
+                                if emptyBlake3Rows.Length > 0 then
+                                    let rows = String.concat ", " emptyBlake3Rows
+
+                                    return
+                                        Error
+                                            $"Local state database contains empty BLAKE3 values in status rows: {rows}. Run a normal Grace command to reset the local state database, or move the local state database aside and retry."
+                                else
+                                    let directoriesByParent = Dictionary<string, List<DirectoryVersionId>>()
+                                    let filesByDirectory = Dictionary<DirectoryVersionId, List<LocalFileVersion>>()
+
+                                    directories
+                                    |> Seq.iter (fun directory ->
+                                        let mutable existing = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                        if directoriesByParent.TryGetValue(directory.ParentPath, &existing) then
+                                            existing.Add(directory.DirectoryVersionId)
+                                        else
+                                            directoriesByParent.Add(directory.ParentPath, List<DirectoryVersionId>([ directory.DirectoryVersionId ])))
+
+                                    files
+                                    |> Seq.iter (fun file ->
+                                        let localFile =
+                                            LocalFileVersion.CreateWithHashes
+                                                file.RelativePath
+                                                file.Sha256Hash
+                                                file.Blake3Hash
+                                                file.IsBinary
+                                                file.SizeBytes
+                                                file.CreatedAt
+                                                file.UploadedToObjectStorage
+                                                file.LastWriteTimeUtc
+
+                                        let mutable existing = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                        if filesByDirectory.TryGetValue(file.DirectoryVersionId, &existing) then
+                                            existing.Add(localFile)
+                                        else
+                                            filesByDirectory.Add(file.DirectoryVersionId, List<LocalFileVersion>([ localFile ])))
+
+                                    let index = GraceIndex()
+
+                                    directories
+                                    |> Seq.iter (fun directory ->
+                                        let directoriesForPath =
+                                            let mutable list = Unchecked.defaultof<List<DirectoryVersionId>>
+
+                                            if directoriesByParent.TryGetValue(directory.RelativePath, &list) then
+                                                list
+                                            else
+                                                List<DirectoryVersionId>()
+
+                                        let filesForPath =
+                                            let mutable list = Unchecked.defaultof<List<LocalFileVersion>>
+
+                                            if filesByDirectory.TryGetValue(directory.DirectoryVersionId, &list) then
+                                                list
+                                            else
+                                                List<LocalFileVersion>()
+
+                                        let localDirectory =
+                                            LocalDirectoryVersion.CreateWithHashes
+                                                directory.DirectoryVersionId
+                                                ownerId
+                                                organizationId
+                                                repositoryId
+                                                directory.RelativePath
+                                                directory.Sha256Hash
+                                                directory.Blake3Hash
+                                                directoriesForPath
+                                                filesForPath
+                                                directory.SizeBytes
+                                                directory.LastWriteTimeUtc
+
+                                        index.TryAdd(directory.DirectoryVersionId, localDirectory)
+                                        |> ignore)
+
+                                    return
+                                        Ok
+                                            {
+                                                Index = index
+                                                RootDirectoryId = meta.RootDirectoryId
+                                                RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                                                LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
+                                                LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
+                                            }
                     with
                     | ex -> return Error ex.Message
         }

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1491,6 +1491,12 @@ module LocalStateDb =
 
                                 if not (columnExists connection "status_files" "blake3_hash") then
                                     "status_files.blake3_hash"
+
+                                if not (columnExists connection "object_cache_directories" "blake3_hash") then
+                                    "object_cache_directories.blake3_hash"
+
+                                if not (columnExists connection "object_cache_directory_files" "blake3_hash") then
+                                    "object_cache_directory_files.blake3_hash"
                             |]
 
                         if schemaVersion <> Some SchemaVersion then

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -494,6 +494,13 @@ module LocalStateDb =
                 parameters.AddWithValue("$last_dir", defaultStatus.LastSuccessfulDirectoryVersionUpload.ToUnixTimeTicks())
                 |> ignore)
 
+    let private hasRequiredWritableSchema (connection: SqliteConnection) =
+        columnExists connection "status_meta" "root_directory_blake3_hash"
+        && columnExists connection "status_directories" "blake3_hash"
+        && columnExists connection "status_files" "blake3_hash"
+        && columnExists connection "object_cache_directories" "blake3_hash"
+        && columnExists connection "object_cache_directory_files" "blake3_hash"
+
     let private recreateDatabase (dbPath: string) =
         try
             SqliteConnection.ClearAllPools()
@@ -574,6 +581,12 @@ module LocalStateDb =
                                                     let createdAtTicks = getCurrentInstant().ToUnixTimeTicks()
                                                     setMetaValue connection "schema_version" SchemaVersion
                                                     setMetaValue connection "created_at_unix_ticks" $"{createdAtTicks}"
+
+                                                if
+                                                    not recreate
+                                                    && not (hasRequiredWritableSchema connection)
+                                                then
+                                                    recreate <- true
 
                                                 if not recreate then
                                                     logTrace "status_meta ensuring default row"
@@ -675,7 +688,22 @@ module LocalStateDb =
             Blake3Hash String.Empty
 
     let private setStatusMeta (connection: SqliteConnection) (graceStatus: GraceStatus) =
-        let rootDirectoryBlake3Hash = getRootDirectoryBlake3Hash graceStatus
+        let incomingRootDirectoryBlake3Hash = getRootDirectoryBlake3Hash graceStatus
+
+        let statusHasRootIdentity =
+            graceStatus.RootDirectoryId
+            <> DirectoryVersionId.Empty
+            || not (String.IsNullOrWhiteSpace(string graceStatus.RootDirectorySha256Hash))
+
+        let rootDirectoryBlake3Hash =
+            if not (String.IsNullOrWhiteSpace(string incomingRootDirectoryBlake3Hash)) then
+                incomingRootDirectoryBlake3Hash
+            elif not statusHasRootIdentity then
+                incomingRootDirectoryBlake3Hash
+            else
+                match readStatusMetaInternal connection with
+                | Some meta when not (String.IsNullOrWhiteSpace(string meta.RootDirectoryBlake3Hash)) -> meta.RootDirectoryBlake3Hash
+                | _ -> incomingRootDirectoryBlake3Hash
 
         executeNonQueryWithParams
             connection

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -501,6 +501,18 @@ module LocalStateDb =
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
 
+    let private hasEmptyWritableStatusBlake3Rows (connection: SqliteConnection) =
+        if columnExists connection "status_directories" "blake3_hash"
+           && columnExists connection "status_files" "blake3_hash" then
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT EXISTS(SELECT 1 FROM status_directories WHERE TRIM(blake3_hash) = '' LIMIT 1) OR EXISTS(SELECT 1 FROM status_files WHERE TRIM(blake3_hash) = '' LIMIT 1);"
+
+            Convert.ToInt32(command.ExecuteScalar()) <> 0
+        else
+            false
+
     let private recreateDatabase (dbPath: string) =
         try
             SqliteConnection.ClearAllPools()
@@ -586,6 +598,10 @@ module LocalStateDb =
                                                     not recreate
                                                     && not (hasRequiredWritableSchema connection)
                                                 then
+                                                    recreate <- true
+
+                                                if not recreate
+                                                   && hasEmptyWritableStatusBlake3Rows connection then
                                                     recreate <- true
 
                                                 if not recreate then
@@ -702,7 +718,12 @@ module LocalStateDb =
                 incomingRootDirectoryBlake3Hash
             else
                 match readStatusMetaInternal connection with
-                | Some meta when not (String.IsNullOrWhiteSpace(string meta.RootDirectoryBlake3Hash)) -> meta.RootDirectoryBlake3Hash
+                | Some meta when
+                    meta.RootDirectoryId = graceStatus.RootDirectoryId
+                    && meta.RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
+                    && not (String.IsNullOrWhiteSpace(string meta.RootDirectoryBlake3Hash))
+                    ->
+                    meta.RootDirectoryBlake3Hash
                 | _ -> incomingRootDirectoryBlake3Hash
 
         executeNonQueryWithParams

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -47,7 +47,11 @@ module Storage =
             fileVersion.GetObjectFileName
         else
             let file = FileInfo($"{fileVersion.RelativePath}")
-            $"{file.Name.Replace(file.Extension, String.Empty)}_{fileVersion.Sha256Hash}_{fileVersion.Blake3Hash}{file.Extension}"
+
+            if file.Extension = String.Empty then
+                $"{file.Name}_{fileVersion.Sha256Hash}_{fileVersion.Blake3Hash}"
+            else
+                $"{file.Name.Replace(file.Extension, String.Empty)}_{fileVersion.Sha256Hash}_{fileVersion.Blake3Hash}{file.Extension}"
 
     let internal readStringResponseWithLifecycle (response: HttpResponseMessage) correlationId errorPrefix =
         task {

--- a/src/Grace.SDK/Storage.SDK.fs
+++ b/src/Grace.SDK/Storage.SDK.fs
@@ -42,6 +42,13 @@ module Storage =
 
     let private contentBlockPlacement contentBlockAddress etag = { ObjectKey = StorageKeys.contentBlockObjectKey contentBlockAddress; ETag = etag }
 
+    let internal getLocalObjectCacheFileName (fileVersion: FileVersion) =
+        if String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash) then
+            fileVersion.GetObjectFileName
+        else
+            let file = FileInfo($"{fileVersion.RelativePath}")
+            $"{file.Name.Replace(file.Extension, String.Empty)}_{fileVersion.Sha256Hash}_{fileVersion.Blake3Hash}{file.Extension}"
+
     let internal readStringResponseWithLifecycle (response: HttpResponseMessage) correlationId errorPrefix =
         task {
             let! responseText = response.Content.ReadAsStringAsync()
@@ -82,9 +89,11 @@ module Storage =
                             else
                                 getNativeFilePath fileVersion.RelativeDirectory
 
-                        let tempFilePath = Path.Combine(Path.GetTempPath(), relativeDirectory, fileVersion.GetObjectFileName)
+                        let localObjectCacheFileName = getLocalObjectCacheFileName fileVersion
 
-                        let objectFilePath = Path.Combine(Current().ObjectDirectory, fileVersion.RelativePath, fileVersion.GetObjectFileName)
+                        let tempFilePath = Path.Combine(Path.GetTempPath(), relativeDirectory, localObjectCacheFileName)
+
+                        let objectFilePath = Path.Combine(Current().ObjectDirectory, fileVersion.RelativePath, localObjectCacheFileName)
 
                         let tempFileInfo = FileInfo(tempFilePath)
                         let objectFileInfo = FileInfo(objectFilePath)
@@ -243,8 +252,7 @@ module Storage =
                                     $"""attachment; creation-date="{fileVersion.CreatedAt.ToString(InstantPattern.General.PatternText, CultureInfo.InvariantCulture)}" """
                             )
 
-                        let objectFilePath =
-                            $"{Current().ObjectDirectory}{Path.DirectorySeparatorChar}{fileVersion.RelativePath}{Path.DirectorySeparatorChar}{fileVersion.GetObjectFileName}"
+                        let objectFilePath = Path.Combine(Current().ObjectDirectory, string fileVersion.RelativePath, getLocalObjectCacheFileName fileVersion)
 
                         let normalizedObjectFilePath = Path.GetFullPath(objectFilePath)
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -81,6 +81,30 @@ type StorageWholeFileCompatibility() =
         parameters.CorrelationId <- generateCorrelationId ()
         parameters
 
+    let uploadLegacyWholeFileBlob repositoryId (fileVersion: FileVersion) (payload: byte array) =
+        task {
+            let legacyFileVersion = FileVersion.Create fileVersion.RelativePath fileVersion.Sha256Hash String.Empty fileVersion.IsBinary fileVersion.Size
+
+            let! uploadResponse =
+                Client.PostAsync("/storage/getUploadMetadataForFiles", createJsonContent (createUploadParameters repositoryId legacyFileVersion))
+
+            let! uploadContent = uploadResponse.Content.ReadAsStringAsync()
+            Assert.That(uploadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadContent)
+
+            let metadata = getUploadMetadataJson uploadContent
+
+            let blobUri =
+                Uri(
+                    (requireJsonProperty "BlobUriWithSasToken" metadata)
+                        .GetString()
+                )
+
+            let blobClient = BlockBlobClient(blobUri)
+            use payloadStream = new MemoryStream(payload, writable = false)
+            let! _ = blobClient.UploadAsync(payloadStream)
+            return StorageKeys.legacyWholeFileContentObjectKey fileVersion
+        }
+
     [<Test>]
     member _.SmallWholeFileContentPopulatesContentReferenceWithoutChangingEndpointMetadata() =
         task {
@@ -107,6 +131,12 @@ type StorageWholeFileCompatibility() =
                 (requireJsonProperty "Sha256Hash" metadata)
                     .GetString(),
                 Is.EqualTo(sha256Hash)
+            )
+
+            Assert.That(
+                (requireJsonProperty "Blake3Hash" metadata)
+                    .GetString(),
+                Is.EqualTo(String.Empty)
             )
 
             assertWholeFileContentReference metadata
@@ -166,6 +196,18 @@ type StorageWholeFileCompatibility() =
             Assert.That(secondUploadUri, Does.Contain("small_shared-sha256_second-blake3.bin"))
             Assert.That(firstUploadUri, Is.Not.EqualTo(secondUploadUri))
 
+            Assert.That(
+                (requireJsonProperty "Blake3Hash" firstMetadata)
+                    .GetString(),
+                Is.EqualTo(firstFileVersion.Blake3Hash)
+            )
+
+            Assert.That(
+                (requireJsonProperty "Blake3Hash" secondMetadata)
+                    .GetString(),
+                Is.EqualTo(secondFileVersion.Blake3Hash)
+            )
+
             let! firstDownloadResponse = Client.PostAsync("/storage/getDownloadUri", createJsonContent (createDownloadParameters repositoryId firstFileVersion))
             let! firstDownloadUri = firstDownloadResponse.Content.ReadAsStringAsync()
             Assert.That(firstDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstDownloadUri)
@@ -178,6 +220,40 @@ type StorageWholeFileCompatibility() =
             Assert.That(secondDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), secondDownloadUri)
             Assert.That(secondDownloadUri, Does.Contain("small_shared-sha256_second-blake3.bin"))
             Assert.That(firstDownloadUri, Is.Not.EqualTo(secondDownloadUri))
+        }
+
+    [<Test>]
+    member _.SmallWholeFileDownloadFallsBackToLegacyShaOnlyBlobWhenCurrentBlake3KeyIsMissing() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let relativeDirectory = $"wholefile-legacy-fallback/{Guid.NewGuid():N}"
+            let relativePath = $"{relativeDirectory}/small.txt"
+            let payload = Encoding.UTF8.GetBytes($"Grace legacy whole-file fallback {Guid.NewGuid():N}")
+            let sha256Hash = computeSha256Hash payload
+
+            let fileVersion =
+                FileVersion.CreateWithHashes
+                    (RelativePath relativePath)
+                    (Sha256Hash sha256Hash)
+                    (Blake3Hash "existing-history-blake3")
+                    String.Empty
+                    false
+                    (int64 payload.Length)
+
+            let! legacyBlobName = uploadLegacyWholeFileBlob repositoryId fileVersion payload
+            let currentBlobName = StorageKeys.wholeFileContentObjectKey fileVersion
+
+            Assert.That(currentBlobName, Is.Not.EqualTo(legacyBlobName))
+
+            let! downloadResponse = Client.PostAsync("/storage/getDownloadUri", createJsonContent (createDownloadParameters repositoryId fileVersion))
+            let! downloadUriText = downloadResponse.Content.ReadAsStringAsync()
+            Assert.That(downloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), downloadUriText)
+            Assert.That(downloadUriText, Does.Contain(legacyBlobName))
+            Assert.That(downloadUriText, Does.Not.Contain(currentBlobName))
+
+            let downloadClient = BlobClient(Uri(downloadUriText))
+            let! downloaded = downloadClient.DownloadContentAsync()
+            Assert.That(downloaded.Value.Content.ToArray(), Is.EquivalentTo(payload))
         }
 
 [<NonParallelizable>]

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -125,6 +125,61 @@ type StorageWholeFileCompatibility() =
             Assert.That(downloadUri, Does.Contain(fileVersion.GetObjectFileName))
         }
 
+    [<Test>]
+    member _.SmallWholeFileMetadataUsesBlake3SpecificBlobKeysWhenPresent() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let relativeDirectory = $"wholefile-dual-hash/{Guid.NewGuid():N}"
+            let relativePath = $"{relativeDirectory}/small.bin"
+            let sharedSha256Hash = "shared-sha256"
+
+            let firstFileVersion =
+                FileVersion.CreateWithHashes (RelativePath relativePath) (Sha256Hash sharedSha256Hash) (Blake3Hash "first-blake3") String.Empty true 128L
+
+            let secondFileVersion =
+                FileVersion.CreateWithHashes (RelativePath relativePath) (Sha256Hash sharedSha256Hash) (Blake3Hash "second-blake3") String.Empty true 128L
+
+            let! firstUploadResponse =
+                Client.PostAsync("/storage/getUploadMetadataForFiles", createJsonContent (createUploadParameters repositoryId firstFileVersion))
+
+            let! firstUploadContent = firstUploadResponse.Content.ReadAsStringAsync()
+            Assert.That(firstUploadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstUploadContent)
+
+            let! secondUploadResponse =
+                Client.PostAsync("/storage/getUploadMetadataForFiles", createJsonContent (createUploadParameters repositoryId secondFileVersion))
+
+            let! secondUploadContent = secondUploadResponse.Content.ReadAsStringAsync()
+            Assert.That(secondUploadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), secondUploadContent)
+
+            let firstMetadata = getUploadMetadataJson firstUploadContent
+            let secondMetadata = getUploadMetadataJson secondUploadContent
+
+            let firstUploadUri =
+                (requireJsonProperty "BlobUriWithSasToken" firstMetadata)
+                    .GetString()
+
+            let secondUploadUri =
+                (requireJsonProperty "BlobUriWithSasToken" secondMetadata)
+                    .GetString()
+
+            Assert.That(firstUploadUri, Does.Contain("small_shared-sha256_first-blake3.bin"))
+            Assert.That(secondUploadUri, Does.Contain("small_shared-sha256_second-blake3.bin"))
+            Assert.That(firstUploadUri, Is.Not.EqualTo(secondUploadUri))
+
+            let! firstDownloadResponse = Client.PostAsync("/storage/getDownloadUri", createJsonContent (createDownloadParameters repositoryId firstFileVersion))
+            let! firstDownloadUri = firstDownloadResponse.Content.ReadAsStringAsync()
+            Assert.That(firstDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstDownloadUri)
+            Assert.That(firstDownloadUri, Does.Contain("small_shared-sha256_first-blake3.bin"))
+
+            let! secondDownloadResponse =
+                Client.PostAsync("/storage/getDownloadUri", createJsonContent (createDownloadParameters repositoryId secondFileVersion))
+
+            let! secondDownloadUri = secondDownloadResponse.Content.ReadAsStringAsync()
+            Assert.That(secondDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), secondDownloadUri)
+            Assert.That(secondDownloadUri, Does.Contain("small_shared-sha256_second-blake3.bin"))
+            Assert.That(firstDownloadUri, Is.Not.EqualTo(secondDownloadUri))
+        }
+
 [<NonParallelizable>]
 type StorageContentBlockSasRoutes() =
 

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -56,6 +56,32 @@ module Storage =
 
         StorageKeys.wholeFileContentObjectKey fileVersion
 
+    let private getLegacyWholeFileContentObjectKey (fileVersion: FileVersion) =
+        normalizeWholeFileContentReference fileVersion
+        |> ignore
+
+        StorageKeys.legacyWholeFileContentObjectKey fileVersion
+
+    let private getReadableWholeFileContentObjectKey (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId =
+        task {
+            let currentBlobName = getWholeFileContentObjectKey fileVersion
+
+            if StorageKeys.hasBlake3SpecificWholeFileContentObjectKey fileVersion then
+                let! currentBlobClient = getAzureBlobClient repositoryDto currentBlobName correlationId
+                let! currentExists = currentBlobClient.ExistsAsync()
+
+                if currentExists.Value then
+                    return currentBlobName
+                else
+                    let legacyBlobName = getLegacyWholeFileContentObjectKey fileVersion
+                    let! legacyBlobClient = getAzureBlobClient repositoryDto legacyBlobName correlationId
+                    let! legacyExists = legacyBlobClient.ExistsAsync()
+
+                    if legacyExists.Value then return legacyBlobName else return currentBlobName
+            else
+                return currentBlobName
+        }
+
     let private getContentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = StorageKeys.contentBlockObjectKey contentBlockAddress
 
     let private resolveStorageIds (graceIds: GraceIds) (parameters: StorageParameters) =
@@ -377,7 +403,7 @@ module Storage =
         task {
             match repositoryDto.ObjectStorageProvider with
             | AzureBlobStorage ->
-                let blobName = getWholeFileContentObjectKey fileVersion
+                let! blobName = getReadableWholeFileContentObjectKey repositoryDto fileVersion (getCorrelationId context)
                 let! blobClient = getAzureBlobClient repositoryDto blobName (getCorrelationId context)
                 let! azureResponse = blobClient.GetPropertiesAsync()
                 let blobProperties = azureResponse.Value
@@ -405,7 +431,7 @@ module Storage =
                     let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
                     let! repositoryDto = repositoryActor.Get correlationId
 
-                    let blobName = getWholeFileContentObjectKey parameters.FileVersion
+                    let! blobName = getReadableWholeFileContentObjectKey repositoryDto parameters.FileVersion correlationId
                     let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
                     context.SetStatusCode StatusCodes.Status200OK
                     //log.LogTrace("fileVersion: {fileVersion.RelativePath}; downloadUri: {downloadUri}", [| parameters.FileVersion.RelativePath, downloadUri |])
@@ -887,6 +913,7 @@ module Storage =
                                                     RelativePath = fileVersion.RelativePath
                                                     BlobUriWithSasToken = blobUriWithSasToken
                                                     Sha256Hash = fileVersion.Sha256Hash
+                                                    Blake3Hash = fileVersion.Blake3Hash
                                                     ContentReference = contentReference
                                                 }
 

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -168,7 +168,14 @@ module Storage =
             Message: string
         }
 
-    type UploadMetadata = { RelativePath: RelativePath; BlobUriWithSasToken: Uri; Sha256Hash: Sha256Hash; ContentReference: FileContentReference }
+    type UploadMetadata =
+        {
+            RelativePath: RelativePath
+            BlobUriWithSasToken: Uri
+            Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
+            ContentReference: FileContentReference
+        }
 
     type GetUploadMetadataForFilesParameters() =
         inherit StorageParameters()

--- a/src/Grace.Shared/StorageKeys.Shared.fs
+++ b/src/Grace.Shared/StorageKeys.Shared.fs
@@ -25,6 +25,14 @@ module StorageKeys =
     /// Builds the current repository-scoped object key for whole-file content.
     let wholeFileContentObjectKey (fileVersion: FileVersion) = $"{fileVersion.RelativePath}/{wholeFileContentObjectFileName fileVersion}"
 
+    /// Builds the legacy SHA-only repository-scoped object key for whole-file content.
+    let legacyWholeFileContentObjectKey (fileVersion: FileVersion) = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+
+    /// Returns true when the current whole-file key differs from the legacy SHA-only key.
+    let hasBlake3SpecificWholeFileContentObjectKey (fileVersion: FileVersion) =
+        wholeFileContentObjectKey fileVersion
+        <> legacyWholeFileContentObjectKey fileVersion
+
     /// Builds the StoragePool-scoped object key for a content-addressed ContentBlock payload.
     let contentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = $"{CasPrefix}/{ContentBlocksPrefix}/{contentBlockAddress}"
 

--- a/src/Grace.Shared/StorageKeys.Shared.fs
+++ b/src/Grace.Shared/StorageKeys.Shared.fs
@@ -1,5 +1,6 @@
 namespace Grace.Shared
 
+open System
 open Grace.Types.Common
 
 module StorageKeys =
@@ -15,8 +16,14 @@ module StorageKeys =
     [<Literal>]
     let private ContentBlockMetadataPrefix = "content-block-metadata"
 
+    let private wholeFileContentObjectFileName (fileVersion: FileVersion) =
+        if String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash) then
+            fileVersion.GetObjectFileName
+        else
+            Utilities.getObjectFileName fileVersion.RelativePath $"{fileVersion.Sha256Hash}_{fileVersion.Blake3Hash}"
+
     /// Builds the current repository-scoped object key for whole-file content.
-    let wholeFileContentObjectKey (fileVersion: FileVersion) = $"{fileVersion.RelativePath}/{fileVersion.GetObjectFileName}"
+    let wholeFileContentObjectKey (fileVersion: FileVersion) = $"{fileVersion.RelativePath}/{wholeFileContentObjectFileName fileVersion}"
 
     /// Builds the StoragePool-scoped object key for a content-addressed ContentBlock payload.
     let contentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = $"{CasPrefix}/{ContentBlocksPrefix}/{contentBlockAddress}"

--- a/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
@@ -3,6 +3,7 @@ namespace Grace.Types.Tests
 open Grace.Shared
 open Grace.Types.Common
 open NUnit.Framework
+open System
 
 [<Parallelizable(ParallelScope.All)>]
 type StorageKeysSharedTests() =
@@ -21,12 +22,46 @@ type StorageKeysSharedTests() =
         Assert.That(key, Is.EqualTo("src/Grace.Server/Storage.Server.fs/Storage.Server_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.fs"))
 
     [<Test>]
+    member _.WholeFileContentObjectKeyIncludesBlake3WhenPresent() =
+        let fileVersion =
+            FileVersion.CreateWithHashes
+                (RelativePath "src/Grace.Server/Storage.Server.fs")
+                (Sha256Hash "shared-sha256")
+                (Blake3Hash "first-blake3")
+                String.Empty
+                false
+                1234L
+
+        let key = StorageKeys.wholeFileContentObjectKey fileVersion
+
+        Assert.That(key, Is.EqualTo("src/Grace.Server/Storage.Server.fs/Storage.Server_shared-sha256_first-blake3.fs"))
+
+    [<Test>]
     member _.WholeFileContentObjectKeyPreservesExtensionlessBlobKeyShape() =
         let fileVersion = FileVersion.Create "Dockerfile" "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" "" false 2048L
 
         let key = StorageKeys.wholeFileContentObjectKey fileVersion
 
         Assert.That(key, Is.EqualTo("Dockerfile/Dockerfile_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"))
+
+    [<Test>]
+    member _.WholeFileContentObjectKeyIncludesBlake3ForExtensionlessFilesWhenPresent() =
+        let fileVersion =
+            FileVersion.CreateWithHashes (RelativePath "Dockerfile") (Sha256Hash "shared-sha256") (Blake3Hash "first-blake3") String.Empty false 2048L
+
+        let key = StorageKeys.wholeFileContentObjectKey fileVersion
+
+        Assert.That(key, Is.EqualTo("Dockerfile/Dockerfile_shared-sha256_first-blake3"))
+
+    [<Test>]
+    member _.WholeFileContentObjectKeySeparatesSameSha256DifferentBlake3() =
+        let first =
+            FileVersion.CreateWithHashes (RelativePath "src/appsettings.json") (Sha256Hash "shared-sha256") (Blake3Hash "first-blake3") String.Empty false 512L
+
+        let second =
+            FileVersion.CreateWithHashes (RelativePath "src/appsettings.json") (Sha256Hash "shared-sha256") (Blake3Hash "second-blake3") String.Empty false 512L
+
+        Assert.That(StorageKeys.wholeFileContentObjectKey first, Is.Not.EqualTo(StorageKeys.wholeFileContentObjectKey second))
 
     [<Test>]
     member _.ContentBlockObjectKeyDependsOnlyOnContentBlockAddress() =


### PR DESCRIPTION
Related to #352
Part of #343

## Summary

- Bumps the local SQLite state schema to v4 and persists root `DirectoryVersion` BLAKE3 in `status_meta` alongside root SHA-256.
- Keeps local status, object-cache, worker, and Doctor schema expectations aligned with dual-hash state.
- Rejects incompatible legacy or partial local-state DBs with deterministic reset guidance instead of manufacturing empty BLAKE3 values.
- Fixes object-cache reuse, whole-file transfer paths, `connect` skip logic, and working-tree materialization so same SHA-256 with different BLAKE3 uses distinct local and remote whole-file variants and replaces stale cached/working bytes.
- Preserves existing root BLAKE3 metadata during incremental/meta-only status updates only when the stored root id and SHA match the incoming root identity.

## Scope Notes

- This PR intentionally updates local SQLite persistence, local object-cache paths, whole-file transfer paths, whole-file storage object keys, and internal CLI/Doctor schema expectations.
- Remote whole-file object keys now include BLAKE3 when populated; legacy empty-BLAKE3 versions keep the SHA-only key shape.
- No OpenAPI, SDK public surface, public JSON, generated files, or public CLI output contracts changed.
- Issue-owned path expansion:
  - `src/Grace.CLI/Command/Doctor.CLI.fs` and `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs` because Doctor is the read-only local-state schema proof surface and the Fast gate includes the Doctor suite.
  - `src/Grace.CLI/Command/Connect.CLI.fs` and `src/Grace.CLI/Command/Watch.CLI.fs` because local object-cache path construction and connect skip behavior had to stay aligned across cache use sites.
  - `src/Grace.SDK/Storage.SDK.fs`, `src/Grace.Shared/StorageKeys.Shared.fs`, `src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs`, `src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs`, and `src/Grace.Server.Tests/Storage.Server.Tests.fs` because direct whole-file local transfer paths and remote whole-file blob keys had to use dual-hash identity while preserving legacy SHA-only compatibility.

## Proof Matrix

| Requirement | Proof |
| --- | --- |
| Local status stores both root hashes | `LocalStateDb.Tests` asserts `status_meta` root SHA-256 and BLAKE3 round-trip. |
| Directory/file rows round-trip BLAKE3 | `LocalStateDb.Tests` read-only snapshot round-trip asserts root, directory, and file BLAKE3 values. |
| Meta-only updates preserve root BLAKE3 safely | `LocalStateDb.Tests` covers preserving existing non-empty root BLAKE3 only when stored root id/SHA match the incoming root identity. |
| Old SHA-only state is explicit | Legacy schema and missing-column cases return deterministic reset guidance rather than adding empty BLAKE3 columns. |
| Partial v4 state is explicit | Writable and read-only initialization check required v4 status/object-cache columns and row content before using them. |
| Empty persisted BLAKE3 is actionable | Writable initialization detects empty BLAKE3 values in status rows and recreates the DB, matching read-only guidance. |
| Same SHA-256 with different BLAKE3 is a real change | Current-state/object-cache tests prove stale cached bytes are replaced when BLAKE3 differs. |
| Local object-cache variants do not overwrite | BLAKE3-populated local object-cache paths include BLAKE3; legacy empty-BLAKE3 rows still resolve to SHA-only filenames. |
| Extensionless dual-hash files transfer | `StorageKeys.Shared.Tests` covers extensionless dual-hash names; storage transfer tests cover whole-file direct paths. |
| Whole-file transfers use local dual-hash paths | `ManifestUpload.SDK.Tests` covers direct upload/download local path alignment. |
| Whole-file storage keys are dual-hash-safe | `StorageKeys.Shared.Tests` and `Storage.Server.Tests` cover BLAKE3-populated remote whole-file keys and empty-BLAKE3 legacy compatibility. |
| `connect` skip logic includes BLAKE3 | `Connect.CLI.Tests` covers same-SHA/different-BLAKE3 remote files not being skipped as unchanged. |
| Working tree updates include BLAKE3 | Current-state/materialization tests prove same-size/same-SHA files are updated when populated BLAKE3 differs. |
| Worker alignment | Local state worker writes root SHA-256 and BLAKE3 status metadata. |
| Doctor alignment | Doctor expects schema v4 and keeps read-only local-state checks aligned. |
| Failure ordering | Existing save/materialization paths are preserved; local status writes remain after successful operations, and this slice does not move save/update ordering earlier. |

## Validation

Passed:

- `dotnet tool run fantomas -- src\Grace.CLI\LocalStateDb.CLI.fs src\Grace.CLI\Command\Services.CLI.fs src\Grace.CLI\Command\Doctor.CLI.fs src\Grace.CLI.LocalStateDb.Worker\Program.fs src\Grace.CLI.Tests\LocalStateDb.Tests.fs src\Grace.CLI.Tests\Watch.Tests.fs src\Grace.CLI.Tests\Doctor.CLI.Tests.fs`
  - Passed; all files unchanged before the first push.
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj; if ($LASTEXITCODE -eq 0) { dotnet test --no-build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~WatchTests|FullyQualifiedName~CurrentStateCaptureCliTests|FullyQualifiedName~DoctorCliTests" }`
  - Passed, `156/156` before the first push.
- `dotnet tool run fantomas -- src\Grace.CLI\LocalStateDb.CLI.fs src\Grace.CLI\Command\Services.CLI.fs src\Grace.CLI.Tests\LocalStateDb.Tests.fs src\Grace.CLI.Tests\CurrentStateCapture.CLI.Tests.fs`
  - Passed after `7b460875ee24fec204af9fb4a066ead01ee34697`.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~WatchTests|FullyQualifiedName~CurrentStateCaptureCliTests|FullyQualifiedName~DoctorCliTests"`
  - Passed after `7b460875ee24fec204af9fb4a066ead01ee34697`, `160/160`.
- `dotnet tool run fantomas src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI/Command/Connect.CLI.fs src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs src/Grace.CLI.Tests/LocalStateDb.Tests.fs`
  - Passed after `1aaf1a35df23b11428cbde9e2b6ccbf7217fb600`.
- `dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~WatchTests|FullyQualifiedName~CurrentStateCaptureCliTests|FullyQualifiedName~DoctorCliTests"`
  - Passed after `1aaf1a35df23b11428cbde9e2b6ccbf7217fb600`, `162/162`.
- `dotnet tool run fantomas src/Grace.SDK/Storage.SDK.fs src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI/Command/Connect.CLI.fs src/Grace.CLI.Tests/Connect.CLI.Tests.fs src/Grace.CLI.Tests/LocalStateDb.Tests.fs src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs`
  - Passed after `136d41892041f6453b5d756be95cedfc5e046933`.
- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~WatchTests|FullyQualifiedName~CurrentStateCapture|FullyQualifiedName~DoctorCliTests|FullyQualifiedName~ConnectTests|FullyQualifiedName~ManifestUploadSdkTests"`
  - Passed after `136d41892041f6453b5d756be95cedfc5e046933`, `181/181`.
- `dotnet tool run fantomas C:\Source\Grace-gh-352\src\Grace.SDK\Storage.SDK.fs C:\Source\Grace-gh-352\src\Grace.Shared\StorageKeys.Shared.fs C:\Source\Grace-gh-352\src\Grace.Types.Tests\StorageKeys.Shared.Tests.fs C:\Source\Grace-gh-352\src\Grace.CLI.Tests\ManifestUpload.SDK.Tests.fs C:\Source\Grace-gh-352\src\Grace.Server.Tests\Storage.Server.Tests.fs`
  - Passed after `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`.
- `dotnet test C:\Source\Grace-gh-352\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~StorageKeysSharedTests"`
  - Passed after `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`, `8/8`.
- `dotnet test C:\Source\Grace-gh-352\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~ManifestUploadSdkTests"`
  - Passed after `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`, `16/16`.
- `dotnet test C:\Source\Grace-gh-352\src\Grace.Server.Tests\Grace.Server.Tests.fsproj --configuration Release --filter "FullyQualifiedName~StorageWholeFileCompatibility"`
  - Passed after `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`, `2/2`.
- `pwsh ./scripts/validate.ps1 -Fast`
  - Passed before and after `7b460875ee24fec204af9fb4a066ead01ee34697`, after `1aaf1a35df23b11428cbde9e2b6ccbf7217fb600`, after `136d41892041f6453b5d756be95cedfc5e046933`, and after `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`. Latest: build succeeded with `0` warnings and `0` errors; fast profile passed.
- `git diff --check`
  - Passed after each push, including `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`.

## Review Status

- Worker bot-prevention self-review: completed before each push.
- High-risk pre-PR review waiver: this slice changes local persistence, stateful CLI flows, Doctor local-state checks, cache behavior, local cache path naming, whole-file local and remote transfer identity, and working-tree materialization, but the user explicitly prohibited manual Codex review requests. This PR relies on the repository's automatic Codex Code Review Bot after PR updates.
- Automatic Codex Code Review Bot:
  - `6d9b3ab41a5ff0a74e96985ef28998bc33185217`: findings fixed in `7b460875ee24fec204af9fb4a066ead01ee34697`; inline threads resolved.
  - `7b460875ee24fec204af9fb4a066ead01ee34697`: findings fixed in `1aaf1a35df23b11428cbde9e2b6ccbf7217fb600`; inline threads resolved.
  - `1aaf1a35df23b11428cbde9e2b6ccbf7217fb600`: findings fixed in `136d41892041f6453b5d756be95cedfc5e046933`; inline threads resolved.
  - `136d41892041f6453b5d756be95cedfc5e046933`: findings fixed in `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`; inline threads resolved.
  - `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`: pending automatic bot result.
- Hosted validation: pending on `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`.
- Prevention line: local SQLite v4 persists root SHA-256 and BLAKE3, preserves existing root BLAKE3 for same-root meta-only incremental updates only, detects partial v4 or legacy SHA-only state before using missing columns or empty rows, keeps read-only and writable required-column checks aligned, keeps the worker and Doctor schema expectations aligned, treats same SHA-256 with different BLAKE3 as changed before skipping connect/materialization work, stores local dual-hash cache variants separately, keeps extensionless dual-hash file names valid, keeps direct whole-file local transfers and remote whole-file object keys on dual-hash identity when BLAKE3 is populated, and updates working files when populated BLAKE3 differs.

## Residual Risk

- Persisted empty BLAKE3 status rows are intentionally treated as incompatible local state and require reset/recreate guidance rather than in-place repair.
- `status_meta.root_directory_blake3_hash` is derived from the root directory entry in `GraceStatus.Index`; incremental/meta-only writes preserve existing non-empty root BLAKE3 only when the stored and incoming root identity match, while truly empty/default status can still write empty default metadata.
- Local cache and remote whole-file object-key shape changes for BLAKE3-populated entries; old SHA-only cache/blob names remain the compatibility path for versions without BLAKE3.
## Latest 00e0a25 Fix Pass

Commit `00e0a25917c1c5ee4a34d01ed7ad4f980e3de16b` fixes the automatic Codex findings from `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0` and the hosted `Validate / full` server-test failure shape.

Additional proof:

- `UploadMetadata` now includes BLAKE3, `/storage/getUploadMetadataForFiles` returns it, and CLI upload pairing matches on relative path, SHA-256, and BLAKE3.
- Actor whole-file reads now route through shared whole-file storage-key helpers instead of independently constructing SHA-only blob names.
- Read paths prefer the current BLAKE3-specific whole-file key and fall back read-only to the legacy SHA-only key when the current blob is absent; upload/write paths still target the current dual-hash key.
- The hosted failure pattern, `The file was not found in object storage` for annotate whole-file content, was covered by rerunning the two representative annotate tests locally.

Additional validation after `00e0a25917c1c5ee4a34d01ed7ad4f980e3de16b`:

- `dotnet tool run fantomas ...` on touched F# files: passed.
- `dotnet test --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~UploadMetadataMatchingIncludesBlake3WhenPathAndShaCollide"`: passed.
- `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~StorageWholeFileCompatibility"`: passed, `3/3`.
- `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~AnnotateOlderTargetReferenceIncludesLocalAncestorsBeforeNewestReferences|FullyQualifiedName~AnnotateChildRebaseFetchesParentHistoryBeforeBasedOnPromotion"`: passed, `2/2`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Review status update:

- `1f50d29f1aab97ea12fd4ffd0701efabf49cc7a0`: findings fixed in `00e0a25917c1c5ee4a34d01ed7ad4f980e3de16b`; inline threads resolved.
- `00e0a25917c1c5ee4a34d01ed7ad4f980e3de16b`: automatic Codex Code Review Bot gave a no-issues `+1` reaction; hosted `Validate / full` passed; no unresolved review threads remain.

Prevention line update: whole-file storage identity now carries BLAKE3 through upload metadata matching, actor read paths use the same shared storage-key boundary as server/SDK paths, and legacy SHA-only whole-file blobs remain readable through an explicit read-only fallback.