### PR TITLE
Document authorization roles and bootstrap guidance

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -79,6 +79,63 @@ export grace__authz__bootstrap__system_admin_users="auth0|abc123"
 
 ---
 
+## Authorization roles and creation boundaries
+
+Authentication identifies the caller. Authorization decides whether that caller can act at a system, owner,
+organization, repository, branch, or path scope. Use `grace access list-roles` for the live role catalog, and use the
+full role IDs shown here when granting roles.
+
+### System support roles
+
+* `SystemAdmin`: full system administration, including system security administration. It includes `SystemAdmin`,
+  `SystemOperate`, system read, and descendant owner, organization, repository, branch, path, approval, and webhook
+  operations.
+* `SystemOperator`: support-operator role for system-level operations and descendant administration. It includes
+  `SystemOperate`, system read, and descendant admin/write/read operations. It does **not** include `SystemAdmin`.
+* `SystemReader`: support-reader role for system-wide visibility. It includes system read and descendant read
+  operations. It does **not** include `SystemOperate`, write, admin, or security administration operations.
+
+`SystemOperate` is the system-level support operation permission. Owner creation requires either `SystemAdmin` or
+`SystemOperate` on the system resource, so a support operator can create owners without also receiving system security
+administration.
+
+### Canonical role IDs
+
+Current role IDs use full scope names. Do not grant or document abbreviated `Org*` or `Repo*` names as current
+contracts.
+
+| Scope | Admin | Contributor / writer | Reader |
+| ----- | ----- | -------------------- | ------ |
+| System | `SystemAdmin` | `SystemOperator` | `SystemReader` |
+| Owner | `OwnerAdmin` | `OwnerContributor` | `OwnerReader` |
+| Organization | `OrganizationAdmin` | `OrganizationContributor` | `OrganizationReader` |
+| Repository | `RepositoryAdmin` | `RepositoryContributor` | `RepositoryReader` |
+| Branch | `BranchAdmin` | `BranchWriter` | `BranchReader` |
+
+### Scope creation and creator-admin grants
+
+Scope creation is authorized against the parent scope. When creation succeeds, Grace ensures the authenticated creator
+has the admin role on the newly created scope. If an inherited assignment already gives the creator admin authority,
+Grace does not need to persist a duplicate direct grant.
+
+| Created scope | Required authorization on parent | Creator-admin role on new scope |
+| ------------- | -------------------------------- | ------------------------------- |
+| Owner | `SystemAdmin` or `SystemOperate` on system | `OwnerAdmin` |
+| Organization | `OwnerAdmin` or `OwnerWrite` on owner | `OrganizationAdmin` |
+| Repository | `OrganizationAdmin` or `OrganizationWrite` on organization | `RepositoryAdmin` |
+| Branch | `RepositoryAdmin` or `RepositoryWrite` on repository | `BranchAdmin` |
+
+Creator-admin grants are live creation behavior, not migration or backfill behavior. They apply to the authenticated
+user principal that creates the scope. They are not granted to every group or claim that helped authorize the create
+request.
+
+Non-scope creation does not create admin grants. For example, DirectoryVersion creation, directory save operations,
+reference creation through branch assign/checkpoint/commit/promote/save/tag/external/rebase flows, artifacts, promotion
+sets, reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating
+those objects does not make the creator a repository, branch, or system admin.
+
+---
+
 ## Development without Auth0 (TestAuth)
 
 For local development, you can skip Auth0 entirely by enabling the built-in TestAuth handler.
@@ -163,6 +220,7 @@ PowerShell:
 
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -172,6 +230,7 @@ bash / zsh:
 
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
+unset GRACE_TOKEN
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -180,6 +239,10 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 `grace auth whoami` proves authentication. `grace auth token create` also requires authorization: the authenticated
 principal must already have a role such as `SystemAdmin`, either from first-admin bootstrap seeding or from an existing
 admin grant.
