### PR TITLE
Implement authorization scope roles and creator grants

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -79,6 +79,63 @@ export grace__authz__bootstrap__system_admin_users="auth0|abc123"
 
 ---
 
+## Authorization roles and creation boundaries
+
+Authentication identifies the caller. Authorization decides whether that caller can act at a system, owner,
+organization, repository, branch, or path scope. Use `grace access list-roles` for the live role catalog, and use the
+full role IDs shown here when granting roles.
+
+### System support roles
+
+* `SystemAdmin`: full system administration, including system security administration. It includes `SystemAdmin`,
+  `SystemOperate`, system read, and descendant owner, organization, repository, branch, path, approval, and webhook
+  operations.
+* `SystemOperator`: support-operator role for system-level operations and descendant administration. It includes
+  `SystemOperate`, system read, and descendant admin/write/read operations. It does **not** include `SystemAdmin`.
+* `SystemReader`: support-reader role for system-wide visibility. It includes system read and descendant read
+  operations. It does **not** include `SystemOperate`, write, admin, or security administration operations.
+
+`SystemOperate` is the system-level support operation permission. Owner creation requires either `SystemAdmin` or
+`SystemOperate` on the system resource, so a support operator can create owners without also receiving system security
+administration.
+
+### Canonical role IDs
+
+Current role IDs use full scope names. Do not grant or document abbreviated `Org*` or `Repo*` names as current
+contracts.
+
+| Scope | Admin | Contributor / writer | Reader |
+| ----- | ----- | -------------------- | ------ |
+| System | `SystemAdmin` | `SystemOperator` | `SystemReader` |
+| Owner | `OwnerAdmin` | `OwnerContributor` | `OwnerReader` |
+| Organization | `OrganizationAdmin` | `OrganizationContributor` | `OrganizationReader` |
+| Repository | `RepositoryAdmin` | `RepositoryContributor` | `RepositoryReader` |
+| Branch | `BranchAdmin` | `BranchWriter` | `BranchReader` |
+
+### Scope creation and creator-admin grants
+
+Scope creation is authorized against the parent scope. When creation succeeds, Grace ensures the authenticated creator
+has the admin role on the newly created scope. If an inherited assignment already gives the creator admin authority,
+Grace does not need to persist a duplicate direct grant.
+
+| Created scope | Required authorization on parent | Creator-admin role on new scope |
+| ------------- | -------------------------------- | ------------------------------- |
+| Owner | `SystemAdmin` or `SystemOperate` on system | `OwnerAdmin` |
+| Organization | `OwnerAdmin` or `OwnerWrite` on owner | `OrganizationAdmin` |
+| Repository | `OrganizationAdmin` or `OrganizationWrite` on organization | `RepositoryAdmin` |
+| Branch | `RepositoryAdmin` or `RepositoryWrite` on repository | `BranchAdmin` |
+
+Creator-admin grants are live creation behavior, not migration or backfill behavior. They apply to the authenticated
+user principal that creates the scope. They are not granted to every group or claim that helped authorize the create
+request.
+
+Non-scope creation does not create admin grants. For example, DirectoryVersion creation, directory save operations,
+reference creation through branch assign/checkpoint/commit/promote/save/tag/external/rebase flows, artifacts, promotion
+sets, reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating
+those objects does not make the creator a repository, branch, or system admin.
+
+---
+
 ## Development without Auth0 (TestAuth)
 
 For local development, you can skip Auth0 entirely by enabling the built-in TestAuth handler.
@@ -163,6 +220,7 @@ PowerShell:
 
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -172,6 +230,7 @@ bash / zsh:
 
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
+unset GRACE_TOKEN
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -180,6 +239,10 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 `grace auth whoami` proves authentication. `grace auth token create` also requires authorization: the authenticated
 principal must already have a role such as `SystemAdmin`, either from first-admin bootstrap seeding or from an existing
 admin grant.
+
+MSA/OIDC authentication alone does not authorize first-time scope creation. For a fresh local/debug environment, seed
+the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing admin to grant the needed role
+before creating owners, organizations, repositories, branches, or PATs.
 
 ---
 
@@ -290,6 +353,11 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 1. **Error** if `GRACE_TOKEN_FILE` is set (local token storage is intentionally disabled).
 1. **M2M mode** if M2M env vars are set.
 1. **Interactive mode** if you have logged in previously (token stored in OS secure store).
+
+Because `GRACE_TOKEN` wins before M2M and interactive login, a stale or revoked PAT can mask a fresh interactive
+OIDC/MSA login. Unset `GRACE_TOKEN` when you want the CLI to use cached interactive credentials, and use
+`grace auth token status --output Verbose` or `grace doctor --check Authentication` when the active auth source is
+unclear.
 
 ### Primary CLI commands
 
@@ -656,7 +724,8 @@ export grace__auth__oidc__m2m_scopes="read:foo write:bar"
 * `GRACE_TOKEN` (optional)
   **No default.**
   Source: output from `grace auth token create`.
-  Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M.
+  Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M. Unset stale or
+  revoked values before troubleshooting interactive OIDC/MSA login.
 
 * `GRACE_TOKEN_FILE`
   **Not supported.** Local plaintext token file storage is intentionally disabled.
