### PR TITLE
Rename CLI auth and access command groups

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -36,8 +36,8 @@ export GRACE_SERVER_URI="http://localhost:5000"
 
 1. **Login via the CLI**:
 
-   * `grace auth login` — Interactive login (tries PKCE first, then falls back to Device Code).
-   * `grace auth whoami` — Verifies your identity against the running server.
+   * `grace authenticate login` — Interactive login (tries PKCE first, then falls back to Device Code).
+   * `grace authenticate whoami` — Verifies your identity against the running server.
 
 ---
 
@@ -82,7 +82,7 @@ export grace__authz__bootstrap__system_admin_users="auth0|abc123"
 ## Authorization roles and creation boundaries
 
 Authentication identifies the caller. Authorization decides whether that caller can act at a system, owner,
-organization, repository, branch, or path scope. Use `grace access list-roles` for the live role catalog, and use the
+organization, repository, branch, or path scope. Use `grace authorize list-roles` for the live role catalog, and use the
 full role IDs shown here when granting roles.
 
 ### System support roles
@@ -227,9 +227,9 @@ PowerShell:
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 bash / zsh:
@@ -237,13 +237,13 @@ bash / zsh:
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
 unset GRACE_TOKEN
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
-`grace auth whoami` proves authentication. `grace auth token create` requires an authenticated principal that maps to a
-Grace User; it does not require an RBAC role before token creation.
+`grace authenticate whoami` proves authentication. `grace authenticate token create` requires an authenticated
+principal that maps to a Grace User; it does not require an RBAC role before token creation.
 
 MSA/OIDC authentication alone does not authorize first-time scope creation or other protected operations. For a fresh
 local/debug environment, seed the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing
@@ -363,22 +363,22 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 
 Because `GRACE_TOKEN` wins before M2M and interactive login, a stale or revoked PAT can mask a fresh interactive
 OIDC/MSA login. Unset `GRACE_TOKEN` when you want the CLI to use cached interactive credentials, and use
-`grace auth token status --output Verbose` or `grace doctor --check Authentication` when the active auth source is
+`grace authenticate token status --output Verbose` or `grace doctor --check Authentication` when the active auth source
 unclear.
 
 ### Primary CLI commands
 
-* `grace auth login [--auth pkce|device]`
+* `grace authenticate login [--auth pkce|device]`
   Interactive login to Auth0; stores access/refresh tokens in the OS secure store. If `--auth` is not
   specified, the CLI attempts PKCE and falls back to Device Code.
 
-* `grace auth status`
+* `grace authenticate status`
   Shows whether the CLI currently has usable credentials (PAT, M2M, or interactive).
 
-* `grace auth whoami`
+* `grace authenticate whoami`
   Calls the server and prints the authenticated identity information.
 
-* `grace auth logout`
+* `grace authenticate logout`
   Clears the cached interactive token from the secure store.
 
 * `grace doctor --check Authentication`
@@ -409,13 +409,13 @@ only through Grace's normal authorization checks.
 
 #### CLI (recommended)
 
-* `grace auth token create --name "<token-name>"`
+* `grace authenticate token create --name "<token-name>"`
   Creates a PAT with the server-default lifetime.
 
-* `grace auth token create --name "<token-name>" --expires-in 30d`
+* `grace authenticate token create --name "<token-name>" --expires-in 30d`
   Creates a PAT that expires after the given duration. Supported suffixes: `s`, `m`, `h`, `d`.
 
-* `grace auth token create --name "<token-name>" --no-expiry`
+* `grace authenticate token create --name "<token-name>" --no-expiry`
   Creates a non-expiring PAT **only if** the server allows it.
 
 #### Notes
@@ -447,16 +447,16 @@ If you are calling the HTTP API directly, use the standard Authorization header:
 
 ### Listing and revoking PATs
 
-* `grace auth token list`
+* `grace authenticate token list`
   Lists active PATs for the current principal.
 
-* `grace auth token list --all`
+* `grace authenticate token list --all`
   Lists active + expired + revoked tokens.
 
-* `grace auth token revoke <token-id>`
+* `grace authenticate token revoke <token-id>`
   Revokes a PAT by token ID (GUID). Revoked tokens are no longer accepted.
 
