### PR TITLE
Enforce scope creation authorization

### DIFF
--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -67,6 +67,15 @@ type EndpointAuthorizationManifestTests() =
         for method_, path in routes do
             assertRouteSecurity method_ path expectedSecurity
 
+    let rec includesSecurity expectedSecurity actualSecurity =
+        actualSecurity = expectedSecurity
+        || match actualSecurity with
+           | AnyOf requirements
+           | AllOf requirements ->
+               requirements
+               |> List.exists (includesSecurity expectedSecurity)
+           | _ -> false
+
     let assertRouteRequiresSecurity method_ path (expectedSecurity: EndpointSecurity) =
         let matchingDefinitions =
             definitions
@@ -74,19 +83,74 @@ type EndpointAuthorizationManifestTests() =
                 definition.Method = method_
                 && definition.Path = path)
 
-        let rec includesSecurity actualSecurity =
-            actualSecurity = expectedSecurity
-            || match actualSecurity with
-               | AllOf requirements -> requirements |> List.exists includesSecurity
-               | _ -> false
+        match matchingDefinitions with
+        | [ definition ] ->
+            Assert.That(
+                includesSecurity expectedSecurity definition.Security,
+                Is.True,
+                $"Expected {method_} {path} to require {expectedSecurity}, but manifest uses {definition.Security}."
+            )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
+
+    let assertRouteDoesNotRequireSecurity method_ path (unexpectedSecurity: EndpointSecurity) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
 
         match matchingDefinitions with
         | [ definition ] ->
             Assert.That(
-                includesSecurity definition.Security,
-                Is.True,
-                $"Expected {method_} {path} to require {expectedSecurity}, but manifest uses {definition.Security}."
+                includesSecurity unexpectedSecurity definition.Security,
+                Is.False,
+                $"Expected {method_} {path} not to require {unexpectedSecurity}, but manifest uses {definition.Security}."
             )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
+
+    let writeOrAdmin adminOperation writeOperation resourceKind =
+        AnyOf [ Authorized(adminOperation, resourceKind)
+                Authorized(writeOperation, resourceKind) ]
+
+    let rec operationsInSecurity security =
+        match security with
+        | Authorized (operation, _) -> [ operation ]
+        | AnyOf requirements
+        | AllOf requirements -> requirements |> List.collect operationsInSecurity
+        | AllowAnonymous
+        | Authenticated -> []
+
+    let assertRouteUsesCanonicalOperationNames method_ path (expectedOperationNames: string list) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
+
+        match matchingDefinitions with
+        | [ definition ] ->
+            let actualOperationNames =
+                definition.Security
+                |> operationsInSecurity
+                |> List.map string
+                |> List.toArray
+
+            Assert.That(actualOperationNames, Is.EquivalentTo(expectedOperationNames), $"{method_} {path} must use canonical full operation names.")
+
+            let abbreviatedNames =
+                actualOperationNames
+                |> Array.filter (fun operationName ->
+                    [
+                        "OrgAdmin"
+                        "OrgWrite"
+                        "RepoAdmin"
+                        "RepoWrite"
+                    ]
+                    |> List.contains operationName)
+
+            Assert.That(abbreviatedNames, Is.Empty, $"{method_} {path} must not use stale abbreviated operation names.")
         | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
         | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
 
@@ -251,6 +315,64 @@ type EndpointAuthorizationManifestTests() =
         |> assertRoutesUseSecurity (Authorized(Operation.PathWrite, ResourceKind.Path))
 
     [<Test>]
