### PR TITLE
Improve auth status text and JSON output

### DIFF
--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -275,7 +275,7 @@ try {
         Write-Host "Skipped (temporarily disabled pending full repo formatting)."
     } elseif (-not $SkipFormat) {
         Write-Section "Format"
-        Invoke-External "dotnet tool restore" { dotnet tool restore }
+        #Invoke-External "dotnet tool restore" { dotnet tool restore }
 
         $formatTargets = Get-FormatTargets
         if (-not $formatTargets -or $formatTargets.Length -eq 0) {

--- a/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
+++ b/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.300" />
+    <PackageReference Update="FSharp.Core" Version="10.1.301" />
   </ItemGroup>
 </Project>

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -1,14 +1,45 @@
 namespace Grace.CLI.Tests
 
 open FsUnit
+open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Types
 open NUnit.Framework
+open Spectre.Console
 open System
+open System.IO
+open System.Text.Json
 
 [<NonParallelizable>]
 module AuthTests =
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    let private runWithCapturedStdoutAndStderr (args: string array) =
+        use standardOutWriter = new StringWriter()
+        use standardErrorWriter = new StringWriter()
+        let originalOut = Console.Out
+        let originalError = Console.Error
+
+        try
+            Console.SetOut(standardOutWriter)
+            Console.SetError(standardErrorWriter)
+            setAnsiConsoleOutput standardOutWriter
+            let exitCode = GraceCommand.main args
+            exitCode, standardOutWriter.ToString(), standardErrorWriter.ToString()
+        finally
+            Console.SetOut(originalOut)
+            Console.SetError(originalError)
+            setAnsiConsoleOutput originalOut
+
+    let private parseJsonOutput (output: string) =
+        output
+        |> fun value -> value.Trim()
+        |> JsonDocument.Parse
+
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
         let original = Environment.GetEnvironmentVariable(name)
 
@@ -21,13 +52,43 @@ module AuthTests =
         finally
             Environment.SetEnvironmentVariable(name, original)
 
+    let private withClearedEnv names action =
+        let rec loop remaining =
+            match remaining with
+            | [] -> action ()
+            | name :: tail -> withEnv name None (fun () -> loop tail)
+
+        loop names
+
     let private clearOidcEnv (action: unit -> unit) =
-        withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority None (fun () ->
-            withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience None (fun () ->
-                withEnv Constants.EnvironmentVariables.GraceAuthOidcCliClientId None (fun () ->
-                    withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId None (fun () ->
-                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret None (fun () ->
-                            withEnv Constants.EnvironmentVariables.GraceServerUri None action)))))
+        withClearedEnv
+            [
+                Constants.EnvironmentVariables.GraceAuthOidcAuthority
+                Constants.EnvironmentVariables.GraceAuthOidcAudience
+                Constants.EnvironmentVariables.GraceAuthOidcCliClientId
+                Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort
+                Constants.EnvironmentVariables.GraceAuthOidcCliScopes
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientId
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret
+                Constants.EnvironmentVariables.GraceAuthOidcM2mScopes
+                Constants.EnvironmentVariables.GraceTokenFile
+                Constants.EnvironmentVariables.GraceServerUri
+                "USERPROFILE"
+                "HOME"
+                "LOCALAPPDATA"
+                "APPDATA"
+            ]
+            action
+
+    let private withoutAuthEnv (action: unit -> unit) = clearOidcEnv (fun () -> withEnv Constants.EnvironmentVariables.GraceToken None action)
+
+    let private assertAuthStatusJson (output: string) =
+        use document = parseJsonOutput output
+
+        document
+            .RootElement
+            .GetProperty("ReturnValue")
+            .Clone()
 
     [<Test>]
     let ``tryGetAccessToken returns Error when auth is not configured`` () =
@@ -61,3 +122,145 @@ module AuthTests =
                 match result with
                 | Ok _ -> Assert.Fail("Expected Error for invalid GRACE_TOKEN.")
                 | Error _ -> ()))
