### PR TITLE
I20 end-to-end dual-hash workflow proof

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -68,6 +68,7 @@ module BranchCommandTests =
             TargetReferenceId = targetReferenceId
             RootDirectoryId = Guid.NewGuid()
             RootDirectorySha256Hash = Sha256Hash "root-sha"
+            RootDirectoryBlake3Hash = Blake3Hash "root-blake3"
             Source = ExplicitReference
             CreatedSaveMessage = None
         }
@@ -222,7 +223,7 @@ module BranchCommandTests =
         |> should equal $"{directoryBlake3Hash} (SHA-256 {directorySha256Hash})"
 
     [<Test>]
-    let ``list contents formatter shows unavailable for missing legacy BLAKE3`` () =
+    let ``list contents formatter shows unavailable for missing BLAKE3`` () =
         let parseResult = parse [| "branch"; "list-contents" |]
         let displayMode = Common.HashOptions.bindVersionHashDisplayMode parseResult
 

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -28,25 +28,33 @@ module CurrentStateCaptureCliTests =
     let private rootBlake3 = Blake3Hash "current-root-blake3"
     let private savedReferenceId = Guid.NewGuid()
 
-    let private rootDirectoryVersion directoryVersionId sha256Hash =
-        LocalDirectoryVersion.Create
+    let private rootDirectoryVersionWithHashes directoryVersionId sha256Hash blake3Hash =
+        LocalDirectoryVersion.CreateWithHashes
             directoryVersionId
             OwnerId.Empty
             OrganizationId.Empty
             RepositoryId.Empty
             Constants.RootDirectoryPath
             sha256Hash
+            blake3Hash
             (List<DirectoryVersionId>())
             (List<LocalFileVersion>())
             0L
             DateTime.UtcNow
+
+    let private rootDirectoryVersion directoryVersionId sha256Hash = rootDirectoryVersionWithHashes directoryVersionId sha256Hash rootBlake3
 
     let private graceStatus directoryVersionId sha256Hash =
         let root = rootDirectoryVersion directoryVersionId sha256Hash
         let index = GraceIndex()
         index.TryAdd(directoryVersionId, root) |> ignore
 
-        { GraceStatus.Default with Index = index; RootDirectoryId = directoryVersionId; RootDirectorySha256Hash = sha256Hash }
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = directoryVersionId
+            RootDirectorySha256Hash = sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
 
     let private referenceDto referenceId directoryVersionId sha256Hash =
         { ReferenceDto.Default with
@@ -55,6 +63,7 @@ module CurrentStateCaptureCliTests =
             ReferenceType = ReferenceType.Save
             DirectoryId = directoryVersionId
             Sha256Hash = sha256Hash
+            Blake3Hash = rootBlake3
         }
 
     let private branch saveEnabled latestReference =
@@ -197,9 +206,57 @@ module CurrentStateCaptureCliTests =
             captured.RootDirectoryId
             |> should equal rootDirectoryId
 
+            captured.RootDirectoryBlake3Hash
+            |> should equal rootBlake3
+
             captured.Source |> should equal GraceWatch
             readStatusCalled |> should equal false
         | Error error -> Assert.Fail($"Expected GraceWatch success, got: {error.Error}")
+
+    [<Test>]
+    let ``unchanged local state does not reuse same SHA-256 reference with different BLAKE3`` () =
+        let staleReferenceId = Guid.NewGuid()
+        let createdSaveId = Guid.NewGuid()
+        let differentBlake3 = Blake3Hash "different-root-blake3"
+        let staleReference = { referenceDto staleReferenceId rootDirectoryId rootSha with Blake3Hash = differentBlake3 }
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+
+        let operations =
+            { defaultOperations (branch true staleReference) with
+                CreateSaveReference =
+                    fun rootDirectoryVersion _ ->
+                        createdSaveRoot <- rootDirectoryVersion
+                        Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.TargetReferenceId
+            |> should not' (equal staleReferenceId)
+
+            captured.RootDirectoryId
+            |> should equal rootDirectoryId
+
+            captured.RootDirectorySha256Hash
+            |> should equal rootSha
+
+            captured.RootDirectoryBlake3Hash
+            |> should equal rootBlake3
+
+            captured.Source |> should equal CreatedSave
+
+            createdSaveRoot.Sha256Hash |> should equal rootSha
+
+            createdSaveRoot.Blake3Hash
+            |> should equal rootBlake3
+        | Error error -> Assert.Fail($"Expected mismatched BLAKE3 reference to create a new save, got: {error.Error}")
 
     [<Test>]
     let ``unchanged child branch does not use parent BasedOn reference`` () =
@@ -222,6 +279,9 @@ module CurrentStateCaptureCliTests =
 
                         rootDirectoryVersion.Sha256Hash
                         |> should equal rootSha
+
+                        rootDirectoryVersion.Blake3Hash
+                        |> should equal rootBlake3
 
                         Task.FromResult(Ok(createdSaveId))
             }
@@ -247,6 +307,7 @@ module CurrentStateCaptureCliTests =
         let mutable uploadedDirectories = false
         let mutable appliedStatus = false
         let mutable saveMessage = String.Empty
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
 
         let differences =
             List<FileSystemDifference>(
@@ -271,7 +332,8 @@ module CurrentStateCaptureCliTests =
                         appliedStatus <- true
                         Task.FromResult(())
                 CreateSaveReference =
-                    fun _ message ->
+                    fun rootDirectoryVersion message ->
+                        createdSaveRoot <- rootDirectoryVersion
                         saveMessage <- message
                         Task.FromResult(Ok(createdSaveId))
             }