+    member _.ScopeCreationRoutesRequireParentWriteOrAdminOperations() =
+        [
+            "POST", "/owner/create", writeOrAdmin Operation.SystemAdmin Operation.SystemOperate ResourceKind.System
+            "POST", "/organization/create", writeOrAdmin Operation.OwnerAdmin Operation.OwnerWrite ResourceKind.Owner
+            "POST", "/repository/create", writeOrAdmin Operation.OrganizationAdmin Operation.OrganizationWrite ResourceKind.Organization
+            "POST", "/branch/create", writeOrAdmin Operation.RepositoryAdmin Operation.RepositoryWrite ResourceKind.Repository
+        ]
+        |> List.iter (fun (method_, path, expectedSecurity) -> assertRouteSecurity method_ path expectedSecurity)
+
+        assertRouteDoesNotRequireSecurity "POST" "/branch/create" (Authorized(Operation.BranchWrite, ResourceKind.Branch))
+
+    [<Test>]
+    member _.CreationRouteOperationsUseCanonicalFullNames() =
+        [
+            "POST", "/owner/create", [ "SystemAdmin"; "SystemOperate" ]
+            "POST", "/organization/create", [ "OwnerAdmin"; "OwnerWrite" ]
+            "POST",
+            "/repository/create",
+            [
+                "OrganizationAdmin"
+                "OrganizationWrite"
+            ]
+            "POST", "/branch/create", [ "RepositoryAdmin"; "RepositoryWrite" ]
+            "POST", "/directory/create", [ "RepositoryAdmin"; "RepositoryWrite" ]
+            "POST", "/directory/saveDirectoryVersions", [ "RepositoryAdmin"; "RepositoryWrite" ]
+        ]
+        |> List.iter (fun (method_, path, expectedOperationNames) -> assertRouteUsesCanonicalOperationNames method_ path expectedOperationNames)
+
+    [<Test>]
+    member _.BranchReferenceCreationRoutesUseBranchWriteOrAdminNotRepositoryScopeCreation() =
+        [
+            "POST", "/branch/assign"
+            "POST", "/branch/checkpoint"
+            "POST", "/branch/commit"
+            "POST", "/branch/createExternal"
+            "POST", "/branch/promote"
+            "POST", "/branch/save"
+            "POST", "/branch/tag"
+        ]
+        |> assertRoutesUseSecurity (writeOrAdmin Operation.BranchAdmin Operation.BranchWrite ResourceKind.Branch)
+
+        assertRouteDoesNotRequireSecurity "POST" "/branch/save" (Authorized(Operation.RepositoryWrite, ResourceKind.Repository))
+
+    [<Test>]
+    member _.RepositoryContainedCreationRoutesRequireRepositoryWriteOrAdminOperations() =
+        [
+            "POST", "/artifact/create"
+            "POST", "/directory/create"
+            "POST", "/directory/saveDirectoryVersions"
+            "POST", "/promotion-set/create"
+            "POST", "/reminder/create"
+            "POST", "/validation-set/create"
+            "POST", "/validation-result/record"
+            "POST", "/work/create"
+        ]
+        |> assertRoutesUseSecurity (writeOrAdmin Operation.RepositoryAdmin Operation.RepositoryWrite ResourceKind.Repository)
+
+    [<Test>]
     member _.BranchAnnotateRequiresBranchReadAndPathRead() =
         assertRouteRequiresSecurity "POST" "/branch/annotate" (Authorized(Operation.BranchRead, ResourceKind.Branch))
         assertRouteRequiresSecurity "POST" "/branch/annotate" (Authorized(Operation.PathRead, ResourceKind.Path))