+
+    [<Test>]
+    let ``auth status human output starts with authenticated banner and active source`` () =
+        let token = PersonalAccessToken.formatToken "user-1" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        clearOidcEnv (fun () ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "auth"
+                                                      "status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+
+                let normalized = standardOut.Replace("\r\n", "\n")
+
+                normalized.StartsWith("Authenticated\n\n")
+                |> should equal true
+
+                let activeSourceIndex = normalized.IndexOf("Active source:")
+                let tokenIndex = normalized.IndexOf("GRACE_TOKEN:")
+
+                activeSourceIndex
+                |> should be (greaterThanOrEqualTo 0)
+
+                tokenIndex
+                |> should be (greaterThan activeSourceIndex)
+
+                normalized
+                |> should contain "Environment (GRACE_TOKEN)"
+
+                normalized |> should not' (contain token)))
+
+    [<Test>]
+    let ``auth status json emits structured authenticated return value`` () =
+        let token = PersonalAccessToken.formatToken "user-1" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        clearOidcEnv (fun () ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "auth"
+                                                      "status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut |> should not' (contain token)
+
+                let returnValue = assertAuthStatusJson standardOut
+
+                returnValue
+                    .GetProperty("Authenticated")
+                    .GetBoolean()
+                |> should equal true
+
+                returnValue.GetProperty("Status").GetString()
+                |> should equal "Authenticated"
+
+                returnValue
+                    .GetProperty("ActiveSource")
+                    .GetString()
+                |> should equal "Environment (GRACE_TOKEN)"
+
+                returnValue
+                    .GetProperty("Sources")
+                    .GetProperty("GraceToken")
+                    .GetProperty("Valid")
+                    .GetBoolean()
+                |> should equal true
+
+                returnValue
+                    .GetProperty("Diagnostics")
+                    .GetArrayLength()
+                |> should equal 0))
+
+    [<Test>]
+    let ``auth status json reports unauthenticated when no source is available`` () =
+        withoutAuthEnv (fun () ->
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "auth"
+                                                  "status" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            let returnValue = assertAuthStatusJson standardOut
+
+            returnValue
+                .GetProperty("Authenticated")
+                .GetBoolean()
+            |> should equal false
+
+            returnValue.GetProperty("Status").GetString()
+            |> should equal "Not authenticated"
+
+            returnValue
+                .GetProperty("ActiveSource")
+                .GetString()
+            |> should equal "None")
+
+    [<Test>]
+    let ``auth status json reports invalid GRACE_TOKEN without leaking raw value`` () =
+        let token = "not-a-pat-secret-value"
+
+        clearOidcEnv (fun () ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "auth"
+                                                      "status" |]
+
+                exitCode |> should equal 0
+                standardError |> should equal String.Empty
+                standardOut |> should not' (contain token)
+
+                let returnValue = assertAuthStatusJson standardOut
+
+                returnValue
+                    .GetProperty("Authenticated")
+                    .GetBoolean()
+                |> should equal false
+
+                returnValue
+                    .GetProperty("ActiveSource")
+                    .GetString()
+                |> should equal "Environment (GRACE_TOKEN invalid)"
+
+                returnValue
+                    .GetProperty("Sources")
+                    .GetProperty("GraceToken")
+                    .GetProperty("Valid")
+                    .GetBoolean()
+                |> should equal false
+
+                returnValue
+                    .GetProperty("Diagnostics")
+                    .GetArrayLength()
+                |> should be (greaterThan 0)))

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -96,6 +96,18 @@ module AuthTests =
         | false, _ -> true
         | true, property -> property.ValueKind = JsonValueKind.Null
 
+    let private assertBooleanProperty (root: JsonElement) (name: string) (expected: bool) =
+        let mutable property = Unchecked.defaultof<JsonElement>
+
+        root.TryGetProperty(name, &property)
+        |> should equal true
+
+        (property.ValueKind = JsonValueKind.True
+         || property.ValueKind = JsonValueKind.False)
+        |> should equal true
+
+        property.GetBoolean() |> should equal expected
+
     let private assertSerializedAuthStatusJson (status: Auth.AuthStatusOutput) =
         use document =
             JsonSerializer.Serialize(status, Constants.JsonSerializerOptions)
@@ -115,7 +127,7 @@ module AuthTests =
             InteractiveTokenPresent = false
             InteractiveExpiresAt = None
             InteractiveSubject = None
-            SecureStoreAvailable = true
+            SecureStoreAvailable = false
             SecureStoreError = None
             ConfigError = None
             Now = now
@@ -250,10 +262,7 @@ module AuthTests =
 
             let returnValue = assertAuthStatusJson standardOut
 
-            returnValue
-                .GetProperty("Authenticated")
-                .GetBoolean()
-            |> should equal false
+            assertBooleanProperty returnValue "Authenticated" false
 
             returnValue.GetProperty("Status").GetString()
             |> should equal "Not authenticated"
@@ -261,7 +270,22 @@ module AuthTests =
             returnValue
                 .GetProperty("ActiveSource")
                 .GetString()
-            |> should equal "None")
+            |> should equal "None"
+
+            let sources = returnValue.GetProperty("Sources")
+            let graceToken = sources.GetProperty("GraceToken")
+            let graceTokenFile = sources.GetProperty("GraceTokenFile")
+            let m2m = sources.GetProperty("M2m")
+            let interactive = sources.GetProperty("Interactive")
+
+            assertBooleanProperty graceToken "Present" false
+            assertBooleanProperty graceToken "Valid" false
+            assertBooleanProperty graceTokenFile "Present" false
+            assertBooleanProperty graceTokenFile "Supported" false
+            assertBooleanProperty m2m "Configured" false
+            assertBooleanProperty interactive "Configured" false
+            assertBooleanProperty interactive "TokenPresent" false
+            assertBooleanProperty interactive "SecureStoreAvailable" false)
 
     [<Test>]
     let ``auth status json reports invalid GRACE_TOKEN without leaking raw value`` () =
@@ -281,22 +305,20 @@ module AuthTests =
 
                 let returnValue = assertAuthStatusJson standardOut
 
-                returnValue
-                    .GetProperty("Authenticated")
-                    .GetBoolean()
-                |> should equal false
+                assertBooleanProperty returnValue "Authenticated" false
 
                 returnValue
                     .GetProperty("ActiveSource")
                     .GetString()
                 |> should equal "Environment (GRACE_TOKEN invalid)"
 
-                returnValue
-                    .GetProperty("Sources")
-                    .GetProperty("GraceToken")
-                    .GetProperty("Valid")
-                    .GetBoolean()
-                |> should equal false
+                let graceToken =
+                    returnValue
+                        .GetProperty("Sources")
+                        .GetProperty("GraceToken")
+
+                assertBooleanProperty graceToken "Present" true
+                assertBooleanProperty graceToken "Valid" false
 
                 returnValue
                     .GetProperty("Diagnostics")