@@ -287,6 +349,12 @@ module CurrentStateCaptureCliTests =
 
             captured.RootDirectoryId
             |> should equal updatedRootId
+
+            captured.RootDirectoryBlake3Hash
+            |> should equal createdSaveRoot.Blake3Hash
+
+            createdSaveRoot.Blake3Hash
+            |> should not' (equal (Blake3Hash String.Empty))
 
             captured.Source |> should equal CreatedSave
 
@@ -336,13 +404,14 @@ module CurrentStateCaptureCliTests =
             )
 
         let updatedRoot =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 rootDirectoryId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 rootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<LocalFileVersion>([| changedFile; unchangedFile |]))
                 (changedFile.Size + unchangedFile.Size)
@@ -360,7 +429,15 @@ module CurrentStateCaptureCliTests =
         let changedPath = RelativePath "src/file.txt"
 
         let changedFile =
-            LocalFileVersion.Create changedPath (Sha256Hash "changed-file-sha") false 12L (Grace.Shared.Utilities.getCurrentInstant ()) true DateTime.UtcNow
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (Sha256Hash "changed-file-sha")
+                (Blake3Hash "changed-file-blake3")
+                false
+                12L
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
 
         let mutable uploadedFiles = List<LocalFileVersion>()
 
@@ -374,13 +451,14 @@ module CurrentStateCaptureCliTests =
         let updatedStatus = graceStatus updatedRootId updatedRootSha
 
         let updatedRoot =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 updatedRootId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 updatedRootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<LocalFileVersion>([| changedFile |]))
                 changedFile.Size
@@ -458,13 +536,14 @@ module CurrentStateCaptureCliTests =
         let updatedStatus = graceStatus updatedRootId updatedRootSha
 
         let updatedRoot =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 updatedRootId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 updatedRootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<LocalFileVersion>([| changedFile |]))
                 changedFile.Size
@@ -539,13 +618,14 @@ module CurrentStateCaptureCliTests =
         savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
 
         let savedRoot =
-            DirectoryVersion.Create
+            DirectoryVersion.CreateWithHashes
                 rootDirectoryId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 rootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<FileVersion>([| savedManifestFile |]))
                 unchangedFile.Size
@@ -562,13 +642,14 @@ module CurrentStateCaptureCliTests =
         let updatedStatus = graceStatus updatedRootId updatedRootSha
 
         let updatedRoot =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 updatedRootId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 updatedRootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<LocalFileVersion>([| changedFile; unchangedFile |]))
                 (changedFile.Size + unchangedFile.Size)
@@ -607,14 +688,14 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
-    let ``local changes preserve saved manifest references when unchanged sibling has legacy local Blake3`` () =
+    let ``local changes preserve saved manifest references and dual-hash save identity`` () =
         let updatedRootId = Guid.NewGuid()
         let updatedRootSha = Sha256Hash "updated-root-sha"
         let createdSaveId = Guid.NewGuid()
         let changedPath = RelativePath "src/changed.txt"
-        let unchangedPath = RelativePath "src/unchanged-legacy-large.bin"
+        let unchangedPath = RelativePath "src/unchanged-large-proof.bin"
         let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
-        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with legacy local state")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with current dual hashes")
 
         let changedFile =
             LocalFileVersion.CreateWithHashes
@@ -627,17 +708,7 @@ module CurrentStateCaptureCliTests =
                 true
                 DateTime.UtcNow
 
-        let unchangedLocalLegacyFile =
-            LocalFileVersion.Create
-                unchangedPath
-                (sha256Hash unchangedPayload)
-                true
-                (int64 unchangedPayload.Length)
-                (Grace.Shared.Utilities.getCurrentInstant ())
-                true
-                DateTime.UtcNow
-
-        let savedManifestLocalFile =
+        let unchangedFile =
             LocalFileVersion.CreateWithHashes
                 unchangedPath
                 (sha256Hash unchangedPayload)
@@ -648,20 +719,21 @@ module CurrentStateCaptureCliTests =
                 true
                 DateTime.UtcNow
 
-        let savedManifestFile = savedManifestLocalFile.ToFileVersion
+        let savedManifestFile = unchangedFile.ToFileVersion
         savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
 
         let savedRoot =
-            DirectoryVersion.Create
+            DirectoryVersion.CreateWithHashes
                 rootDirectoryId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 rootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
                 (List<FileVersion>([| savedManifestFile |]))
-                unchangedLocalLegacyFile.Size
+                unchangedFile.Size
 
         let mutable savedDirectoryVersions = List<DirectoryVersion>()
         let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
@@ -678,21 +750,17 @@ module CurrentStateCaptureCliTests =
         let updatedStatus = graceStatus updatedRootId updatedRootSha
 
         let updatedRoot =
-            LocalDirectoryVersion.Create
+            LocalDirectoryVersion.CreateWithHashes
                 updatedRootId
                 OwnerId.Empty
                 OrganizationId.Empty
                 RepositoryId.Empty
                 Constants.RootDirectoryPath
                 updatedRootSha
+                rootBlake3
                 (List<DirectoryVersionId>())
-                (List<LocalFileVersion>(
-                    [|
-                        changedFile
-                        unchangedLocalLegacyFile
-                    |]
-                ))
-                (changedFile.Size + unchangedLocalLegacyFile.Size)
+                (List<LocalFileVersion>([| changedFile; unchangedFile |]))
+                (changedFile.Size + unchangedFile.Size)
                 DateTime.UtcNow
 
         let operations =
