### PR TITLE
I14 Reference BLAKE3 locator semantics

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open NUnit.Framework
 open System
+open System.CommandLine
 
 [<Parallelizable(ParallelScope.All)>]
 module BranchCommandParsingTests =
@@ -30,6 +31,17 @@ module BranchCommandParsingTests =
                 branchId.ToString()
             |]
 
+    let private referenceSourceRoot =
+        let rootCommand = RootCommand("Reference source-only parser")
+        rootCommand.Options.Add(Common.Options.correlationId)
+        rootCommand.Options.Add(Common.Options.source)
+        rootCommand.Options.Add(Common.Options.output)
+        rootCommand.Options.Add(Common.Options.schema)
+        rootCommand.Options.Add(Common.Options.examples)
+        rootCommand.Options.Add(Common.Options.select)
+        rootCommand.Subcommands.Add(Reference.Build)
+        rootCommand
+
     let private assertParses args =
         let parseResult = GraceCommand.rootCommand.Parse(withIds args)
         parseResult.Errors.Count |> should equal 0
@@ -38,6 +50,11 @@ module BranchCommandParsingTests =
     let private assertDoesNotParse args =
         let parseResult = GraceCommand.rootCommand.Parse(withIds args)
         Assert.That(parseResult.Errors.Count, Is.GreaterThan(0))
+        parseResult
+
+    let private assertReferenceSourceParses args =
+        let parseResult = referenceSourceRoot.Parse(withIds args)
+        parseResult.Errors.Count |> should equal 0
         parseResult
 
     [<Test>]
@@ -146,10 +163,10 @@ module BranchCommandParsingTests =
     [<Test>]
     let ``reference assign parses BLAKE3 hash option`` () =
         let parseResult =
-            assertParses [| "reference"
-                            "assign"
-                            "--blake3-hash"
-                            blake3Hash |]
+            assertReferenceSourceParses [| "reference"
+                                           "assign"
+                                           "--blake3-hash"
+                                           blake3Hash |]
 
         parseResult.GetValue<string>("--blake3-hash")
         |> should equal blake3Hash
@@ -157,12 +174,12 @@ module BranchCommandParsingTests =
     [<Test>]
     let ``reference assign preserves SHA-256 and BLAKE3 locator evidence`` () =
         let parseResult =
-            assertParses [| "reference"
-                            "assign"
-                            "--sha256-hash"
-                            sha256Hash
-                            "--blake3-hash"
-                            blake3Hash |]
+            assertReferenceSourceParses [| "reference"
+                                           "assign"
+                                           "--sha256-hash"
+                                           sha256Hash
+                                           "--blake3-hash"
+                                           blake3Hash |]
 
         parseResult.GetValue<string>("--sha256-hash")
         |> should equal sha256Hash
@@ -175,12 +192,12 @@ module BranchCommandParsingTests =
         let message = "Promote CLI candidate"
 
         let parseResult =
-            assertParses [| "reference"
-                            "assign"
-                            "--sha256-hash"
-                            sha256Hash
-                            "--message"
-                            message |]
+            assertReferenceSourceParses [| "reference"
+                                           "assign"
+                                           "--sha256-hash"
+                                           sha256Hash
+                                           "--message"
+                                           message |]
 
         let parameters = Reference.buildAssignParameters parseResult
 
@@ -188,14 +205,26 @@ module BranchCommandParsingTests =
         parameters.Message |> should equal message
 
     [<Test>]
-    let ``reference delete is not exposed from root command`` () =
-        let parseResult =
-            assertDoesNotParse [| "reference"
-                                  "delete" |]
+    let ``source-only reference commands are not exposed from root command`` () =
+        for commandName in
+            [|
+                "assign"
+                "checkpoint"
+                "commit"
+                "create-external"
+                "delete"
+                "get"
+                "promote"
+                "save"
+                "tag"
+            |] do
+            let parseResult =
+                assertDoesNotParse [| "reference"
+                                      commandName |]
 
-        parseResult.Errors
-        |> Seq.exists (fun error -> error.Message.Contains("Unrecognized command or argument 'delete'", StringComparison.OrdinalIgnoreCase))
-        |> should equal true
+            parseResult.Errors
+            |> Seq.exists (fun error -> error.Message.Contains("Unrecognized command or argument 'reference'", StringComparison.OrdinalIgnoreCase))
+            |> should equal true
 
     [<Test>]
     let ``forbidden branch annotate V1 options are unavailable`` () =