-* `grace auth token status`
+* `grace authenticate token status`
   Shows whether the current `GRACE_TOKEN` is present and parseable.
 
 ### How PAT “permissions” work in Grace
@@ -483,28 +483,28 @@ granting/revoking roles and path permissions for that principal.
 
 Primary CLI commands for authorization management:
 
-* `grace access grant-role ...`
+* `grace authorize grant-role ...`
   Grants a role to a principal at a scope (Owner/Organization/Repository/Branch/System).
 
-* `grace access revoke-role ...`
+* `grace authorize revoke-role ...`
   Revokes a role from a principal at a scope.
 
-* `grace access list-role-assignments ...`
+* `grace authorize list-role-assignments ...`
   Lists role assignments at a scope (optionally filtered by principal).
 
-* `grace access upsert-path-permission ...`
+* `grace authorize upsert-path-permission ...`
   Sets or updates a path permission entry in a repository.
 
-* `grace access remove-path-permission ...`
+* `grace authorize remove-path-permission ...`
   Removes a path permission entry.
 
-* `grace access list-path-permissions ...`
+* `grace authorize list-path-permissions ...`
   Lists path permissions, optionally scoped to a path prefix.
 
-* `grace access check ...`
+* `grace authorize check ...`
   Asks the server “would this principal be allowed to do operation X on resource Y?”
 
-> For detailed role IDs and operations, use `grace access list-roles` and consult the authorization types
+> For detailed role IDs and operations, use `grace authorize list-roles` and consult the authorization types
 > in `Grace.Types.Authorization`.
 
 ---
@@ -603,11 +603,11 @@ server env vars below).
 
 1. Login:
 
-   * `grace auth login` — Interactive Auth0 login (tries PKCE, then device flow).
+   * `grace authenticate login` — Interactive Auth0 login (tries PKCE, then device flow).
 
 1. Verify:
 
-   * `grace auth whoami` — Calls the server and prints the authenticated identity.
+   * `grace authenticate whoami` — Calls the server and prints the authenticated identity.
 
 ##### Server-side requirements for auto-configuration
 
@@ -674,11 +674,11 @@ not expose `/auth/oidc/config`), you can configure the CLI directly via environm
 
 1. Login:
 
-   * `grace auth login` — Interactive Auth0 login (tries PKCE, then device flow).
+   * `grace authenticate login` — Interactive Auth0 login (tries PKCE, then device flow).
 
 1. Verify:
 
-   * `grace auth whoami` — Calls the server and prints the authenticated identity.
+   * `grace authenticate whoami` — Calls the server and prints the authenticated identity.
 
 ---
 
@@ -732,7 +732,7 @@ export grace__auth__oidc__m2m_scopes="read:foo write:bar"
 
 * `GRACE_TOKEN` (optional)
   **No default.**
-  Source: output from `grace auth token create`.
+  Source: output from `grace authenticate token create`.
   Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M. Unset stale or
   revoked values before troubleshooting interactive OIDC/MSA login.
 
@@ -823,7 +823,7 @@ You can create Auth0 resources non-interactively.
 
 ## Troubleshooting
 
-### `grace auth login` fails and mentions refresh tokens
+### `grace authenticate login` fails and mentions refresh tokens
 
 Ensure:
 
@@ -846,16 +846,16 @@ Quick checks:
 PowerShell:
 
 ```powershell
-grace auth status --output Verbose
-grace auth token status --output Verbose
+grace authenticate status --output Verbose
+grace authenticate token status --output Verbose
 grace status --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
-grace auth status --output Verbose
-grace auth token status --output Verbose
+grace authenticate status --output Verbose
+grace authenticate token status --output Verbose
 grace status --output Verbose
 ```
 
@@ -864,17 +864,17 @@ If `GRACE_TOKEN` is false and interactive token is false, authenticate first:
 PowerShell:
 
 ```powershell
-grace auth login --auth device
+grace authenticate login --auth device
 # or
-grace auth login --auth pkce
+grace authenticate login --auth pkce
 ```
 
 bash / zsh:
 
 ```bash
-grace auth login --auth device
+grace authenticate login --auth device
 # or
-grace auth login --auth pkce
+grace authenticate login --auth pkce
 ```
 
 If you are using a PAT:
