### PR TITLE
Add scoped version hash prefix resolver

### DIFF
--- a/src/Grace.Actors/Services.Actor.fs
+++ b/src/Grace.Actors/Services.Actor.fs
@@ -141,6 +141,41 @@ module Services =
     /// Logger instance for the Services.Actor module.
     let private log = loggerFactory.CreateLogger("Services.Actor")
 
+    type VersionHashPrefixResolution<'T> =
+        | NoMatches
+        | UniqueMatch of 'T
+        | AmbiguousMatches of 'T array
+
+    let internal maxVersionHashPrefixResolutionMatches = 2
+
+    let internal resolveVersionHashPrefixMatches<'T> (matches: seq<'T>) : VersionHashPrefixResolution<'T> =
+        let boundedMatches =
+            matches
+            |> Seq.truncate maxVersionHashPrefixResolutionMatches
+            |> Seq.toArray
+
+        match boundedMatches.Length with
+        | 0 -> NoMatches
+        | 1 -> UniqueMatch boundedMatches[0]
+        | _ -> AmbiguousMatches boundedMatches
+
+    let internal tryGetUniqueVersionHashPrefixMatch<'T> (resolution: VersionHashPrefixResolution<'T>) =
+        match resolution with
+        | UniqueMatch value -> Some value
+        | NoMatches
+        | AmbiguousMatches _ -> None
+
+    let internal resolveScopedVersionHashPrefix<'T> (hashPrefix: string) (getHash: 'T -> string) (matches: seq<'T>) : VersionHashPrefixResolution<'T> =
+        let normalizedPrefix = hashPrefix.Trim()
+
+        matches
+        |> Seq.filter (fun candidate ->
+            let candidateHash = getHash candidate
+
+            not (String.IsNullOrWhiteSpace candidateHash)
+            && candidateHash.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+        |> resolveVersionHashPrefixMatches
+
     let private defaultAzureCredential = lazy (DefaultAzureCredential())
 
     let private serviceBusClient =
@@ -1510,11 +1545,18 @@ module Services =
                     .ToArray()
         }
 
+    /// Resolves a reference by its SHA-256 hash.
+    let getReferenceResolutionBySha256Hash (repositoryId: RepositoryId) (branchId: BranchId) (sha256Hash: Sha256Hash) =
+        task {
+            let! references = getReferencesBySha256Hash repositoryId branchId sha256Hash maxVersionHashPrefixResolutionMatches
+            return resolveScopedVersionHashPrefix sha256Hash (fun (referenceDto: ReferenceDto) -> referenceDto.Sha256Hash) references
+        }
+
     /// Gets a reference by its SHA-256 hash.
     let getReferenceBySha256Hash (repositoryId: RepositoryId) (branchId: BranchId) (sha256Hash: Sha256Hash) =
         task {
-            let! references = getReferencesBySha256Hash repositoryId branchId sha256Hash 1
-            if references.Length > 0 then return Some references[0] else return None
+            let! resolution = getReferenceResolutionBySha256Hash repositoryId branchId sha256Hash
+            return tryGetUniqueVersionHashPrefixMatch resolution
         }
 
     /// Gets a list of references for a given branch.
@@ -2210,10 +2252,10 @@ module Services =
                     .ToArray()
         }
 
-    /// Gets a DirectoryVersion by searching using a Sha256Hash value.
-    let getDirectoryVersionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
+    /// Resolves a DirectoryVersion by searching using a Sha256Hash value.
+    let getDirectoryVersionResolutionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
         task {
-            let mutable directoryVersion = DirectoryVersion.Default
+            let directoryVersions = List<DirectoryVersion>()
 
             match actorStateStorageProvider with
             | Unknown -> ()
@@ -2225,7 +2267,7 @@ module Services =
                     let queryDefinition =
                         QueryDefinition(
                             """
-                            SELECT TOP 1 c.State
+                            SELECT TOP @maxCount c.State
                             FROM c
                             WHERE STARTSWITH(c.State[0].Event.created.Sha256Hash, @sha256Hash, true)
                                 AND c.GrainType = @grainType
@@ -2233,14 +2275,13 @@ module Services =
                             ORDER BY c.State[0].Event.created.CreatedAt DESC
                             """
                         )
+                            .WithParameter("@maxCount", maxVersionHashPrefixResolutionMatches)
                             .WithParameter("@sha256Hash", sha256Hash)
                             .WithParameter("@grainType", StateName.DirectoryVersion)
                             .WithParameter("@partitionKey", repositoryId)
 
                     try
                         let iterator = cosmosContainer.GetItemQueryIterator<DirectoryVersionEventValue>(queryDefinition, requestOptions = queryRequestOptions)
-
-                        let directoryVersionDtos = List<DirectoryVersionDto>()
 
                         while iterator.HasMoreResults do
                             let! results = DefaultAsyncRetryPolicy.ExecuteAsync(fun () -> iterator.ReadNextAsync())
@@ -2263,10 +2304,7 @@ module Services =
                                             |> DirectoryVersionDto.UpdateDto directoryEvent)
                                         DirectoryVersionDto.Default
 