--- a/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
@@ -144,6 +144,33 @@ module BranchCommandParsingTests =
         |> should equal (String.Empty, blake3Hash)
 
     [<Test>]
+    let ``reference assign parses BLAKE3 hash option`` () =
+        let parseResult =
+            assertParses [| "reference"
+                            "assign"
+                            "--blake3-hash"
+                            blake3Hash |]
+
+        parseResult.GetValue<string>("--blake3-hash")
+        |> should equal blake3Hash
+
+    [<Test>]
+    let ``reference assign preserves SHA-256 and BLAKE3 locator evidence`` () =
+        let parseResult =
+            assertParses [| "reference"
+                            "assign"
+                            "--sha256-hash"
+                            sha256Hash
+                            "--blake3-hash"
+                            blake3Hash |]
+
+        parseResult.GetValue<string>("--sha256-hash")
+        |> should equal sha256Hash
+
+        parseResult.GetValue<string>("--blake3-hash")
+        |> should equal blake3Hash
+
+    [<Test>]
     let ``forbidden branch annotate V1 options are unavailable`` () =
         for forbiddenOption in
             [|

--- a/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
@@ -171,6 +171,33 @@ module BranchCommandParsingTests =
         |> should equal blake3Hash
 
     [<Test>]
+    let ``reference assign preserves message in assign parameters`` () =
+        let message = "Promote CLI candidate"
+
+        let parseResult =
+            assertParses [| "reference"
+                            "assign"
+                            "--sha256-hash"
+                            sha256Hash
+                            "--message"
+                            message |]
+
+        let parameters = Reference.buildAssignParameters parseResult
+
+        parameters.Sha256Hash |> should equal sha256Hash
+        parameters.Message |> should equal message
+
+    [<Test>]
+    let ``reference delete is not exposed from root command`` () =
+        let parseResult =
+            assertDoesNotParse [| "reference"
+                                  "delete" |]
+
+        parseResult.Errors
+        |> Seq.exists (fun error -> error.Message.Contains("Unrecognized command or argument 'delete'", StringComparison.OrdinalIgnoreCase))
+        |> should equal true
+
+    [<Test>]
     let ``forbidden branch annotate V1 options are unavailable`` () =
         for forbiddenOption in
             [|

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -282,14 +282,18 @@ module CommandOutputContractRegistryTests =
             |> List.map commandId
 
         let registered =
-            CommandOutputContract.entries
-            |> List.filter (fun entry -> entry.Identity.CommandId <> "reference.delete")
+            CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 203
+        let sourceOnlyIds =
+            CommandOutputContract.sourceOnlyEntries
+            |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered
-        |> should not' (contain "reference.delete")
+        discovered.Length
+        |> should equal CommandOutputContract.routedEntries.Length
+
+        for sourceOnlyId in sourceOnlyIds do
+            discovered |> should not' (contain sourceOnlyId)
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -276,16 +276,20 @@ module CommandOutputContractRegistryTests =
         |> should equal CommandOutputContract.entries.Length
 
     [<Test>]
-    let ``every live routed leaf command has one registry entry`` () =
+    let ``every live leaf command has one registry entry`` () =
         let discovered =
             CommandOutputContract.discoverLeafCommands GraceCommand.rootCommand
             |> List.map commandId
 
         let registered =
-            CommandOutputContract.routedEntries
+            CommandOutputContract.entries
+            |> List.filter (fun entry -> entry.Identity.CommandId <> "reference.delete")
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 195
+        discovered.Length |> should equal 203
+
+        discovered
+        |> should not' (contain "reference.delete")
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -184,6 +184,15 @@ module Reference =
                 Arity = ArgumentArity.ExactlyOne
             )
 
+        let blake3Hash =
+            new Option<String>(
+                OptionName.Blake3Hash,
+                [||],
+                Required = false,
+                Description = "The full or partial BLAKE3 hash value of the version.",
+                Arity = ArgumentArity.ExactlyOne
+            )
+
         let enabled =
             new Option<bool>(
                 OptionName.Enabled,
@@ -208,6 +217,13 @@ module Reference =
             )
 
     let private valueOrEmpty (value: string) = if String.IsNullOrWhiteSpace(value) then String.Empty else value
+
+    let private getOptionalBlake3Hash (parseResult: ParseResult) =
+        if isNull (parseResult.GetResult(Options.blake3Hash)) then
+            String.Empty
+        else
+            parseResult.GetValue(Options.blake3Hash)
+            |> valueOrEmpty
 
     let private ReferenceValidations (parseResult: ParseResult) = Ok parseResult
 
@@ -433,57 +449,60 @@ module Reference =
                     return renderOutput parseResult (GraceResult.Error graceError)
             }
 