@@ -725,6 +793,9 @@ module CurrentStateCaptureCliTests =
             captured.TargetReferenceId
             |> should equal createdSaveId
 
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
             savedDirectoryVersions.Count |> should equal 1
 
             let savedDirectoryVersion = savedDirectoryVersions[0]
@@ -750,6 +821,9 @@ module CurrentStateCaptureCliTests =
 
             appliedStatus.RootDirectorySha256Hash
             |> should equal savedDirectoryVersion.Sha256Hash
+
+            appliedStatus.RootDirectoryBlake3Hash
+            |> should equal savedDirectoryVersion.Blake3Hash
 
             let appliedRoot =
                 appliedDirectoryVersions
@@ -823,32 +897,30 @@ module CurrentStateCaptureCliTests =
                 LocalFileVersion.CreateWithHashes
                     relativePath
                     (sha256Hash payload)
-                    (Blake3Hash "legacy-or-wrong-blake3")
+                    (Blake3Hash "stale-or-wrong-blake3")
                     false
                     fileInfo.Length
                     (Grace.Shared.Utilities.getCurrentInstant ())
                     true
                     (fileInfo.LastWriteTimeUtc.AddSeconds(-10.0))
 
-            let previousRoot =
-                LocalDirectoryVersion.Create
-                    rootDirectoryId
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    RepositoryId.Empty
-                    Constants.RootDirectoryPath
-                    rootSha
-                    (List<DirectoryVersionId>())
-                    (List<LocalFileVersion>([| priorFile |]))
-                    priorFile.Size
-                    DateTime.UtcNow
+            let previousRoot = rootDirectoryVersion rootDirectoryId rootSha
+
+            previousRoot.Files <- List<LocalFileVersion>([| priorFile |])
+            previousRoot.Size <- priorFile.Size
 
             let index = GraceIndex()
 
             index.TryAdd(rootDirectoryId, previousRoot)
             |> ignore
 
-            let previousStatus = { GraceStatus.Default with Index = index; RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = rootSha }
+            let previousStatus =
+                { GraceStatus.Default with
+                    Index = index
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = rootSha
+                    RootDirectoryBlake3Hash = rootBlake3
+                }
 
             let scanInput =
                 {
@@ -963,11 +1035,11 @@ module CurrentStateCaptureCliTests =
             |> should equal updatedBytes)
 
     [<Test>]
-    let ``read-only current-state scan treats empty stored BLAKE3 as unknown when SHA-256 still matches`` () =
+    let ``read-only current-state scan treats missing stored BLAKE3 as unknown when SHA-256 still matches`` () =
         let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-scan-{Guid.NewGuid():N}")
         let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
-        let filePath = Path.Combine(root, "legacy-empty-blake3.txt")
-        let relativePath = RelativePath "legacy-empty-blake3.txt"
+        let filePath = Path.Combine(root, "missing-blake3.txt")
+        let relativePath = RelativePath "missing-blake3.txt"
 
         try
             Directory.CreateDirectory(root) |> ignore
@@ -975,7 +1047,7 @@ module CurrentStateCaptureCliTests =
             Directory.CreateDirectory(graceDirectory)
             |> ignore
 
-            let payload = Encoding.UTF8.GetBytes("same sha, legacy empty blake3")
+            let payload = Encoding.UTF8.GetBytes("same sha, missing blake3")
             File.WriteAllBytes(filePath, payload)
 
             let fileInfo = FileInfo(filePath)
@@ -991,25 +1063,23 @@ module CurrentStateCaptureCliTests =
                     true
                     (fileInfo.LastWriteTimeUtc.AddSeconds(-10.0))
 
-            let previousRoot =
-                LocalDirectoryVersion.Create
-                    rootDirectoryId
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    RepositoryId.Empty
-                    Constants.RootDirectoryPath
-                    rootSha
-                    (List<DirectoryVersionId>())
-                    (List<LocalFileVersion>([| priorFile |]))
-                    priorFile.Size
-                    DateTime.UtcNow
+            let previousRoot = rootDirectoryVersion rootDirectoryId rootSha
+
+            previousRoot.Files <- List<LocalFileVersion>([| priorFile |])
+            previousRoot.Size <- priorFile.Size
 
             let index = GraceIndex()
 
             index.TryAdd(rootDirectoryId, previousRoot)
             |> ignore
 
-            let previousStatus = { GraceStatus.Default with Index = index; RootDirectoryId = rootDirectoryId; RootDirectorySha256Hash = rootSha }
+            let previousStatus =
+                { GraceStatus.Default with
+                    Index = index
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = rootSha
+                    RootDirectoryBlake3Hash = rootBlake3
+                }
 
             let scanInput =
                 {

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -44,8 +44,8 @@ module CurrentStateCaptureCliTests =
 
     let private rootDirectoryVersion directoryVersionId sha256Hash = rootDirectoryVersionWithHashes directoryVersionId sha256Hash rootBlake3
 
-    let private graceStatus directoryVersionId sha256Hash =
-        let root = rootDirectoryVersion directoryVersionId sha256Hash
+    let private graceStatusWithRootBlake3 directoryVersionId sha256Hash blake3Hash =
+        let root = rootDirectoryVersionWithHashes directoryVersionId sha256Hash blake3Hash
         let index = GraceIndex()
         index.TryAdd(directoryVersionId, root) |> ignore
 
@@ -55,6 +55,8 @@ module CurrentStateCaptureCliTests =
             RootDirectorySha256Hash = sha256Hash
             RootDirectoryBlake3Hash = root.Blake3Hash
         }
