### PR TITLE
I16 CLI human BLAKE3 output defaults

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -130,40 +130,46 @@ module BranchCommandTests =
 
     let private directorySha256Hash = Sha256Hash "111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000"
 
+    let private directoryBlake3Hash = Blake3Hash "9999888877776666555544443333222211110000ffffeeeeddddccccbbbbaaaa"
+
     let private fileSha256Hash = Sha256Hash "aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
 
+    let private fileBlake3Hash = Blake3Hash "bbbbccccddddeeeeffff0000111122223333444455556666777788889999aaaa"
+
     let private branchDirectoryWithFile () =
-        let file = FileVersion.Create "src/App.fs" fileSha256Hash String.Empty false 123L
+        let file = FileVersion.CreateWithHashes "src/App.fs" fileSha256Hash fileBlake3Hash String.Empty false 123L
 
         let files = List<FileVersion>()
         files.Add(file)
 
-        DirectoryVersion.Create
+        DirectoryVersion.CreateWithHashes
             (Guid.NewGuid())
             ownerId
             organizationId
             repositoryId
             Constants.RootDirectoryPath
             directorySha256Hash
+            directoryBlake3Hash
             (List<DirectoryVersionId>())
             files
             123L
 
     [<Test>]
-    let ``list contents formatter uses short hashes by default`` () =
+    let ``list contents formatter uses short BLAKE3 hashes by default`` () =
         let parseResult = parse [| "branch"; "list-contents" |]
         let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
 
-        Branch.formatListContentsSha256Hash displayMode directorySha256Hash
-        |> should equal "11112222"
+        Branch.formatListContentsVersionHash displayMode directoryBlake3Hash directorySha256Hash
+        |> should equal "99998888"
 
         let _, output =
             captureOutput (fun () ->
                 Branch.printContents parseResult [| branchDirectoryWithFile () |]
                 0)
 
-        output |> should contain "11112222"
-        output |> should contain "aaaabbbb"
+        output |> should contain "BLAKE3 version hash"
+        output |> should contain "99998888"
+        output |> should contain "bbbbcccc"
 
         output
         |> should not' (contain $"{directorySha256Hash}")
@@ -180,16 +186,28 @@ module BranchCommandTests =
 
         let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
 
-        Branch.formatListContentsSha256Hash displayMode directorySha256Hash
-        |> should equal $"{directorySha256Hash}"
+        Branch.formatListContentsVersionHash displayMode directoryBlake3Hash directorySha256Hash
+        |> should equal $"{directoryBlake3Hash}"
 
         let _, output =
             captureOutput (fun () ->
                 Branch.printContents parseResult [| branchDirectoryWithFile () |]
                 0)
 
-        output |> should contain $"{directorySha256Hash}"
-        output |> should contain $"{fileSha256Hash}"
+        output |> should contain $"{directoryBlake3Hash}"
+        output |> should contain $"{fileBlake3Hash}"
+
+    [<Test>]
+    let ``list contents formatter adds SHA-256 when requested`` () =
+        let parseResult =
+            parse [| "branch"
+                     "list-contents"
+                     "--show-sha256" |]
+
+        let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
+
+        Branch.formatListContentsVersionHash displayMode directoryBlake3Hash directorySha256Hash
+        |> should equal "99998888 (SHA-256 11112222)"
 
     [<Test>]
     let ``list contents formatter honors deprecated full sha display option`` () =
@@ -200,8 +218,16 @@ module BranchCommandTests =
 
         let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
 
-        Branch.formatListContentsSha256Hash displayMode directorySha256Hash
-        |> should equal $"{directorySha256Hash}"
+        Branch.formatListContentsVersionHash displayMode directoryBlake3Hash directorySha256Hash
+        |> should equal $"{directoryBlake3Hash} (SHA-256 {directorySha256Hash})"
+
+    [<Test>]
+    let ``list contents formatter shows unavailable for missing legacy BLAKE3`` () =
+        let parseResult = parse [| "branch"; "list-contents" |]
+        let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
+
+        Branch.formatListContentsVersionHash displayMode (Blake3Hash String.Empty) directorySha256Hash
+        |> should equal Common.HashOptions.MissingVersionHashText
 
     [<Test>]
     let ``annotate handler maps options to parameters`` () =

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -762,18 +762,13 @@ module Branch =
                     return renderOutput parseResult (GraceResult.Error graceError)
             }
 