-    type Assign() =
-        inherit AsynchronousCommandLineAction()
+    let private assignImpl (parseResult: ParseResult) : Tasks.Task<int> =
+        try
+            if parseResult |> verbose then printParseResult parseResult
 
-        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
-            task {
-                try
-                    if parseResult |> verbose then printParseResult parseResult
+            let graceIds = parseResult |> getNormalizedIdsAndNames
+            let validateIncomingParameters = parseResult |> ReferenceValidations
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
-                    let validateIncomingParameters = parseResult |> ReferenceValidations
+            let directoryVersionId =
+                if
+                    not
+                    <| isNull (parseResult.GetResult(Options.directoryVersionId))
+                then
+                    parseResult.GetValue(Options.directoryVersionId)
+                else
+                    Guid.Empty
 
-                    let directoryVersionId =
-                        if
-                            not
-                            <| isNull (parseResult.GetResult(Options.directoryVersionId))
-                        then
-                            parseResult.GetValue(Options.directoryVersionId)
-                        else
-                            Guid.Empty
+            let sha256Hash =
+                parseResult.GetValue(Options.sha256Hash)
+                |> valueOrEmpty
 
-                    let sha256Hash = parseResult.GetValue(Options.sha256Hash)
+            let blake3Hash = parseResult |> getOptionalBlake3Hash
 
-                    match validateIncomingParameters with
-                    | Ok _ ->
-                        match (directoryVersionId, sha256Hash) with
-                        | (directoryVersionId, sha256Hash) when
-                            directoryVersionId = Guid.Empty
-                            && sha256Hash = String.Empty
-                            ->
-                            let error =
-                                GraceError.Create
-                                    (getErrorMessage ReferenceError.EitherDirectoryVersionIdOrSha256HashRequired)
-                                    (parseResult |> getCorrelationId)
+            match validateIncomingParameters with
+            | Error graceError -> Task.FromResult(Error graceError |> renderOutput parseResult)
+            | Ok _ ->
+                match (directoryVersionId, sha256Hash, blake3Hash) with
+                | (directoryVersionId, sha256Hash, blake3Hash) when
+                    directoryVersionId = Guid.Empty
+                    && sha256Hash = String.Empty
+                    && blake3Hash = String.Empty
+                    ->
+                    let error =
+                        GraceError.Create (getErrorMessage ReferenceError.EitherDirectoryVersionIdOrSha256HashRequired) (parseResult |> getCorrelationId)
 
-                            return Error error |> renderOutput parseResult
-                        | _ ->
-                            let assignParameters =
-                                Parameters.Branch.AssignParameters(
-                                    OwnerId = graceIds.OwnerIdString,
-                                    OwnerName = graceIds.OwnerName,
-                                    OrganizationId = graceIds.OrganizationIdString,
-                                    OrganizationName = graceIds.OrganizationName,
-                                    RepositoryId = graceIds.RepositoryIdString,
-                                    RepositoryName = graceIds.RepositoryName,
-                                    BranchId = graceIds.BranchIdString,
-                                    BranchName = graceIds.BranchName,
-                                    DirectoryVersionId = directoryVersionId,
-                                    Sha256Hash = sha256Hash,
-                                    CorrelationId = getCorrelationId parseResult
-                                )
+                    Task.FromResult(Error error |> renderOutput parseResult)
+                | _ ->
+                    let assignParameters =
+                        Parameters.Branch.AssignParameters(
+                            OwnerId = graceIds.OwnerIdString,
+                            OwnerName = graceIds.OwnerName,
+                            OrganizationId = graceIds.OrganizationIdString,
+                            OrganizationName = graceIds.OrganizationName,
+                            RepositoryId = graceIds.RepositoryIdString,
+                            RepositoryName = graceIds.RepositoryName,
+                            BranchId = graceIds.BranchIdString,
+                            BranchName = graceIds.BranchName,
+                            DirectoryVersionId = directoryVersionId,
+                            Sha256Hash = sha256Hash,
+                            Blake3Hash = blake3Hash,
+                            CorrelationId = getCorrelationId parseResult
+                        )
 
+                    task {
+                        try
                             let! result =
                                 if parseResult |> hasOutput then
                                     progress
@@ -500,13 +519,22 @@ module Reference =
                                     Grace.SDK.Branch.Assign(assignParameters)
 
                             return result |> renderOutput parseResult
-                    | Error graceError -> return Error graceError |> renderOutput parseResult
-                with
-                | ex ->
-                    let error = GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)
+                        with
+                        | ex ->
+                            let error = GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)
 