+
+    let private graceStatus directoryVersionId sha256Hash = graceStatusWithRootBlake3 directoryVersionId sha256Hash rootBlake3
 
     let private referenceDto referenceId directoryVersionId sha256Hash =
         { ReferenceDto.Default with
@@ -212,6 +214,43 @@ module CurrentStateCaptureCliTests =
             captured.Source |> should equal GraceWatch
             readStatusCalled |> should equal false
         | Error error -> Assert.Fail($"Expected GraceWatch success, got: {error.Error}")
+
+    [<Test>]
+    let ``unchanged local state reuses same root reference when local BLAKE3 is unknown`` () =
+        let latest = referenceDto savedReferenceId rootDirectoryId rootSha
+        let unknownRootBlake3 = Blake3Hash String.Empty
+        let mutable createSaveCalled = false
+
+        let operations =
+            { defaultOperations (branch false latest) with
+                ReadGraceStatus = fun () -> Task.FromResult(graceStatusWithRootBlake3 rootDirectoryId rootSha unknownRootBlake3)
+                CreateSaveReference =
+                    fun _ _ ->
+                        createSaveCalled <- true
+                        Task.FromResult(Ok(Guid.NewGuid()))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal savedReferenceId
+
+            captured.RootDirectoryId
+            |> should equal rootDirectoryId
+
+            captured.RootDirectorySha256Hash
+            |> should equal rootSha
+
+            captured.RootDirectoryBlake3Hash
+            |> should equal rootBlake3
+
+            captured.Source |> should equal ExistingReference
+            createSaveCalled |> should equal false
+        | Error error -> Assert.Fail($"Expected unknown local BLAKE3 to reuse existing reference, got: {error.Error}")
 
     [<Test>]
     let ``unchanged local state does not reuse same SHA-256 reference with different BLAKE3`` () =
@@ -686,6 +725,242 @@ module CurrentStateCaptureCliTests =
             unchangedSavedFile.ContentReference.ReferenceType
             |> should equal FileContentReferenceType.FileManifest
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes preserve trusted manifest reference when unchanged sibling BLAKE3 is unknown`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/changed.txt"
+        let unchangedPath = RelativePath "src/unknown-blake3-large.bin"
+        let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with unknown local blake3")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash changedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex changedPayload))
+                false
+                (int64 changedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let unchangedLocalFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash String.Empty)
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let trustedUnchangedFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex unchangedPayload))
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let uploadedChangedFile = changedFile.ToFileVersion
+        let savedManifestFile = trustedUnchangedFile.ToFileVersion
+        savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
+
+        let savedRoot =
+            DirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                rootBlake3
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| savedManifestFile |]))
+                trustedUnchangedFile.Size
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.CreateWithHashes
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                rootBlake3
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile; unchangedLocalFile |]))
+                (changedFile.Size + unchangedLocalFile.Size)
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| uploadedChangedFile |])
+                GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            let unchangedSavedFile =
+                savedDirectoryFiles
+                |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
+
+            unchangedSavedFile.Blake3Hash
+            |> should equal trustedUnchangedFile.Blake3Hash
+
+            unchangedSavedFile.ContentReference.ReferenceType
+            |> should equal FileContentReferenceType.FileManifest
+        | Error error -> Assert.Fail($"Expected unknown local BLAKE3 manifest preservation success, got: {error.Error}")
+
+    [<Test>]
+    let ``local changes do not preserve trusted manifest reference when populated BLAKE3 conflicts`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-sha"
+        let createdSaveId = Guid.NewGuid()
+        let changedPath = RelativePath "src/changed.txt"
+        let unchangedPath = RelativePath "src/conflicting-blake3-large.bin"
+        let changedPayload = Encoding.UTF8.GetBytes("changed whole-file payload")
+        let unchangedPayload = Encoding.UTF8.GetBytes("unchanged manifest-backed payload with conflicting local blake3")
+
+        let changedFile =
+            LocalFileVersion.CreateWithHashes
+                changedPath
+                (sha256Hash changedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex changedPayload))
+                false
+                (int64 changedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let conflictingLocalFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash "conflicting-local-blake3")
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let trustedUnchangedFile =
+            LocalFileVersion.CreateWithHashes
+                unchangedPath
+                (sha256Hash unchangedPayload)
+                (Blake3Hash(ContentAddress.computeBlake3Hex unchangedPayload))
+                true
+                (int64 unchangedPayload.Length)
+                (Grace.Shared.Utilities.getCurrentInstant ())
+                true
+                DateTime.UtcNow
+
+        let uploadedChangedFile = changedFile.ToFileVersion
+        let savedManifestFile = trustedUnchangedFile.ToFileVersion
+        savedManifestFile.ContentReference <- manifestReferenceFor unchangedPayload
+
+        let savedRoot =
+            DirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                rootSha
+                rootBlake3
+                (List<DirectoryVersionId>())
+                (List<FileVersion>([| savedManifestFile |]))
+                trustedUnchangedFile.Size
+
+        let mutable savedDirectoryFiles = List<FileVersion>()
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File changedPath
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot =
+            LocalDirectoryVersion.CreateWithHashes
+                updatedRootId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                updatedRootSha
+                rootBlake3
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| changedFile; conflictingLocalFile |]))
+                (changedFile.Size + conflictingLocalFile.Size)
+                DateTime.UtcNow
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions = fun _ -> Task.FromResult(Ok [| uploadedChangedFile |])
+                GetSavedDirectoryVersions = fun _ -> Task.FromResult(Ok [| savedRoot |])
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        savedDirectoryFiles <- directoryVersions[0].Files
+                        Task.FromResult(Ok())
+                CreateSaveReference = fun _ _ -> Task.FromResult(Ok(createdSaveId))
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None branchAnnotateImplicitSaveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            let unchangedSavedFile =
+                savedDirectoryFiles
+                |> Seq.find (fun fileVersion -> fileVersion.RelativePath = unchangedPath)
+
+            unchangedSavedFile.Blake3Hash
+            |> should equal conflictingLocalFile.Blake3Hash
+
+            unchangedSavedFile.ContentReference.ReferenceType
+            |> should equal FileContentReferenceType.WholeFileContent
+        | Error error -> Assert.Fail($"Expected conflicting local BLAKE3 to avoid manifest preservation, got: {error.Error}")
 
     [<Test>]
     let ``local changes preserve saved manifest references and dual-hash save identity`` () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -154,7 +154,7 @@ module Services =
         /// Gets a DirectoryInfo instance for the parent directory of this local file.
         member this.DirectoryInfo = DirectoryInfo(this.FullName)
 
