### PR TITLE
I19 non-version SHA-256 regression proof

### DIFF
--- a/src/Grace.Authorization.Tests/PersonalAccessToken.Tests.fs
+++ b/src/Grace.Authorization.Tests/PersonalAccessToken.Tests.fs
@@ -16,9 +16,11 @@ type PersonalAccessTokenTests() =
 
         let token = formatToken userId tokenId secret
 
+        Assert.That(token, Is.EqualTo("grace_pat_v1_dXNlci0xMjM.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA"))
+
         match tryParseToken token with
         | None -> Assert.Fail("Expected token to parse.")
-        | Some (parsedUserId, parsedTokenId, parsedSecret) ->
+        | Some(parsedUserId, parsedTokenId, parsedSecret) ->
             Assert.That(parsedUserId, Is.EqualTo(userId))
             Assert.That(parsedTokenId, Is.EqualTo(tokenId))
             Assert.That(parsedSecret, Is.EquivalentTo(secret))
@@ -29,8 +31,8 @@ type PersonalAccessTokenTests() =
             try
                 tryParseToken input |> ignore
                 true
-            with
-            | _ -> false
+            with _ ->
+                false
 
         Check.QuickThrowOnFailure property
 
@@ -39,31 +41,19 @@ type PersonalAccessTokenTests() =
         let tokenId = Guid.NewGuid().ToString("N")
         let goodUser = "user-123"
 
-        let goodSecret =
-            Convert
-                .ToBase64String(Array.init 32 (fun i -> byte (i + 1)))
-                .TrimEnd('=')
-                .Replace('+', '-')
-                .Replace('/', '_')
+        let goodSecret = Convert.ToBase64String(Array.init 32 (fun i -> byte (i + 1))).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 
-        let goodUserB64 =
-            Convert
-                .ToBase64String(System.Text.Encoding.UTF8.GetBytes(goodUser))
-                .TrimEnd('=')
-                .Replace('+', '-')
-                .Replace('/', '_')
+        let goodUserB64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(goodUser)).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 
         let malformed =
-            [
-                ""
-                " "
-                "not-a-token"
-                $"{TokenPrefix}{goodUserB64}.{tokenId}" // missing segment
-                $"{TokenPrefix}{goodUserB64}.{Guid.NewGuid()}.{goodSecret}" // wrong guid format
-                $"{TokenPrefix}@@@.{tokenId}.{goodSecret}" // invalid user b64
-                $"{TokenPrefix}{goodUserB64}.{tokenId}.@@@" // invalid secret b64
-                $"{TokenPrefix}{goodUserB64}.{tokenId}.abcd" // wrong secret length
-            ]
+            [ ""
+              " "
+              "not-a-token"
+              $"{TokenPrefix}{goodUserB64}.{tokenId}" // missing segment
+              $"{TokenPrefix}{goodUserB64}.{Guid.NewGuid()}.{goodSecret}" // wrong guid format
+              $"{TokenPrefix}@@@.{tokenId}.{goodSecret}" // invalid user b64
+              $"{TokenPrefix}{goodUserB64}.{tokenId}.@@@" // invalid secret b64
+              $"{TokenPrefix}{goodUserB64}.{tokenId}.abcd" ] // wrong secret length
 
         for value in malformed do
             Assert.That(tryParseToken value, Is.EqualTo(None), $"Expected malformed token to be rejected: {value}")

--- a/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
@@ -26,13 +26,11 @@ type DedupeIndexServerTests() =
         let mutable physicalOffset = 0L
 
         let chunks =
-            [|
-                for index in 0 .. chunkCount - 1 do
-                    let chunkBytes = bytes $"{name}-chunk-{index:D2}-{String('x', 128)}"
-                    let input: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = physicalOffset; Bytes = chunkBytes }
-                    physicalOffset <- physicalOffset + int64 chunkBytes.Length
-                    input
-            |]
+            [| for index in 0 .. chunkCount - 1 do
+                   let chunkBytes = bytes $"{name}-chunk-{index:D2}-{String('x', 128)}"
+                   let input: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = physicalOffset; Bytes = chunkBytes }
+                   physicalOffset <- physicalOffset + int64 chunkBytes.Length
+                   input |]
 
         match ContentBlockFormat.encode chunks with
         | Ok block -> block
@@ -40,27 +38,15 @@ type DedupeIndexServerTests() =
             Assert.Fail($"Expected test content block to encode, got {error}.")
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
-    let decodedChunkAddresses (block: ContentBlockFormat.EncodedContentBlock) =
-        block.Chunks
-        |> Array.map (fun chunk -> chunk.Address)
+    let decodedChunkAddresses (block: ContentBlockFormat.EncodedContentBlock) = block.Chunks |> Array.map (fun chunk -> chunk.Address)
 
     let manifestFor (block: ContentBlockFormat.EncodedContentBlock) =
-        let size =
-            block.Chunks
-            |> Array.sumBy (fun chunk -> int64 chunk.Length)
+        let size = block.Chunks |> Array.sumBy (fun chunk -> int64 chunk.Length)
 
         let fileHash = FileContentHash(ContentAddress.computeBlake3Hex block.Payload)
 
         let manifest =
-            FileManifest.Create(
-                ManifestAddress String.Empty,
-                RabinChunking.SuiteName,
-                fileHash,
-                size,
-                [
-                    ContentBlock.Create(block.Address, 0L, size)
-                ]
-            )
+            FileManifest.Create(ManifestAddress String.Empty, RabinChunking.SuiteName, fileHash, size, [ ContentBlock.Create(block.Address, 0L, size) ])
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
 
@@ -68,38 +54,30 @@ type DedupeIndexServerTests() =
         { UploadSessionDto.Default with
             RepositoryId = repositoryId
             LifecycleState = UploadSessionLifecycleState.RetentionPending
-            FinalizedManifestAddress = Some manifest.ManifestAddress
-        }
+            FinalizedManifestAddress = Some manifest.ManifestAddress }
 
     let nonFinalizedSession () =
         { UploadSessionDto.Default with
             RepositoryId = repositoryId
             LifecycleState = UploadSessionLifecycleState.UploadingBlocks
-            FinalizedManifestAddress = None
-        }
+            FinalizedManifestAddress = None }
 
     let metadataFor activeManifestCount metadataVersion (block: ContentBlockFormat.EncodedContentBlock) =
