### PR TITLE
Rename auth APIs to authenticate and authorize

### DIFF
--- a/scripts/start-debuglocal.ps1
+++ b/scripts/start-debuglocal.ps1
@@ -281,8 +281,8 @@ function Invoke-AuthProbe(
 ) {
   Write-Step "Running auth readiness probe." "Green"
 
-  $oidcConfigUri = "$GraceServerUri/auth/oidc/config"
-  $authMeUri = "$GraceServerUri/auth/me"
+  $oidcConfigUri = "$GraceServerUri/authenticate/oidc/config"
+  $authMeUri = "$GraceServerUri/authenticate/me"
   $headers = @{ "x-grace-user-id" = $BootstrapUserId }
 
   Write-Detail "Probe 1/2: GET $oidcConfigUri"
@@ -292,7 +292,7 @@ function Invoke-AuthProbe(
     $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "auth probe" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
     Set-LastFailureInfo -FailureInfo $failure
     $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
-    throw "Auth probe failed at /auth/oidc/config (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
+    throw "Auth probe failed at /authenticate/oidc/config (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
   }
 
   Write-Detail "Probe 2/2: GET $authMeUri (x-grace-user-id=$BootstrapUserId)"
@@ -302,7 +302,7 @@ function Invoke-AuthProbe(
     $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "auth probe" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
     Set-LastFailureInfo -FailureInfo $failure
     $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
-    throw "Auth probe failed at /auth/me (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
+    throw "Auth probe failed at /authenticate/me (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
   }
 
   Write-Detail "Auth readiness probe passed." "Green"
@@ -315,7 +315,7 @@ function Invoke-TokenBootstrapWithRetry(
   [int] $MaxAttempts,
   [int] $InitialBackoffSeconds
 ) {
-  $tokenUri = "$GraceServerUri/auth/token/create"
+  $tokenUri = "$GraceServerUri/authenticate/token/create"
   $headers = @{ "x-grace-user-id" = $BootstrapUserId }
   $safeMaxAttempts = [Math]::Max($MaxAttempts, 1)
   $safeInitialBackoff = [Math]::Max($InitialBackoffSeconds, 1)

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -266,22 +266,58 @@ type EndpointAuthorizationManifestTests() =
         |> assertRoutesUseSecurity (Authorized(Operation.WebhookDeliveryRead, ResourceKind.Repository))
 
     [<Test>]
+    member _.AuthorizationRoutesUseExpectedAuthenticatedAndAdminPolicies() =
+        [
+            "GET", "/authorize/list-roles"
+            "POST", "/authorize/check-permission"
+        ]
+        |> assertRoutesUseSecurity Authenticated
+
+        [
+            "POST", "/authorize/grant-role"
+            "POST", "/authorize/list-role-assignments"
+            "POST", "/authorize/revoke-role"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.SystemAdmin, ResourceKind.System))
+
+        [
+            "POST", "/authorize/list-path-permissions"
+            "POST", "/authorize/remove-path-permission"
+            "POST", "/authorize/upsert-path-permission"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryAdmin, ResourceKind.Repository))
+
+    [<Test>]
     member _.AuthRoutesUseExpectedAnonymousAndAuthenticatedPolicies() =
         [
-            "GET", "/auth/login"
-            "GET", "/auth/login/%s"
-            "GET", "/auth/oidc/config"
+            "GET", "/authenticate/login"
+            "GET", "/authenticate/login/%s"
+            "GET", "/authenticate/oidc/config"
         ]
         |> assertRoutesUseSecurity AllowAnonymous
 
         [
-            "GET", "/auth/logout"
-            "GET", "/auth/me"
-            "POST", "/auth/token/create"
-            "POST", "/auth/token/list"
-            "POST", "/auth/token/revoke"
+            "GET", "/authenticate/logout"
+            "GET", "/authenticate/me"
+            "POST", "/authenticate/token/create"
+            "POST", "/authenticate/token/list"
+            "POST", "/authenticate/token/revoke"
         ]
         |> assertRoutesUseSecurity Authenticated