@@ -363,6 +385,7 @@ module AuthTests =
                     GraceTokenValid = true
                     InteractiveConfigured = true
                     InteractiveTokenPresent = true
+                    SecureStoreAvailable = true
                     InteractiveExpiresAt = Some expiresAt
                     InteractiveSubject = Some subject
                 }
@@ -412,6 +435,7 @@ module AuthTests =
                 { defaultStatusContext (expiresAt.Plus(Duration.FromDays(30.0))) with
                     InteractiveConfigured = true
                     InteractiveTokenPresent = true
+                    SecureStoreAvailable = true
                     InteractiveExpiresAt = Some expiresAt
                     InteractiveSubject = Some "expired-user"
                 }
@@ -455,6 +479,7 @@ module AuthTests =
                 { defaultStatusContext now with
                     InteractiveConfigured = true
                     InteractiveTokenPresent = true
+                    SecureStoreAvailable = true
                     InteractiveExpiresAt = Some expiresAt
                     InteractiveSubject = Some subject
                 }

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Types
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -90,6 +91,36 @@ module AuthTests =
             .GetProperty("ReturnValue")
             .Clone()
 
+    let private isMissingOrNull (root: JsonElement) (name: string) =
+        match root.TryGetProperty(name) with
+        | false, _ -> true
+        | true, property -> property.ValueKind = JsonValueKind.Null
+
+    let private assertSerializedAuthStatusJson (status: Auth.AuthStatusOutput) =
+        use document =
+            JsonSerializer.Serialize(status, Constants.JsonSerializerOptions)
+            |> parseJsonOutput
+
+        document.RootElement.Clone()
+
+    let private defaultStatusContext now : Auth.AuthStatusContext =
+        {
+            GraceTokenPresent = false
+            GraceTokenValid = false
+            GraceTokenError = None
+            GraceTokenFilePresent = false
+            GraceTokenFileError = None
+            M2mConfigured = false
+            InteractiveConfigured = false
+            InteractiveTokenPresent = false
+            InteractiveExpiresAt = None
+            InteractiveSubject = None
+            SecureStoreAvailable = true
+            SecureStoreError = None
+            ConfigError = None
+            Now = now
+        }
+
     [<Test>]
     let ``tryGetAccessToken returns Error when auth is not configured`` () =
         clearOidcEnv (fun () ->
@@ -124,7 +155,7 @@ module AuthTests =
                 | Error _ -> ()))
 
     [<Test>]
-    let ``auth status human output starts with authenticated banner and active source`` () =
+    let ``auth status human output writes authenticated banner before active source`` () =
         let token = PersonalAccessToken.formatToken "user-1" (Guid.NewGuid()) (Array.zeroCreate 32)
 
         clearOidcEnv (fun () ->
@@ -138,14 +169,15 @@ module AuthTests =
 
                 let normalized = standardOut.Replace("\r\n", "\n")
 
-                normalized.StartsWith("Authenticated\n\n")
-                |> should equal true
-
+                let authenticatedIndex = normalized.IndexOf("Authenticated")
                 let activeSourceIndex = normalized.IndexOf("Active source:")
                 let tokenIndex = normalized.IndexOf("GRACE_TOKEN:")
 
-                activeSourceIndex
+                authenticatedIndex
                 |> should be (greaterThanOrEqualTo 0)
+
+                activeSourceIndex
+                |> should be (greaterThan authenticatedIndex)
 
                 tokenIndex
                 |> should be (greaterThan activeSourceIndex)
@@ -196,7 +228,13 @@ module AuthTests =
                 returnValue
                     .GetProperty("Diagnostics")
                     .GetArrayLength()
-                |> should equal 0))
+                |> should equal 0
+
+                isMissingOrNull returnValue "AccessTokenExpiresAt"
+                |> should equal true
+
+                isMissingOrNull returnValue "Subject"
+                |> should equal true))
 
     [<Test>]
     let ``auth status json reports unauthenticated when no source is available`` () =
@@ -264,3 +302,179 @@ module AuthTests =
                     .GetProperty("Diagnostics")
                     .GetArrayLength()
                 |> should be (greaterThan 0)))