-        {
-            Class = nameof ContentBlockMetadata
-            StoragePoolId = storagePoolId
-            ContentBlockAddress = block.Address
-            BlockFormatVersion = 1s
-            StoragePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some $"etag-{metadataVersion}" }
-            Ranges =
-                [|
-                    {
-                        OrdinalStart = 0
-                        OrdinalCount = block.Chunks.Length
-                        ActiveManifestCount = activeManifestCount
-                        PhysicalOffset = 0L
-                        PhysicalLength = block.Payload.LongLength
-                    }
-                |]
-            TotalPhysicalBytes = block.Payload.LongLength
-            ActivePhysicalBytes = if activeManifestCount > 0 then block.Payload.LongLength else 0L
-            MetadataVersion = metadataVersion
-            UpdatedAt = timestamp
-        }
+        { Class = nameof ContentBlockMetadata
+          StoragePoolId = storagePoolId
+          ContentBlockAddress = block.Address
+          BlockFormatVersion = 1s
+          StoragePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some $"etag-{metadataVersion}" }
+          Ranges =
+            [| { OrdinalStart = 0
+                 OrdinalCount = block.Chunks.Length
+                 ActiveManifestCount = activeManifestCount
+                 PhysicalOffset = 0L
+                 PhysicalLength = block.Payload.LongLength } |]
+          TotalPhysicalBytes = block.Payload.LongLength
+          ActivePhysicalBytes = if activeManifestCount > 0 then block.Payload.LongLength else 0L
+          MetadataVersion = metadataVersion
+          UpdatedAt = timestamp }
 
     let payloadFor (block: ContentBlockFormat.EncodedContentBlock) : FinalizeManifestBlockPayload = { Address = block.Address; Payload = block.Payload }
 
@@ -115,6 +93,16 @@ type DedupeIndexServerTests() =
         let preimage = $"grace.dedupe-index.v1.protected-window\n{storagePoolId}\n{chunkAddress}"
         let hash = SHA256.HashData(Encoding.UTF8.GetBytes(preimage))
         $"protected-sha256:{Convert.ToHexString(hash).ToLowerInvariant()}"
+
+    [<Test>]
+    member _.ProtectedChunkAddressKnownVectorKeepsSha256LabelAndPreimageStable() =
+        let chunkAddress = ChunkAddress "chunk-blake3-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        let protectedAddress = protectedChunkAddress storagePoolId chunkAddress
+
+        Assert.That(protectedAddress, Is.EqualTo("protected-sha256:12ddb278d672194eeefe9d1bec08a381a8a514a40c65fc206296f68b213dab86"))
+
+        Assert.That(protectedAddress, Does.StartWith("protected-sha256:"))
+        Assert.That(protectedAddress, Does.Not.Contain("blake3"))
 
     [<Test>]
     member _.WritesOnlyAfterFinalizedManifestAndActiveMetadataWithoutRawInventory() =
@@ -165,23 +153,15 @@ type DedupeIndexServerTests() =
             let tail = bytes $"limit-tail-{index}-{String('y', 128)}"
 
             let chunks: ContentBlockFormat.ContentBlockInputChunk array =
-                [|
-                    let firstChunk: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = 0L; Bytes = sharedChunkBytes }
-                    firstChunk
+                [| let firstChunk: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = 0L; Bytes = sharedChunkBytes }
+                   firstChunk
 
-                    for ordinal in 1..11 do
-                        let chunk: ContentBlockFormat.ContentBlockInputChunk =
-                            {
-                                PhysicalOffset =
-                                    int64 (
-                                        sharedChunkBytes.Length
-                                        + (ordinal - 1) * tail.Length
-                                    )
-                                Bytes = bytes $"limit-{index}-{ordinal}-{String('z', 128)}"
-                            }
+                   for ordinal in 1..11 do
+                       let chunk: ContentBlockFormat.ContentBlockInputChunk =
+                           { PhysicalOffset = int64 (sharedChunkBytes.Length + (ordinal - 1) * tail.Length)
+                             Bytes = bytes $"limit-{index}-{ordinal}-{String('z', 128)}" }
 
-                        chunk
-                |]
+                       chunk |]
 
             match ContentBlockFormat.encode chunks with
             | Ok block -> block
@@ -190,12 +170,10 @@ type DedupeIndexServerTests() =
                 Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
         let records =
-            [|
-                for index in 0 .. MaxCandidateWindowsPerKeyChunk + 2 do
-                    let block = createBlock index
-                    let manifest = manifestFor block
-                    DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block (metadataFor 1 (int64 index + 1L) block))
-            |]
+            [| for index in 0 .. MaxCandidateWindowsPerKeyChunk + 2 do
+                   let block = createBlock index
+                   let manifest = manifestFor block
+                   DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block (metadataFor 1 (int64 index + 1L) block)) |]
             |> Array.concat
 
         let requestedChunk = (decodedChunkAddresses firstBlock)[0]
@@ -210,13 +188,11 @@ type DedupeIndexServerTests() =
         let matchingChunk = (decodedChunkAddresses duplicateBlock)[0]
 
         let requested =
-            [|
-                yield matchingChunk
-                yield matchingChunk
-                yield String.Empty
-                for index in 0 .. MaxDiscoveryKeyChunkAddresses + 10 do
-                    yield $"missing-key-{index:D3}"
-            |]
+            [| yield matchingChunk
+               yield matchingChunk
+               yield String.Empty
+               for index in 0 .. MaxDiscoveryKeyChunkAddresses + 10 do
+                   yield $"missing-key-{index:D3}" |]
 
         let result = discover Array.empty requested
 
@@ -231,13 +207,8 @@ type DedupeIndexServerTests() =
     [<Test>]
     member _.DiscoveryResponseBudgetTruncatesProtectedWindowsAndMarksPartial() =
         let blocks =
-            [|
-                for index in
-                    0 .. MaxResponseProtectedChunks
-                         / MinimumAcceptedReuseRunLength
-                         + 8 do
-                    encodedBlock $"budget-{index:D4}" MinimumAcceptedReuseRunLength
-            |]
+            [| for index in 0 .. MaxResponseProtectedChunks / MinimumAcceptedReuseRunLength + 8 do
+                   encodedBlock $"budget-{index:D4}" MinimumAcceptedReuseRunLength |]
 
         let records =
             blocks