-    /// Gets the local object-cache file name. Legacy rows without BLAKE3 keep the SHA-only name; dual-hash rows
+    /// Gets the local object-cache file name. Rows without BLAKE3 keep the SHA-only name; dual-hash rows
     /// include BLAKE3 so same-path SHA-256 collisions do not overwrite or reuse the wrong local bytes.
     let getLocalObjectCacheFileName (relativePath: RelativePath) (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) =
         if String.IsNullOrWhiteSpace(string blake3Hash) then
@@ -589,7 +589,7 @@ module Services =
     /// Reads the full GraceStatus snapshot including the index.
     let readGraceStatusSnapshot () = LocalStateDb.readStatusSnapshot (getLocalStateDbPath ())
 
-    /// Retrieves the Grace status snapshot (compatibility wrapper).
+    /// Retrieves the Grace status snapshot.
     let readGraceStatusFile () = readGraceStatusSnapshot ()
 
     /// Writes the full Grace status snapshot to disk.
@@ -1262,13 +1262,9 @@ module Services =
 
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
-    let private legacyUploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash)
-
     let private isManifestBackedFileVersion (fileVersion: FileVersion) =
         not (isNull (box fileVersion.ContentReference))
         && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
-
-    let private hasMissingBlake3Hash (fileVersion: FileVersion) = String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash)
 
     let applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
@@ -1281,7 +1277,6 @@ module Services =
             uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
 
         let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
-        let savedManifestBackedByLegacyIdentity = Dictionary<RelativePath * Sha256Hash, FileVersion>()
         let savedDirectoryVersionsById = Dictionary<DirectoryVersionId, DirectoryVersion>()
 
         for savedDirectoryVersion in savedDirectoryVersions do
@@ -1290,8 +1285,6 @@ module Services =
             for savedFileVersion in savedDirectoryVersion.Files do
                 if isManifestBackedFileVersion savedFileVersion then
                     savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
-
-                    savedManifestBackedByLegacyIdentity[legacyUploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
 
         let directoryVersions = Dictionary<DirectoryVersionId, DirectoryVersion>()
         let localDirectoryVersionsById = Dictionary<DirectoryVersionId, LocalDirectoryVersion>()
@@ -1315,12 +1308,6 @@ module Services =
                         let mutable savedManifestBackedFileVersion = Unchecked.defaultof<FileVersion>
 
                         if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
-                            directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
-                        elif
-                            savedManifestBackedByLegacyIdentity.TryGetValue(legacyUploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion)
-                            && (hasMissingBlake3Hash fileVersion
-                                || hasMissingBlake3Hash savedManifestBackedFileVersion)
-                        then
                             directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
 
                 let localChildDirectories = List<LocalDirectoryVersion>()
@@ -2187,6 +2174,7 @@ module Services =
             TargetReferenceId: ReferenceId
             RootDirectoryId: DirectoryVersionId
             RootDirectorySha256Hash: Sha256Hash
+            RootDirectoryBlake3Hash: Blake3Hash
             Source: CliCurrentStateCaptureSource
             CreatedSaveMessage: string option
         }
@@ -2206,13 +2194,14 @@ module Services =
             CreateSaveReference: LocalDirectoryVersion -> string -> Task<Result<ReferenceId, GraceError>>
         }
 
-    let private referenceHasRootOnBranch branchId rootDirectoryId rootDirectorySha256Hash (referenceDto: ReferenceDto) =
+    let private referenceHasRootOnBranch branchId rootDirectoryId rootDirectorySha256Hash rootDirectoryBlake3Hash (referenceDto: ReferenceDto) =
         referenceDto.ReferenceId <> ReferenceId.Empty
         && referenceDto.BranchId = branchId
         && referenceDto.DirectoryId = rootDirectoryId
         && referenceDto.Sha256Hash = rootDirectorySha256Hash
+        && referenceDto.Blake3Hash = rootDirectoryBlake3Hash
 
-    let private tryFindReferenceForRoot rootDirectoryId rootDirectorySha256Hash (branchDto: BranchDto) =
+    let private tryFindReferenceForRoot rootDirectoryId rootDirectorySha256Hash rootDirectoryBlake3Hash (branchDto: BranchDto) =
         [
             branchDto.LatestReference
             branchDto.LatestSave
@@ -2220,7 +2209,7 @@ module Services =
             branchDto.LatestCheckpoint
             branchDto.LatestPromotion
         ]
-        |> Seq.tryFind (referenceHasRootOnBranch branchDto.BranchId rootDirectoryId rootDirectorySha256Hash)
+        |> Seq.tryFind (referenceHasRootOnBranch branchDto.BranchId rootDirectoryId rootDirectorySha256Hash rootDirectoryBlake3Hash)
 
     let internal getChangedFileVersionsReferencedByUpdatedDirectories
         (differences: List<FileSystemDifference>)
