### PR TITLE
Update authn authz docs validation surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The first-time steps below use **local emulators** and **test authentication** (
 Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 
 ```powershell
-grace auth whoami
+grace authenticate whoami
 ```
 
 For a read-only diagnostic report that checks local configuration, authentication environment, local state, and

--- a/_endpoint_stub.txt
+++ b/_endpoint_stub.txt
@@ -1,22 +1,23 @@
     endpoint "GET" "/" Authenticated
-    endpoint "POST" "/access/checkPermission" Authenticated
-    endpoint "POST" "/access/grantRole" Authenticated
-    endpoint "POST" "/access/listPathPermissions" Authenticated
-    endpoint "POST" "/access/listRoleAssignments" Authenticated
-    endpoint "GET" "/access/listRoles" Authenticated
-    endpoint "POST" "/access/removePathPermission" Authenticated
-    endpoint "POST" "/access/revokeRole" Authenticated
-    endpoint "POST" "/access/upsertPathPermission" Authenticated
+    endpoint "POST" "/authorize/check-permission" Authenticated
+    endpoint "POST" "/authorize/grant-role" (Authorized(SystemAdmin, System))
+    endpoint "POST" "/authorize/list-path-permissions" (Authorized(RepositoryAdmin, Repository))
+    endpoint "POST" "/authorize/list-role-assignments" (Authorized(SystemAdmin, System))
+    endpoint "GET" "/authorize/list-roles" Authenticated
+    endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
+    endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+    endpoint "POST" "/authorize/show" Authenticated
+    endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
     endpoint "POST" "/admin/deleteAllFromCosmosDB" Authenticated
     endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" Authenticated
-    endpoint "GET" "/auth/login" Authenticated
-    endpoint "GET" "/auth/login/%s" Authenticated
-    endpoint "GET" "/auth/logout" Authenticated
-    endpoint "GET" "/auth/me" Authenticated
-    endpoint "GET" "/auth/oidc/config" Authenticated
-    endpoint "POST" "/auth/token/create" Authenticated
-    endpoint "POST" "/auth/token/list" Authenticated
-    endpoint "POST" "/auth/token/revoke" Authenticated
+    endpoint "GET" "/authenticate/login" AllowAnonymous
+    endpoint "GET" "/authenticate/login/%s" AllowAnonymous
+    endpoint "GET" "/authenticate/logout" Authenticated
+    endpoint "GET" "/authenticate/me" Authenticated
+    endpoint "GET" "/authenticate/oidc/config" AllowAnonymous
+    endpoint "POST" "/authenticate/token/create" Authenticated
+    endpoint "POST" "/authenticate/token/list" Authenticated
+    endpoint "POST" "/authenticate/token/revoke" Authenticated
     endpoint "POST" "/branch/assign" Authenticated
     endpoint "POST" "/branch/checkpoint" Authenticated
     endpoint "POST" "/branch/commit" Authenticated

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -63,7 +63,7 @@ Set one or both of these environment variables (semicolon-delimited list):
 
 * The values must be **principal IDs**, not emails or display names.
 * For Auth0/OIDC, the user principal ID is taken from the `sub` claim (exposed as `grace_user_id`).
-* You can confirm the user ID with `GET /auth/me` (`GraceUserId` in the response).
+* You can confirm the user ID with `GET /authenticate/me` (`GraceUserId` in the response).
 
 PowerShell:
 
@@ -194,13 +194,13 @@ When enabled, Grace authenticates requests using headers:
    PowerShell:
 
    ```powershell
-   Invoke-RestMethod "http://localhost:5000/auth/me" -Headers @{ "x-grace-user-id" = "dev-scott" }
+   Invoke-RestMethod "http://localhost:5000/authenticate/me" -Headers @{ "x-grace-user-id" = "dev-scott" }
    ```
 
    bash / zsh:
 
    ```bash
-   curl -H "x-grace-user-id: dev-scott" "http://localhost:5000/auth/me"
+   curl -H "x-grace-user-id: dev-scott" "http://localhost:5000/authenticate/me"
    ```
 
 On first activation (with no existing assignments), Grace will seed `SystemAdmin` for `dev-scott`.
@@ -221,8 +221,9 @@ pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -Sk
 ```
 
 `-SkipAuthProbe` is required for the true zero-OIDC bootstrap path because the default auth probe checks
-`/auth/oidc/config` before TestAuth PAT creation. Omit `-SkipAuthProbe` when OIDC/MSA settings are configured and you
-want the startup helper to verify both `/auth/oidc/config` and `/auth/me` before creating the PAT.
+`/authenticate/oidc/config` before TestAuth PAT creation. Omit `-SkipAuthProbe` when OIDC/MSA settings are configured
+and you want the startup helper to verify both `/authenticate/oidc/config` and `/authenticate/me` before creating the
+PAT.
 
 If OIDC/MSA is configured instead, use the interactive CLI path:
 
@@ -372,6 +373,10 @@ unclear.
 
 ### Primary CLI commands
 
+The canonical command groups are `grace authenticate` and `grace authorize`. The CLI also accepts short aliases:
+`grace authn` for authentication commands, `grace authz` for authorization commands, and root `grace login` /
+`grace logout` aliases for the common interactive sign-in and sign-out flows.
+
 * `grace authenticate login [--auth pkce|device]`
   Interactive login to Auth0; stores access/refresh tokens in the OS secure store. If `--auth` is not
   specified, the CLI attempts PKCE and falls back to Device Code.
@@ -384,6 +389,13 @@ unclear.
 
 * `grace authenticate logout`
   Clears the cached interactive token from the secure store.
+
+Equivalent aliases:
+
+* `grace authn status`
+* `grace authn whoami`
+* `grace login`
+* `grace logout`
 
 * `grace doctor --check Authentication`
   Produces a read-only diagnostic report for local authentication environment checks. Doctor parses
@@ -508,6 +520,8 @@ Primary CLI commands for authorization management:
 * `grace authorize check ...`
   Asks the server “would this principal be allowed to do operation X on resource Y?”
 
+Equivalent short forms use the `authz` alias, for example `grace authz check ...`.
+
 > For detailed role IDs and operations, use `grace authorize list-roles` and consult the authorization types
 > in `Grace.Types.Authorization`.
 
@@ -555,7 +569,7 @@ These variables enable Auth0 JWT authentication on the server.
 
 Recommended (for CLI auto-config):
 
-* `grace__auth__oidc__cli_client_id` (optional for server auth; required for `/auth/oidc/config`)
+* `grace__auth__oidc__cli_client_id` (optional for server auth; required for `/authenticate/oidc/config`)
   **No default.**
   Source: Auth0 Native app Client ID.
 
@@ -582,7 +596,7 @@ If you set only:
 
 …then the CLI can fetch the OIDC configuration automatically by calling:
 
-* `GET /auth/oidc/config` — Returns the server’s OIDC settings needed for interactive login.
+* `GET /authenticate/oidc/config` — Returns the server’s OIDC settings needed for interactive login.
 
 This works **only if** the server is configured with OIDC and has the values needed to publish them (see
 server env vars below).
@@ -615,7 +629,7 @@ server env vars below).
 
 ##### Server-side requirements for auto-configuration
 
-For `GET /auth/oidc/config` to return useful values, the server must be configured with:
+For `GET /authenticate/oidc/config` to return useful values, the server must be configured with:
 
 * `grace__auth__oidc__authority` — `https://<tenant-domain>/`
 * `grace__auth__oidc__audience` — Auth0 API Identifier
@@ -629,7 +643,7 @@ supply the client ID locally (see Advanced).
 #### Advanced: set OIDC settings on the client
 
 If you cannot use server auto-configuration (for example, you are testing against an endpoint that does
-not expose `/auth/oidc/config`), you can configure the CLI directly via environment variables.
+not expose `/authenticate/oidc/config`), you can configure the CLI directly via environment variables.
 
 ##### Required
 

