### PR TITLE
Allow OIDC auth in debug TestAuth mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ so links stay traceable without relying on epic-branch auto-close behavior.
   before commit/push/handoff steps, and before the final response. Also ask the worker to send a short chat heartbeat
   roughly every five minutes while still working so the orchestrator can distinguish active progress from a stalled or
   lost worker without interrupting it.
+- Agents must never sleep or poll for more than 120 seconds in one command. This includes `Start-Sleep`, `wait_agent`,
+  long-polling commands, watch loops, and tool waits. Use repeated shorter checks instead, updating the status file
+  between checks when the wait is part of a long-running workflow.
 - Worker subagents should finish their assigned implementation or fix as soon as they have a validated result and a
   handoff. By default, do not make workers update GitHub issues, pull request bodies, review comments, conversation
   resolution, labels, checklists, or merge/cleanup state. The orchestrator owns those GitHub coordination updates and

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -144,14 +144,18 @@ The canonical zero-external-auth bootstrap helper uses this path and prints a us
 PowerShell:
 
 ```powershell
-pwsh ./scripts/start-debuglocal.ps1 -GraceServerUri "http://localhost:5000"
+pwsh ./scripts/start-debuglocal.ps1 -GraceServerUri "http://localhost:5000" -SkipAuthProbe
 ```
 
 bash / zsh:
 
 ```bash
-pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000"
+pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -SkipAuthProbe
 ```
+
+`-SkipAuthProbe` is required for the true zero-OIDC bootstrap path because the default auth probe checks
+`/auth/oidc/config` before TestAuth PAT creation. Omit `-SkipAuthProbe` when OIDC/MSA settings are configured and you
+want the startup helper to verify both `/auth/oidc/config` and `/auth/me` before creating the PAT.
 
 If OIDC/MSA is configured instead, use the interactive CLI path:
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -84,6 +84,16 @@ export grace__authz__bootstrap__system_admin_users="auth0|abc123"
 For local development, you can skip Auth0 entirely by enabling the built-in TestAuth handler.
 This is intended for **dev/test only**.
 
+Debug/TestAuth mode also supports normal JWT bearer authentication when OIDC is configured. Scheme selection is
+deterministic:
+
+1. Grace PAT bearer tokens use `GracePat`.
+1. Non-PAT bearer tokens use OIDC/JWT validation when server OIDC settings are present.
+1. Explicit `x-grace-user-id` requests use TestAuth in testing mode.
+1. Testing requests with no bearer token use TestAuth so local bootstrap can still challenge through the TestAuth path.
+
+TestAuth does not trust arbitrary bearer tokens, and the CLI's `GRACE_TOKEN` environment variable remains PAT-only.
+
 ### Enable TestAuth
 
 Set:
@@ -128,6 +138,44 @@ When enabled, Grace authenticates requests using headers:
 
 On first activation (with no existing assignments), Grace will seed `SystemAdmin` for `dev-scott`.
 After that, bootstrap is a no-op.
+
+The canonical zero-external-auth bootstrap helper uses this path and prints a usable PAT:
+
+PowerShell:
+
+```powershell
+pwsh ./scripts/start-debuglocal.ps1 -GraceServerUri "http://localhost:5000"
+```
+
+bash / zsh:
+
+```bash
+pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000"
+```
+
+If OIDC/MSA is configured instead, use the interactive CLI path:
+
+PowerShell:
+
+```powershell
+$env:GRACE_SERVER_URI="http://localhost:5000"
+grace auth login
+grace auth whoami --output Verbose
+grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+```
+
+bash / zsh:
+
+```bash
+export GRACE_SERVER_URI="http://localhost:5000"
+grace auth login
+grace auth whoami --output Verbose
+grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+```
+
+`grace auth whoami` proves authentication. `grace auth token create` also requires authorization: the authenticated
+principal must already have a role such as `SystemAdmin`, either from first-admin bootstrap seeding or from an existing
+admin grant.
 
 ---
 

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -442,6 +442,10 @@ five minutes while still working. The heartbeat should be a status update, not a
 is blocked. The orchestrator may read the status file and thread output to monitor progress, and should avoid
 interrupting an active worker only to ask for status.
 