@@ -815,6 +884,24 @@ export GRACE_TOKEN="grace_pat_v1_..."
 grace auth token status --output Verbose
 ```
 
+If you are trying to use interactive OIDC/MSA login, make sure a stale PAT is not taking precedence:
+
+PowerShell:
+
+```powershell
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
+grace auth status --output Verbose
+grace auth whoami --output Verbose
+```
+
+bash / zsh:
+
+```bash
+unset GRACE_TOKEN
+grace auth status --output Verbose
+grace auth whoami --output Verbose
+```
+
 Why logs may look empty:
 
 * `grace status` maps to `branch status`, which calls `/branch/Get` and `/branch/GetParentBranch`.
@@ -839,7 +926,8 @@ If `grace auth whoami` shows your expected `GraceUserId`, but:
 * `grace access check --operation SystemAdmin --resource system --output Json`
   returns `Denied: missing permission SystemAdmin.`,
 
-and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context mismatch**.
+and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context
+mismatch**.
 
 Typical mismatch causes:
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -112,6 +112,12 @@ contracts.
 | Repository | `RepositoryAdmin` | `RepositoryContributor` | `RepositoryReader` |
 | Branch | `BranchAdmin` | `BranchWriter` | `BranchReader` |
 
+Approval-specific role IDs:
+
+| Scope | Role ID | Allows |
+| ----- | ------- | ------ |
+| Repository or branch | `ApprovalResponder` | Read and respond to approval requests |
+
 ### Scope creation and creator-admin grants
 
 Scope creation is authorized against the parent scope. When creation succeeds, Grace ensures the authenticated creator
@@ -130,9 +136,9 @@ user principal that creates the scope. They are not granted to every group or cl
 request.
 
 Non-scope creation does not create admin grants. For example, DirectoryVersion creation, directory save operations,
-reference creation through branch assign/checkpoint/commit/promote/save/tag/external/rebase flows, artifacts, promotion
-sets, reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating
-those objects does not make the creator a repository, branch, or system admin.
+reference creation through branch assign/checkpoint/commit/promote/save/tag/external flows, artifacts, promotion sets,
+reminders, validation records, and work items remain normal repository or branch write/admin operations. Creating those
+objects does not make the creator a repository, branch, or system admin.
 
 ---
 
@@ -236,13 +242,14 @@ grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
-`grace auth whoami` proves authentication. `grace auth token create` also requires authorization: the authenticated
-principal must already have a role such as `SystemAdmin`, either from first-admin bootstrap seeding or from an existing
-admin grant.
+`grace auth whoami` proves authentication. `grace auth token create` requires an authenticated principal that maps to a
+Grace User; it does not require an RBAC role before token creation.
 
-MSA/OIDC authentication alone does not authorize first-time scope creation. For a fresh local/debug environment, seed
-the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing admin to grant the needed role
-before creating owners, organizations, repositories, branches, or PATs.
+MSA/OIDC authentication alone does not authorize first-time scope creation or other protected operations. For a fresh
+local/debug environment, seed the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing
+admin to grant the needed role before creating owners, organizations, repositories, or branches. A PAT created before
+RBAC grants will authenticate the principal, but it will not authorize protected operations until normal Grace
+authorization permits them.
 
 ---
 
@@ -396,7 +403,9 @@ A PAT string looks like:
 
 ### Creating a PAT
 
-You must already be authenticated (interactive Auth0 login, or an existing PAT, or M2M) to create a PAT.
+You must already be authenticated (interactive Auth0 login, or an existing PAT, or M2M) as a mapped Grace User to
+create a PAT. PAT creation itself does not require an RBAC role; the resulting PAT still authorizes protected operations
+only through Grace's normal authorization checks.
 
 #### CLI (recommended)
 

--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -59,6 +59,59 @@ type AuthorizationSemanticsTests() =
         | Denied _ -> ()
         | Allowed reason -> Assert.Fail($"Expected Denied but got Allowed: {reason}")
 
+    let assertOperationAllowed roleId scope operation resource =
+        let result = checkPermission roleCatalog [ createAssignment scope roleId ] [] [ principal ] Set.empty operation resource
+
+        assertAllowed result
+
+    let assertOperationDenied roleId scope operation resource =
+        let result = checkPermission roleCatalog [ createAssignment scope roleId ] [] [ principal ] Set.empty operation resource
+
+        assertDenied result
+
+    [<Test>]
+    member _.RoleCatalogContainsOnlyCanonicalRoles() =
+        let expectedRoleIds =
+            [
+                "SystemAdmin"
+                "SystemOperator"
+                "SystemReader"
+                "OwnerAdmin"
+                "OwnerContributor"
+                "OwnerReader"
+                "OrganizationAdmin"
+                "OrganizationContributor"
+                "OrganizationReader"
+                "RepositoryAdmin"
+                "RepositoryContributor"
+                "RepositoryReader"
+                "BranchAdmin"
+                "BranchWriter"
+                "BranchReader"
+                "ApprovalResponder"
+            ]
+
+        let actualRoleIds = roleCatalog |> List.map (fun role -> role.RoleId)
+
+        Assert.That(actualRoleIds, Is.EquivalentTo expectedRoleIds)
+        Assert.That(actualRoleIds |> List.length, Is.EqualTo(expectedRoleIds.Length))
+
+    [<Test>]
+    member _.OldAbbreviatedRoleIdsAreUnknown() =
+        let oldRoleIds =
+            [
+                "OrgAdmin"
+                "OrgReader"
+                "RepoAdmin"
+                "RepoContributor"
+                "RepoReader"
+                "rEpOrEaDeR"
+                "oRgAdMiN"
+            ]
+
+        for roleId in oldRoleIds do
+            Assert.That(RoleCatalog.tryGet roleId |> Option.isNone, Is.True, $"Old role ID '{roleId}' should not be accepted.")
+
     [<Test>]
     member _.RoleCatalogMatrixMatchesPermissionChecks() =
         for role in roleCatalog do
@@ -78,40 +131,40 @@ type AuthorizationSemanticsTests() =
                         if expectedAllowed then assertAllowed result else assertDenied result
 
     [<Test>]
-    member _.RepoAdminIncludesBranchAdmin() =
-        let repoAdmin =
+    member _.RepositoryAdminIncludesBranchAdmin() =
+        let repositoryAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
-        Assert.That(repoAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
 
     [<Test>]
     member _.ApprovalOperationsUseConservativeRoleGrants() =
-        let repoAdmin =
+        let repositoryAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
-        let repoReader =
+        let repositoryReader =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoReader", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryReader", StringComparison.OrdinalIgnoreCase))
 
-        let repoContributor =
+        let repositoryContributor =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoContributor", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryContributor", StringComparison.OrdinalIgnoreCase))
 
         let responder =
             roleCatalog
             |> List.find (fun role -> role.RoleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase))
 
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains WebhookManage, Is.True)
-        Assert.That(repoAdmin.AllowedOperations.Contains WebhookDeliveryRead, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains WebhookManage, Is.True)
+        Assert.That(repositoryAdmin.AllowedOperations.Contains WebhookDeliveryRead, Is.True)
 
-        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(repoReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
-        Assert.That(repoContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+        Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
+        Assert.That(repositoryContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
 
         Assert.That(responder.AppliesTo.Contains("repository"), Is.True)
         Assert.That(responder.AppliesTo.Contains("branch"), Is.True)
@@ -120,11 +173,101 @@ type AuthorizationSemanticsTests() =
         Assert.That(responder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
 
     [<Test>]
+    member _.SystemOperatorHasDescendantAdminWriteReadButNoSystemAdmin() =
+        let systemScope = Scope.System
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "SystemOperator" systemScope SystemOperate Resource.System
+        assertOperationAllowed "SystemOperator" systemScope SystemRead Resource.System
+        assertOperationDenied "SystemOperator" systemScope SystemAdmin Resource.System
+
+        assertOperationAllowed "SystemOperator" systemScope OwnerAdmin ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OwnerWrite ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OwnerRead ownerResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationAdmin organizationResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationWrite organizationResource
+        assertOperationAllowed "SystemOperator" systemScope OrganizationRead organizationResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryAdmin repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryWrite repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope RepositoryRead repositoryResource
+        assertOperationAllowed "SystemOperator" systemScope BranchAdmin branchResource
+        assertOperationAllowed "SystemOperator" systemScope BranchWrite branchResource
+        assertOperationAllowed "SystemOperator" systemScope BranchRead branchResource
+        assertOperationAllowed "SystemOperator" systemScope PathWrite pathResource
+        assertOperationAllowed "SystemOperator" systemScope PathRead pathResource
+
+    [<Test>]
+    member _.SystemReaderHasOnlySystemWideReadCoverage() =
+        let systemScope = Scope.System
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "SystemReader" systemScope SystemRead Resource.System
+        assertOperationDenied "SystemReader" systemScope SystemOperate Resource.System
+        assertOperationDenied "SystemReader" systemScope SystemAdmin Resource.System
+        assertOperationAllowed "SystemReader" systemScope OwnerRead ownerResource
+        assertOperationAllowed "SystemReader" systemScope OrganizationRead organizationResource
+        assertOperationAllowed "SystemReader" systemScope RepositoryRead repositoryResource
+        assertOperationAllowed "SystemReader" systemScope BranchRead branchResource
+        assertOperationAllowed "SystemReader" systemScope PathRead pathResource
+        assertOperationDenied "SystemReader" systemScope OwnerWrite ownerResource
+        assertOperationDenied "SystemReader" systemScope OrganizationWrite organizationResource
+        assertOperationDenied "SystemReader" systemScope RepositoryWrite repositoryResource
+        assertOperationDenied "SystemReader" systemScope BranchWrite branchResource
+        assertOperationDenied "SystemReader" systemScope PathWrite pathResource
+        assertOperationDenied "SystemReader" systemScope OwnerAdmin ownerResource
+        assertOperationDenied "SystemReader" systemScope OrganizationAdmin organizationResource
+        assertOperationDenied "SystemReader" systemScope RepositoryAdmin repositoryResource
+        assertOperationDenied "SystemReader" systemScope BranchAdmin branchResource
+
+    [<Test>]
+    member _.ContributorRolesWriteDescendantsWithoutAdminAuthority() =
+        let ownerScope = Scope.Owner ownerId
+        let organizationScope = Scope.Organization(ownerId, organizationId)
+        let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+        let ownerResource = Resource.Owner ownerId
+        let organizationResource = Resource.Organization(ownerId, organizationId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let pathResource = Resource.Path(ownerId, organizationId, repositoryId, "/docs/readme.md")
+
+        assertOperationAllowed "OwnerContributor" ownerScope OwnerWrite ownerResource
+        assertOperationAllowed "OwnerContributor" ownerScope OrganizationWrite organizationResource
+        assertOperationAllowed "OwnerContributor" ownerScope RepositoryWrite repositoryResource
+        assertOperationAllowed "OwnerContributor" ownerScope BranchWrite branchResource
+        assertOperationAllowed "OwnerContributor" ownerScope PathWrite pathResource
+        assertOperationDenied "OwnerContributor" ownerScope OwnerAdmin ownerResource
+        assertOperationDenied "OwnerContributor" ownerScope OrganizationAdmin organizationResource
+        assertOperationDenied "OwnerContributor" ownerScope RepositoryAdmin repositoryResource
+        assertOperationDenied "OwnerContributor" ownerScope BranchAdmin branchResource
+
+        assertOperationAllowed "OrganizationContributor" organizationScope OrganizationWrite organizationResource
+        assertOperationAllowed "OrganizationContributor" organizationScope RepositoryWrite repositoryResource
+        assertOperationAllowed "OrganizationContributor" organizationScope BranchWrite branchResource
+        assertOperationAllowed "OrganizationContributor" organizationScope PathWrite pathResource
+        assertOperationDenied "OrganizationContributor" organizationScope OrganizationAdmin organizationResource
+        assertOperationDenied "OrganizationContributor" organizationScope RepositoryAdmin repositoryResource
+        assertOperationDenied "OrganizationContributor" organizationScope BranchAdmin branchResource
+
+        assertOperationAllowed "RepositoryContributor" repositoryScope RepositoryWrite repositoryResource
+        assertOperationAllowed "RepositoryContributor" repositoryScope BranchWrite branchResource
+        assertOperationAllowed "RepositoryContributor" repositoryScope PathWrite pathResource
+        assertOperationDenied "RepositoryContributor" repositoryScope RepositoryAdmin repositoryResource
+        assertOperationDenied "RepositoryContributor" repositoryScope BranchAdmin branchResource
+
+    [<Test>]
     member _.IrrelevantAssignmentsDoNotAffectDecision() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoAdmin"
+            let assignment = createAssignment scope "RepositoryAdmin"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
             let extraAssignment = { assignment with Principal = otherPrincipal }
@@ -140,10 +283,10 @@ type AuthorizationSemanticsTests() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoAdmin"
+            let assignment = createAssignment scope "RepositoryAdmin"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
-            let unrelatedAssignment = createAssignment (Scope.Branch(ownerId, organizationId, repositoryId, branchId)) "RepoAdmin"
+            let unrelatedAssignment = createAssignment (Scope.Branch(ownerId, organizationId, repositoryId, branchId)) "RepositoryAdmin"
 
             let withUnrelated = checkPermission roleCatalog [ unrelatedAssignment; assignment ] [] [ principal ] Set.empty operation resource
 
@@ -156,10 +299,10 @@ type AuthorizationSemanticsTests() =
         let property (operation: Operation) =
             let scope = Scope.Repository(ownerId, organizationId, repositoryId)
             let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-            let assignment = createAssignment scope "RepoReader"
+            let assignment = createAssignment scope "RepositoryReader"
             let baseResult = checkPermission roleCatalog [ assignment ] [] [ principal ] Set.empty operation resource
 
-            let mixedCaseAssignment = createAssignment scope "rEpOrEaDeR"
+            let mixedCaseAssignment = createAssignment scope "rEpOsItOrYrEaDeR"
 
             let withMixedCase = checkPermission roleCatalog [ mixedCaseAssignment ] [] [ principal ] Set.empty operation resource
 
@@ -176,8 +319,8 @@ type AuthorizationSemanticsTests() =
             | _ ->
                 let scope = Scope.Repository(ownerId, organizationId, repositoryId)
                 let resource = Resource.Repository(ownerId, organizationId, repositoryId)
-                let baseAssignment = createAssignment scope "RepoReader"
-                let extraAssignment = createAssignment scope "RepoAdmin"
+                let baseAssignment = createAssignment scope "RepositoryReader"
+                let extraAssignment = createAssignment scope "RepositoryAdmin"
 
                 let baseResult = checkPermission roleCatalog [ baseAssignment ] [] [ principal ] Set.empty operation resource
 

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -235,7 +235,7 @@ type EndpointAuthorizationManifestTests() =
         [
             "POST", "/storage/discoverContentBlocks"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryRead, ResourceKind.Repository))
 
         [
             "POST", "/storage/claimReuseRanges"
@@ -269,7 +269,7 @@ type EndpointAuthorizationManifestTests() =
             "POST", "/work/links/remove/reference"
             "POST", "/work/update"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoWrite, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryWrite, ResourceKind.Repository))
 
         [
             "POST", "/work/get"
@@ -278,4 +278,4 @@ type EndpointAuthorizationManifestTests() =
             "POST", "/work/attachments/show"
             "POST", "/work/attachments/download"
         ]
-        |> assertRoutesUseSecurity (Authorized(Operation.RepoRead, ResourceKind.Repository))
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryRead, ResourceKind.Repository))

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -67,6 +67,15 @@ type EndpointAuthorizationManifestTests() =
         for method_, path in routes do
             assertRouteSecurity method_ path expectedSecurity
 
+    let rec includesSecurity expectedSecurity actualSecurity =
+        actualSecurity = expectedSecurity
+        || match actualSecurity with
+           | AnyOf requirements
+           | AllOf requirements ->
+               requirements
+               |> List.exists (includesSecurity expectedSecurity)
+           | _ -> false
+
     let assertRouteRequiresSecurity method_ path (expectedSecurity: EndpointSecurity) =
         let matchingDefinitions =
             definitions
@@ -74,19 +83,74 @@ type EndpointAuthorizationManifestTests() =
                 definition.Method = method_
                 && definition.Path = path)
 
-        let rec includesSecurity actualSecurity =
-            actualSecurity = expectedSecurity
-            || match actualSecurity with
-               | AllOf requirements -> requirements |> List.exists includesSecurity
-               | _ -> false
+        match matchingDefinitions with
+        | [ definition ] ->
+            Assert.That(
+                includesSecurity expectedSecurity definition.Security,
+                Is.True,
+                $"Expected {method_} {path} to require {expectedSecurity}, but manifest uses {definition.Security}."
+            )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
+
+    let assertRouteDoesNotRequireSecurity method_ path (unexpectedSecurity: EndpointSecurity) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
 
         match matchingDefinitions with
         | [ definition ] ->
             Assert.That(
-                includesSecurity definition.Security,
-                Is.True,
-                $"Expected {method_} {path} to require {expectedSecurity}, but manifest uses {definition.Security}."
+                includesSecurity unexpectedSecurity definition.Security,
+                Is.False,
+                $"Expected {method_} {path} not to require {unexpectedSecurity}, but manifest uses {definition.Security}."
             )
+        | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
+        | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
+
+    let writeOrAdmin adminOperation writeOperation resourceKind =
+        AnyOf [ Authorized(adminOperation, resourceKind)
+                Authorized(writeOperation, resourceKind) ]
+
+    let rec operationsInSecurity security =
+        match security with
+        | Authorized (operation, _) -> [ operation ]
+        | AnyOf requirements
+        | AllOf requirements -> requirements |> List.collect operationsInSecurity
+        | AllowAnonymous
+        | Authenticated -> []
+
+    let assertRouteUsesCanonicalOperationNames method_ path (expectedOperationNames: string list) =
+        let matchingDefinitions =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Method = method_
+                && definition.Path = path)
+
+        match matchingDefinitions with
+        | [ definition ] ->
+            let actualOperationNames =
+                definition.Security
+                |> operationsInSecurity
+                |> List.map string
+                |> List.toArray
+
+            Assert.That(actualOperationNames, Is.EquivalentTo(expectedOperationNames), $"{method_} {path} must use canonical full operation names.")
+
+            let abbreviatedNames =
+                actualOperationNames
+                |> Array.filter (fun operationName ->
+                    [
+                        "OrgAdmin"
+                        "OrgWrite"
+                        "RepoAdmin"
+                        "RepoWrite"
+                    ]
+                    |> List.contains operationName)
+
+            Assert.That(abbreviatedNames, Is.Empty, $"{method_} {path} must not use stale abbreviated operation names.")
         | [] -> Assert.Fail($"Expected EndpointAuthorizationManifest to include {method_} {path}.")
         | _ -> Assert.Fail($"Expected EndpointAuthorizationManifest to include one entry for {method_} {path}.")
 
@@ -251,6 +315,64 @@ type EndpointAuthorizationManifestTests() =
         |> assertRoutesUseSecurity (Authorized(Operation.PathWrite, ResourceKind.Path))
 
     [<Test>]
+    member _.ScopeCreationRoutesRequireParentWriteOrAdminOperations() =
+        [
+            "POST", "/owner/create", writeOrAdmin Operation.SystemAdmin Operation.SystemOperate ResourceKind.System
+            "POST", "/organization/create", writeOrAdmin Operation.OwnerAdmin Operation.OwnerWrite ResourceKind.Owner
+            "POST", "/repository/create", writeOrAdmin Operation.OrganizationAdmin Operation.OrganizationWrite ResourceKind.Organization
+            "POST", "/branch/create", writeOrAdmin Operation.RepositoryAdmin Operation.RepositoryWrite ResourceKind.Repository
+        ]
+        |> List.iter (fun (method_, path, expectedSecurity) -> assertRouteSecurity method_ path expectedSecurity)
+
+        assertRouteDoesNotRequireSecurity "POST" "/branch/create" (Authorized(Operation.BranchWrite, ResourceKind.Branch))
+
+    [<Test>]
+    member _.CreationRouteOperationsUseCanonicalFullNames() =
+        [
+            "POST", "/owner/create", [ "SystemAdmin"; "SystemOperate" ]
+            "POST", "/organization/create", [ "OwnerAdmin"; "OwnerWrite" ]
+            "POST",
+            "/repository/create",
+            [
+                "OrganizationAdmin"
+                "OrganizationWrite"
+            ]
+            "POST", "/branch/create", [ "RepositoryAdmin"; "RepositoryWrite" ]
+            "POST", "/directory/create", [ "RepositoryAdmin"; "RepositoryWrite" ]
+            "POST", "/directory/saveDirectoryVersions", [ "RepositoryAdmin"; "RepositoryWrite" ]
+        ]
+        |> List.iter (fun (method_, path, expectedOperationNames) -> assertRouteUsesCanonicalOperationNames method_ path expectedOperationNames)
+
+    [<Test>]
+    member _.BranchReferenceCreationRoutesUseBranchWriteOrAdminNotRepositoryScopeCreation() =
+        [
+            "POST", "/branch/assign"
+            "POST", "/branch/checkpoint"
+            "POST", "/branch/commit"
+            "POST", "/branch/createExternal"
+            "POST", "/branch/promote"
+            "POST", "/branch/save"
+            "POST", "/branch/tag"
+        ]
+        |> assertRoutesUseSecurity (writeOrAdmin Operation.BranchAdmin Operation.BranchWrite ResourceKind.Branch)
+
+        assertRouteDoesNotRequireSecurity "POST" "/branch/save" (Authorized(Operation.RepositoryWrite, ResourceKind.Repository))
+
+    [<Test>]
+    member _.RepositoryContainedCreationRoutesRequireRepositoryWriteOrAdminOperations() =
+        [
+            "POST", "/artifact/create"
+            "POST", "/directory/create"
+            "POST", "/directory/saveDirectoryVersions"
+            "POST", "/promotion-set/create"
+            "POST", "/reminder/create"
+            "POST", "/validation-set/create"
+            "POST", "/validation-result/record"
+            "POST", "/work/create"
+        ]
+        |> assertRoutesUseSecurity (writeOrAdmin Operation.RepositoryAdmin Operation.RepositoryWrite ResourceKind.Repository)
+
+    [<Test>]
     member _.BranchAnnotateRequiresBranchReadAndPathRead() =
         assertRouteRequiresSecurity "POST" "/branch/annotate" (Authorized(Operation.BranchRead, ResourceKind.Branch))
         assertRouteRequiresSecurity "POST" "/branch/annotate" (Authorized(Operation.PathRead, ResourceKind.Path))
@@ -258,7 +380,6 @@ type EndpointAuthorizationManifestTests() =
     [<Test>]
     member _.SelectedWorkItemRoutesUseExpectedPolicies() =
         [
-            "POST", "/work/create"
             "POST", "/work/add-summary"
             "POST", "/work/link/artifact"
             "POST", "/work/link/promotion-set"

--- a/src/Grace.Authorization.Tests/PermissionEvaluator.Tests.fs
+++ b/src/Grace.Authorization.Tests/PermissionEvaluator.Tests.fs
@@ -37,7 +37,7 @@ type PermissionEvaluatorTests() =
 
             let! _ =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, resource)
 
             let expected = scopesForResource resource
             Assert.That(capturedScopes, Is.EquivalentTo(expected))
@@ -48,7 +48,12 @@ type PermissionEvaluatorTests() =
         task {
             let getAssignmentsForScope (scope: Scope, _correlationId: CorrelationId) =
                 match scope with
-                | Scope.Organization _ -> Task.FromResult([ createAssignment scope "OrgAdmin" ])
+                | Scope.Organization _ ->
+                    Task.FromResult(
+                        [
+                            createAssignment scope "OrganizationAdmin"
+                        ]
+                    )
                 | _ -> Task.FromResult([])
 
             let evaluator = GracePermissionEvaluator(getAssignmentsForScope, emptyPathPermissions)
@@ -56,7 +61,7 @@ type PermissionEvaluatorTests() =
 
             let! result =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoWrite, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryWrite, resource)
 
             match result with
             | Allowed _ -> ()
@@ -78,7 +83,7 @@ type PermissionEvaluatorTests() =
 
             let! _ =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, repositoryResource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, repositoryResource)
 
             Assert.That(pathPermissionCalls, Is.EqualTo(0))
 
@@ -101,7 +106,7 @@ type PermissionEvaluatorTests() =
 
             let! result =
                 (evaluator :> IGracePermissionEvaluator)
-                    .CheckAsync([ principal ], Set.empty, Operation.RepoRead, resource)
+                    .CheckAsync([ principal ], Set.empty, Operation.RepositoryRead, resource)
 
             match result with
             | Denied _ -> ()

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -58,7 +58,7 @@ module CommandOutputContractRegistryTests =
         | "--fire-at" -> "2026-01-01T00:00:00Z"
         | "--format" -> "json"
         | "--gate" -> "build"
-        | "--operation" -> "RepoRead"
+        | "--operation" -> "RepositoryRead"
         | "--organization-type"
         | "--owner-type"
         | "--visibility" -> "Public"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -69,6 +69,7 @@ module CommandOutputContractRegistryTests =
         | "--promotion-mode" -> "IndividualOnly"
         | "--resource"
         | "--scope" -> "repository"
+        | "--role" -> "RepositoryReader"
         | "--search-visibility" -> "Visible"
         | "--set" -> "Active"
         | "--status" -> "Active"

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -109,6 +109,7 @@ module CommandParsingTests =
     [<TestCase("RepositoryAdmin")>]
     [<TestCase("RepositoryContributor")>]
     [<TestCase("RepositoryReader")>]
+    [<TestCase("repositoryreader")>]
     [<TestCase("BranchAdmin")>]
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
@@ -128,12 +129,15 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
-    let ``access role commands reject stale short role ids`` roleId =
+    let ``access grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
+    [<TestCase("OrgAdmin")>]
+    [<TestCase("RepositoryReader")>]
+    let ``access revoke role accepts raw role ids for cleanup`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
-        revokeParseResult.Errors.Count |> should equal 1
+        revokeParseResult.Errors.Count |> should equal 0
 
 
 namespace Grace.CLI.Tests

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -69,6 +69,72 @@ module CommandParsingTests =
 
         parseResult.Errors.Count |> should equal 0
 