+
+    [<Test>]
+    member _.AuthenticationAndAuthorizationRoutesDoNotKeepLegacyPrefixes() =
+        let legacyRoutes =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Path.StartsWith("/auth/", StringComparison.Ordinal)
+                || definition.Path.StartsWith("/access/", StringComparison.Ordinal))
+
+        if not legacyRoutes.IsEmpty then
+            legacyRoutes
+            |> List.map (fun definition -> $"{definition.Method} {definition.Path}")
+            |> String.concat Environment.NewLine
+            |> fun routes -> Assert.Fail($"Legacy auth/access routes must not remain in EndpointAuthorizationManifest:{Environment.NewLine}{routes}")
 
     [<Test>]
     member _.MetricsAndManualRoutesUseExpectedPolicies() =

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -572,7 +572,7 @@ module AuthTests =
 
                 exitCode |> should not' (equal 0)
                 standardOut |> should contain "401 Unauthorized"
-                standardOut |> should contain "auth/me"
+                standardOut |> should contain "authenticate/me"
 
                 standardOut
                 |> should not' (contain "JsonException")
@@ -602,7 +602,9 @@ module AuthTests =
 
                     exitCode |> should not' (equal 0)
                     standardOut |> should contain "401 Unauthorized"
-                    standardOut |> should contain "auth/token/create"
+
+                    standardOut
+                    |> should contain "authenticate/token/create"
 
                     standardOut
                     |> should not' (contain "JsonException")

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1092,7 +1092,7 @@ module DoctorCliTests =
                             principalRequests.Count |> should equal 1
 
                             principalRequests[0].RelativePath
-                            |> should equal "auth/me"
+                            |> should equal "authenticate/me"
 
                             principalRequests[0].BearerToken
                             |> should equal (Some token)))))

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -1444,7 +1444,7 @@ module Auth =
             task {
                 let correlationId = parseResult |> getCorrelationId
                 let parameters = CommonParameters(CorrelationId = correlationId)
-                let! result = Grace.SDK.Common.getServer<CommonParameters, AuthInfo> (parameters, "auth/me")
+                let! result = Grace.SDK.Common.getServer<CommonParameters, AuthInfo> (parameters, "authenticate/me")
 
                 match result with
                 | Ok graceReturnValue ->

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -367,7 +367,7 @@ module Doctor =
                 Id = ServerAuthPrincipalAvailableCheckId
                 Category = "Server"
                 Title = "Grace authenticated principal"
-                Description = "Optionally probes /auth/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
+                Description = "Optionally probes /authenticate/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
                 DefaultEnabled = false
                 SupportsOffline = false
             }
@@ -928,15 +928,15 @@ module Doctor =
                 | Some token ->
                     let effectiveServerUri = resolveEffectiveServerUri context.ConfigurationState context.EnvironmentServerUri
 
-                    match probeServer "auth/me" (Some token) effectiveServerUri
+                    match probeServer "authenticate/me" (Some token) effectiveServerUri
                           |> fun task -> task.GetAwaiter().GetResult()
                         with
                     | ServerProbeSucceeded response when isSuccessfulHttpStatus response.StatusCode ->
                         ok
-                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
+                            $"Authenticated principal endpoint /authenticate/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
                     | ServerProbeSucceeded response ->
                         failed
-                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
+                            $"Authenticated principal endpoint /authenticate/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
                     | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
                     | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
                     | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."

--- a/src/Grace.SDK/Access.SDK.fs
+++ b/src/Grace.SDK/Access.SDK.fs
@@ -10,38 +10,32 @@ type Access() =
 
     /// Grants a role to a principal at a scope.
     static member public GrantRole(parameters: GrantRoleParameters) =
-        postServer<GrantRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.GrantRole)}")
+        postServer<GrantRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/grant-role")
 
     /// Revokes a role from a principal at a scope.
     static member public RevokeRole(parameters: RevokeRoleParameters) =
-        postServer<RevokeRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.RevokeRole)}")
+        postServer<RevokeRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/revoke-role")
 
     /// Lists role assignments at a scope, optionally filtered by principal.
     static member public ListRoleAssignments(parameters: ListRoleAssignmentsParameters) =
-        postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.ListRoleAssignments)}")
+        postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-role-assignments")
 
     /// Upserts a repository path permission.
     static member public UpsertPathPermission(parameters: UpsertPathPermissionParameters) =