+Agents must never sleep or poll for more than 120 seconds in one command. This applies to `Start-Sleep`, `wait_agent`,
+long-polling commands, watch loops, and tool waits. Use repeated shorter checks instead, and update the status file
+between checks when monitoring long-running validation, generation, CI, or review activity.
+
 Before editing files, the implementation worker should post or include a lightweight preflight after reading the issue:
 
 ```markdown
@@ -555,6 +559,8 @@ The review loop is blocking:
 1. After the implementation subagent pushes a commit, monitor the pull request for Codex Code Review Bot activity.
 2. Wait for the bot to put 👀 on the pull request body for the current head commit, then wait for either a 👍🏻 reaction
    or a bot review comment.
+   Use repeated checks no longer than 120 seconds each; do not run one long sleep, watch, `wait_agent`, or poll command
+   while waiting for the bot.
 3. If the bot switches the PR-body reaction to 👍🏻 and there are no unresolved bot review comments for the current head,
    record that no-issues state in `Review Status` and continue toward merge readiness.
 4. If the bot writes a top-level PR comment or inline pull-request-review comment with findings, update

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -64,6 +64,9 @@ update the issue before editing the new paths.
   Codex Code Review Bot to review the refreshed PR head. A bot signal on a stale commit does not satisfy the completion
   gate. For sub-issue PRs targeting an epic integration branch, run that freshness gate against the current epic branch;
   for the final epic-to-`main` PR, run it against current `origin/main`.
+- Never sleep or poll for more than 120 seconds in one command. This applies to `Start-Sleep`, `wait_agent`,
+  long-polling commands, watch loops, and tool waits; use repeated shorter checks instead, with status updates between
+  checks during long workflows.
 - Resolve all compilation errors before considering a task complete.
 - Run impacted tests for each task and fix failures introduced by your changes.
 - Create a new git commit after each completed task to keep review scope clear.

--- a/src/Grace.Authorization.Tests/AGENTS.md
+++ b/src/Grace.Authorization.Tests/AGENTS.md
@@ -1,0 +1,25 @@
+# Grace.Authorization.Tests Agents Guide
+
+Global policies live in `../AGENTS.md`; follow them before touching tests here.
+
+## Purpose
+
+- Cover authorization-sensitive contracts, including endpoint manifest coverage, duplicate route declarations, RBAC role
+  semantics, principal claim mapping, PAT behavior, and path permission decisions.
+- Prefer this project for deterministic auth and authorization contract tests that do not need an HTTP host, Aspire
+  resources, storage emulators, Service Bus, Redis, or Orleans runtime state.
+
+## Project Rules
+
+1. Keep route authorization tests synchronized with `Grace.Server/Security/EndpointAuthorizationManifest.Server.fs` and
+   the route map in `Grace.Server/Startup.Server.fs`.
+1. Use server unit tests for pure server helper behavior when the test naturally belongs beside server-adjacent code.
+1. Use `Grace.Server.Tests` only when the behavior needs the hosted HTTP pipeline or Aspire-backed resources.
+1. Do not log bearer tokens, PATs, Authorization headers, secrets, or credential-bearing URLs in test output.
+
+## Validation
+
+- Run targeted Fantomas formatting or checks before build/test validation after F# changes.
+- Build `src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj` in Release before project-specific
+  `--no-build` tests.
+- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate.

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -10,7 +10,12 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Net
+open System.Net.Sockets
+open System.Text
 open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
 
 [<NonParallelizable>]
 module AuthTests =
@@ -38,7 +43,7 @@ module AuthTests =
 
     let private parseJsonOutput (output: string) =
         output
-        |> fun value -> value.Trim()
+        |> (fun value -> value.Trim())
         |> JsonDocument.Parse
 
     let private withEnv (name: string) (value: string option) (action: unit -> unit) =
@@ -82,6 +87,57 @@ module AuthTests =
             action
 
     let private withoutAuthEnv (action: unit -> unit) = clearOidcEnv (fun () -> withEnv Constants.EnvironmentVariables.GraceToken None action)
+
+    let private withSingleHttpResponse (statusCode: int) (reasonPhrase: string) (body: string) (action: unit -> unit) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        use cancellation = new CancellationTokenSource()
+        listener.Start()
+
+        let writeResponse (client: TcpClient) =
+            task {
+                use client = client
+                use stream = client.GetStream()
+                let buffer = Array.zeroCreate<byte> 8192
+                let! _ = stream.ReadAsync(buffer, 0, buffer.Length)
+                let bodyBytes = Encoding.UTF8.GetBytes(body)
+
+                let responseHeaders = $"HTTP/1.1 {statusCode} {reasonPhrase}\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+
+                let headerBytes = Encoding.ASCII.GetBytes(responseHeaders)
+                do! stream.WriteAsync(headerBytes, 0, headerBytes.Length)
+
+                if bodyBytes.Length > 0 then
+                    do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length)
+            }
+
+        let rec serve () =
+            task {
+                if not cancellation.IsCancellationRequested then
+                    try
+                        let! client =
+                            listener
+                                .AcceptTcpClientAsync(cancellation.Token)
+                                .AsTask()
+
+                        do! writeResponse client
+                        return! serve ()
+                    with
+                    | :? OperationCanceledException -> return ()
+                    | :? ObjectDisposedException -> return ()
+            }
+
+        let serverTask = Task.Run(Func<Task>(fun () -> serve ()))
+
+        let port = (listener.LocalEndpoint :?> IPEndPoint).Port
+
+        try
+            withEnv Constants.EnvironmentVariables.GraceServerUri (Some $"http://127.0.0.1:{port}") action
+        finally
+            cancellation.Cancel()
+            listener.Stop()
+
+            if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
+                Assert.Fail("Timed out waiting for the test HTTP responder to stop.")
 
     let private assertAuthStatusJson (output: string) =
         use document = parseJsonOutput output
@@ -503,3 +559,55 @@ module AuthTests =
 
         returnValue.GetProperty("Subject").GetString()
         |> should equal subject
+
+    [<Test>]
+    let ``auth whoami reports empty unauthorized body without json parse exception`` () =
+        withoutAuthEnv (fun () ->
+            withSingleHttpResponse 401 "Unauthorized" String.Empty (fun () ->
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Verbose"
+                                                      "auth"
+                                                      "whoami" |]
+
+                exitCode |> should not' (equal 0)
+                standardOut |> should contain "401 Unauthorized"
+                standardOut |> should contain "auth/me"
+
+                standardOut
+                |> should not' (contain "JsonException")
+
+                standardOut
+                |> should not' (contain "The input does not contain any JSON tokens")
+
+                standardError |> should equal String.Empty))
+
+    [<Test>]
+    let ``auth token create reports empty unauthorized body without json parse exception`` () =
+        let token = PersonalAccessToken.formatToken "user-1" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        clearOidcEnv (fun () ->
+            withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
+                withSingleHttpResponse 401 "Unauthorized" String.Empty (fun () ->
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Verbose"
+                                                          "auth"
+                                                          "token"
+                                                          "create"
+                                                          "--name"
+                                                          "local-dev"
+                                                          "--expires-in"
+                                                          "30d" |]
+
+                    exitCode |> should not' (equal 0)
+                    standardOut |> should contain "401 Unauthorized"
+                    standardOut |> should contain "auth/token/create"
+
+                    standardOut
+                    |> should not' (contain "JsonException")
+
+                    standardOut
+                    |> should not' (contain "The input does not contain any JSON tokens")
+
+                    standardError |> should equal String.Empty)))

--- a/src/Grace.SDK/Auth.SDK.fs
+++ b/src/Grace.SDK/Auth.SDK.fs
@@ -11,6 +11,30 @@ open System.Net.Http.Headers
 open System.Net.Http.Json
 open System.Threading.Tasks
 
+module ResponseErrors =
+
+    let private statusDescription (response: HttpResponseMessage) =
+        let reason =
+            if String.IsNullOrWhiteSpace response.ReasonPhrase then
+                response.StatusCode.ToString()
+            else
+                response.ReasonPhrase
+
+        $"{int response.StatusCode} {reason}"
+
+    let fromResponse (correlationId: string) (route: string) (response: HttpResponseMessage) =
+        task {
+            let! responseBody = response.Content.ReadAsStringAsync()
+
+            if String.IsNullOrWhiteSpace responseBody then
+                return GraceError.Create $"Server returned {statusDescription response} for {route} without an error body." correlationId
+            else
+                try
+                    return deserialize<GraceError> responseBody
+                with
+                | _ -> return GraceError.Create responseBody correlationId
+        }
+
 module Auth =
 
     type TokenProvider = unit -> Task<string option>
@@ -65,7 +89,7 @@ module Auth =
                         |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! graceError = response.Content.ReadFromJsonAsync<GraceError>(Constants.JsonSerializerOptions)
+                    let! graceError = ResponseErrors.fromResponse correlationId "auth/oidc/config" response
 
                     return
                         Error graceError

--- a/src/Grace.SDK/Common.SDK.fs
+++ b/src/Grace.SDK/Common.SDK.fs
@@ -59,7 +59,7 @@ module Common =
                         |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! graceError = response.Content.ReadFromJsonAsync<GraceError>(Constants.JsonSerializerOptions)
+                    let! graceError = ResponseErrors.fromResponse parameters.CorrelationId route response
 
                     return
                         Error graceError
@@ -114,23 +114,13 @@ module Common =
                         |> enhance "StatusCode" $"{response.StatusCode}"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! responseAsString = response.Content.ReadAsStringAsync()
+                    let! graceError = ResponseErrors.fromResponse parameters.CorrelationId route response
 
-                    try
-                        let graceError = deserialize<GraceError> (responseAsString)
-
-                        return
-                            Error graceError
-                            |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
-                            |> enhance "StatusCode" $"{response.StatusCode}"
-                            |> ClientIdentity.enhanceWithLifecycleDiagnostics response
-                    with
-                    | ex ->
-                        return
-                            Error(GraceError.Create $"{responseAsString}" parameters.CorrelationId)
-                            |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
-                            |> enhance "StatusCode" $"{response.StatusCode}"
-                            |> ClientIdentity.enhanceWithLifecycleDiagnostics response
+                    return
+                        Error graceError
+                        |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
+                        |> enhance "StatusCode" $"{response.StatusCode}"
+                        |> ClientIdentity.enhanceWithLifecycleDiagnostics response
             with
             | ex ->
                 let exceptionResponse = Utilities.ExceptionResponse.Create ex

--- a/src/Grace.SDK/PersonalAccessToken.SDK.fs
+++ b/src/Grace.SDK/PersonalAccessToken.SDK.fs
@@ -50,23 +50,13 @@ module PersonalAccessToken =
                         |> enhance "StatusCode" $"{response.StatusCode}"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! responseAsString = response.Content.ReadAsStringAsync()
+                    let! graceError = ResponseErrors.fromResponse parameters.CorrelationId route response
 
-                    try
-                        let graceError = deserialize<GraceError> responseAsString
-
-                        return
-                            Error graceError
-                            |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
-                            |> enhance "StatusCode" $"{response.StatusCode}"
-                            |> ClientIdentity.enhanceWithLifecycleDiagnostics response
-                    with
-                    | _ ->
-                        return
-                            Error(GraceError.Create $"{responseAsString}" parameters.CorrelationId)
-                            |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
-                            |> enhance "StatusCode" $"{response.StatusCode}"
-                            |> ClientIdentity.enhanceWithLifecycleDiagnostics response
+                    return
+                        Error graceError
+                        |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
+                        |> enhance "StatusCode" $"{response.StatusCode}"
+                        |> ClientIdentity.enhanceWithLifecycleDiagnostics response
             with
             | ex ->
                 let exceptionResponse = Utilities.ExceptionResponse.Create ex

--- a/src/Grace.Server.Unit.Tests/AuthSchemeSelection.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AuthSchemeSelection.Unit.Tests.fs
@@ -10,38 +10,56 @@ type AuthSchemeSelectionUnitTests() =
 
     let gracePatHeader = $"Bearer {TokenPrefix}user.token.secret"
 
-    let assertScheme (expected: string) isTesting hasOidc (authorization: string) =
-        Assert.That(AuthSchemeSelection.selectScheme isTesting hasOidc authorization, Is.EqualTo(expected))
+    let assertScheme (expected: string) isTesting hasOidc (authorization: string) (testUserId: string) =
+        Assert.That(AuthSchemeSelection.selectScheme isTesting hasOidc authorization testUserId, Is.EqualTo(expected))
 
     [<Test>]
-    member _.TestingModeWithNoAuthHeaderSelectsTestAuth() = assertScheme TestAuth.SchemeName true false null
+    member _.TestingModeWithNoAuthHeaderSelectsTestAuth() = assertScheme TestAuth.SchemeName true false null null
 
     [<Test>]
-    member _.TestingModeWithGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName true false gracePatHeader
+    member _.TestingModeWithGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName true false gracePatHeader null
 
     [<Test>]
-    member _.TestingModeWithNonPatBearerSelectsTestAuth() = assertScheme TestAuth.SchemeName true false "Bearer external-jwt-token"
+    member _.TestingModeWithGracePatBearerAndTestUserSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName true true gracePatHeader "debug-user"
 
     [<Test>]
-    member _.ProductionWithOidcAndNonPatBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true "Bearer external-jwt-token"
+    member _.TestingModeWithOidcAndNonPatBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme true true "Bearer external-jwt-token" null
 
     [<Test>]
-    member _.ProductionWithOidcAndGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName false true gracePatHeader
+    member _.TestingModeWithOidcAndNonPatBearerPlusTestUserSelectsJwt() =
+        assertScheme JwtBearerDefaults.AuthenticationScheme true true "Bearer external-jwt-token" "debug-user"
 
     [<Test>]
-    member _.ProductionWithOidcAndNoBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true null
+    member _.TestingModeWithNonPatBearerWithoutOidcSelectsPatAuth() =
+        assertScheme PersonalAccessTokenAuth.SchemeName true false "Bearer external-jwt-token" null
+
+    [<Test>]
+    member _.TestingModeWithExplicitTestUserSelectsTestAuth() = assertScheme TestAuth.SchemeName true false null "debug-user"
+
+    [<Test>]
+    member _.TestingModeWithNonPatBearerWithoutOidcAndExplicitTestUserSelectsTestAuth() =
+        assertScheme TestAuth.SchemeName true false "Bearer external-jwt-token" "debug-user"
+
+    [<Test>]
+    member _.ProductionWithOidcAndNonPatBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true "Bearer external-jwt-token" null
+
+    [<Test>]
+    member _.ProductionWithOidcAndGracePatBearerSelectsPatAuth() = assertScheme PersonalAccessTokenAuth.SchemeName false true gracePatHeader null
+
+    [<Test>]
+    member _.ProductionWithOidcAndNoBearerSelectsJwt() = assertScheme JwtBearerDefaults.AuthenticationScheme false true null null
 
     [<Test>]
     member _.ProductionWithoutOidcSelectsPat() =
-        assertScheme PersonalAccessTokenAuth.SchemeName false false "Bearer external-jwt-token"
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "Bearer external-jwt-token" null
 
-        assertScheme PersonalAccessTokenAuth.SchemeName false false null
+        assertScheme PersonalAccessTokenAuth.SchemeName false false null null
 
     [<Test>]
     member _.WhitespaceAndMalformedHeadersSelectExistingFallback() =
-        assertScheme TestAuth.SchemeName true false "   "
-        assertScheme TestAuth.SchemeName true false "Basic abc123"
-        assertScheme JwtBearerDefaults.AuthenticationScheme false true "   "
-        assertScheme JwtBearerDefaults.AuthenticationScheme false true "Basic abc123"
-        assertScheme PersonalAccessTokenAuth.SchemeName false false "   "
-        assertScheme PersonalAccessTokenAuth.SchemeName false false "Basic abc123"
+        assertScheme TestAuth.SchemeName true false "   " null
+        assertScheme TestAuth.SchemeName true false "Basic abc123" null
+        assertScheme JwtBearerDefaults.AuthenticationScheme false true "   " null
+        assertScheme JwtBearerDefaults.AuthenticationScheme false true "Basic abc123" null
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "Bearer    " null
+        assertScheme PersonalAccessTokenAuth.SchemeName false false "Basic abc123" null

--- a/src/Grace.Server/Security/AuthSchemeSelection.Server.fs
+++ b/src/Grace.Server/Security/AuthSchemeSelection.Server.fs
@@ -23,8 +23,25 @@ module AuthSchemeSelection =
         else
             false
 
-    let selectScheme (isTesting: bool) (hasOidc: bool) (authorization: string) =
-        if isGracePatBearer authorization then PersonalAccessTokenAuth.SchemeName
-        else if isTesting then TestAuth.SchemeName
-        else if hasOidc then JwtBearerDefaults.AuthenticationScheme
-        else PersonalAccessTokenAuth.SchemeName
+    let private hasBearerAuthorization (authorization: string) =
+        not (String.IsNullOrWhiteSpace authorization)
+        && authorization.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase)
+
+    let private hasExplicitTestUser (testUserId: string) = not (String.IsNullOrWhiteSpace testUserId)
+
+    let selectScheme (isTesting: bool) (hasOidc: bool) (authorization: string) (testUserId: string) =
+        if isGracePatBearer authorization then
+            PersonalAccessTokenAuth.SchemeName
+        elif hasBearerAuthorization authorization && hasOidc then
+            JwtBearerDefaults.AuthenticationScheme
+        elif isTesting && hasExplicitTestUser testUserId then
+            TestAuth.SchemeName
+        elif
+            isTesting
+            && not (hasBearerAuthorization authorization)
+        then
+            TestAuth.SchemeName
+        else if hasOidc then
+            JwtBearerDefaults.AuthenticationScheme
+        else
+            PersonalAccessTokenAuth.SchemeName

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1757,35 +1757,15 @@ module Application =
                     || value.Equals("true", StringComparison.OrdinalIgnoreCase)
                     || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
 
-            if isTesting then
-                services
-                    .AddAuthentication(fun options ->
-                        options.DefaultScheme <- "GraceAuth"
-                        options.DefaultChallengeScheme <- "GraceAuth")
-                    .AddPolicyScheme(
-                        "GraceAuth",
-                        "GraceAuth",
-                        fun options ->
-                            options.ForwardDefaultSelector <-
-                                fun context ->
-                                    let authorization = context.Request.Headers.Authorization.ToString()
-                                    AuthSchemeSelection.selectScheme true false authorization
-                    )
-                    .AddScheme<AuthenticationSchemeOptions, GraceTestAuthHandler>(TestAuth.SchemeName, (fun _ -> ()))
-                    .AddScheme<AuthenticationSchemeOptions, PersonalAccessTokenAuth.PersonalAccessTokenAuthHandler>(
-                        PersonalAccessTokenAuth.SchemeName,
-                        fun _ -> ()
-                    )
-                |> ignore
-            else
-                let oidcConfig = ExternalAuthConfig.tryGetOidcConfig configuration
-                let hasOidc = oidcConfig |> Option.isSome
+            let oidcConfig = ExternalAuthConfig.tryGetOidcConfig configuration
+            let hasOidc = oidcConfig |> Option.isSome
 
-                let authBuilder =
-                    services.AddAuthentication (fun options ->
-                        options.DefaultScheme <- "GraceAuth"
-                        options.DefaultChallengeScheme <- "GraceAuth")
+            let authBuilder =
+                services.AddAuthentication (fun options ->
+                    options.DefaultScheme <- "GraceAuth"
+                    options.DefaultChallengeScheme <- "GraceAuth")
 
+            let schemeBuilder =
                 authBuilder
                     .AddPolicyScheme(
                         "GraceAuth",
@@ -1794,33 +1774,45 @@ module Application =
                             options.ForwardDefaultSelector <-
                                 fun context ->
                                     let authorization = context.Request.Headers.Authorization.ToString()
-                                    AuthSchemeSelection.selectScheme false hasOidc authorization
+
+                                    let testUserId =
+                                        context
+                                            .Request
+                                            .Headers[ TestAuth.UserIdHeader ]
+                                            .ToString()
+
+                                    AuthSchemeSelection.selectScheme isTesting hasOidc authorization testUserId
                     )
                     .AddScheme<AuthenticationSchemeOptions, PersonalAccessTokenAuth.PersonalAccessTokenAuthHandler>(
                         PersonalAccessTokenAuth.SchemeName,
                         fun _ -> ()
                     )
+
+            if isTesting then
+                schemeBuilder.AddScheme<AuthenticationSchemeOptions, GraceTestAuthHandler>(TestAuth.SchemeName, (fun _ -> ()))
                 |> ignore
+            else
+                schemeBuilder |> ignore
 
-                match oidcConfig with
-                | Some config ->
-                    authBuilder.AddJwtBearer(
-                        JwtBearerDefaults.AuthenticationScheme,
-                        fun options ->
-                            options.Authority <- config.Authority
-                            options.Audience <- config.Audience
+            match oidcConfig with
+            | Some config ->
+                authBuilder.AddJwtBearer(
+                    JwtBearerDefaults.AuthenticationScheme,
+                    fun options ->
+                        options.Authority <- config.Authority
+                        options.Audience <- config.Audience
 
-                            options.TokenValidationParameters <-
-                                TokenValidationParameters(
-                                    ValidateIssuer = true,
-                                    ValidateAudience = true,
-                                    NameClaimType = "name",
-                                    RoleClaimType = "roles",
-                                    ValidAudience = config.Audience
-                                )
-                    )
-                    |> ignore
-                | None -> ()
+                        options.TokenValidationParameters <-
+                            TokenValidationParameters(
+                                ValidateIssuer = true,
+                                ValidateAudience = true,
+                                NameClaimType = "name",
+                                RoleClaimType = "roles",
+                                ValidAudience = config.Audience
+                            )
+                )
+                |> ignore
+            | None -> ()
 
             services.AddAuthorization (fun options ->
                 options.FallbackPolicy <-

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -65,17 +65,19 @@ Use this path when you want zero external auth for a new local environment:
 PowerShell:
 
 ```powershell