+
+MSA/OIDC authentication alone does not authorize first-time scope creation. For a fresh local/debug environment, seed
+the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing admin to grant the needed role
+before creating owners, organizations, repositories, branches, or PATs.
 
 ---
 
@@ -290,6 +353,11 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 1. **Error** if `GRACE_TOKEN_FILE` is set (local token storage is intentionally disabled).
 1. **M2M mode** if M2M env vars are set.
 1. **Interactive mode** if you have logged in previously (token stored in OS secure store).
+
+Because `GRACE_TOKEN` wins before M2M and interactive login, a stale or revoked PAT can mask a fresh interactive
+OIDC/MSA login. Unset `GRACE_TOKEN` when you want the CLI to use cached interactive credentials, and use
+`grace auth token status --output Verbose` or `grace doctor --check Authentication` when the active auth source is
+unclear.
 
 ### Primary CLI commands
 
@@ -656,7 +724,8 @@ export grace__auth__oidc__m2m_scopes="read:foo write:bar"
 * `GRACE_TOKEN` (optional)
   **No default.**
   Source: output from `grace auth token create`.
-  Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M.
+  Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M. Unset stale or
+  revoked values before troubleshooting interactive OIDC/MSA login.
 
 * `GRACE_TOKEN_FILE`
   **Not supported.** Local plaintext token file storage is intentionally disabled.
@@ -815,6 +884,24 @@ export GRACE_TOKEN="grace_pat_v1_..."
 grace auth token status --output Verbose
 ```
 
+If you are trying to use interactive OIDC/MSA login, make sure a stale PAT is not taking precedence:
+
+PowerShell:
+
+```powershell
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
+grace auth status --output Verbose
+grace auth whoami --output Verbose
+```
+
+bash / zsh:
+
+```bash
+unset GRACE_TOKEN
+grace auth status --output Verbose
+grace auth whoami --output Verbose
+```
+
 Why logs may look empty:
 
 * `grace status` maps to `branch status`, which calls `/branch/Get` and `/branch/GetParentBranch`.
@@ -839,7 +926,8 @@ If `grace auth whoami` shows your expected `GraceUserId`, but:
 * `grace access check --operation SystemAdmin --resource system --output Json`
   returns `Denied: missing permission SystemAdmin.`,
 
-and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context mismatch**.
+and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context
+mismatch**.
 
 Typical mismatch causes:
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -112,6 +112,12 @@ contracts.
 | Repository | `RepositoryAdmin` | `RepositoryContributor` | `RepositoryReader` |
 | Branch | `BranchAdmin` | `BranchWriter` | `BranchReader` |
 
+Approval-specific role IDs:
+
+| Scope | Role ID | Allows |
+| ----- | ------- | ------ |
+| Repository or branch | `ApprovalResponder` | Read and respond to approval requests |
+
 ### Scope creation and creator-admin grants
 
 Scope creation is authorized against the parent scope. When creation succeeds, Grace ensures the authenticated creator
@@ -130,9 +136,9 @@ user principal that creates the scope. They are not granted to every group or cl
 request.
 
 Non-scope creation does not create admin grants. For example, DirectoryVersion creation, directory save operations,
-reference creation through branch assign/checkpoint/commit/promote/save/tag/external/rebase flows, artifacts, promotion
-sets, reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating
-those objects does not make the creator a repository, branch, or system admin.
+reference creation through branch assign/checkpoint/commit/promote/save/tag/external flows, artifacts, promotion sets,
+reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating those
+objects does not make the creator a repository, branch, or system admin.
 
 ---
 
@@ -236,13 +242,14 @@ grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
-`grace auth whoami` proves authentication. `grace auth token create` also requires authorization: the authenticated
-principal must already have a role such as `SystemAdmin`, either from first-admin bootstrap seeding or from an existing
-admin grant.
+`grace auth whoami` proves authentication. `grace auth token create` requires an authenticated principal that maps to a
+Grace User; it does not require an RBAC role before token creation.
 
-MSA/OIDC authentication alone does not authorize first-time scope creation. For a fresh local/debug environment, seed
-the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing admin to grant the needed role
-before creating owners, organizations, repositories, branches, or PATs.
+MSA/OIDC authentication alone does not authorize first-time scope creation or other protected operations. For a fresh
+local/debug environment, seed the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing
+admin to grant the needed role before creating owners, organizations, repositories, or branches. A PAT created before
+RBAC grants will authenticate the principal, but it will not authorize protected operations until normal Grace
+authorization permits them.
 
 ---
 
@@ -396,7 +403,9 @@ A PAT string looks like:
 
 ### Creating a PAT
 
-You must already be authenticated (interactive Auth0 login, or an existing PAT, or M2M) to create a PAT.
+You must already be authenticated (interactive Auth0 login, or an existing PAT, or M2M) as a mapped Grace User to
+create a PAT. PAT creation itself does not require an RBAC role; the resulting PAT still authorizes protected operations
+only through Grace's normal authorization checks.
 
 #### CLI (recommended)
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -103,7 +103,8 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
 SystemAdmin assignment with `grace__authz__bootstrap__system_admin_users` or have an existing admin grant the needed
-role before PAT creation and other protected operations will succeed.
+role before protected operations will succeed. An authenticated caller that maps to a Grace User can create a PAT before
+RBAC grants; that PAT still authorizes protected operations only through Grace's normal authorization checks.
 
 `GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
 interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