+
+    [<Test>]
+    let ``auth status json reports configured M2M as unverified and unauthenticated`` () =
+        let m2mSecret = "m2m-client-secret-value"
+
+        clearOidcEnv (fun () ->
+            withEnv Constants.EnvironmentVariables.GraceToken None (fun () ->
+                withEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority (Some "https://tenant.example.com/") (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceAuthOidcAudience (Some "https://api.example.com") (fun () ->
+                        withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId (Some "m2m-client-id") (fun () ->
+                            withEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret (Some m2mSecret) (fun () ->
+                                let exitCode, standardOut, standardError =
+                                    runWithCapturedStdoutAndStderr [| "--output"
+                                                                      "Json"
+                                                                      "auth"
+                                                                      "status" |]
+
+                                exitCode |> should equal 0
+                                standardError |> should equal String.Empty
+                                standardOut |> should not' (contain m2mSecret)
+
+                                let returnValue = assertAuthStatusJson standardOut
+
+                                returnValue
+                                    .GetProperty("Authenticated")
+                                    .GetBoolean()
+                                |> should equal false
+
+                                returnValue.GetProperty("Status").GetString()
+                                |> should equal "Not authenticated"
+
+                                returnValue
+                                    .GetProperty("ActiveSource")
+                                    .GetString()
+                                |> should equal "M2M (client credentials)"
+
+                                returnValue
+                                    .GetProperty("Sources")
+                                    .GetProperty("M2m")
+                                    .GetProperty("Configured")
+                                    .GetBoolean()
+                                |> should equal true
+
+                                isMissingOrNull returnValue "AccessTokenExpiresAt"
+                                |> should equal true
+
+                                isMissingOrNull returnValue "Subject"
+                                |> should equal true))))))
+
+    [<Test>]
+    let ``auth status json keeps stale interactive cache nested when GRACE_TOKEN is active`` () =
+        let expiresAt = Instant.FromUtc(2024, 1, 1, 0, 0)
+        let subject = "cached-user-1"
+
+        let status =
+            Auth.buildAuthStatus
+                { defaultStatusContext (expiresAt.Plus(Duration.FromDays(30.0))) with
+                    GraceTokenPresent = true
+                    GraceTokenValid = true
+                    InteractiveConfigured = true
+                    InteractiveTokenPresent = true
+                    InteractiveExpiresAt = Some expiresAt
+                    InteractiveSubject = Some subject
+                }
+
+        let returnValue = assertSerializedAuthStatusJson status
+
+        returnValue
+            .GetProperty("Authenticated")
+            .GetBoolean()
+        |> should equal true
+
+        returnValue
+            .GetProperty("ActiveSource")
+            .GetString()
+        |> should equal "Environment (GRACE_TOKEN)"
+
+        isMissingOrNull returnValue "AccessTokenExpiresAt"
+        |> should equal true
+
+        isMissingOrNull returnValue "Subject"
+        |> should equal true
+
+        let interactive =
+            returnValue
+                .GetProperty("Sources")
+                .GetProperty("Interactive")
+
+        interactive
+            .GetProperty("TokenPresent")
+            .GetBoolean()
+        |> should equal true
+
+        interactive
+            .GetProperty("AccessTokenExpiresAt")
+            .GetString()
+        |> should equal "2024-01-01T00:00:00Z"
+
+        interactive.GetProperty("Subject").GetString()
+        |> should equal subject
+
+    [<Test>]
+    let ``auth status json reports expired interactive cache as unauthenticated`` () =
+        let expiresAt = Instant.FromUtc(2024, 1, 1, 0, 0)
+
+        let status =
+            Auth.buildAuthStatus
+                { defaultStatusContext (expiresAt.Plus(Duration.FromDays(30.0))) with
+                    InteractiveConfigured = true
+                    InteractiveTokenPresent = true
+                    InteractiveExpiresAt = Some expiresAt
+                    InteractiveSubject = Some "expired-user"
+                }
+
+        let returnValue = assertSerializedAuthStatusJson status
+
+        returnValue
+            .GetProperty("Authenticated")
+            .GetBoolean()
+        |> should equal false
+
+        returnValue.GetProperty("Status").GetString()
+        |> should equal "Not authenticated"
+
+        returnValue
+            .GetProperty("ActiveSource")
+            .GetString()
+        |> should equal "Interactive (cached token expired)"
+
+        isMissingOrNull returnValue "AccessTokenExpiresAt"
+        |> should equal true
+
+        isMissingOrNull returnValue "Subject"
+        |> should equal true
+
+        returnValue
+            .GetProperty("Sources")
+            .GetProperty("Interactive")
+            .GetProperty("AccessTokenExpiresAt")
+            .GetString()
+        |> should equal "2024-01-01T00:00:00Z"
+
+    [<Test>]
+    let ``auth status json promotes fresh interactive cache details when interactive is active`` () =
+        let now = Instant.FromUtc(2024, 1, 1, 0, 0)
+        let expiresAt = now.Plus(Duration.FromHours(2.0))
+        let subject = "fresh-user"
+
+        let status =
+            Auth.buildAuthStatus
+                { defaultStatusContext now with
+                    InteractiveConfigured = true
+                    InteractiveTokenPresent = true
+                    InteractiveExpiresAt = Some expiresAt
+                    InteractiveSubject = Some subject
+                }
+
+        let returnValue = assertSerializedAuthStatusJson status
+
+        returnValue
+            .GetProperty("Authenticated")
+            .GetBoolean()
+        |> should equal true
+
+        returnValue
+            .GetProperty("ActiveSource")
+            .GetString()
+        |> should equal "Interactive (cached token)"
+
+        returnValue
+            .GetProperty("AccessTokenExpiresAt")
+            .GetString()
+        |> should equal "2024-01-01T02:00:00Z"
+
+        returnValue.GetProperty("Subject").GetString()
+        |> should equal subject

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -70,17 +70,17 @@ module Auth =
 
     type TokenStore = { Helper: MsalCacheHelper; StorageProperties: StorageCreationProperties; LockFilePath: string; InProcessLock: SemaphoreSlim }
 
-    type AuthStatusGraceTokenSource = { Present: bool; Valid: bool; Error: string option }
+    type AuthStatusGraceTokenSource = { Present: bool option; Valid: bool option; Error: string option }
 
-    type AuthStatusTokenFileSource = { Present: bool; Supported: bool; Error: string option }
+    type AuthStatusTokenFileSource = { Present: bool option; Supported: bool option; Error: string option }
 