-                    return Error error |> renderOutput parseResult
-            }
+                            return Error error |> renderOutput parseResult
+                    }
+        with
+        | ex ->
+            let error = GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)
+
+            Task.FromResult(Error error |> renderOutput parseResult)
+
+    type Assign() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> = assignImpl parseResult
 
     type CreateReferenceCommand = CreateReferenceParameters -> Task<GraceResult<string>>
 
@@ -621,7 +649,7 @@ module Reference =
 
                                         //let mutable rootDirectoryId = DirectoryId.Empty
                                         //let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
-                                        let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty)
+                                        let rootDirectoryVersion = ref (DirectoryVersionId.Empty, Sha256Hash String.Empty, Blake3Hash String.Empty)
                                         let mutable applyLocalStatusAfterReferenceSave = fun () -> Task.FromResult(())
 
                                         match! getGraceWatchStatus () with
@@ -632,7 +660,10 @@ module Reference =
                                             t3.Value <- 100.0
                                             t4.Value <- 100.0
 
-                                            rootDirectoryVersion.Value <- (graceWatchStatus.RootDirectoryId, graceWatchStatus.RootDirectorySha256Hash)
+                                            rootDirectoryVersion.Value <-
+                                                (graceWatchStatus.RootDirectoryId,
+                                                 graceWatchStatus.RootDirectorySha256Hash,
+                                                 graceWatchStatus.RootDirectoryBlake3Hash)
                                         | None ->
                                             t0.StartTask() // Read Grace status file.
                                             let! previousGraceStatus = readGraceStatusFile ()
@@ -653,7 +684,11 @@ module Reference =
 
                                             newGraceStatus <- updatedGraceStatus
 
-                                            rootDirectoryVersion.Value <- (newGraceStatus.RootDirectoryId, newGraceStatus.RootDirectorySha256Hash)
+                                            rootDirectoryVersion.Value <-
+                                                (newGraceStatus.RootDirectoryId,
+                                                 newGraceStatus.RootDirectorySha256Hash,
+                                                 (getRootDirectoryVersion newGraceStatus)
+                                                     .Blake3Hash)
 
                                             t2.Value <- 100.0
 
@@ -740,7 +775,13 @@ module Reference =
                                                 | Error error -> raise (InvalidOperationException($"Error uploading directory versions: {error.Error}"))
 
                                                 newGraceStatus <- syncGraceStatusRootDirectoryHash newGraceStatus
-                                                rootDirectoryVersion.Value <- (newGraceStatus.RootDirectoryId, newGraceStatus.RootDirectorySha256Hash)
+
+                                                rootDirectoryVersion.Value <-
+                                                    (newGraceStatus.RootDirectoryId,
+                                                     newGraceStatus.RootDirectorySha256Hash,
+                                                     (getRootDirectoryVersion newGraceStatus)
+                                                         .Blake3Hash)
+
                                                 lastDirectoryVersionUpload <- getCurrentInstant ()
 
                                             t4.Value <- 100.0
@@ -756,7 +797,7 @@ module Reference =
 
                                         t5.StartTask() // Create new reference.
 
-                                        let (rootDirectoryId, rootDirectorySha256Hash) = rootDirectoryVersion.Value
+                                        let (rootDirectoryId, rootDirectorySha256Hash, rootDirectoryBlake3Hash) = rootDirectoryVersion.Value
 
                                         let sdkParameters =
                                             Parameters.Branch.CreateReferenceParameters(
@@ -770,6 +811,7 @@ module Reference =
                                                 RepositoryName = graceIds.RepositoryName,
                                                 DirectoryVersionId = rootDirectoryId,
                                                 Sha256Hash = rootDirectorySha256Hash,
+                                                Blake3Hash = rootDirectoryBlake3Hash,
                                                 Message = message,
                                                 CorrelationId = graceIds.CorrelationId
                                             )
@@ -875,6 +917,7 @@ module Reference =
                                 RepositoryName = graceIds.RepositoryName,
                                 DirectoryVersionId = rootDirectoryVersion.DirectoryVersionId,
                                 Sha256Hash = rootDirectoryVersion.Sha256Hash,