@@ -247,9 +218,7 @@ type DedupeIndexServerTests() =
                 DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block metadata))
             |> Array.concat
 
-        let requested =
-            blocks
-            |> Array.map (fun block -> (decodedChunkAddresses block)[0])
+        let requested = blocks |> Array.map (fun block -> (decodedChunkAddresses block)[0])
 
         let result = discover records requested
 
@@ -279,41 +248,31 @@ type DedupeIndexServerTests() =
         let authoritativeMetadata =
             { metadataFor 1 8L block with
                 Ranges =
-                    [|
-                        {
-                            OrdinalStart = candidate.OrdinalStart
-                            OrdinalCount = candidate.OrdinalCount
-                            ActiveManifestCount = 1
-                            PhysicalOffset = 0L
-                            PhysicalLength = block.Payload.LongLength
-                        }
-                    |]
-            }
+                    [| { OrdinalStart = candidate.OrdinalStart
+                         OrdinalCount = candidate.OrdinalCount
+                         ActiveManifestCount = 1
+                         PhysicalOffset = 0L
+                         PhysicalLength = block.Payload.LongLength } |] }
 
         let discovery =
             UploadSessionCommand.IssueDedupeDiscovery
-                {
-                    OperationId = "op-discovery"
-                    ExpiresAt = timestamp.Plus(Duration.FromMinutes(5L))
-                    MinimumReuseRunLength = MinimumAcceptedReuseRunLength
-                    Hints = [| hint |]
-                }
+                { OperationId = "op-discovery"
+                  ExpiresAt = timestamp.Plus(Duration.FromMinutes(5L))
+                  MinimumReuseRunLength = MinimumAcceptedReuseRunLength
+                  Hints = [| hint |] }
 
         let started =
             { UploadSessionDto.Default with
                 UploadSessionId = Guid.NewGuid()
                 RepositoryId = repositoryId
-                LifecycleState = UploadSessionLifecycleState.Started
-            }
+                LifecycleState = UploadSessionLifecycleState.Started }
 
         let eventMetadata =
-            {
-                Timestamp = timestamp
-                CorrelationId = "corr-stale-candidate"
-                Principal = "tester"
-                ClientType = Microsoft.FSharp.Core.Option.None
-                Properties = Dictionary<string, string>()
-            }
+            { Timestamp = timestamp
+              CorrelationId = "corr-stale-candidate"
+              Principal = "tester"
+              ClientType = Microsoft.FSharp.Core.Option.None
+              Properties = Dictionary<string, string>() }
 
         let issued =
             match Grace.Actors.UploadSession.decideCommand [] started discovery eventMetadata with
@@ -326,14 +285,7 @@ type DedupeIndexServerTests() =
 
         let claim =
             UploadSessionCommand.ClaimReuseRanges
-                {
-                    OperationId = "op-claim"
-                    DiscoveryOperationId = "op-discovery"
-                    Ranges =
-                        [|
-                            { Hint = hint; Metadata = authoritativeMetadata }
-                        |]
-                }
+                { OperationId = "op-claim"; DiscoveryOperationId = "op-discovery"; Ranges = [| { Hint = hint; Metadata = authoritativeMetadata } |] }
 
         match Grace.Actors.UploadSession.decideCommand discoveryEvents discoveredSession claim eventMetadata with
         | Ok _ -> Assert.Fail("Expected stale index candidate to be rejected by authoritative metadata at claim time.")
@@ -351,14 +303,10 @@ type DedupeIndexServerTests() =
         let requested = [| (decodedChunkAddresses block)[0] |]
 
         let incrementalCandidates =
-            (discover incremental requested)
-                .CandidateContentBlocks
+            (discover incremental requested).CandidateContentBlocks
             |> Array.map candidateShape
 
-        let rebuiltCandidates =
-            (discover rebuilt requested)
-                .CandidateContentBlocks
-            |> Array.map candidateShape
+        let rebuiltCandidates = (discover rebuilt requested).CandidateContentBlocks |> Array.map candidateShape
 
         Assert.That(rebuiltCandidates.Length, Is.EqualTo(incrementalCandidates.Length))
 
@@ -373,8 +321,9 @@ type DedupeIndexServerTests() =
         let newerMetadata = metadataFor 1 11L block
 
         let rebuilt =
-            DedupeIndex.rebuild [| sourceFor (finalizedSession manifest) manifest block olderMetadata
-                                   sourceFor (finalizedSession manifest) manifest block newerMetadata |]
+            DedupeIndex.rebuild
+                [| sourceFor (finalizedSession manifest) manifest block olderMetadata
+                   sourceFor (finalizedSession manifest) manifest block newerMetadata |]
 
         let matchingRecords =
             rebuilt
@@ -466,8 +415,7 @@ type DedupeIndexServerTests() =
         let registration: DedupeIndex.FinalizedManifestRegistration =
             { StoragePoolId = storagePoolId; Session = finalizedSession manifest; Manifest = manifest; BlockPayloads = [| payloadFor block |] }
 
-        DedupeIndex.registerFinalizedManifest registration
-        |> ignore
+        DedupeIndex.registerFinalizedManifest registration |> ignore
 
         let firstRecords = DedupeIndex.writeAfterAuthoritativeMetadata firstMetadata
         let secondRecords = DedupeIndex.writeAfterAuthoritativeMetadata secondMetadata
@@ -561,14 +509,6 @@ type DedupeIndexServerTests() =
 
         Assert.That(result.CandidateContentBlocks[0].MetadataVersion, Is.EqualTo(5L))
 
-        Assert.That(
-            matchingSnapshot
-            |> Array.exists (fun record -> record.MetadataVersion = 1L),
-            Is.False
-        )
+        Assert.That(matchingSnapshot |> Array.exists (fun record -> record.MetadataVersion = 1L), Is.False)
 
-        Assert.That(
-            matchingSnapshot
-            |> Array.exists (fun record -> record.MetadataVersion = 5L),
-            Is.True
-        )
+        Assert.That(matchingSnapshot |> Array.exists (fun record -> record.MetadataVersion = 5L), Is.True)

--- a/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
@@ -18,6 +18,8 @@ open NUnit.Framework
 open System
 open System.Collections.Concurrent
 open System.Collections.Generic
+open System.Security.Cryptography
+open System.Text
 open System.Threading
 open System.Threading.Tasks
 open System.Text.Json