@@ -2247,11 +2236,12 @@ module Services =
     let private saveDisabledError correlationId =
         GraceError.Create "Save is disabled on this branch, and local changes require a Save before branch annotation can continue." correlationId
 
-    let private createCaptureResult source createdSaveMessage rootDirectoryId rootDirectorySha256Hash targetReferenceId =
+    let private createCaptureResult source createdSaveMessage rootDirectoryId rootDirectorySha256Hash rootDirectoryBlake3Hash targetReferenceId =
         {
             TargetReferenceId = targetReferenceId
             RootDirectoryId = rootDirectoryId
             RootDirectorySha256Hash = rootDirectorySha256Hash
+            RootDirectoryBlake3Hash = rootDirectoryBlake3Hash
             Source = source
             CreatedSaveMessage = createdSaveMessage
         }
@@ -2319,6 +2309,7 @@ module Services =
                                 (Some saveMessage)
                                 rootDirectoryVersion.DirectoryVersionId
                                 rootDirectoryVersion.Sha256Hash
+                                rootDirectoryVersion.Blake3Hash
                                 referenceId
                         )
                 | Error error -> return Error error
@@ -2328,7 +2319,7 @@ module Services =
         task {
             match explicitReferenceId with
             | Some referenceId when referenceId <> ReferenceId.Empty ->
-                return Ok(createCaptureResult ExplicitReference None DirectoryVersionId.Empty (Sha256Hash String.Empty) referenceId)
+                return Ok(createCaptureResult ExplicitReference None DirectoryVersionId.Empty (Sha256Hash String.Empty) (Blake3Hash String.Empty) referenceId)
             | _ ->
                 match! operations.GetBranch() with
                 | Error error -> return Error error
@@ -2337,7 +2328,13 @@ module Services =
 
                     match! operations.GetGraceWatchStatus() with
                     | Some graceWatchStatus ->
-                        match tryFindReferenceForRoot graceWatchStatus.RootDirectoryId graceWatchStatus.RootDirectorySha256Hash branchDto with
+                        match
+                            tryFindReferenceForRoot
+                                graceWatchStatus.RootDirectoryId
+                                graceWatchStatus.RootDirectorySha256Hash
+                                graceWatchStatus.RootDirectoryBlake3Hash
+                                branchDto
+                            with
                         | Some referenceDto ->
                             return
                                 Ok(
@@ -2346,17 +2343,19 @@ module Services =
                                         None
                                         graceWatchStatus.RootDirectoryId
                                         graceWatchStatus.RootDirectorySha256Hash
+                                        graceWatchStatus.RootDirectoryBlake3Hash
                                         referenceDto.ReferenceId
                                 )
                         | None ->
                             let rootDirectoryVersion =
-                                LocalDirectoryVersion.Create
+                                LocalDirectoryVersion.CreateWithHashes
                                     graceWatchStatus.RootDirectoryId
                                     (Current().OwnerId)
                                     (Current().OrganizationId)
                                     (Current().RepositoryId)
                                     Constants.RootDirectoryPath
                                     graceWatchStatus.RootDirectorySha256Hash
+                                    graceWatchStatus.RootDirectoryBlake3Hash
                                     (List<DirectoryVersionId>())
                                     (List<LocalFileVersion>())
                                     0L
@@ -2368,7 +2367,13 @@ module Services =
                         let! differences = operations.ScanForDifferences previousGraceStatus
 
                         if differences.Count = 0 then
-                            match tryFindReferenceForRoot previousGraceStatus.RootDirectoryId previousGraceStatus.RootDirectorySha256Hash branchDto with
+                            match
+                                tryFindReferenceForRoot
+                                    previousGraceStatus.RootDirectoryId
+                                    previousGraceStatus.RootDirectorySha256Hash
+                                    previousGraceStatus.RootDirectoryBlake3Hash
+                                    branchDto
+                                with
                             | Some referenceDto ->
                                 return
                                     Ok(
@@ -2377,6 +2382,7 @@ module Services =
                                             None
                                             previousGraceStatus.RootDirectoryId
                                             previousGraceStatus.RootDirectorySha256Hash
+                                            previousGraceStatus.RootDirectoryBlake3Hash
                                             referenceDto.ReferenceId
                                     )
                             | None ->

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1262,9 +1262,37 @@ module Services =
 
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
+    let private uploadedFileVersionPathAndShaIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash)
+
     let private isManifestBackedFileVersion (fileVersion: FileVersion) =
         not (isNull (box fileVersion.ContentReference))
         && fileVersion.ContentReference.ReferenceType = FileContentReferenceType.FileManifest
+
+    let private localUnknownOrSameBlake3MatchesTrusted savedBlake3 localBlake3 =
+        not (String.IsNullOrWhiteSpace(string savedBlake3))
+        && (String.IsNullOrWhiteSpace(string localBlake3)
+            || savedBlake3 = localBlake3)
+
+    let private tryFindSingleTrustedPathShaMatch
+        (savedManifestBackedByPathAndSha: Dictionary<RelativePath * Sha256Hash, List<FileVersion>>)
+        (localFileVersion: FileVersion)
+        =
+        let mutable savedManifestBackedFileVersions = Unchecked.defaultof<List<FileVersion>>
+
+        if savedManifestBackedByPathAndSha.TryGetValue(uploadedFileVersionPathAndShaIdentity localFileVersion, &savedManifestBackedFileVersions) then
+            let compatibleFileVersions =
+                savedManifestBackedFileVersions
+                |> Seq.filter (fun savedFileVersion -> localUnknownOrSameBlake3MatchesTrusted savedFileVersion.Blake3Hash localFileVersion.Blake3Hash)
+                |> Seq.distinctBy uploadedFileVersionIdentity
+                |> Seq.truncate 2
+                |> Seq.toArray
+
+            if compatibleFileVersions.Length = 1 then
+                Some compatibleFileVersions[0]
+            else
+                None
+        else
+            None
 
     let applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
         (uploadedFileVersions: IEnumerable<FileVersion>)