-pwsh ./scripts/start-debuglocal.ps1 -GraceServerUri "http://localhost:5000"
+pwsh ./scripts/start-debuglocal.ps1 -GraceServerUri "http://localhost:5000" -SkipAuthProbe
 ```
 
 bash / zsh:
 
 ```bash
-pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000"
+pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -SkipAuthProbe
 ```
 
 The script creates a PAT through explicit TestAuth headers so the first local SystemAdmin can get started without an
-OIDC tenant.
+OIDC tenant. `-SkipAuthProbe` is required for this true zero-OIDC path because the default preflight checks
+`/auth/oidc/config` before TestAuth PAT creation. Omit it when OIDC/MSA settings are configured and you want the script
+to verify `/auth/oidc/config` and `/auth/me` before creating the PAT.
 
 Use this path when the server has OIDC/MSA settings and you want normal interactive auth:
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -56,6 +56,12 @@ The script prints both the resolved bootstrap user and the source used.
 - if `GRACE_TESTING` is already set in your shell, the script keeps that value;
 - if unset, the script sets `GRACE_TESTING=1` for local TestAuth startup.
 
+Debug/TestAuth mode is additive when OIDC is configured. Grace PAT bearer tokens still use the `GracePat` scheme,
+interactive OIDC/MSA bearer tokens use JWT bearer validation, and explicit `x-grace-user-id` requests still use
+TestAuth for first-time local bootstrap. `GRACE_TOKEN` remains PAT-only; do not put OIDC access tokens in it.
+
+Use this path when you want zero external auth for a new local environment:
+
 PowerShell:
 
 ```powershell
