### PR TITLE
Grant creator admin rights for new scopes

### DIFF
--- a/src/Grace.Server.Unit.Tests/CreatorScopeAdminGrant.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/CreatorScopeAdminGrant.Unit.Tests.fs
@@ -1,0 +1,236 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Shared.Authorization
+open Grace.Shared.Utilities
+open Grace.Types.Authorization
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Threading.Tasks
+
+[<Parallelizable(ParallelScope.All)>]
+type CreatorScopeAdminGrantUnit() =
+
+    let roleCatalog = RoleCatalog.getAll ()
+
+    let userPrincipal userId = { PrincipalType = PrincipalType.User; PrincipalId = userId }
+
+    let groupPrincipal groupId = { PrincipalType = PrincipalType.Group; PrincipalId = groupId }
+
+    let assignment (principal: Principal) (scope: Scope) (roleId: RoleId) : RoleAssignment =
+        { Principal = principal; Scope = scope; RoleId = roleId; Source = "test"; SourceDetail = None; CreatedAt = getCurrentInstant () }
+
+    let runEnsure (creatorUserId: string option) (principals: Principal list) (initialAssignments: RoleAssignment list) (scope: Scope) =
+        task {
+            let grants = ResizeArray<RoleAssignment>()
+            let mutable assignments: RoleAssignment list = initialAssignments
+
+            let checkAdmin principals effectiveClaims operation resource =
+                Task.FromResult(checkPermission roleCatalog assignments [] principals effectiveClaims operation resource)
+
+            let grantCreatorAdmin (grant: RoleAssignment) =
+                task {
+                    grants.Add grant
+                    assignments <- grant :: assignments
+                    return Ok(GraceReturnValue.Create assignments "test-correlation")
+                }
+
+            let! result = CreatorScopeAdminGrant.ensureCreatorAdminCore "test-correlation" creatorUserId principals Set.empty scope checkAdmin grantCreatorAdmin
+
+            return result, Seq.toList grants
+        }
+
+    let assertSingleGrant (expectedPrincipal: Principal) (expectedScope: Scope) (expectedRole: RoleId) (grants: RoleAssignment list) =
+        Assert.That(grants.Length, Is.EqualTo(1))
+        let grant = grants.Head
+        Assert.That(grant.Principal, Is.EqualTo(expectedPrincipal))
+        Assert.That(grant.Scope, Is.EqualTo(expectedScope))
+        Assert.That(grant.RoleId, Is.EqualTo(expectedRole))
+        Assert.That(grant.Source, Is.EqualTo("scope-create"))
+        Assert.That(grant.SourceDetail, Is.EqualTo(Some "creator-admin"))
+
+    let assertOk (expected: CreatorScopeAdminGrant.CreatorAdminGrantResult) (result: Result<CreatorScopeAdminGrant.CreatorAdminGrantResult, GraceError>) =
+        match result with
+        | Ok actual -> Assert.That(actual, Is.EqualTo(expected))
+        | Error error -> Assert.Fail($"Expected Ok {expected} but got Error: {error.Error}")
+
+    [<Test>]
+    member _.OwnerCreationGrantsOwnerAdminToCreatorUserWhenNoInheritedAdminApplies() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] [] scope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator scope "OwnerAdmin" grants
+        }
+
+    [<Test>]
+    member _.OrganizationCreationByOwnerContributorGrantsOrganizationAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment creator ownerScope "OwnerContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator organizationScope "OrganizationAdmin" grants
+        }
+
+    [<Test>]
+    member _.RepositoryCreationByOrganizationContributorGrantsRepositoryAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+            let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+
+            let initialAssignments =
+                [
+                    assignment creator organizationScope "OrganizationContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments repositoryScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator repositoryScope "RepositoryAdmin" grants
+        }
+
+    [<Test>]
+    member _.BranchCreationByRepositoryContributorGrantsBranchAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+            let branchScope = Scope.Branch(ownerId, organizationId, repositoryId, branchId)
+
+            let initialAssignments =
+                [
+                    assignment creator repositoryScope "RepositoryContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments branchScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator branchScope "BranchAdmin" grants
+        }
+
+    [<Test>]
+    member _.InheritedAdminDoesNotCreateRedundantDirectGrant() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment creator ownerScope "OwnerAdmin"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.InheritedAdminAlreadyApplies result
+            Assert.That(grants, Is.Empty)
+        }
+
+    [<Test>]
+    member _.GroupAuthorizedCreationGrantsOnlyTheCreatingUserPrincipal() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let group = groupPrincipal "owner-contributors"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment group ownerScope "OwnerContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator; group ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator organizationScope "OrganizationAdmin" grants
+        }
+
+    [<Test>]
+    member _.GrantPersistenceFailurePreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Error(GraceError.Create "grant failed" "test-correlation"))
+
+            let! result =
+                CreatorScopeAdminGrant.ensureCreatorAdminCore
+                    "test-correlation"
+                    (Some creator.PrincipalId)
+                    [ creator ]
+                    Set.empty
+                    scope
+                    checkAdmin
+                    grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Is.EqualTo("grant failed"))
+            | Ok value -> Assert.Fail($"Expected grant failure but got {value}.")
+        }
+
+    [<Test>]
+    member _.UnprovenGrantPreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Ok(GraceReturnValue.Create [] "test-correlation"))
+
+            let! result =
+                CreatorScopeAdminGrant.ensureCreatorAdminCore
+                    "test-correlation"
+                    (Some creator.PrincipalId)
+                    [ creator ]
+                    Set.empty
+                    scope
+                    checkAdmin
+                    grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Does.Contain("could not be proven"))
+            | Ok value -> Assert.Fail($"Expected unproven grant failure but got {value}.")
+        }
+
+    [<Test>]
+    member _.MissingMappedCreatorUserPreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Ok(GraceReturnValue.Create [] "test-correlation"))
+
+            let! result = CreatorScopeAdminGrant.ensureCreatorAdminCore "test-correlation" None [] Set.empty scope checkAdmin grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Does.Contain("no mapped Grace user id"))
+            | Ok value -> Assert.Fail($"Expected missing user failure but got {value}.")
+        }

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="TestCommon.fs" />
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
+    <Compile Include="CreatorScopeAdminGrant.Unit.Tests.fs" />
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="SecurityPrivacy.Unit.Tests.fs" />

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -447,7 +447,12 @@ module Branch =
                                 | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
         }
 