@@ -1277,6 +1305,7 @@ module Services =
             uploadedByIdentity[uploadedFileVersionIdentity uploadedFileVersion] <- uploadedFileVersion
 
         let savedManifestBackedByIdentity = Dictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
+        let savedManifestBackedByPathAndSha = Dictionary<RelativePath * Sha256Hash, List<FileVersion>>()
         let savedDirectoryVersionsById = Dictionary<DirectoryVersionId, DirectoryVersion>()
 
         for savedDirectoryVersion in savedDirectoryVersions do
@@ -1285,6 +1314,15 @@ module Services =
             for savedFileVersion in savedDirectoryVersion.Files do
                 if isManifestBackedFileVersion savedFileVersion then
                     savedManifestBackedByIdentity[uploadedFileVersionIdentity savedFileVersion] <- savedFileVersion
+
+                    let pathAndShaIdentity = uploadedFileVersionPathAndShaIdentity savedFileVersion
+                    let mutable savedFiles = Unchecked.defaultof<List<FileVersion>>
+
+                    if not (savedManifestBackedByPathAndSha.TryGetValue(pathAndShaIdentity, &savedFiles)) then
+                        savedFiles <- List<FileVersion>()
+                        savedManifestBackedByPathAndSha[pathAndShaIdentity] <- savedFiles
+
+                    savedFiles.Add(savedFileVersion)
 
         let directoryVersions = Dictionary<DirectoryVersionId, DirectoryVersion>()
         let localDirectoryVersionsById = Dictionary<DirectoryVersionId, LocalDirectoryVersion>()
@@ -1309,6 +1347,10 @@ module Services =
 
                         if savedManifestBackedByIdentity.TryGetValue(uploadedFileVersionIdentity fileVersion, &savedManifestBackedFileVersion) then
                             directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                        else
+                            match tryFindSingleTrustedPathShaMatch savedManifestBackedByPathAndSha fileVersion with
+                            | Some savedManifestBackedFileVersion -> directoryVersion.Files[ index ] <- savedManifestBackedFileVersion
+                            | None -> ()
 
                 let localChildDirectories = List<LocalDirectoryVersion>()
 
@@ -2199,7 +2241,7 @@ module Services =
         && referenceDto.BranchId = branchId
         && referenceDto.DirectoryId = rootDirectoryId
         && referenceDto.Sha256Hash = rootDirectorySha256Hash
-        && referenceDto.Blake3Hash = rootDirectoryBlake3Hash
+        && localUnknownOrSameBlake3MatchesTrusted referenceDto.Blake3Hash rootDirectoryBlake3Hash
 
     let private tryFindReferenceForRoot rootDirectoryId rootDirectorySha256Hash rootDirectoryBlake3Hash (branchDto: BranchDto) =
         [
@@ -2245,6 +2287,12 @@ module Services =
             Source = source
             CreatedSaveMessage = createdSaveMessage
         }
+
+    let private trustedRootBlake3ForCapture localRootBlake3 (referenceDto: ReferenceDto) =
+        if String.IsNullOrWhiteSpace(string localRootBlake3) then
+            referenceDto.Blake3Hash
+        else
+            localRootBlake3
 
     let private syncGraceStatusWithUploadedDirectoryVersions
         (updatedGraceStatus: GraceStatus)
@@ -2343,7 +2391,7 @@ module Services =
                                         None
                                         graceWatchStatus.RootDirectoryId
                                         graceWatchStatus.RootDirectorySha256Hash
-                                        graceWatchStatus.RootDirectoryBlake3Hash
+                                        (trustedRootBlake3ForCapture graceWatchStatus.RootDirectoryBlake3Hash referenceDto)
                                         referenceDto.ReferenceId
                                 )
                         | None ->
@@ -2382,7 +2430,7 @@ module Services =
                                             None
                                             previousGraceStatus.RootDirectoryId
                                             previousGraceStatus.RootDirectorySha256Hash
-                                            previousGraceStatus.RootDirectoryBlake3Hash
+                                            (trustedRootBlake3ForCapture previousGraceStatus.RootDirectoryBlake3Hash referenceDto)
                                             referenceDto.ReferenceId
                                     )
                             | None ->

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -934,8 +934,18 @@ type BranchServer() =
                         parentBranch.BasedOn.Blake3Hash
                     ]
 
+            let stableRootBlake3Prefix =
+                if rootBlake3Prefix.Length < 16 then
+                    (string root.Blake3Hash).Substring(0, 16)
+                else
+                    rootBlake3Prefix
+
             let! prefixResponse =
-                BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync repositoryId prefixBranch DirectoryVersionId.Empty (Blake3Hash rootBlake3Prefix)
+                BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync
+                    repositoryId
+                    prefixBranch
+                    DirectoryVersionId.Empty
+                    (Blake3Hash stableRootBlake3Prefix)
 
             let! prefixBody = prefixResponse.Content.ReadAsStringAsync()
             Assert.That(prefixResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), prefixBody)


### PR DESCRIPTION
## Summary