-    type AuthStatusM2mSource = { Configured: bool }
+    type AuthStatusM2mSource = { Configured: bool option }
 
     type AuthStatusInteractiveSource =
         {
-            Configured: bool
-            TokenPresent: bool
-            SecureStoreAvailable: bool
+            Configured: bool option
+            TokenPresent: bool option
+            SecureStoreAvailable: bool option
             AccessTokenExpiresAt: string option
             Subject: string option
             Error: string option
@@ -98,7 +98,7 @@ module Auth =
 
     type AuthStatusOutput =
         {
-            Authenticated: bool
+            Authenticated: bool option
             Status: string
             ActiveSource: string
             Sources: AuthStatusSources
@@ -1073,19 +1073,19 @@ module Auth =
             ]
 
         {
-            Authenticated = authenticated
+            Authenticated = Some authenticated
             Status = statusText
             ActiveSource = activeSource
             Sources =
                 {
-                    GraceToken = { Present = context.GraceTokenPresent; Valid = context.GraceTokenValid; Error = context.GraceTokenError }
-                    GraceTokenFile = { Present = context.GraceTokenFilePresent; Supported = false; Error = context.GraceTokenFileError }
-                    M2m = { Configured = context.M2mConfigured }
+                    GraceToken = { Present = Some context.GraceTokenPresent; Valid = Some context.GraceTokenValid; Error = context.GraceTokenError }
+                    GraceTokenFile = { Present = Some context.GraceTokenFilePresent; Supported = Some false; Error = context.GraceTokenFileError }
+                    M2m = { Configured = Some context.M2mConfigured }
                     Interactive =
                         {
-                            Configured = context.InteractiveConfigured
-                            TokenPresent = context.InteractiveTokenPresent
-                            SecureStoreAvailable = context.SecureStoreAvailable
+                            Configured = Some context.InteractiveConfigured
+                            TokenPresent = Some context.InteractiveTokenPresent
+                            SecureStoreAvailable = Some context.SecureStoreAvailable
                             AccessTokenExpiresAt =
                                 context.InteractiveExpiresAt
                                 |> formatInstantOptionForJson
@@ -1336,7 +1336,7 @@ module Auth =
 
                 let interactiveConfigured = cliConfig |> Option.isSome
                 let interactiveTokenPresent = interactiveBundle |> Option.isSome
-                let secureStoreAvailable = secureStoreError.IsNone
+                let secureStoreAvailable = interactiveConfigured && secureStoreError.IsNone
 
                 let interactiveExpiresAt =
                     interactiveBundle

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -68,6 +68,43 @@ module Auth =
 
     type TokenStore = { Helper: MsalCacheHelper; StorageProperties: StorageCreationProperties; LockFilePath: string; InProcessLock: SemaphoreSlim }
 
+    type AuthStatusGraceTokenSource = { Present: bool; Valid: bool; Error: string option }
+
+    type AuthStatusTokenFileSource = { Present: bool; Supported: bool; Error: string option }
+
+    type AuthStatusM2mSource = { Configured: bool }
+
+    type AuthStatusInteractiveSource =
+        {
+            Configured: bool
+            TokenPresent: bool
+            SecureStoreAvailable: bool
+            AccessTokenExpiresAt: string option
+            Subject: string option
+            Error: string option
+        }
+
+    type AuthStatusSources =
+        {
+            GraceToken: AuthStatusGraceTokenSource
+            GraceTokenFile: AuthStatusTokenFileSource
+            M2m: AuthStatusM2mSource
+            Interactive: AuthStatusInteractiveSource
+        }
+
+    type AuthStatusDiagnostic = { Level: string; Source: string; Message: string }
+
+    type AuthStatusOutput =
+        {
+            Authenticated: bool
+            Status: string
+            ActiveSource: string
+            Sources: AuthStatusSources
+            AccessTokenExpiresAt: string option
+            Subject: string option
+            Diagnostics: AuthStatusDiagnostic array
+        }
+
     type AuthEnvironmentFieldStatus = { Name: string; IsSet: bool; Required: bool }
 
     type AuthInspection =
@@ -1144,6 +1181,15 @@ module Auth =
                     | Error message -> Some message
                     | _ -> None
 
+                let graceTokenFilePresent = isEnvSet Constants.EnvironmentVariables.GraceTokenFile
+
+                let graceTokenFileError =
+                    if graceTokenFilePresent then
+                        Some
+                            $"Local token file storage is disabled. Unset {Constants.EnvironmentVariables.GraceTokenFile} and use {Constants.EnvironmentVariables.GraceToken} for a PAT."
+                    else
+                        None
+
                 let m2mConfigured = tryGetOidcM2mConfig () |> Option.isSome
 
                 let! cliConfigResult = tryGetOidcCliConfig correlationId
@@ -1173,6 +1219,7 @@ module Auth =
 
                 let interactiveConfigured = cliConfig |> Option.isSome
                 let interactiveTokenPresent = interactiveBundle |> Option.isSome
+                let secureStoreAvailable = secureStoreError.IsNone
 
                 let interactiveExpiresAt =
                     interactiveBundle
@@ -1187,6 +1234,8 @@ module Auth =
                         "Environment (GRACE_TOKEN)"
                     elif graceTokenError.IsSome then
                         "Environment (GRACE_TOKEN invalid)"
+                    elif graceTokenFilePresent then
+                        "Environment (GRACE_TOKEN_FILE unsupported)"
                     elif m2mConfigured then
                         "M2M (client credentials)"
                     elif interactiveConfigured then
@@ -1196,11 +1245,74 @@ module Auth =
                     else
                         "None"
 
+                let authenticated =
+                    match activeSource with
+                    | "Environment (GRACE_TOKEN)"
+                    | "M2M (client credentials)"
+                    | "Interactive (cached token)" -> true
+                    | _ -> false
+
+                let statusText = if authenticated then "Authenticated" else "Not authenticated"
+
+                let diagnostics =
+                    [
+                        match graceTokenError with
+                        | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceToken; Message = message }
+                        | None -> ()
+
+                        match graceTokenFileError with
+                        | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceTokenFile; Message = message }
+                        | None -> ()
+
+                        match secureStoreError with
+                        | Some message -> yield { Level = "Error"; Source = "Secure storage"; Message = message }
+                        | None -> ()
+
+                        match configError with
+                        | Some message -> yield { Level = "Error"; Source = "Auth config"; Message = message }
+                        | None -> ()
+                    ]
+
+                let authStatus =
+                    {
+                        Authenticated = authenticated
+                        Status = statusText
+                        ActiveSource = activeSource
+                        Sources =
+                            {
+                                GraceToken = { Present = graceTokenPresent; Valid = graceTokenValid; Error = graceTokenError }
+                                GraceTokenFile = { Present = graceTokenFilePresent; Supported = false; Error = graceTokenFileError }
+                                M2m = { Configured = m2mConfigured }
+                                Interactive =
+                                    {
+                                        Configured = interactiveConfigured
+                                        TokenPresent = interactiveTokenPresent
+                                        SecureStoreAvailable = secureStoreAvailable
+                                        AccessTokenExpiresAt =
+                                            interactiveExpiresAt
+                                            |> Option.map (fun expiresAt -> formatInstantOption (Some expiresAt))
+                                        Subject = interactiveSubject
+                                        Error = secureStoreError
+                                    }
+                            }
+                        AccessTokenExpiresAt =
+                            interactiveExpiresAt
+                            |> Option.map (fun expiresAt -> formatInstantOption (Some expiresAt))
+                        Subject = interactiveSubject
+                        Diagnostics = diagnostics |> List.toArray
+                    }
+
                 if parseResult |> hasOutput then
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]{Markup.Escape(statusText)}[/]")
+                    AnsiConsole.WriteLine()
+                    AnsiConsole.MarkupLine($"[bold {Colors.Important}]Active source:[/] {Markup.Escape(activeSource)}")
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]GRACE_TOKEN:[/] {graceTokenPresent}")
 
                     if graceTokenError.IsSome then
                         AnsiConsole.MarkupLine($"[{Colors.Important}]GRACE_TOKEN error:[/] {Markup.Escape(graceTokenError.Value)}")