+    let private grantRoleArgs roleId =
+        [|
+            "access"
+            "grant-role"
+            "--scope"
+            "repo"
+            "--principal-type"
+            "User"
+            "--principal-id"
+            "user-1"
+            "--role"
+            roleId
+        |]
+
+    let private revokeRoleArgs roleId =
+        [|
+            "access"
+            "revoke-role"
+            "--scope"
+            "repo"
+            "--principal-type"
+            "User"
+            "--principal-id"
+            "user-1"
+            "--role"
+            roleId
+        |]
+
+    [<TestCase("SystemAdmin")>]
+    [<TestCase("SystemOperator")>]
+    [<TestCase("SystemReader")>]
+    [<TestCase("OwnerAdmin")>]
+    [<TestCase("OwnerContributor")>]
+    [<TestCase("OwnerReader")>]
+    [<TestCase("OrganizationAdmin")>]
+    [<TestCase("OrganizationContributor")>]
+    [<TestCase("OrganizationReader")>]
+    [<TestCase("RepositoryAdmin")>]
+    [<TestCase("RepositoryContributor")>]
+    [<TestCase("RepositoryReader")>]
+    [<TestCase("BranchAdmin")>]
+    [<TestCase("BranchWriter")>]
+    [<TestCase("BranchReader")>]
+    [<TestCase("ApprovalResponder")>]
+    let ``access role commands accept canonical role ids`` roleId =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
+        grantParseResult.Errors.Count |> should equal 0
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 0
+
+    [<TestCase("OrgAdmin")>]
+    [<TestCase("OrgContributor")>]
+    [<TestCase("OrgReader")>]
+    [<TestCase("RepoAdmin")>]
+    [<TestCase("RepoContributor")>]
+    [<TestCase("RepoReader")>]
+    [<TestCase("rEpOaDmIn")>]
+    [<TestCase("oRgReAdEr")>]
+    let ``access role commands reject stale short role ids`` roleId =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
+        grantParseResult.Errors.Count |> should equal 1
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 1
+
 
 namespace Grace.CLI.Tests
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -107,7 +107,13 @@ module Access =
                     |]
                 )
 
-        let roleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
+        let roleId =
+            (new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    Authorization.RoleCatalog.getAll ()
+                    |> List.map (fun role -> role.RoleId)
+                    |> List.toArray
+                )
 
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -107,13 +107,22 @@ module Access =
                     |]
                 )
 
-        let roleId =
-            (new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne))
-                .AcceptOnlyFromAmong(
-                    Authorization.RoleCatalog.getAll ()
-                    |> List.map (fun role -> role.RoleId)
-                    |> List.toArray
-                )
+        let private canonicalRoleIds =
+            Authorization.RoleCatalog.getAll ()
+            |> List.map (fun role -> role.RoleId)
+
+        let grantRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
+
+        grantRoleId.Validators.Add (fun optionResult ->
+            let roleId = optionResult.GetValueOrDefault<string>()
+            let allowedRoleIds = String.Join(", ", canonicalRoleIds)
+
+            if canonicalRoleIds
+               |> List.exists (fun canonicalRoleId -> canonicalRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+               |> not then
+                optionResult.AddError($"{OptionName.RoleId} only accepts one of these values: {allowedRoleIds}"))
+
+        let revokeRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
 
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 
@@ -348,7 +357,7 @@ module Access =
                                 PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
                                 PrincipalId = parseResult.GetValue(Options.principalIdRequired),
                                 ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.roleId),
+                                RoleId = parseResult.GetValue(Options.grantRoleId),
                                 Source = parseResult.GetValue(Options.source),
                                 SourceDetail = parseResult.GetValue(Options.sourceDetail),
                                 CorrelationId = getCorrelationId parseResult
@@ -406,7 +415,7 @@ module Access =
                                 PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
                                 PrincipalId = parseResult.GetValue(Options.principalIdRequired),
                                 ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.roleId),
+                                RoleId = parseResult.GetValue(Options.revokeRoleId),
                                 CorrelationId = getCorrelationId parseResult
                             )
 
@@ -809,7 +818,7 @@ module Access =
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
-            |> addOption Options.roleId
+            |> addOption Options.grantRoleId
             |> addOption Options.source
             |> addOption Options.sourceDetail
 
@@ -822,7 +831,7 @@ module Access =
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
-            |> addOption Options.roleId
+            |> addOption Options.revokeRoleId
 
         revokeRoleCommand.Action <- new RevokeRole()
         accessCommand.Subcommands.Add(revokeRoleCommand)

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -156,7 +156,7 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "" ""
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "" ""
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
 
@@ -166,7 +166,7 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "User" userId
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "User" userId
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -178,7 +178,7 @@ type AccessCheckPermissionTests() =
             let groupId = $"{Guid.NewGuid()}"
             use client = createClient userId [ groupId ]
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "Group" groupId
+            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "Group" groupId
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -189,7 +189,8 @@ type AccessCheckPermissionTests() =
             let userId = $"{Guid.NewGuid()}"
             use client = createClient userId []
 
-            let! response = checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepoRead" "User" $"{Guid.NewGuid()}"
+            let! response =
+                checkPermissionAsync client $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" $"{Guid.NewGuid()}" "repo" "RepositoryRead" "User" $"{Guid.NewGuid()}"
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
@@ -316,18 +317,18 @@ type AccessControlSecurityTests() =
             let orgB = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = grantRoleAsync Client "org" ownerId orgA "" "" adminUser "OrgAdmin"
+            let! grantAdmin = grantRoleAsync Client "org" ownerId orgA "" "" adminUser "OrganizationAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = createClientWithUserId adminUser
 
