### PR TITLE
Use canonical authorization role names

### DIFF
--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -59,6 +59,59 @@ type AuthorizationSemanticsTests() =
         | Denied _ -> ()
         | Allowed reason -> Assert.Fail($"Expected Denied but got Allowed: {reason}")
 
+    let assertOperationAllowed roleId scope operation resource =
+        let result = checkPermission roleCatalog [ createAssignment scope roleId ] [] [ principal ] Set.empty operation resource
+
+        assertAllowed result
+
+    let assertOperationDenied roleId scope operation resource =
+        let result = checkPermission roleCatalog [ createAssignment scope roleId ] [] [ principal ] Set.empty operation resource
+
+        assertDenied result
+
+    [<Test>]
+    member _.RoleCatalogContainsOnlyCanonicalRoles() =
+        let expectedRoleIds =
+            [
+                "SystemAdmin"
+                "SystemOperator"
+                "SystemReader"
+                "OwnerAdmin"
+                "OwnerContributor"
+                "OwnerReader"
+                "OrganizationAdmin"
+                "OrganizationContributor"
+                "OrganizationReader"
+                "RepositoryAdmin"
+                "RepositoryContributor"
+                "RepositoryReader"
+                "BranchAdmin"
+                "BranchWriter"
+                "BranchReader"
+                "ApprovalResponder"
+            ]
+
+        let actualRoleIds = roleCatalog |> List.map (fun role -> role.RoleId)
+
+        Assert.That(actualRoleIds, Is.EquivalentTo expectedRoleIds)
+        Assert.That(actualRoleIds |> List.length, Is.EqualTo(expectedRoleIds.Length))
+
+    [<Test>]
+    member _.OldAbbreviatedRoleIdsAreUnknown() =
+        let oldRoleIds =
+            [
+                "OrgAdmin"
+                "OrgReader"
+                "RepoAdmin"
+                "RepoContributor"
+                "RepoReader"
+                "rEpOrEaDeR"
+                "oRgAdMiN"
+            ]
+
+        for roleId in oldRoleIds do
+            Assert.That(RoleCatalog.tryGet roleId |> Option.isNone, Is.True, $"Old role ID '{roleId}' should not be accepted.")
+
     [<Test>]
     member _.RoleCatalogMatrixMatchesPermissionChecks() =
         for role in roleCatalog do
@@ -78,40 +131,40 @@ type AuthorizationSemanticsTests() =
                         if expectedAllowed then assertAllowed result else assertDenied result
 
     [<Test>]
-    member _.RepoAdminIncludesBranchAdmin() =
-        let repoAdmin =
+    member _.RepositoryAdminIncludesBranchAdmin() =
+        let repositoryAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
-        Assert.That(repoAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
 
     [<Test>]
     member _.ApprovalOperationsUseConservativeRoleGrants() =
-        let repoAdmin =
+        let repositoryAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
-        let repoReader =
+        let repositoryReader =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoReader", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryReader", StringComparison.OrdinalIgnoreCase))
 
-        let repoContributor =
+        let repositoryContributor =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoContributor", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryContributor", StringComparison.OrdinalIgnoreCase))
 
         let responder =
             roleCatalog
             |> List.find (fun role -> role.RoleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase))
 
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains WebhookManage, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains WebhookDeliveryRead, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains WebhookManage, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains WebhookDeliveryRead, Is.True)
 