@@ -141,20 +143,16 @@ module private WebhookDispatchTestHelpers =
         properties[nameof PromotionSetId] <- $"{promotionSetId}"
         properties["ActorId"] <- $"{promotionSetId}"
 
-        {
-            Timestamp = Instant.FromUtc(2026, 6, 2, 12, 0)
-            CorrelationId = correlationId
-            Principal = "tester"
-            ClientType = Option.None
-            Properties = properties
-        }
+        { Timestamp = Instant.FromUtc(2026, 6, 2, 12, 0)
+          CorrelationId = correlationId
+          Principal = "tester"
+          ClientType = Option.None
+          Properties = properties }
 
     let appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId =
         let promotionSetEvent: PromotionSetEvent =
-            {
-                Event = PromotionSetEventType.Applied terminalReferenceId
-                Metadata = metadata ownerId organizationId repositoryId targetBranchId promotionSetId "corr-webhook"
-            }
+            { Event = PromotionSetEventType.Applied terminalReferenceId
+              Metadata = metadata ownerId organizationId repositoryId targetBranchId promotionSetId "corr-webhook" }
 
         GraceEvent.PromotionSetEvent promotionSetEvent
 
@@ -169,8 +167,7 @@ module private WebhookDispatchTestHelpers =
             RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
             Status = WebhookRuleStatus.Enabled
             CreatedBy = UserId "tester"
-            CreatedAt = Instant.FromUtc(2026, 6, 2, 11, 0)
-        }
+            CreatedAt = Instant.FromUtc(2026, 6, 2, 11, 0) }
 
     let dispatch transport graceEvent =
         WebhookDispatch.dispatchCommittedEventAsync logger configuration hostEnvironment transport graceEvent CancellationToken.None
@@ -214,37 +211,13 @@ type WebhookDispatchUnitTests() =
 
             use payload = JsonDocument.Parse(request.PayloadJson)
 
-            Assert.That(
-                payload
-                    .RootElement
-                    .GetProperty("eventName")
-                    .GetString(),
-                Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName)
-            )
+            Assert.That(payload.RootElement.GetProperty("eventName").GetString(), Is.EqualTo(ExternalWebhookEventRegistry.PromotionSetAppliedName))
 
-            Assert.That(
-                payload
-                    .RootElement
-                    .GetProperty("eventVersion")
-                    .GetInt32(),
-                Is.EqualTo(1)
-            )
+            Assert.That(payload.RootElement.GetProperty("eventVersion").GetInt32(), Is.EqualTo(1))
 
-            Assert.That(
-                payload
-                    .RootElement
-                    .GetProperty("promotionSetId")
-                    .GetGuid(),
-                Is.EqualTo(promotionSetId)
-            )
+            Assert.That(payload.RootElement.GetProperty("promotionSetId").GetGuid(), Is.EqualTo(promotionSetId))
 
-            Assert.That(
-                payload
-                    .RootElement
-                    .GetProperty("terminalPromotionReferenceId")
-                    .GetGuid(),
-                Is.EqualTo(terminalReferenceId)
-            )
+            Assert.That(payload.RootElement.GetProperty("terminalPromotionReferenceId").GetGuid(), Is.EqualTo(terminalReferenceId))
 
             Assert.That(request.PayloadJson, Does.Not.Contain("DataJson"))
             Assert.That(request.PayloadJson, Does.Not.Contain("AutomationEventEnvelope"))
@@ -254,6 +227,69 @@ type WebhookDispatchUnitTests() =
             Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
             Assert.That(deliveries[0].AttemptCount, Is.EqualTo(1))
             Assert.That(deliveries[0].LastStatusCode, Is.EqualTo(Option.Some 202))
+        }
+
+    [<Test>]
+    member _.CommittedDeliveryHeadersUseStableSha256PayloadDigestAndHmacPreimage() =
+        task {
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let targetBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let promotionSetId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+            let terminalReferenceId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+
+            let rule =
+                WebhookDispatchTestHelpers.rule
+                    (Guid.Parse("77777777-7777-7777-7777-777777777777"))
+                    ownerId
+                    organizationId
+                    repositoryId
+                    (Option.Some targetBranchId)
+
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 202 ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
+
+            Assert.That(result.DeliveredCount, Is.EqualTo(1))
+            let request = transport.Requests |> Array.exactlyOne
+            let payloadBytes = Encoding.UTF8.GetBytes request.PayloadJson
+
+            let payloadSha256 =
+                SHA256.HashData payloadBytes
+                |> Array.map (fun value -> value.ToString("x2", Globalization.CultureInfo.InvariantCulture))
+                |> String.concat String.Empty
+
+            Assert.That(request.Headers["x-grace-webhook-payload-sha256"], Is.EqualTo(payloadSha256))
+            Assert.That(request.Headers["x-grace-webhook-payload-sha256"], Does.Match("^[a-f0-9]{64}$"))
+
+            let deliveryId = request.Headers["x-grace-webhook-delivery-id"]
+            let timestamp = request.Headers["x-grace-webhook-timestamp"]
+            let keyId = request.Headers["x-grace-webhook-signature-key-id"]
+            let signedMaterial = Encoding.UTF8.GetBytes($"{deliveryId}.{timestamp}.{keyId}.{payloadSha256}")
+
+            use hmac = new HMACSHA256(Encoding.UTF8.GetBytes rule.SigningSecretVersion)
+
+            let expectedSignature =
+                hmac.ComputeHash signedMaterial
+                |> Array.map (fun value -> value.ToString("x2", Globalization.CultureInfo.InvariantCulture))
+                |> String.concat String.Empty
+
+            Assert.That(keyId, Is.EqualTo(rule.SigningSecretVersion))
+            Assert.That(request.Headers["x-grace-webhook-signature"], Is.EqualTo($"sha256={expectedSignature}"))
+
+            let tamperedPayloadSha256 =
+                SHA256.HashData(Encoding.UTF8.GetBytes(request.PayloadJson + " "))
+                |> Array.map (fun value -> value.ToString("x2", Globalization.CultureInfo.InvariantCulture))
+                |> String.concat String.Empty
+
+            Assert.That(tamperedPayloadSha256, Is.Not.EqualTo(payloadSha256))
+            Assert.That(Encoding.UTF8.GetString(signedMaterial), Is.EqualTo($"{deliveryId}.{timestamp}.{rule.SigningSecretVersion}.{payloadSha256}"))
         }
 
     [<Test>]