+
+                    if graceTokenFileError.IsSome then
+                        AnsiConsole.MarkupLine($"[{Colors.Important}]GRACE_TOKEN_FILE:[/] {Markup.Escape(graceTokenFileError.Value)}")
 
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]M2M configured:[/] {m2mConfigured}")
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Interactive configured:[/] {interactiveConfigured}")
@@ -1223,10 +1335,8 @@ module Auth =
                     | Some message -> AnsiConsole.MarkupLine($"[{Colors.Important}]Auth config:[/] {Markup.Escape(message)}")
                     | None -> ()
 
-                    AnsiConsole.MarkupLine($"[{Colors.Important}]Active source:[/] {Markup.Escape(activeSource)}")
-
                 return
-                    Ok(GraceReturnValue.Create activeSource correlationId)
+                    Ok(GraceReturnValue.Create authStatus correlationId)
                     |> renderOutput parseResult
             }
 

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -13,9 +13,11 @@ open Grace.Types.Common
 open Microsoft.Identity.Client.Extensions.Msal
 open Spectre.Console
 open NodaTime
+open NodaTime.Text
 open System
 open System.Collections.Generic
 open System.Diagnostics
+open System.Globalization
 open System.Net
 open System.Net.Http
 open System.Security.Cryptography
@@ -983,6 +985,121 @@ module Auth =
         | None -> "Never"
         | Some value -> instantToLocalTime value
 