-        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
-        Assert.That(repoContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+        Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+        Assert.That(repositoryContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
 
         Assert.That(responder.AppliesTo.Contains("repository"), Is.True)
         Assert.That(responder.AppliesTo.Contains("branch"), Is.True)
@@ -120,11 +173,101 @@ type AuthorizationSemanticsTests() =
         Assert.That(responder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
 
     [<Test>]
+    member _.SystemOperatorHasDescendantAdminWriteReadButNoSystemAdmin() =
+        let systemScope = Scope.System
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "SystemOperator" systemScope SystemOperate Resource.System
+        assertOperationAllowed "SystemOperator" systemScope SystemRead Resource.System
+        assertOperationDenied "SystemOperator" systemScope SystemAdmin Resource.System
+
+        assertOperationAllowed "SystemOperator" systemScope OwnerAdmin ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OwnerWrite ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OwnerRead ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationAdmin organizationResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationWrite organizationResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationRead organizationResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryAdmin repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryWrite repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryRead repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope BranchAdmin branchResource
+        assertOperationAllowed "SystemOperator" systemScope BranchWrite branchResource
+        assertOperationAllowed "SystemOperator" systemScope BranchRead branchResource
+        assertOperationAllowed "SystemOperator" systemScope PathWrite pathResource
+        assertOperationAllowed "SystemOperator" systemScope PathRead pathResource
+
+    [<Test>]
+    member _.SystemReaderHasOnlySystemWideReadCoverage() =
+        let systemScope = Scope.System
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "SystemReader" systemScope SystemRead Resource.System
+        assertOperationDenied "SystemReader" systemScope SystemOperate Resource.System
+        assertOperationDenied "SystemReader" systemScope SystemAdmin Resource.System
+        assertOperationAllowed "SystemReader" systemScope OwnerRead ownerResource
+        assertOperationAllowed "SystemReader" systemScope OrganizationRead organizationResource
+        assertOperationAllowed "SystemReader" systemScope RepositoryRead repositoryResource
+        assertOperationAllowed "SystemReader" systemScope BranchRead branchResource
+        assertOperationAllowed "SystemReader" systemScope PathRead pathResource
+        assertOperationDenied "SystemReader" systemScope OwnerWrite ownerResource
+        assertOperationDenied "SystemReader" systemScope OrganizationWrite organizationResource
+        assertOperationDenied "SystemReader" systemScope RepositoryWrite repositoryResource
+        assertOperationDenied "SystemReader" systemScope BranchWrite branchResource
+        assertOperationDenied "SystemReader" systemScope PathWrite pathResource
+        assertOperationDenied "SystemReader" systemScope OwnerAdmin ownerResource
+        assertOperationDenied "SystemReader" systemScope OrganizationAdmin organizationResource
+        assertOperationDenied "SystemReader" systemScope RepositoryAdmin repositoryResource
+        assertOperationDenied "SystemReader" systemScope BranchAdmin branchResource
+
+    [<Test>]
+    member _.ContributorRolesWriteDescendantsWithoutAdminAuthority() =
+        let ownerScope = Scope.Owner ownerId
+        let organizationScope = Scope.Organization(ownerId, organizationId)
+        let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "OwnerContributor" ownerScope OwnerWrite ownerResource
+        assertOperationAllowed "OwnerContributor" ownerScope OrganizationWrite organizationResource
+        assertOperationAllowed "OwnerContributor" ownerScope RepositoryWrite repositoryResource
+        assertOperationAllowed "OwnerContributor" ownerScope BranchWrite branchResource
+        assertOperationAllowed "OwnerContributor" ownerScope PathWrite pathResource
+        assertOperationDenied "OwnerContributor" ownerScope OwnerAdmin ownerResource
+        assertOperationDenied "OwnerContributor" ownerScope OrganizationAdmin organizationResource
+        assertOperationDenied "OwnerContributor" ownerScope RepositoryAdmin repositoryResource
+        assertOperationDenied "OwnerContributor" ownerScope BranchAdmin branchResource
+
+        assertOperationAllowed "OrganizationContributor" organizationScope OrganizationWrite organizationResource
+        assertOperationAllowed "OrganizationContributor" organizationScope RepositoryWrite repositoryResource
+        assertOperationAllowed "OrganizationContributor" organizationScope BranchWrite branchResource
+        assertOperationAllowed "OrganizationContributor" organizationScope PathWrite pathResource
+        assertOperationDenied "OrganizationContributor" organizationScope OrganizationAdmin organizationResource
+        assertOperationDenied "OrganizationContributor" organizationScope RepositoryAdmin repositoryResource
+        assertOperationDenied "OrganizationContributor" organizationScope BranchAdmin branchResource
+
+        assertOperationAllowed "RepositoryContributor" repositoryScope RepositoryWrite repositoryResource
+        assertOperationAllowed "RepositoryContributor" repositoryScope BranchWrite branchResource
+        assertOperationAllowed "RepositoryContributor" repositoryScope PathWrite pathResource
+        assertOperationDenied "RepositoryContributor" repositoryScope RepositoryAdmin repositoryResource
+        assertOperationDenied "RepositoryContributor" repositoryScope BranchAdmin branchResource
+
+    [<Test>]
     member _.IrrelevantAssignmentsDoNotAffectDecision() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoAdmin"
+            let assignment = createAssignment scope "RepositoryAdmin"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
             let extraAssignment = { assignment with Principal = otherPrincipal }
@@ -140,10 +283,10 @@ type AuthorizationSemanticsTests() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoAdmin"
+            let assignment = createAssignment scope "RepositoryAdmin"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
-            let unrelatedAssignment = createAssignment (Scope.Branch(ownerId, organizationId, repositoryId, branchId)) "RepoAdmin"
+            let unrelatedAssignment = createAssignment (Scope.Branch(ownerId, organizationId, repositoryId, branchId)) "RepositoryAdmin"
 
             let withUnrelated = checkPermission roleCatalog [ unrelatedAssignment; assignment ] [] [ principal ] Set.empty operation resource
 
@@ -156,10 +299,10 @@ type AuthorizationSemanticsTests() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoReader"
+            let assignment = createAssignment scope "RepositoryReader"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
-            let mixedCaseAssignment = createAssignment scope "rEpOrEaDeR"
+            let mixedCaseAssignment = createAssignment scope "rEpOsItOrYrEaDeR"
 
             let withMixedCase = checkPermission roleCatalog [ mixedCaseAssignment ] [] [ principal ] Set.empty operation resource
 
@@ -176,8 +319,8 @@ type AuthorizationSemanticsTests() =
             | _ ->
                 let scope = Scope.Repository(ownerId, organizationId, repositoryId)
                 let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-                let baseAssignment = createAssignment scope "RepoReader"
-                let extraAssignment = createAssignment scope "RepoAdmin"
+                let baseAssignment = createAssignment scope "RepositoryReader"
+                let extraAssignment = createAssignment scope "RepositoryAdmin"
 
                 let baseResult = checkPermission roleCatalog [ baseAssignment ] [] [ principal ] Set.empty operation resource
 

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -235,7 +235,7 @@ type EndpointAuthorizationManifestTests() =
         [
             "POST", "/storage/discoverContentBlocks"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryRead, ResourceKind.Repository))
 
         [
             "POST", "/storage/claimReuseRanges"
@@ -269,7 +269,7 @@ type EndpointAuthorizationManifestTests() =
             "POST", "/work/links/remove/reference"
             "POST", "/work/update"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoWrite, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryWrite, ResourceKind.Repository))
 
         [
             "POST", "/work/get"
@@ -278,4 +278,4 @@ type EndpointAuthorizationManifestTests() =
             "POST", "/work/attachments/show"
             "POST", "/work/attachments/download"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryRead, ResourceKind.Repository))

--- a/src/Grace.Authorization.Tests/PermissionEvaluator.Tests.fs
+++ b/src/Grace.Authorization.Tests/PermissionEvaluator.Tests.fs
@@ -37,7 +37,7 @@ type PermissionEvaluatorTests() =
 
             let! _ =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, resource)
 
             let expected = scopesForResource resource
             Assert.That(capturedScopes, Is.EquivalentTo(expected))
@@ -48,7 +48,12 @@ type PermissionEvaluatorTests() =
         task {
             let getAssignmentsForScope (scope: Scope, _correlationId: CorrelationId) =
                 match scope with
-                | Scope.Organization _ -> Task.FromResult([ createAssignment scope "OrgAdmin" ])
+                | Scope.Organization _ ->
+                    Task.FromResult(
+                        [
+                            createAssignment scope "OrganizationAdmin"
+                        ]
+                    )
                 | _ -> Task.FromResult([])
 
             let evaluator = GracePermissionEvaluator(getAssignmentsForScope, emptyPathPermissions)
@@ -56,7 +61,7 @@ type PermissionEvaluatorTests() =
 
             let! result =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoWrite, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryWrite, resource)
 
             match result with
             | Allowed _ -> ()
@@ -78,7 +83,7 @@ type PermissionEvaluatorTests() =
 
             let! _ =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, repositoryResource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, repositoryResource)
 
             Assert.That(pathPermissionCalls, Is.EqualTo(0))
 
@@ -101,7 +106,7 @@ type PermissionEvaluatorTests() =
 
             let! result =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, resource)
 
             match result with
             | Denied _ -> ()

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -58,7 +58,7 @@ module CommandOutputContractRegistryTests =
         | "--fire-at" -> "2026-01-01T00:00:00Z"
         | "--format" -> "json"
         | "--gate" -> "build"
-        | "--operation" -> "RepoRead"
+        | "--operation" -> "RepositoryRead"
         | "--organization-type"
         | "--owner-type"
         | "--visibility" -> "Public"

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -156,7 +156,7 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "" ""
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "" ""
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
 
@@ -166,7 +166,7 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "User" userId
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "User" userId
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -178,7 +178,7 @@ type AccessCheckPermissionTests() =
             let groupId = $"{Guid.NewGuid()}"
             use client = createClient userId [ groupId ]
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "Group" groupId
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "Group" groupId
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -189,7 +189,8 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "User" $"{Guid.NewGuid()}"
+            let! response =
+                checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "User" $"{Guid.NewGuid()}"
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
@@ -316,18 +317,18 @@ type AccessControlSecurityTests() =
             let orgB = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = grantRoleAsync Client "org" ownerId orgA "" "" adminUser "OrgAdmin"
+            let! grantAdmin = grantRoleAsync Client "org" ownerId orgA "" "" adminUser "OrganizationAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = createClientWithUserId adminUser
 