@@ -279,25 +315,21 @@ type WebhookDispatchUnitTests() =
             Assert.That(transport.Requests, Is.Empty)
 
             let referenceEvent: ReferenceEvent =
-                {
-                    Event =
-                        ReferenceEventType.Created(
-                            Guid.NewGuid(),
-                            ownerId,
-                            organizationId,
-                            repositoryId,
-                            otherBranchId,
-                            Guid.NewGuid(),
-                            Sha256Hash String.Empty,
-                            Blake3Hash String.Empty,
-                            ReferenceType.Promotion,
-                            "promotion",
-                            [
-                                ReferenceLinkType.PromotionSetTerminal promotionSetId
-                            ]
-                        )
-                    Metadata = WebhookDispatchTestHelpers.metadata ownerId organizationId repositoryId otherBranchId promotionSetId "corr-reference"
-                }
+                { Event =
+                    ReferenceEventType.Created(
+                        Guid.NewGuid(),
+                        ownerId,
+                        organizationId,
+                        repositoryId,
+                        otherBranchId,
+                        Guid.NewGuid(),
+                        Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
+                        ReferenceType.Promotion,
+                        "promotion",
+                        [ ReferenceLinkType.PromotionSetTerminal promotionSetId ]
+                    )
+                  Metadata = WebhookDispatchTestHelpers.metadata ownerId organizationId repositoryId otherBranchId promotionSetId "corr-reference" }
 
             let! referenceResult = WebhookDispatchTestHelpers.dispatch transport (GraceEvent.ReferenceEvent referenceEvent)
             Assert.That(referenceResult.DeliveryCount, Is.EqualTo(0))
@@ -316,13 +348,7 @@ type WebhookDispatchUnitTests() =
             let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId Option.None
             WebhookStore.upsertRule rule |> ignore
 
-            let transport =
-                WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.Succeeded 200
-                        OutboundWebhookResult.Succeeded 200
-                    ]
-                )
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 200; OutboundWebhookResult.Succeeded 200 ])
 
             let graceEvent = WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId
             let! first = WebhookDispatchTestHelpers.dispatch transport graceEvent
@@ -351,33 +377,18 @@ type WebhookDispatchUnitTests() =
             let transport = WebhookDispatchTestHelpers.BlockingSuccessTransport()
             let graceEvent = WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId
 
-            let dispatches =
-                [|
-                    for _ in 1..16 -> WebhookDispatchTestHelpers.dispatch transport graceEvent
-                |]
+            let dispatches = [| for _ in 1..16 -> WebhookDispatchTestHelpers.dispatch transport graceEvent |]
 
             do! transport.WaitForFirstRequestAsync()
             transport.Release()
 
             let! results = Task.WhenAll dispatches
 
-            Assert.That(
-                results
-                |> Array.sumBy (fun result -> result.DeliveryCount),
-                Is.EqualTo(1)
-            )
+            Assert.That(results |> Array.sumBy (fun result -> result.DeliveryCount), Is.EqualTo(1))
 
-            Assert.That(
-                results
-                |> Array.sumBy (fun result -> result.DeliveredCount),
-                Is.EqualTo(1)
-            )
+            Assert.That(results |> Array.sumBy (fun result -> result.DeliveredCount), Is.EqualTo(1))
 
-            Assert.That(
-                results
-                |> Array.sumBy (fun result -> result.SkippedDuplicateCount),
-                Is.EqualTo(15)
-            )
+            Assert.That(results |> Array.sumBy (fun result -> result.SkippedDuplicateCount), Is.EqualTo(15))
 
             Assert.That(transport.Requests, Has.Length.EqualTo(1))
 
@@ -397,17 +408,14 @@ type WebhookDispatchUnitTests() =
 
             let transientRule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             WebhookStore.upsertRule transientRule |> ignore
 
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable token=response-secret")
-                        OutboundWebhookResult.Succeeded 200
-                    ]
+                    [ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable token=response-secret")
+                      OutboundWebhookResult.Succeeded 200 ]
                 )
 
             let! result =
@@ -453,8 +461,7 @@ type WebhookDispatchUnitTests() =
 
             let timeoutRule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             let successRule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
 
@@ -517,7 +524,7 @@ type WebhookDispatchUnitTests() =
             let transport = WebhookDispatchTestHelpers.CancelAfterSuccessTransport(cancellationTokenSource)
 
             let operation =
-                Func<Task> (fun () ->
+                Func<Task>(fun () ->
                     task {
                         let! _ =
                             WebhookDispatch.dispatchCommittedEventAsync
@@ -532,8 +539,7 @@ type WebhookDispatchUnitTests() =
                     }
                     :> Task)
 
-            Assert.ThrowsAsync<OperationCanceledException>(operation)
-            |> ignore
+            Assert.ThrowsAsync<OperationCanceledException>(operation) |> ignore
 
             Assert.That(transport.Requests, Has.Length.EqualTo(1))
 
@@ -559,17 +565,14 @@ type WebhookDispatchUnitTests() =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
                     Url = { Url = "https://8.8.8.8/original?token=original-secret"; Safety = OutboundUrlSafety.PublicHttps }
                     SigningSecretVersion = "original-secret-version"
-                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             WebhookStore.upsertRule originalRule |> ignore
 
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.Succeeded 200
-                    ]
+                    [ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                      OutboundWebhookResult.Succeeded 200 ]
                 )
 
             let! result =
@@ -583,8 +586,7 @@ type WebhookDispatchUnitTests() =
             let updatedRule =
                 { originalRule with
                     Url = { Url = "https://8.8.4.4/updated?token=updated-secret"; Safety = OutboundUrlSafety.PublicHttps }
-                    SigningSecretVersion = "updated-secret-version"
-                }
+                    SigningSecretVersion = "updated-secret-version" }
 
             WebhookStore.upsertRule updatedRule |> ignore
 
@@ -615,18 +617,15 @@ type WebhookDispatchUnitTests() =
 
             let originalRule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 4; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 4; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             WebhookStore.upsertRule originalRule |> ignore
 
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.Succeeded 200
-                    ]
+                    [ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                      OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                      OutboundWebhookResult.Succeeded 200 ]
                 )
 
             let! result =
@@ -688,10 +687,8 @@ type WebhookDispatchUnitTests() =
 
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.Succeeded 200
-                    ]
+                    [ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                      OutboundWebhookResult.Succeeded 200 ]
                 )
 
             let! dispatchResult =