-            let! allowed = grantRoleAsync adminClient "org" ownerId orgA "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! allowed = grantRoleAsync adminClient "org" ownerId orgA "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(allowed.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! forbidden = grantRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! forbidden = grantRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(forbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! revokeForbidden = revokeRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrgReader"
+            let! revokeForbidden = revokeRoleAsync adminClient "org" ownerId orgB "" "" $"{Guid.NewGuid()}" "OrganizationReader"
             Assert.That(revokeForbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
             let! listAllowed = listRoleAssignmentsAsync adminClient "org" ownerId orgA "" ""
@@ -346,18 +347,18 @@ type AccessControlSecurityTests() =
             let repoB = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId orgId repoA "" adminUser "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId orgId repoA "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = createClientWithUserId adminUser
 
-            let! allowed = grantRoleAsync adminClient "repo" ownerId orgId repoA "" $"{Guid.NewGuid()}" "RepoReader"
+            let! allowed = grantRoleAsync adminClient "repo" ownerId orgId repoA "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(allowed.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! forbidden = grantRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepoReader"
+            let! forbidden = grantRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(forbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! revokeForbidden = revokeRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepoReader"
+            let! revokeForbidden = revokeRoleAsync adminClient "repo" ownerId orgId repoB "" $"{Guid.NewGuid()}" "RepositoryReader"
             Assert.That(revokeForbidden.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
             let! listAllowed = listRoleAssignmentsAsync adminClient "repo" ownerId orgId repoA ""
@@ -409,20 +410,20 @@ type AccessControlSecurityTests() =
             let orgAdminUser = $"{Guid.NewGuid()}"
             let repoWriterUser = $"{Guid.NewGuid()}"
 
-            let! grantRepoAdmin = grantRoleAsync Client "repo" ownerId orgId repoId "" repoAdminUser "RepoAdmin"
-            Assert.That(grantRepoAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantRepositoryAdmin = grantRoleAsync Client "repo" ownerId orgId repoId "" repoAdminUser "RepositoryAdmin"
+            Assert.That(grantRepositoryAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantOrgAdmin = grantRoleAsync Client "org" ownerId orgId "" "" orgAdminUser "OrgAdmin"
-            Assert.That(grantOrgAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantOrganizationAdmin = grantRoleAsync Client "org" ownerId orgId "" "" orgAdminUser "OrganizationAdmin"
+            Assert.That(grantOrganizationAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantRepoWrite = grantRoleAsync Client "repo" ownerId orgId repoId "" repoWriterUser "RepoContributor"
-            Assert.That(grantRepoWrite.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+            let! grantRepositoryWrite = grantRoleAsync Client "repo" ownerId orgId repoId "" repoWriterUser "RepositoryContributor"
+            Assert.That(grantRepositoryWrite.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use repoAdminClient = createClientWithUserId repoAdminUser
             use orgAdminClient = createClientWithUserId orgAdminUser
             use repoWriterClient = createClientWithUserId repoWriterUser
 
-            let! repoAdminCannotGrantOrg = grantRoleAsync repoAdminClient "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "OrgAdmin"
+            let! repoAdminCannotGrantOrg = grantRoleAsync repoAdminClient "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "OrganizationAdmin"
 
             Assert.That(repoAdminCannotGrantOrg.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
@@ -430,9 +431,9 @@ type AccessControlSecurityTests() =
 
             Assert.That(orgAdminCannotGrantOwner.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            let! repoWriterCannotGrantRepoAdmin = grantRoleAsync repoWriterClient "repo" ownerId orgId repoId "" $"{Guid.NewGuid()}" "RepoAdmin"
+            let! repoWriterCannotGrantRepositoryAdmin = grantRoleAsync repoWriterClient "repo" ownerId orgId repoId "" $"{Guid.NewGuid()}" "RepositoryAdmin"
 
-            Assert.That(repoWriterCannotGrantRepoAdmin.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
+            Assert.That(repoWriterCannotGrantRepositoryAdmin.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
     [<Test>]
@@ -453,7 +454,7 @@ type AccessControlSecurityTests() =
             let ownerId = $"{Guid.NewGuid()}"
             let orgId = $"{Guid.NewGuid()}"
 
-            let! response = grantRoleAsync Client "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "RepoAdmin"
+            let! response = grantRoleAsync Client "org" ownerId orgId "" "" $"{Guid.NewGuid()}" "RepositoryAdmin"
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
@@ -638,12 +639,12 @@ type AccessControl() =
             let nonAdminUserId = $"{Guid.NewGuid()}"
             use nonAdminClient = createClientWithUserId nonAdminUserId
 
-            do! grantRoleAsync Client ownerId orgA "" "org" "OrgAdmin" nonAdminUserId
-            do! grantRoleAsync Client ownerId orgB "" "org" "OrgReader" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgA "" "org" "OrganizationAdmin" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgB "" "org" "OrganizationReader" nonAdminUserId
 
-            let! repoAWrite = checkPermissionAsync nonAdminClient ownerId orgA repoA "repo" "RepoWrite" ""
-            let! repoBWrite = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepoWrite" ""
-            let! repoBRead = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepoRead" ""
+            let! repoAWrite = checkPermissionAsync nonAdminClient ownerId orgA repoA "repo" "RepositoryWrite" ""
+            let! repoBWrite = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepositoryWrite" ""
+            let! repoBRead = checkPermissionAsync nonAdminClient ownerId orgB repoB "repo" "RepositoryRead" ""
 
             match repoAWrite with
             | Allowed _ -> ()
@@ -665,8 +666,8 @@ type AccessControl() =
             let! repositoryId = createRepositoryAsync Client organizationId
             let principalId = $"{Guid.NewGuid()}"
 
-            do! grantRoleAsync Client ownerId organizationId "" "org" "OrgAdmin" testUserId
-            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+            do! grantRoleAsync Client ownerId organizationId "" "org" "OrganizationAdmin" testUserId
+            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" principalId
 
             let! afterGrant = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
 
@@ -674,7 +675,7 @@ type AccessControl() =
                 afterGrant
                 |> List.tryFind (fun assignment ->
                     assignment.Principal.PrincipalId = principalId
-                    && assignment.RoleId = "RepoReader"
+                    && assignment.RoleId = "RepositoryReader"
                     && assignment.Source = "test")
 
             Assert.That(granted.IsSome, Is.True)
@@ -687,13 +688,13 @@ type AccessControl() =
             | other -> Assert.Fail($"Expected repository scope, got {other}.")
 
             use principalClient = createClientWithUserId principalId
-            let! allowedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+            let! allowedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepositoryRead" ""
 
             match allowedPermission with
-            | Allowed reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Allowed reason -> Assert.That(reason, Does.Contain("RepositoryRead"))
             | Denied reason -> Assert.Fail($"Expected repo read to be allowed after grant. {reason}")
 
-            do! revokeRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" principalId
+            do! revokeRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" principalId
 
             let! afterRevoke = listRoleAssignmentsAsync Client ownerId organizationId repositoryId "repo"
 
@@ -701,14 +702,14 @@ type AccessControl() =
                 afterRevoke
                 |> List.exists (fun assignment ->
                     assignment.Principal.PrincipalId = principalId
-                    && assignment.RoleId = "RepoReader")
+                    && assignment.RoleId = "RepositoryReader")
 
             Assert.That(stillPresent, Is.False)
 
-            let! deniedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepoRead" ""
+            let! deniedPermission = checkPermissionAsync principalClient ownerId organizationId repositoryId "repo" "RepositoryRead" ""
 
             match deniedPermission with
-            | Denied reason -> Assert.That(reason, Does.Contain("RepoRead"))
+            | Denied reason -> Assert.That(reason, Does.Contain("RepositoryRead"))
             | Allowed reason -> Assert.Fail($"Expected repo read to be denied after revoke. {reason}")
         }
 
@@ -718,7 +719,7 @@ type AccessControl() =
             let! organizationId = createOrganizationAsync Client
             let! repositoryId = createRepositoryAsync Client organizationId
 
-            do! grantRoleAsync Client ownerId organizationId "" "org" "OrgAdmin" testUserId
+            do! grantRoleAsync Client ownerId organizationId "" "org" "OrganizationAdmin" testUserId
 
             do!
                 upsertPathPermissionAsync
@@ -770,7 +771,7 @@ type AccessControl() =
             let! deniedResponse = nonAdminClient.PostAsync("/repository/setDescription", createJsonContent parameters)
             Assert.That(deniedResponse.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
 
-            do! grantRoleAsync Client ownerId orgId "" "org" "OrgAdmin" nonAdminUserId
+            do! grantRoleAsync Client ownerId orgId "" "org" "OrganizationAdmin" nonAdminUserId
 
             let! allowedResponse = nonAdminClient.PostAsync("/repository/setDescription", createJsonContent parameters)
             Assert.That(allowedResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -782,7 +783,7 @@ type AccessControl() =
             let! orgId = createOrganizationAsync Client
             let! repoId = createRepositoryAsync Client orgId
 
-            do! grantRoleAsync Client ownerId orgId "" "org" "OrgAdmin" testUserId
+            do! grantRoleAsync Client ownerId orgId "" "org" "OrganizationAdmin" testUserId
 
             do!
                 upsertPathPermissionAsync
@@ -838,7 +839,7 @@ type AccessControl() =
                 (deserialize<GraceReturnValue<Grace.Types.Branch.BranchDto>> branchBody)
                     .ReturnValue
 
-            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepoReader" testUserId
+            do! grantRoleAsync Client ownerId organizationId repositoryId "repo" "RepositoryReader" testUserId
 
             do! upsertPathPermissionAsync Client ownerId organizationId repositoryId "sensitive/secret.txt" [ ("engineering", "NoAccess") ]
 
@@ -901,7 +902,7 @@ type AccessControl() =
             parameters.ScopeKind <- "owner"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- testUserId
-            parameters.RoleId <- "RepoAdmin"
+            parameters.RoleId <- "RepositoryAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
@@ -956,7 +957,7 @@ type AccessControl() =
             parameters.OrganizationId <- organizationId
             parameters.RepositoryId <- repositoryIds[0]
             parameters.ResourceKind <- "repo"
-            parameters.Operation <- "RepoRead"
+            parameters.Operation <- "RepositoryRead"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- "other-user"
             parameters.CorrelationId <- generateCorrelationId ()
@@ -976,7 +977,7 @@ type AccessControl() =
             parameters.OrganizationId <- organizationId
             parameters.RepositoryId <- repositoryIds[0]
             parameters.ResourceKind <- "repo"
-            parameters.Operation <- "RepoRead"
+            parameters.Operation <- "RepositoryRead"
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- nonAdminUserId
             parameters.CorrelationId <- generateCorrelationId ()
@@ -1287,10 +1288,10 @@ type EndpointAuthorizationTests() =
             let orgReader = $"{Guid.NewGuid()}"
             let orgAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "org" ownerId organizationId "" "" orgReader "OrgReader"
+            let! grantReader = grantRoleAsync Client "org" ownerId organizationId "" "" orgReader "OrganizationReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "org" ownerId organizationId "" "" orgAdmin "OrgAdmin"
+            let! grantAdmin = grantRoleAsync Client "org" ownerId organizationId "" "" orgAdmin "OrganizationAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1327,10 +1328,10 @@ type EndpointAuthorizationTests() =
             let repoReader = $"{Guid.NewGuid()}"
             let repoAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoAdmin "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoAdmin "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1361,16 +1362,16 @@ type EndpointAuthorizationTests() =
         }
 
     [<Test>]
-    member _.WorkCreateRequiresRepoWrite() =
+    member _.WorkCreateRequiresRepositoryWrite() =
         task {
             let repositoryId = repositoryIds[0]
             let repoReader = $"{Guid.NewGuid()}"
             let repoWriter = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1400,13 +1401,13 @@ type EndpointAuthorizationTests() =
             let branchWriter = $"{Guid.NewGuid()}"
             let branchAdmin = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchAdmin "RepoAdmin"
+            let! grantAdmin = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" branchAdmin "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -1462,10 +1463,10 @@ type EndpointAuthorizationTests() =
             let pathReader = $"{Guid.NewGuid()}"
             let pathWriter = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -101,7 +101,7 @@ type AccessBootstrapTests() =
     member _.BootstrapDisabledByDefaultReturnsForbidden() =
         task {
             use client = createClient $"{Guid.NewGuid()}"
-            let! _ownerId = createOwner client
+            let! _ownerId = createOwner Client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
             let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -204,7 +204,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -282,7 +282,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "ApprovalResponder"
@@ -365,7 +365,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -386,7 +386,7 @@ type ApprovalApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -418,7 +418,7 @@ type ApprovalApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -454,7 +454,7 @@ type ApprovalApiIntegrationTests() =
             let adminUser = $"{Guid.NewGuid()}"
             let limitedUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -485,7 +485,7 @@ type ApprovalApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = ApprovalTestHelpers.createAuthenticatedClient adminUser
@@ -652,7 +652,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepoReader"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" userId "RepositoryReader"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId

--- a/src/Grace.Server.Tests/Repository.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Repository.Server.Tests.fs
@@ -28,7 +28,7 @@ type Repository() =
             .Create(fun builder -> builder.AddConsole().AddDebug() |> ignore)
             .CreateLogger("RepositoryTests")
 
-    let grantRepoAdminAsync repositoryId =
+    let grantRepositoryAdminAsync repositoryId =
         task {
             let parameters = Parameters.Access.GrantRoleParameters()
             parameters.OwnerId <- ownerId
@@ -37,7 +37,7 @@ type Repository() =
             parameters.PrincipalType <- "User"
             parameters.PrincipalId <- testUserId
             parameters.ScopeKind <- "repo"
-            parameters.RoleId <- "RepoAdmin"
+            parameters.RoleId <- "RepositoryAdmin"
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
@@ -94,7 +94,7 @@ type Repository() =
             parameters.RepositoryId <- repositoryId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync parameters.RepositoryId
+            do! grantRepositoryAdminAsync parameters.RepositoryId
 
             let! response = Client.PostAsync("/repository/setDescription", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
@@ -136,7 +136,7 @@ type Repository() =
             validParameters.Description <- baseline
             validParameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync repositoryId
+            do! grantRepositoryAdminAsync repositoryId
 
             let! validResponse = Client.PostAsync("/repository/setDescription", createJsonContent validParameters)
             validResponse.EnsureSuccessStatusCode() |> ignore
@@ -324,7 +324,7 @@ type Repository() =
             parameters.Visibility <- "Public"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            do! grantRepoAdminAsync repositoryId
+            do! grantRepositoryAdminAsync repositoryId
 
             let! response = Client.PostAsync("/repository/setVisibility", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -188,7 +188,7 @@ type StorageContentBlockSasRoutes() =
             let repositoryId = repositoryIds[0]
             let pathWriter = $"{Guid.NewGuid()}"
 
-            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepoContributor"
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -213,7 +213,7 @@ type StorageContentBlockSasRoutes() =
             let repositoryId = repositoryIds[0]
             let pathReader = $"{Guid.NewGuid()}"
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -318,7 +318,7 @@ type StorageContentBlockDiscoveryRoutes() =
                     $"chunk-{Guid.NewGuid():N}"
                 |]
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use unauthClient = createUnauthenticatedClient ()
@@ -395,7 +395,7 @@ type StorageContentBlockDiscoveryRoutes() =
             let repoReader = $"{Guid.NewGuid()}"
             let requestedChunkAddresses = Array.init (maxDiscoveryKeyChunkAddresses + 1) (fun index -> $"chunk-{index}-{Guid.NewGuid():N}")
 
-            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepoReader"
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" repoReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use readerClient = createClientWithUserId repoReader

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -158,7 +158,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -275,7 +275,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -354,7 +354,7 @@ type WebhookApiIntegrationTests() =
             let branchId = repositoryDefaultBranchIds[0]
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -373,7 +373,7 @@ type WebhookApiIntegrationTests() =
             let otherBranchId = $"{Guid.NewGuid()}"
             let adminUser = $"{Guid.NewGuid()}"
 
-            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grant = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser
@@ -408,7 +408,7 @@ type WebhookApiIntegrationTests() =
             let adminUser = $"{Guid.NewGuid()}"
             let limitedUser = $"{Guid.NewGuid()}"
 
-            let! grantAdmin = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepoAdmin"
+            let! grantAdmin = WebhookTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use adminClient = WebhookTestHelpers.createAuthenticatedClient adminUser

--- a/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
@@ -935,10 +935,10 @@ type WorkItemLinksAuthorizationIntegrationTests() =
             let repoAdmin = $"{Guid.NewGuid()}"
             let crossRepoPrincipal = $"{Guid.NewGuid()}"
 
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoAdmin "RepoAdmin"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepositoryReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepositoryContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoAdmin "RepositoryAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepositoryAdmin"
 
             use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
             use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"
@@ -1079,9 +1079,9 @@ type WorkItemLinksAuthorizationIntegrationTests() =
             let repoWriter = $"{Guid.NewGuid()}"
             let crossRepoPrincipal = $"{Guid.NewGuid()}"
 
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepoReader"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepoContributor"
-            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepoAdmin"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoReader "RepositoryReader"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync repositoryId repoWriter "RepositoryContributor"
+            do! WorkItemIntegrationHelpers.grantRepoRoleAsync otherRepositoryId crossRepoPrincipal "RepositoryAdmin"
 
             use unauthenticatedClient = WorkItemIntegrationHelpers.createUnauthenticatedClient ()
             use noRoleClient = WorkItemIntegrationHelpers.createAuthenticatedClient $"{Guid.NewGuid()}"

--- a/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
@@ -27,7 +27,7 @@ type AuthorizationUnit() =
         | Allowed reason -> Assert.Fail($"Expected Denied but got Allowed: {reason}")
 
     [<Test>]
-    member _.RoleInheritanceAllowsRepoWriteFromOrgAdmin() =
+    member _.RoleInheritanceAllowsRepositoryWriteFromOrganizationAdmin() =
         let ownerId = Guid.NewGuid()
         let organizationId = Guid.NewGuid()
         let repositoryId = Guid.NewGuid()
@@ -36,11 +36,18 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgAdmin"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationAdmin"
             ]
 
         let result =
-            checkPermission roleCatalog assignments [] [ principal ] Set.empty Operation.RepoWrite (Resource.Repository(ownerId, organizationId, repositoryId))
+            checkPermission
+                roleCatalog
+                assignments
+                []
+                [ principal ]
+                Set.empty
+                Operation.RepositoryWrite
+                (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertAllowed result
 
@@ -54,7 +61,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgAdmin"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationAdmin"
             ]
 
         let denyPermissions = List<ClaimPermission>()
@@ -87,7 +94,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrgReader"
+                createAssignment principal (Scope.Organization(ownerId, organizationId)) "OrganizationReader"
             ]
 
         let allowPermissions = List<ClaimPermission>()
@@ -118,7 +125,8 @@ type AuthorizationUnit() =
 
         let principal = { PrincipalType = PrincipalType.User; PrincipalId = "user-4" }
 
-        let result = checkPermission roleCatalog [] [] [ principal ] Set.empty Operation.RepoRead (Resource.Repository(ownerId, organizationId, repositoryId))
+        let result =
+            checkPermission roleCatalog [] [] [ principal ] Set.empty Operation.RepositoryRead (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertDenied result
 
@@ -133,7 +141,7 @@ type AuthorizationUnit() =
 
         let assignments =
             [
-                createAssignment groupPrincipal (Scope.Repository(ownerId, organizationId, repositoryId)) "RepoReader"
+                createAssignment groupPrincipal (Scope.Repository(ownerId, organizationId, repositoryId)) "RepositoryReader"
             ]
 
         let result =
@@ -143,15 +151,15 @@ type AuthorizationUnit() =
                 []
                 [ userPrincipal; groupPrincipal ]
                 Set.empty
-                Operation.RepoRead
+                Operation.RepositoryRead
                 (Resource.Repository(ownerId, organizationId, repositoryId))
 
         assertAllowed result
 
     [<Test>]
-    member _.RepoAdminIncludesBranchAdmin() =
+    member _.RepositoryAdminIncludesBranchAdmin() =
         let repoAdmin =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("RepoAdmin", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(repoAdmin.AllowedOperations.Contains Operation.BranchAdmin, Is.True)

--- a/src/Grace.Server.Unit.Tests/CreatorScopeAdminGrant.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/CreatorScopeAdminGrant.Unit.Tests.fs
@@ -1,0 +1,236 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Shared.Authorization
+open Grace.Shared.Utilities
+open Grace.Types.Authorization
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Threading.Tasks
+
+[<Parallelizable(ParallelScope.All)>]
+type CreatorScopeAdminGrantUnit() =
+
+    let roleCatalog = RoleCatalog.getAll ()
+
+    let userPrincipal userId = { PrincipalType = PrincipalType.User; PrincipalId = userId }
+
+    let groupPrincipal groupId = { PrincipalType = PrincipalType.Group; PrincipalId = groupId }
+
+    let assignment (principal: Principal) (scope: Scope) (roleId: RoleId) : RoleAssignment =
+        { Principal = principal; Scope = scope; RoleId = roleId; Source = "test"; SourceDetail = None; CreatedAt = getCurrentInstant () }
+
+    let runEnsure (creatorUserId: string option) (principals: Principal list) (initialAssignments: RoleAssignment list) (scope: Scope) =
+        task {
+            let grants = ResizeArray<RoleAssignment>()
+            let mutable assignments: RoleAssignment list = initialAssignments
+
+            let checkAdmin principals effectiveClaims operation resource =
+                Task.FromResult(checkPermission roleCatalog assignments [] principals effectiveClaims operation resource)
+
+            let grantCreatorAdmin (grant: RoleAssignment) =
+                task {
+                    grants.Add grant
+                    assignments <- grant :: assignments
+                    return Ok(GraceReturnValue.Create assignments "test-correlation")
+                }
+
+            let! result = CreatorScopeAdminGrant.ensureCreatorAdminCore "test-correlation" creatorUserId principals Set.empty scope checkAdmin grantCreatorAdmin
+
+            return result, Seq.toList grants
+        }
+
+    let assertSingleGrant (expectedPrincipal: Principal) (expectedScope: Scope) (expectedRole: RoleId) (grants: RoleAssignment list) =
+        Assert.That(grants.Length, Is.EqualTo(1))
+        let grant = grants.Head
+        Assert.That(grant.Principal, Is.EqualTo(expectedPrincipal))
+        Assert.That(grant.Scope, Is.EqualTo(expectedScope))
+        Assert.That(grant.RoleId, Is.EqualTo(expectedRole))
+        Assert.That(grant.Source, Is.EqualTo("scope-create"))
+        Assert.That(grant.SourceDetail, Is.EqualTo(Some "creator-admin"))
+
+    let assertOk (expected: CreatorScopeAdminGrant.CreatorAdminGrantResult) (result: Result<CreatorScopeAdminGrant.CreatorAdminGrantResult, GraceError>) =
+        match result with
+        | Ok actual -> Assert.That(actual, Is.EqualTo(expected))
+        | Error error -> Assert.Fail($"Expected Ok {expected} but got Error: {error.Error}")
+
+    [<Test>]
+    member _.OwnerCreationGrantsOwnerAdminToCreatorUserWhenNoInheritedAdminApplies() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] [] scope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator scope "OwnerAdmin" grants
+        }
+
+    [<Test>]
+    member _.OrganizationCreationByOwnerContributorGrantsOrganizationAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment creator ownerScope "OwnerContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator organizationScope "OrganizationAdmin" grants
+        }
+
+    [<Test>]
+    member _.RepositoryCreationByOrganizationContributorGrantsRepositoryAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+            let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+
+            let initialAssignments =
+                [
+                    assignment creator organizationScope "OrganizationContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments repositoryScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator repositoryScope "RepositoryAdmin" grants
+        }
+
+    [<Test>]
+    member _.BranchCreationByRepositoryContributorGrantsBranchAdminToCreatorUser() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+            let branchScope = Scope.Branch(ownerId, organizationId, repositoryId, branchId)
+
+            let initialAssignments =
+                [
+                    assignment creator repositoryScope "RepositoryContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments branchScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator branchScope "BranchAdmin" grants
+        }
+
+    [<Test>]
+    member _.InheritedAdminDoesNotCreateRedundantDirectGrant() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment creator ownerScope "OwnerAdmin"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.InheritedAdminAlreadyApplies result
+            Assert.That(grants, Is.Empty)
+        }
+
+    [<Test>]
+    member _.GroupAuthorizedCreationGrantsOnlyTheCreatingUserPrincipal() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let group = groupPrincipal "owner-contributors"
+            let ownerScope = Scope.Owner ownerId
+            let organizationScope = Scope.Organization(ownerId, organizationId)
+
+            let initialAssignments =
+                [
+                    assignment group ownerScope "OwnerContributor"
+                ]
+
+            let! result, grants = runEnsure (Some creator.PrincipalId) [ creator; group ] initialAssignments organizationScope
+
+            assertOk CreatorScopeAdminGrant.DirectGrantPersisted result
+            assertSingleGrant creator organizationScope "OrganizationAdmin" grants
+        }
+
+    [<Test>]
+    member _.GrantPersistenceFailurePreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Error(GraceError.Create "grant failed" "test-correlation"))
+
+            let! result =
+                CreatorScopeAdminGrant.ensureCreatorAdminCore
+                    "test-correlation"
+                    (Some creator.PrincipalId)
+                    [ creator ]
+                    Set.empty
+                    scope
+                    checkAdmin
+                    grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Is.EqualTo("grant failed"))
+            | Ok value -> Assert.Fail($"Expected grant failure but got {value}.")
+        }
+
+    [<Test>]
+    member _.UnprovenGrantPreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let creator = userPrincipal "creator-user"
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Ok(GraceReturnValue.Create [] "test-correlation"))
+
+            let! result =
+                CreatorScopeAdminGrant.ensureCreatorAdminCore
+                    "test-correlation"
+                    (Some creator.PrincipalId)
+                    [ creator ]
+                    Set.empty
+                    scope
+                    checkAdmin
+                    grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Does.Contain("could not be proven"))
+            | Ok value -> Assert.Fail($"Expected unproven grant failure but got {value}.")
+        }
+
+    [<Test>]
+    member _.MissingMappedCreatorUserPreventsSuccess() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let scope = Scope.Owner ownerId
+            let checkAdmin _ _ _ _ = Task.FromResult(Denied "missing admin")
+            let grantCreatorAdmin _ = Task.FromResult(Ok(GraceReturnValue.Create [] "test-correlation"))
+
+            let! result = CreatorScopeAdminGrant.ensureCreatorAdminCore "test-correlation" None [] Set.empty scope checkAdmin grantCreatorAdmin
+
+            match result with
+            | Error error -> Assert.That(error.Error, Does.Contain("no mapped Grace user id"))
+            | Ok value -> Assert.Fail($"Expected missing user failure but got {value}.")
+        }

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="TestCommon.fs" />
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
+    <Compile Include="CreatorScopeAdminGrant.Unit.Tests.fs" />
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="SecurityPrivacy.Unit.Tests.fs" />

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -64,18 +64,18 @@ module Access =
         match scope with
         | Scope.System -> Operation.SystemAdmin
         | Scope.Owner _ -> Operation.OwnerAdmin
-        | Scope.Organization _ -> Operation.OrgAdmin
-        | Scope.Repository _ -> Operation.RepoAdmin
+        | Scope.Organization _ -> Operation.OrganizationAdmin
+        | Scope.Repository _ -> Operation.RepositoryAdmin
         | Scope.Branch _ -> Operation.BranchAdmin
 
     let private adminOperationForResource (resource: Resource) =
         match resource with
         | Resource.System -> Operation.SystemAdmin
         | Resource.Owner _ -> Operation.OwnerAdmin
-        | Resource.Organization _ -> Operation.OrgAdmin
-        | Resource.Repository _ -> Operation.RepoAdmin
+        | Resource.Organization _ -> Operation.OrganizationAdmin
+        | Resource.Repository _ -> Operation.RepositoryAdmin
         | Resource.Branch _ -> Operation.BranchAdmin
-        | Resource.Path (ownerId, organizationId, repositoryId, _relativePath) -> Operation.RepoAdmin
+        | Resource.Path (ownerId, organizationId, repositoryId, _relativePath) -> Operation.RepositoryAdmin
 
     let private authorize (context: HttpContext) (operation: Operation) (resource: Resource) =
         task {
@@ -406,7 +406,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason
@@ -432,7 +432,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason
@@ -461,7 +461,7 @@ module Access =
                 match tryParseRepositoryResource parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok repositoryResource ->
-                    let! authorizationResult = authorize context Operation.RepoAdmin repositoryResource
+                    let! authorizationResult = authorize context Operation.RepositoryAdmin repositoryResource
 
                     match authorizationResult with
                     | Error reason -> return! forbiddenResult context reason

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -447,7 +447,12 @@ module Branch =
                                 | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
         }
 
-    let processCommand<'T when 'T :> BranchParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<BranchCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> BranchParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<BranchCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             let startTime = getCurrentInstant ()
             let graceIds = getGraceIds context
@@ -485,7 +490,20 @@ module Branch =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                    .enhance(nameof BranchId, graceIds.BranchId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -566,6 +584,9 @@ module Branch =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> BranchParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<BranchCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     let processQuery<'T, 'U when 'T :> BranchParameters>
         (context: HttpContext)
@@ -709,8 +730,21 @@ module Branch =
                     }
                     |> ValueTask<BranchCommand>
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Branch(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, graceIds.BranchId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Rebases a branch on its parent branch.

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -63,6 +63,7 @@
 		<Compile Include="Security\AuthSchemeSelection.Server.fs" />
 		<Compile Include="Security\OutboundUrlSafety.Server.fs" />
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
+		<Compile Include="Security\CreatorScopeAdminGrant.Server.fs" />
 		<Compile Include="Security\MetricsAuthorization.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />
 		<Compile Include="Security\EndpointAuthorizationManifest.Server.fs" />

--- a/src/Grace.Server/Organization.Server.fs
+++ b/src/Grace.Server/Organization.Server.fs
@@ -5,6 +5,7 @@ open Grace.Actors.Constants
 open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -31,10 +32,11 @@ module Organization =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Organization.Server")
 
-    let processCommand<'T when 'T :> OrganizationParameters>
+    let processCommandWithPostSuccess<'T when 'T :> OrganizationParameters>
         (context: HttpContext)
         (validations: Validations<'T>)
         (command: 'T -> ValueTask<OrganizationCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
         =
         task {
             let graceIds = getGraceIds context
@@ -66,7 +68,18 @@ module Organization =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -143,6 +156,13 @@ module Organization =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> OrganizationParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<OrganizationCommand>)
+        =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     /// Generic processor for all Organization queries.
     let processQuery<'T, 'U when 'T :> OrganizationParameters>
@@ -232,9 +252,22 @@ module Organization =
                     }
                     |> ValueTask<OrganizationCommand>
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Organization(graceIds.OwnerId, graceIds.OrganizationId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 log.LogDebug("{CurrentInstant}: In Grace.Server.Create.", getCurrentInstantExtended ())
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Set the name of an organization.

--- a/src/Grace.Server/Owner.Server.fs
+++ b/src/Grace.Server/Owner.Server.fs
@@ -6,6 +6,7 @@ open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Server.ApplicationContext
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -36,7 +37,12 @@ module Owner =
     let activitySource = new ActivitySource("Owner")
 
     /// Generic processor for all Owner commands.
-    let processCommand<'T when 'T :> OwnerParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<OwnerCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> OwnerParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<OwnerCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             let commandName = context.Items["Command"] :?> string
             let graceIds = getGraceIds context
@@ -87,7 +93,17 @@ module Owner =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -163,6 +179,9 @@ module Owner =
                 return! context |> result500ServerError graceError
         }
 
+    let processCommand<'T when 'T :> OwnerParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<OwnerCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
+
     /// Generic processor for all Owner queries.
     let processQuery<'T, 'U when 'T :> OwnerParameters>
         (context: HttpContext)
@@ -233,8 +252,17 @@ module Owner =
                     Create(ownerIdGuid, OwnerName parameters.OwnerName)
                     |> returnValueTask
 
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match! CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope context (Grace.Types.Authorization.Scope.Owner graceIds.OwnerId) with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
                 context.Items.Add("Command", nameof Create)
-                return! processCommand context validations command
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Set the name of an owner.

--- a/src/Grace.Server/Repository.Server.fs
+++ b/src/Grace.Server/Repository.Server.fs
@@ -7,6 +7,7 @@ open Grace.Actors.Constants
 open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
@@ -32,7 +33,6 @@ open System.Linq
 open System.Threading.Tasks
 open System.Text
 open System.Text.Json
-open Microsoft.AspNetCore.Http.HttpResults
 
 module Repository =
 
@@ -42,7 +42,12 @@ module Repository =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Repository.Server")
 
-    let processCommand<'T when 'T :> RepositoryParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<RepositoryCommand>) =
+    let processCommandWithPostSuccess<'T when 'T :> RepositoryParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<RepositoryCommand>)
+        (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        =
         task {
             use activity = activitySource.StartActivity("processCommand", ActivityKind.Server)
             let graceIds = getGraceIds context
@@ -74,7 +79,19 @@ module Repository =
                                 .enhance ("Path", context.Request.Path.Value)
                             |> ignore
 
-                            return! context |> result200Ok graceReturnValue
+                            match! postSuccess () with
+                            | Ok () -> return! context |> result200Ok graceReturnValue
+                            | Error graceError ->
+                                graceError
+                                    .enhance(parameterDictionary)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                    .enhance("Command", commandName)
+                                    .enhance ("Path", context.Request.Path.Value)
+                                |> ignore
+
+                                return! context |> result500ServerError graceError
                         | Error graceError ->
                             graceError
                                 .enhance(parameterDictionary)
@@ -166,6 +183,9 @@ module Repository =
 
                 return! context |> result500ServerError graceError
         }
+
+    let processCommand<'T when 'T :> RepositoryParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<RepositoryCommand>) =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
 
     let processQuery<'T, 'U when 'T :> RepositoryParameters>
         (context: HttpContext)
@@ -266,7 +286,20 @@ module Repository =
                     }
                     |> ValueTask<RepositoryCommand>
 
-                return! processCommand context validations command
+                let ensureCreatorAdmin () =
+                    task {
+                        let graceIds = getGraceIds context
+
+                        match!
+                            CreatorScopeAdminGrant.ensureCreatorAdminForCreatedScope
+                                context
+                                (Grace.Types.Authorization.Scope.Repository(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId))
+                            with
+                        | Ok _ -> return Ok()
+                        | Error error -> return Error error
+                    }
+
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
             }
 
     /// Sets the search visibility of the repository.

--- a/src/Grace.Server/Security/AuthorizationMiddleware.Server.fs
+++ b/src/Grace.Server/Security/AuthorizationMiddleware.Server.fs
@@ -57,6 +57,15 @@ module AuthorizationMiddleware =
             |> List.map formatPrincipal
             |> String.concat ", "
 
+    let private formatOperationSummary (operations: Operation list) =
+        match operations with
+        | [] -> "None"
+        | [ operation ] -> $"{operation}"
+        | _ ->
+            operations
+            |> List.map (fun operation -> $"{operation}")
+            |> String.concat " OR "
+
     let private tryGetIdentityName (context: HttpContext) =
         let identity = context.User.Identity
 
@@ -123,6 +132,56 @@ module AuthorizationMiddleware =
                     | Allowed _ -> return! next context
                     | Denied reason ->
                         logDenied context operation principalSummary (formatResource resource) reason
+                        return! forbidden reason next context
+            }
+
+    let requiresAnyPermission (operations: Operation list) (resourceFromContext: HttpContext -> Task<Resource>) : HttpHandler =
+        if operations.IsEmpty then
+            invalidArg (nameof operations) "At least one authorization operation is required."
+
+        fun next context ->
+            task {
+                match PrincipalMapper.tryGetUserId context.User with
+                | None ->
+                    let principalSummary =
+                        PrincipalMapper.getPrincipals context.User
+                        |> formatPrincipalSummary context
+
+                    logMissingAuthentication context operations.Head principalSummary
+                    return! RequestErrors.UNAUTHORIZED "Grace" "Access" "Authentication required." next context
+                | Some _ ->
+                    let principals = PrincipalMapper.getPrincipals context.User
+                    let principalSummary = formatPrincipals principals
+                    let claims = PrincipalMapper.getEffectiveClaims context.User
+                    let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+                    let! resource = resourceFromContext context
+                    let mutable allowed = false
+                    let mutable deniedReason: string option = None
+                    let mutable index = 0
+
+                    while not allowed && index < operations.Length do
+                        let operation = operations[index]
+                        let! decision = evaluator.CheckAsync(principals, claims, operation, resource)
+
+                        match decision with
+                        | Allowed _ -> allowed <- true
+                        | Denied reason ->
+                            deniedReason <-
+                                match deniedReason with
+                                | Some existing -> Some $"{existing}; {operation}: {reason}"
+                                | None -> Some $"{operation}: {reason}"
+
+                        index <- index + 1
+
+                    if allowed then
+                        return! next context
+                    else
+                        let reason =
+                            deniedReason
+                            |> Option.defaultValue "No matching authorization operation was allowed."
+
+                        let operationSummary = formatOperationSummary operations
+                        logDenied context operations.Head principalSummary (formatResource resource) $"{operationSummary}: {reason}"
                         return! forbidden reason next context
             }
 

--- a/src/Grace.Server/Security/CreatorScopeAdminGrant.Server.fs
+++ b/src/Grace.Server/Security/CreatorScopeAdminGrant.Server.fs
@@ -1,0 +1,115 @@
+namespace Grace.Server.Security
+
+open Grace.Actors
+open Grace.Actors.Extensions.ActorProxy
+open Grace.Server.Services
+open Grace.Shared.Utilities
+open Grace.Types.Authorization
+open Grace.Types.Common
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open System
+open System.Threading.Tasks
+
+module CreatorScopeAdminGrant =
+
+    type CreatorAdminGrantResult =
+        | InheritedAdminAlreadyApplies
+        | DirectGrantPersisted
+
+    type AdminCheck = Principal list -> Set<string> -> Operation -> Resource -> Task<PermissionCheckResult>
+
+    type GrantCreatorAdmin = RoleAssignment -> Task<GraceResult<RoleAssignment list>>
+
+    let internal resourceForScope scope =
+        match scope with
+        | Scope.System -> Resource.System
+        | Scope.Owner ownerId -> Resource.Owner ownerId
+        | Scope.Organization (ownerId, organizationId) -> Resource.Organization(ownerId, organizationId)
+        | Scope.Repository (ownerId, organizationId, repositoryId) -> Resource.Repository(ownerId, organizationId, repositoryId)
+        | Scope.Branch (ownerId, organizationId, repositoryId, branchId) -> Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+
+    let internal adminOperationForScope scope =
+        match scope with
+        | Scope.System -> Operation.SystemAdmin
+        | Scope.Owner _ -> Operation.OwnerAdmin
+        | Scope.Organization _ -> Operation.OrganizationAdmin
+        | Scope.Repository _ -> Operation.RepositoryAdmin
+        | Scope.Branch _ -> Operation.BranchAdmin
+
+    let internal adminRoleForScope scope =
+        match scope with
+        | Scope.System -> "SystemAdmin"
+        | Scope.Owner _ -> "OwnerAdmin"
+        | Scope.Organization _ -> "OrganizationAdmin"
+        | Scope.Repository _ -> "RepositoryAdmin"
+        | Scope.Branch _ -> "BranchAdmin"
+
+    let internal ensureCreatorAdminCore
+        (correlationId: CorrelationId)
+        (creatorUserId: string option)
+        (principals: Principal list)
+        (effectiveClaims: Set<string>)
+        (scope: Scope)
+        (checkAdmin: AdminCheck)
+        (grantCreatorAdmin: GrantCreatorAdmin)
+        =
+        task {
+            match creatorUserId with
+            | None ->
+                return Error(GraceError.Create "Cannot grant creator admin because the authenticated principal has no mapped Grace user id." correlationId)
+            | Some userId when String.IsNullOrWhiteSpace userId ->
+                return Error(GraceError.Create "Cannot grant creator admin because the authenticated principal has no mapped Grace user id." correlationId)
+            | Some userId ->
+                let operation = adminOperationForScope scope
+                let resource = resourceForScope scope
+
+                match! checkAdmin principals effectiveClaims operation resource with
+                | Allowed _ -> return Ok InheritedAdminAlreadyApplies
+                | Denied _ ->
+                    let creatorPrincipal = { PrincipalType = PrincipalType.User; PrincipalId = userId }
+
+                    let assignment =
+                        {
+                            Principal = creatorPrincipal
+                            Scope = scope
+                            RoleId = adminRoleForScope scope
+                            Source = "scope-create"
+                            SourceDetail = Some "creator-admin"
+                            CreatedAt = getCurrentInstant ()
+                        }
+
+                    match! grantCreatorAdmin assignment with
+                    | Error error -> return Error error
+                    | Ok _ ->
+                        match! checkAdmin [ creatorPrincipal ] Set.empty operation resource with
+                        | Allowed _ -> return Ok DirectGrantPersisted
+                        | Denied reason ->
+                            return
+                                Error(
+                                    GraceError.Create
+                                        $"Creator admin grant for role '{assignment.RoleId}' on the new scope could not be proven: {reason}"
+                                        correlationId
+                                )
+        }
+
+    let ensureCreatorAdminForCreatedScope (context: HttpContext) (scope: Scope) =
+        let correlationId = getCorrelationId context
+        let creatorUserId = PrincipalMapper.tryGetUserId context.User
+        let principals = PrincipalMapper.getPrincipals context.User
+        let effectiveClaims = PrincipalMapper.getEffectiveClaims context.User
+
+        let checkAdmin principals effectiveClaims operation resource =
+            task {
+                let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+                return! evaluator.CheckAsync(principals, effectiveClaims, operation, resource)
+            }
+
+        let grantCreatorAdmin assignment =
+            task {
+                let scopeKey = AccessControl.getScopeKey assignment.Scope
+                let actorProxy = Grace.Actors.Extensions.ActorProxy.AccessControl.CreateActorProxy scopeKey correlationId
+                return! actorProxy.Handle (AccessControlCommand.GrantRole assignment) (createMetadata context)
+            }
+
+        ensureCreatorAdminCore correlationId creatorUserId principals effectiveClaims scope checkAdmin grantCreatorAdmin

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -27,12 +27,12 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/" AllowAnonymous
             endpoint "POST" "/access/checkPermission" Authenticated
             endpoint "POST" "/access/grantRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/listPathPermissions" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/listPathPermissions" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/access/listRoleAssignments" (Authorized(SystemAdmin, System))
             endpoint "GET" "/access/listRoles" Authenticated
-            endpoint "POST" "/access/removePathPermission" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/removePathPermission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/access/revokeRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
@@ -67,11 +67,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/auth/token/create" Authenticated
             endpoint "POST" "/auth/token/list" Authenticated
             endpoint "POST" "/auth/token/revoke" Authenticated
-            endpoint "POST" "/agent/session/active" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/listActive" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/start" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/agent/session/status" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/agent/session/stop" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/agent/session/active" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/listActive" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/agent/session/status" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/agent/session/stop" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/branch/assign" Authenticated
             endpoint
                 "POST"
@@ -125,8 +125,8 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/validation-set/update" Authenticated
             endpoint "POST" "/validation-set/delete" Authenticated
             endpoint "POST" "/validation-result/record" Authenticated
-            endpoint "POST" "/artifact/create" (Authorized(RepoWrite, Repository))
-            endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/artifact/create" (Authorized(RepositoryWrite, Repository))
+            endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/diff/getDiff" Authenticated
             endpoint "POST" "/diff/getDiffBySha256Hash" Authenticated
             endpoint "POST" "/diff/populate" Authenticated
@@ -140,10 +140,10 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/healthz" AllowAnonymous
             endpoint "POST" "/organization/create" Authenticated
             endpoint "POST" "/organization/delete" Authenticated
-            endpoint "POST" "/organization/get" (Authorized(OrgRead, Organization))
+            endpoint "POST" "/organization/get" (Authorized(OrganizationRead, Organization))
             endpoint "POST" "/organization/listRepositories" Authenticated
             endpoint "POST" "/organization/setDescription" Authenticated
-            endpoint "POST" "/organization/setName" (Authorized(OrgAdmin, Organization))
+            endpoint "POST" "/organization/setName" (Authorized(OrganizationAdmin, Organization))
             endpoint "POST" "/organization/setSearchVisibility" Authenticated
             endpoint "POST" "/organization/setType" Authenticated
             endpoint "POST" "/organization/undelete" Authenticated
@@ -173,7 +173,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/repository/create" Authenticated
             endpoint "POST" "/repository/delete" Authenticated
             endpoint "POST" "/repository/exists" Authenticated
-            endpoint "POST" "/repository/get" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/repository/get" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/repository/getBranches" Authenticated
             endpoint "POST" "/repository/getBranchesByBranchId" Authenticated
             endpoint "POST" "/repository/getReferencesByReferenceId" Authenticated
@@ -191,7 +191,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/repository/setRecordSaves" Authenticated
             endpoint "POST" "/repository/setSaveDays" Authenticated
             endpoint "POST" "/repository/setStatus" Authenticated
-            endpoint "POST" "/repository/setVisibility" (Authorized(RepoAdmin, Repository))
+            endpoint "POST" "/repository/setVisibility" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/repository/undelete" Authenticated
             endpoint "POST" "/review/checkpoint" Authenticated
             endpoint "POST" "/review/candidate/attestations" Authenticated
@@ -208,7 +208,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/getDownloadUri" (Authorized(PathRead, Path))
             endpoint "POST" "/storage/claimReuseRanges" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/confirmContentBlockUpload" (Authorized(PathWrite, Path))
-            endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepoRead, Repository))
+            endpoint "POST" "/storage/discoverContentBlocks" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/storage/finalizeManifestUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/getContentBlockDownloadUri" (Authorized(PathRead, Path))
             endpoint "POST" "/storage/getContentBlockUploadUri" (Authorized(PathWrite, Path))
@@ -217,21 +217,21 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/issueDedupeDiscovery" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
-            endpoint "POST" "/work/create" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/add-summary" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/get" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/link/artifact" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/link/promotion-set" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/link/reference" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/list" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/list" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/show" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/attachments/download" (Authorized(RepoRead, Repository))
-            endpoint "POST" "/work/links/remove/artifact" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/artifact-type" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/promotion-set" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/links/remove/reference" (Authorized(RepoWrite, Repository))
-            endpoint "POST" "/work/update" (Authorized(RepoWrite, Repository))
+            endpoint "POST" "/work/create" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/add-summary" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/get" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/link/artifact" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/link/promotion-set" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/link/reference" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/list" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/list" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/show" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/attachments/download" (Authorized(RepositoryRead, Repository))
+            endpoint "POST" "/work/links/remove/artifact" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/artifact-type" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/promotion-set" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/links/remove/reference" (Authorized(RepositoryWrite, Repository))
+            endpoint "POST" "/work/update" (Authorized(RepositoryWrite, Repository))
             endpoint "GET" "/metrics" (Authorized(SystemAdmin, System))
             endpoint "GET" "/notifications" Authenticated
         ]

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -16,6 +16,7 @@ module EndpointAuthorizationManifest =
         | AllowAnonymous
         | Authenticated
         | Authorized of Operation * ResourceKind