--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -166,7 +166,7 @@ The v1 catalog contains 27 check IDs:
 | `server.connectivity` | Server | No | No | Reserved compatibility catalog entry. |
 | `server.healthz.reachable` | Server | No | No | Probes `/healthz` with a short timeout. |
 | `server.lifecycle.headers` | Server | No | No | Surfaces Grace SDK lifecycle response headers from `/healthz`. |
-| `server.auth-principal.available` | Server | No | No | Probes `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present. |
+| `server.auth-principal.available` | Server | No | No | Probes `/authenticate/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present. |
 
 ## Working Tree Scan
 
@@ -196,7 +196,8 @@ Doctor can help explain local authentication setup without exposing secrets:
 - `GRACE_TOKEN_FILE` is reported as unsupported; set `GRACE_TOKEN` instead.
 - OIDC M2M and CLI environment completeness is checked without token requests, browser/device-code flow, refresh,
   secure-store reads, or provider validation.
-- `server.auth-principal.available` calls `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present.
+- `server.auth-principal.available` calls `/authenticate/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is
+  present.
 
 Do not paste doctor JSON into public places without reviewing paths and environment names. The report is designed to
 avoid raw secrets, but summaries may include local file paths or configured server URIs.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -19,7 +19,7 @@ The contract version is `cli-json-v1`. The charter is recorded in
 PowerShell:
 
 ```powershell
-grace --output Json auth logout
+grace --output Json authenticate logout
 grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
@@ -29,7 +29,7 @@ grace --output Json doctor --select Status
 bash / zsh:
 
 ```bash