@@ -702,14 +699,7 @@ type WebhookDispatchUnitTests() =
             Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
             let delivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
 
-            WebhookStore.upsertDelivery
-                { delivery with
-                    NextAttemptAt =
-                        Some(
-                            getCurrentInstant()
-                                .Minus(Duration.FromSeconds(1.0))
-                        )
-                }
+            WebhookStore.upsertDelivery { delivery with NextAttemptAt = Some(getCurrentInstant().Minus(Duration.FromSeconds(1.0))) }
             |> ignore
 
             let! retryResult =
@@ -736,8 +726,7 @@ type WebhookDispatchUnitTests() =
 
             let transientRule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             let exhaustedRule = { transientRule with WebhookRuleId = Guid.NewGuid() }
 
@@ -745,10 +734,8 @@ type WebhookDispatchUnitTests() =
 
             let exhaustedTransport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                    ]
+                    [ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
+                      OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable") ]
                 )
 
             let! exhaustedResult =
@@ -792,32 +779,20 @@ type WebhookDispatchUnitTests() =
 
             let rule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 3; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             WebhookStore.upsertRule rule |> ignore
 
             let! dispatchResult =
                 WebhookDispatchTestHelpers.dispatch
-                    (WebhookDispatchTestHelpers.RecordingTransport(
-                        [
-                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        ]
-                    ))
+                    (WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable") ]))
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
 
             Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
 
             let scheduledDelivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
 
-            let dueDelivery =
-                { scheduledDelivery with
-                    NextAttemptAt =
-                        Some(
-                            getCurrentInstant()
-                                .Minus(Duration.FromSeconds(1.0))
-                        )
-                }
+            let dueDelivery = { scheduledDelivery with NextAttemptAt = Some(getCurrentInstant().Minus(Duration.FromSeconds(1.0))) }
 
             WebhookStore.upsertDelivery dueDelivery |> ignore
 
@@ -825,7 +800,7 @@ type WebhookDispatchUnitTests() =
             let transport = WebhookDispatchTestHelpers.CancelingTransport(cancellationTokenSource)
 
             let operation =
-                Func<Task> (fun () ->
+                Func<Task>(fun () ->
                     task {
                         let! _ =
                             WebhookDispatch.processScheduledRetriesAsync
@@ -841,14 +816,11 @@ type WebhookDispatchUnitTests() =
                     }
                     :> Task)
 
-            Assert.ThrowsAsync<OperationCanceledException>(operation)
-            |> ignore
+            Assert.ThrowsAsync<OperationCanceledException>(operation) |> ignore
 
             Assert.That(transport.Requests, Has.Length.EqualTo(1))
 
-            let unchangedDelivery =
-                WebhookStore.tryGetDelivery dueDelivery.WebhookDeliveryId
-                |> Option.get
+            let unchangedDelivery = WebhookStore.tryGetDelivery dueDelivery.WebhookDeliveryId |> Option.get
 
             Assert.That(unchangedDelivery.Status, Is.EqualTo(dueDelivery.Status))
             Assert.That(unchangedDelivery.AttemptCount, Is.EqualTo(dueDelivery.AttemptCount))
@@ -877,20 +849,12 @@ type WebhookDispatchUnitTests() =
 
             let! firstDispatchResult =
                 WebhookDispatchTestHelpers.dispatch
-                    (WebhookDispatchTestHelpers.RecordingTransport(
-                        [
-                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        ]
-                    ))
+                    (WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable") ]))
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId firstTargetBranchId promotionSetId (Guid.NewGuid()))
 
             let! secondDispatchResult =
                 WebhookDispatchTestHelpers.dispatch
-                    (WebhookDispatchTestHelpers.RecordingTransport(
-                        [
-                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        ]
-                    ))
+                    (WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable") ]))
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId secondTargetBranchId promotionSetId (Guid.NewGuid()))
 
             Assert.That(firstDispatchResult.FailedCount, Is.EqualTo(1))
@@ -900,25 +864,21 @@ type WebhookDispatchUnitTests() =
 
             let firstDueDelivery =
                 { (WebhookStore.listDeliveries firstRule.Scope firstRule.WebhookRuleId true)[0] with
-                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(2.0)))
-                }
+                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(2.0))) }
 
             let secondDueDelivery =
                 { (WebhookStore.listDeliveries secondRule.Scope secondRule.WebhookRuleId true)[0] with
-                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(1.0)))
-                }
+                    NextAttemptAt = Some(now.Minus(Duration.FromSeconds(1.0))) }
 
-            WebhookStore.upsertDelivery firstDueDelivery
-            |> ignore
+            WebhookStore.upsertDelivery firstDueDelivery |> ignore
 
-            WebhookStore.upsertDelivery secondDueDelivery
-            |> ignore
+            WebhookStore.upsertDelivery secondDueDelivery |> ignore
 
             use cancellationTokenSource = new CancellationTokenSource()
             let transport = WebhookDispatchTestHelpers.CancelAfterSuccessTransport(cancellationTokenSource)
 
             let operation =
-                Func<Task> (fun () ->
+                Func<Task>(fun () ->
                     task {
                         let! _ =
                             WebhookDispatch.processScheduledRetriesAsync
@@ -934,21 +894,16 @@ type WebhookDispatchUnitTests() =
                     }
                     :> Task)
 
-            Assert.ThrowsAsync<OperationCanceledException>(operation)
-            |> ignore
+            Assert.ThrowsAsync<OperationCanceledException>(operation) |> ignore
 
             Assert.That(transport.Requests, Has.Length.EqualTo(1))
 
-            let firstRetriedDelivery =
-                WebhookStore.tryGetDelivery firstDueDelivery.WebhookDeliveryId
-                |> Option.get
+            let firstRetriedDelivery = WebhookStore.tryGetDelivery firstDueDelivery.WebhookDeliveryId |> Option.get
 
             Assert.That(firstRetriedDelivery.Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
             Assert.That(firstRetriedDelivery.AttemptCount, Is.EqualTo(2))
 
-            let unchangedSecondDelivery =
-                WebhookStore.tryGetDelivery secondDueDelivery.WebhookDeliveryId
-                |> Option.get
+            let unchangedSecondDelivery = WebhookStore.tryGetDelivery secondDueDelivery.WebhookDeliveryId |> Option.get
 
             Assert.That(unchangedSecondDelivery.Status, Is.EqualTo(secondDueDelivery.Status))
             Assert.That(unchangedSecondDelivery.AttemptCount, Is.EqualTo(secondDueDelivery.AttemptCount))
@@ -969,32 +924,20 @@ type WebhookDispatchUnitTests() =
 
             let rule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 }
-                }
+                    RetryPolicy = { MaxAttempts = 2; InitialDelaySeconds = 1; MaxDelaySeconds = 8 } }
 
             WebhookStore.upsertRule rule |> ignore
 
             let! dispatchResult =
                 WebhookDispatchTestHelpers.dispatch
