### PR TITLE
Add authz self-service commands

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -116,7 +116,11 @@ Approval-specific role IDs:
 
 | Scope | Role ID | Allows |
 | ----- | ------- | ------ |
-| Repository or branch | `ApprovalResponder` | Read and respond to approval requests |
+| Repository | `RepositoryApprovalResponder` | Read and respond to repository approval requests |
+| Branch | `BranchApprovalResponder` | Read and respond to branch approval requests |
+
+`role:ApprovalResponder` remains a legacy approval selector compatibility alias. Do not use `ApprovalResponder` as a
+grantable role ID.
 
 ### Scope creation and creator-admin grants
 

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -129,8 +129,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `203`
-- JSON-ready routed commands: `182`
+- Total leaf commands: `205`
+- JSON-ready routed commands: `184`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`

--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -17,6 +17,7 @@ type AuthorizationSemanticsTests() =
 
     let principal = { PrincipalType = PrincipalType.User; PrincipalId = "user-1" }
     let otherPrincipal = { PrincipalType = PrincipalType.User; PrincipalId = "user-2" }
+    let groupPrincipal = { PrincipalType = PrincipalType.Group; PrincipalId = "group-1" }
 
     let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
     let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
@@ -88,7 +89,8 @@ type AuthorizationSemanticsTests() =
                 "BranchAdmin"
                 "BranchWriter"
                 "BranchReader"
-                "ApprovalResponder"
+                "RepositoryApprovalResponder"
+                "BranchApprovalResponder"
             ]
 
         let actualRoleIds = roleCatalog |> List.map (fun role -> role.RoleId)
@@ -105,6 +107,7 @@ type AuthorizationSemanticsTests() =
                 "RepoAdmin"
                 "RepoContributor"
                 "RepoReader"
+                "ApprovalResponder"
                 "rEpOrEaDeR"
                 "oRgAdMiN"
             ]
@@ -139,6 +142,34 @@ type AuthorizationSemanticsTests() =
         Assert.That(repositoryAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
 
     [<Test>]
+    member _.EveryRoleMapsToExactlyOneAssignmentScope() =
+        for role in roleCatalog do
+            Assert.That(role.AppliesTo.Count, Is.EqualTo(1), $"Role '{role.RoleId}' must map to exactly one assignment scope.")
+
+            RoleCatalog.tryGetSingleScopeKind role.RoleId
+            |> Option.isSome
+            |> fun hasScope -> Assert.That(hasScope, Is.True, $"Role '{role.RoleId}' should expose a derived assignment scope.")
+
+    [<Test>]
+    member _.SelfAssignmentQueriesUseOnlyEffectiveCallerPrincipalsAcrossScopeLadder() =
+        let resource = Resource.Repository(ownerId, organizationId, repositoryId)
+
+        let queries = Grace.Server.Access.selfAssignmentQueriesForResource [ principal; groupPrincipal; principal ] resource
+
+        let expectedScopes = scopesForResource resource
+        let actualScopes = queries |> List.map fst |> List.distinct
+        Assert.That((actualScopes = expectedScopes), Is.True)
+
+        let actualPrincipals = queries |> List.map snd |> Set.ofList
+        Assert.That((actualPrincipals = Set.ofList [ principal; groupPrincipal ]), Is.True)
+
+        queries
+        |> List.exists (fun (_, queryPrincipal) -> queryPrincipal = otherPrincipal)
+        |> fun containsOtherPrincipal -> Assert.That(containsOtherPrincipal, Is.False)
+
+        Assert.That(queries.Length, Is.EqualTo(expectedScopes.Length * 2))
+
+    [<Test>]
     member _.ApprovalOperationsUseConservativeRoleGrants() =
         let repositoryAdmin =
             roleCatalog
@@ -152,9 +183,13 @@ type AuthorizationSemanticsTests() =
             roleCatalog
             |> List.find (fun role -> role.RoleId.Equals("RepositoryContributor", StringComparison.OrdinalIgnoreCase))
 
-        let responder =
+        let repositoryResponder =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryApprovalResponder", StringComparison.OrdinalIgnoreCase))
+
+        let branchResponder =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("BranchApprovalResponder", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
         Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
@@ -166,11 +201,15 @@ type AuthorizationSemanticsTests() =
         Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
         Assert.That(repositoryContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
 
-        Assert.That(responder.AppliesTo.Contains("repository"), Is.True)
-        Assert.That(responder.AppliesTo.Contains("branch"), Is.True)
-        Assert.That(responder.AllowedOperations.Count, Is.EqualTo(2))
-        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+        Assert.That(repositoryResponder.AppliesTo, Is.EquivalentTo([ "repository" ]))
+        Assert.That(repositoryResponder.AllowedOperations.Count, Is.EqualTo(2))
+        Assert.That(repositoryResponder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryResponder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+
+        Assert.That(branchResponder.AppliesTo, Is.EquivalentTo([ "branch" ]))
+        Assert.That(branchResponder.AllowedOperations.Count, Is.EqualTo(2))
+        Assert.That(branchResponder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(branchResponder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
 
     [<Test>]
     member _.SystemOperatorHasDescendantAdminWriteReadButNoSystemAdmin() =

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -270,6 +270,7 @@ type EndpointAuthorizationManifestTests() =
         [
             "GET", "/authorize/list-roles"
             "POST", "/authorize/check-permission"
+            "POST", "/authorize/show"
         ]
         |> assertRoutesUseSecurity Authenticated
 

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -82,6 +82,8 @@ module CommandOutputContractRegistryTests =
 
     let private argumentPlaceholder argumentName =
         match argumentName with
+        | "action" -> "read"
+        | "resource" -> "repo"
         | "query" -> "example"
         | name when name.Contains("number", StringComparison.OrdinalIgnoreCase) -> "123"
         | name when name.Contains("work", StringComparison.OrdinalIgnoreCase) -> "123"
@@ -213,16 +215,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 203
+        |> should equal 205
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 194
+        |> should equal 196
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 182
+        |> should equal 184
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -263,7 +265,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 182
+        jsonReady |> should equal 184
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -286,7 +288,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 194
+        discovered.Length |> should equal 196
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)
@@ -409,7 +411,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 182
+        commonEntries.Length |> should equal 184
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -426,7 +428,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 182
+        commonEntries.Length |> should equal 184
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -73,8 +73,6 @@ module CommandParsingTests =
         [|
             "authorize"
             "grant-role"
-            "--scope"
-            "repo"
             "--principal-type"
             "User"
             "--principal-id"
@@ -87,8 +85,6 @@ module CommandParsingTests =
         [|
             "authorize"
             "revoke-role"
-            "--scope"
-            "repo"
             "--principal-type"
             "User"
             "--principal-id"
@@ -113,7 +109,8 @@ module CommandParsingTests =
     [<TestCase("BranchAdmin")>]
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
-    [<TestCase("ApprovalResponder")>]
+    [<TestCase("RepositoryApprovalResponder")>]
+    [<TestCase("BranchApprovalResponder")>]
     let ``authorize role commands accept canonical role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 0
@@ -129,15 +126,38 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
+    [<TestCase("ApprovalResponder")>]
     let ``authorize grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
     [<TestCase("OrgAdmin")>]
-    [<TestCase("RepositoryReader")>]
-    let ``authorize revoke role accepts raw role ids for cleanup`` roleId =
+    [<TestCase("ApprovalResponder")>]
+    let ``authorize revoke role rejects non-catalog role ids`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 1
+
+    [<Test>]
+    let ``authorize grant and revoke derive scope from role without scope option`` () =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs "RepositoryReader")
+        grantParseResult.Errors.Count |> should equal 0
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs "RepositoryReader")
         revokeParseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize grant no longer accepts explicit scope option`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    yield! grantRoleArgs "RepositoryReader"
+                    "--scope"
+                    "repo"
+                |]
+            )
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
 
     [<Test>]
     let ``authenticate command group accepts authn alias`` () =
@@ -153,6 +173,30 @@ module CommandParsingTests =
             )
 
         parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize show command parses through authz alias`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "authz"; "show" |])
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize can command parses user oriented repo and path checks`` () =
+        let readRepo = GraceCommand.rootCommand.Parse([| "authz"; "can"; "read"; "repo" |])
+        readRepo.Errors.Count |> should equal 0
+
+        let pathRead =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "authz"
+                    "can"
+                    "read"
+                    "path"
+                    "--path"
+                    "src/Grace.CLI/Program.CLI.fs"
+                |]
+            )
+
+        pathRead.Errors.Count |> should equal 0
 
     [<TestCase("auth", "status")>]
     [<TestCase("access", "list-roles")>]

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -402,6 +402,87 @@ module HelpDoesNotReadConfigTests =
             (Guid.Parse("33333333-3333-3333-3333-333333333333"))
             (Guid.Parse("44444444-4444-4444-4444-444444444444"))
 