+                                Blake3Hash = rootDirectoryVersion.Blake3Hash,
                                 Message = message,
                                 CorrelationId = graceIds.CorrelationId
                             )
@@ -1427,6 +1470,7 @@ module Reference =
             new Command("assign", Description = "Assign a promotion to this branch.")
             |> addOption Options.directoryVersionId
             |> addOption Options.sha256Hash
+            |> addOption Options.blake3Hash
             |> addOption Options.message
             |> addCommonOptions
 

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -449,32 +449,56 @@ module Reference =
                     return renderOutput parseResult (GraceResult.Error graceError)
             }
 
+    let buildAssignParameters (parseResult: ParseResult) : Parameters.Branch.AssignParameters =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let directoryVersionId =
+            if
+                not
+                <| isNull (parseResult.GetResult(Options.directoryVersionId))
+            then
+                parseResult.GetValue(Options.directoryVersionId)
+            else
+                Guid.Empty
+
+        let sha256Hash =
+            parseResult.GetValue(Options.sha256Hash)
+            |> valueOrEmpty
+
+        let message =
+            parseResult.GetValue(Options.message)
+            |> valueOrEmpty
+
+        let blake3Hash = parseResult |> getOptionalBlake3Hash
+
+        Parameters.Branch.AssignParameters(
+            OwnerId = graceIds.OwnerIdString,
+            OwnerName = graceIds.OwnerName,
+            OrganizationId = graceIds.OrganizationIdString,
+            OrganizationName = graceIds.OrganizationName,
+            RepositoryId = graceIds.RepositoryIdString,
+            RepositoryName = graceIds.RepositoryName,
+            BranchId = graceIds.BranchIdString,
+            BranchName = graceIds.BranchName,
+            DirectoryVersionId = directoryVersionId,
+            Sha256Hash = sha256Hash,
+            Blake3Hash = blake3Hash,
+            Message = message,
+            CorrelationId = getCorrelationId parseResult
+        )
+
     let private assignImpl (parseResult: ParseResult) : Tasks.Task<int> =
         try
             if parseResult |> verbose then printParseResult parseResult
 
-            let graceIds = parseResult |> getNormalizedIdsAndNames
             let validateIncomingParameters = parseResult |> ReferenceValidations
-
-            let directoryVersionId =
-                if
-                    not
-                    <| isNull (parseResult.GetResult(Options.directoryVersionId))
-                then
-                    parseResult.GetValue(Options.directoryVersionId)
-                else
-                    Guid.Empty
-
-            let sha256Hash =
-                parseResult.GetValue(Options.sha256Hash)
-                |> valueOrEmpty
-
-            let blake3Hash = parseResult |> getOptionalBlake3Hash
 
             match validateIncomingParameters with
             | Error graceError -> Task.FromResult(Error graceError |> renderOutput parseResult)
             | Ok _ ->
-                match (directoryVersionId, sha256Hash, blake3Hash) with
+                let assignParameters = buildAssignParameters parseResult
+
+                match (assignParameters.DirectoryVersionId, assignParameters.Sha256Hash, assignParameters.Blake3Hash) with
                 | (directoryVersionId, sha256Hash, blake3Hash) when
                     directoryVersionId = Guid.Empty
                     && sha256Hash = String.Empty
@@ -485,22 +509,6 @@ module Reference =
 
                     Task.FromResult(Error error |> renderOutput parseResult)
                 | _ ->