-                    (WebhookDispatchTestHelpers.RecordingTransport(
-                        [
-                            OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable")
-                        ]
-                    ))
+                    (WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.TransientFailure(Option.Some 503, "service unavailable") ]))
                     (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId (Guid.NewGuid()))
 
             Assert.That(dispatchResult.FailedCount, Is.EqualTo(1))
 
             let scheduledDelivery = (WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true)[0]
 
-            WebhookStore.upsertDelivery
-                { scheduledDelivery with
-                    NextAttemptAt =
-                        Some(
-                            getCurrentInstant()
-                                .Minus(Duration.FromSeconds(1.0))
-                        )
-                }
+            WebhookStore.upsertDelivery { scheduledDelivery with NextAttemptAt = Some(getCurrentInstant().Minus(Duration.FromSeconds(1.0))) }
             |> ignore
 
             let! retryResult =
@@ -1029,8 +972,7 @@ type WebhookDispatchUnitTests() =
 
             let rule =
                 { WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId) with
-                    Url = { Url = "https://127.0.0.1/hook?token=secret"; Safety = OutboundUrlSafety.PublicHttps }
-                }
+                    Url = { Url = "https://127.0.0.1/hook?token=secret"; Safety = OutboundUrlSafety.PublicHttps } }
 
             WebhookStore.upsertRule rule |> ignore
 
@@ -1094,12 +1036,10 @@ type WebhookDispatchUnitTests() =
 
             let transport =
                 WebhookDispatchTestHelpers.RecordingTransport(
-                    [
-                        OutboundWebhookResult.PermanentFailure(
-                            Option.Some 400,
-                            "bad response from https://example.test/hook?token=response-token&signature=response-signature secret=response-secret"
-                        )
-                    ]
+                    [ OutboundWebhookResult.PermanentFailure(
+                          Option.Some 400,
+                          "bad response from https://example.test/hook?token=response-token&signature=response-signature secret=response-secret"
+                      ) ]
                 )
 
             let! result =

--- a/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
@@ -30,31 +30,18 @@ type ContentAddressTypesTests() =
     [<Test>]
     member _.FileHashKnownVectorsAreByteOnly() =
         let vectors =
-            [
-                "empty",
-                Array.empty,
-                "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                "abc",
-                Encoding.UTF8.GetBytes("abc"),
-                "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-                "binary",
-                [|
-                    0uy
-                    1uy
-                    2uy
-                    3uy
-                    4uy
-                    255uy
-                    128uy
-                    64uy
-                    10uy
-                    13uy
-                |],
-                "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
-                "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2"
-            ]
+            [ "empty",
+              Array.empty,
+              "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+              "abc",
+              Encoding.UTF8.GetBytes("abc"),
+              "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+              "binary",
+              [| 0uy; 1uy; 2uy; 3uy; 4uy; 255uy; 128uy; 64uy; 10uy; 13uy |],
+              "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
+              "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2" ]
 
         for name, bytes, expectedBlake3, expectedSha256 in vectors do
             use blake3Stream = new ChunkedReadStream(bytes, 3)
@@ -69,31 +56,18 @@ type ContentAddressTypesTests() =
     [<Test>]
     member _.CombinedFileHashesMatchKnownVectors() =
         let vectors =
-            [
-                "empty",
-                Array.empty,
-                "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                "abc",
-                Encoding.UTF8.GetBytes("abc"),
-                "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-                "binary",
-                [|
-                    0uy
-                    1uy
-                    2uy
-                    3uy
-                    4uy
-                    255uy
-                    128uy
-                    64uy
-                    10uy
-                    13uy
-                |],
-                "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
-                "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2"
-            ]
+            [ "empty",
+              Array.empty,
+              "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+              "abc",
+              Encoding.UTF8.GetBytes("abc"),
+              "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+              "binary",
+              [| 0uy; 1uy; 2uy; 3uy; 4uy; 255uy; 128uy; 64uy; 10uy; 13uy |],
+              "08127a2b7e4a048ef7db8e3a94a4134688b78630e2fed93d58a1aaa14c51402e",
+              "75a6070abf8bf13e756be4607e09f22fa9a7e4d737ba4d354dfd85b4437b1ec2" ]
 
         for name, bytes, expectedBlake3, expectedSha256 in vectors do
             use stream = new ChunkedReadStream(bytes, 3)
@@ -122,6 +96,20 @@ type ContentAddressTypesTests() =
         Assert.That(firstSha256, Is.EqualTo(secondSha256))
 
     [<Test>]
+    member _.SamePayloadKeepsVersionSha256SeparateFromCasBlake3Address() =
+        let bytes = Encoding.UTF8.GetBytes("abc")
+
+        use versionStream = new ChunkedReadStream(bytes, 2)
+        let versionSha256 = runTask (Services.computeSha256ForFile versionStream (RelativePath "src/version.txt"))
+        let casChunkAddress = ContentAddress.computeChunkAddress bytes
+        let casFileHash = ContentAddress.computeBlake3Hex bytes
+
+        Assert.That(versionSha256, Is.EqualTo(Sha256Hash "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"))
+        Assert.That(casChunkAddress, Is.EqualTo(ChunkAddress "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"))
+        Assert.That(casFileHash, Is.EqualTo($"{casChunkAddress}"))
+        Assert.That($"{casChunkAddress}", Is.Not.EqualTo($"{versionSha256}"))
+
+    [<Test>]
     member _.AddressValidationRequiresLowercaseSixtyFourHexCharacters() =
         Assert.That(ContentAddress.isValidAddress ("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"), Is.True)
 
@@ -144,13 +132,11 @@ type ContentAddressTypesTests() =
         let chunkB = ContentAddress.computeChunkAddress (Encoding.UTF8.GetBytes("beta chunk"))
 
         let expectedPreimage =