@@ -115,10 +116,11 @@ Scope creation uses normal authorization in DebugLocal and production:
 - repository creation requires `OrganizationAdmin` or `OrganizationWrite` on the parent organization;
 - branch creation requires `RepositoryAdmin` or `RepositoryWrite` on the parent repository.
 
-After successful scope creation, Grace ensures the authenticated creator has the matching admin role on the new scope:
-`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`. Non-scope creation such as DirectoryVersion,
-directory save, reference creation, artifacts, promotion sets, reminders, validation records, and work items does not
-create admin grants.
+After successful scope creation, Grace ensures the authenticated creator has effective admin authority on the new scope.
+Grace creates a direct matching admin grant (`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`) only
+when inherited admin authority does not already apply. Non-scope creation such as DirectoryVersion, directory save,
+reference creation, artifacts, promotion sets, reminders, validation records, and work items does not create admin
+grants.
 
 ## DebugLocal Reliability Switches
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -85,6 +85,7 @@ PowerShell:
 
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -94,6 +95,7 @@ bash / zsh:
 
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
+unset GRACE_TOKEN
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -102,6 +104,21 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
 SystemAdmin assignment with `grace__authz__bootstrap__system_admin_users` or have an existing admin grant the needed
 role before PAT creation and other protected operations will succeed.