@@ -67,6 +73,33 @@ bash / zsh:
 ```bash
 pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000"
 ```
+
+The script creates a PAT through explicit TestAuth headers so the first local SystemAdmin can get started without an
+OIDC tenant.
+
+Use this path when the server has OIDC/MSA settings and you want normal interactive auth:
+
+PowerShell:
+
+```powershell
+$env:GRACE_SERVER_URI="http://localhost:5000"
+grace auth login
+grace auth whoami --output Verbose
+grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+```
+
+bash / zsh:
+
+```bash
+export GRACE_SERVER_URI="http://localhost:5000"
+grace auth login
+grace auth whoami --output Verbose
+grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+```
+
+Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
+SystemAdmin assignment with `grace__authz__bootstrap__system_admin_users` or have an existing admin grant the needed
+role before PAT creation and other protected operations will succeed.
 
 ## DebugLocal Reliability Switches
 
@@ -190,7 +223,7 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 ### CLI / Client
 
 - `GRACE_SERVER_URI`: Grace server base URL (include port, omit trailing slash).
-- `GRACE_TOKEN`: PAT for non-interactive auth.
+- `GRACE_TOKEN`: Grace PAT for non-interactive auth. OIDC/MSA access tokens are not valid here.
 - `GRACE_TOKEN_FILE`: override for token file path.
 
 ### Reminders