+        | AnyOf of EndpointSecurity list
         | AllOf of EndpointSecurity list
 
     type EndpointSecurityDefinition = { Method: string; Path: string; Security: EndpointSecurity }
@@ -72,16 +73,36 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/agent/session/status" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/stop" (Authorized(RepositoryWrite, Repository))
-            endpoint "POST" "/branch/assign" Authenticated
+            endpoint
+                "POST"
+                "/branch/assign"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint
                 "POST"
                 "/branch/annotate"
                 (AllOf [ Authorized(BranchRead, Branch)
                          Authorized(PathRead, Path) ])
-            endpoint "POST" "/branch/checkpoint" Authenticated
-            endpoint "POST" "/branch/commit" (Authorized(BranchWrite, Branch))
-            endpoint "POST" "/branch/create" Authenticated
-            endpoint "POST" "/branch/createExternal" Authenticated
+            endpoint
+                "POST"
+                "/branch/checkpoint"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
+            endpoint
+                "POST"
+                "/branch/commit"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
+            endpoint
+                "POST"
+                "/branch/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
+            endpoint
+                "POST"
+                "/branch/createExternal"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/delete" Authenticated
             endpoint "POST" "/branch/enableAssign" Authenticated
             endpoint "POST" "/branch/enableAutoRebase" Authenticated