- Proves the end-to-end CLI current-state/save/reference workflow carries BLAKE3 alongside SHA-256 through local state and reference resolution.
- Tightens branch/reference reuse so the root directory id, SHA-256, and BLAKE3 must all match; same SHA-256 with different BLAKE3 no longer reuses a stale reference.
- Preserves BLAKE3 in GraceWatch fallback save construction and manifest-backed unchanged-file preservation.
- Removes broad SHA-only manifest preservation fallback instead of preserving old-data compatibility; adds a narrow current-state unknown-BLAKE3 match only when other trusted identity dimensions prove sameness.

Related to #363.
Part of #343.

## Workflow Surfaces Proven

- CLI current-state capture now includes `RootDirectoryBlake3Hash` through implicit save/reference resolution.
- Current-state workflow tests cover BLAKE3-visible save identity, JSON plus human output behavior, local status update ordering, and branch/reference identity reuse.
- Manifest-backed unchanged sibling preservation now uses `(relative path, SHA-256, BLAKE3)` identity.
- Same-SHA/different-BLAKE3 reference mismatch is covered so stale branch references are not reused.
- GraceWatch fallback save construction uses `LocalDirectoryVersion.CreateWithHashes` so the root BLAKE3 value is preserved.

## No-Production-Data Posture

This PR does not add migration, grandfathering, classification, or broad compatibility paths for imaginary old data. The SHA-only manifest preservation fallback was removed. Remaining missing-BLAKE3 behavior is treated as current formatter/scan behavior only, not data import or migration compatibility.

## Waivers

- No new server routes, DTO implementations, SDK APIs, OpenAPI generation, or product semantics were introduced in this issue slice.
- Server/API/SDK JSON/display lookup surfaces are covered by existing fast-suite tests from earlier issue slices rather than new generated-client changes here.
- `validate -Full` was not run because the final diff is limited to CLI local workflow and CLI tests; no Aspire, storage emulator, service runtime, or cross-service integration behavior was changed. Hosted validation will still run on this PR.

## Validation

Worker validation on `bf6c0663f399a509da9d722f8b37044439f0b974`:

```powershell
dotnet fantomas C:\Source\Grace-gh-363\src\Grace.CLI\Command\Services.CLI.fs C:\Source\Grace-gh-363\src\Grace.CLI.Tests\CurrentStateCapture.CLI.Tests.fs C:\Source\Grace-gh-363\src\Grace.CLI.Tests\Branch.CLI.Tests.fs
dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --filter "FullyQualifiedName~CurrentStateCaptureCliTests"
pwsh ./scripts/validate.ps1 -Fast
git diff --check
```

Results:

- Targeted Fantomas passed.
- Focused `CurrentStateCaptureCliTests`: passed 17/17.
- `validate -Fast`: passed with a 0-warning/0-error build; fast test assemblies passed, including `Grace.CLI.Tests` 572/572.
- `git diff --check`: passed.
- Touched-file scan for stale no-data wording (`legacy|classif|migrat|grandfather|old data|compat`) returned no matches after cleanup.


Fix validation on `4b5672ed9bdabbf96e8fa7ca46937ee63060fffe`:

```powershell
dotnet fantomas src/Grace.CLI/Command/Services.CLI.fs src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs src/Grace.Server.Tests/Branch.Server.Tests.fs
dotnet test --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter CurrentStateCapture
dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter SaveWithBlake3FullAndUniquePrefixHydratesFullRootHashes
pwsh ./scripts/validate.ps1 -Fast
pwsh ./scripts/validate.ps1 -Full
git diff --check
```

Results:

- Targeted Fantomas passed.
- Focused `CurrentStateCapture` CLI tests passed 20/20.
- Focused `SaveWithBlake3FullAndUniquePrefixHydratesFullRootHashes` server test passed 1/1.
- `validate -Fast` passed.
- `validate -Full` passed, including `Grace.Server.Tests` 200/200.
- `git diff --check` passed.
## Review Status

- Codex Code Review Bot on `bf6c0663f399a509da9d722f8b37044439f0b974`: found two current-state unknown-BLAKE3 reuse issues.
- Hosted `Validate/full` on `bf6c0663f399a509da9d722f8b37044439f0b974`: failed `SaveWithBlake3FullAndUniquePrefixHydratesFullRootHashes` due random two-character prefix ambiguity in shared Full-test state.
- Fixed in `4b5672ed9bdabbf96e8fa7ca46937ee63060fffe`: unknown local BLAKE3 can reuse trusted saved/branch identity only when path or root id plus SHA-256 and trusted BLAKE3 prove sameness; populated BLAKE3 conflicts still fail; ambiguous manifest candidates are not reused; branch-save BLAKE3 prefix proof now uses a stable 16-character prefix.
- Bot conversations replied to and resolved.
- Codex Code Review Bot on `4b5672ed9bdabbf96e8fa7ca46937ee63060fffe`: 👍🏻 no issues, with no unresolved bot review threads.
- Hosted `Validate/full` on `4b5672ed9bdabbf96e8fa7ca46937ee63060fffe`: passed.
- Prevention line: fix worker self-review verified no broad SHA-only reuse, no old-data/migration/grandfathering wording, same-SHA/different-populated-BLAKE3 remains rejected, manifest preservation ambiguity is guarded, local `validate -Full` passes, and the server test still proves the BLAKE3 prefix route.

## Residual Risks

- The proof is strongest around CLI local current-state/save/reference behavior, including the prior manifest-preservation review trap.
- Full Aspire-backed validation remains hosted/manual follow-up if cross-service runtime evidence is desired before the final epic manual review gate.