-                                directoryVersionDtos.Add(directoryVersionDto))
-
-                            if directoryVersionDtos.Count > 0 then
-                                directoryVersion <- directoryVersionDtos[0].DirectoryVersion
+                                directoryVersions.Add(directoryVersionDto.DirectoryVersion))
 
                         if (indexMetrics.Length >= 2)
                            && (requestCharge.Length >= 2)
@@ -2289,11 +2327,14 @@ module Services =
                     stringBuilderPool.Return(requestCharge)
             | MongoDB -> ()
 
-            if directoryVersion.DirectoryVersionId
-               <> DirectoryVersion.Default.DirectoryVersionId then
-                return Some directoryVersion
-            else
-                return None
+            return resolveScopedVersionHashPrefix sha256Hash (fun (directoryVersion: DirectoryVersion) -> directoryVersion.Sha256Hash) directoryVersions
+        }
+
+    /// Gets a DirectoryVersion by searching using a Sha256Hash value.
+    let getDirectoryVersionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
+        task {
+            let! resolution = getDirectoryVersionResolutionBySha256Hash repositoryId sha256Hash correlationId
+            return tryGetUniqueVersionHashPrefixMatch resolution
         }
 
     /// Gets the most recent DirectoryVersion with HashesValidated = true by RelativePath.
@@ -2369,10 +2410,10 @@ module Services =
                 return None
         }
 
-    /// Gets a Root DirectoryVersion by searching using a Sha256Hash value.
-    let getRootDirectoryVersionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
+    /// Resolves a Root DirectoryVersion by searching using a Sha256Hash value.
+    let getRootDirectoryVersionResolutionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
         task {
-            let mutable directoryVersion = DirectoryVersion.Default
+            let directoryVersions = List<DirectoryVersion>()
 
             match actorStateStorageProvider with
             | Unknown -> ()
@@ -2384,7 +2425,7 @@ module Services =
                     let queryDefinition =
                         QueryDefinition(
                             $"""
-                            SELECT TOP 1 c.State
+                            SELECT TOP @maxCount c.State
                             FROM c
                             WHERE STARTSWITH(c.State[0].Event.created.Sha256Hash, @sha256Hash, true)
                                 AND (
@@ -2396,6 +2437,7 @@ module Services =
                             ORDER BY c.State[0].Event.created.CreatedAt DESC
                             """
                         )
+                            .WithParameter("@maxCount", maxVersionHashPrefixResolutionMatches)
                             .WithParameter("@sha256Hash", sha256Hash)
                             .WithParameter("@rootRelativePath", Constants.RootDirectoryPath)
                             .WithParameter("@slashRootRelativePath", RelativePath "/")
@@ -2404,7 +2446,6 @@ module Services =
 
                     try
                         let iterator = cosmosContainer.GetItemQueryIterator<DirectoryVersionEventValue>(queryDefinition, requestOptions = queryRequestOptions)
-                        let directoryVersionDtos = List<DirectoryVersionDto>()
 
                         while iterator.HasMoreResults do
                             let! results = iterator.ReadNextAsync()
@@ -2427,10 +2468,7 @@ module Services =
                                             |> DirectoryVersionDto.UpdateDto directoryEvent)
                                         DirectoryVersionDto.Default
 
-                                directoryVersionDtos.Add(directoryVersionDto))
-
-                        if directoryVersionDtos.Count > 0 then
-                            directoryVersion <- directoryVersionDtos[0].DirectoryVersion
+                                directoryVersions.Add(directoryVersionDto.DirectoryVersion))
 
                         if (indexMetrics.Length >= 2)
                            && (requestCharge.Length >= 2)
@@ -2458,11 +2496,14 @@ module Services =
                     stringBuilderPool.Return(requestCharge)
             | MongoDB -> ()
 