### PR DESCRIPTION
## Summary

- Allows Debug/TestAuth mode to use normal OIDC/JWT bearer authentication when OIDC configuration exists, while preserving Grace PAT and explicit TestAuth paths.
- Improves auth client handling for empty-body 401 responses so CLI auth commands surface actionable errors instead of JSON parse exceptions.
- Updates Debug/local auth documentation for first-time TestAuth bootstrap and interactive OIDC/MSA bootstrap.

Closes #399

## Validation

- `dotnet tool restore`: passed after NuGet access; restored repo-pinned `fantomas-tool` `4.7.9`.
- `dotnet C:\Users\scott\.nuget\packages\fantomas-tool\4.7.9\tools\netcoreapp3.1\any\fantomas-tool.dll <touched F# files>`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~AuthSchemeSelection"`: passed, 13 tests.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "Name~empty"`: passed, 5 tests.
- `npx --yes markdownlint-cli2 "src/docs/ENVIRONMENT.md" "docs/Authentication.md" "src/Grace.Authorization.Tests/AGENTS.md"`: passed, 0 errors.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Fast test set reported Authorization 39, Types 96, Server.Unit 503, CLI 510; `Grace.Server.Tests` had no matches for the Fast filter.
- `git diff --check`: passed.
- GitHub Actions `full`: passed on `13b53cc9d233803977fce8f3d4edf6fc385821cc` in 5m45s.

