### PR TITLE
Restrict CLI role IDs to canonical names

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -69,6 +69,7 @@ module CommandOutputContractRegistryTests =
         | "--promotion-mode" -> "IndividualOnly"
         | "--resource"
         | "--scope" -> "repository"
+        | "--role" -> "RepositoryReader"
         | "--search-visibility" -> "Visible"
         | "--set" -> "Active"
         | "--status" -> "Active"

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -109,6 +109,7 @@ module CommandParsingTests =
     [<TestCase("RepositoryAdmin")>]
     [<TestCase("RepositoryContributor")>]
     [<TestCase("RepositoryReader")>]
+    [<TestCase("repositoryreader")>]
     [<TestCase("BranchAdmin")>]
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
@@ -128,12 +129,15 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
-    let ``access role commands reject stale short role ids`` roleId =
+    let ``access grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
+    [<TestCase("OrgAdmin")>]
+    [<TestCase("RepositoryReader")>]
+    let ``access revoke role accepts raw role ids for cleanup`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
-        revokeParseResult.Errors.Count |> should equal 1
+        revokeParseResult.Errors.Count |> should equal 0
 
 
 namespace Grace.CLI.Tests

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -69,6 +69,72 @@ module CommandParsingTests =
 
         parseResult.Errors.Count |> should equal 0
 
+    let private grantRoleArgs roleId =
+        [|
+            "access"
+            "grant-role"
+            "--scope"
+            "repo"
+            "--principal-type"
+            "User"
+            "--principal-id"
+            "user-1"
+            "--role"
+            roleId
+        |]
+
+    let private revokeRoleArgs roleId =
+        [|
+            "access"
+            "revoke-role"
+            "--scope"
+            "repo"
+            "--principal-type"
+            "User"
+            "--principal-id"
+            "user-1"
+            "--role"
+            roleId
+        |]
+
+    [<TestCase("SystemAdmin")>]
+    [<TestCase("SystemOperator")>]
+    [<TestCase("SystemReader")>]
+    [<TestCase("OwnerAdmin")>]
+    [<TestCase("OwnerContributor")>]
+    [<TestCase("OwnerReader")>]
+    [<TestCase("OrganizationAdmin")>]
+    [<TestCase("OrganizationContributor")>]
+    [<TestCase("OrganizationReader")>]
+    [<TestCase("RepositoryAdmin")>]
+    [<TestCase("RepositoryContributor")>]
+    [<TestCase("RepositoryReader")>]
+    [<TestCase("BranchAdmin")>]
+    [<TestCase("BranchWriter")>]
+    [<TestCase("BranchReader")>]
+    [<TestCase("ApprovalResponder")>]
+    let ``access role commands accept canonical role ids`` roleId =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
+        grantParseResult.Errors.Count |> should equal 0
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 0
+
+    [<TestCase("OrgAdmin")>]
+    [<TestCase("OrgContributor")>]
+    [<TestCase("OrgReader")>]
+    [<TestCase("RepoAdmin")>]
+    [<TestCase("RepoContributor")>]
+    [<TestCase("RepoReader")>]
+    [<TestCase("rEpOaDmIn")>]
+    [<TestCase("oRgReAdEr")>]
+    let ``access role commands reject stale short role ids`` roleId =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
+        grantParseResult.Errors.Count |> should equal 1
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 1
+
 
 namespace Grace.CLI.Tests
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -107,7 +107,13 @@ module Access =
                     |]
                 )
 
-        let roleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
+        let roleId =
+            (new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    Authorization.RoleCatalog.getAll ()
+                    |> List.map (fun role -> role.RoleId)
+                    |> List.toArray
+                )
 
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -107,13 +107,22 @@ module Access =
                     |]
                 )
 
-        let roleId =
-            (new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne))
-                .AcceptOnlyFromAmong(
-                    Authorization.RoleCatalog.getAll ()
-                    |> List.map (fun role -> role.RoleId)
-                    |> List.toArray
-                )
+        let private canonicalRoleIds =
+            Authorization.RoleCatalog.getAll ()
+            |> List.map (fun role -> role.RoleId)
+
+        let grantRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
+
+        grantRoleId.Validators.Add (fun optionResult ->
+            let roleId = optionResult.GetValueOrDefault<string>()
+            let allowedRoleIds = String.Join(", ", canonicalRoleIds)
+
+            if canonicalRoleIds
+               |> List.exists (fun canonicalRoleId -> canonicalRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+               |> not then
+                optionResult.AddError($"{OptionName.RoleId} only accepts one of these values: {allowedRoleIds}"))
+
+        let revokeRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
 
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 
@@ -348,7 +357,7 @@ module Access =
                                 PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
                                 PrincipalId = parseResult.GetValue(Options.principalIdRequired),
                                 ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.roleId),
+                                RoleId = parseResult.GetValue(Options.grantRoleId),
                                 Source = parseResult.GetValue(Options.source),
                                 SourceDetail = parseResult.GetValue(Options.sourceDetail),
                                 CorrelationId = getCorrelationId parseResult
@@ -406,7 +415,7 @@ module Access =
                                 PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
                                 PrincipalId = parseResult.GetValue(Options.principalIdRequired),
                                 ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.roleId),
+                                RoleId = parseResult.GetValue(Options.revokeRoleId),
                                 CorrelationId = getCorrelationId parseResult
                             )
 
@@ -809,7 +818,7 @@ module Access =
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
-            |> addOption Options.roleId
+            |> addOption Options.grantRoleId
             |> addOption Options.source
             |> addOption Options.sourceDetail
 
@@ -822,7 +831,7 @@ module Access =
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
-            |> addOption Options.roleId
+            |> addOption Options.revokeRoleId
 
         revokeRoleCommand.Action <- new RevokeRole()
         accessCommand.Subcommands.Add(revokeRoleCommand)


### PR DESCRIPTION
## Summary

- Restricts CLI role-id parsing to canonical full-name roles.
- Adds focused CLI parsing coverage for canonical names and stale short-name rejection.
- Updates command-output contract placeholder drift to use a canonical role id.
- Fixes review feedback by making grant-role canonical matching case-insensitive and allowing revoke-role to pass raw stale role IDs for cleanup.
- Inspects SDK/OpenAPI role surfaces and records that no SDK helper or OpenAPI role enum artifact required changes.

## Related Issue

Related to #405.
Part of #401.

## Validation

Initial implementation:

- `dotnet fantomas src\Grace.CLI\Command\Access.CLI.fs src\Grace.CLI.Tests\Program.CLI.Tests.fs`: passed
- `dotnet fantomas src\Grace.CLI.Tests\CommandOutputContract.CLI.Tests.fs`: passed, unchanged
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`: passed
- `dotnet test --no-build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~CommandParsingTests"`: passed, 118 tests
- `dotnet test --no-build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~CommandOutputContractRegistryTests"`: passed, 20 tests
- `pwsh ./scripts/validate.ps1 -Fast`: passed
- `git diff --check`: passed
- GitHub Actions `full`: passed for `5c29d8da42b4e5e2126d86463e6108454d8cb90b`