@@ -258,7 +380,6 @@ type EndpointAuthorizationManifestTests() =
     [<Test>]
     member _.SelectedWorkItemRoutesUseExpectedPolicies() =
         [
-            "POST", "/work/create"
             "POST", "/work/add-summary"
             "POST", "/work/link/artifact"
             "POST", "/work/link/promotion-set"

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -101,7 +101,7 @@ type AccessBootstrapTests() =
     member _.BootstrapDisabledByDefaultReturnsForbidden() =
         task {
             use client = createClient $"{Guid.NewGuid()}"
-            let! _ownerId = createOwner client
+            let! _ownerId = createOwner Client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
             let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)

--- a/src/Grace.Server/Security/AuthorizationMiddleware.Server.fs
+++ b/src/Grace.Server/Security/AuthorizationMiddleware.Server.fs
@@ -57,6 +57,15 @@ module AuthorizationMiddleware =
             |> List.map formatPrincipal
             |> String.concat ", "
 
+    let private formatOperationSummary (operations: Operation list) =
+        match operations with
+        | [] -> "None"
+        | [ operation ] -> $"{operation}"
+        | _ ->
+            operations
+            |> List.map (fun operation -> $"{operation}")
+            |> String.concat " OR "
+
     let private tryGetIdentityName (context: HttpContext) =
         let identity = context.User.Identity
 
@@ -123,6 +132,56 @@ module AuthorizationMiddleware =
                     | Allowed _ -> return! next context
                     | Denied reason ->
                         logDenied context operation principalSummary (formatResource resource) reason
+                        return! forbidden reason next context
+            }
+
+    let requiresAnyPermission (operations: Operation list) (resourceFromContext: HttpContext -> Task<Resource>) : HttpHandler =
+        if operations.IsEmpty then
+            invalidArg (nameof operations) "At least one authorization operation is required."
+
+        fun next context ->
+            task {
+                match PrincipalMapper.tryGetUserId context.User with
+                | None ->
+                    let principalSummary =
+                        PrincipalMapper.getPrincipals context.User
+                        |> formatPrincipalSummary context
+
+                    logMissingAuthentication context operations.Head principalSummary
+                    return! RequestErrors.UNAUTHORIZED "Grace" "Access" "Authentication required." next context
+                | Some _ ->
+                    let principals = PrincipalMapper.getPrincipals context.User
+                    let principalSummary = formatPrincipals principals
+                    let claims = PrincipalMapper.getEffectiveClaims context.User
+                    let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+                    let! resource = resourceFromContext context
+                    let mutable allowed = false
+                    let mutable deniedReason: string option = None
+                    let mutable index = 0
+
+                    while not allowed && index < operations.Length do
+                        let operation = operations[index]
+                        let! decision = evaluator.CheckAsync(principals, claims, operation, resource)
+
+                        match decision with
+                        | Allowed _ -> allowed <- true
+                        | Denied reason ->
+                            deniedReason <-
+                                match deniedReason with
+                                | Some existing -> Some $"{existing}; {operation}: {reason}"
+                                | None -> Some $"{operation}: {reason}"
+
+                        index <- index + 1
+
+                    if allowed then
+                        return! next context
+                    else
+                        let reason =
+                            deniedReason
+                            |> Option.defaultValue "No matching authorization operation was allowed."
+
+                        let operationSummary = formatOperationSummary operations
+                        logDenied context operations.Head principalSummary (formatResource resource) $"{operationSummary}: {reason}"
                         return! forbidden reason next context
             }
 

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -16,6 +16,7 @@ module EndpointAuthorizationManifest =
         | AllowAnonymous
         | Authenticated
         | Authorized of Operation * ResourceKind
+        | AnyOf of EndpointSecurity list
         | AllOf of EndpointSecurity list
 
     type EndpointSecurityDefinition = { Method: string; Path: string; Security: EndpointSecurity }
@@ -72,16 +73,36 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/agent/session/status" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/stop" (Authorized(RepositoryWrite, Repository))
-            endpoint "POST" "/branch/assign" Authenticated
+            endpoint
+                "POST"
+                "/branch/assign"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint
                 "POST"
                 "/branch/annotate"
                 (AllOf [ Authorized(BranchRead, Branch)
                          Authorized(PathRead, Path) ])
-            endpoint "POST" "/branch/checkpoint" Authenticated
-            endpoint "POST" "/branch/commit" (Authorized(BranchWrite, Branch))
-            endpoint "POST" "/branch/create" Authenticated
-            endpoint "POST" "/branch/createExternal" Authenticated
+            endpoint
+                "POST"
+                "/branch/checkpoint"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
+            endpoint
+                "POST"
+                "/branch/commit"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
+            endpoint
+                "POST"
+                "/branch/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
+            endpoint
+                "POST"
+                "/branch/createExternal"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/delete" Authenticated
             endpoint "POST" "/branch/enableAssign" Authenticated
             endpoint "POST" "/branch/enableAutoRebase" Authenticated
@@ -106,13 +127,29 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/branch/getTags" Authenticated
             endpoint "POST" "/branch/getVersion" Authenticated
             endpoint "POST" "/branch/listContents" Authenticated