Review fix validation:

- `npx --yes markdownlint-cli2 "AGENTS.md" "docs/Authentication.md" "docs/Development process.md" "src/AGENTS.md" "src/docs/ENVIRONMENT.md"`: passed, 0 errors.
- Focused/script/validate command: skipped because the review fix is docs-only; no script or F# behavior changed.
- `git diff --check`: passed.

## Review Status

- Implementation worker: completed in `C:\Source\Grace-gh-399` on `agent/399-debug-auth-oidc-testauth`.
- Worker bot-prevention self-review: completed over auth scheme precedence, mixed Authorization/TestAuth headers, missing OIDC config, PAT precedence, anonymous-token-creation avoidance, client-side header behavior, secret redaction, docs clarity, and formatter churn.
- Codex Code Review Bot: reviewed `fa0f616f64238547c65f4a1b09c21c498cbada5c` and opened one P2 finding in `docs/Authentication.md` line 142.
- Fix commit: `13b53cc9d233803977fce8f3d4edf6fc385821cc` updated zero-OIDC bootstrap docs to use `-SkipAuthProbe` and added the 120-second maximum sleep/poll command rule to agent docs.
- Bot finding response: replied to `discussion_r3410547567` with fix and validation evidence; conversation resolved.
- Final Codex Code Review Bot state: no-issues thumbs-up reaction observed on PR body for current head `13b53cc9d233803977fce8f3d4edf6fc385821cc`; no unresolved bot threads remain.

## Docs Impact

- Updated Debug/local auth guidance in `/docs`, including `src/docs/ENVIRONMENT.md` and `docs/Authentication.md`.
- Added project-local authorization-test guidance in `src/Grace.Authorization.Tests/AGENTS.md`.
- Updated `AGENTS.md`, `src/AGENTS.md`, and `docs/Development process.md` to state that agents must not sleep or poll for more than 120 seconds in one command.

## Residual Risk

- A live external OIDC/MSA token smoke was not run locally. Coverage is deterministic scheme selection, testing startup registration for JwtBearer when OIDC config exists, PAT/TestAuth precedence tests, and CLI empty-body 401 regression tests.
- Grace pins `fantomas-tool` `4.7.9`; avoid the user-global Fantomas `7.0.3` for this branch to prevent unrelated formatter churn.