-    let private getShortHash (sha256Hash: Sha256Hash) =
-        if String.IsNullOrWhiteSpace(sha256Hash) then String.Empty
-        elif sha256Hash.Length <= 8 then sha256Hash
-        else sha256Hash.Substring(0, 8)
+    let internal formatListContentsVersionHash (hashDisplayMode: HashOptions.VersionHashDisplayMode) (blake3Hash: Blake3Hash) (sha256Hash: Sha256Hash) =
+        HashOptions.formatVersionHashPair hashDisplayMode blake3Hash sha256Hash
 
-    let internal formatListContentsSha256Hash (hashDisplayMode: HashOptions.VersionHashDisplayMode) (sha256Hash: Sha256Hash) =
-        if hashDisplayMode.FullHashes then $"{sha256Hash}" else getShortHash sha256Hash
-
-    let private tryGetRootSha256Hash (directoryVersions: IEnumerable<DirectoryVersion>) =
+    let private tryGetRootVersionHashes (directoryVersions: IEnumerable<DirectoryVersion>) =
         directoryVersions
         |> Seq.tryFind (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
-        |> Option.map (fun directoryVersion -> directoryVersion.Sha256Hash)
+        |> Option.map (fun directoryVersion -> directoryVersion.Blake3Hash, directoryVersion.Sha256Hash)
 
     let printContents (parseResult: ParseResult) (directoryVersions: IEnumerable<DirectoryVersion>) =
         let hashDisplayMode = HashOptions.bindVersionHashDisplayMode parseResult
@@ -796,7 +791,7 @@ module Branch =
 
                 if i = 0 then
                     AnsiConsole.MarkupLine(
-                        $"[{Colors.Important}]Created At                   SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
+                        $"[{Colors.Important}]Created At                   BLAKE3 version hash  Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
                     )
 
                     AnsiConsole.MarkupLine(
@@ -811,14 +806,14 @@ module Branch =
                     + $"({directoryVersion.DirectoryVersionId})"
 
                 AnsiConsole.MarkupLine(
-                    $"[{Colors.Highlighted}]{formatInstantAligned directoryVersion.CreatedAt}   {formatListContentsSha256Hash hashDisplayMode directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
+                    $"[{Colors.Highlighted}]{formatInstantAligned directoryVersion.CreatedAt}   {formatListContentsVersionHash hashDisplayMode directoryVersion.Blake3Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
                 )
                 //if parseResult.CommandResult.Command.Options.Contains(Options.listFiles) then
                 let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
 
                 for file in sortedFiles do
                     AnsiConsole.MarkupLine(
-                        $"[{Colors.Verbose}]{formatInstantAligned file.CreatedAt}   {formatListContentsSha256Hash hashDisplayMode file.Sha256Hash}  {file.Size, 13:N0}  |- {file.RelativePath.Split('/').LastOrDefault()}[/]"
+                        $"[{Colors.Verbose}]{formatInstantAligned file.CreatedAt}   {formatListContentsVersionHash hashDisplayMode file.Blake3Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.RelativePath.Split('/').LastOrDefault()}[/]"
                     ))
 
     let private listContentsImpl (parseResult: ParseResult) : Tasks.Task<int> =
@@ -903,12 +898,15 @@ module Branch =
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
 
-                    match tryGetRootSha256Hash directoryVersions with
-                    | Some rootSha256Hash ->
+                    match tryGetRootVersionHashes directoryVersions with
+                    | Some (rootBlake3Hash, rootSha256Hash) ->
                         let hashDisplayMode = HashOptions.bindVersionHashDisplayMode parseResult
 
-                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Root SHA-256 hash: {formatListContentsSha256Hash hashDisplayMode rootSha256Hash}[/]")
-                    | None -> AnsiConsole.MarkupLine($"[{Colors.Error}]Root SHA-256 hash: unavailable (root directory entry missing from server response).[/]")
+                        AnsiConsole.MarkupLine(
+                            $"[{Colors.Highlighted}]Root BLAKE3 version hash: {formatListContentsVersionHash hashDisplayMode rootBlake3Hash rootSha256Hash}[/]"
+                        )
+                    | None ->
+                        AnsiConsole.MarkupLine($"[{Colors.Error}]Root BLAKE3 version hash: unavailable (root directory entry missing from server response).[/]")
 
                     if directoryCount > 0 then
                         printContents parseResult directoryVersions
@@ -2504,7 +2502,7 @@ module Branch =
             [|
                 TableColumn($"[{Colors.Important}]Type[/]")
                 TableColumn($"[{Colors.Important}]Message[/]")
-                TableColumn($"[{Colors.Important}]SHA-256[/]")
+                TableColumn($"[{Colors.Important}]BLAKE3 version hash[/]")
                 TableColumn($"[{Colors.Important}]When[/]", Alignment = Justify.Right)
                 TableColumn($"[{Colors.Important}][/]")
             |]
@@ -2529,11 +2527,7 @@ module Branch =
             //logToAnsiConsole Colors.Verbose $"{serialize row}"
             let hashDisplayMode = HashOptions.bindVersionHashDisplayMode parseResult
 
-            let sha256Hash =
-                if hashDisplayMode.FullHashes then
-                    $"{row.Sha256Hash}"
-                else
-                    $"{getShortSha256Hash row.Sha256Hash}"
+            let versionHash = HashOptions.formatVersionHashPair hashDisplayMode row.Blake3Hash row.Sha256Hash
 
             let localCreatedAtTime = row.CreatedAt.ToDateTimeUtc().ToLocalTime()
 
@@ -2544,7 +2538,7 @@ module Branch =
                     [|
                         $"{getDiscriminatedUnionCaseName (row.ReferenceType)}"
                         $"{row.ReferenceText}"
-                        sha256Hash
+                        versionHash
                         ago row.CreatedAt
                         $"[{Colors.Deemphasized}]{referenceTime}[/]"
                         $"[{Colors.Deemphasized}]{row.ReferenceId}[/]"
@@ -2556,7 +2550,7 @@ module Branch =
                     [|
                         $"{getDiscriminatedUnionCaseName (row.ReferenceType)}"
                         $"{row.ReferenceText}"
-                        sha256Hash
+                        versionHash
                         ago row.CreatedAt
                         $"[{Colors.Deemphasized}]{referenceTime}[/]"
                     |]

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -240,10 +240,32 @@ module Common =
 
         type VersionHashDisplayMode = { FullHashes: bool; ShowSha256: bool; UsedDeprecatedFullSha: bool }
 
+        [<Literal>]
+        let MissingVersionHashText = "unavailable"
+
         let private algorithmName algorithm =
             match algorithm with
             | Blake3 -> "BLAKE3"
             | Sha256Compatibility -> "SHA-256"
+
+        let private shortHash (value: string) =
+            if String.IsNullOrWhiteSpace value then MissingVersionHashText
+            elif value.Length <= 8 then value
+            else value.Substring(0, 8)
+
+        let formatVersionHash (hashDisplayMode: VersionHashDisplayMode) (value: string) =
+            if String.IsNullOrWhiteSpace value then MissingVersionHashText
+            elif hashDisplayMode.FullHashes then value
+            else shortHash value
+
+        let formatVersionHashPair (hashDisplayMode: VersionHashDisplayMode) (blake3Hash: Blake3Hash) (sha256Hash: Sha256Hash) =
+            let blake3Display = formatVersionHash hashDisplayMode $"{blake3Hash}"
+
+            if hashDisplayMode.ShowSha256 then
+                let sha256Display = formatVersionHash hashDisplayMode $"{sha256Hash}"
+                $"{blake3Display} (SHA-256 {sha256Display})"
+            else
+                blake3Display
 
         let private isHex value =
             value

--- a/src/Grace.CLI/Command/Reference.CLI.fs
+++ b/src/Grace.CLI/Command/Reference.CLI.fs
@@ -212,6 +212,8 @@ module Reference =
     let private ReferenceValidations (parseResult: ParseResult) = Ok parseResult
 
     let printContents (parseResult: ParseResult) (directoryVersions: IEnumerable<DirectoryVersion>) =
+        let hashDisplayMode = HashOptions.bindVersionHashDisplayMode parseResult
+
         let longestRelativePath =
             getLongestRelativePath (
                 directoryVersions
@@ -228,7 +230,7 @@ module Reference =
 
             if i = 0 then
                 AnsiConsole.MarkupLine(
-                    $"[{Colors.Important}]Created At                   SHA-256            Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
+                    $"[{Colors.Important}]Created At                   BLAKE3 version hash  Size  Path{additionalSpaces}[/][{Colors.Deemphasized}] (DirectoryVersionId)[/]"
                 )
 
                 AnsiConsole.MarkupLine(
@@ -243,14 +245,14 @@ module Reference =
                 + $"({directoryVersion.DirectoryVersionId})"
 
             AnsiConsole.MarkupLine(
-                $"[{Colors.Highlighted}]{formatInstantAligned directoryVersion.CreatedAt}   {getShortSha256Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
+                $"[{Colors.Highlighted}]{formatInstantAligned directoryVersion.CreatedAt}   {HashOptions.formatVersionHashPair hashDisplayMode directoryVersion.Blake3Hash directoryVersion.Sha256Hash}  {directoryVersion.Size, 13:N0}  /{directoryVersion.RelativePath}[/] [{Colors.Deemphasized}] {rightAlignedDirectoryVersionId}[/]"
             )
             //if parseResult.CommandResult.Command.Options.Contains(Options.listFiles) then
             let sortedFiles = directoryVersion.Files.OrderBy(fun f -> f.RelativePath)
 
             for file in sortedFiles do
                 AnsiConsole.MarkupLine(
-                    $"[{Colors.Verbose}]{formatInstantAligned file.CreatedAt}   {getShortSha256Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.RelativePath.Split('/').LastOrDefault()}[/]"
+                    $"[{Colors.Verbose}]{formatInstantAligned file.CreatedAt}   {HashOptions.formatVersionHashPair hashDisplayMode file.Blake3Hash file.Sha256Hash}  {file.Size, 13:N0}  |- {file.RelativePath.Split('/').LastOrDefault()}[/]"
                 ))
 
     type GetRecursiveSize() =
@@ -417,7 +419,11 @@ module Reference =
                             AnsiConsole.MarkupLine($"[{Colors.Important}]All values taken from the selected version of this branch from the server.[/]")
                             AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories: {directoryCount}.[/]")
                             AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of files: {fileCount}; total file size: {totalFileSize:N0}.[/]")
-                            AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(0, 8)}[/]")
+                            let hashDisplayMode = HashOptions.bindVersionHashDisplayMode parseResult
+
+                            AnsiConsole.MarkupLine(
+                                $"[{Colors.Highlighted}]Root BLAKE3 version hash: {HashOptions.formatVersionHashPair hashDisplayMode rootDirectoryVersion.Blake3Hash rootDirectoryVersion.Sha256Hash}[/]"
+                            )
 
                             printContents parseResult directoryVersions
                             return result |> renderOutput parseResult


### PR DESCRIPTION
## Summary

- Adds shared human version-hash display helpers for BLAKE3-first CLI output.
- Updates branch `list-contents` and branch reference tables so human output defaults to BLAKE3 version hashes.
- Keeps SHA-256 visible by explicit `--show-sha256` opt-in, and keeps `--full-hashes` controlling abbreviated versus full display.
- Renders missing legacy BLAKE3 as `unavailable` instead of a blank successful hash.
- Updates source-only `Reference.CLI.fs` list-content human output for consistency without routing `Reference.Build` from production root.

Related to #359.
Part of #343.

## Validation

Worker validation on commit `6964c26859bfdb1bfa4563d2808d308b9b742250`:

```powershell
dotnet tool run fantomas -- src\Grace.CLI\Command\Common.CLI.fs src\Grace.CLI\Command\Branch.CLI.fs src\Grace.CLI\Command\Reference.CLI.fs src\Grace.CLI.Tests\Branch.CLI.Tests.fs
dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~BranchCommandTests"
pwsh ./scripts/validate.ps1 -Fast
git diff --check
```

Results:

- Fantomas passed.
- Focused branch command tests passed, 18/18.
- `validate -Fast` passed: build 0 warnings and 0 errors; `Grace.Authorization.Tests` 39/39, `Grace.Types.Tests` 122/122, `Grace.Server.Unit.Tests` 564/564, `Grace.CLI.Tests` 567/567. `Grace.Server.Tests` had no Fast-filter matches.
- `git diff --check` passed.

Hosted validation on PR head `6964c26859bfdb1bfa4563d2808d308b9b742250`:

- `Validate / full`: passed.

## Review Status

- Codex Code Review Bot on `6964c26859bfdb1bfa4563d2808d308b9b742250`: 👍 no issues.
- Prevention line: worker self-review verified lookup/display separation, no resolver/save/reference creation changes, no JSON shape changes, no SDK/OpenAPI/local-state/CAS/dedupe behavior changes, BLAKE3-first human version display, SHA-256 opt-in display, full-hash behavior for both algorithms, and missing legacy BLAKE3 shown as `unavailable`.

## Residual Risks

- `Reference.CLI.fs` remains source-only/unrouted and was compile-covered rather than command-output tested.
- Branch reference table output uses the shared formatter but does not have a direct private-table snapshot test.
- JSON output shape remains waived to #360.
- OpenAPI/SDK contract refresh remains waived to #361.
- Non-version SHA-256 proof remains waived to #362.