@@ -106,13 +127,29 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/branch/getTags" Authenticated
             endpoint "POST" "/branch/getVersion" Authenticated
             endpoint "POST" "/branch/listContents" Authenticated
-            endpoint "POST" "/branch/promote" Authenticated
+            endpoint
+                "POST"
+                "/branch/promote"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/rebase" Authenticated
-            endpoint "POST" "/branch/save" Authenticated
+            endpoint
+                "POST"
+                "/branch/save"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/setPromotionMode" Authenticated
-            endpoint "POST" "/branch/tag" Authenticated
+            endpoint
+                "POST"
+                "/branch/tag"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/branch/updateParentBranch" Authenticated
-            endpoint "POST" "/promotion-set/create" Authenticated
+            endpoint
+                "POST"
+                "/promotion-set/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/promotion-set/get" Authenticated
             endpoint "POST" "/promotion-set/get-events" Authenticated
             endpoint "POST" "/promotion-set/update-input-promotions" Authenticated
@@ -120,25 +157,49 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/promotion-set/apply" Authenticated
             endpoint "POST" "/promotion-set/%O/resolve-conflicts" Authenticated
             endpoint "POST" "/promotion-set/delete" Authenticated
-            endpoint "POST" "/validation-set/create" Authenticated
+            endpoint
+                "POST"
+                "/validation-set/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/validation-set/get" Authenticated
             endpoint "POST" "/validation-set/update" Authenticated
             endpoint "POST" "/validation-set/delete" Authenticated
-            endpoint "POST" "/validation-result/record" Authenticated
-            endpoint "POST" "/artifact/create" (Authorized(RepositoryWrite, Repository))
+            endpoint
+                "POST"
+                "/validation-result/record"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
+            endpoint
+                "POST"
+                "/artifact/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "GET" "/artifact/%O/download-uri" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/diff/getDiff" Authenticated
             endpoint "POST" "/diff/getDiffBySha256Hash" Authenticated
             endpoint "POST" "/diff/populate" Authenticated
-            endpoint "POST" "/directory/create" Authenticated
+            endpoint
+                "POST"
+                "/directory/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/directory/get" Authenticated
             endpoint "POST" "/directory/getByDirectoryIds" Authenticated
             endpoint "POST" "/directory/getBySha256Hash" Authenticated
             endpoint "POST" "/directory/getDirectoryVersionsRecursive" Authenticated
             endpoint "POST" "/directory/getZipFile" Authenticated
-            endpoint "POST" "/directory/saveDirectoryVersions" Authenticated
+            endpoint
+                "POST"
+                "/directory/saveDirectoryVersions"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "GET" "/healthz" AllowAnonymous
-            endpoint "POST" "/organization/create" Authenticated
+            endpoint
+                "POST"
+                "/organization/create"
+                (AnyOf [ Authorized(OwnerAdmin, Owner)
+                         Authorized(OwnerWrite, Owner) ])
             endpoint "POST" "/organization/delete" Authenticated
             endpoint "POST" "/organization/get" (Authorized(OrganizationRead, Organization))
             endpoint "POST" "/organization/listRepositories" Authenticated
@@ -147,7 +208,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/organization/setSearchVisibility" Authenticated
             endpoint "POST" "/organization/setType" Authenticated
             endpoint "POST" "/organization/undelete" Authenticated
-            endpoint "POST" "/owner/create" Authenticated
+            endpoint
+                "POST"
+                "/owner/create"
+                (AnyOf [ Authorized(SystemAdmin, System)
+                         Authorized(SystemOperate, System) ])
             endpoint "POST" "/owner/delete" Authenticated
             endpoint "POST" "/owner/get" (Authorized(OwnerRead, Owner))
             endpoint "POST" "/owner/listOrganizations" Authenticated
@@ -164,13 +229,21 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/queue/pause" Authenticated
             endpoint "POST" "/queue/resume" Authenticated
             endpoint "POST" "/queue/status" Authenticated
-            endpoint "POST" "/reminder/create" Authenticated
+            endpoint
+                "POST"
+                "/reminder/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/reminder/delete" Authenticated
             endpoint "POST" "/reminder/get" Authenticated
             endpoint "POST" "/reminder/list" Authenticated
             endpoint "POST" "/reminder/reschedule" Authenticated
             endpoint "POST" "/reminder/updateTime" Authenticated
-            endpoint "POST" "/repository/create" Authenticated
+            endpoint
+                "POST"
+                "/repository/create"
+                (AnyOf [ Authorized(OrganizationAdmin, Organization)
+                         Authorized(OrganizationWrite, Organization) ])
             endpoint "POST" "/repository/delete" Authenticated
             endpoint "POST" "/repository/exists" Authenticated
             endpoint "POST" "/repository/get" (Authorized(RepositoryRead, Repository))
@@ -217,7 +290,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/storage/issueDedupeDiscovery" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/registerContentBlockUpload" (Authorized(PathWrite, Path))
             endpoint "POST" "/storage/startManifestUploadSession" (Authorized(PathWrite, Path))
-            endpoint "POST" "/work/create" (Authorized(RepositoryWrite, Repository))
+            endpoint
+                "POST"
+                "/work/create"
+                (AnyOf [ Authorized(RepositoryAdmin, Repository)
+                         Authorized(RepositoryWrite, Repository) ])
             endpoint "POST" "/work/add-summary" (Authorized(RepositoryWrite, Repository))
             endpoint "POST" "/work/get" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/work/link/artifact" (Authorized(RepositoryWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -274,15 +274,47 @@ module Application =
 
         let requireSystemAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.SystemAdmin (fun _ -> task { return Resource.System })
 
+        let requireSystemOperateOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.SystemAdmin
+                    Operation.SystemOperate
+                ]
+                (fun _ -> task { return Resource.System })
+
         let requireOwnerAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerAdmin ownerResourceFromContext
+
+        let requireOwnerWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.OwnerAdmin
+                    Operation.OwnerWrite
+                ]
+                ownerResourceFromContext
 
         let requireOwnerRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerRead ownerResourceFromContext
 
         let requireOrganizationAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationAdmin organizationResourceFromContext
 
+        let requireOrganizationWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.OrganizationAdmin
+                    Operation.OrganizationWrite
+                ]
+                organizationResourceFromContext
+
         let requireOrganizationRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationRead organizationResourceFromContext
 
         let requireRepositoryAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryAdmin repositoryResourceFromContext
+
+        let requireRepositoryWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.RepositoryAdmin
+                    Operation.RepositoryWrite
+                ]
+                repositoryResourceFromContext
 
         let requireRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryRead repositoryResourceFromContext
 
@@ -291,6 +323,14 @@ module Application =
         let requireArtifactRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
 
         let requireBranchAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchAdmin branchResourceFromContext
+
+        let requireBranchWriteOrAdmin: HttpHandler =
+            AuthorizationMiddleware.requiresAnyPermission
+                [
+                    Operation.BranchAdmin
+                    Operation.BranchWrite
+                ]
+                branchResourceFromContext
 
         let requireBranchRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchRead branchResourceFromContext
 