-        postServer<UpsertPathPermissionParameters, PathPermission list> (
-            parameters |> ensureCorrelationIdIsSet,
-            $"access/{nameof (Access.UpsertPathPermission)}"
-        )
+        postServer<UpsertPathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/upsert-path-permission")
 
     /// Removes a repository path permission.
     static member public RemovePathPermission(parameters: RemovePathPermissionParameters) =
-        postServer<RemovePathPermissionParameters, PathPermission list> (
-            parameters |> ensureCorrelationIdIsSet,
-            $"access/{nameof (Access.RemovePathPermission)}"
-        )
+        postServer<RemovePathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/remove-path-permission")
 
     /// Lists repository path permissions.
     static member public ListPathPermissions(parameters: ListPathPermissionsParameters) =
-        postServer<ListPathPermissionsParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.ListPathPermissions)}")
+        postServer<ListPathPermissionsParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-path-permissions")
 
     /// Checks a permission against the current or specified principal.
     static member public CheckPermission(parameters: CheckPermissionParameters) =
-        postServer<CheckPermissionParameters, PermissionCheckResult> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.CheckPermission)}")
+        postServer<CheckPermissionParameters, PermissionCheckResult> (parameters |> ensureCorrelationIdIsSet, "authorize/check-permission")
 
     /// Lists the configured roles.
     static member public ListRoles(parameters: CommonParameters) =
-        getServer<CommonParameters, RoleDefinition list> (parameters |> ensureCorrelationIdIsSet, "access/listRoles")
+        getServer<CommonParameters, RoleDefinition list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-roles")

--- a/src/Grace.SDK/Auth.SDK.fs
+++ b/src/Grace.SDK/Auth.SDK.fs
@@ -76,7 +76,7 @@ module Auth =
                 let startTime = getCurrentInstant ()
 
                 let graceServerUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
-                let serverUri = Uri($"{graceServerUri}/auth/oidc/config")
+                let serverUri = Uri($"{graceServerUri}/authenticate/oidc/config")
 
                 let! response = Constants.DefaultAsyncRetryPolicy.ExecuteAsync(fun _ -> httpClient.GetAsync(serverUri))
                 let endTime = getCurrentInstant ()
@@ -89,7 +89,7 @@ module Auth =
                         |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! graceError = ResponseErrors.fromResponse correlationId "auth/oidc/config" response
+                    let! graceError = ResponseErrors.fromResponse correlationId "authenticate/oidc/config" response
 
                     return
                         Error graceError

--- a/src/Grace.SDK/PersonalAccessToken.SDK.fs
+++ b/src/Grace.SDK/PersonalAccessToken.SDK.fs
@@ -64,10 +64,10 @@ module PersonalAccessToken =
         }
 
     let Create (parameters: CreatePersonalAccessTokenParameters) =
-        postServerWithEnv<CreatePersonalAccessTokenParameters, PersonalAccessTokenCreated> (parameters, "auth/token/create")
+        postServerWithEnv<CreatePersonalAccessTokenParameters, PersonalAccessTokenCreated> (parameters, "authenticate/token/create")
 
     let List (parameters: ListPersonalAccessTokensParameters) =
-        postServerWithEnv<ListPersonalAccessTokensParameters, PersonalAccessTokenSummary list> (parameters, "auth/token/list")
+        postServerWithEnv<ListPersonalAccessTokensParameters, PersonalAccessTokenSummary list> (parameters, "authenticate/token/list")
 
     let Revoke (parameters: RevokePersonalAccessTokenParameters) =
-        postServerWithEnv<RevokePersonalAccessTokenParameters, PersonalAccessTokenSummary> (parameters, "auth/token/revoke")
+        postServerWithEnv<RevokePersonalAccessTokenParameters, PersonalAccessTokenSummary> (parameters, "authenticate/token/revoke")

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -48,7 +48,7 @@ type AccessBootstrapEnabledTests() =
             let! _ownerId = createOwner client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -104,7 +104,7 @@ type AccessBootstrapTests() =
             let! _ownerId = createOwner Client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