-            endpoint "POST" "/branch/promote" Authenticated
+            endpoint
+                "POST"
+                "/branch/promote"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/rebase" Authenticated
-            endpoint "POST" "/branch/save" Authenticated
+            endpoint
+                "POST"
+                "/branch/save"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/setPromotionMode" Authenticated
-            endpoint "POST" "/branch/tag" Authenticated
+            endpoint
+                "POST"
+                "/branch/tag"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/updateParentBranch" Authenticated
-            endpoint "POST" "/promotion-set/create" Authenticated
+            endpoint
+                "POST"
+                "/promotion-set/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/promotion-set/get" Authenticated
             endpoint "POST" "/promotion-set/get-events" Authenticated
             endpoint "POST" "/promotion-set/update-input-promotions" Authenticated
@@ -120,25 +157,49 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/promotion-set/apply" Authenticated
             endpoint "POST" "/promotion-set/%O/resolve-conflicts" Authenticated
             endpoint "POST" "/promotion-set/delete" Authenticated
-            endpoint "POST" "/validation-set/create" Authenticated
+            endpoint
+                "POST"
+                "/validation-set/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/validation-set/get" Authenticated
             endpoint "POST" "/validation-set/update" Authenticated
             endpoint "POST" "/validation-set/delete" Authenticated
-            endpoint "POST" "/validation-result/record" Authenticated
-            endpoint "POST" "/artifact/create" (Authorized(RepositoryWrite, Repository))
+            endpoint
+                "POST"
+                "/validation-result/record"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
+            endpoint
+                "POST"
+                "/artifact/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/diff/getDiff" Authenticated
             endpoint "POST" "/diff/getDiffBySha256Hash" Authenticated
             endpoint "POST" "/diff/populate" Authenticated
-            endpoint "POST" "/directory/create" Authenticated
+            endpoint
+                "POST"
+                "/directory/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/directory/get" Authenticated
             endpoint "POST" "/directory/getByDirectoryIds" Authenticated
             endpoint "POST" "/directory/getBySha256Hash" Authenticated
             endpoint "POST" "/directory/getDirectoryVersionsRecursive" Authenticated
             endpoint "POST" "/directory/getZipFile" Authenticated
-            endpoint "POST" "/directory/saveDirectoryVersions" Authenticated
+            endpoint
+                "POST"
+                "/directory/saveDirectoryVersions"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "GET" "/healthz" AllowAnonymous
-            endpoint "POST" "/organization/create" Authenticated
+            endpoint
+                "POST"
+                "/organization/create"
+                (AnyOf [ Authorized(OwnerAdmin, Owner)
+                         Authorized(OwnerWrite, Owner) ])
             endpoint "POST" "/organization/delete" Authenticated
             endpoint "POST" "/organization/get" (Authorized(OrganizationRead, Organization))
             endpoint "POST" "/organization/listRepositories" Authenticated
@@ -147,7 +208,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/organization/setSearchVisibility" Authenticated
             endpoint "POST" "/organization/setType" Authenticated
             endpoint "POST" "/organization/undelete" Authenticated
-            endpoint "POST" "/owner/create" Authenticated
+            endpoint
+                "POST"
+                "/owner/create"
+                (AnyOf [ Authorized(SystemAdmin, System)
+                         Authorized(SystemOperate, System) ])
             endpoint "POST" "/owner/delete" Authenticated
             endpoint "POST" "/owner/get" (Authorized(OwnerRead, Owner))
             endpoint "POST" "/owner/listOrganizations" Authenticated
@@ -164,13 +229,21 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/queue/pause" Authenticated
             endpoint "POST" "/queue/resume" Authenticated
             endpoint "POST" "/queue/status" Authenticated
-            endpoint "POST" "/reminder/create" Authenticated
+            endpoint
+                "POST"
+                "/reminder/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/reminder/delete" Authenticated
             endpoint "POST" "/reminder/get" Authenticated
             endpoint "POST" "/reminder/list" Authenticated
             endpoint "POST" "/reminder/reschedule" Authenticated
             endpoint "POST" "/reminder/updateTime" Authenticated
-            endpoint "POST" "/repository/create" Authenticated
+            endpoint
+                "POST"
+                "/repository/create"
+                (AnyOf [ Authorized(OrganizationAdmin, Organization)
+                         Authorized(OrganizationWrite, Organization) ])
             endpoint "POST" "/repository/delete" Authenticated
             endpoint "POST" "/repository/exists" Authenticated
             endpoint "POST" "/repository/get" (Authorized(RepositoryRead, Repository))