+    let private formatInstantForJson (instant: NodaTime.Instant) = instant.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)
+
+    let private formatInstantOptionForJson (instant: NodaTime.Instant option) = instant |> Option.map formatInstantForJson
+
+    type internal AuthStatusContext =
+        {
+            GraceTokenPresent: bool
+            GraceTokenValid: bool
+            GraceTokenError: string option
+            GraceTokenFilePresent: bool
+            GraceTokenFileError: string option
+            M2mConfigured: bool
+            InteractiveConfigured: bool
+            InteractiveTokenPresent: bool
+            InteractiveExpiresAt: NodaTime.Instant option
+            InteractiveSubject: string option
+            SecureStoreAvailable: bool
+            SecureStoreError: string option
+            ConfigError: string option
+            Now: NodaTime.Instant
+        }
+
+    let internal buildAuthStatus (context: AuthStatusContext) =
+        let interactiveTokenFresh =
+            context.InteractiveExpiresAt
+            |> Option.exists (fun expiresAt -> expiresAt > context.Now.Plus(safetyWindow))
+
+        let activeSource =
+            if context.GraceTokenValid then
+                "Environment (GRACE_TOKEN)"
+            elif context.GraceTokenError.IsSome then
+                "Environment (GRACE_TOKEN invalid)"
+            elif context.GraceTokenFilePresent then
+                "Environment (GRACE_TOKEN_FILE unsupported)"
+            elif context.M2mConfigured then
+                "M2M (client credentials)"
+            elif context.InteractiveConfigured then
+                if context.SecureStoreError.IsSome then
+                    "Interactive (secure storage unavailable)"
+                elif interactiveTokenFresh then
+                    "Interactive (cached token)"
+                elif context.InteractiveTokenPresent then
+                    "Interactive (cached token expired)"
+                else
+                    "Interactive (no cached token)"
+            else
+                "None"
+
+        let authenticated =
+            match activeSource with
+            | "Environment (GRACE_TOKEN)"
+            | "Interactive (cached token)" -> true
+            | _ -> false
+
+        let statusText = if authenticated then "Authenticated" else "Not authenticated"
+
+        let activeInteractiveExpiresAt =
+            if activeSource = "Interactive (cached token)" then
+                context.InteractiveExpiresAt
+            else
+                None
+
+        let activeInteractiveSubject =
+            if activeSource = "Interactive (cached token)" then
+                context.InteractiveSubject
+            else
+                None
+
+        let diagnostics =
+            [
+                match context.GraceTokenError with
+                | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceToken; Message = message }
+                | None -> ()
+
+                match context.GraceTokenFileError with
+                | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceTokenFile; Message = message }
+                | None -> ()
+
+                match context.SecureStoreError with
+                | Some message -> yield { Level = "Error"; Source = "Secure storage"; Message = message }
+                | None -> ()
+
+                match context.ConfigError with
+                | Some message -> yield { Level = "Error"; Source = "Auth config"; Message = message }
+                | None -> ()
+            ]
+
+        {
+            Authenticated = authenticated
+            Status = statusText
+            ActiveSource = activeSource
+            Sources =
+                {
+                    GraceToken = { Present = context.GraceTokenPresent; Valid = context.GraceTokenValid; Error = context.GraceTokenError }
+                    GraceTokenFile = { Present = context.GraceTokenFilePresent; Supported = false; Error = context.GraceTokenFileError }
+                    M2m = { Configured = context.M2mConfigured }
+                    Interactive =
+                        {
+                            Configured = context.InteractiveConfigured
+                            TokenPresent = context.InteractiveTokenPresent
+                            SecureStoreAvailable = context.SecureStoreAvailable
+                            AccessTokenExpiresAt =
+                                context.InteractiveExpiresAt
+                                |> formatInstantOptionForJson
+                            Subject = context.InteractiveSubject
+                            Error = context.SecureStoreError
+                        }
+                }
+            AccessTokenExpiresAt =
+                activeInteractiveExpiresAt
+                |> formatInstantOptionForJson
+            Subject = activeInteractiveSubject
+            Diagnostics = diagnostics |> List.toArray
+        }
+
     module private LoginOptions =
         let auth =
             (new Option<string>("--auth", Required = false, Description = "Authentication flow: pkce (browser) or device.", Arity = ArgumentArity.ExactlyOne))
@@ -1229,83 +1346,29 @@ module Auth =
                     interactiveBundle
                     |> Option.bind (fun bundle -> bundle.Subject)
 
-                let activeSource =
-                    if graceTokenValid then
-                        "Environment (GRACE_TOKEN)"
-                    elif graceTokenError.IsSome then
-                        "Environment (GRACE_TOKEN invalid)"
-                    elif graceTokenFilePresent then
-                        "Environment (GRACE_TOKEN_FILE unsupported)"
-                    elif m2mConfigured then
-                        "M2M (client credentials)"
-                    elif interactiveConfigured then
-                        if secureStoreError.IsSome then "Interactive (secure storage unavailable)"
-                        elif interactiveTokenPresent then "Interactive (cached token)"
-                        else "Interactive (no cached token)"
-                    else
-                        "None"
-
-                let authenticated =
-                    match activeSource with
-                    | "Environment (GRACE_TOKEN)"
-                    | "M2M (client credentials)"
-                    | "Interactive (cached token)" -> true
-                    | _ -> false
-
-                let statusText = if authenticated then "Authenticated" else "Not authenticated"
-
-                let diagnostics =
-                    [
-                        match graceTokenError with
-                        | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceToken; Message = message }
-                        | None -> ()
-
-                        match graceTokenFileError with
-                        | Some message -> yield { Level = "Error"; Source = Constants.EnvironmentVariables.GraceTokenFile; Message = message }
-                        | None -> ()
-
-                        match secureStoreError with
-                        | Some message -> yield { Level = "Error"; Source = "Secure storage"; Message = message }
-                        | None -> ()
-
-                        match configError with
-                        | Some message -> yield { Level = "Error"; Source = "Auth config"; Message = message }
-                        | None -> ()
-                    ]
-
                 let authStatus =