-grace --output Json auth logout
+grace --output Json authenticate logout
 grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
@@ -80,11 +80,11 @@ An error emits a `GraceError` document:
   "Command": {
     "Id": "authenticate.logout",
     "Path": [
-      "auth",
+      "authenticate",
       "logout"
     ],
     "GroupPath": [
-      "auth"
+      "authenticate"
     ],
     "Name": "logout"
   },

--- a/skills/grace/references/public-surfaces.md
+++ b/skills/grace/references/public-surfaces.md
@@ -56,8 +56,8 @@ Rules:
 
 Current high-signal command groups:
 
-- `grace auth` for login, status, whoami, PAT create/list/revoke/status.
-- `grace access` for role assignments and path permissions.
+- `grace authenticate` with alias `authn` for login, status, whoami, PAT create/list/revoke/status.
+- `grace authorize` with alias `authz` for role assignments and path permissions.
 - `grace workitem` with aliases `work`, `work-item`, and `wi`.
 - `grace review` for candidate review operations and review report output.
 - `grace candidate` for candidate-first reviewer projections.

--- a/skills/grace/references/security-and-auth.md
+++ b/skills/grace/references/security-and-auth.md
@@ -38,9 +38,9 @@ security-sensitive logging, or review of public access boundaries.
 
 ## Authentication
 
-- PATs use the `GracePat` auth scheme and `/auth/token/*` endpoints.
+- PATs use the `GracePat` auth scheme and `/authenticate/token/*` endpoints.
 - `GRACE_TOKEN` accepts Grace PATs only.
-- OIDC configuration is exposed through `/auth/oidc/config`.
+- OIDC configuration is exposed through `/authenticate/oidc/config`.
 - Auth0/OIDC settings use `grace__auth__oidc__*` environment keys.
 - TestAuth is controlled through local/test configuration; verify `GRACE_TESTING=1` before assuming it is available.
 - Local token files are disabled in the CLI. Do not re-enable local token persistence without a current product decision.


### PR DESCRIPTION
## Summary

- Updates public docs and Grace skill references to the final `authenticate`/`authn` and `authorize`/`authz` command surface.
- Documents root aliases `grace login` and `grace logout`.
- Updates authentication route examples from `/auth/*` to `/authenticate/*` and authorization static route references to `/authorize/*`.
- Updates machine-readable CLI examples for the renamed command IDs.
- Refreshes `_endpoint_stub.txt` so the tracked endpoint stub reflects the current authn/authz routes and policies.

## Validation

- `npx --yes markdownlint-cli2 "README.md" "docs/**/*.md" "src/docs/**/*.md" "skills/grace/**/*.md"`: failed on 68 pre-existing unrelated Markdown issues in older docs; none were in touched files.
- `npx --yes markdownlint-cli2 "README.md" "docs/Authentication.md" "docs/Grace doctor.md" "docs/Machine-readable CLI output.md" "skills/grace/references/public-surfaces.md" "skills/grace/references/security-and-auth.md"`: passed, 0 errors.
- Static stale-surface search for `grace auth`, `grace access`, `/auth/`, `/access/`, `auth.logout`, and `access.check`: completed; only intentional/source-level exceptions remain.
- `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending`: failed in the generated-client matrix proof outside this docs-only patch. The failure was `acceptedTier` expected `raw-openapi-generator-behind-facades`, actual `none`; Rust expected accepted with guardrails but was rejected after probe failure; Rust generated client `cargo check` exited `101`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- Release CLI help smoke checks passed for `grace authenticate --help`, `grace authn --help`, `grace login --help`, `grace logout --help`, `grace authorize --help`, and `grace authz --help`.
- `git diff --check`: passed.
- GitHub Actions `full`: passed on head `994319dabca8278c90fc04fa0f7ba864aebbd827`.

## Stale-Surface Exceptions

- `docs/Validation coverage final audit.md`: historical phrase `webhook/access/operational`, not a current `grace access` command or `/access/` route.
- `src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs`: intentional negative test asserting `/auth/` and `/access/` legacy route prefixes do not remain in the endpoint manifest.
- Source member/type names such as `Access.CheckPermission`, `CheckPermissionParameters`, and `Auth.Logout`: implementation identifiers, not stale public command IDs or route strings.

## Review Status

- First-pass worker self-review completed over the final diff.
- Codex Code Review Bot gave a thumbs-up on head `994319dabca8278c90fc04fa0f7ba864aebbd827`.
- No review threads were opened.
- No runtime implementation files were changed.
- No issue-owned path expansion was needed.

## Residual Risk

- Broad MarkdownLint and OpenAPI generated-client proof still have unrelated/pre-existing failures. The touched Markdown files are lint-clean and `validate -Fast` passed.

Related to #418
Part of #414