@@ -883,14 +883,14 @@ PowerShell:
 
 ```powershell
 $env:GRACE_TOKEN="grace_pat_v1_..."
-grace auth token status --output Verbose
+grace authenticate token status --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
 export GRACE_TOKEN="grace_pat_v1_..."
-grace auth token status --output Verbose
+grace authenticate token status --output Verbose
 ```
 
 If you are trying to use interactive OIDC/MSA login, make sure a stale PAT is not taking precedence:
@@ -899,16 +899,16 @@ PowerShell:
 
 ```powershell
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth status --output Verbose
-grace auth whoami --output Verbose
+grace authenticate status --output Verbose
+grace authenticate whoami --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
 unset GRACE_TOKEN
-grace auth status --output Verbose
-grace auth whoami --output Verbose
+grace authenticate status --output Verbose
+grace authenticate whoami --output Verbose
 ```
 
 Why logs may look empty:
@@ -928,11 +928,11 @@ Also note:
 * During development, TestAuth may be available. See this file for setup details:
   `docs/Authentication.md` -> **Development without Auth0 (TestAuth)**.
 
-### You can see `SystemAdmin` in Cosmos, but `grace access check` says denied
+### You can see `SystemAdmin` in Cosmos, but `grace authorize check` says denied
 
-If `grace auth whoami` shows your expected `GraceUserId`, but:
+If `grace authenticate whoami` shows your expected `GraceUserId`, but:
 
-* `grace access check --operation SystemAdmin --resource system --output Json`
+* `grace authorize check --operation SystemAdmin --resource system --output Json`
   returns `Denied: missing permission SystemAdmin.`,
 
 and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context
@@ -955,15 +955,15 @@ What to verify first:
 PowerShell:
 
 ```powershell
-grace auth whoami --output Json
-grace access check --operation SystemAdmin --resource system --output Json
+grace authenticate whoami --output Json
+grace authorize check --operation SystemAdmin --resource system --output Json
 ```
 
 bash / zsh:
 
 ```bash
-grace auth whoami --output Json
-grace access check --operation SystemAdmin --resource system --output Json
+grace authenticate whoami --output Json
+grace authorize check --operation SystemAdmin --resource system --output Json
 ```
 
 Then verify server configuration:
@@ -978,7 +978,7 @@ Recommended recovery steps:
 2. Re-run the two checks above.
 3. Re-open Cosmos and confirm the `system` AccessControl actor document for the active service context
    contains your user principal.
-4. If needed, use a current `SystemAdmin` principal to grant your role again via `grace access grant-role`.
+4. If needed, use a current `SystemAdmin` principal to grant your role again via `grace authorize grant-role`.
 
 ### Headless environments / CI
 
@@ -986,4 +986,4 @@ Use:
 
 * M2M auth (client credentials env vars), or
 * PATs (`GRACE_TOKEN`), or
-* `grace auth login --auth device` if interactive login is still acceptable.
+* `grace authenticate login --auth device` if interactive login is still acceptable.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -20,8 +20,8 @@ PowerShell:
 
 ```powershell
 grace --output Json auth logout
-grace auth logout --schema
-grace auth logout --examples
+grace authenticate logout --schema
+grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
 ```
@@ -30,8 +30,8 @@ bash / zsh:
 
 ```bash
 grace --output Json auth logout
-grace auth logout --schema
-grace auth logout --examples
+grace authenticate logout --schema
+grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
 ```
