### PR TITLE
I17 CLI JSON dual-hash contract

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -506,6 +506,54 @@ module BranchCommandTests =
         |> should equal "src/App.fs"
 
     [<Test>]
+    let ``list contents json includes full dual hashes regardless of human display flags`` () =
+        let assertJsonContainsFullDualHashes (parseResult: System.CommandLine.ParseResult) =
+            parseResult.Errors.Count |> should equal 0
+
+            let exitCode, output =
+                captureOutput (fun () ->
+                    let result = Ok(GraceReturnValue.Create [| branchDirectoryWithFile () |] correlationId)
+                    Common.renderOutput parseResult result)
+
+            exitCode |> should equal 0
+
+            use document = JsonDocument.Parse(output)
+            let directory = document.RootElement.GetProperty("ReturnValue")[0]
+
+            directory.GetProperty("Sha256Hash").GetString()
+            |> should equal $"{directorySha256Hash}"
+
+            directory.GetProperty("Blake3Hash").GetString()
+            |> should equal $"{directoryBlake3Hash}"
+
+            let file = directory.GetProperty("Files")[0]
+
+            file.GetProperty("Sha256Hash").GetString()
+            |> should equal $"{fileSha256Hash}"
+
+            file.GetProperty("Blake3Hash").GetString()
+            |> should equal $"{fileBlake3Hash}"
+
+        let fullHashesParseResult =
+            parse [| "--output"
+                     "Json"
+                     "branch"
+                     "list-contents"
+                     "--full-hashes"
+                     "--show-sha256" |]
+
+        assertJsonContainsFullDualHashes fullHashesParseResult
+
+        let deprecatedFullShaParseResult =
+            parse [| "--output"
+                     "Json"
+                     "branch"
+                     "list-contents"
+                     "--full-sha" |]
+
+        assertJsonContainsFullDualHashes deprecatedFullShaParseResult
+
+    [<Test>]
     let ``select output remains one machine readable document and skips human spans`` () =
         let parseResult =
             parse [| "branch"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -580,6 +580,78 @@ module CommandOutputContractRegistryTests =
         |> should equal null
 
     [<Test>]
+    let ``maintenance list contents local dto serializes explicit dual hash fields`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "--output"
+                    "Json"
+                    "maintenance"
+                    "list-contents"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        let dto: Common.LocalOutputDto.MaintenanceListContentsDto =
+            {
+                Summary = { DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = Some "root-sha256" }
+                Directories =
+                    [|
+                        {
+                            RelativePath = "."
+                            DirectoryVersionId = Guid.Parse placeholderGuid
+                            Sha256Hash = "directory-sha256"
+                            Blake3Hash = "directory-blake3"
+                            Size = 12L
+                            LastWriteTimeUtc = DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc)
+                            Files =
+                                [|
+                                    {
+                                        RelativePath = "README.md"
+                                        FileName = "README.md"
+                                        Sha256Hash = "file-sha256"
+                                        Blake3Hash = "file-blake3"
+                                        Size = 12L
+                                        LastWriteTimeUtc = DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc)
+                                    }
+                                |]
+                        }
+                    |]
+            }
+
+        let exitCode, output =
+            captureStdout (fun () ->
+                GraceReturnValue.Create dto "corr-local-list-contents-dto"
+                |> Ok
+                |> Common.renderOutput parseResult)
+
+        exitCode |> should equal 0
+        assertOneJsonObjectStdout output
+
+        use document = parseJsonDocument output
+
+        let directory =
+            document
+                .RootElement
+                .GetProperty("ReturnValue")
+                .GetProperty("Directories")[0]
+
+        directory.GetProperty("Sha256Hash").GetString()
+        |> should equal "directory-sha256"
+
+        directory.GetProperty("Blake3Hash").GetString()
+        |> should equal "directory-blake3"
+
+        let file = directory.GetProperty("Files")[0]
+
+        file.GetProperty("Sha256Hash").GetString()
+        |> should equal "file-sha256"
+
+        file.GetProperty("Blake3Hash").GetString()
+        |> should equal "file-blake3"
+
+    [<Test>]
     let ``watch json mode is registered as immediate error only`` () =
         let identity = CommandOutputContract.commandIdentity [] "watch"
 

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -538,7 +538,7 @@ module CommandOutputContractRegistryTests =
         parseResult.Errors.Count |> should equal 0
 
         let dto: Common.LocalOutputDto.MaintenanceStatsDto =
-            { DirectoryCount = 3; FileCount = 5; TotalFileSize = 89L; RootSha256Hash = Some "0123456789abcdef" }
+            { DirectoryCount = 3; FileCount = 5; TotalFileSize = 89L; RootSha256Hash = Some "0123456789abcdef"; RootBlake3Hash = Some "af1349b9f5f9a1a6" }
 
         let exitCode, output =
             captureStdout (fun () ->
@@ -571,6 +571,11 @@ module CommandOutputContractRegistryTests =
             .GetString()
         |> should equal "0123456789abcdef"
 
+        returnValue
+            .GetProperty("RootBlake3Hash")
+            .GetString()
+        |> should equal "af1349b9f5f9a1a6"
+
         let mutable camelCaseReturnValue = Unchecked.defaultof<JsonElement>
 
         root.TryGetProperty("returnValue", &camelCaseReturnValue)
@@ -595,7 +600,7 @@ module CommandOutputContractRegistryTests =
 
         let dto: Common.LocalOutputDto.MaintenanceListContentsDto =
             {
-                Summary = { DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = Some "root-sha256" }
+                Summary = { DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = Some "root-sha256"; RootBlake3Hash = Some "root-blake3" }
                 Directories =
                     [|
                         {
@@ -630,6 +635,18 @@ module CommandOutputContractRegistryTests =
         assertOneJsonObjectStdout output
 
         use document = parseJsonDocument output
+
+        let summary =
+            document
+                .RootElement
+                .GetProperty("ReturnValue")
+                .GetProperty("Summary")
+
+        summary.GetProperty("RootSha256Hash").GetString()
+        |> should equal "root-sha256"
+
+        summary.GetProperty("RootBlake3Hash").GetString()
+        |> should equal "root-blake3"
 
         let directory =
             document

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -192,8 +192,9 @@ module MaintenanceCliTests =
 
     [<Test>]
     let ``maintenance scan json emits scan envelope with clean stdout`` () =
-        withTempRepo (fun _ ->
+        withTempRepo (fun root ->
             createIndex ()
+            File.WriteAllText(Path.Combine(root, "changed.txt"), "changed content")
 
             let exitCode, standardOut, standardError = runJsonMaintenance [| "scan" |]
 
@@ -225,7 +226,30 @@ module MaintenanceCliTests =
                     "NewDirectoryVersions"
                 )
                 .ValueKind
-            |> should equal JsonValueKind.Array)
+            |> should equal JsonValueKind.Array
+
+            let newDirectoryVersions = returnValue.GetProperty("NewDirectoryVersions")
+
+            newDirectoryVersions.GetArrayLength()
+            |> should greaterThan 0
+
+            let newDirectoryVersion = newDirectoryVersions[0]
+
+            newDirectoryVersion
+                .GetProperty(
+                    "Sha256Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64
+
+            newDirectoryVersion
+                .GetProperty(
+                    "Blake3Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64)
 
     [<Test>]
     let ``maintenance stats json emits stats envelope with clean stdout`` () =
@@ -277,4 +301,30 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Number
 
             returnValue.GetProperty("Directories").ValueKind
-            |> should equal JsonValueKind.Array)
+            |> should equal JsonValueKind.Array
+
+            let directories = returnValue.GetProperty("Directories")
+
+            directories.GetArrayLength()
+            |> should greaterThan 0
+
+            let directory = directories[0]
+
+            directory.GetProperty("Sha256Hash").GetString()
+                .Length
+            |> should equal 64
+
+            directory.GetProperty("Blake3Hash").GetString()
+                .Length
+            |> should equal 64
+
+            let files = directory.GetProperty("Files")
+            files.GetArrayLength() |> should greaterThan 0
+
+            let file = files[0]
+
+            file.GetProperty("Sha256Hash").GetString().Length
+            |> should equal 64
+
+            file.GetProperty("Blake3Hash").GetString().Length
+            |> should equal 64)

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -4,6 +4,7 @@ open FsUnit
 open Grace.CLI
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -99,6 +100,34 @@ module MaintenanceCliTests =
             .ValueKind
         |> should equal JsonValueKind.Number
 
+        returnValue
+            .GetProperty(
+                "RootSha256Hash"
+            )
+            .GetString()
+            .Length
+        |> should equal 64
+
+        returnValue
+            .GetProperty(
+                "RootBlake3Hash"
+            )
+            .GetString()
+            .Length
+        |> should equal 64
+
+    let private writeStatusMetaOnlySnapshot root =
+        let status =
+            { GraceStatus.Default with
+                RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
+                RootDirectorySha256Hash = Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                RootDirectoryBlake3Hash = Blake3Hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+
+        LocalStateDb.replaceStatusSnapshot (Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)) status
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
+
     [<Test>]
     let ``maintenance check ignore entries json emits one clean envelope`` () =
         withTempRepo (fun _ ->
@@ -150,7 +179,23 @@ module MaintenanceCliTests =
             |> should equal JsonValueKind.Number
 
             returnValue.GetProperty("TotalFileSize").ValueKind
-            |> should equal JsonValueKind.Number)
+            |> should equal JsonValueKind.Number
+
+            returnValue
+                .GetProperty(
+                    "RootSha256Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64
+
+            returnValue
+                .GetProperty(
+                    "RootBlake3Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64)
 
     [<Test>]
     let ``maintenance update-index json exception emits one clean error envelope`` () =
@@ -279,7 +324,46 @@ module MaintenanceCliTests =
                     "RootSha256Hash"
                 )
                 .ValueKind
-            |> should not' (equal JsonValueKind.Undefined))
+            |> should not' (equal JsonValueKind.Undefined)
+
+            returnValue
+                .GetProperty(
+                    "RootSha256Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64
+
+            returnValue
+                .GetProperty(
+                    "RootBlake3Hash"
+                )
+                .GetString()
+                .Length
+            |> should equal 64)
+
+    [<Test>]
+    let ``maintenance stats json includes root hashes from status metadata when root row is absent`` () =
+        withTempRepo (fun root ->
+            writeStatusMetaOnlySnapshot root
+
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "stats" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty("RootSha256Hash")
+                .GetString()
+            |> should equal "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+            returnValue
+                .GetProperty("RootBlake3Hash")
+                .GetString()
+            |> should equal "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 
     [<Test>]
     let ``maintenance list contents json emits contents envelope with clean stdout`` () =
@@ -328,3 +412,33 @@ module MaintenanceCliTests =
 
             file.GetProperty("Blake3Hash").GetString().Length
             |> should equal 64)
+
+    [<Test>]
+    let ``maintenance list contents json with directories disabled emits dual hash summary`` () =
+        withTempRepo (fun _ ->
+            createIndex ()
+
+            let exitCode, standardOut, standardError =
+                runJsonMaintenance [| "list-contents"
+                                      "--list-directories"
+                                      "false" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+            let summary = returnValue.GetProperty("Summary")
+
+            summary.GetProperty("RootSha256Hash").GetString()
+                .Length
+            |> should equal 64
+
+            summary.GetProperty("RootBlake3Hash").GetString()
+                .Length
+            |> should equal 64
+
+            returnValue
+                .GetProperty("Directories")
+                .GetArrayLength()
+            |> should equal 0)

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -88,7 +88,7 @@ module Common =
 
         type ReviewReportExportDto = { CandidateId: string; Format: string; OutputFile: string; BytesWritten: int64 }
 
-        type MaintenanceStatsDto = { DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string option }
+        type MaintenanceStatsDto = { DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string option; RootBlake3Hash: string option }
 
         type MaintenanceListContentsFileDto =
             {

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -90,13 +90,22 @@ module Common =
 
         type MaintenanceStatsDto = { DirectoryCount: int; FileCount: int; TotalFileSize: int64; RootSha256Hash: string option }
 
-        type MaintenanceListContentsFileDto = { RelativePath: string; FileName: string; Sha256Hash: string; Size: int64; LastWriteTimeUtc: DateTime }
+        type MaintenanceListContentsFileDto =
+            {
+                RelativePath: string
+                FileName: string
+                Sha256Hash: string
+                Blake3Hash: string
+                Size: int64
+                LastWriteTimeUtc: DateTime
+            }
 
         type MaintenanceListContentsDirectoryDto =
             {
                 RelativePath: string
                 DirectoryVersionId: Guid
                 Sha256Hash: string
+                Blake3Hash: string
                 Size: int64
                 LastWriteTimeUtc: DateTime
                 Files: MaintenanceListContentsFileDto array
@@ -108,7 +117,7 @@ module Common =
 
         type MaintenanceScanDifferenceDto = { DifferenceType: string; FileSystemEntryType: string; RelativePath: string }
 
-        type MaintenanceScanDirectoryVersionDto = { DirectoryVersionId: Guid; RelativePath: string; Sha256Hash: string }
+        type MaintenanceScanDirectoryVersionDto = { DirectoryVersionId: Guid; RelativePath: string; Sha256Hash: string; Blake3Hash: string }
 
         type MaintenanceScanDto =
             {

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -125,6 +125,21 @@ module Maintenance =
         rootHashFromIndex
         |> Option.orElse rootHashFromStatusMeta
 
+    let private tryGetRootBlake3Hash (graceStatus: GraceStatus) =
+        let rootHashFromIndex =
+            graceStatus.Index.Values
+            |> Seq.tryFind (fun directoryVersion -> directoryVersion.RelativePath = Constants.RootDirectoryPath)
+            |> Option.map (fun directoryVersion -> directoryVersion.Blake3Hash)
+
+        let rootHashFromStatusMeta =
+            if String.IsNullOrWhiteSpace(string graceStatus.RootDirectoryBlake3Hash) then
+                None
+            else
+                Some graceStatus.RootDirectoryBlake3Hash
+
+        rootHashFromIndex
+        |> Option.orElse rootHashFromStatusMeta
+
     let private getShortHash (sha256Hash: Sha256Hash) =
         if String.IsNullOrWhiteSpace(sha256Hash) then String.Empty
         elif sha256Hash.Length <= 8 then sha256Hash
@@ -153,6 +168,9 @@ module Maintenance =
             TotalFileSize = totalFileSize
             RootSha256Hash =
                 tryGetRootSha256Hash graceStatus
+                |> Option.map string
+            RootBlake3Hash =
+                tryGetRootBlake3Hash graceStatus
                 |> Option.map string
         }
 

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -171,6 +171,7 @@ module Maintenance =
                                     LocalOutputDto.MaintenanceListContentsFileDto.RelativePath = string file.RelativePath
                                     FileName = file.FileInfo.Name
                                     Sha256Hash = string file.Sha256Hash
+                                    Blake3Hash = string file.Blake3Hash
                                     Size = int64 file.Size
                                     LastWriteTimeUtc = file.LastWriteTimeUtc
                                 }: LocalOutputDto.MaintenanceListContentsFileDto)
@@ -182,6 +183,7 @@ module Maintenance =
                          LocalOutputDto.MaintenanceListContentsDirectoryDto.RelativePath = string directoryVersion.RelativePath
                          DirectoryVersionId = directoryVersion.DirectoryVersionId
                          Sha256Hash = string directoryVersion.Sha256Hash
+                         Blake3Hash = string directoryVersion.Blake3Hash
                          Size = int64 directoryVersion.Size
                          LastWriteTimeUtc = directoryVersion.LastWriteTimeUtc
                          Files = files
@@ -212,6 +214,7 @@ module Maintenance =
                          LocalOutputDto.MaintenanceScanDirectoryVersionDto.DirectoryVersionId = directoryVersion.DirectoryVersionId
                          RelativePath = string directoryVersion.RelativePath
                          Sha256Hash = string directoryVersion.Sha256Hash
+                         Blake3Hash = string directoryVersion.Blake3Hash
                      }: LocalOutputDto.MaintenanceScanDirectoryVersionDto))
                 |> Seq.toArray
         }

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -527,7 +527,11 @@ module Services =
         if rootDirectoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
             graceStatus
         else
-            { graceStatus with RootDirectoryId = rootDirectoryVersion.DirectoryVersionId; RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash }
+            { graceStatus with
+                RootDirectoryId = rootDirectoryVersion.DirectoryVersionId
+                RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash
+                RootDirectoryBlake3Hash = rootDirectoryVersion.Blake3Hash
+            }
 
     let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
 
@@ -576,6 +580,7 @@ module Services =
                 { GraceStatus.Default with
                     RootDirectoryId = meta.RootDirectoryId
                     RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = meta.RootDirectoryBlake3Hash
                     LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
                     LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
                 }
@@ -909,7 +914,11 @@ module Services =
                     logToAnsiConsole Colors.Verbose $"Finished createNewGraceStatusFile. newGraceStatus.Index.Count: {newGraceStatus.Index.Count}."
 
                 let newGraceStatus =
-                    { newGraceStatus with RootDirectoryId = rootDirectoryVersion.DirectoryVersionId; RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash }
+                    { newGraceStatus with
+                        RootDirectoryId = rootDirectoryVersion.DirectoryVersionId
+                        RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash
+                        RootDirectoryBlake3Hash = rootDirectoryVersion.Blake3Hash
+                    }
 
                 return newGraceStatus
             with
@@ -1697,6 +1706,7 @@ module Services =
                         { newGraceStatus with
                             RootDirectoryId = newRootDirectoryVersion.DirectoryVersionId
                             RootDirectorySha256Hash = newRootDirectoryVersion.Sha256Hash
+                            RootDirectoryBlake3Hash = newRootDirectoryVersion.Blake3Hash
                         }
 
                 return (newGraceStatus, newDirectoryVersions)
@@ -1982,6 +1992,7 @@ module Services =
                 Index = newGraceIndex
                 RootDirectoryId = rootDirectoryVersion.DirectoryVersionId
                 RootDirectorySha256Hash = rootDirectoryVersion.Sha256Hash
+                RootDirectoryBlake3Hash = rootDirectoryVersion.Blake3Hash
                 LastSuccessfulDirectoryVersionUpload = graceStatus.LastSuccessfulDirectoryVersionUpload
                 LastSuccessfulFileUpload = graceStatus.LastSuccessfulFileUpload
             }
@@ -2285,7 +2296,14 @@ module Services =
             else
                 updatedGraceStatus.RootDirectorySha256Hash
 
-        { updatedGraceStatus with Index = syncedIndex; RootDirectorySha256Hash = rootDirectorySha256Hash }, List<LocalDirectoryVersion>(syncedDirectoryVersions)
+        let rootDirectoryBlake3Hash =
+            if syncedIndex.TryGetValue(updatedGraceStatus.RootDirectoryId, &syncedRootDirectoryVersion) then
+                syncedRootDirectoryVersion.Blake3Hash
+            else
+                updatedGraceStatus.RootDirectoryBlake3Hash
+
+        { updatedGraceStatus with Index = syncedIndex; RootDirectorySha256Hash = rootDirectorySha256Hash; RootDirectoryBlake3Hash = rootDirectoryBlake3Hash },
+        List<LocalDirectoryVersion>(syncedDirectoryVersions)
 
     let private createSaveForCurrentRoot operations branchDto saveMessage correlationId rootDirectoryVersion =
         task {

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -221,15 +221,18 @@ module CommandOutputContract =
                 "FileCount", scalarSchema "integer"
                 "TotalFileSize", scalarSchema "integer"
                 "RootSha256Hash", nullableStringSchema "Root directory SHA-256 hash when the local index contains or records it."
+                "RootBlake3Hash", nullableStringSchema "Root directory BLAKE3 hash when the local index contains it."
             ]
             [|
                 "DirectoryCount"
                 "FileCount"
                 "TotalFileSize"
                 "RootSha256Hash"
+                "RootBlake3Hash"
             |]
 
-    let private maintenanceStatsExample = box {| DirectoryCount = 1; FileCount = 2; TotalFileSize = 42L; RootSha256Hash = "0123456789abcdef" |}
+    let private maintenanceStatsExample =
+        box {| DirectoryCount = 1; FileCount = 2; TotalFileSize = 42L; RootSha256Hash = "0123456789abcdef"; RootBlake3Hash = "af1349b9f5f9a1a6" |}
 
     let private maintenanceListContentsFileSchema =
         schemaObject
@@ -285,7 +288,7 @@ module CommandOutputContract =
     let private maintenanceListContentsExample =
         box
             {|
-                Summary = {| DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = "0123456789abcdef" |}
+                Summary = {| DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = "0123456789abcdef"; RootBlake3Hash = "af1349b9f5f9a1a6" |}
                 Directories =
                     [|
                         {|

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -238,6 +238,7 @@ module CommandOutputContract =
                 "RelativePath", scalarSchema "string"
                 "FileName", scalarSchema "string"
                 "Sha256Hash", scalarSchema "string"
+                "Blake3Hash", scalarSchema "string"
                 "Size", scalarSchema "integer"
                 "LastWriteTimeUtc", stringDateTimeSchema
             ]
@@ -245,6 +246,7 @@ module CommandOutputContract =
                 "RelativePath"
                 "FileName"
                 "Sha256Hash"
+                "Blake3Hash"
                 "Size"
                 "LastWriteTimeUtc"
             |]
@@ -256,6 +258,7 @@ module CommandOutputContract =
                 "RelativePath", scalarSchema "string"
                 "DirectoryVersionId", scalarSchema "string"
                 "Sha256Hash", scalarSchema "string"
+                "Blake3Hash", scalarSchema "string"
                 "Size", scalarSchema "integer"
                 "LastWriteTimeUtc", stringDateTimeSchema
                 "Files", arraySchema maintenanceListContentsFileSchema "Files in the indexed directory when file listing is enabled."
@@ -264,6 +267,7 @@ module CommandOutputContract =
                 "RelativePath"
                 "DirectoryVersionId"
                 "Sha256Hash"
+                "Blake3Hash"
                 "Size"
                 "LastWriteTimeUtc"
                 "Files"
@@ -288,6 +292,7 @@ module CommandOutputContract =
                             RelativePath = "."
                             DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
                             Sha256Hash = "0123456789abcdef"
+                            Blake3Hash = "af1349b9f5f9a1a6"
                             Size = 12L
                             LastWriteTimeUtc = "2026-06-05T00:00:00Z"
                             Files =
@@ -296,6 +301,7 @@ module CommandOutputContract =
                                         RelativePath = "README.md"
                                         FileName = "README.md"
                                         Sha256Hash = "abcdef0123456789"
+                                        Blake3Hash = "b9f5f9a1a6af1349"
                                         Size = 12L
                                         LastWriteTimeUtc = "2026-06-05T00:00:00Z"
                                     |}
@@ -336,11 +342,13 @@ module CommandOutputContract =
                 "DirectoryVersionId", scalarSchema "string"
                 "RelativePath", scalarSchema "string"
                 "Sha256Hash", scalarSchema "string"
+                "Blake3Hash", scalarSchema "string"
             ]
             [|
                 "DirectoryVersionId"
                 "RelativePath"
                 "Sha256Hash"
+                "Blake3Hash"
             |]
 
     let private maintenanceScanSchema =
@@ -370,7 +378,12 @@ module CommandOutputContract =
                 NewDirectoryVersionCount = 1
                 NewDirectoryVersions =
                     [|
-                        {| DirectoryVersionId = "11111111-1111-1111-1111-111111111111"; RelativePath = "."; Sha256Hash = "0123456789abcdef" |}
+                        {|
+                            DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
+                            RelativePath = "."
+                            Sha256Hash = "0123456789abcdef"
+                            Blake3Hash = "af1349b9f5f9a1a6"
+                        |}
                     |]
             |}
 

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -62,8 +62,8 @@
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.8" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-		<PackageReference Include="MessagePack" Version="3.1.6" />
-		<PackageReference Include="MessagePack.Annotations" Version="3.1.6" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="MessagePack.Annotations" Version="3.1.7" />
 		<PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
 		<PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -700,6 +700,8 @@ module LocalStateDb =
             && graceStatus.Index.TryGetValue(graceStatus.RootDirectoryId, &rootDirectory)
         then
             rootDirectory.Blake3Hash
+        elif not (String.IsNullOrWhiteSpace(string graceStatus.RootDirectoryBlake3Hash)) then
+            graceStatus.RootDirectoryBlake3Hash
         else
             Blake3Hash String.Empty
 
@@ -1445,6 +1447,7 @@ module LocalStateDb =
                         Index = index
                         RootDirectoryId = meta.RootDirectoryId
                         RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                        RootDirectoryBlake3Hash = meta.RootDirectoryBlake3Hash
                         LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
                         LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
                     }
@@ -1657,6 +1660,7 @@ module LocalStateDb =
                                                 Index = index
                                                 RootDirectoryId = meta.RootDirectoryId
                                                 RootDirectorySha256Hash = meta.RootDirectorySha256Hash
+                                                RootDirectoryBlake3Hash = meta.RootDirectoryBlake3Hash
                                                 LastSuccessfulFileUpload = meta.LastSuccessfulFileUpload
                                                 LastSuccessfulDirectoryVersionUpload = meta.LastSuccessfulDirectoryVersionUpload
                                             }

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -136,8 +136,8 @@
 		<PackageReference Include="dotenv.net" Version="4.0.2" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
 		<PackageReference Include="Giraffe" Version="8.2.0" />
-		<PackageReference Include="MessagePack" Version="3.1.6" />
-		<PackageReference Include="MessagePack.Annotations" Version="3.1.6" />
+		<PackageReference Include="MessagePack" Version="3.1.7" />
+		<PackageReference Include="MessagePack.Annotations" Version="3.1.7" />
 		<PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -86,8 +86,8 @@
         <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
         <PackageReference Include="FSharpPlus" Version="1.9.1" />
-        <PackageReference Include="MessagePack" Version="3.1.6" />
-        <PackageReference Include="MessagePack.Annotations" Version="3.1.6" />
+        <PackageReference Include="MessagePack" Version="3.1.7" />
+        <PackageReference Include="MessagePack.Annotations" Version="3.1.7" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
         <PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />

--- a/src/Grace.Types/Common.Types.fs
+++ b/src/Grace.Types/Common.Types.fs
@@ -1206,6 +1206,8 @@ module Common =
             LastSuccessfulFileUpload: Instant
             [<Key(4)>]
             LastSuccessfulDirectoryVersionUpload: Instant
+            [<Key(5)>]
+            RootDirectoryBlake3Hash: Blake3Hash
         }
 
         static member Default =
@@ -1215,6 +1217,7 @@ module Common =
                 RootDirectorySha256Hash = Sha256Hash String.Empty
                 LastSuccessfulFileUpload = getCurrentInstant ()
                 LastSuccessfulDirectoryVersionUpload = getCurrentInstant ()
+                RootDirectoryBlake3Hash = Blake3Hash String.Empty
             }
 
     /// GraceObjectCache is a snapshot of the contents of the local object cache.

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -56,8 +56,8 @@
         <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
         <PackageReference Include="FSharpPlus" Version="1.9.1" />
-        <PackageReference Include="MessagePack" Version="3.1.6" />
-        <PackageReference Include="MessagePack.Annotations" Version="3.1.6" />
+        <PackageReference Include="MessagePack" Version="3.1.7" />
+        <PackageReference Include="MessagePack.Annotations" Version="3.1.7" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
         <PackageReference Include="MessagePack.NodaTime" Version="3.5.4" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />


### PR DESCRIPTION
## Summary

- Adds `Blake3Hash` beside existing `Sha256Hash` in CLI-local maintenance JSON DTOs for list-contents files/directories and scan directory versions.
- Adds `RootBlake3Hash` beside existing `RootSha256Hash` in maintenance summary/stats JSON, including metadata fallback when the root directory row is absent.
- Maps full BLAKE3 values from local version objects and status metadata into those JSON DTOs.
- Updates machine-readable command output schema/examples to advertise both algorithm-specific hash fields.
- Adds JSON contract tests for nested directory/file arrays, scan results, summary-only maintenance output, local DTO serialization, status metadata fallback, and `branch list-contents --output Json` under human display flags.
- Updates direct `MessagePack` and `MessagePack.Annotations` package references from 3.1.6 to 3.1.7 to clear hosted restore failure NU1903 for GHSA-hv8m-jj95-wg3x.

Related to #360.
Part of #343.

## Validation

Worker validation on commit `ba0bf43c09c46d086220ff7fca03470ea20c4eb9`:

```powershell
dotnet fantomas src/Grace.CLI/Command/Common.CLI.fs src/Grace.CLI/Command/Maintenance.CLI.fs src/Grace.CLI/CommandOutputContract.CLI.fs src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs src/Grace.CLI.Tests/Branch.CLI.Tests.fs src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
dotnet build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release
dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --no-build --filter "FullyQualifiedName~MaintenanceCliTests|FullyQualifiedName~CommandOutputContractRegistryTests|FullyQualifiedName~BranchCommandTests"
pwsh ./scripts/validate.ps1 -Fast
git diff --check
```

Results:

- Fantomas passed.
- Focused Release build passed.
- Focused JSON/contract/branch tests passed, 47/47.
- `validate -Fast` passed.
- `git diff --check` passed.

Fix validation on commit `a825003405d146f1e35858d75c1f57286fe11827`:

```powershell
dotnet fantomas src/Grace.Types/Common.Types.fs src/Grace.CLI/LocalStateDb.CLI.fs src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI/Command/Common.CLI.fs src/Grace.CLI/Command/Maintenance.CLI.fs src/Grace.CLI/CommandOutputContract.CLI.fs src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~MaintenanceCliTests|FullyQualifiedName~CommandOutputContractRegistryTests"
dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~LocalStateDbTests"
git diff --check
```

Results:

- Fantomas passed.
- Focused Release build passed with 0 warnings and 0 errors.
- Focused JSON/contract tests passed, 30/30.
- Focused local-state DB tests passed, 49/49.
- `git diff --check` passed.

CI/package validation on commit `30ffe7cc2b7df27045f2a2b7d7c8ab4cd84f00ec`:

```powershell
dotnet restore src/Grace.slnx
pwsh ./scripts/validate.ps1 -Fast
git diff --check
dotnet restore src/Grace.slnx
```

Results:

- Restore passed and no longer reported NU1903 for GHSA-hv8m-jj95-wg3x.
- `validate -Fast` passed: build 0 warnings and 0 errors; `Grace.Types.Tests` 122/122, `Grace.Authorization.Tests` 39/39, `Grace.Server.Unit.Tests` 564/564, `Grace.CLI.Tests` 571/571.
- `git diff --check` passed.
- Final restore after XML cleanup passed.

Hosted validation on PR head `30ffe7cc2b7df27045f2a2b7d7c8ab4cd84f00ec`:

- `Validate / full`: passed.

## Review Status

- Codex Code Review Bot on `ba0bf43c09c46d086220ff7fca03470ea20c4eb9`: found one issue.
- Fixed in `a825003405d146f1e35858d75c1f57286fe11827`: maintenance summary/stats JSON now includes and populates `RootBlake3Hash` beside `RootSha256Hash`, including status metadata fallback.
- Bot conversation replied to and resolved.
- Hosted `Validate / full` on `a825003405d146f1e35858d75c1f57286fe11827`: failed during restore due to MessagePack 3.1.6 advisory NU1903.
- Fixed in `30ffe7cc2b7df27045f2a2b7d7c8ab4cd84f00ec`: direct MessagePack package references updated to patched 3.1.7; local restore and `validate -Fast` passed.
- Codex Code Review Bot on `30ffe7cc2b7df27045f2a2b7d7c8ab4cd84f00ec`: 👍 no issues.
- Prevention line: final package worker self-review verified no serialization keys, MessagePack object contracts, JSON shape, OpenAPI/static SDK output, CLI behavior, or CAS/dedupe/security surfaces changed in the package remediation.

## Residual Risks

- Legacy local records with empty BLAKE3 serialize the actual empty value rather than fabricating a success hash; this is the explicit legacy behavior for this CLI-local JSON slice.
- OpenAPI/static SDK refresh remains waived to #361.
- Non-version SHA-256 proof remains waived to #362.