-    let processCommand<'T when 'T :> BranchParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<BranchCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> BranchParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<BranchCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             let startTime = getCurrentInstant ()
             let graceIds = getGraceIds context
@@ -485,7 +490,20 @@ module Branch =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                    .enhance(nameof BranchId, graceIds.BranchId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -566,6 +584,9 @@ module Branch =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> BranchParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<BranchCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     let processQuery<'T, 'U when 'T :> BranchParameters>
         (context: HttpContext)
@@ -709,8 +730,21 @@ module Branch =
                     }
                     |> ValueTask<BranchCommand>
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Branch(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, graceIds.BranchId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Rebases a branch on its parent branch.

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -63,6 +63,7 @@
 		<Compile Include="Security\AuthSchemeSelection.Server.fs" />
 		<Compile Include="Security\OutboundUrlSafety.Server.fs" />
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
+		<Compile Include="Security\CreatorScopeAdminGrant.Server.fs" />
 		<Compile Include="Security\MetricsAuthorization.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />
 		<Compile Include="Security\EndpointAuthorizationManifest.Server.fs" />

--- a/src/Grace.Server/Organization.Server.fs
+++ b/src/Grace.Server/Organization.Server.fs
@@ -5,6 +5,7 @@ open Grace.Actors.Constants
 open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -31,10 +32,11 @@ module Organization =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Organization.Server")
 
-    let processCommand<'T when 'T :> OrganizationParameters>
+    let processCommandWithPostSuccess<'T when 'T :> OrganizationParameters>
         (context: HttpContext)
         (validations: Validations<'T>)
         (command: 'T -> ValueTask<OrganizationCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
         =
         task {
             let graceIds = getGraceIds context
@@ -66,7 +68,18 @@ module Organization =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -143,6 +156,13 @@ module Organization =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> OrganizationParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<OrganizationCommand>)
+        =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     /// Generic processor for all Organization queries.
     let processQuery<'T, 'U when 'T :> OrganizationParameters>
@@ -232,9 +252,22 @@ module Organization =
                     }
                     |> ValueTask<OrganizationCommand>
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Organization(graceIds.OwnerId, graceIds.OrganizationId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 log.LogDebug("{CurrentInstant}: In Grace.Server.Create.", getCurrentInstantExtended ())
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Set the name of an organization.

--- a/src/Grace.Server/Owner.Server.fs
+++ b/src/Grace.Server/Owner.Server.fs
@@ -6,6 +6,7 @@ open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Server.ApplicationContext
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -36,7 +37,12 @@ module Owner =
     let activitySource = new ActivitySource("Owner")
 
     /// Generic processor for all Owner commands.
-    let processCommand<'T when 'T :> OwnerParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<OwnerCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> OwnerParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<OwnerCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             let commandName = context.Items["Command"] :?> string
             let graceIds = getGraceIds context
@@ -87,7 +93,17 @@ module Owner =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -163,6 +179,9 @@ module Owner =
                 return! context |> result500ServerError graceError
         }
 
+    let processCommand<'T when 'T :> OwnerParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<OwnerCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
+
     /// Generic processor for all Owner queries.
     let processQuery<'T, 'U when 'T :> OwnerParameters>
         (context: HttpContext)
@@ -233,8 +252,17 @@ module Owner =
                     Create(ownerIdGuid, OwnerName parameters.OwnerName)
                     |> returnValueTask
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match! CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope context (Grace.Types.Authorization.Scope.Owner graceIds.OwnerId) with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Set the name of an owner.

--- a/src/Grace.Server/Repository.Server.fs
+++ b/src/Grace.Server/Repository.Server.fs
@@ -7,6 +7,7 @@ open Grace.Actors.Constants
 open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -32,7 +33,6 @@ open System.Linq
 open System.Threading.Tasks
 open System.Text
 open System.Text.Json
-open Microsoft.AspNetCore.Http.HttpResults
 
 module Repository =
 
@@ -42,7 +42,12 @@ module Repository =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Repository.Server")
 
-    let processCommand<'T when 'T :> RepositoryParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<RepositoryCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> RepositoryParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<RepositoryCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             use activity = activitySource.StartActivity("processCommand", ActivityKind.Server)
             let graceIds = getGraceIds context
@@ -74,7 +79,19 @@ module Repository =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -166,6 +183,9 @@ module Repository =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> RepositoryParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<RepositoryCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     let processQuery<'T, 'U when 'T :> RepositoryParameters>
         (context: HttpContext)
@@ -266,7 +286,20 @@ module Repository =
                     }
                     |> ValueTask<RepositoryCommand>
 
-                return! processCommand context validations command
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Repository(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Sets the search visibility of the repository.

--- a/src/Grace.Server/Security/CreatorScopeAdminGrant.Server.fs
+++ b/src/Grace.Server/Security/CreatorScopeAdminGrant.Server.fs
@@ -1,0 +1,115 @@
+namespace Grace.Server.Security
+
+open Grace.Actors
+open Grace.Actors.Extensions.ActorProxy
+open Grace.Server.Services
+open Grace.Shared.Utilities
+open Grace.Types.Authorization
+open Grace.Types.Common
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open System
+open System.Threading.Tasks
+
+module CreatorScopeAdminGrant =
+
+    type CreatorAdminGrantResult =
+        | InheritedAdminAlreadyApplies
+        | DirectGrantPersisted
+
+    type AdminCheck = Principal list -> Set<string> -> Operation -> Resource -> Task<PermissionCheckResult>
+
+    type GrantCreatorAdmin = RoleAssignment -> Task<GraceResult<RoleAssignment list>>
+
+    let internal resourceForScope scope =
+        match scope with
+        | Scope.System -> Resource.System
+        | Scope.Owner ownerId -> Resource.Owner ownerId
+        | Scope.Organization (ownerId, organizationId) -> Resource.Organization(ownerId, organizationId)
+        | Scope.Repository (ownerId, organizationId, repositoryId) -> Resource.Repository(ownerId, organizationId, repositoryId)
+        | Scope.Branch (ownerId, organizationId, repositoryId, branchId) -> Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+
+    let internal adminOperationForScope scope =
+        match scope with
+        | Scope.System -> Operation.SystemAdmin
+        | Scope.Owner _ -> Operation.OwnerAdmin
+        | Scope.Organization _ -> Operation.OrganizationAdmin
+        | Scope.Repository _ -> Operation.RepositoryAdmin
+        | Scope.Branch _ -> Operation.BranchAdmin
+
+    let internal adminRoleForScope scope =
+        match scope with
+        | Scope.System -> "SystemAdmin"
+        | Scope.Owner _ -> "OwnerAdmin"
+        | Scope.Organization _ -> "OrganizationAdmin"
+        | Scope.Repository _ -> "RepositoryAdmin"
+        | Scope.Branch _ -> "BranchAdmin"
+
+    let internal ensureCreatorAdminCore
+        (correlationId: CorrelationId)
+        (creatorUserId: string option)
+        (principals: Principal list)
+        (effectiveClaims: Set<string>)
+        (scope: Scope)
+        (checkAdmin: AdminCheck)
+        (grantCreatorAdmin: GrantCreatorAdmin)
+        =
+        task {
+            match creatorUserId with
+            | None ->
+                return Error(GraceError.Create "Cannot grant creator admin because the authenticated principal has no mapped Grace user id." correlationId)
+            | Some userId when String.IsNullOrWhiteSpace userId ->
+                return Error(GraceError.Create "Cannot grant creator admin because the authenticated principal has no mapped Grace user id." correlationId)
+            | Some userId ->
+                let operation = adminOperationForScope scope
+                let resource = resourceForScope scope
+
+                match! checkAdmin principals effectiveClaims operation resource with
+                | Allowed _ -> return Ok InheritedAdminAlreadyApplies
+                | Denied _ ->
+                    let creatorPrincipal = { PrincipalType = PrincipalType.User; PrincipalId = userId }
+
+                    let assignment =
+                        {
+                            Principal = creatorPrincipal
+                            Scope = scope
+                            RoleId = adminRoleForScope scope
+                            Source = "scope-create"
+                            SourceDetail = Some "creator-admin"
+                            CreatedAt = getCurrentInstant ()
+                        }
+
+                    match! grantCreatorAdmin assignment with
+                    | Error error -> return Error error
+                    | Ok _ ->
+                        match! checkAdmin [ creatorPrincipal ] Set.empty operation resource with
+                        | Allowed _ -> return Ok DirectGrantPersisted
+                        | Denied reason ->
+                            return
+                                Error(
+                                    GraceError.Create
+                                        $"Creator admin grant for role '{assignment.RoleId}' on the new scope could not be proven: {reason}"
+                                        correlationId
+                                )
+        }
+
+    let ensureCreatorAdminForCreatedScope (context: HttpContext) (scope: Scope) =
+        let correlationId = getCorrelationId context
+        let creatorUserId = PrincipalMapper.tryGetUserId context.User
+        let principals = PrincipalMapper.getPrincipals context.User
+        let effectiveClaims = PrincipalMapper.getEffectiveClaims context.User
+
+        let checkAdmin principals effectiveClaims operation resource =
+            task {
+                let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+                return! evaluator.CheckAsync(principals, effectiveClaims, operation, resource)
+            }
+
+        let grantCreatorAdmin assignment =
+            task {
+                let scopeKey = AccessControl.getScopeKey assignment.Scope
+                let actorProxy = Grace.Actors.Extensions.ActorProxy.AccessControl.CreateActorProxy scopeKey correlationId
+                return! actorProxy.Handle (AccessControlCommand.GrantRole assignment) (createMetadata context)
+            }
+
+        ensureCreatorAdminCore correlationId creatorUserId principals effectiveClaims scope checkAdmin grantCreatorAdmin


### PR DESCRIPTION
## Summary

- Adds a server helper that ensures newly created authorization scopes leave the authenticated mapped Grace User with effective admin before the create response succeeds.
- Wires the helper into Owner, Organization, Repository, and Branch create success paths only.
- Adds focused unit coverage for required grants, inherited-admin skip behavior, group-authorized user-only grants, and fail-closed grant/proof failures.

## Issue Link

Related to #404.
Part of #401.

This PR targets the epic integration branch, so it intentionally uses non-closing issue wording. The orchestrator will close #404 after the PR is merged into `epic/401-authorization-scope-roles`.

## No Production Data Migration

There is no production data to preserve, migrate, grandfather, backfill, or classify for this epic. This PR does not add legacy role aliases, migration scripts, compatibility shims, or production-data repair behavior. Review should focus on the current create invariants, identity targeting, persistence ordering, and tests.

## Validation

Worker validation on `ae9adae3a2cf9d7d4b680c97ca284ba2fa2c5a3b`:

- `dotnet tool run fantomas` on touched F# files: passed.
- `dotnet test --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter CreatorScopeAdminGrantUnit`: passed, 9/9.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Authorization: 48 passed.
  - Types: 96 passed.
  - Server.Unit: 512 passed.
  - CLI: 536 passed, 1 skipped.
- `git diff --check`: passed.

GitHub validation on PR #411:

- Validate / `full`: success on `ae9adae3a2cf9d7d4b680c97ca284ba2fa2c5a3b`.

## Review Status

- Worker bot-prevention self-review: complete.
- Codex Code Review Bot: latest-head `👍` on `ae9adae3a2cf9d7d4b680c97ca284ba2fa2c5a3b`; no review threads or findings.
- GitHub Actions: `full` success.

Prevention line: this PR explicitly avoids migration/backfill/legacy role work because there is no production data to migrate, and it fail-closes if a needed creator-admin grant cannot be persisted and proven.