@@ -217,7 +290,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/issueDedupeDiscovery" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
-            endpoint "POST" "/work/create" (Authorized(RepositoryWrite, Repository))
+            endpoint
+                "POST"
+                "/work/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/work/add-summary" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/work/get" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/work/link/artifact" (Authorized(RepositoryWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -274,15 +274,47 @@ module Application =
 
         let requireSystemAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.SystemAdmin (fun _ -> task { return Resource.System })
 
+        let requireSystemOperateOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.SystemAdmin
+                    Operation.SystemOperate
+                ]
+                (fun _ -> task { return Resource.System })
+
         let requireOwnerAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerAdmin ownerResourceFromContext
+
+        let requireOwnerWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.OwnerAdmin
+                    Operation.OwnerWrite
+                ]
+                ownerResourceFromContext
 
         let requireOwnerRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerRead ownerResourceFromContext
 
         let requireOrganizationAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationAdmin organizationResourceFromContext
 
+        let requireOrganizationWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.OrganizationAdmin
+                    Operation.OrganizationWrite
+                ]
+                organizationResourceFromContext
+
         let requireOrganizationRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationRead organizationResourceFromContext
 
         let requireRepositoryAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryAdmin repositoryResourceFromContext
+
+        let requireRepositoryWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.RepositoryAdmin
+                    Operation.RepositoryWrite
+                ]
+                repositoryResourceFromContext
 
         let requireRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryRead repositoryResourceFromContext
 
@@ -291,6 +323,14 @@ module Application =
         let requireArtifactRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
 
         let requireBranchAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchAdmin branchResourceFromContext
+
+        let requireBranchWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.BranchAdmin
+                    Operation.BranchWrite
+                ]
+                branchResourceFromContext
 
         let requireBranchRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchRead branchResourceFromContext
 