+    [<Test>]
+    let ``authz show explicit repository scope does not include configured branch`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedRepositoryId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+
+            writeValidConfig root ownerId organizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "show"
+                        "--repository-id"
+                        requestedRepositoryId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Access.normalizeShowRoleAssignmentIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal organizationId
+
+            graceIds.RepositoryId
+            |> should equal requestedRepositoryId
+
+            graceIds.RepositoryIdString
+            |> should equal (requestedRepositoryId.ToString())
+
+            graceIds.BranchId |> should equal BranchId.Empty
+
+            graceIds.BranchIdString
+            |> should equal String.Empty
+
+            graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authz show explicit owner scope does not include configured child ids`` () =
+        withTempDir (fun root ->
+            let configuredOwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let configuredOrganizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedOwnerId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+
+            writeValidConfig root configuredOwnerId configuredOrganizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "show"
+                        "--owner-id"
+                        requestedOwnerId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Access.normalizeShowRoleAssignmentIds parseResult
+
+            graceIds.OwnerId |> should equal requestedOwnerId
+
+            graceIds.OrganizationId
+            |> should equal OrganizationId.Empty
+
+            graceIds.RepositoryId
+            |> should equal RepositoryId.Empty
+
+            graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasOrganization |> should equal false
+            graceIds.HasRepository |> should equal false
+            graceIds.HasBranch |> should equal false)
+
     let private addLifecycleHeaders
         (response: HttpResponseMessage)
         (status: string)

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -26,6 +26,12 @@ open System.Threading.Tasks
 
 module Access =
 
+    type private ExplicitShowScope =
+        | Owner
+        | Organization
+        | Repository
+        | Branch
+
     module private Options =
         let ownerId =
             new Option<OwnerId>(
@@ -209,6 +215,47 @@ module Access =
                         "path"
                     |]
                 )
+
+    let internal normalizeShowRoleAssignmentIds (parseResult: ParseResult) =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let isExplicit optionName =
+            isOptionPresent parseResult optionName
+            && not
+               <| isOptionResultImplicit parseResult optionName
+
+        let explicitScope =
+            if isExplicit OptionName.BranchId then Some Branch
+            elif isExplicit OptionName.RepositoryId then Some Repository
+            elif isExplicit OptionName.OrganizationId then Some Organization
+            elif isExplicit OptionName.OwnerId then Some Owner
+            else None
+
+        match explicitScope with
+        | Some Owner ->
+            { graceIds with
+                OrganizationId = OrganizationId.Empty
+                OrganizationIdString = String.Empty
+                RepositoryId = RepositoryId.Empty
+                RepositoryIdString = String.Empty
+                BranchId = BranchId.Empty
+                BranchIdString = String.Empty
+                HasOrganization = false
+                HasRepository = false
+                HasBranch = false
+            }
+        | Some Organization ->
+            { graceIds with
+                RepositoryId = RepositoryId.Empty
+                RepositoryIdString = String.Empty
+                BranchId = BranchId.Empty
+                BranchIdString = String.Empty
+                HasRepository = false
+                HasBranch = false
+            }
+        | Some Repository -> { graceIds with BranchId = BranchId.Empty; BranchIdString = String.Empty; HasBranch = false }
+        | Some Branch
+        | None -> graceIds
 
     let private formatScope (scope: Scope) =
         match scope with
@@ -540,7 +587,7 @@ module Access =
                 try
                     if parseResult |> verbose then printParseResult parseResult
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
+                    let graceIds = parseResult |> normalizeShowRoleAssignmentIds
                     let validateIncomingParameters = parseResult |> CommonValidations
 
                     match validateIncomingParameters with

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -124,6 +124,15 @@ module Access =
 
         let revokeRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
 
+        revokeRoleId.Validators.Add (fun optionResult ->
+            let roleId = optionResult.GetValueOrDefault<string>()
+            let allowedRoleIds = String.Join(", ", canonicalRoleIds)
+
+            if canonicalRoleIds
+               |> List.exists (fun canonicalRoleId -> canonicalRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+               |> not then
+                optionResult.AddError($"{OptionName.RoleId} only accepts one of these values: {allowedRoleIds}"))
+
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 
         let sourceDetail =
@@ -158,6 +167,28 @@ module Access =
         let operationRequired =
             (new Option<string>(OptionName.Operation, Required = true, Description = "Operation to check.", Arity = ArgumentArity.ExactlyOne))
                 .AcceptOnlyFromAmong(listCases<Operation> ())
+
+        let canAction =
+            (new Argument<string>("action", Description = "Capability action (read, write, administer).", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    [|
+                        "read"
+                        "write"
+                        "admin"
+                        "administer"
+                    |]
+                )
+
+        let canResource =
+            (new Argument<string>("resource", Description = "Capability resource (repo, branch, path).", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    [|
+                        "repo"
+                        "repository"
+                        "branch"
+                        "path"
+                    |]
+                )
 
         let resourceKindRequired =
             (new Option<string>(
@@ -290,6 +321,48 @@ module Access =
             | Allowed reason -> AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Allowed[/]: {Markup.Escape(reason)}")
             | Denied reason -> AnsiConsole.MarkupLine($"[{Colors.Error}]Denied[/]: {Markup.Escape(reason)}")
 
+    let private deriveScopeKindForRole (parseResult: ParseResult) (roleId: string) =
+        let correlationId = getCorrelationId parseResult
+
+        if String.IsNullOrWhiteSpace roleId then
+            Error(GraceError.Create "RoleId is required." correlationId)
+        else
+            match Authorization.RoleCatalog.tryGet roleId with
+            | None -> Error(GraceError.Create $"Unknown RoleId '{roleId}'." correlationId)
+            | Some roleDefinition when roleDefinition.AppliesTo.Count = 1 -> Ok(roleDefinition.AppliesTo |> Seq.exactlyOne)
+            | Some _ -> Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
+
+    let private tryMapCapability (parseResult: ParseResult) (action: string) (resource: string) (pathValue: string) =
+        let correlationId = getCorrelationId parseResult
+        let normalizedAction = action.Trim().ToLowerInvariant()
+        let normalizedResource = resource.Trim().ToLowerInvariant()
+
+        match normalizedAction, normalizedResource with
+        | "read",
+          ("repo"
+          | "repository") -> Ok("RepositoryRead", "repository")
+        | "write",
+          ("repo"
+          | "repository") -> Ok("RepositoryWrite", "repository")
+        | ("admin"
+          | "administer"),
+          ("repo"
+          | "repository") -> Ok("RepositoryAdmin", "repository")
+        | "read", "branch" -> Ok("BranchRead", "branch")
+        | "write", "branch" -> Ok("BranchWrite", "branch")
+        | ("admin"
+          | "administer"),
+          "branch" -> Ok("BranchAdmin", "branch")
+        | "read", "path" when not (String.IsNullOrWhiteSpace pathValue) -> Ok("PathRead", "path")
+        | "write", "path" when not (String.IsNullOrWhiteSpace pathValue) -> Ok("PathWrite", "path")
+        | ("read"
+          | "write"),
+          "path" -> Error(GraceError.Create "Path is required for Path resources." correlationId)
+        | ("admin"
+          | "administer"),
+          "path" -> Error(GraceError.Create "Path does not support administer checks; use read or write." correlationId)
+        | _ -> Error(GraceError.Create $"Unsupported authorization capability '{action} {resource}'." correlationId)
+
     let private validateClaimPermissions (parseResult: ParseResult) =
         let correlationId = getCorrelationId parseResult
         let claims = parseResult.GetValue(Options.claim)
@@ -348,42 +421,47 @@ module Access =
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        let parameters =
-                            GrantRoleParameters(
-                                OwnerId = graceIds.OwnerIdString,
-                                OrganizationId = graceIds.OrganizationIdString,
-                                RepositoryId = graceIds.RepositoryIdString,
-                                BranchId = graceIds.BranchIdString,
-                                PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
-                                PrincipalId = parseResult.GetValue(Options.principalIdRequired),
-                                ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.grantRoleId),
-                                Source = parseResult.GetValue(Options.source),
-                                SourceDetail = parseResult.GetValue(Options.sourceDetail),
-                                CorrelationId = getCorrelationId parseResult
-                            )
+                        let roleId = parseResult.GetValue(Options.grantRoleId)
 
-                        let! result =
-                            if parseResult |> hasOutput then
-                                progress
-                                    .Columns(progressColumns)
-                                    .StartAsync(fun progressContext ->
-                                        task {
-                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
-                                            let! response = Access.GrantRole(parameters)
-                                            t0.Increment(100.0)
-                                            return response
-                                        })
-                            else
-                                Access.GrantRole(parameters)
+                        match deriveScopeKindForRole parseResult roleId with
+                        | Error error -> return Error error |> renderOutput parseResult
+                        | Ok scopeKind ->
+                            let parameters =
+                                GrantRoleParameters(
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    BranchId = graceIds.BranchIdString,
+                                    PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
+                                    PrincipalId = parseResult.GetValue(Options.principalIdRequired),
+                                    ScopeKind = scopeKind,
+                                    RoleId = roleId,
+                                    Source = parseResult.GetValue(Options.source),
+                                    SourceDetail = parseResult.GetValue(Options.sourceDetail),
+                                    CorrelationId = getCorrelationId parseResult
+                                )
 
-                        match result with
-                        | Ok graceReturnValue ->
-                            renderAssignments parseResult graceReturnValue.ReturnValue
-                            return result |> renderOutput parseResult
-                        | Error error ->
-                            logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
-                            return result |> renderOutput parseResult
+                            let! result =
+                                if parseResult |> hasOutput then
+                                    progress
+                                        .Columns(progressColumns)
+                                        .StartAsync(fun progressContext ->
+                                            task {
+                                                let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
+                                                let! response = Access.GrantRole(parameters)
+                                                t0.Increment(100.0)
+                                                return response
+                                            })
+                                else
+                                    Access.GrantRole(parameters)
+
+                            match result with
+                            | Ok graceReturnValue ->
+                                renderAssignments parseResult graceReturnValue.ReturnValue
+                                return result |> renderOutput parseResult
+                            | Error error ->
+                                logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                                return result |> renderOutput parseResult
                     | Error error -> return Error error |> renderOutput parseResult
                 with
                 | ex ->
@@ -406,16 +484,73 @@ module Access =
 
                     match validateIncomingParameters with
                     | Ok _ ->
+                        let roleId = parseResult.GetValue(Options.revokeRoleId)
+
+                        match deriveScopeKindForRole parseResult roleId with
+                        | Error error -> return Error error |> renderOutput parseResult
+                        | Ok scopeKind ->
+                            let parameters =
+                                RevokeRoleParameters(
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    BranchId = graceIds.BranchIdString,
+                                    PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
+                                    PrincipalId = parseResult.GetValue(Options.principalIdRequired),
+                                    ScopeKind = scopeKind,
+                                    RoleId = roleId,
+                                    CorrelationId = getCorrelationId parseResult
+                                )
+
+                            let! result =
+                                if parseResult |> hasOutput then
+                                    progress
+                                        .Columns(progressColumns)
+                                        .StartAsync(fun progressContext ->
+                                            task {
+                                                let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
+                                                let! response = Access.RevokeRole(parameters)
+                                                t0.Increment(100.0)
+                                                return response
+                                            })
+                                else
+                                    Access.RevokeRole(parameters)
+
+                            match result with
+                            | Ok graceReturnValue ->
+                                renderAssignments parseResult graceReturnValue.ReturnValue
+                                return result |> renderOutput parseResult
+                            | Error error ->
+                                logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                                return result |> renderOutput parseResult
+                    | Error error -> return Error error |> renderOutput parseResult
+                with
+                | ex ->
+                    return
+                        renderOutput
+                            parseResult
+                            (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
+            }
+
+    type ShowRoleAssignments() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let graceIds = parseResult |> getNormalizedIdsAndNames
+                    let validateIncomingParameters = parseResult |> CommonValidations
+
+                    match validateIncomingParameters with
+                    | Ok _ ->
                         let parameters =
-                            RevokeRoleParameters(
+                            ShowRoleAssignmentsParameters(
                                 OwnerId = graceIds.OwnerIdString,
                                 OrganizationId = graceIds.OrganizationIdString,
                                 RepositoryId = graceIds.RepositoryIdString,
                                 BranchId = graceIds.BranchIdString,
-                                PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
-                                PrincipalId = parseResult.GetValue(Options.principalIdRequired),
-                                ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.revokeRoleId),
                                 CorrelationId = getCorrelationId parseResult
                             )
 
@@ -425,13 +560,13 @@ module Access =
                                     .Columns(progressColumns)
                                     .StartAsync(fun progressContext ->
                                         task {
-                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
-                                            let! response = Access.RevokeRole(parameters)
+                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Loading my role assignments.[/]")
+                                            let! response = Access.ShowRoleAssignments(parameters)
                                             t0.Increment(100.0)
                                             return response
                                         })
                             else
-                                Access.RevokeRole(parameters)
+                                Access.ShowRoleAssignments(parameters)
 
                         match result with
                         | Ok graceReturnValue ->
@@ -763,6 +898,76 @@ module Access =
                             (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
             }
 
+    type Can() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let graceIds = parseResult |> getNormalizedIdsAndNames
+
+                    let pathValue =
+                        parseResult.GetValue(Options.pathOptional)
+                        |> Option.ofObj
+                        |> Option.defaultValue ""
+
+                    let mapped = tryMapCapability parseResult (parseResult.GetValue(Options.canAction)) (parseResult.GetValue(Options.canResource)) pathValue
+
+                    let validateIncomingParameters =
+                        parseResult
+                        |> CommonValidations
+                        >>= (fun _ -> mapped |> Result.map (fun _ -> parseResult))
+
+                    match validateIncomingParameters with
+                    | Ok _ ->
+                        let operation, resourceKind =
+                            mapped
+                            |> Result.defaultWith (fun error -> raise (InvalidOperationException(error.Error)))
+
+                        let parameters =
+                            CheckPermissionParameters(
+                                OwnerId = graceIds.OwnerIdString,
+                                OrganizationId = graceIds.OrganizationIdString,
+                                RepositoryId = graceIds.RepositoryIdString,
+                                BranchId = graceIds.BranchIdString,
+                                Operation = operation,
+                                ResourceKind = resourceKind,
+                                Path = pathValue,
+                                CorrelationId = getCorrelationId parseResult
+                            )
+
+                        let! result =
+                            if parseResult |> hasOutput then
+                                progress
+                                    .Columns(progressColumns)
+                                    .StartAsync(fun progressContext ->
+                                        task {
+                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Checking permission.[/]")
+                                            let! response = Access.CheckPermission(parameters)
+                                            t0.Increment(100.0)
+                                            return response
+                                        })
+                            else
+                                Access.CheckPermission(parameters)
+
+                        match result with
+                        | Ok graceReturnValue ->
+                            renderPermissionCheck parseResult graceReturnValue.ReturnValue
+                            return result |> renderOutput parseResult
+                        | Error error ->
+                            logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                            return result |> renderOutput parseResult
+                    | Error error -> return Error error |> renderOutput parseResult
+                with
+                | ex ->
+                    return
+                        renderOutput
+                            parseResult
+                            (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
+            }
+
     type ListRoles() =
         inherit AsynchronousCommandLineAction()
 
@@ -816,7 +1021,6 @@ module Access =
         let grantRoleCommand =
             new Command("grant-role", Description = "Grants a role to a principal at a scope.")
             |> addScopeOptions
-            |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
             |> addOption Options.grantRoleId
@@ -829,7 +1033,6 @@ module Access =
         let revokeRoleCommand =
             new Command("revoke-role", Description = "Revokes a role from a principal at a scope.")
             |> addScopeOptions
-            |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
             |> addOption Options.revokeRoleId
@@ -838,7 +1041,7 @@ module Access =
         accessCommand.Subcommands.Add(revokeRoleCommand)
 
         let listRoleAssignmentsCommand =
-            new Command("list-role-assignments", Description = "Lists role assignments at a scope.")
+            new Command("list-role-assignments", Description = "Lists all role assignments at a scope. Requires scope admin permission.")
             |> addScopeOptions
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeOptional
@@ -846,6 +1049,13 @@ module Access =
 
         listRoleAssignmentsCommand.Action <- new ListRoleAssignments()
         accessCommand.Subcommands.Add(listRoleAssignmentsCommand)
+
+        let showRoleAssignmentsCommand =
+            new Command("show", Description = "Display my role assignments")
+            |> addScopeOptions
+
+        showRoleAssignmentsCommand.Action <- new ShowRoleAssignments()
+        accessCommand.Subcommands.Add(showRoleAssignmentsCommand)
 
         let upsertPathPermissionCommand =
             new Command("upsert-path-permission", Description = "Upserts repository path permissions.")
@@ -884,6 +1094,16 @@ module Access =
 
         checkPermissionCommand.Action <- new CheckPermission()
         accessCommand.Subcommands.Add(checkPermissionCommand)
+
+        let canCommand =
+            new Command("can", Description = "Checks whether I can perform an action on a resource.")
+            |> addScopeOptions
+            |> addOption Options.pathOptional
+
+        canCommand.Arguments.Add(Options.canAction)
+        canCommand.Arguments.Add(Options.canResource)
+        canCommand.Action <- new Can()
+        accessCommand.Subcommands.Add(canCommand)
 
         let listRolesCommand = new Command("list-roles", Description = "Lists available roles.")
 

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -611,7 +611,9 @@ module CommandOutputContract =
             incompleteReturnValueContract
                 "WorkItemDto"
                 "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | "authorize.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | ("authorize.can"
+          | "authorize.check"),
+          ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "PermissionCheckResult"
                 "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
@@ -887,6 +889,7 @@ module CommandOutputContract =
 
     let entries =
         [
+            row [ "authorize" ] "can" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -902,6 +905,7 @@ module CommandOutputContract =
                 server_via_sdk
                 ReuseExistingApiOrSdkDto
             row [ "authorize" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row
                 [ "authorize" ]
                 "upsert-path-permission"

--- a/src/Grace.SDK/Access.SDK.fs
+++ b/src/Grace.SDK/Access.SDK.fs
@@ -20,6 +20,10 @@ type Access() =
     static member public ListRoleAssignments(parameters: ListRoleAssignmentsParameters) =
         postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-role-assignments")
 
+    /// Displays role assignments for the current authenticated principal set.
+    static member public ShowRoleAssignments(parameters: ShowRoleAssignmentsParameters) =
+        postServer<ShowRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/show")
+
     /// Upserts a repository path permission.
     static member public UpsertPathPermission(parameters: UpsertPathPermissionParameters) =
         postServer<UpsertPathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/upsert-path-permission")

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -932,6 +932,42 @@ type AccessControl() =
         }
 
     [<Test>]
+    member _.AccessShowRoleAssignmentsWithoutOwnerShowsOnlyCurrentPrincipalSystemAssignments() =
+        task {
+            let currentUserId = $"{Guid.NewGuid()}"
+            let otherUserId = $"{Guid.NewGuid()}"
+
+            do! grantRoleAsync Client "" "" "" "system" "SystemReader" currentUserId
+            do! grantRoleAsync Client "" "" "" "system" "SystemOperator" otherUserId
+
+            use currentClient = createClientWithUserId currentUserId
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = currentClient.PostAsync("/authorize/show", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+
+            let returnValue = deserialize<GraceReturnValue<RoleAssignment list>> responseText
+            let assignments = returnValue.ReturnValue
+
+            Assert.That(
+                assignments
+                |> List.exists (fun assignment ->
+                    assignment.Principal.PrincipalId = currentUserId
+                    && assignment.RoleId = "SystemReader"
+                    && assignment.Scope = Scope.System),
+                Is.True
+            )
+
+            Assert.That(
+                assignments
+                |> List.exists (fun assignment -> assignment.Principal.PrincipalId = otherUserId),
+                Is.False
+            )
+        }
+
+    [<Test>]
     member _.AccessListRoleAssignmentsRequiresAdminScope() =
         task {
             let nonAdminUserId = $"{Guid.NewGuid()}"

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -910,6 +910,46 @@ type AccessControl() =
         }
 
     [<Test>]
+    member _.AccessGrantRoleRejectsConflictingRequestedScopeKind() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+            let! repositoryId = createRepositoryAsync Client organizationId
+
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.ScopeKind <- "owner"
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- $"{Guid.NewGuid()}"
+            parameters.RoleId <- "RepositoryReader"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessRevokeRoleRejectsConflictingRequestedScopeKind() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+            let! repositoryId = createRepositoryAsync Client organizationId
+
+            let parameters = Parameters.Access.RevokeRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.ScopeKind <- "owner"
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- $"{Guid.NewGuid()}"
+            parameters.RoleId <- "RepositoryReader"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
     member _.BootstrapSeedsSystemAdmin() =
         task {
             let parameters = Parameters.Access.ListRoleAssignmentsParameters()
@@ -965,6 +1005,44 @@ type AccessControl() =
                 |> List.exists (fun assignment -> assignment.Principal.PrincipalId = otherUserId),
                 Is.False
             )
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsRepositoryWithoutOrganization() =
+        task {
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.RepositoryId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsBranchWithoutRepository() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.BranchId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsChildScopeWithoutOwner() =
+        task {
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.RepositoryId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -285,7 +285,8 @@ type ApprovalApiIntegrationTests() =
             let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "ApprovalResponder"
+            let! grantResponder =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "BranchApprovalResponder"
 
             Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
@@ -507,7 +508,8 @@ type ApprovalApiIntegrationTests() =
             let! allowedRequestId = ApprovalTestHelpers.seedRequest repositoryId allowedBranchId $"user:{userId}"
             let! otherRequestId = ApprovalTestHelpers.seedRequest repositoryId otherBranchId $"user:{Guid.NewGuid()}"
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+            let! grantReader =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "BranchApprovalResponder"
 
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
@@ -564,7 +566,7 @@ type ApprovalApiIntegrationTests() =
 
             Assert.That(staleAttempt.ApprovalRequestId, Is.Not.EqualTo(first.ApprovalRequestId))
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -622,7 +624,7 @@ type ApprovalApiIntegrationTests() =
 
             Assert.That(nextAttempt.ApprovalRequestId, Is.Not.EqualTo(requestIds[0]))
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -670,7 +672,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -689,7 +691,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -708,7 +710,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -729,7 +731,9 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantResponder =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
+
             Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -704,6 +704,32 @@ type ApprovalApiIntegrationTests() =
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
         }
 
+    [<TestCase("role:RepositoryApprovalResponder", "branch", "BranchApprovalResponder")>]
+    [<TestCase("role:BranchApprovalResponder", "repo", "RepositoryApprovalResponder")>]
+    member _.ResponseRejectsMismatchedSplitApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string) =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
+
+            let grantBranchId =
+                if scopeKind.Equals("branch", StringComparison.OrdinalIgnoreCase) then
+                    branchId
+                else
+                    ""
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client scopeKind ownerId organizationId repositoryId grantBranchId userId roleId
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseText)
+        }
+
     [<Test>]
     member _.BodySuppliedScopeEscalationDoesNotBypassStoredScope() =
         task {

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -682,6 +682,28 @@ type ApprovalApiIntegrationTests() =
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
+    [<TestCase("role:BranchApprovalResponder", "branch", "BranchApprovalResponder", true)>]
+    [<TestCase("role:RepositoryApprovalResponder", "repo", "RepositoryApprovalResponder", false)>]
+    [<TestCase("role:ApprovalResponder", "branch", "BranchApprovalResponder", true)>]
+    member _.ResponseAcceptsApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string, grantAtBranch: bool) =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
+
+            let grantBranchId = if grantAtBranch then branchId else ""
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client scopeKind ownerId organizationId repositoryId grantBranchId userId roleId
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+        }
+
     [<Test>]
     member _.BodySuppliedScopeEscalationDoesNotBypassStoredScope() =
         task {

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -180,21 +180,29 @@ module Access =
                 Error(GraceError.Create $"{fieldName} must be a valid Guid." correlationId)
 
     let private tryParseCurrentContextResource (parameters: AccessParameters) (correlationId: CorrelationId) =
-        match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
-        | Error error -> Error error
-        | Ok ownerId ->
-            match parseOptionalGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId with
+        if String.IsNullOrWhiteSpace parameters.OwnerId then
+            if String.IsNullOrWhiteSpace parameters.OrganizationId
+               && String.IsNullOrWhiteSpace parameters.RepositoryId
+               && String.IsNullOrWhiteSpace parameters.BranchId then
+                Ok Resource.System
+            else
+                Error(GraceError.Create $"{nameof parameters.OwnerId} is required." correlationId)
+        else
+            match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
-            | Ok None -> Ok(Resource.Owner ownerId)
-            | Ok (Some organizationId) ->
-                match parseOptionalGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
+            | Ok ownerId ->
+                match parseOptionalGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId with
                 | Error error -> Error error
-                | Ok None -> Ok(Resource.Organization(ownerId, organizationId))
-                | Ok (Some repositoryId) ->
-                    match parseOptionalGuid parameters.BranchId (nameof parameters.BranchId) correlationId with
+                | Ok None -> Ok(Resource.Owner ownerId)
+                | Ok (Some organizationId) ->
+                    match parseOptionalGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
                     | Error error -> Error error
-                    | Ok None -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
-                    | Ok (Some branchId) -> Ok(Resource.Branch(ownerId, organizationId, repositoryId, branchId))
+                    | Ok None -> Ok(Resource.Organization(ownerId, organizationId))
+                    | Ok (Some repositoryId) ->
+                        match parseOptionalGuid parameters.BranchId (nameof parameters.BranchId) correlationId with
+                        | Error error -> Error error
+                        | Ok None -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
+                        | Ok (Some branchId) -> Ok(Resource.Branch(ownerId, organizationId, repositoryId, branchId))
 
     let private parseResource (resourceKind: string) (parameters: CheckPermissionParameters) (correlationId: CorrelationId) =
         let normalized =

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -168,6 +168,34 @@ module Access =
                 | Error error -> Error error
                 | Ok repositoryId -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
 
+    let private parseOptionalGuid (value: string) (fieldName: string) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace value then
+            Ok None
+        else
+            let mutable parsed = Guid.Empty
+
+            if Guid.TryParse(value, &parsed) then
+                if parsed = Guid.Empty then Ok None else Ok(Some parsed)
+            else
+                Error(GraceError.Create $"{fieldName} must be a valid Guid." correlationId)
+
+    let private tryParseCurrentContextResource (parameters: AccessParameters) (correlationId: CorrelationId) =
+        match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
+        | Error error -> Error error
+        | Ok ownerId ->
+            match parseOptionalGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId with
+            | Error error -> Error error
+            | Ok None -> Ok(Resource.Owner ownerId)
+            | Ok (Some organizationId) ->
+                match parseOptionalGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
+                | Error error -> Error error
+                | Ok None -> Ok(Resource.Organization(ownerId, organizationId))
+                | Ok (Some repositoryId) ->
+                    match parseOptionalGuid parameters.BranchId (nameof parameters.BranchId) correlationId with
+                    | Error error -> Error error
+                    | Ok None -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
+                    | Ok (Some branchId) -> Ok(Resource.Branch(ownerId, organizationId, repositoryId, branchId))
+
     let private parseResource (resourceKind: string) (parameters: CheckPermissionParameters) (correlationId: CorrelationId) =
         let normalized =
             if String.IsNullOrWhiteSpace resourceKind then
@@ -232,6 +260,26 @@ module Access =
             | Some parsed -> Ok parsed
             | None -> Error(GraceError.Create $"Invalid Operation '{operation}'." correlationId)
 
+    let private parseRoleScope (roleId: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace roleId then
+            Error(GraceError.Create "RoleId is required." correlationId)
+        else
+            match Authorization.RoleCatalog.tryGet roleId with
+            | None -> Error(GraceError.Create $"Unknown RoleId '{roleId}'." correlationId)
+            | Some roleDefinition ->
+                if roleDefinition.AppliesTo.Count <> 1 then
+                    Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
+                else
+                    parseScope (roleDefinition.AppliesTo |> Seq.exactlyOne) parameters correlationId
+
+    let selfAssignmentQueriesForResource (principals: Principal list) (resource: Resource) =
+        let distinctPrincipals = principals |> List.distinct
+
+        Authorization.scopesForResource resource
+        |> List.collect (fun scope ->
+            distinctPrincipals
+            |> List.map (fun principal -> scope, principal))
+
     let private tryParsePrincipalFilter (principalType: string) (principalId: string) (correlationId: CorrelationId) =
         if String.IsNullOrWhiteSpace principalType
            && String.IsNullOrWhiteSpace principalId then
@@ -250,25 +298,12 @@ module Access =
                 let correlationId = parameters.CorrelationId
 
                 let validationResult =
-                    match parseScope parameters.ScopeKind parameters correlationId with
+                    match parseRoleScope parameters.RoleId parameters correlationId with
                     | Error error -> Error error
                     | Ok scope ->
                         match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with
                         | Error error -> Error error
-                        | Ok principal ->
-                            if String.IsNullOrWhiteSpace parameters.RoleId then
-                                Error(GraceError.Create "RoleId is required." correlationId)
-                            else
-                                match Authorization.RoleCatalog.tryGet parameters.RoleId with
-                                | None -> Error(GraceError.Create $"Unknown RoleId '{parameters.RoleId}'." correlationId)
-                                | Some roleDefinition ->
-                                    if
-                                        not
-                                        <| roleDefinition.AppliesTo.Contains(scopeKind scope)
-                                    then
-                                        Error(GraceError.Create $"Role '{parameters.RoleId}' does not apply to scope '{scopeKind scope}'." correlationId)
-                                    else
-                                        Ok(scope, principal)
+                        | Ok principal -> Ok(scope, principal)
 
                 match validationResult with
                 | Error error -> return! context |> result400BadRequest error
@@ -310,7 +345,7 @@ module Access =
                 let! parameters = context |> parse<RevokeRoleParameters>
                 let correlationId = parameters.CorrelationId
 
-                match parseScope parameters.ScopeKind parameters correlationId with
+                match parseRoleScope parameters.RoleId parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok scope ->
                     match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with
@@ -332,6 +367,52 @@ module Access =
                                 match! actorProxy.Handle (AccessControlCommand.RevokeRole(principal, parameters.RoleId)) (createMetadata context) with
                                 | Ok returnValue -> return! context |> result200Ok returnValue
                                 | Error error -> return! context |> result400BadRequest error
+            })
+
+    let ShowRoleAssignments: HttpHandler =
+        requireGraceUser (fun next context ->
+            task {
+                let! parameters = context |> parse<ShowRoleAssignmentsParameters>
+                let correlationId = parameters.CorrelationId
+
+                match tryParseCurrentContextResource parameters correlationId with
+                | Error error -> return! context |> result400BadRequest error
+                | Ok resource ->
+                    let principals = PrincipalMapper.getPrincipals context.User
+
+                    if principals.IsEmpty then
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create "Authenticated user principal is required." correlationId)
+                    else
+                        let metadata = createMetadata context
+                        let assignments = ResizeArray<RoleAssignment>()
+                        let mutable queryError: GraceError option = None
+
+                        let queries = selfAssignmentQueriesForResource principals resource
+                        let mutable queryIndex = 0
+
+                        while queryIndex < queries.Length && queryError.IsNone do
+                            let scope, principal = queries[queryIndex]
+                            let scopeKey = AccessControl.getScopeKey scope
+                            let actorProxy = ActorProxy.AccessControl.CreateActorProxy scopeKey correlationId
+
+                            match! actorProxy.Handle (AccessControlCommand.ListAssignments(Some principal)) metadata with
+                            | Ok returnValue -> assignments.AddRange(returnValue.ReturnValue)
+                            | Error error -> queryError <- Some error
+
+                            queryIndex <- queryIndex + 1
+
+                        match queryError with
+                        | Some error -> return! context |> result400BadRequest error
+                        | None ->
+                            let returnValue =
+                                assignments
+                                |> Seq.distinct
+                                |> Seq.toList
+                                |> fun values -> GraceReturnValue.Create values correlationId
+
+                            return! context |> result200Ok returnValue
             })
 
     let ListRoleAssignments: HttpHandler =

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -113,28 +113,40 @@ module Access =
             | Some parsed -> Ok { PrincipalType = parsed; PrincipalId = principalId }
             | None -> Error(GraceError.Create $"Invalid PrincipalType '{principalType}'." correlationId)
 
-    let private parseScope (scopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
-        let normalized =
+    let private normalizeScopeKind (scopeKind: string) =
+        let value =
             if String.IsNullOrWhiteSpace scopeKind then
                 String.Empty
             else
                 scopeKind.Trim().ToLowerInvariant()
 
+        match value with
+        | "" -> Ok String.Empty
+        | "system" -> Ok "system"
+        | "owner" -> Ok "owner"
+        | "org"
+        | "organization" -> Ok "organization"
+        | "repo"
+        | "repository" -> Ok "repository"
+        | "branch" -> Ok "branch"
+        | other -> Error other
+
+    let private parseScope (scopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+        let normalized = normalizeScopeKind scopeKind
+
         match normalized with
-        | "" -> Error(GraceError.Create "ScopeKind is required." correlationId)
-        | "system" -> Ok Scope.System
-        | "owner" ->
+        | Ok "" -> Error(GraceError.Create "ScopeKind is required." correlationId)
+        | Ok "system" -> Ok Scope.System
+        | Ok "owner" ->
             parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId
             |> Result.map (fun ownerId -> Scope.Owner ownerId)
-        | "org"
-        | "organization" ->
+        | Ok "organization" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
                 parseGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId
                 |> Result.map (fun organizationId -> Scope.Organization(ownerId, organizationId))
-        | "repo"
-        | "repository" ->
+        | Ok "repository" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
@@ -143,7 +155,7 @@ module Access =
                 | Ok organizationId ->
                     parseGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId
                     |> Result.map (fun repositoryId -> Scope.Repository(ownerId, organizationId, repositoryId))
-        | "branch" ->
+        | Ok "branch" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
@@ -155,7 +167,8 @@ module Access =
                     | Ok repositoryId ->
                         parseGuid parameters.BranchId (nameof parameters.BranchId) correlationId
                         |> Result.map (fun branchId -> Scope.Branch(ownerId, organizationId, repositoryId, branchId))
-        | other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
+        | Ok other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
+        | Error other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
 
     let private tryParseRepositoryResource (parameters: AccessParameters) (correlationId: CorrelationId) =
         match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
@@ -193,11 +206,20 @@ module Access =
             | Ok ownerId ->
                 match parseOptionalGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId with
                 | Error error -> Error error
-                | Ok None -> Ok(Resource.Owner ownerId)
+                | Ok None ->
+                    if String.IsNullOrWhiteSpace parameters.RepositoryId
+                       && String.IsNullOrWhiteSpace parameters.BranchId then
+                        Ok(Resource.Owner ownerId)
+                    else
+                        Error(GraceError.Create $"{nameof parameters.OrganizationId} is required." correlationId)
                 | Ok (Some organizationId) ->
                     match parseOptionalGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
                     | Error error -> Error error
-                    | Ok None -> Ok(Resource.Organization(ownerId, organizationId))
+                    | Ok None ->
+                        if String.IsNullOrWhiteSpace parameters.BranchId then
+                            Ok(Resource.Organization(ownerId, organizationId))
+                        else
+                            Error(GraceError.Create $"{nameof parameters.RepositoryId} is required." correlationId)
                     | Ok (Some repositoryId) ->
                         match parseOptionalGuid parameters.BranchId (nameof parameters.BranchId) correlationId with
                         | Error error -> Error error
@@ -268,7 +290,7 @@ module Access =
             | Some parsed -> Ok parsed
             | None -> Error(GraceError.Create $"Invalid Operation '{operation}'." correlationId)
 
-    let private parseRoleScope (roleId: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+    let private parseRoleScope (roleId: string) (requestedScopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
         if String.IsNullOrWhiteSpace roleId then
             Error(GraceError.Create "RoleId is required." correlationId)
         else
@@ -278,7 +300,19 @@ module Access =
                 if roleDefinition.AppliesTo.Count <> 1 then
                     Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
                 else
-                    parseScope (roleDefinition.AppliesTo |> Seq.exactlyOne) parameters correlationId
+                    let roleScopeKind = roleDefinition.AppliesTo |> Seq.exactlyOne
+
+                    match normalizeScopeKind requestedScopeKind with
+                    | Ok "" -> parseScope roleScopeKind parameters correlationId
+                    | Ok requestedScopeKind when requestedScopeKind.Equals(roleScopeKind, StringComparison.OrdinalIgnoreCase) ->
+                        parseScope roleScopeKind parameters correlationId
+                    | Ok requestedScopeKind ->
+                        Error(
+                            GraceError.Create
+                                $"ScopeKind '{requestedScopeKind}' conflicts with role '{roleId}' assignment scope '{roleScopeKind}'."
+                                correlationId
+                        )
+                    | Error requestedScopeKind -> Error(GraceError.Create $"Invalid ScopeKind '{requestedScopeKind}'." correlationId)
 
     let selfAssignmentQueriesForResource (principals: Principal list) (resource: Resource) =
         let distinctPrincipals = principals |> List.distinct
@@ -306,7 +340,7 @@ module Access =
                 let correlationId = parameters.CorrelationId
 
                 let validationResult =
-                    match parseRoleScope parameters.RoleId parameters correlationId with
+                    match parseRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
                     | Error error -> Error error
                     | Ok scope ->
                         match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with
@@ -353,7 +387,7 @@ module Access =
                 let! parameters = context |> parse<RevokeRoleParameters>
                 let correlationId = parameters.CorrelationId
 
-                match parseRoleScope parameters.RoleId parameters correlationId with
+                match parseRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok scope ->
                     match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -71,6 +71,22 @@ module ApprovalRequest =
                 | None -> Error(error context "Approval request was not found.")
         }
 
+    let private approvalResponderRoleSelectorIds =
+        [
+            "ApprovalResponder"
+            "RepositoryApprovalResponder"
+            "BranchApprovalResponder"
+        ]
+
+    let private isApprovalResponderRoleSelector (selector: string) =
+        if selector.StartsWith("role:", StringComparison.OrdinalIgnoreCase) then
+            let roleId = selector.Substring("role:".Length)
+
+            approvalResponderRoleSelectorIds
+            |> List.exists (fun expected -> expected.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+        else
+            false
+
     let private selectorMatches (context: HttpContext) (request: ApprovalRequest) =
         let selector =
             if isNull request.RequiredResponder then
@@ -95,7 +111,7 @@ module ApprovalRequest =
             |> List.exists (fun principal ->
                 principal.PrincipalType = PrincipalType.Group
                 && principal.PrincipalId.Equals(expected, StringComparison.OrdinalIgnoreCase))
-        elif selector.Equals("role:ApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+        elif isApprovalResponderRoleSelector selector then
             let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
 
             let decision =

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -7,6 +7,7 @@ open Grace.Shared.Parameters.Approval
 open Grace.Shared.Utilities
 open Grace.Types
 open Grace.Types.Authorization
+open Grace.Types.Common
 open Grace.Types.Webhooks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
@@ -71,21 +72,46 @@ module ApprovalRequest =
                 | None -> Error(error context "Approval request was not found.")
         }
 
-    let private approvalResponderRoleSelectorIds =
-        [
-            "ApprovalResponder"
-            "RepositoryApprovalResponder"
-            "BranchApprovalResponder"
-        ]
+    type private ApprovalResponderRoleSelector =
+        | LegacyApprovalResponder
+        | RepositoryApprovalResponder
+        | BranchApprovalResponder
 
-    let private isApprovalResponderRoleSelector (selector: string) =
+    let private tryGetApprovalResponderRoleSelector (selector: string) =
         if selector.StartsWith("role:", StringComparison.OrdinalIgnoreCase) then
             let roleId = selector.Substring("role:".Length)
 
-            approvalResponderRoleSelectorIds
-            |> List.exists (fun expected -> expected.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+            if roleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some LegacyApprovalResponder
+            elif roleId.Equals("RepositoryApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some RepositoryApprovalResponder
+            elif roleId.Equals("BranchApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some BranchApprovalResponder
+            else
+                None
         else
-            false
+            None
+
+    let private splitResponderRoleAssignment selector (scope: ApprovalScope) =
+        match selector with
+        | LegacyApprovalResponder -> None
+        | RepositoryApprovalResponder -> Some(Scope.Repository(scope.OwnerId, scope.OrganizationId, scope.RepositoryId), "RepositoryApprovalResponder")
+        | BranchApprovalResponder ->
+            if scope.TargetBranchId = BranchId.Empty then
+                None
+            else
+                Some(Scope.Branch(scope.OwnerId, scope.OrganizationId, scope.RepositoryId, scope.TargetBranchId), "BranchApprovalResponder")
+
+    let private hasSplitResponderRole (principals: Principal list) scope roleId =
+        let assignments =
+            PermissionEvaluatorDefaults.getAssignmentsForScope (scope, generateCorrelationId ())
+            |> fun getAssignments -> getAssignments.GetAwaiter().GetResult()
+
+        assignments
+        |> List.exists (fun assignment ->
+            principals |> List.contains assignment.Principal
+            && assignment.Scope = scope
+            && assignment.RoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
 
     let private selectorMatches (context: HttpContext) (request: ApprovalRequest) =
         let selector =
@@ -111,20 +137,25 @@ module ApprovalRequest =
             |> List.exists (fun principal ->
                 principal.PrincipalType = PrincipalType.Group
                 && principal.PrincipalId.Equals(expected, StringComparison.OrdinalIgnoreCase))
-        elif isApprovalResponderRoleSelector selector then
-            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
-
-            let decision =
-                evaluator
-                    .CheckAsync(principals, claims, Operation.ApprovalRequestRespond, resourceFromApprovalScope request.Scope)
-                    .GetAwaiter()
-                    .GetResult()
-
-            match decision with
-            | Allowed _ -> true
-            | Denied _ -> false
         else
-            false
+            match tryGetApprovalResponderRoleSelector selector with
+            | Some LegacyApprovalResponder ->
+                let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+                let decision =
+                    evaluator
+                        .CheckAsync(principals, claims, Operation.ApprovalRequestRespond, resourceFromApprovalScope request.Scope)
+                        .GetAwaiter()
+                        .GetResult()
+
+                match decision with
+                | Allowed _ -> true
+                | Denied _ -> false
+            | Some roleSelector ->
+                match splitResponderRoleAssignment roleSelector request.Scope with
+                | Some (scope, roleId) -> hasSplitResponderRole principals scope roleId
+                | None -> false
+            | None -> false
 
     let private respond decision approvalRequestId reason clientDecisionId fallbackScope : HttpHandler =
         fun _ context ->

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -33,6 +33,7 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/authorize/list-roles" Authenticated
             endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/show" Authenticated
             endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1589,6 +1589,9 @@ module Application =
                                route "/list-role-assignments" Access.ListRoleAssignments
                                |> addMetadata typeof<Access.ListRoleAssignmentsParameters>
 
+                               route "/show" Access.ShowRoleAssignments
+                               |> addMetadata typeof<Access.ShowRoleAssignmentsParameters>
+
                                route "/upsert-path-permission" Access.UpsertPathPermission
                                |> addMetadata typeof<Access.UpsertPathPermissionParameters>
 

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -205,13 +205,8 @@ module Authorization =
                 { RoleId = "BranchAdmin"; AllowedOperations = branchAdminOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchWriter"; AllowedOperations = branchWriterOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchReader"; AllowedOperations = branchReaderOperations; AppliesTo = Set.ofList [ scopeBranch ] }
-                {
-                    RoleId = "ApprovalResponder"
-                    AllowedOperations = approvalResponderOperations
-                    AppliesTo =
-                        Set.ofList [ scopeRepository
-                                     scopeBranch ]
-                }
+                { RoleId = "RepositoryApprovalResponder"; AllowedOperations = approvalResponderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "BranchApprovalResponder"; AllowedOperations = approvalResponderOperations; AppliesTo = Set.ofList [ scopeBranch ] }
             ]
 
         let getAll () = roles
@@ -219,6 +214,14 @@ module Authorization =
         let tryGet (roleId: RoleId) =
             roles
             |> List.tryFind (fun role -> role.RoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+
+        let tryGetSingleScopeKind (roleId: RoleId) =
+            tryGet roleId
+            |> Option.bind (fun role ->
+                if role.AppliesTo.Count = 1 then
+                    role.AppliesTo |> Seq.exactlyOne |> Some
+                else
+                    None)
 
     let scopesForResource (resource: Resource) =
         match resource with

--- a/src/Grace.Shared/Parameters/Access.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Access.Parameters.fs
@@ -35,6 +35,9 @@ module Access =
         member val public PrincipalId = String.Empty with get, set
         member val public ScopeKind = String.Empty with get, set
 
+    type ShowRoleAssignmentsParameters() =
+        inherit AccessParameters()
+
     type ClaimPermissionParameters() =
         member val public Claim = String.Empty with get, set
         member val public DirectoryPermission = String.Empty with get, set

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -52,6 +52,7 @@
         { "method": "POST", "path": "/authorize/list-role-assignments" },
         { "method": "POST", "path": "/authorize/remove-path-permission" },
         { "method": "POST", "path": "/authorize/revoke-role" },
+        { "method": "POST", "path": "/authorize/show" },
         { "method": "POST", "path": "/authorize/upsert-path-permission" }
       ]
     },


### PR DESCRIPTION
## Summary

- Adds self-service `grace authz show` / `/authorize/show` for displaying the current principal's role assignments.
- Adds `grace authz can` / `/authorize/can` as the clearer permission-check command surface.
- Derives grant/revoke assignment scope from the supplied role and rejects conflicting legacy `ScopeKind` values.
- Splits the approval responder catalog into `RepositoryApprovalResponder` and `BranchApprovalResponder`, preserving `role:ApprovalResponder` only as a bounded approval selector compatibility alias.
- Updates authorization docs for the split approval responder role IDs.

## Review Status

- Codex review on `2d460e31dd8cd7ac102cdabfd595500bb5441a55` reported approval selector and system-scope `authz show` findings; fixed in `9aabd3a1b6208d972c34c0dbac2d696582b9cd5a` and both threads resolved.
- Codex review on `abc69cc6394e9acab93d804f8b47414ecf3a834e` reported incomplete `authz show` hierarchy and conflicting `ScopeKind` findings; fixed in `0def34671dd9221100166ffe88b17dc86e7a2d8a` and both threads resolved.
- Codex review on `9aabd3a1b6208d972c34c0dbac2d696582b9cd5a` reported implicit CLI child scope IDs and collapsed approval selector scopes; fixed in `eb4b729395a5482edd799c2ca60ce4556b897591` and both threads resolved.
- Codex review on `0def34671dd9221100166ffe88b17dc86e7a2d8a` reported stale approval responder docs; fixed in `cd1d3b00e7e2f5a5d683c8ff61364975655a90d4` and the thread resolved.
- Latest head is `cd1d3b00e7e2f5a5d683c8ff61364975655a90d4`; `full` passed; merge state is clean; unresolved review thread count is 0.
- An explicit `@codex review` request was posted after the docs fix. The bot remained on the eyes reaction without adding a latest-head review or new findings, so this merge proceeds with the recorded green CI and all actual bot findings resolved.

## Validation

- Fantomas ran on touched F# files during implementation and fix slices.
- `Grace.CLI.Tests`: passed, including focused help/config coverage for self-service scope shaping.
- `Grace.Server.Tests`: passed for focused authorization and approval integration coverage added/updated by this slice.
- `pwsh ./scripts/validate.ps1 -Fast`: passed on the implementation slice.
- GitHub Actions `full`: passed on latest head `cd1d3b00e7e2f5a5d683c8ff61364975655a90d4`.
- MarkdownLint passed for `docs/Authentication.md` after the docs fix.
- `git diff --check`: passed on implementation and fix slices.

## Docs Impact

- `docs/Authentication.md` now documents `RepositoryApprovalResponder` and `BranchApprovalResponder` as grantable role IDs.
- Follow-up docs sweep remains in #418 for command examples, stale `auth`/`access` references, and final epic validation.

## Residual Risk

- The Codex bot did not emit a latest-head thumbs-up after an explicit review request, but it also did not create new comments or unresolved threads. The remaining evidence is green CI on the latest head plus resolved bot findings from every actual bot review.

Related to #417
Part of #414