-                    {
-                        Authenticated = authenticated
-                        Status = statusText
-                        ActiveSource = activeSource
-                        Sources =
-                            {
-                                GraceToken = { Present = graceTokenPresent; Valid = graceTokenValid; Error = graceTokenError }
-                                GraceTokenFile = { Present = graceTokenFilePresent; Supported = false; Error = graceTokenFileError }
-                                M2m = { Configured = m2mConfigured }
-                                Interactive =
-                                    {
-                                        Configured = interactiveConfigured
-                                        TokenPresent = interactiveTokenPresent
-                                        SecureStoreAvailable = secureStoreAvailable
-                                        AccessTokenExpiresAt =
-                                            interactiveExpiresAt
-                                            |> Option.map (fun expiresAt -> formatInstantOption (Some expiresAt))
-                                        Subject = interactiveSubject
-                                        Error = secureStoreError
-                                    }
-                            }
-                        AccessTokenExpiresAt =
-                            interactiveExpiresAt
-                            |> Option.map (fun expiresAt -> formatInstantOption (Some expiresAt))
-                        Subject = interactiveSubject
-                        Diagnostics = diagnostics |> List.toArray
-                    }
+                    buildAuthStatus
+                        {
+                            GraceTokenPresent = graceTokenPresent
+                            GraceTokenValid = graceTokenValid
+                            GraceTokenError = graceTokenError
+                            GraceTokenFilePresent = graceTokenFilePresent
+                            GraceTokenFileError = graceTokenFileError
+                            M2mConfigured = m2mConfigured
+                            InteractiveConfigured = interactiveConfigured
+                            InteractiveTokenPresent = interactiveTokenPresent
+                            InteractiveExpiresAt = interactiveExpiresAt
+                            InteractiveSubject = interactiveSubject
+                            SecureStoreAvailable = secureStoreAvailable
+                            SecureStoreError = secureStoreError
+                            ConfigError = configError
+                            Now = getCurrentInstant ()
+                        }
 
                 if parseResult |> hasOutput then
-                    AnsiConsole.MarkupLine($"[{Colors.Important}]{Markup.Escape(statusText)}[/]")
+                    AnsiConsole.MarkupLine($"[{Colors.Important}]{Markup.Escape(authStatus.Status)}[/]")
                     AnsiConsole.WriteLine()
-                    AnsiConsole.MarkupLine($"[bold {Colors.Important}]Active source:[/] {Markup.Escape(activeSource)}")
+                    AnsiConsole.MarkupLine($"[bold {Colors.Important}]Active source:[/] {Markup.Escape(authStatus.ActiveSource)}")
                     AnsiConsole.MarkupLine($"[{Colors.Highlighted}]GRACE_TOKEN:[/] {graceTokenPresent}")
 
                     if graceTokenError.IsSome then


### PR DESCRIPTION
Closes #397

## Summary

- Updates `grace auth status` human output so the first line is the authentication summary, followed by a blank line and the emphasized active source before the remaining details.
- Replaces the JSON `ReturnValue` string with a structured auth-status object containing authentication state, active source, source/config/token booleans, optional expiry/subject, and diagnostics without token or secret values.
- Adds focused CLI auth-status tests covering authenticated, unauthenticated, invalid `GRACE_TOKEN`, and JSON output behavior.

## Review Status

- Implementation worker: completed in `3cb89c2ba9d0d214702fcbef71e96ba29d8372eb`; branch rebased onto `9889bb3` and republished as `0c35cd5`; review fixes pushed in `b85881f2927f071928816dfb4c6b46abbe209c99`.
- Codex Code Review Bot: original three findings fixed in `b85881f`; follow-up JSON boolean and secure-store findings fixed in `59a414e`; Codex Code Review Bot reported no issues with a thumbs-up reaction on latest head `7ffdcd8`.
- Open bot findings: none currently unresolved after `59a414e`; maintainer follow-up commit `7ffdcd8` updates `scripts/validate.ps1`; GitHub `full` passed on latest head and Codex Code Review Bot reported no issues with a thumbs-up reaction. The `NU1605` package downgrade was fixed in `b85881f` by aligning `Grace.CLI.LocalStateDb.Worker` to `FSharp.Core` `10.1.301`.

## Validation

- `dotnet fantomas src\Grace.CLI\Command\Auth.CLI.fs src\Grace.CLI.Tests\Auth.Tests.fs`: passed.
- Pre-rebase `dotnet test src\\Grace.CLI.Tests\\Grace.CLI.Tests.fsproj --configuration Release -p:TreatWarningsAsErrors=false --filter AuthTests`: passed, 7 passed, 0 failed.\n- Post-rebase `dotnet test src\\Grace.CLI.Tests\\Grace.CLI.Tests.fsproj --configuration Release --filter AuthTests`: failed during restore on `NU1605` FSharp.Core downgrade before tests ran.
- `git diff --check`: passed.
- Pre-rebase `pwsh ./scripts/validate.ps1 -Fast`: blocked before tests ran during restore/build because `MessagePack` `3.1.6` was reported as `NU1903`.\n- Post-fix `pwsh ./scripts/validate.ps1 -Fast`: passed; build succeeded with 0 warnings and 0 errors; selected fast suites passed (Authorization 39, Types 96, Server.Unit 498, CLI 508).

## Docs Impact

No docs changed. Nearby auth docs describe command usage and authentication configuration, not the previous `auth status` output order or JSON `ReturnValue` shape.

## Residual Risk

- The package-update `main` commit removed the prior `MessagePack` `NU1903` blocker. The `FSharp.Core` `NU1605` downgrade in `Grace.CLI.LocalStateDb.Worker` was fixed in this PR because it blocked validation on the refreshed branch.
- `--schema` and routed `--select` metadata were not expanded in this slice; the runtime JSON `ReturnValue` is now structured, and broader command-output registry work can be tracked separately if Grace wants formal schema/select metadata for `auth status`.