@@ -1028,22 +1068,22 @@ module Application =
                 subRoute
                     "/branch"
                     [
-                        POST [ route "/assign" Branch.Assign
+                        POST [ route "/assign" (composeHandlers requireBranchWriteOrAdmin Branch.Assign)
                                |> addMetadata typeof<Branch.AssignParameters>
 
                                route "/annotate" (composeHandlers requireBranchRead (composeHandlers requireAnnotatePathRead Branch.Annotate))
                                |> addMetadata typeof<Branch.AnnotateParameters>
 
-                               (route "/checkpoint" Branch.Checkpoint
+                               (route "/checkpoint" (composeHandlers requireBranchWriteOrAdmin Branch.Checkpoint)
                                 |> addMetadata typeof<Branch.CreateReferenceParameters>)
 
-                               route "/commit" (composeHandlers requireBranchWrite Branch.Commit)
+                               route "/commit" (composeHandlers requireBranchWriteOrAdmin Branch.Commit)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
-                               route "/create" Branch.Create
+                               route "/create" (composeHandlers requireRepositoryWriteOrAdmin Branch.Create)
                                |> addMetadata typeof<Branch.CreateBranchParameters>
 
-                               route "/createExternal" Branch.CreateExternal
+                               route "/createExternal" (composeHandlers requireBranchWriteOrAdmin Branch.CreateExternal)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/delete" Branch.Delete
@@ -1121,16 +1161,16 @@ module Application =
                                route "/listContents" Branch.ListContents
                                |> addMetadata typeof<Branch.ListContentsParameters>
 
-                               route "/promote" Branch.Promote
+                               route "/promote" (composeHandlers requireBranchWriteOrAdmin Branch.Promote)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/rebase" Branch.Rebase
                                |> addMetadata typeof<Branch.RebaseParameters>
 
-                               route "/save" Branch.Save
+                               route "/save" (composeHandlers requireBranchWriteOrAdmin Branch.Save)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
-                               route "/tag" Branch.Tag
+                               route "/tag" (composeHandlers requireBranchWriteOrAdmin Branch.Tag)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/updateParentBranch" Branch.UpdateParentBranch
@@ -1151,7 +1191,7 @@ module Application =
                 subRoute
                     "/directory"
                     [
-                        POST [ route "/create" DirectoryVersion.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin DirectoryVersion.Create)
                                |> addMetadata typeof<DirectoryVersion.CreateParameters>
 
                                route "/get" DirectoryVersion.Get
@@ -1169,14 +1209,14 @@ module Application =
                                route "/getZipFile" DirectoryVersion.GetZipFile
                                |> addMetadata typeof<DirectoryVersion.GetZipFileParameters>
 
-                               route "/saveDirectoryVersions" DirectoryVersion.SaveDirectoryVersions
+                               route "/saveDirectoryVersions" (composeHandlers requireRepositoryWriteOrAdmin DirectoryVersion.SaveDirectoryVersions)
                                |> addMetadata typeof<DirectoryVersion.SaveDirectoryVersionsParameters> ]
                     ]
                 subRoute "/notifications" [ GET [] ]
                 subRoute
                     "/organization"
                     [
-                        POST [ route "/create" Organization.Create
+                        POST [ route "/create" (composeHandlers requireOwnerWriteOrAdmin Organization.Create)
                                |> addMetadata typeof<Organization.CreateOrganizationParameters>
 
                                route "/delete" Organization.Delete
@@ -1206,7 +1246,7 @@ module Application =
                 subRoute
                     "/owner"
                     [
-                        POST [ route "/create" Owner.Create
+                        POST [ route "/create" (composeHandlers requireSystemOperateOrAdmin Owner.Create)
                                |> addMetadata typeof<Owner.CreateOwnerParameters>
 
                                route "/delete" Owner.Delete
@@ -1254,7 +1294,7 @@ module Application =
                 subRoute
                     "/work"
                     [
-                        POST [ route "/create" (composeHandlers requireRepositoryWrite WorkItem.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin WorkItem.Create)
                                |> addMetadata typeof<WorkItem.CreateWorkItemParameters>
 
                                route "/get" (composeHandlers requireRepositoryRead WorkItem.Get)
@@ -1371,7 +1411,7 @@ module Application =
                 subRoute
                     "/promotion-set"
                     [
-                        POST [ route "/create" PromotionSet.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin PromotionSet.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.PromotionSet.CreatePromotionSetParameters>
 
                                route "/get" PromotionSet.Get
@@ -1398,7 +1438,7 @@ module Application =
                 subRoute
                     "/validation-set"
                     [
-                        POST [ route "/create" ValidationSet.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin ValidationSet.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Validation.CreateValidationSetParameters>
 
                                route "/get" ValidationSet.Get
@@ -1413,13 +1453,13 @@ module Application =
                 subRoute
                     "/validation-result"
                     [
-                        POST [ route "/record" ValidationResult.Record
+                        POST [ route "/record" (composeHandlers requireRepositoryWriteOrAdmin ValidationResult.Record)
                                |> addMetadata typeof<Grace.Shared.Parameters.Validation.RecordValidationResultParameters> ]
                     ]
                 subRoute
                     "/artifact"
                     [
-                        POST [ route "/create" (composeHandlers requireRepositoryWrite Artifact.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin Artifact.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Artifact.CreateArtifactParameters> ]
 
                         GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepositoryRead (Artifact.GetDownloadUri artifactId)) ]
@@ -1427,7 +1467,7 @@ module Application =
                 subRoute
                     "/repository"
                     [
-                        POST [ route "/create" Repository.Create
+                        POST [ route "/create" (composeHandlers requireOrganizationWriteOrAdmin Repository.Create)
                                |> addMetadata typeof<Repository.CreateRepositoryParameters>
 
                                route "/delete" (composeHandlers requireRepositoryAdmin Repository.Delete)
@@ -1598,7 +1638,7 @@ module Application =
                                route "/reschedule" Reminder.Reschedule
                                |> addMetadata typeof<Reminder.RescheduleReminderParameters>
 
-                               route "/create" Reminder.Create
+                               route "/create" (composeHandlers requireRepositoryWriteOrAdmin Reminder.Create)
                                |> addMetadata typeof<Reminder.CreateReminderParameters> ]
                     ]
                 subRoute


### PR DESCRIPTION
## Summary

- Enforces parent-scope authorization for scope creation routes.
- Keeps scope creation distinct from branch reference and repository-contained creation.
- Updates authorization manifest/runtime handling and focused manifest tests for full operation names.
- Fixes the full-validation bootstrap-disabled test setup after refreshing onto the current epic branch.
- Does not implement creator-admin grants; #404 owns that behavior.

## Related Issue

Related to #403.
Part of #401.

## Write Set

- `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs`
- `src/Grace.Server/Security/AuthorizationMiddleware.Server.fs`
- `src/Grace.Server/Startup.Server.fs`
- `src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs`
- `src/Grace.Server.Tests/Access.Server.Tests.fs`

The write set expanded to `AuthorizationMiddleware.Server.fs` and `Startup.Server.fs` because the parent write/admin alternatives for create routes needed runtime authorization handling in addition to manifest metadata. The `Access.Server.Tests.fs` update is test-only and preserves the random non-admin client for the forbidden grant assertion while using the shared bootstrapped admin client to create the setup owner.

## Validation

Initial implementation `dafe72839fd66f2bb3484e205c5ef53d6094c956`:

- `dotnet tool run fantomas src\Grace.Authorization.Tests\EndpointAuthorizationManifest.Tests.fs src\Grace.Server\Security\AuthorizationMiddleware.Server.fs src\Grace.Server\Security\EndpointAuthorizationManifest.Server.fs src\Grace.Server\Startup.Server.fs`: passed
- `dotnet test --configuration Release src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --filter EndpointAuthorizationManifestTests`: passed, 15/15
- `pwsh ./scripts/validate.ps1 -Fast`: passed
- `git diff --check`: passed

Refresh/fix `b37d4b8eb3a860d3f97845e50ed1b96e0b030b9d`:

- `git fetch origin`: passed
- `git rebase origin/epic/401-authorization-scope-roles`: passed; refreshed from stale `dafe728` onto current epic head `e4acc65`
- Initial `pwsh ./scripts/validate.ps1 -Full`: failed only `Grace.Server.Tests.AccessServerTests.BootstrapDisabledByDefaultReturnsForbidden`; stale CI Doctor failure did not reproduce
- `dotnet tool run fantomas --check Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs Grace.Server/Security/AuthorizationMiddleware.Server.fs Grace.Server/Security/EndpointAuthorizationManifest.Server.fs Grace.Server/Startup.Server.fs Grace.Server.Tests/Access.Server.Tests.fs` from `src`: passed, no changes required
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~BootstrapDisabledByDefaultReturnsForbidden"`: passed, 1/1
- Final `pwsh ./scripts/validate.ps1 -Full`: passed; Types 96/96, Authorization 48/48, CLI 536/537 with 1 skipped, Server.Unit 503/503, Server integration 176/176
- `git diff --check`: passed
- GitHub Actions `full`: passed for `b37d4b8eb3a860d3f97845e50ed1b96e0b030b9d`

## Review Status

- Implementation worker handoff: complete at `dafe72839fd66f2bb3484e205c5ef53d6094c956`.
- Initial bot-prevention self-review: completed by worker; checked route/manifest alignment, parent-scope authorization, branch reference boundary, repository-contained creation coverage, full operation-name assertions, no creator-admin grants, no legacy aliases or migration shims, and no unexpected deletions.
- Codex Code Review Bot on `dafe72839fd66f2bb3484e205c5ef53d6094c956`: 👍 no issues.
- GitHub Actions `full` on stale merge ref: failed; triaged in PR comment.
- CI fix worker handoff: complete at `b37d4b8eb3a860d3f97845e50ed1b96e0b030b9d`.
- Bot-prevention self-review after refresh/fix: completed; checked authorization-scope route matrix, `AnyOf` behavior, manifest/startup alignment, branch-reference boundary, repository-contained creation routes, no creator-admin grants, no legacy aliases/shims/migrations, and test-only repair.
- Codex Code Review Bot on `b37d4b8eb3a860d3f97845e50ed1b96e0b030b9d`: 👍 no issues; GraphQL scan found no review threads.
- GitHub Actions `full` on `b37d4b8eb3a860d3f97845e50ed1b96e0b030b9d`: passed.

## No Production Data Migration

There is no production role data to preserve, migrate, grandfather, backfill, or classify for this epic. This PR intentionally does not add legacy aliases, compatibility shims, migration scripts, or repair paths for old role ids.

## Residual Risk

None for this slice. Scope creator-admin grants remain owned by #404.