+
+`GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
+interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
+
+Scope creation uses normal authorization in DebugLocal and production:
+
+- owner creation requires `SystemAdmin` or the support operation `SystemOperate` on the system resource;
+- organization creation requires `OwnerAdmin` or `OwnerWrite` on the parent owner;
+- repository creation requires `OrganizationAdmin` or `OrganizationWrite` on the parent organization;
+- branch creation requires `RepositoryAdmin` or `RepositoryWrite` on the parent repository.
+
+After successful scope creation, Grace ensures the authenticated creator has the matching admin role on the new scope:
+`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`. Non-scope creation such as DirectoryVersion,
+directory save, reference creation, artifacts, promotion sets, reminders, validation records, and work items does not
+create admin grants.
 
 ## DebugLocal Reliability Switches
 
@@ -225,8 +242,9 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 ### CLI / Client
 
 - `GRACE_SERVER_URI`: Grace server base URL (include port, omit trailing slash).
-- `GRACE_TOKEN`: Grace PAT for non-interactive auth. OIDC/MSA access tokens are not valid here.
-- `GRACE_TOKEN_FILE`: override for token file path.
+- `GRACE_TOKEN`: Grace PAT for non-interactive auth. OIDC/MSA access tokens are not valid here. This value wins before
+  M2M and interactive login.
+- `GRACE_TOKEN_FILE`: not supported; local plaintext token file storage is intentionally disabled.
 
 ### Reminders
 


### PR DESCRIPTION
## Summary

- Documents the current authorization role model, including `SystemAdmin`, `SystemOperator`, `SystemReader`, `SystemOperate`, and `ApprovalResponder`.
- Documents full-name `Organization*` and `Repository*` role IDs as the current contract.
- Documents scope creation authorization, creator-admin grants, non-scope creation boundaries, local Debug/bootstrap guidance, PAT creation boundaries, and stale `GRACE_TOKEN` troubleshooting.

## Issue Link

Related to #406.
Part of #401.

This PR targets the epic integration branch, so it intentionally uses non-closing issue wording. The orchestrator will close #406 after the PR is merged into `epic/401-authorization-scope-roles`.

## No Production Data Migration

There is no production data to preserve, migrate, grandfather, backfill, or classify for this epic. The docs intentionally do not add migration instructions, compatibility aliases, or production-data repair guidance for old `Org*` / `Repo*` role IDs. Review should focus on whether the documentation matches current source behavior.

## Validation

Initial worker validation on `102bf2b4efe4fb2fd6275d08a3d46167d41b87f2`:

- `npx --yes markdownlint-cli2 "docs/Authentication.md" "src/docs/ENVIRONMENT.md"`: passed, `0 error(s)`.
- Focused PowerShell stale role-name search across `docs` and `src/docs` for current-contract `OrgAdmin`, `OrgContributor`, `OrgReader`, `OrgWrite`, `RepoAdmin`, `RepoContributor`, `RepoReader`, `RepoWrite`: passed, no matches.
- `git diff --check`: passed.

Fix worker validation on `1368094cb52bba1c952d52496e584f25e975135c`:

- `npx --yes markdownlint-cli2 "docs/Authentication.md" "src/docs/ENVIRONMENT.md"`: passed, `0 error(s)`.
- Focused stale-role search across `docs` and `src/docs` for current-contract `OrgAdmin`, `OrgContributor`, `OrgReader`, `OrgWrite`, `RepoAdmin`, `RepoContributor`, `RepoReader`, `RepoWrite`: passed, no matches.
- `git diff --check`: passed.
- Bot-prevention self-review confirmed all four Codex findings were addressed.

GitHub validation:

- Validate / `full`: passed on `102bf2b4efe4fb2fd6275d08a3d46167d41b87f2`.
- Validate / `full`: passed on `1368094cb52bba1c952d52496e584f25e975135c`.

## Review Status

- Worker bot-prevention self-review: complete on `102bf2b4efe4fb2fd6275d08a3d46167d41b87f2`.
- Codex Code Review Bot found four P2 docs issues on `102bf2b4efe4fb2fd6275d08a3d46167d41b87f2`.
- Fix commit `1368094cb52bba1c952d52496e584f25e975135c` addresses all four findings:
  - Added `ApprovalResponder` to canonical role documentation.
  - Corrected PAT guidance so PAT creation requires authentication as a mapped Grace User, not prior RBAC.
  - Removed `rebase` from branch write/admin examples.
  - Clarified inherited creator-admin behavior as effective admin, not always a direct matching grant.
- Review thread replies/resolution: complete; all four review threads resolved.
- Codex Code Review Bot: latest-head `👍` on `1368094cb52bba1c952d52496e584f25e975135c`.

Prevention line: these docs explicitly state that MSA authentication is not authorization by itself, Debug does not bypass authorization, PAT creation is authentication-gated while protected operations remain authorization-gated, inherited creator-admin may be effective rather than direct, and there is no production data migration or legacy-role compatibility requirement.