Review fix `9f9c81c6e0754763ed69826d66612d0bd106adfc`:

- `dotnet tool run fantomas -- Grace.CLI\Command\Access.CLI.fs Grace.CLI.Tests\Program.CLI.Tests.fs`: passed
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`: passed, 0 warnings, 0 errors
- `dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`: passed, 537/537
- `pwsh ./scripts/validate.ps1 -Fast`: passed
- `git diff --check`: passed
- GitHub Actions `full`: passed for `9f9c81c6e0754763ed69826d66612d0bd106adfc`

## Review Status

- Implementation worker handoff: complete at `5c29d8d`.
- Bot-prevention self-review: completed by worker; checked parser boundary, CLI contract placeholder drift, stale `Org*`/`Repo*` visibility, scoped diff, forbidden server authorization manifest paths, and validation coverage.
- Codex Code Review Bot on `5c29d8d`: found two P2 findings.
  - Preserve case-insensitive canonical role IDs.
  - Allow `revoke-role` to remove stale raw role IDs without making those IDs valid grant targets.
- Review fix worker handoff: complete at `9f9c81c6e0754763ed69826d66612d0bd106adfc`.
- Bot review thread replies: posted for both findings with fix commit and validation evidence.
- Bot review threads: resolved.
- Codex Code Review Bot on `9f9c81c6e0754763ed69826d66612d0bd106adfc`: 👍 no issues; GraphQL scan found no unresolved review threads.
- GitHub Actions `full` on `9f9c81c6e0754763ed69826d66612d0bd106adfc`: passed.

## Contract Surface Notes

- `src/Grace.CLI` and `src/Grace.CLI.Tests` were updated.
- SDK/OpenAPI were inspected; no SDK role helper or OpenAPI role enum/source artifact needed changes.
- Access OpenAPI routes remain classified internal in `src/OpenAPI/RouteClassification.json`.

## No Production Data Migration

There is no production role data to preserve, migrate, grandfather, backfill, or classify for this epic. This PR intentionally does not add legacy aliases, compatibility shims, migration scripts, or repair paths for old role ids.

## Residual Risk

None for this slice. Route authorization behavior remains owned by #403; docs remain owned by #406.