-            [
-                "grace.cas.v1.content-block"
-                "format:raw-chunks"
-                "chunk-count:2"
-                $"chunk:0:{chunkA}"
-                $"chunk:1:{chunkB}"
-            ]
+            [ "grace.cas.v1.content-block"
+              "format:raw-chunks"
+              "chunk-count:2"
+              $"chunk:0:{chunkA}"
+              $"chunk:1:{chunkB}" ]
             |> String.concat "\n"
             |> fun value -> value + "\n"
 
@@ -172,25 +158,21 @@ type ContentAddressTypesTests() =
         let blockAddress = ContentBlockAddress "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f"
 
         let blocks =
-            [
-                ContentBlock.Create(blockAddress, 0L, 4096L)
-                ContentBlock.Create(blockAddress, 4096L, 4096L)
-            ]
+            [ ContentBlock.Create(blockAddress, 0L, 4096L)
+              ContentBlock.Create(blockAddress, 4096L, 4096L) ]
 
         let manifest = FileManifest.Create(ManifestAddress "", 8192L, blocks)
         let fileContentHash = FileContentHash "fb283dfc43483eae4cfb9f3eb0d1da0c46c9c557acfab283907eeb3803008bae"
         let manifest = FileManifest.Create(ManifestAddress "", RabinChunking.SuiteName, fileContentHash, manifest.Size, blocks)
 
         let expectedPreimage =
-            [
-                "grace.cas.v1.file-manifest"
-                $"chunking-suite:{RabinChunking.SuiteName}"
-                $"file-content-hash:{fileContentHash}"
-                "size:8192"
-                "block-count:2"
-                $"block:0:{blockAddress}:0:4096"
-                $"block:1:{blockAddress}:4096:4096"
-            ]
+            [ "grace.cas.v1.file-manifest"
+              $"chunking-suite:{RabinChunking.SuiteName}"
+              $"file-content-hash:{fileContentHash}"
+              "size:8192"
+              "block-count:2"
+              $"block:0:{blockAddress}:0:4096"
+              $"block:1:{blockAddress}:4096:4096" ]
             |> String.concat "\n"
             |> fun value -> value + "\n"
 


### PR DESCRIPTION
## Summary

- Adds focused regression proof that protected non-version SHA-256 surfaces did not move during the BLAKE3 version-hash rollout.
- Proves webhook payload/signature SHA-256/HMAC behavior, dedupe protected-label preimage, PAT token format, and CAS-vs-version hash boundaries.
- Keeps the slice test-only: no production hashing helpers, security preimages, CAS address algorithms, or validators changed.

Related to #362.
Part of #343.

## Protected Surfaces Checked

- Webhook SHA-256/HMAC: `x-grace-webhook-payload-sha256` remains lowercase SHA-256 over payload bytes; `x-grace-webhook-signature` remains `sha256=<HMAC-SHA256>` over `deliveryId.timestamp.keyId.payloadSha256`.
- Dedupe protected labels: known vector covers `protected-sha256:<digest>` from the `grace.dedupe-index.v1.protected-window` preimage.
- CAS/address boundary: same payload proves version SHA-256 for `abc` remains `ba7816...15ad` while CAS chunk/file-content addressing remains BLAKE3 `6437...9d85`.
- PAT token/checksum-facing auth shape: exact `grace_pat_v1_...` formatting vector plus malformed-token rejection coverage.

## Explicit Waivers

- Private PAT actor secret-hash storage (`PersonalAccessToken.Actor.ComputeHash`), CLI OIDC namespace/PKCE SHA-256, and non-security deterministic ID/checksum helpers were inventoried but not changed. This slice did not add new production seams because the regression proof could be written at existing public/test boundaries, and `validate -Fast` covers the relevant auth, CLI, and server unit suites.

## No-Production-Legacy Posture

This PR does not accept empty or malformed hashes, add SHA-only fallbacks, weaken validators, or model broad legacy production compatibility. The new tests assert current desired protected behavior directly, so old local/dev/generated state must match these invariants, be recomputed, or fail clearly rather than being grandfathered.

## Validation

Worker validation on `61a49b7e3e44fc09586e9f957df931500de359ff`:

```powershell
dotnet tool restore
fantomas src/Grace.Authorization.Tests/PersonalAccessToken.Tests.fs src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs src/Grace.Types.Tests/ContentAddress.Types.Tests.fs
dotnet test --configuration Release src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --filter "FullyQualifiedName~PersonalAccessTokenTests"
dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~DedupeIndexServerTests|FullyQualifiedName~WebhookDispatchUnitTests"
dotnet test --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj --filter "FullyQualifiedName~ContentAddressTypesTests"
pwsh ./scripts/validate.ps1 -Fast
git diff --check
```

Results:

- `dotnet tool restore`: passed.
- Repo-local `dotnet tool run fantomas` would not launch after restore, so the worker used available global Fantomas 7.0.3; formatting passed on the four touched F# test files.
- Focused `Grace.Authorization.Tests`: passed 3/3.
- Focused `Grace.Server.Unit.Tests`: passed 33/33.
- Focused `Grace.Types.Tests`: passed 9/9.
- `validate -Fast`: passed with a 0-warning/0-error build; Authorization 39/39, Types 123/123, Server.Unit 566/566, CLI 570 passed / 1 skipped.
- `git diff --check`: passed.

## Review Status

- Codex Code Review Bot on `61a49b7e3e44fc09586e9f957df931500de359ff`: 👍🏻 no issues, with no unresolved bot review threads.
- Hosted `Validate/full` on `61a49b7e3e44fc09586e9f957df931500de359ff`: passed.
- Prevention line: worker self-review verified the diff is test-only, does not globally replace SHA-256, does not treat CAS BLAKE3 addresses as version graph hashes, does not change protected production hash helpers, and does not broaden contracts for imaginary production legacy data.

## Residual Risks

- Global Fantomas 7.0.3 formatted surrounding code in the four touched test files more aggressively than repo-local Fantomas 4.7.9 likely would have. The larger formatting diff is limited to issue-owned focused test files and was validated afterward.
- The proof intentionally uses existing public/test boundaries rather than adding new testability seams for private PAT actor secret hashing, CLI OIDC namespace/PKCE SHA-256, or non-security deterministic ID/checksum helpers.