-                    let assignParameters =
-                        Parameters.Branch.AssignParameters(
-                            OwnerId = graceIds.OwnerIdString,
-                            OwnerName = graceIds.OwnerName,
-                            OrganizationId = graceIds.OrganizationIdString,
-                            OrganizationName = graceIds.OrganizationName,
-                            RepositoryId = graceIds.RepositoryIdString,
-                            RepositoryName = graceIds.RepositoryName,
-                            BranchId = graceIds.BranchIdString,
-                            BranchName = graceIds.BranchName,
-                            DirectoryVersionId = directoryVersionId,
-                            Sha256Hash = sha256Hash,
-                            Blake3Hash = blake3Hash,
-                            CorrelationId = getCorrelationId parseResult
-                        )
-
                     task {
                         try
                             let! result =
@@ -1458,13 +1466,6 @@ module Reference =
 
         getCommand.Action <- new Get()
         referenceCommand.Subcommands.Add(getCommand)
-
-        let deleteCommand =
-            new Command("delete", Description = "Delete the branch.")
-            |> addCommonOptions
-
-        deleteCommand.Action <- new Delete()
-        referenceCommand.Subcommands.Add(deleteCommand)
 
         let assignCommand =
             new Command("assign", Description = "Assign a promotion to this branch.")

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -479,6 +479,7 @@ module GraceCommand =
                 CommandNames =
                     [
                         "branch"
+                        "reference"
                         "diff"
                         "directory-version"
                         "watch"
@@ -830,6 +831,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(Connect.Build)
         rootCommand.Subcommands.Add(Watch.Build)
         rootCommand.Subcommands.Add(Branch.Build)
+        rootCommand.Subcommands.Add(Reference.Build)
         rootCommand.Subcommands.Add(DirectoryVersion.Build)
         rootCommand.Subcommands.Add(Diff.Build)
         rootCommand.Subcommands.Add(Repository.Build)

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -479,7 +479,6 @@ module GraceCommand =
                 CommandNames =
                     [
                         "branch"
-                        "reference"
                         "diff"
                         "directory-version"
                         "watch"
@@ -831,7 +830,6 @@ module GraceCommand =
         rootCommand.Subcommands.Add(Connect.Build)
         rootCommand.Subcommands.Add(Watch.Build)
         rootCommand.Subcommands.Add(Branch.Build)
-        rootCommand.Subcommands.Add(Reference.Build)
         rootCommand.Subcommands.Add(DirectoryVersion.Build)
         rootCommand.Subcommands.Add(Diff.Build)
         rootCommand.Subcommands.Add(Repository.Build)


### PR DESCRIPTION
## Summary

- Adds source-only `--blake3-hash` support to `reference assign` parsing while preserving SHA-256 locator evidence.
- Threads root DirectoryVersion BLAKE3 through reference assign parameter construction for the source-only reference command path.
- Keeps the stale `Reference.Build` command tree unrouted from the production root until each subcommand has safe reference-specific handlers and truthful command contracts.
- Adds focused parser and command inventory coverage for BLAKE3 assignment, message propagation, dual-hash evidence, and source-only reference command reachability.

Related to #357.
Part of #343.

## Validation

Initial worker validation on commit `5071892255fb214f86f7a6f0b791ca6fd9cf2923`:

```powershell
dotnet tool run fantomas src/Grace.CLI/Command/Reference.CLI.fs src/Grace.CLI/Program.CLI.fs src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs
dotnet build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release
dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --no-build --filter FullyQualifiedName~BranchCommandParsingTests
git diff --check
```

Fix validation on commit `bfa298d962a6ae2d83046e8eebacfa9df44e2d84`:

```powershell
dotnet tool run fantomas src/Grace.CLI/Command/Reference.CLI.fs src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
git diff --check
```

Fix validation on commit `c09f5abbd2a096ff8931b79937e925481c55a3dc`:

```powershell
dotnet tool run fantomas src/Grace.CLI/Program.CLI.fs src/Grace.CLI.Tests/Branch.CLI.Parsing.Tests.fs src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
git diff --check
```

Hosted validation on PR head `c09f5abbd2a096ff8931b79937e925481c55a3dc`:

- `Validate / full`: passed.

## Review Status

- Codex Code Review Bot on `5071892255fb214f86f7a6f0b791ca6fd9cf2923`: found two issues.
- Fixed in `bfa298d962a6ae2d83046e8eebacfa9df44e2d84`: preserve `reference assign --message`, and hide unsafe `reference delete` root command wiring.
- Codex Code Review Bot on `bfa298d962a6ae2d83046e8eebacfa9df44e2d84`: found two deeper routing/contract issues.
- Fixed in `c09f5abbd2a096ff8931b79937e925481c55a3dc`: keep stale `Reference.Build` unrouted from production root, keep #357 parser coverage in a test-only root, and make command output contract tests compare live root discovery against routed entries only.
- Bot conversations replied to and resolved.
- Codex Code Review Bot on `c09f5abbd2a096ff8931b79937e925481c55a3dc`: 👍 no issues.
- Prevention line: fix worker self-review verified source-only reference commands are not production-reachable, routed command contract audits are truthful, and no I15/I16/I17 output work or stale handler rewrites were introduced.

## Residual Risks

- The source-only `Reference.Build` module still contains stale handlers, but it is intentionally not reachable from the production root. Future work should route individual reference commands only after their handlers and command contracts are corrected.
- `src/Grace.CLI/Program.CLI.fs` was an issue-owned path expansion for the attempted root reference wiring; after review fixes, the production root stays unrouted and this PR keeps only source-only/parser coverage for #357.