@@ -78,7 +78,7 @@ An error emits a `GraceError` document:
   "Kind": "schema",
   "ContractVersion": "cli-json-v1",
   "Command": {
-    "Id": "auth.logout",
+    "Id": "authenticate.logout",
     "Path": [
       "auth",
       "logout"

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -229,7 +229,7 @@ module AuthTests =
         clearOidcEnv (fun () ->
             withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
                 let exitCode, standardOut, standardError =
-                    runWithCapturedStdoutAndStderr [| "auth"
+                    runWithCapturedStdoutAndStderr [| "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -264,7 +264,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Json"
-                                                      "auth"
+                                                      "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -310,7 +310,7 @@ module AuthTests =
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
                                                   "Json"
-                                                  "auth"
+                                                  "authenticate"
                                                   "status" |]
 
             exitCode |> should equal 0
@@ -352,7 +352,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Json"
-                                                      "auth"
+                                                      "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -394,7 +394,7 @@ module AuthTests =
                                 let exitCode, standardOut, standardError =
                                     runWithCapturedStdoutAndStderr [| "--output"
                                                                       "Json"
-                                                                      "auth"
+                                                                      "authenticate"
                                                                       "status" |]
 
                                 exitCode |> should equal 0
@@ -567,7 +567,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Verbose"
-                                                      "auth"
+                                                      "authenticate"
                                                       "whoami" |]
 
                 exitCode |> should not' (equal 0)
@@ -592,7 +592,7 @@ module AuthTests =
                     let exitCode, standardOut, standardError =
                         runWithCapturedStdoutAndStderr [| "--output"
                                                           "Verbose"
-                                                          "auth"
+                                                          "authenticate"
                                                           "token"
                                                           "create"
                                                           "--name"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -587,7 +587,7 @@ module CommandOutputContractRegistryTests =
 
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+        let identity = CommandOutputContract.commandIdentity [ "authenticate" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -595,7 +595,8 @@ module CommandOutputContractRegistryTests =
 
             document.Kind |> should equal "schema"
 
-            document.Command.Id |> should equal "auth.logout"
+            document.Command.Id
+            |> should equal "authenticate.logout"
 
             match document.Schema with
             | Some schema ->
@@ -655,7 +656,7 @@ module CommandOutputContractRegistryTests =
                     .GetString()
                 |> should equal "string"
             | None -> Assert.Fail("Schema introspection should include a schema document.")
-        | None -> Assert.Fail("auth.logout should have a registry entry.")
+        | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
     [<Test>]
     let ``maintenance registry entries expose schema ready local dto metadata`` () =
@@ -781,7 +782,7 @@ module CommandOutputContractRegistryTests =
             [
                 CommandOutputContract.commandIdentity [ "repository" ] "get", "RepositoryDto metadata is incomplete"
                 CommandOutputContract.commandIdentity [ "workitem" ] "show", "WorkItemDto metadata is incomplete"
-                CommandOutputContract.commandIdentity [ "access" ] "check", "PermissionCheckResult metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "authorize" ] "check", "PermissionCheckResult metadata is incomplete"
             ]
 
         for identity, expectedNote in cases do
@@ -810,7 +811,7 @@ module CommandOutputContractRegistryTests =
 
     [<Test>]
     let ``examples for schema ready commands parse as Grace envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+        let identity = CommandOutputContract.commandIdentity [ "authenticate" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -848,7 +849,7 @@ module CommandOutputContractRegistryTests =
 
             errorRoot.GetProperty("CorrelationId").GetString()
             |> should equal "correlation-id"
-        | None -> Assert.Fail("auth.logout should have a registry entry.")
+        | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
     [<Test>]
     let ``all registry schema and example documents serialize as json`` () =

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -71,7 +71,7 @@ module CommandParsingTests =
 
     let private grantRoleArgs roleId =
         [|
-            "access"
+            "authorize"
             "grant-role"
             "--scope"
             "repo"
@@ -85,7 +85,7 @@ module CommandParsingTests =
 
     let private revokeRoleArgs roleId =
         [|
-            "access"
+            "authorize"
             "revoke-role"
             "--scope"
             "repo"
@@ -114,7 +114,7 @@ module CommandParsingTests =
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
     [<TestCase("ApprovalResponder")>]
-    let ``access role commands accept canonical role ids`` roleId =
+    let ``authorize role commands accept canonical role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 0
 
@@ -129,15 +129,38 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
-    let ``access grant role rejects stale short role ids`` roleId =
+    let ``authorize grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
     [<TestCase("OrgAdmin")>]
     [<TestCase("RepositoryReader")>]
-    let ``access revoke role accepts raw role ids for cleanup`` roleId =
+    let ``authorize revoke role accepts raw role ids for cleanup`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
         revokeParseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authenticate command group accepts authn alias`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "authn"; "status" |])
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize command group accepts authz alias`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                grantRoleArgs "RepositoryReader"
+                |> Array.updateAt 0 "authz"
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+    [<TestCase("auth", "status")>]
+    [<TestCase("access", "list-roles")>]
+    let ``old auth and access command groups are not accepted`` commandGroup commandName =
+        let parseResult = GraceCommand.rootCommand.Parse([| commandGroup; commandName |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
 
 
 namespace Grace.CLI.Tests
@@ -376,7 +399,7 @@ module HelpDoesNotReadConfigTests =
             writeInvalidConfig root
 
             let exitCode, _ =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -386,7 +409,7 @@ module HelpDoesNotReadConfigTests =
     let ``help works without config`` () =
         withTempDir (fun _ ->
             let exitCode, _ =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -396,7 +419,7 @@ module HelpDoesNotReadConfigTests =
     let ``help shows symbolic defaults`` () =
         withTempDir (fun _ ->
             let exitCode, output =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -497,7 +520,7 @@ module HelpDoesNotReadConfigTests =
             let exitCode, output =
                 runWithCapturedOutput [| "--output"
                                          "Json"
-                                         "auth"
+                                         "authenticate"
                                          "logout"
                                          "--examples" |]
 
@@ -513,7 +536,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Command")
                 .GetProperty("Id")
                 .GetString()
-            |> should equal "auth.logout"
+            |> should equal "authenticate.logout"
 
             let examples = rootElement.GetProperty("Examples")
             examples.GetArrayLength() |> should equal 2
@@ -523,6 +546,73 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("ReturnValue")
                 .GetString()
             |> should equal "Signed out.")
+
+    [<Test>]
+    let ``root login alias emits schema introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "login"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.login")
+
+    [<Test>]
+    let ``root login alias preserves preceding global options for schema introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "login"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.login")
+
+    [<Test>]
+    let ``root logout alias preserves preceding global options for examples introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "logout"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.logout")
 
     [<Test>]
     let ``examples for missing dto metadata emit explicit unsupported document`` () =
@@ -1049,7 +1139,7 @@ module HelpDoesNotReadConfigTests =
         let parseResult =
             GraceCommand.rootCommand.Parse(
                 [|
-                    "auth"
+                    "authenticate"
                     "logout"
                     "--select"
                     "Value"
@@ -1440,7 +1530,7 @@ module HelpDoesNotReadConfigTests =
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
                                                   "Json"
-                                                  "access"
+                                                  "authorize"
                                                   "list-roles" |]
 
             exitCode |> should equal -1
@@ -1487,7 +1577,7 @@ module HelpDoesNotReadConfigTests =
             let branchId = Guid.NewGuid()
             writeValidConfig root ownerId orgId repoId branchId
 
-            let parseResult = GraceCommand.rootCommand.Parse([| "access"; "grant-role" |])
+            let parseResult = GraceCommand.rootCommand.Parse([| "authorize"; "grant-role" |])
 
             let output = captureOutput (fun () -> Common.printParseResult parseResult)
 
@@ -1506,7 +1596,7 @@ module HelpDoesNotReadConfigTests =
             let branchId = Guid.NewGuid()
             writeValidConfig root ownerId orgId repoId branchId
 
-            let parseResult = GraceCommand.rootCommand.Parse([| "access"; "grant-role" |])
+            let parseResult = GraceCommand.rootCommand.Parse([| "authorize"; "grant-role" |])
             let graceIds = Services.getNormalizedIdsAndNames parseResult
 
             graceIds.OwnerId |> should equal ownerId
@@ -1632,15 +1722,19 @@ module RootHelpGroupingTests =
             output |> should contain "Review and promotion:"
 
             output
-            |> should contain "Administration and access:"
+            |> should contain "Administration and authorization:"
 
             output |> should contain "Local utilities:"
 
             let gettingStarted = sliceBetween output "Getting started:" "Day-to-day development:"
 
-            gettingStarted |> should contain "auth"
+            gettingStarted |> should contain "authenticate"
             gettingStarted |> should contain "connect"
             gettingStarted |> should contain "config"
+
+            gettingStarted
+            |> should not' (contain $"{Environment.NewLine}    auth ")
+
             gettingStarted |> should not' (contain "branch")
 
             let dayToDay = sliceBetween output "Day-to-day development:" "Review and promotion:"
@@ -1651,7 +1745,7 @@ module RootHelpGroupingTests =
             dayToDay |> should contain "watch"
             dayToDay |> should not' (contain "work")
 
-            let reviewAndPromotion = sliceBetween output "Review and promotion:" "Administration and access:"
+            let reviewAndPromotion = sliceBetween output "Review and promotion:" "Administration and authorization:"
 
             reviewAndPromotion |> should contain "workitem"
             reviewAndPromotion |> should contain "review"
@@ -1662,7 +1756,14 @@ module RootHelpGroupingTests =
             reviewAndPromotion |> should contain "webhook"
 
             reviewAndPromotion
-            |> should contain "promotion-set")
+            |> should contain "promotion-set"
+
+            let administration = sliceBetween output "Administration and authorization:" "Local utilities:"
+
+            administration |> should contain "authorize"
+
+            administration
+            |> should not' (contain $"{Environment.NewLine}    access "))
 
     [<Test>]
     let ``subcommand help is not grouped`` () =
@@ -1681,7 +1782,7 @@ module RootHelpGroupingTests =
             |> should not' (contain "Review and promotion:")
 
             output
-            |> should not' (contain "Administration and access:")
+            |> should not' (contain "Administration and authorization:")
 
             output |> should not' (contain "Local utilities:"))
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -810,7 +810,8 @@ module Access =
             |> addOption Options.repositoryId
             |> addOption Options.branchId
 
-        let accessCommand = new Command("access", Description = "Manages access control and permissions.")
+        let accessCommand = new Command("authorize", Description = "Manages access control and permissions.")
+        accessCommand.Aliases.Add("authz")
 
         let grantRoleCommand =
             new Command("grant-role", Description = "Grants a role to a principal at a scope.")

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -830,7 +830,7 @@ module Auth =
     let private tryRefreshTokenAsync (config: OidcCliConfig) (bundle: TokenBundle) =
         task {
             if String.IsNullOrWhiteSpace bundle.RefreshToken then
-                return Error "Refresh token missing. Run 'grace auth login' again."
+                return Error "Refresh token missing. Run 'grace authenticate login' again."
             else
                 let endpoint = buildEndpoint config.Authority "oauth/token"
 
@@ -1161,7 +1161,7 @@ module Auth =
 
     let private authDevelopmentGuidance = "During development, TestAuth may be available. See docs/Authentication.md for details."
 
-    let private authenticationRequiredMessage = $"Authentication required. Run 'grace auth login' and try again. {authDevelopmentGuidance}"
+    let private authenticationRequiredMessage = $"Authentication required. Run 'grace authenticate login' and try again. {authDevelopmentGuidance}"
 
     let private addAuthDevelopmentGuidance (message: string) =
         if String.IsNullOrWhiteSpace message then
@@ -1677,7 +1677,8 @@ module Auth =
             }
 
     let Build =
-        let authCommand = new Command("auth", Description = "Authenticate with Grace.")
+        let authCommand = new Command("authenticate", Description = "Authenticate with Grace.")
+        authCommand.Aliases.Add("authn")
 
         let loginCommand = new Command("login", Description = "Sign in with Auth0 (PKCE or device flow).")
         loginCommand.Options.Add(LoginOptions.auth)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -152,7 +152,8 @@ module Watch =
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
         | Ok (Some token) when not (String.IsNullOrWhiteSpace token) -> Ok token
-        | Ok _ -> Error $"No access token is available. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
+        | Ok _ ->
+            Error $"No access token is available. Run `grace authenticate login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
         | Error message -> Error $"Unable to acquire an access token for SignalR notifications: {message}"
 
     let private getSignalRAccessToken () =
@@ -833,7 +834,7 @@ module Watch =
                     && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
                     ->
                     let message =
-                        $"SignalR negotiation failed with 401 Unauthorized. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
+                        $"SignalR negotiation failed with 401 Unauthorized. Run `grace authenticate login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
 
                     if parseResult |> json then
                         return renderJsonError parseResult message

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -611,11 +611,11 @@ module CommandOutputContract =
             incompleteReturnValueContract
                 "WorkItemDto"
                 "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | "access.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | "authorize.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "PermissionCheckResult"
                 "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
-        | "auth.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | "authenticate.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             supportedReturnValueContract
                 "string"
                 "GraceReturnValue<string>"
@@ -887,14 +887,30 @@ module CommandOutputContract =
 
     let entries =
         [
-            row [ "access" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-role-assignments" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-roles" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "remove-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "upsert-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-role-assignments" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-roles" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "authorize" ]
+                "remove-path-permission"
+                true
+                true
+                common_renderOutput_envelope
+                mutating_state_transition
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "authorize" ]
+                "upsert-path-permission"
+                true
+                true
+                common_renderOutput_envelope
+                mutating_state_transition
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -921,16 +937,16 @@ module CommandOutputContract =
             row [ "approval"; "request" ] "reject" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "request" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "request" ] "wait" true true common_renderOutput_envelope workflow_accepted_operation server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "login" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "logout" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "clear" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "revoke" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "login" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "logout" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "clear" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "revoke" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "annotate" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
             row [ "branch" ] "assign" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -73,6 +73,8 @@ module GraceCommand =
         aliases.Add("commit", [ "branch"; "commit" ])
         aliases.Add("commits", [ "branch"; "get-commits" ])
         aliases.Add("dir", [ "maint"; "list-contents" ])
+        aliases.Add("login", [ "authenticate"; "login" ])
+        aliases.Add("logout", [ "authenticate"; "logout" ])
         aliases.Add("ls", [ "maint"; "list-contents" ])
         aliases.Add("promote", [ "branch"; "promote" ])
         aliases.Add("promotions", [ "branch"; "get-promotions" ])
@@ -473,7 +475,7 @@ module GraceCommand =
 
     let private rootHelpSections =
         [
-            { Heading = "Getting started"; CommandNames = [ "auth"; "connect"; "config" ] }
+            { Heading = "Getting started"; CommandNames = [ "authenticate"; "connect"; "config" ] }
             {
                 Heading = "Day-to-day development"
                 CommandNames =
@@ -499,13 +501,13 @@ module GraceCommand =
                     ]
             }
             {
-                Heading = "Administration and access"
+                Heading = "Administration and authorization"
                 CommandNames =
                     [
                         "owner"
                         "organization"
                         "repository"
-                        "access"
+                        "authorize"
                         "admin"
                     ]
             }
@@ -1009,8 +1011,6 @@ module GraceCommand =
             if args.Length = 0 then
                 Array.empty<string>
             else
-                let firstToken = if isCaseInsensitive then args[ 0 ].ToLowerInvariant() else args[0]
-
                 let normalizeOutputEqualsToken (arg: string) =
                     let outputEqualsPrefix = $"{OptionName.Output}="
 
@@ -1018,6 +1018,37 @@ module GraceCommand =
                         $"{OptionName.Output}={arg.Substring(outputEqualsPrefix.Length)}"
                     else
                         arg
+
+                let tryFindTopLevelCommandIndex (args: string array) =
+                    let comparison =
+                        if isCaseInsensitive then
+                            StringComparison.InvariantCultureIgnoreCase
+                        else
+                            StringComparison.InvariantCulture
+
+                    let isOptionWithValue (token: string) =
+                        token.Equals(OptionName.Output, comparison)
+                        || token.Equals("-o", comparison)
+                        || token.Equals(OptionName.CorrelationId, comparison)
+                        || token.Equals("-c", comparison)
+                        || token.Equals(OptionName.Source, comparison)
+                        || token.Equals(OptionName.Select, comparison)
+
+                    let rec loop index =
+                        if index >= args.Length then
+                            None
+                        else
+                            let token = args[index]
+
+                            if token = "--" then
+                                if index + 1 < args.Length then Some(index + 1) else None
+                            elif token.StartsWith("-", StringComparison.Ordinal) then
+                                let nextIndex = if isOptionWithValue token then index + 2 else index + 1
+                                loop nextIndex
+                            else
+                                Some index
+
+                    loop 0
 
                 let properCasedArgs =
                     args
@@ -1043,18 +1074,30 @@ module GraceCommand =
                         else
                             normalizedArg)
 
-                if aliases.ContainsKey(firstToken) then
-                    let newArgs = List<string>()
+                match tryFindTopLevelCommandIndex args with
+                | Some commandIndex ->
+                    let aliasToken =
+                        if isCaseInsensitive then
+                            args[ commandIndex ].ToLowerInvariant()
+                        else
+                            args[commandIndex]
 
-                    for token in aliases[ firstToken ].Reverse() do
-                        newArgs.Insert(0, token)
+                    if aliases.ContainsKey(aliasToken) then
+                        let newArgs = List<string>()
 
-                    for token in properCasedArgs[1..] do
-                        newArgs.Add(token)
+                        for token in properCasedArgs[0 .. commandIndex - 1] do
+                            newArgs.Add(token)
 
-                    newArgs.ToArray()
-                else
-                    properCasedArgs
+                        for token in aliases[aliasToken] do
+                            newArgs.Add(token)
+
+                        for token in properCasedArgs[commandIndex + 1 ..] do
+                            newArgs.Add(token)
+
+                        newArgs.ToArray()
+                    else
+                        properCasedArgs
+                | None -> properCasedArgs
 
         let mutable argvNormalized = normalizeArgsForHistory args
 
@@ -1368,7 +1411,7 @@ module GraceCommand =
                             [
                                 "config"
                                 "history"
-                                "auth"
+                                "authenticate"
                                 "connect"
                                 "alias"
                                 "doctor"

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -31,7 +31,7 @@ type AuthEndpoints() =
             Assert.That(body, Does.StartWith("<!doctype html>"))
             Assert.That(body, Does.Contain("<title>Grace Login</title>"))
             Assert.That(body, Does.Contain("Interactive browser login is not available on the server in this phase."))
-            Assert.That(body, Does.Contain("grace auth login"))
+            Assert.That(body, Does.Contain("grace authenticate login"))
         }
 
     [<Test>]

--- a/src/Grace.Server/Auth.Server.fs
+++ b/src/Grace.Server/Auth.Server.fs
@@ -53,7 +53,7 @@ module Auth =
         |> ignore
 
         builder.AppendLine(
-            "<p>Interactive browser login is not available on the server in this phase. Use the CLI (grace auth login) or provide GRACE_TOKEN / Auth0 M2M credentials.</p>"
+            "<p>Interactive browser login is not available on the server in this phase. Use the CLI (grace authenticate login) or provide GRACE_TOKEN / Auth0 M2M credentials.</p>"
         )
         |> ignore
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -86,9 +86,9 @@ PowerShell:
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 bash / zsh:
@@ -96,9 +96,9 @@ bash / zsh:
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
 unset GRACE_TOKEN
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
@@ -107,7 +107,7 @@ role before protected operations will succeed. An authenticated caller that maps
 RBAC grants; that PAT still authorizes protected operations only through Grace's normal authorization checks.
 
 `GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
-interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
+interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace authenticate login` succeeds.
 
 Scope creation uses normal authorization in DebugLocal and production:
 


### PR DESCRIPTION
## Summary

- Rename the CLI command groups from `auth`/`access` to `authenticate`/`authorize`.
- Add `authn` and `authz` aliases plus root `login` and `logout` aliases.
- Update command output metadata, parser/help tests, and directly coupled command examples so the renamed surface is consistent.

Part of #414. Related to #416.

## Validation

- `dotnet tool run fantomas -- <touched F# files>`: passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed, 544/544.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `npx --yes markdownlint-cli2 docs/Authentication.md "docs/Machine-readable CLI output.md" src/docs/ENVIRONMENT.md`: passed.
- `git diff --check`: passed.

Skipped `pwsh ./scripts/validate.ps1 -Fast` for this child PR because focused CLI tests cover parser/help/contract behavior and the only server change is a static guidance string plus matching assertion; the final epic release-candidate branch will run the fast gate.

## Review Status

- Implementation worker completed bot-prevention self-review over alias/global option interactions, schema/example drift, stale command IDs, root alias behavior, accidental `auth`/`access` compatibility, docs examples, stdout cleanliness, token redaction, and test false positives.
- Codex Code Review Bot reviewed latest commit `030436d5ab2a8499ec63a66da2ae33ce31f1415a` and reported no issues with a 👍🏻 reaction; no top-level, inline, or review-thread comments were present.

## Docs Impact

- Updated command examples directly coupled to this CLI rename.
- Broader stale-surface audit remains owned by #418.

## Residual Risk

- Full repo `validate -Fast` remains deferred to the epic release-candidate gate.