-            let! allowed = grantRoleAsync adminClient "org" ownerId orgA "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! allowed = grantRoleAsync adminClient "org" ownerId orgA "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(allowed.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! forbidden = grantRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! forbidden = grantRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(forbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! revokeForbidden = revokeRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! revokeForbidden = revokeRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(revokeForbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
             let! listAllowed = listRoleAssignmentsAsync adminClient "org" ownerId orgA "" ""
@@ -346,18 +347,18 @@ type AccessControlSecurityTests() =
             let repoB = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId orgId repoA "" adminUser "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId orgId repoA "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = createClientWithUserId adminUser
 
-            let! allowed = grantRoleAsync adminClient "repo" ownerId orgId repoA "" $"{Guid.NewGuid()}" "RepoReader"
+            let! allowed = grantRoleAsync adminClient "repo" ownerId orgId repoA "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(allowed.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! forbidden = grantRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepoReader"
+            let! forbidden = grantRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(forbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! revokeForbidden = revokeRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepoReader"
+            let! revokeForbidden = revokeRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(revokeForbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
             let! listAllowed = listRoleAssignmentsAsync adminClient "repo" ownerId orgId repoA ""
@@ -409,20 +410,20 @@ type AccessControlSecurityTests() =
             let orgAdminUser = $"{Guid.NewGuid()}"
             let repoWriterUser = $"{Guid.NewGuid()}"
 
-            let! grantRepoAdmin = grantRoleAsync Client "repo" ownerId orgId repoId "" repoAdminUser "RepoAdmin"
-            Assert.That(grantRepoAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantRepositoryAdmin = grantRoleAsync Client "repo" ownerId orgId repoId "" repoAdminUser "RepositoryAdmin"
+            Assert.That(grantRepositoryAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantOrgAdmin = grantRoleAsync Client "org" ownerId orgId "" "" orgAdminUser "OrgAdmin"
-            Assert.That(grantOrgAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantOrganizationAdmin = grantRoleAsync Client "org" ownerId orgId "" "" orgAdminUser "OrganizationAdmin"
+            Assert.That(grantOrganizationAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantRepoWrite = grantRoleAsync Client "repo" ownerId orgId repoId "" repoWriterUser "RepoContributor"
-            Assert.That(grantRepoWrite.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantRepositoryWrite = grantRoleAsync Client "repo" ownerId orgId repoId "" repoWriterUser "RepositoryContributor"
+            Assert.That(grantRepositoryWrite.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use repoAdminClient = createClientWithUserId repoAdminUser
             use orgAdminClient = createClientWithUserId orgAdminUser
             use repoWriterClient = createClientWithUserId repoWriterUser
 
-            let! repoAdminCannotGrantOrg = grantRoleAsync repoAdminClient "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "OrgAdmin"
+            let! repoAdminCannotGrantOrg = grantRoleAsync repoAdminClient "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "OrganizationAdmin"
 
             Assert.That(repoAdminCannotGrantOrg.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
@@ -430,9 +431,9 @@ type AccessControlSecurityTests() =
 
             Assert.That(orgAdminCannotGrantOwner.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! repoWriterCannotGrantRepoAdmin = grantRoleAsync repoWriterClient "repo" ownerId orgId repoId "" $"{Guid.NewGuid()}" "RepoAdmin"
+            let! repoWriterCannotGrantRepositoryAdmin = grantRoleAsync repoWriterClient "repo" ownerId orgId repoId "" $"{Guid.NewGuid()}" "RepositoryAdmin"
 
-            Assert.That(repoWriterCannotGrantRepoAdmin.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+            Assert.That(repoWriterCannotGrantRepositoryAdmin.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
     [<Test>]
@@ -453,7 +454,7 @@ type AccessControlSecurityTests() =
             let ownerId = $"{Guid.NewGuid()}"
             let orgId = $"{Guid.NewGuid()}"
 
-            let! response = grantRoleAsync Client "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "RepoAdmin"
+            let! response = grantRoleAsync Client "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "RepositoryAdmin"
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
@@ -638,12 +639,12 @@ type AccessControl() =
             let nonAdminUserId = $"{Guid.NewGuid()}"
             use nonAdminClient = createClientWithUserId nonAdminUserId
 
-            do! grantRoleAsync Client ownerId orgA "" "org" "OrgAdmin" nonAdminUserId
-            do! grantRoleAsync Client ownerId orgB "" "org" "OrgReader" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgA "" "org" "OrganizationAdmin" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgB "" "org" "OrganizationReader" nonAdminUserId
 
-            let! repoAWrite = checkPermissionAsync nonAdminClient ownerId orgA repoA "repo" "RepoWrite" ""
-            let! repoBWrite = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepoWrite" ""
-            let! repoBRead = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepoRead" ""
+            let! repoAWrite = checkPermissionAsync nonAdminClient ownerId orgA repoA "repo" "RepositoryWrite" ""
+            let! repoBWrite = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepositoryWrite" ""
+            let! repoBRead = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepositoryRead" ""
 
             match repoAWrite with
             | Allowed _ -> ()
@@ -665,8 +666,8 @@ type AccessControl() =
             let! repositoryId = createRepositoryAsync Client organizationId
             let principalId = $"{Guid.NewGuid()}"
 
-            do! grantRoleAsync Client ownerId organizationId "" "org" "OrgAdmin" testUserId
-            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+            do! grantRoleAsync Client ownerId organizationId "" "org" "OrganizationAdmin" testUserId
+            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" principalId
 
             let! afterGrant = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
 
@@ -674,7 +675,7 @@ type AccessControl() =
                 afterGrant
                 |> List.tryFind (fun assignment ->
                     assignment.Principal.PrincipalId = principalId
-                    && assignment.RoleId = "RepoReader"
+                    && assignment.RoleId = "RepositoryReader"
                     && assignment.Source = "test")
 
             Assert.That(granted.IsSome, Is.True)
@@ -687,13 +688,13 @@ type AccessControl() =
             | other -> Assert.Fail($"Expected repository scope, got {other}.")
 
             use principalClient = createClientWithUserId principalId
-            let! allowedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+            let! allowedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepositoryRead" ""
 
             match allowedPermission with
-            | Allowed reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Allowed reason -> Assert.That(reason, Does.Contain("RepositoryRead"))
             | Denied reason -> Assert.Fail($"Expected repo read to be allowed after grant. {reason}")
 
-            do! revokeRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+            do! revokeRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" principalId
 
             let! afterRevoke = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
 
@@ -701,14 +702,14 @@ type AccessControl() =
                 afterRevoke
                 |> List.exists (fun assignment ->
                     assignment.Principal.PrincipalId = principalId
-                    && assignment.RoleId = "RepoReader")
+                    && assignment.RoleId = "RepositoryReader")
 
             Assert.That(stillPresent, Is.False)
 
-            let! deniedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+            let! deniedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepositoryRead" ""
 
             match deniedPermission with
-            | Denied reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Denied reason -> Assert.That(reason, Does.Contain("RepositoryRead"))
             | Allowed reason -> Assert.Fail($"Expected repo read to be denied after revoke. {reason}")
         }
 
@@ -718,7 +719,7 @@ type AccessControl() =
             let! organizationId = createOrganizationAsync Client
             let! repositoryId = createRepositoryAsync Client organizationId
 
-            do! grantRoleAsync Client ownerId organizationId "" "org" "OrgAdmin" testUserId
+            do! grantRoleAsync Client ownerId organizationId "" "org" "OrganizationAdmin" testUserId
 
             do!
                 upsertPathPermissionAsync
@@ -770,7 +771,7 @@ type AccessControl() =
             let! deniedResponse = nonAdminClient.PostAsync("/repository/setDescription", createJsonContent parameters)
             Assert.That(deniedResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            do! grantRoleAsync Client ownerId orgId "" "org" "OrgAdmin" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgId "" "org" "OrganizationAdmin" nonAdminUserId
 
             let! allowedResponse = nonAdminClient.PostAsync("/repository/setDescription", createJsonContent parameters)
             Assert.That(allowedResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -782,7 +783,7 @@ type AccessControl() =
             let! orgId = createOrganizationAsync Client
             let! repoId = createRepositoryAsync Client orgId
 
-            do! grantRoleAsync Client ownerId orgId "" "org" "OrgAdmin" testUserId
+            do! grantRoleAsync Client ownerId orgId "" "org" "OrganizationAdmin" testUserId
 
             do!
                 upsertPathPermissionAsync
@@ -838,7 +839,7 @@ type AccessControl() =
                 (deserialize<GraceReturnValue<Grace.Types.Branch.BranchDto>> branchBody)
                     .ReturnValue
 
-            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" testUserId
+            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" testUserId
 
             do! upsertPathPermissionAsync Client ownerId organizationId repositoryId "sensitive/secret.txt" [ ("engineering", "NoAccess") ]
 
@@ -901,7 +902,7 @@ type AccessControl() =
             parameters.ScopeKind <- "owner"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- testUserId
-            parameters.RoleId <- "RepoAdmin"
+            parameters.RoleId <- "RepositoryAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
@@ -956,7 +957,7 @@ type AccessControl() =
             parameters.OrganizationId <- organizationId
             parameters.RepositoryId <- repositoryIds[0]
             parameters.ResourceKind <- "repo"
-            parameters.Operation <- "RepoRead"
+            parameters.Operation <- "RepositoryRead"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- "other-user"
             parameters.CorrelationId <- generateCorrelationId ()
@@ -976,7 +977,7 @@ type AccessControl() =
             parameters.OrganizationId <- organizationId
             parameters.RepositoryId <- repositoryIds[0]
             parameters.ResourceKind <- "repo"
-            parameters.Operation <- "RepoRead"
+            parameters.Operation <- "RepositoryRead"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- nonAdminUserId
             parameters.CorrelationId <- generateCorrelationId ()
@@ -1287,10 +1288,10 @@ type EndpointAuthorizationTests() =
             let orgReader = $"{Guid.NewGuid()}"
             let orgAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "org" ownerId organizationId "" "" orgReader "OrgReader"
+            let! grantReader = grantRoleAsync Client "org" ownerId organizationId "" "" orgReader "OrganizationReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "org" ownerId organizationId "" "" orgAdmin "OrgAdmin"
+            let! grantAdmin = grantRoleAsync Client "org" ownerId organizationId "" "" orgAdmin "OrganizationAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1327,10 +1328,10 @@ type EndpointAuthorizationTests() =
             let repoReader = $"{Guid.NewGuid()}"
             let repoAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoAdmin "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoAdmin "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1361,16 +1362,16 @@ type EndpointAuthorizationTests() =
         }
 
     [<Test>]
-    member _.WorkCreateRequiresRepoWrite() =
+    member _.WorkCreateRequiresRepositoryWrite() =
         task {
             let repositoryId = repositoryIds[0]
             let repoReader = $"{Guid.NewGuid()}"
             let repoWriter = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1400,13 +1401,13 @@ type EndpointAuthorizationTests() =
             let branchWriter = $"{Guid.NewGuid()}"
             let branchAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchAdmin "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchAdmin "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1462,10 +1463,10 @@ type EndpointAuthorizationTests() =
             let pathReader = $"{Guid.NewGuid()}"
             let pathWriter = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -204,7 +204,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -282,7 +282,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "ApprovalResponder"
@@ -365,7 +365,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -386,7 +386,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -418,7 +418,7 @@ type ApprovalApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -454,7 +454,7 @@ type ApprovalApiIntegrationTests() =
             let adminUser = $"{Guid.NewGuid()}"
             let limitedUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -485,7 +485,7 @@ type ApprovalApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -652,7 +652,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepoReader"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepositoryReader"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId

--- a/src/Grace.Server.Tests/Repository.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Repository.Server.Tests.fs
@@ -28,7 +28,7 @@ type Repository() =
             .Create(fun builder -> builder.AddConsole().AddDebug() |> ignore)
             .CreateLogger("RepositoryTests")
 
-    let grantRepoAdminAsync repositoryId =
+    let grantRepositoryAdminAsync repositoryId =
         task {
             let parameters = Parameters.Access.GrantRoleParameters()
             parameters.OwnerId <- ownerId
@@ -37,7 +37,7 @@ type Repository() =
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- testUserId
             parameters.ScopeKind <- "repo"
-            parameters.RoleId <- "RepoAdmin"
+            parameters.RoleId <- "RepositoryAdmin"
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
@@ -94,7 +94,7 @@ type Repository() =
             parameters.RepositoryId <- repositoryId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync parameters.RepositoryId
+            do! grantRepositoryAdminAsync parameters.RepositoryId
 
             let! response = Client.PostAsync("/repository/setDescription", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
@@ -136,7 +136,7 @@ type Repository() =
             validParameters.Description <- baseline
             validParameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync repositoryId
+            do! grantRepositoryAdminAsync repositoryId
 
             let! validResponse = Client.PostAsync("/repository/setDescription", createJsonContent validParameters)
             validResponse.EnsureSuccessStatusCode() |> ignore
@@ -324,7 +324,7 @@ type Repository() =
             parameters.Visibility <- "Public"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync repositoryId
+            do! grantRepositoryAdminAsync repositoryId
 
             let! response = Client.PostAsync("/repository/setVisibility", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -188,7 +188,7 @@ type StorageContentBlockSasRoutes() =
             let repositoryId = repositoryIds[0]
             let pathWriter = $"{Guid.NewGuid()}"
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -213,7 +213,7 @@ type StorageContentBlockSasRoutes() =
             let repositoryId = repositoryIds[0]
             let pathReader = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -318,7 +318,7 @@ type StorageContentBlockDiscoveryRoutes() =
                     $"chunk-{Guid.NewGuid():N}"
                 |]
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -395,7 +395,7 @@ type StorageContentBlockDiscoveryRoutes() =
             let repoReader = $"{Guid.NewGuid()}"
             let requestedChunkAddresses = Array.init (maxDiscoveryKeyChunkAddresses + 1) (fun index -> $"chunk-{index}-{Guid.NewGuid():N}")
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use readerClient = createClientWithUserId repoReader

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -158,7 +158,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -275,7 +275,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -354,7 +354,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -373,7 +373,7 @@ type WebhookApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -408,7 +408,7 @@ type WebhookApiIntegrationTests() =
             let adminUser = $"{Guid.NewGuid()}"
             let limitedUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser

--- a/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
@@ -935,10 +935,10 @@ type WorkItemLinksAuthorizationIntegrationTests() =
             let repoAdmin = $"{Guid.NewGuid()}"
             let crossRepoPrincipal = $"{Guid.NewGuid()}"
 
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoAdmin "RepoAdmin"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepositoryReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepositoryContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoAdmin "RepositoryAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepositoryAdmin"
 
             use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
             use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
@@ -1079,9 +1079,9 @@ type WorkItemLinksAuthorizationIntegrationTests() =
             let repoWriter = $"{Guid.NewGuid()}"
             let crossRepoPrincipal = $"{Guid.NewGuid()}"
 
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepositoryReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepositoryContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepositoryAdmin"
 
             use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
             use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"

--- a/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
@@ -27,7 +27,7 @@ type AuthorizationUnit() =
         | Allowed reason -> Assert.Fail($"Expected Denied but got Allowed: {reason}")
 
     [<Test>]
-    member _.RoleInheritanceAllowsRepoWriteFromOrgAdmin() =
+    member _.RoleInheritanceAllowsRepositoryWriteFromOrganizationAdmin() =
         let ownerId = Guid.NewGuid()
         let organizationId = Guid.NewGuid()
         let repositoryId = Guid.NewGuid()
@@ -36,11 +36,18 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgAdmin"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationAdmin"
             ]
 
         let result =
-            checkPermission roleCatalog assignments [] [ principal ] Set.empty Operation.RepoWrite (Resource.Repository(ownerId, organizationId, repositoryId))
+            checkPermission
+                roleCatalog
+                assignments
+                []
+                [ principal ]
+                Set.empty
+                Operation.RepositoryWrite
+                (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertAllowed result
 
@@ -54,7 +61,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgAdmin"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationAdmin"
             ]
 
         let denyPermissions = List<ClaimPermission>()
@@ -87,7 +94,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgReader"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationReader"
             ]
 
         let allowPermissions = List<ClaimPermission>()
@@ -118,7 +125,8 @@ type AuthorizationUnit() =
 
         let principal = { PrincipalType = PrincipalType.User; PrincipalId = "user-4" }
 
-        let result = checkPermission roleCatalog [] [] [ principal ] Set.empty Operation.RepoRead (Resource.Repository(ownerId, organizationId, repositoryId))
+        let result =
+            checkPermission roleCatalog [] [] [ principal ] Set.empty Operation.RepositoryRead (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertDenied result
 
@@ -133,7 +141,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment groupPrincipal (Scope.Repository(ownerId, organizationId, repositoryId)) "RepoReader"
+                createAssignment groupPrincipal (Scope.Repository(ownerId, organizationId, repositoryId)) "RepositoryReader"
             ]
 
         let result =
@@ -143,15 +151,15 @@ type AuthorizationUnit() =
                 []
                 [ userPrincipal; groupPrincipal ]
                 Set.empty
-                Operation.RepoRead
+                Operation.RepositoryRead
                 (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertAllowed result
 
     [<Test>]
-    member _.RepoAdminIncludesBranchAdmin() =
+    member _.RepositoryAdminIncludesBranchAdmin() =
         let repoAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(repoAdmin.AllowedOperations.Contains Operation.BranchAdmin, Is.True)

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -64,18 +64,18 @@ module Access =
         match scope with
         | Scope.System -> Operation.SystemAdmin
         | Scope.Owner _ -> Operation.OwnerAdmin
-        | Scope.Organization _ -> Operation.OrgAdmin
-        | Scope.Repository _ -> Operation.RepoAdmin
+        | Scope.Organization _ -> Operation.OrganizationAdmin
+        | Scope.Repository _ -> Operation.RepositoryAdmin
         | Scope.Branch _ -> Operation.BranchAdmin
 
     let private adminOperationForResource (resource: Resource) =
         match resource with
         | Resource.System -> Operation.SystemAdmin
         | Resource.Owner _ -> Operation.OwnerAdmin
-        | Resource.Organization _ -> Operation.OrgAdmin
-        | Resource.Repository _ -> Operation.RepoAdmin
+        | Resource.Organization _ -> Operation.OrganizationAdmin
+        | Resource.Repository _ -> Operation.RepositoryAdmin
         | Resource.Branch _ -> Operation.BranchAdmin
-        | Resource.Path (ownerId, organizationId, repositoryId, _relativePath) -> Operation.RepoAdmin
+        | Resource.Path (ownerId, organizationId, repositoryId, _relativePath) -> Operation.RepositoryAdmin
 
     let private authorize (context: HttpContext) (operation: Operation) (resource: Resource) =
         task {
@@ -406,7 +406,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason
@@ -432,7 +432,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason
@@ -461,7 +461,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -27,12 +27,12 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/" AllowAnonymous
             endpoint "POST" "/access/checkPermission" Authenticated
             endpoint "POST" "/access/grantRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/listPathPermissions" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/listPathPermissions" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/access/listRoleAssignments" (Authorized(SystemAdmin, System))
             endpoint "GET" "/access/listRoles" Authenticated
-            endpoint "POST" "/access/removePathPermission" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/removePathPermission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/access/revokeRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
@@ -67,11 +67,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/auth/token/create" Authenticated
             endpoint "POST" "/auth/token/list" Authenticated
             endpoint "POST" "/auth/token/revoke" Authenticated
-            endpoint "POST" "/agent/session/active" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/listActive" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/start" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/agent/session/status" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/stop" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/agent/session/active" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/listActive" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/agent/session/status" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/stop" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/branch/assign" Authenticated
             endpoint
                 "POST"
@@ -125,8 +125,8 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/validation-set/update" Authenticated
             endpoint "POST" "/validation-set/delete" Authenticated
             endpoint "POST" "/validation-result/record" Authenticated
-            endpoint "POST" "/artifact/create" (Authorized(RepoWrite, Repository))
-            endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/artifact/create" (Authorized(RepositoryWrite, Repository))
+            endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/diff/getDiff" Authenticated
             endpoint "POST" "/diff/getDiffBySha256Hash" Authenticated
             endpoint "POST" "/diff/populate" Authenticated
@@ -140,10 +140,10 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/healthz" AllowAnonymous
             endpoint "POST" "/organization/create" Authenticated
             endpoint "POST" "/organization/delete" Authenticated
-            endpoint "POST" "/organization/get" (Authorized(OrgRead, Organization))
+            endpoint "POST" "/organization/get" (Authorized(OrganizationRead, Organization))
             endpoint "POST" "/organization/listRepositories" Authenticated
             endpoint "POST" "/organization/setDescription" Authenticated
-            endpoint "POST" "/organization/setName" (Authorized(OrgAdmin, Organization))
+            endpoint "POST" "/organization/setName" (Authorized(OrganizationAdmin, Organization))
             endpoint "POST" "/organization/setSearchVisibility" Authenticated
             endpoint "POST" "/organization/setType" Authenticated
             endpoint "POST" "/organization/undelete" Authenticated
@@ -173,7 +173,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/repository/create" Authenticated
             endpoint "POST" "/repository/delete" Authenticated
             endpoint "POST" "/repository/exists" Authenticated
-            endpoint "POST" "/repository/get" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/repository/get" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/repository/getBranches" Authenticated
             endpoint "POST" "/repository/getBranchesByBranchId" Authenticated
             endpoint "POST" "/repository/getReferencesByReferenceId" Authenticated
@@ -191,7 +191,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/repository/setRecordSaves" Authenticated
             endpoint "POST" "/repository/setSaveDays" Authenticated
             endpoint "POST" "/repository/setStatus" Authenticated
-            endpoint "POST" "/repository/setVisibility" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/repository/setVisibility" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/repository/undelete" Authenticated
             endpoint "POST" "/review/checkpoint" Authenticated
             endpoint "POST" "/review/candidate/attestations" Authenticated
@@ -208,7 +208,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/getDownloadUri" (Authorized(PathRead, Path))
             endpoint "POST" "/storage/claimReuseRanges" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/confirmContentBlockUpload" (Authorized(PathWrite, Path))
-            endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/storage/finalizeManifestUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getContentBlockDownloadUri" (Authorized(PathRead, Path))
             endpoint "POST" "/storage/getContentBlockUploadUri" (Authorized(PathWrite, Path))
@@ -217,21 +217,21 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/issueDedupeDiscovery" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
-            endpoint "POST" "/work/create" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/add-summary" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/get" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/link/artifact" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/link/promotion-set" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/link/reference" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/list" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/list" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/show" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/download" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/links/remove/artifact" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/artifact-type" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/promotion-set" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/reference" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/update" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/create" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/add-summary" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/get" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/link/artifact" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/link/promotion-set" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/link/reference" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/list" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/list" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/show" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/download" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/links/remove/artifact" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/artifact-type" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/promotion-set" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/reference" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/update" (Authorized(RepositoryWrite, Repository))
             endpoint "GET" "/metrics" (Authorized(SystemAdmin, System))
             endpoint "GET" "/notifications" Authenticated
         ]

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -147,7 +147,8 @@ module Application =
                     | _ -> Error(GraceError.Create $"{queryParameterName} is required." correlationId)
 
                 match tryGetQueryGuid "ownerId", tryGetQueryGuid "organizationId", tryGetQueryGuid "repositoryId" with
-                | Ok ownerId, Ok organizationId, Ok repositoryId -> return Ok(Operation.RepoRead, Resource.Repository(ownerId, organizationId, repositoryId))
+                | Ok ownerId, Ok organizationId, Ok repositoryId ->
+                    return Ok(Operation.RepositoryRead, Resource.Repository(ownerId, organizationId, repositoryId))
                 | Error error, _, _
                 | _, Error error, _
                 | _, _, Error error -> return Error error
@@ -277,17 +278,17 @@ module Application =
 
         let requireOwnerRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerRead ownerResourceFromContext
 
-        let requireOrgAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrgAdmin organizationResourceFromContext
+        let requireOrganizationAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationAdmin organizationResourceFromContext
 
-        let requireOrgRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrgRead organizationResourceFromContext
+        let requireOrganizationRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationRead organizationResourceFromContext
 
-        let requireRepoAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoAdmin repositoryResourceFromContext
+        let requireRepositoryAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryAdmin repositoryResourceFromContext
 
-        let requireRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoRead repositoryResourceFromContext
+        let requireRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryRead repositoryResourceFromContext
 
-        let requireRepoWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoWrite repositoryResourceFromContext
+        let requireRepositoryWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryWrite repositoryResourceFromContext
 
-        let requireArtifactRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
+        let requireArtifactRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
 
         let requireBranchAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchAdmin branchResourceFromContext
 
@@ -1181,7 +1182,7 @@ module Application =
                                route "/delete" Organization.Delete
                                |> addMetadata typeof<Organization.DeleteOrganizationParameters>
 
-                               route "/get" (composeHandlers requireOrgRead Organization.Get)
+                               route "/get" (composeHandlers requireOrganizationRead Organization.Get)
                                |> addMetadata typeof<Organization.GetOrganizationParameters>
 
                                route "/listRepositories" Organization.ListRepositories
@@ -1190,7 +1191,7 @@ module Application =
                                route "/setDescription" Organization.SetDescription
                                |> addMetadata typeof<Organization.SetOrganizationDescriptionParameters>
 
-                               route "/setName" (composeHandlers requireOrgAdmin Organization.SetName)
+                               route "/setName" (composeHandlers requireOrganizationAdmin Organization.SetName)
                                |> addMetadata typeof<Organization.SetOrganizationNameParameters>
 
                                route "/setSearchVisibility" Organization.SetSearchVisibility
@@ -1235,67 +1236,67 @@ module Application =
                 subRoute
                     "/agent"
                     [
-                        POST [ route "/session/start" (composeHandlers requireRepoWrite startAgentSession)
+                        POST [ route "/session/start" (composeHandlers requireRepositoryWrite startAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.StartAgentSessionParameters>
 
-                               route "/session/stop" (composeHandlers requireRepoWrite stopAgentSession)
+                               route "/session/stop" (composeHandlers requireRepositoryWrite stopAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.StopAgentSessionParameters>
 
-                               route "/session/status" (composeHandlers requireRepoRead getAgentSessionStatus)
+                               route "/session/status" (composeHandlers requireRepositoryRead getAgentSessionStatus)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.GetAgentSessionStatusParameters>
 
-                               route "/session/active" (composeHandlers requireRepoRead getActiveAgentSession)
+                               route "/session/active" (composeHandlers requireRepositoryRead getActiveAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.GetActiveAgentSessionParameters>
 
-                               route "/session/listActive" (composeHandlers requireRepoRead listActiveAgentSessions)
+                               route "/session/listActive" (composeHandlers requireRepositoryRead listActiveAgentSessions)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.ListActiveAgentSessionsParameters> ]
                     ]
                 subRoute
                     "/work"
                     [
-                        POST [ route "/create" (composeHandlers requireRepoWrite WorkItem.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWrite WorkItem.Create)
                                |> addMetadata typeof<WorkItem.CreateWorkItemParameters>
 
-                               route "/get" (composeHandlers requireRepoRead WorkItem.Get)
+                               route "/get" (composeHandlers requireRepositoryRead WorkItem.Get)
                                |> addMetadata typeof<WorkItem.GetWorkItemParameters>
 
-                               route "/update" (composeHandlers requireRepoWrite WorkItem.Update)
+                               route "/update" (composeHandlers requireRepositoryWrite WorkItem.Update)
                                |> addMetadata typeof<WorkItem.UpdateWorkItemParameters>
 
-                               route "/add-summary" (composeHandlers requireRepoWrite WorkItem.AddSummary)
+                               route "/add-summary" (composeHandlers requireRepositoryWrite WorkItem.AddSummary)
                                |> addMetadata typeof<WorkItem.AddSummaryParameters>
 
-                               route "/link/reference" (composeHandlers requireRepoWrite WorkItem.LinkReference)
+                               route "/link/reference" (composeHandlers requireRepositoryWrite WorkItem.LinkReference)
                                |> addMetadata typeof<WorkItem.LinkReferenceParameters>
 
-                               route "/link/artifact" (composeHandlers requireRepoWrite WorkItem.LinkArtifact)
+                               route "/link/artifact" (composeHandlers requireRepositoryWrite WorkItem.LinkArtifact)
                                |> addMetadata typeof<WorkItem.LinkArtifactParameters>
 
-                               route "/link/promotion-set" (composeHandlers requireRepoWrite WorkItem.LinkPromotionSet)
+                               route "/link/promotion-set" (composeHandlers requireRepositoryWrite WorkItem.LinkPromotionSet)
                                |> addMetadata typeof<WorkItem.LinkPromotionSetParameters>
 
-                               route "/links/list" (composeHandlers requireRepoRead WorkItem.GetLinks)
+                               route "/links/list" (composeHandlers requireRepositoryRead WorkItem.GetLinks)
                                |> addMetadata typeof<WorkItem.GetWorkItemLinksParameters>
 
-                               route "/attachments/list" (composeHandlers requireRepoRead WorkItem.ListAttachments)
+                               route "/attachments/list" (composeHandlers requireRepositoryRead WorkItem.ListAttachments)
                                |> addMetadata typeof<WorkItem.ListWorkItemAttachmentsParameters>
 
-                               route "/attachments/show" (composeHandlers requireRepoRead WorkItem.ShowAttachment)
+                               route "/attachments/show" (composeHandlers requireRepositoryRead WorkItem.ShowAttachment)
                                |> addMetadata typeof<WorkItem.ShowWorkItemAttachmentParameters>
 
-                               route "/attachments/download" (composeHandlers requireRepoRead WorkItem.DownloadAttachment)
+                               route "/attachments/download" (composeHandlers requireRepositoryRead WorkItem.DownloadAttachment)
                                |> addMetadata typeof<WorkItem.DownloadWorkItemAttachmentParameters>
 
-                               route "/links/remove/reference" (composeHandlers requireRepoWrite WorkItem.RemoveReferenceLink)
+                               route "/links/remove/reference" (composeHandlers requireRepositoryWrite WorkItem.RemoveReferenceLink)
                                |> addMetadata typeof<WorkItem.RemoveReferenceLinkParameters>
 
-                               route "/links/remove/promotion-set" (composeHandlers requireRepoWrite WorkItem.RemovePromotionSetLink)
+                               route "/links/remove/promotion-set" (composeHandlers requireRepositoryWrite WorkItem.RemovePromotionSetLink)
                                |> addMetadata typeof<WorkItem.RemovePromotionSetLinkParameters>
 
-                               route "/links/remove/artifact" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactLink)
+                               route "/links/remove/artifact" (composeHandlers requireRepositoryWrite WorkItem.RemoveArtifactLink)
                                |> addMetadata typeof<WorkItem.RemoveArtifactLinkParameters>
 
-                               route "/links/remove/artifact-type" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactTypeLinks)
+                               route "/links/remove/artifact-type" (composeHandlers requireRepositoryWrite WorkItem.RemoveArtifactTypeLinks)
                                |> addMetadata typeof<WorkItem.RemoveArtifactTypeLinksParameters> ]
                     ]
                 subRoute
@@ -1418,10 +1419,10 @@ module Application =
                 subRoute
                     "/artifact"
                     [
-                        POST [ route "/create" (composeHandlers requireRepoWrite Artifact.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWrite Artifact.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Artifact.CreateArtifactParameters> ]
 
-                        GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepoRead (Artifact.GetDownloadUri artifactId)) ]
+                        GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepositoryRead (Artifact.GetDownloadUri artifactId)) ]
                     ]
                 subRoute
                     "/repository"
@@ -1429,13 +1430,13 @@ module Application =
                         POST [ route "/create" Repository.Create
                                |> addMetadata typeof<Repository.CreateRepositoryParameters>
 
-                               route "/delete" (composeHandlers requireRepoAdmin Repository.Delete)
+                               route "/delete" (composeHandlers requireRepositoryAdmin Repository.Delete)
                                |> addMetadata typeof<Repository.DeleteRepositoryParameters>
 
                                route "/exists" Repository.Exists
                                |> addMetadata typeof<Repository.RepositoryParameters>
 
-                               route "/get" (composeHandlers requireRepoRead Repository.Get)
+                               route "/get" (composeHandlers requireRepositoryRead Repository.Get)
                                |> addMetadata typeof<Repository.RepositoryParameters>
 
                                route "/getBranches" Repository.GetBranches
@@ -1471,7 +1472,7 @@ module Application =
                                route "/setConflictResolutionPolicy" Repository.SetConflictResolutionPolicy
                                |> addMetadata typeof<Repository.SetConflictResolutionPolicyParameters>
 
-                               route "/setDescription" (composeHandlers requireRepoAdmin Repository.SetDescription)
+                               route "/setDescription" (composeHandlers requireRepositoryAdmin Repository.SetDescription)
                                |> addMetadata typeof<Repository.SetRepositoryDescriptionParameters>
 
                                route "/setLogicalDeleteDays" Repository.SetLogicalDeleteDays
@@ -1489,7 +1490,7 @@ module Application =
                                route "/setStatus" Repository.SetStatus
                                |> addMetadata typeof<Repository.SetRepositoryStatusParameters>
 
-                               route "/setVisibility" (composeHandlers requireRepoAdmin Repository.SetVisibility)
+                               route "/setVisibility" (composeHandlers requireRepositoryAdmin Repository.SetVisibility)
                                |> addMetadata typeof<Repository.SetRepositoryVisibilityParameters>
 
                                route "/undelete" Repository.Undelete
@@ -1501,7 +1502,7 @@ module Application =
                         POST [ route "/getUploadMetadataForFiles" (composeHandlers requirePathWrite Storage.GetUploadMetadataForFiles)
                                |> addMetadata typeof<Storage.GetUploadMetadataForFilesParameters>
 
-                               route "/discoverContentBlocks" (composeHandlers requireRepoRead Storage.DiscoverContentBlocks)
+                               route "/discoverContentBlocks" (composeHandlers requireRepositoryRead Storage.DiscoverContentBlocks)
                                |> addMetadata typeof<Storage.DiscoverContentBlocksParameters>
 
                                route "/startManifestUploadSession" (composeHandlers requirePathWriteForUploadSession Storage.StartManifestUploadSession)

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -17,35 +17,74 @@ module Authorization =
 
         let private systemAdminOperations =
             set [ SystemAdmin
+                  SystemOperate
+                  SystemRead
                   OwnerAdmin
+                  OwnerWrite
                   OwnerRead
-                  OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoRead
-                  RepoWrite
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   BranchAdmin
-                  BranchRead
                   BranchWrite
+                  BranchRead
                   PathRead
                   PathWrite
                   ApprovalPolicyManage
                   ApprovalRequestRead
                   ApprovalRequestRespond
                   WebhookManage
+                  WebhookDeliveryRead ]
+
+        let private systemOperatorOperations =
+            set [ SystemOperate
+                  SystemRead
+                  OwnerAdmin
+                  OwnerWrite
+                  OwnerRead
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
+                  BranchAdmin
+                  BranchWrite
+                  BranchRead
+                  PathRead
+                  PathWrite
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
+
+        let private systemReaderOperations =
+            set [ SystemRead
+                  OwnerRead
+                  OrganizationRead
+                  RepositoryRead
+                  BranchRead
+                  PathRead
+                  ApprovalRequestRead
                   WebhookDeliveryRead ]
 
         let private ownerAdminOperations =
             set [ OwnerAdmin
+                  OwnerWrite
                   OwnerRead
-                  OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoRead
-                  RepoWrite
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   BranchAdmin
-                  BranchRead
                   BranchWrite
+                  BranchRead
                   PathRead
                   PathWrite
                   ApprovalPolicyManage
@@ -53,20 +92,33 @@ module Authorization =
                   ApprovalRequestRespond
                   WebhookManage
                   WebhookDeliveryRead ]
+
+        let private ownerContributorOperations =
+            set [ OwnerWrite
+                  OwnerRead
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryWrite
+                  RepositoryRead
+                  BranchWrite
+                  BranchRead
+                  PathWrite
+                  PathRead ]
 
         let private ownerReaderOperations =
             set [ OwnerRead
-                  OrgRead
-                  RepoRead
+                  OrganizationRead
+                  RepositoryRead
                   BranchRead
                   PathRead ]
 
-        let private orgAdminOperations =
-            set [ OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoWrite
-                  RepoRead
+        let private organizationAdminOperations =
+            set [ OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchAdmin
@@ -78,16 +130,26 @@ module Authorization =
                   WebhookManage
                   WebhookDeliveryRead ]
 
-        let private orgReaderOperations =
-            set [ OrgRead
-                  RepoRead
+        let private organizationContributorOperations =
+            set [ OrganizationWrite
+                  OrganizationRead
+                  RepositoryWrite
+                  RepositoryRead
+                  PathWrite
+                  PathRead
+                  BranchWrite
+                  BranchRead ]
+
+        let private organizationReaderOperations =
+            set [ OrganizationRead
+                  RepositoryRead
                   PathRead
                   BranchRead ]
 
-        let private repoAdminOperations =
-            set [ RepoAdmin
-                  RepoWrite
-                  RepoRead
+        let private repositoryAdminOperations =
+            set [ RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchAdmin
@@ -99,16 +161,16 @@ module Authorization =
                   WebhookManage
                   WebhookDeliveryRead ]
 
-        let private repoContributorOperations =
-            set [ RepoWrite
-                  RepoRead
+        let private repositoryContributorOperations =
+            set [ RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchWrite
                   BranchRead ]
 
-        let private repoReaderOperations =
-            set [ RepoRead
+        let private repositoryReaderOperations =
+            set [ RepositoryRead
                   PathRead
                   BranchRead
                   ApprovalRequestRead ]
@@ -129,13 +191,17 @@ module Authorization =
         let private roles: RoleDefinition list =
             [
                 { RoleId = "SystemAdmin"; AllowedOperations = systemAdminOperations; AppliesTo = Set.ofList [ scopeSystem ] }
+                { RoleId = "SystemOperator"; AllowedOperations = systemOperatorOperations; AppliesTo = Set.ofList [ scopeSystem ] }
+                { RoleId = "SystemReader"; AllowedOperations = systemReaderOperations; AppliesTo = Set.ofList [ scopeSystem ] }
                 { RoleId = "OwnerAdmin"; AllowedOperations = ownerAdminOperations; AppliesTo = Set.ofList [ scopeOwner ] }
+                { RoleId = "OwnerContributor"; AllowedOperations = ownerContributorOperations; AppliesTo = Set.ofList [ scopeOwner ] }
                 { RoleId = "OwnerReader"; AllowedOperations = ownerReaderOperations; AppliesTo = Set.ofList [ scopeOwner ] }
-                { RoleId = "OrgAdmin"; AllowedOperations = orgAdminOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
-                { RoleId = "OrgReader"; AllowedOperations = orgReaderOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
-                { RoleId = "RepoAdmin"; AllowedOperations = repoAdminOperations; AppliesTo = Set.ofList [ scopeRepository ] }
-                { RoleId = "RepoContributor"; AllowedOperations = repoContributorOperations; AppliesTo = Set.ofList [ scopeRepository ] }
-                { RoleId = "RepoReader"; AllowedOperations = repoReaderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "OrganizationAdmin"; AllowedOperations = organizationAdminOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "OrganizationContributor"; AllowedOperations = organizationContributorOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "OrganizationReader"; AllowedOperations = organizationReaderOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "RepositoryAdmin"; AllowedOperations = repositoryAdminOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "RepositoryContributor"; AllowedOperations = repositoryContributorOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "RepositoryReader"; AllowedOperations = repositoryReaderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
                 { RoleId = "BranchAdmin"; AllowedOperations = branchAdminOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchWriter"; AllowedOperations = branchWriterOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchReader"; AllowedOperations = branchReaderOperations; AppliesTo = Set.ofList [ scopeBranch ] }

--- a/src/Grace.Types/Authorization.Types.fs
+++ b/src/Grace.Types/Authorization.Types.fs
@@ -57,16 +57,20 @@ module Authorization =
     [<KnownType("GetKnownTypes")>]
     type Operation =
         | SystemAdmin
+        | SystemOperate
+        | SystemRead
         | OwnerAdmin
+        | OwnerWrite
         | OwnerRead
-        | OrgAdmin
-        | OrgRead
-        | RepoAdmin
-        | RepoRead
-        | RepoWrite
+        | OrganizationAdmin
+        | OrganizationWrite
+        | OrganizationRead
+        | RepositoryAdmin
+        | RepositoryWrite
+        | RepositoryRead
         | BranchAdmin
-        | BranchRead
         | BranchWrite
+        | BranchRead
         | PathRead
         | PathWrite
         | ApprovalPolicyManage


### PR DESCRIPTION
## Summary

- Replaces abbreviated authorization role and operation names with canonical full names.
- Adds `SystemOperator`, `SystemReader`, `SystemOperate`, and missing write-level operations.
- Updates role semantics and affected compile/test references across authorization, server manifests, access helpers, and contract tests.

## Related Issue

Related to #402.
Part of #401.

## Write Set

The issue-owned core write set was expanded for compile/test fallout from the enum and role-id rename:

- `src/Grace.Types/Authorization.Types.fs`
- `src/Grace.Shared/Authorization.Shared.fs`
- `src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs`
- Authorization manifest and permission tests directly referencing renamed operations/roles
- Server access/route guard references directly caused by canonical operation names
- CLI/server tests with expected role or operation text

No server endpoint behavior was intentionally changed beyond canonical operation references and local helper names.

## Validation

- `dotnet tool run fantomas <touched F# files>`: passed
- `dotnet build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`: passed
- `dotnet test --no-build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`: passed, 44/44
- `pwsh ./scripts/validate.ps1 -Fast`: passed
- `git diff --check`: passed
- GitHub Actions `full`: passed for `c007e613549107ad0ec3fe95877454900a62f508`

## Review Status

- Implementation worker handoff: complete at `c007e61`.
- Bot-prevention self-review: completed by worker; checked stale role aliases, stale operation names, `SystemOperator` versus `SystemAdmin` separation, `SystemReader` write/admin leakage, approval/webhook permissions, contributor admin exclusions, and write-set scope.
- Codex Code Review Bot: 👍 no issues on current head `c007e613549107ad0ec3fe95877454900a62f508`; GraphQL scan found no top-level comments, reviews, or inline review comments.
- Merge readiness: CI `full` passed and PR was mergeable.

## Docs Impact

User-facing docs and CLI/OpenAPI propagation are intentionally deferred to sibling issues #405 and #406.

## No Production Data Migration

There is no production role data to preserve, migrate, grandfather, backfill, or classify for this epic. This PR intentionally does not add legacy aliases, compatibility shims, migration scripts, or repair paths for old role ids.

## Residual Risk

This is the shared contract slice for the epic. Dependent route authorization, creator-grant, CLI/SDK/OpenAPI, and docs changes remain in #403-#406.