-            if directoryVersion.DirectoryVersionId
-               <> DirectoryVersion.Default.DirectoryVersionId then
-                return Some directoryVersion
-            else
-                return None
+            return resolveScopedVersionHashPrefix sha256Hash (fun (directoryVersion: DirectoryVersion) -> directoryVersion.Sha256Hash) directoryVersions
+        }
+
+    /// Gets a Root DirectoryVersion by searching using a Sha256Hash value.
+    let getRootDirectoryVersionBySha256Hash (repositoryId: RepositoryId) (sha256Hash: Sha256Hash) correlationId =
+        task {
+            let! resolution = getRootDirectoryVersionResolutionBySha256Hash repositoryId sha256Hash correlationId
+            return tryGetUniqueVersionHashPrefixMatch resolution
         }
 
     /// Gets a Root DirectoryVersion by searching using a Sha256Hash value.

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
     <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />
+    <Compile Include="Services.VersionHashPrefixResolution.Tests.fs" />
     <Compile Include="Services.EffectivePromotion.Tests.fs" />
     <Compile Include="Validation.Artifact.Contract.Tests.fs" />
     <Compile Include="Policy.Determinism.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/Services.VersionHashPrefixResolution.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Services.VersionHashPrefixResolution.Tests.fs
@@ -1,0 +1,174 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors
+open Grace.Types.Common
+open NUnit.Framework
+open System
+
+type HashCandidate =
+    {
+        RepositoryId: RepositoryId
+        ReferenceId: ReferenceId
+        DirectoryVersionId: DirectoryVersionId
+        Sha256Hash: Sha256Hash
+        Blake3Hash: Blake3Hash
+    }
+
+[<Parallelizable(ParallelScope.All)>]
+type ServicesVersionHashPrefixResolutionTests() =
+    let repositoryId = Guid.Parse("11111111-3530-4444-8888-111111111111")
+    let otherRepositoryId = Guid.Parse("22222222-3530-4444-8888-222222222222")
+    let sharedDirectoryVersionId = Guid.Parse("33333333-3530-4444-8888-333333333333")
+
+    let candidate index repositoryId directoryVersionId (sha256Hash: string) (blake3Hash: string) =
+        {
+            RepositoryId = repositoryId
+            ReferenceId = Guid.Parse($"44444444-3530-4444-8888-00000000000{index}")
+            DirectoryVersionId = directoryVersionId
+            Sha256Hash = Sha256Hash sha256Hash
+            Blake3Hash = Blake3Hash blake3Hash
+        }
+
+    let uniqueSha256 = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    let ambiguousSha256 = "abffff0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    let unrelatedSha256 = "cdffff0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+    [<Test>]
+    member _.Sha256PrefixResolutionReturnsNoMatchesForZeroScopedCandidates() =
+        let resolution =
+            [
+                candidate 1 repositoryId (Guid.NewGuid()) unrelatedSha256 "ab-only-in-blake3"
+            ]
+            |> Services.resolveScopedVersionHashPrefix "ab" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.NoMatches -> Assert.Pass()
+        | _ -> Assert.Fail($"Expected zero matches, got {resolution}.")
+
+    [<Test>]
+    member _.Sha256PrefixResolutionReturnsUniqueMatchForOneScopedCandidate() =
+        let expected = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "blake3-value"
+
+        let resolution =
+            [
+                expected
+                candidate 2 repositoryId (Guid.NewGuid()) unrelatedSha256 "ab-only-in-blake3"
+            ]
+            |> Services.resolveScopedVersionHashPrefix "abc" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.UniqueMatch actual -> Assert.That(actual.ReferenceId, Is.EqualTo(expected.ReferenceId))
+        | _ -> Assert.Fail($"Expected one match, got {resolution}.")
+
+    [<Test>]
+    member _.Sha256PrefixResolutionReturnsAmbiguousMatchesInsteadOfFirstMatch() =
+        let first = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "first-blake3"
+        let second = candidate 2 repositoryId (Guid.NewGuid()) ambiguousSha256 "second-blake3"
+
+        let resolution =
+            [
+                first
+                second
+                candidate 3 repositoryId (Guid.NewGuid()) "ab11110123456789abcdef0123456789abcdef0123456789abcdef0123456789" "third-blake3"
+            ]
+            |> Services.resolveScopedVersionHashPrefix "ab" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.AmbiguousMatches matches ->
+            Assert.That(matches, Has.Length.EqualTo(Services.maxVersionHashPrefixResolutionMatches))
+
+            Assert.That(
+                matches
+                |> Array.map (fun candidate -> candidate.ReferenceId),
+                Does.Contain(first.ReferenceId)
+            )
+
+            Assert.That(
+                matches
+                |> Array.map (fun candidate -> candidate.ReferenceId),
+                Does.Contain(second.ReferenceId)
+            )
+        | _ -> Assert.Fail($"Expected ambiguous matches, got {resolution}.")
+
+    [<Test>]
+    member _.OptionCompatibilityWrapperOnlyReturnsUniqueMatches() =
+        let first = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "first-blake3"
+        let second = candidate 2 repositoryId (Guid.NewGuid()) ambiguousSha256 "second-blake3"
+
+        let uniqueResult = Services.tryGetUniqueVersionHashPrefixMatch (Services.UniqueMatch first)
+
+        let zeroResult = Services.tryGetUniqueVersionHashPrefixMatch Services.NoMatches
+
+        let ambiguousResult =
+            Services.tryGetUniqueVersionHashPrefixMatch (
+                Services.AmbiguousMatches [| first
+                                             second |]
+            )
+
+        Assert.That(uniqueResult, Is.EqualTo(Some first))
+        Assert.That(zeroResult, Is.EqualTo(None))
+        Assert.That(ambiguousResult, Is.EqualTo(None))
+
+    [<Test>]
+    member _.ExactSha256ResolutionStillRejectsMultipleVersionGraphObjects() =
+        let first = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "first-blake3"
+        let second = candidate 2 repositoryId (Guid.NewGuid()) uniqueSha256 "second-blake3"
+
+        let resolution =
+            [ first; second ]
+            |> Services.resolveScopedVersionHashPrefix uniqueSha256 (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.AmbiguousMatches matches -> Assert.That(matches, Has.Length.EqualTo(2))
+        | _ -> Assert.Fail($"Expected exact-hash ambiguity, got {resolution}.")
+
+    [<Test>]
+    member _.TwoCharacterSha256PrefixUsesSameUniqueRuleWithinRepositoryScope() =
+        let expected = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "first-blake3"
+        let samePrefixOtherRepository = candidate 2 otherRepositoryId (Guid.NewGuid()) ambiguousSha256 "other-repository-blake3"
+
+        let scopedCandidates =
+            [ expected; samePrefixOtherRepository ]
+            |> List.filter (fun candidate -> candidate.RepositoryId = repositoryId)
+
+        let resolution =
+            scopedCandidates
+            |> Services.resolveScopedVersionHashPrefix "ab" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.UniqueMatch actual -> Assert.That(actual.ReferenceId, Is.EqualTo(expected.ReferenceId))
+        | _ -> Assert.Fail($"Expected repository-scoped unique match, got {resolution}.")
+
+    [<Test>]
+    member _.ReferenceScopeTreatsMultipleReferencesToOneRootAsAmbiguousReferences() =
+        let first = candidate 1 repositoryId sharedDirectoryVersionId uniqueSha256 "first-blake3"
+        let second = candidate 2 repositoryId sharedDirectoryVersionId ambiguousSha256 "second-blake3"
+
+        let resolution =
+            [ first; second ]
+            |> Services.resolveScopedVersionHashPrefix "ab" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.AmbiguousMatches matches ->
+            Assert.That(matches, Has.Length.EqualTo(2))
+
+            Assert.That(
+                matches
+                |> Array.map (fun candidate -> candidate.DirectoryVersionId)
+                |> Array.distinct,
+                Has.Length.EqualTo(1)
+            )
+        | _ -> Assert.Fail($"Expected reference-scope ambiguity, got {resolution}.")
+
+    [<Test>]
+    member _.Sha256ResolutionDoesNotMixBlake3NamespaceMatches() =
+        let shaOnly = candidate 1 repositoryId (Guid.NewGuid()) uniqueSha256 "cd-blake3"
+        let blake3Only = candidate 2 repositoryId (Guid.NewGuid()) unrelatedSha256 "ab-blake3"
+
+        let resolution =
+            [ shaOnly; blake3Only ]
+            |> Services.resolveScopedVersionHashPrefix "ab" (fun candidate -> candidate.Sha256Hash)
+
+        match resolution with
+        | Services.UniqueMatch actual -> Assert.That(actual.ReferenceId, Is.EqualTo(shaOnly.ReferenceId))
+        | _ -> Assert.Fail($"Expected SHA-256-only match, got {resolution}.")


### PR DESCRIPTION
Related to #353
Part of #343

## Summary

- Adds an explicit zero/one/many result type for scoped version hash prefix resolution.
- Replaces SHA-256 first-match lookup internals for references, directory versions, and root directory versions so legacy option wrappers only return a value when resolution is unique.
- Caps ambiguity proof at two matches and keeps lookup scoped by the existing authorized repository/root/branch filters before prefix classification.
- Adds focused server unit coverage for positive, negative, ambiguous, exact-hash, two-character-prefix, namespace, and reference-scope edge cases.

## Scope Notes

- Public BLAKE3 routes, public route ambiguity vocabulary, OpenAPI, SDK, CLI, JSON, and generated contract updates are intentionally deferred to I11-I14 and later epic slices.
- Existing route-facing option signatures are preserved for compatibility in this slice; internally, the distinct resolver result is now available for later public contract work.
- No global CAS hash search helper was introduced.

## Proof Matrix

| Requirement | Proof |
| --- | --- |
| Zero/one/many resolver exists | `VersionHashPrefixResolution<'T>` defines `NoMatches`, `UniqueMatch`, and `AmbiguousMatches`. |
| Existing SHA-256 wrappers stop first-match behavior | Reference, directory-version, and root-directory SHA-256 wrappers return `Some` only for `UniqueMatch`. |
| Query limit avoids unbounded ambiguity scans | Directory/root-directory queries use `TOP @maxCount` with `maxVersionHashPrefixResolutionMatches = 2`; in-memory scoped resolver tests prove at-most-two classification. |
| Positive lookup works | `Sha256PrefixResolutionReturnsUniqueMatchForOneScopedCandidate`. |
| Zero matches are distinct | `Sha256PrefixResolutionReturnsNoMatchesForZeroScopedCandidates`. |
| Ambiguous SHA-256 no longer chooses first | `Sha256PrefixResolutionReturnsAmbiguousMatchesInsteadOfFirstMatch`. |
| Boundary prefixes are covered | `TwoCharacterSha256PrefixUsesSameUniqueRuleWithinRepositoryScope` and `ExactSha256ResolutionStillRejectsMultipleVersionGraphObjects`. |
| Algorithm namespaces do not mix | `Sha256ResolutionDoesNotMixBlake3NamespaceMatches`. |
| Reference scope remains distinct from directory scope | `ReferenceScopeTreatsMultipleReferencesToOneRootAsAmbiguousReferences`. |
| Compatibility wrapper behavior is explicit | `OptionCompatibilityWrapperOnlyReturnsUniqueMatches`. |

## Validation

Passed:

- `dotnet tool run fantomas C:\Source\Grace-gh-353\src\Grace.Actors\Services.Actor.fs C:\Source\Grace-gh-353\src\Grace.Server.Unit.Tests\Services.VersionHashPrefixResolution.Tests.fs`
- `dotnet test C:\Source\Grace-gh-353\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --configuration Release --filter FullyQualifiedName~ServicesVersionHashPrefixResolutionTests`
  - Passed, `8/8`.
- `pwsh ./scripts/validate.ps1 -Fast`
  - Passed. The fast profile produced the normal no-matching-tests notice for `Grace.Server.Tests`; selected Fast projects/tests passed.
- `git diff --check`

## Review Status

- Worker bot-prevention self-review: completed before push.
- High-risk pre-PR review waiver: this slice touches internal lookup identity in `Services.Actor.fs`, but the issue scope intentionally preserves public route signatures and the user explicitly prohibited manual Codex review requests. This PR relies on the repository's automatic Codex Code Review Bot after PR creation and updates.
- Automatic Codex Code Review Bot: no-issues `+1` reaction on `301f6738879b9cb7c6e0786de6740955388207b3`; no unresolved review threads.
- Hosted validation: `Validate / full` passed on `301f6738879b9cb7c6e0786de6740955388207b3`.
- Prevention line: scoped version hash prefix resolution now classifies zero, one, and many matches after existing repository/branch/root scoping, fetches only enough matches to prove ambiguity, preserves algorithm-specific namespaces, and prevents SHA-256 compatibility wrappers from returning first/newest matches when prefixes are ambiguous.

## Residual Risk

- Existing public route behavior still collapses ambiguous prefix resolution to the legacy option/not-found compatibility path. I11-I14 own the public route/API ambiguity vocabulary and BLAKE3 route expansion.