@@ -1028,22 +1068,22 @@ module Application =
                 subRoute
                     "/branch"
                     [
-                        POST [ route "/assign" Branch.Assign
+                        POST [ route "/assign" (composeHandlers requireBranchWriteOrAdmin Branch.Assign)
                                |> addMetadata typeof<Branch.AssignParameters>
 
                                route "/annotate" (composeHandlers requireBranchRead (composeHandlers requireAnnotatePathRead Branch.Annotate))
                                |> addMetadata typeof<Branch.AnnotateParameters>
 
-                               (route "/checkpoint" Branch.Checkpoint
+                               (route "/checkpoint" (composeHandlers requireBranchWriteOrAdmin Branch.Checkpoint)
                                 |> addMetadata typeof<Branch.CreateReferenceParameters>)
 
-                               route "/commit" (composeHandlers requireBranchWrite Branch.Commit)
+                               route "/commit" (composeHandlers requireBranchWriteOrAdmin Branch.Commit)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
-                               route "/create" Branch.Create
+                               route "/create" (composeHandlers requireRepositoryWriteOrAdmin Branch.Create)
                                |> addMetadata typeof<Branch.CreateBranchParameters>
 
-                               route "/createExternal" Branch.CreateExternal
+                               route "/createExternal" (composeHandlers requireBranchWriteOrAdmin Branch.CreateExternal)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/delete" Branch.Delete
@@ -1121,16 +1161,16 @@ module Application =
                                route "/listContents" Branch.ListContents
                                |> addMetadata typeof<Branch.ListContentsParameters>
 
-                               route "/promote" Branch.Promote
+                               route "/promote" (composeHandlers requireBranchWriteOrAdmin Branch.Promote)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/rebase" Branch.Rebase
                                |> addMetadata typeof<Branch.RebaseParameters>
 
-                               route "/save" Branch.Save
+                               route "/save" (composeHandlers requireBranchWriteOrAdmin Branch.Save)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
-                               route "/tag" Branch.Tag
+                               route "/tag" (composeHandlers requireBranchWriteOrAdmin Branch.Tag)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 
                                route "/updateParentBranch" Branch.UpdateParentBranch
@@ -1151,7 +1191,7 @@ module Application =
                 subRoute
                     "/directory"
                     [
-                        POST [ route "/create" DirectoryVersion.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin DirectoryVersion.Create)
                                |> addMetadata typeof<DirectoryVersion.CreateParameters>
 
                                route "/get" DirectoryVersion.Get
@@ -1169,14 +1209,14 @@ module Application =
                                route "/getZipFile" DirectoryVersion.GetZipFile
                                |> addMetadata typeof<DirectoryVersion.GetZipFileParameters>
 
-                               route "/saveDirectoryVersions" DirectoryVersion.SaveDirectoryVersions
+                               route "/saveDirectoryVersions" (composeHandlers requireRepositoryWriteOrAdmin DirectoryVersion.SaveDirectoryVersions)
                                |> addMetadata typeof<DirectoryVersion.SaveDirectoryVersionsParameters> ]
                     ]
                 subRoute "/notifications" [ GET [] ]
                 subRoute
                     "/organization"
                     [
-                        POST [ route "/create" Organization.Create
+                        POST [ route "/create" (composeHandlers requireOwnerWriteOrAdmin Organization.Create)
                                |> addMetadata typeof<Organization.CreateOrganizationParameters>
 
                                route "/delete" Organization.Delete
@@ -1206,7 +1246,7 @@ module Application =
                 subRoute
                     "/owner"
                     [
-                        POST [ route "/create" Owner.Create
+                        POST [ route "/create" (composeHandlers requireSystemOperateOrAdmin Owner.Create)
                                |> addMetadata typeof<Owner.CreateOwnerParameters>
 
                                route "/delete" Owner.Delete
@@ -1254,7 +1294,7 @@ module Application =
                 subRoute
                     "/work"
                     [
-                        POST [ route "/create" (composeHandlers requireRepositoryWrite WorkItem.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin WorkItem.Create)
                                |> addMetadata typeof<WorkItem.CreateWorkItemParameters>
 
                                route "/get" (composeHandlers requireRepositoryRead WorkItem.Get)
@@ -1371,7 +1411,7 @@ module Application =
                 subRoute
                     "/promotion-set"
                     [
-                        POST [ route "/create" PromotionSet.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin PromotionSet.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.PromotionSet.CreatePromotionSetParameters>
 
                                route "/get" PromotionSet.Get
@@ -1398,7 +1438,7 @@ module Application =
                 subRoute
                     "/validation-set"
                     [
-                        POST [ route "/create" ValidationSet.Create
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin ValidationSet.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Validation.CreateValidationSetParameters>
 
                                route "/get" ValidationSet.Get
@@ -1413,13 +1453,13 @@ module Application =
                 subRoute
                     "/validation-result"
                     [
-                        POST [ route "/record" ValidationResult.Record
+                        POST [ route "/record" (composeHandlers requireRepositoryWriteOrAdmin ValidationResult.Record)
                                |> addMetadata typeof<Grace.Shared.Parameters.Validation.RecordValidationResultParameters> ]
                     ]
                 subRoute
                     "/artifact"
                     [
-                        POST [ route "/create" (composeHandlers requireRepositoryWrite Artifact.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWriteOrAdmin Artifact.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Artifact.CreateArtifactParameters> ]
 
                         GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepositoryRead (Artifact.GetDownloadUri artifactId)) ]
@@ -1427,7 +1467,7 @@ module Application =
                 subRoute
                     "/repository"
                     [
-                        POST [ route "/create" Repository.Create
+                        POST [ route "/create" (composeHandlers requireOrganizationWriteOrAdmin Repository.Create)
                                |> addMetadata typeof<Repository.CreateRepositoryParameters>
 
                                route "/delete" (composeHandlers requireRepositoryAdmin Repository.Delete)
@@ -1598,7 +1638,7 @@ module Application =
                                route "/reschedule" Reminder.Reschedule
                                |> addMetadata typeof<Reminder.RescheduleReminderParameters>
 
-                               route "/create" Reminder.Create
+                               route "/create" (composeHandlers requireRepositoryWriteOrAdmin Reminder.Create)
                                |> addMetadata typeof<Reminder.CreateReminderParameters> ]
                     ]
                 subRoute

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -147,7 +147,8 @@ module Application =
                     | _ -> Error(GraceError.Create $"{queryParameterName} is required." correlationId)
 
                 match tryGetQueryGuid "ownerId", tryGetQueryGuid "organizationId", tryGetQueryGuid "repositoryId" with
-                | Ok ownerId, Ok organizationId, Ok repositoryId -> return Ok(Operation.RepoRead, Resource.Repository(ownerId, organizationId, repositoryId))
+                | Ok ownerId, Ok organizationId, Ok repositoryId ->
+                    return Ok(Operation.RepositoryRead, Resource.Repository(ownerId, organizationId, repositoryId))
                 | Error error, _, _
                 | _, Error error, _
                 | _, _, Error error -> return Error error
@@ -277,17 +278,17 @@ module Application =
 
         let requireOwnerRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OwnerRead ownerResourceFromContext
 
-        let requireOrgAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrgAdmin organizationResourceFromContext
+        let requireOrganizationAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationAdmin organizationResourceFromContext
 
-        let requireOrgRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrgRead organizationResourceFromContext
+        let requireOrganizationRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.OrganizationRead organizationResourceFromContext
 
-        let requireRepoAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoAdmin repositoryResourceFromContext
+        let requireRepositoryAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryAdmin repositoryResourceFromContext
 
-        let requireRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoRead repositoryResourceFromContext
+        let requireRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryRead repositoryResourceFromContext
 
-        let requireRepoWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepoWrite repositoryResourceFromContext
+        let requireRepositoryWrite: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.RepositoryWrite repositoryResourceFromContext
 
-        let requireArtifactRepoRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
+        let requireArtifactRepositoryRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved artifactRepositoryPermissionFromQuery
 
         let requireBranchAdmin: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.BranchAdmin branchResourceFromContext
 
@@ -1181,7 +1182,7 @@ module Application =
                                route "/delete" Organization.Delete
                                |> addMetadata typeof<Organization.DeleteOrganizationParameters>
 
-                               route "/get" (composeHandlers requireOrgRead Organization.Get)
+                               route "/get" (composeHandlers requireOrganizationRead Organization.Get)
                                |> addMetadata typeof<Organization.GetOrganizationParameters>
 
                                route "/listRepositories" Organization.ListRepositories
@@ -1190,7 +1191,7 @@ module Application =
                                route "/setDescription" Organization.SetDescription
                                |> addMetadata typeof<Organization.SetOrganizationDescriptionParameters>
 
-                               route "/setName" (composeHandlers requireOrgAdmin Organization.SetName)
+                               route "/setName" (composeHandlers requireOrganizationAdmin Organization.SetName)
                                |> addMetadata typeof<Organization.SetOrganizationNameParameters>
 
                                route "/setSearchVisibility" Organization.SetSearchVisibility
@@ -1235,67 +1236,67 @@ module Application =
                 subRoute
                     "/agent"
                     [
-                        POST [ route "/session/start" (composeHandlers requireRepoWrite startAgentSession)
+                        POST [ route "/session/start" (composeHandlers requireRepositoryWrite startAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.StartAgentSessionParameters>
 
-                               route "/session/stop" (composeHandlers requireRepoWrite stopAgentSession)
+                               route "/session/stop" (composeHandlers requireRepositoryWrite stopAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.StopAgentSessionParameters>
 
-                               route "/session/status" (composeHandlers requireRepoRead getAgentSessionStatus)
+                               route "/session/status" (composeHandlers requireRepositoryRead getAgentSessionStatus)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.GetAgentSessionStatusParameters>
 
-                               route "/session/active" (composeHandlers requireRepoRead getActiveAgentSession)
+                               route "/session/active" (composeHandlers requireRepositoryRead getActiveAgentSession)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.GetActiveAgentSessionParameters>
 
-                               route "/session/listActive" (composeHandlers requireRepoRead listActiveAgentSessions)
+                               route "/session/listActive" (composeHandlers requireRepositoryRead listActiveAgentSessions)
                                |> addMetadata typeof<Grace.Shared.Parameters.Common.ListActiveAgentSessionsParameters> ]
                     ]
                 subRoute
                     "/work"
                     [
-                        POST [ route "/create" (composeHandlers requireRepoWrite WorkItem.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWrite WorkItem.Create)
                                |> addMetadata typeof<WorkItem.CreateWorkItemParameters>
 
-                               route "/get" (composeHandlers requireRepoRead WorkItem.Get)
+                               route "/get" (composeHandlers requireRepositoryRead WorkItem.Get)
                                |> addMetadata typeof<WorkItem.GetWorkItemParameters>
 
-                               route "/update" (composeHandlers requireRepoWrite WorkItem.Update)
+                               route "/update" (composeHandlers requireRepositoryWrite WorkItem.Update)
                                |> addMetadata typeof<WorkItem.UpdateWorkItemParameters>
 
-                               route "/add-summary" (composeHandlers requireRepoWrite WorkItem.AddSummary)
+                               route "/add-summary" (composeHandlers requireRepositoryWrite WorkItem.AddSummary)
                                |> addMetadata typeof<WorkItem.AddSummaryParameters>
 
-                               route "/link/reference" (composeHandlers requireRepoWrite WorkItem.LinkReference)
+                               route "/link/reference" (composeHandlers requireRepositoryWrite WorkItem.LinkReference)
                                |> addMetadata typeof<WorkItem.LinkReferenceParameters>
 
-                               route "/link/artifact" (composeHandlers requireRepoWrite WorkItem.LinkArtifact)
+                               route "/link/artifact" (composeHandlers requireRepositoryWrite WorkItem.LinkArtifact)
                                |> addMetadata typeof<WorkItem.LinkArtifactParameters>
 
-                               route "/link/promotion-set" (composeHandlers requireRepoWrite WorkItem.LinkPromotionSet)
+                               route "/link/promotion-set" (composeHandlers requireRepositoryWrite WorkItem.LinkPromotionSet)
                                |> addMetadata typeof<WorkItem.LinkPromotionSetParameters>
 
-                               route "/links/list" (composeHandlers requireRepoRead WorkItem.GetLinks)
+                               route "/links/list" (composeHandlers requireRepositoryRead WorkItem.GetLinks)
                                |> addMetadata typeof<WorkItem.GetWorkItemLinksParameters>
 
-                               route "/attachments/list" (composeHandlers requireRepoRead WorkItem.ListAttachments)
+                               route "/attachments/list" (composeHandlers requireRepositoryRead WorkItem.ListAttachments)
                                |> addMetadata typeof<WorkItem.ListWorkItemAttachmentsParameters>
 
-                               route "/attachments/show" (composeHandlers requireRepoRead WorkItem.ShowAttachment)
+                               route "/attachments/show" (composeHandlers requireRepositoryRead WorkItem.ShowAttachment)
                                |> addMetadata typeof<WorkItem.ShowWorkItemAttachmentParameters>
 
-                               route "/attachments/download" (composeHandlers requireRepoRead WorkItem.DownloadAttachment)
+                               route "/attachments/download" (composeHandlers requireRepositoryRead WorkItem.DownloadAttachment)
                                |> addMetadata typeof<WorkItem.DownloadWorkItemAttachmentParameters>
 
-                               route "/links/remove/reference" (composeHandlers requireRepoWrite WorkItem.RemoveReferenceLink)
+                               route "/links/remove/reference" (composeHandlers requireRepositoryWrite WorkItem.RemoveReferenceLink)
                                |> addMetadata typeof<WorkItem.RemoveReferenceLinkParameters>
 
-                               route "/links/remove/promotion-set" (composeHandlers requireRepoWrite WorkItem.RemovePromotionSetLink)
+                               route "/links/remove/promotion-set" (composeHandlers requireRepositoryWrite WorkItem.RemovePromotionSetLink)
                                |> addMetadata typeof<WorkItem.RemovePromotionSetLinkParameters>
 
-                               route "/links/remove/artifact" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactLink)
+                               route "/links/remove/artifact" (composeHandlers requireRepositoryWrite WorkItem.RemoveArtifactLink)
                                |> addMetadata typeof<WorkItem.RemoveArtifactLinkParameters>
 
-                               route "/links/remove/artifact-type" (composeHandlers requireRepoWrite WorkItem.RemoveArtifactTypeLinks)
+                               route "/links/remove/artifact-type" (composeHandlers requireRepositoryWrite WorkItem.RemoveArtifactTypeLinks)
                                |> addMetadata typeof<WorkItem.RemoveArtifactTypeLinksParameters> ]
                     ]
                 subRoute
@@ -1418,10 +1419,10 @@ module Application =
                 subRoute
                     "/artifact"
                     [
-                        POST [ route "/create" (composeHandlers requireRepoWrite Artifact.Create)
+                        POST [ route "/create" (composeHandlers requireRepositoryWrite Artifact.Create)
                                |> addMetadata typeof<Grace.Shared.Parameters.Artifact.CreateArtifactParameters> ]
 
-                        GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepoRead (Artifact.GetDownloadUri artifactId)) ]
+                        GET [ routef "/%O/download-uri" (fun artifactId -> composeHandlers requireArtifactRepositoryRead (Artifact.GetDownloadUri artifactId)) ]
                     ]
                 subRoute
                     "/repository"
@@ -1429,13 +1430,13 @@ module Application =
                         POST [ route "/create" Repository.Create
                                |> addMetadata typeof<Repository.CreateRepositoryParameters>
 
-                               route "/delete" (composeHandlers requireRepoAdmin Repository.Delete)
+                               route "/delete" (composeHandlers requireRepositoryAdmin Repository.Delete)
                                |> addMetadata typeof<Repository.DeleteRepositoryParameters>
 
                                route "/exists" Repository.Exists
                                |> addMetadata typeof<Repository.RepositoryParameters>
 
-                               route "/get" (composeHandlers requireRepoRead Repository.Get)
+                               route "/get" (composeHandlers requireRepositoryRead Repository.Get)
                                |> addMetadata typeof<Repository.RepositoryParameters>
 
                                route "/getBranches" Repository.GetBranches
@@ -1471,7 +1472,7 @@ module Application =
                                route "/setConflictResolutionPolicy" Repository.SetConflictResolutionPolicy
                                |> addMetadata typeof<Repository.SetConflictResolutionPolicyParameters>
 
-                               route "/setDescription" (composeHandlers requireRepoAdmin Repository.SetDescription)
+                               route "/setDescription" (composeHandlers requireRepositoryAdmin Repository.SetDescription)
                                |> addMetadata typeof<Repository.SetRepositoryDescriptionParameters>
 
                                route "/setLogicalDeleteDays" Repository.SetLogicalDeleteDays
@@ -1489,7 +1490,7 @@ module Application =
                                route "/setStatus" Repository.SetStatus
                                |> addMetadata typeof<Repository.SetRepositoryStatusParameters>
 
-                               route "/setVisibility" (composeHandlers requireRepoAdmin Repository.SetVisibility)
+                               route "/setVisibility" (composeHandlers requireRepositoryAdmin Repository.SetVisibility)
                                |> addMetadata typeof<Repository.SetRepositoryVisibilityParameters>
 
                                route "/undelete" Repository.Undelete
@@ -1501,7 +1502,7 @@ module Application =
                         POST [ route "/getUploadMetadataForFiles" (composeHandlers requirePathWrite Storage.GetUploadMetadataForFiles)
                                |> addMetadata typeof<Storage.GetUploadMetadataForFilesParameters>
 
-                               route "/discoverContentBlocks" (composeHandlers requireRepoRead Storage.DiscoverContentBlocks)
+                               route "/discoverContentBlocks" (composeHandlers requireRepositoryRead Storage.DiscoverContentBlocks)
                                |> addMetadata typeof<Storage.DiscoverContentBlocksParameters>
 
                                route "/startManifestUploadSession" (composeHandlers requirePathWriteForUploadSession Storage.StartManifestUploadSession)

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -17,35 +17,74 @@ module Authorization =
 
         let private systemAdminOperations =
             set [ SystemAdmin
+                  SystemOperate
+                  SystemRead
                   OwnerAdmin
+                  OwnerWrite
                   OwnerRead
-                  OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoRead
-                  RepoWrite
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   BranchAdmin
-                  BranchRead
                   BranchWrite
+                  BranchRead
                   PathRead
                   PathWrite
                   ApprovalPolicyManage
                   ApprovalRequestRead
                   ApprovalRequestRespond
                   WebhookManage
+                  WebhookDeliveryRead ]
+
+        let private systemOperatorOperations =
+            set [ SystemOperate
+                  SystemRead
+                  OwnerAdmin
+                  OwnerWrite
+                  OwnerRead
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
+                  BranchAdmin
+                  BranchWrite
+                  BranchRead
+                  PathRead
+                  PathWrite
+                  ApprovalPolicyManage
+                  ApprovalRequestRead
+                  ApprovalRequestRespond
+                  WebhookManage
+                  WebhookDeliveryRead ]
+
+        let private systemReaderOperations =
+            set [ SystemRead
+                  OwnerRead
+                  OrganizationRead
+                  RepositoryRead
+                  BranchRead
+                  PathRead
+                  ApprovalRequestRead
                   WebhookDeliveryRead ]
 
         let private ownerAdminOperations =
             set [ OwnerAdmin
+                  OwnerWrite
                   OwnerRead
-                  OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoRead
-                  RepoWrite
+                  OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   BranchAdmin
-                  BranchRead
                   BranchWrite
+                  BranchRead
                   PathRead
                   PathWrite
                   ApprovalPolicyManage
@@ -53,20 +92,33 @@ module Authorization =
                   ApprovalRequestRespond
                   WebhookManage
                   WebhookDeliveryRead ]
+
+        let private ownerContributorOperations =
+            set [ OwnerWrite
+                  OwnerRead
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryWrite
+                  RepositoryRead
+                  BranchWrite
+                  BranchRead
+                  PathWrite
+                  PathRead ]
 
         let private ownerReaderOperations =
             set [ OwnerRead
-                  OrgRead
-                  RepoRead
+                  OrganizationRead
+                  RepositoryRead
                   BranchRead
                   PathRead ]
 
-        let private orgAdminOperations =
-            set [ OrgAdmin
-                  OrgRead
-                  RepoAdmin
-                  RepoWrite
-                  RepoRead
+        let private organizationAdminOperations =
+            set [ OrganizationAdmin
+                  OrganizationWrite
+                  OrganizationRead
+                  RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchAdmin
@@ -78,16 +130,26 @@ module Authorization =
                   WebhookManage
                   WebhookDeliveryRead ]
 
-        let private orgReaderOperations =
-            set [ OrgRead
-                  RepoRead
+        let private organizationContributorOperations =
+            set [ OrganizationWrite
+                  OrganizationRead
+                  RepositoryWrite
+                  RepositoryRead
+                  PathWrite
+                  PathRead
+                  BranchWrite
+                  BranchRead ]
+
+        let private organizationReaderOperations =
+            set [ OrganizationRead
+                  RepositoryRead
                   PathRead
                   BranchRead ]
 
-        let private repoAdminOperations =
-            set [ RepoAdmin
-                  RepoWrite
-                  RepoRead
+        let private repositoryAdminOperations =
+            set [ RepositoryAdmin
+                  RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchAdmin
@@ -99,16 +161,16 @@ module Authorization =
                   WebhookManage
                   WebhookDeliveryRead ]
 
-        let private repoContributorOperations =
-            set [ RepoWrite
-                  RepoRead
+        let private repositoryContributorOperations =
+            set [ RepositoryWrite
+                  RepositoryRead
                   PathWrite
                   PathRead
                   BranchWrite
                   BranchRead ]
 
-        let private repoReaderOperations =
-            set [ RepoRead
+        let private repositoryReaderOperations =
+            set [ RepositoryRead
                   PathRead
                   BranchRead
                   ApprovalRequestRead ]
@@ -129,13 +191,17 @@ module Authorization =
         let private roles: RoleDefinition list =
             [
                 { RoleId = "SystemAdmin"; AllowedOperations = systemAdminOperations; AppliesTo = Set.ofList [ scopeSystem ] }
+                { RoleId = "SystemOperator"; AllowedOperations = systemOperatorOperations; AppliesTo = Set.ofList [ scopeSystem ] }
+                { RoleId = "SystemReader"; AllowedOperations = systemReaderOperations; AppliesTo = Set.ofList [ scopeSystem ] }
                 { RoleId = "OwnerAdmin"; AllowedOperations = ownerAdminOperations; AppliesTo = Set.ofList [ scopeOwner ] }
+                { RoleId = "OwnerContributor"; AllowedOperations = ownerContributorOperations; AppliesTo = Set.ofList [ scopeOwner ] }
                 { RoleId = "OwnerReader"; AllowedOperations = ownerReaderOperations; AppliesTo = Set.ofList [ scopeOwner ] }
-                { RoleId = "OrgAdmin"; AllowedOperations = orgAdminOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
-                { RoleId = "OrgReader"; AllowedOperations = orgReaderOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
-                { RoleId = "RepoAdmin"; AllowedOperations = repoAdminOperations; AppliesTo = Set.ofList [ scopeRepository ] }
-                { RoleId = "RepoContributor"; AllowedOperations = repoContributorOperations; AppliesTo = Set.ofList [ scopeRepository ] }
-                { RoleId = "RepoReader"; AllowedOperations = repoReaderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "OrganizationAdmin"; AllowedOperations = organizationAdminOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "OrganizationContributor"; AllowedOperations = organizationContributorOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "OrganizationReader"; AllowedOperations = organizationReaderOperations; AppliesTo = Set.ofList [ scopeOrganization ] }
+                { RoleId = "RepositoryAdmin"; AllowedOperations = repositoryAdminOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "RepositoryContributor"; AllowedOperations = repositoryContributorOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "RepositoryReader"; AllowedOperations = repositoryReaderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
                 { RoleId = "BranchAdmin"; AllowedOperations = branchAdminOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchWriter"; AllowedOperations = branchWriterOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchReader"; AllowedOperations = branchReaderOperations; AppliesTo = Set.ofList [ scopeBranch ] }

--- a/src/Grace.Types/Authorization.Types.fs
+++ b/src/Grace.Types/Authorization.Types.fs
@@ -57,16 +57,20 @@ module Authorization =
     [<KnownType("GetKnownTypes")>]
     type Operation =
         | SystemAdmin
+        | SystemOperate
+        | SystemRead
         | OwnerAdmin
+        | OwnerWrite
         | OwnerRead
-        | OrgAdmin
-        | OrgRead
-        | RepoAdmin
-        | RepoRead
-        | RepoWrite
+        | OrganizationAdmin
+        | OrganizationWrite
+        | OrganizationRead
+        | RepositoryAdmin
+        | RepositoryWrite
+        | RepositoryRead
         | BranchAdmin
-        | BranchRead
         | BranchWrite
+        | BranchRead
         | PathRead
         | PathWrite
         | ApprovalPolicyManage

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -103,7 +103,8 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
 SystemAdmin assignment with `grace__authz__bootstrap__system_admin_users` or have an existing admin grant the needed
-role before PAT creation and other protected operations will succeed.
+role before protected operations will succeed. An authenticated caller that maps to a Grace User can create a PAT before
+RBAC grants; that PAT still authorizes protected operations only through Grace's normal authorization checks.
 
 `GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
 interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
@@ -115,10 +116,11 @@ Scope creation uses normal authorization in DebugLocal and production:
 - repository creation requires `OrganizationAdmin` or `OrganizationWrite` on the parent organization;
 - branch creation requires `RepositoryAdmin` or `RepositoryWrite` on the parent repository.
 
-After successful scope creation, Grace ensures the authenticated creator has the matching admin role on the new scope:
-`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`. Non-scope creation such as DirectoryVersion,
-directory save, reference creation, artifacts, promotion sets, reminders, validation records, and work items does not
-create admin grants.
+After successful scope creation, Grace ensures the authenticated creator has effective admin authority on the new scope.
+Grace creates a direct matching admin grant (`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`) only
+when inherited admin authority does not already apply. Non-scope creation such as DirectoryVersion, directory save,
+reference creation, artifacts, promotion sets, reminders, validation records, and work items does not create admin
+grants.
 
 ## DebugLocal Reliability Switches
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -85,6 +85,7 @@ PowerShell:
 
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
+Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -94,6 +95,7 @@ bash / zsh:
 
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
+unset GRACE_TOKEN
 grace auth login
 grace auth whoami --output Verbose
 grace auth token create --name "local-dev" --expires-in 30d --output Verbose
@@ -102,6 +104,21 @@ grace auth token create --name "local-dev" --expires-in 30d --output Verbose
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
 SystemAdmin assignment with `grace__authz__bootstrap__system_admin_users` or have an existing admin grant the needed
 role before PAT creation and other protected operations will succeed.
+
+`GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
+interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
+
+Scope creation uses normal authorization in DebugLocal and production:
+
+- owner creation requires `SystemAdmin` or the support operation `SystemOperate` on the system resource;
+- organization creation requires `OwnerAdmin` or `OwnerWrite` on the parent owner;
+- repository creation requires `OrganizationAdmin` or `OrganizationWrite` on the parent organization;
+- branch creation requires `RepositoryAdmin` or `RepositoryWrite` on the parent repository.
+
+After successful scope creation, Grace ensures the authenticated creator has the matching admin role on the new scope:
+`OwnerAdmin`, `OrganizationAdmin`, `RepositoryAdmin`, or `BranchAdmin`. Non-scope creation such as DirectoryVersion,
+directory save, reference creation, artifacts, promotion sets, reminders, validation records, and work items does not
+create admin grants.
 
 ## DebugLocal Reliability Switches
 
@@ -225,8 +242,9 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 ### CLI / Client
 
 - `GRACE_SERVER_URI`: Grace server base URL (include port, omit trailing slash).
-- `GRACE_TOKEN`: Grace PAT for non-interactive auth. OIDC/MSA access tokens are not valid here.
-- `GRACE_TOKEN_FILE`: override for token file path.
+- `GRACE_TOKEN`: Grace PAT for non-interactive auth. OIDC/MSA access tokens are not valid here. This value wins before
+  M2M and interactive login.
+- `GRACE_TOKEN_FILE`: not supported; local plaintext token file storage is intentionally disabled.
 
 ### Reminders
 


### PR DESCRIPTION
## Summary

- Implements the canonical authorization scope-role model across `System -> Owner -> Organization -> Repository -> Branch`.
- Replaces abbreviated role names with full current-contract names, including `Organization*` and `Repository*`, and adds support roles `SystemOperator` and `SystemReader`.
- Enforces scope and non-scope create authorization, including parent `Admin OR Write` requirements for child scope creation.
- Ensures successful scope creation leaves the authenticated mapped Grace User with effective admin on the new scope before the response succeeds.
- Updates CLI role contract surfaces, tests, and documentation for local Debug/bootstrap guidance.

## Issue Links

Closes #401.
Closes #407.

Completed sub-issues:

- #402 - Full-name roles, operations, and system support roles
- #403 - Route authorization for scope and non-scope creation
- #404 - Scope creator admin grants
- #405 - CLI, SDK, OpenAPI, schemas, and examples
- #406 - Documentation and first-time stand-up guidance

## No Production Data Migration

There is no production data to preserve, migrate, grandfather, backfill, or classify for this epic. This release candidate intentionally does not add legacy role aliases, migration scripts, compatibility shims, or production-data repair logic for old role IDs. Review should focus on current source behavior, tests, generated/public surfaces, docs, and explicit local reset semantics.

## Final Integration Evidence

Branch/head:

- Source branch: `epic/401-authorization-scope-roles`
- Final validated head: `c6778d751c03ef67e2b8ad9d609c96489aad3c7c`
- Base freshness: `origin/main...HEAD` was `0 13`; `origin/main` had no commits missing from the epic branch before final validation.
- Scoped diff: 29 changed files; no deletions in `git diff --name-status --diff-filter=D origin/main...HEAD`.

Final local validation from `C:\Source\Grace-epic-401` on `c6778d751c03ef67e2b8ad9d609c96489aad3c7c`:

- `npx --yes markdownlint-cli2 "docs/Authentication.md" "src/docs/ENVIRONMENT.md"`: passed, `0 error(s)`.
- Focused stale abbreviated-role search across `docs` and `src/docs`: passed, no current-contract `Org*` / `Repo*` matches.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build succeeded with 0 warnings and 0 errors.
  - `Grace.Authorization.Tests`: 48 passed.
  - `Grace.Types.Tests`: 96 passed.
  - `Grace.Server.Unit.Tests`: 512 passed.
  - `Grace.CLI.Tests`: 536 passed, 1 skipped.

GitHub validation:

- Validate / `full`: passed on `c6778d751c03ef67e2b8ad9d609c96489aad3c7c`.

## Review Status

- Sub-issue PRs #408, #409, #410, #411, and #412 were merged into the epic branch with validation evidence.
- Codex Code Review Bot feedback from sub-issue PRs was fixed, replied to, resolved, and re-reviewed before each merge.
- Final release-candidate Codex Code Review Bot: latest-head `👍` on `c6778d751c03ef67e2b8ad9d609c96489aad3c7c`.
- Final GitHub Actions validation: `full` success on `c6778d751c03ef67e2b8ad9d609c96489aad3c7c`.

Prevention line: this release candidate keeps Debug and production authorization semantics aligned, distinguishes authentication from authorization, treats stale `GRACE_TOKEN` as a token-source issue, and explicitly rejects migration/backfill/legacy role compatibility because there is no production data to migrate.