@@ -147,7 +147,7 @@ type AccessCheckPermissionTests() =
             parameters.PrincipalId <- principalId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/checkPermission", createJsonContent parameters)
+            return! client.PostAsync("/authorize/check-permission", createJsonContent parameters)
         }
 
     [<Test>]
@@ -230,7 +230,7 @@ type AccessControlSecurityTests() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let revokeRoleAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId principalId roleId =
@@ -246,7 +246,7 @@ type AccessControlSecurityTests() =
             parameters.RoleId <- roleId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/revokeRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
         }
 
     let listRoleAssignmentsAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId =
@@ -259,7 +259,7 @@ type AccessControlSecurityTests() =
             parameters.ScopeKind <- scopeKind
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            return! client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
         }
 
     [<Test>]
@@ -523,7 +523,7 @@ type AccessControl() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -542,7 +542,7 @@ type AccessControl() =
                 claimPermission.DirectoryPermission <- permission
                 parameters.ClaimPermissions.Add(claimPermission)
 
-            let! response = client.PostAsync("/access/upsertPathPermission", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/upsert-path-permission", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -557,7 +557,7 @@ type AccessControl() =
             parameters.Path <- path
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/check-permission", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PermissionCheckResult>> response
             return returnValue.ReturnValue
@@ -575,7 +575,7 @@ type AccessControl() =
             parameters.RoleId <- roleId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/revokeRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -588,7 +588,7 @@ type AccessControl() =
             parameters.ScopeKind <- scopeKind
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             let! responseText = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
             let returnValue = deserialize<GraceReturnValue<RoleAssignment list>> responseText
@@ -876,7 +876,7 @@ type AccessControl() =
             parameters.RoleId <- "SystemAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -890,7 +890,7 @@ type AccessControl() =
             parameters.RoleId <- "NotARealRole"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -905,7 +905,7 @@ type AccessControl() =
             parameters.RoleId <- "RepositoryAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -916,7 +916,7 @@ type AccessControl() =
             parameters.ScopeKind <- "system"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<RoleAssignment list>> response
@@ -942,7 +942,7 @@ type AccessControl() =
             parameters.ScopeKind <- "owner"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -962,7 +962,7 @@ type AccessControl() =
             parameters.PrincipalId <- "other-user"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/check-permission", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -982,7 +982,7 @@ type AccessControl() =
             parameters.PrincipalId <- nonAdminUserId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/check-permission", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
 
@@ -1028,7 +1028,7 @@ type EndpointAuthorizationTests() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let getDefaultBranchAsync (repositoryId: string) =
@@ -1217,13 +1217,13 @@ type EndpointAuthorizationTests() =
             let! healthResponse = client.GetAsync("/healthz")
             Assert.That(healthResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! configResponse = client.GetAsync("/auth/oidc/config")
+            let! configResponse = client.GetAsync("/authenticate/oidc/config")
             Assert.That(configResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! loginResponse = client.GetAsync("/auth/login")
+            let! loginResponse = client.GetAsync("/authenticate/login")
             Assert.That(loginResponse.StatusCode, Is.AnyOf(HttpStatusCode.OK, HttpStatusCode.Redirect))
 
-            let! providerLoginResponse = client.GetAsync("/auth/login/test")
+            let! providerLoginResponse = client.GetAsync("/authenticate/login/test")
             Assert.That(providerLoginResponse.StatusCode, Is.AnyOf(HttpStatusCode.OK, HttpStatusCode.Redirect, HttpStatusCode.NotFound))
         }
 

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -73,7 +73,7 @@ module private ApprovalTestHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let createPolicyParameters (repositoryId: string) (branchId: string) =

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -24,7 +24,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.LoginPageShowsNoProvidersWhenNotConfigured() =
         task {
-            let! response = Client.GetAsync("/auth/login")
+            let! response = Client.GetAsync("/authenticate/login")
             response.EnsureSuccessStatusCode() |> ignore
             Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/html"))
             let! body = response.Content.ReadAsStringAsync()
@@ -37,7 +37,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.LoginProviderReturnsNotFoundWhenNotConfigured() =
         task {
-            let! response = Client.GetAsync("/auth/login/microsoft")
+            let! response = Client.GetAsync("/authenticate/login/microsoft")
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
             Assert.That(body, Does.Contain("Login provider not available."))
@@ -67,7 +67,7 @@ type AuthEndpoints() =
             use unauthenticatedClient = new HttpClient()
             unauthenticatedClient.BaseAddress <- Client.BaseAddress
 
-            let! response = unauthenticatedClient.GetAsync("/auth/oidc/config")
+            let! response = unauthenticatedClient.GetAsync("/authenticate/oidc/config")
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<OidcClientConfig>> response
@@ -80,7 +80,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.AuthMeReturnsGraceUserId() =
         task {
-            let! response = Client.GetAsync("/auth/me")
+            let! response = Client.GetAsync("/authenticate/me")
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<AuthInfo>> response
             Assert.That(returnValue.ReturnValue.GraceUserId, Is.EqualTo(testUserId))
@@ -93,7 +93,7 @@ type AuthEndpoints() =
         task {
             use unauthenticatedClient = new HttpClient()
             unauthenticatedClient.BaseAddress <- Client.BaseAddress
-            let! response = unauthenticatedClient.GetAsync("/auth/me")
+            let! response = unauthenticatedClient.GetAsync("/authenticate/me")
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
         }
 
@@ -102,7 +102,7 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
@@ -112,7 +112,7 @@ type AuthEndpoints() =
             patClient.BaseAddress <- Client.BaseAddress
             patClient.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", token)
 
-            let! meResponse = patClient.GetAsync("/auth/me")
+            let! meResponse = patClient.GetAsync("/authenticate/me")
             meResponse.EnsureSuccessStatusCode() |> ignore
 
             let! meValue = deserializeContent<GraceReturnValue<AuthInfo>> meResponse
@@ -124,20 +124,20 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             let created = returnValue.ReturnValue
 
             let revokeParameters = Grace.Shared.Parameters.Auth.RevokePersonalAccessTokenParameters()
             revokeParameters.TokenId <- created.Summary.TokenId
-            let! revokeResponse = Client.PostAsync("/auth/token/revoke", createJsonContent revokeParameters)
+            let! revokeResponse = Client.PostAsync("/authenticate/token/revoke", createJsonContent revokeParameters)
             revokeResponse.EnsureSuccessStatusCode() |> ignore
 
             use patClient = new HttpClient()
             patClient.BaseAddress <- Client.BaseAddress
             patClient.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", created.Token)
-            let! meResponse = patClient.GetAsync("/auth/me")
+            let! meResponse = patClient.GetAsync("/authenticate/me")
             Assert.That(meResponse.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
         }
 
@@ -147,7 +147,7 @@ type AuthEndpoints() =
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
             parameters.ExpiresInSeconds <- 400L * 86400L
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -156,12 +156,12 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! createdReturn = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
 
             let listParameters = Grace.Shared.Parameters.Auth.ListPersonalAccessTokensParameters()
-            let! listResponse = Client.PostAsync("/auth/token/list", createJsonContent listParameters)
+            let! listResponse = Client.PostAsync("/authenticate/token/list", createJsonContent listParameters)
             listResponse.EnsureSuccessStatusCode() |> ignore
             let! listReturn = deserializeContent<GraceReturnValue<PersonalAccessTokenSummary list>> listResponse
 
@@ -175,12 +175,12 @@ type AuthEndpoints() =
 
             let revokeParameters = Grace.Shared.Parameters.Auth.RevokePersonalAccessTokenParameters()
             revokeParameters.TokenId <- createdId
-            let! revokeResponse = Client.PostAsync("/auth/token/revoke", createJsonContent revokeParameters)
+            let! revokeResponse = Client.PostAsync("/authenticate/token/revoke", createJsonContent revokeParameters)
             revokeResponse.EnsureSuccessStatusCode() |> ignore
 
             let listWithRevoked = Grace.Shared.Parameters.Auth.ListPersonalAccessTokensParameters()
             listWithRevoked.IncludeRevoked <- true
-            let! revokedResponse = Client.PostAsync("/auth/token/list", createJsonContent listWithRevoked)
+            let! revokedResponse = Client.PostAsync("/authenticate/token/list", createJsonContent listWithRevoked)
 
             revokedResponse.EnsureSuccessStatusCode()
             |> ignore

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -356,7 +356,7 @@ module BranchServerTestHelpers =
             parameters.TokenName <- $"branch-sdk-{Guid.NewGuid():N}"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             return returnValue.ReturnValue.Token

--- a/src/Grace.Server.Tests/Repository.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Repository.Server.Tests.fs
@@ -41,7 +41,7 @@ type Repository() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -153,7 +153,7 @@ type StorageContentBlockSasRoutes() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let setContentBlockParameters (parameters: Parameters.Storage.StorageParameters) repositoryId =
@@ -262,7 +262,7 @@ type StorageContentBlockDiscoveryRoutes() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let createDiscoveryJson repositoryId (keyChunkAddresses: string array) =

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -61,7 +61,7 @@ module private WebhookTestHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let ruleParameters (repositoryId: string) (branchId: string) =

--- a/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
@@ -43,7 +43,7 @@ module private WorkItemIntegrationHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
         }
@@ -513,7 +513,7 @@ module private WorkItemIntegrationHelpers =
             parameters.TokenName <- $"workitem-sdk-{Guid.NewGuid():N}"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             return returnValue.ReturnValue.Token

--- a/src/Grace.Server/AGENTS.md
+++ b/src/Grace.Server/AGENTS.md
@@ -24,7 +24,7 @@ code.
   should be intentional and well documented here.
 - Coordinate contracts and message flows with `Grace.Actors`, `Grace.SDK`, and
   `Grace.Types` so that clients and grain logic remain in sync.
-- Personal access tokens (PATs) use the `GracePat` auth scheme, `/auth/token/*`
+- Personal access tokens (PATs) use the `GracePat` auth scheme, `/authenticate/token/*`
   endpoints, and are governed by `grace__auth__pat__*` lifetime policies.
   Authorization headers are redacted in request logging.
 - Auth0 JWT bearer validation is configured via

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -26,14 +26,14 @@ module EndpointAuthorizationManifest =
     let definitions: EndpointSecurityDefinition list =
         [
             endpoint "GET" "/" AllowAnonymous
-            endpoint "POST" "/access/checkPermission" Authenticated
-            endpoint "POST" "/access/grantRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/listPathPermissions" (Authorized(RepositoryAdmin, Repository))
-            endpoint "POST" "/access/listRoleAssignments" (Authorized(SystemAdmin, System))
-            endpoint "GET" "/access/listRoles" Authenticated
-            endpoint "POST" "/access/removePathPermission" (Authorized(RepositoryAdmin, Repository))
-            endpoint "POST" "/access/revokeRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/check-permission" Authenticated
+            endpoint "POST" "/authorize/grant-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/list-path-permissions" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/list-role-assignments" (Authorized(SystemAdmin, System))
+            endpoint "GET" "/authorize/list-roles" Authenticated
+            endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
@@ -60,14 +60,14 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/webhook/rule/test" (Authorized(WebhookManage, Repository))
             endpoint "POST" "/webhook/delivery/list" (Authorized(WebhookDeliveryRead, Repository))
             endpoint "POST" "/webhook/delivery/show" (Authorized(WebhookDeliveryRead, Repository))
-            endpoint "GET" "/auth/login" AllowAnonymous
-            endpoint "GET" "/auth/login/%s" AllowAnonymous
-            endpoint "GET" "/auth/logout" Authenticated
-            endpoint "GET" "/auth/me" Authenticated
-            endpoint "GET" "/auth/oidc/config" AllowAnonymous
-            endpoint "POST" "/auth/token/create" Authenticated
-            endpoint "POST" "/auth/token/list" Authenticated
-            endpoint "POST" "/auth/token/revoke" Authenticated
+            endpoint "GET" "/authenticate/login" AllowAnonymous
+            endpoint "GET" "/authenticate/login/%s" AllowAnonymous
+            endpoint "GET" "/authenticate/logout" Authenticated
+            endpoint "GET" "/authenticate/me" Authenticated
+            endpoint "GET" "/authenticate/oidc/config" AllowAnonymous
+            endpoint "POST" "/authenticate/token/create" Authenticated
+            endpoint "POST" "/authenticate/token/list" Authenticated
+            endpoint "POST" "/authenticate/token/revoke" Authenticated
             endpoint "POST" "/agent/session/active" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/listActive" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1578,32 +1578,32 @@ module Application =
                                |> addMetadata typeof<Storage.GetUploadUriParameters> ]
                     ]
                 subRoute
-                    "/access"
+                    "/authorize"
                     [
-                        POST [ route "/grantRole" Access.GrantRole
+                        POST [ route "/grant-role" Access.GrantRole
                                |> addMetadata typeof<Access.GrantRoleParameters>
 
-                               route "/revokeRole" Access.RevokeRole
+                               route "/revoke-role" Access.RevokeRole
                                |> addMetadata typeof<Access.RevokeRoleParameters>
 
-                               route "/listRoleAssignments" Access.ListRoleAssignments
+                               route "/list-role-assignments" Access.ListRoleAssignments
                                |> addMetadata typeof<Access.ListRoleAssignmentsParameters>
 
-                               route "/upsertPathPermission" Access.UpsertPathPermission
+                               route "/upsert-path-permission" Access.UpsertPathPermission
                                |> addMetadata typeof<Access.UpsertPathPermissionParameters>
 
-                               route "/removePathPermission" Access.RemovePathPermission
+                               route "/remove-path-permission" Access.RemovePathPermission
                                |> addMetadata typeof<Access.RemovePathPermissionParameters>
 
-                               route "/listPathPermissions" Access.ListPathPermissions
+                               route "/list-path-permissions" Access.ListPathPermissions
                                |> addMetadata typeof<Access.ListPathPermissionsParameters>
 
-                               route "/checkPermission" Access.CheckPermission
+                               route "/check-permission" Access.CheckPermission
                                |> addMetadata typeof<Access.CheckPermissionParameters> ]
-                        GET [ route "/listRoles" Access.ListRoles ]
+                        GET [ route "/list-roles" Access.ListRoles ]
                     ]
                 subRoute
-                    "/auth"
+                    "/authenticate"
                     [
                         GET [ route "/me" Auth.Me
                               route "/oidc/config" (Auth.OidcConfig configuration)

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -45,14 +45,14 @@
       "reason": "Access-control administration and permission-inspection routes are internal authorization operations, not public OpenAPI expansion targets for this slice.",
       "traceIds": [ "B-020", "B-024", "B-041", "surf-startup-admin" ],
       "routes": [
-        { "method": "GET", "path": "/access/listRoles" },
-        { "method": "POST", "path": "/access/checkPermission" },
-        { "method": "POST", "path": "/access/grantRole" },
-        { "method": "POST", "path": "/access/listPathPermissions" },
-        { "method": "POST", "path": "/access/listRoleAssignments" },
-        { "method": "POST", "path": "/access/removePathPermission" },
-        { "method": "POST", "path": "/access/revokeRole" },
-        { "method": "POST", "path": "/access/upsertPathPermission" }
+        { "method": "GET", "path": "/authorize/list-roles" },
+        { "method": "POST", "path": "/authorize/check-permission" },
+        { "method": "POST", "path": "/authorize/grant-role" },
+        { "method": "POST", "path": "/authorize/list-path-permissions" },
+        { "method": "POST", "path": "/authorize/list-role-assignments" },
+        { "method": "POST", "path": "/authorize/remove-path-permission" },
+        { "method": "POST", "path": "/authorize/revoke-role" },
+        { "method": "POST", "path": "/authorize/upsert-path-permission" }
       ]
     },
     {
@@ -60,14 +60,14 @@
       "reason": "Authentication, personal access token, and OIDC bootstrap routes are server identity flows kept outside the current public OpenAPI route expansion.",
       "traceIds": [ "B-020", "B-024", "drift-003", "surf-host" ],
       "routes": [
-        { "method": "GET", "path": "/auth/login" },
-        { "method": "GET", "path": "/auth/login/%s" },
-        { "method": "GET", "path": "/auth/logout" },
-        { "method": "GET", "path": "/auth/me" },
-        { "method": "GET", "path": "/auth/oidc/config" },
-        { "method": "POST", "path": "/auth/token/create" },
-        { "method": "POST", "path": "/auth/token/list" },
-        { "method": "POST", "path": "/auth/token/revoke" }
+        { "method": "GET", "path": "/authenticate/login" },
+        { "method": "GET", "path": "/authenticate/login/%s" },
+        { "method": "GET", "path": "/authenticate/logout" },
+        { "method": "GET", "path": "/authenticate/me" },
+        { "method": "GET", "path": "/authenticate/oidc/config" },
+        { "method": "POST", "path": "/authenticate/token/create" },
+        { "method": "POST", "path": "/authenticate/token/list" },
+        { "method": "POST", "path": "/authenticate/token/revoke" }
       ]
     },
     {

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -76,8 +76,8 @@ pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -Sk
 
 The script creates a PAT through explicit TestAuth headers so the first local SystemAdmin can get started without an
 OIDC tenant. `-SkipAuthProbe` is required for this true zero-OIDC path because the default preflight checks
-`/auth/oidc/config` before TestAuth PAT creation. Omit it when OIDC/MSA settings are configured and you want the script
-to verify `/auth/oidc/config` and `/auth/me` before creating the PAT.
+`/authenticate/oidc/config` before TestAuth PAT creation. Omit it when OIDC/MSA settings are configured and you want
+the script to verify `/authenticate/oidc/config` and `/authenticate/me` before creating the PAT.
 
 Use this path when the server has OIDC/MSA settings and you want normal interactive auth:
 
@@ -126,7 +126,7 @@ grants.
 
 These are script parameters (not environment variables):
 
-- `-SkipAuthProbe`: skip auth preflight (`/auth/oidc/config`, `/auth/me`).
+- `-SkipAuthProbe`: skip auth preflight (`/authenticate/oidc/config`, `/authenticate/me`).
 - `-NoTokenBootstrap`: skip PAT creation.
 - `-TokenBootstrapMaxAttempts`: set max token bootstrap attempts.
 - `-TokenBootstrapInitialBackoffSeconds`: set initial retry backoff.


### PR DESCRIPTION
## Summary

- Rename Grace server auth/access route prefixes to `/authenticate` and `/authorize`.
- Keep SDK route strings, endpoint authorization manifest coverage, OpenAPI route classification, local bootstrap probes, and focused tests aligned.
- Update nearest server/runtime guidance that would otherwise send developers to stale `/auth/*` paths.

Part of #414. Related to #415.

## Validation

- `dotnet tool run fantomas -- <touched F# files>`: passed on retry.
- `dotnet build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj`: passed, 50/50.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`: ran and failed only on a pre-existing generated-client matrix failure present on `origin/epic/414-authn-authz-surface` (Rust generated client cargo check exit `101`, `acceptedTier: none`).
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Freshness -AllowPending`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check Quality -AllowPending`: passed with 2 existing pending gates.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed, 537/537.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `npx --yes markdownlint-cli2 "src/Grace.Server/AGENTS.md" "src/docs/ENVIRONMENT.md"`: passed.
- Legacy route scan for `/auth/*` and `/access/*`: passed; only negative-test guards remain.
- `git diff --check`: passed.

Skipped `pwsh ./scripts/validate.ps1 -Fast` for this child PR because focused Authorization, CLI, OpenAPI, and Server.Tests compile coverage directly covers the slice; the final epic release-candidate branch will run the fast gate.

## Review Status

- Implementation worker completed bot-prevention self-review over route/security/contract drift, stale direct route strings, stale OpenAPI classification, false-positive tests, endpoint policy changes, Auth0 `oauth/*` accidental drift, scripts, and docs.
- Codex Code Review Bot reviewed latest commit `5f7429098b388748cf6ecdde0ae5dc7c218ebcde` and reported no issues with a 👍🏻 reaction; no top-level or inline review comments were present.

## Docs Impact

- Updated nearest server/runtime guidance for the new route prefixes.
- Broader public docs sweep remains owned by #418.

## Residual Risk

- `prove-openapi -Check All` has a pre-existing generated-client matrix failure on the epic base; route-focused OpenAPI Freshness and Quality checks passed for this slice.

