### PR TITLE
Rename auth access surface to authenticate authorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The first-time steps below use **local emulators** and **test authentication** (
 Once you have `GRACE_SERVER_URI` and `GRACE_TOKEN` set, run:
 
 ```powershell
-grace auth whoami
+grace authenticate whoami
 ```
 
 For a read-only diagnostic report that checks local configuration, authentication environment, local state, and

--- a/_endpoint_stub.txt
+++ b/_endpoint_stub.txt
@@ -1,22 +1,23 @@
     endpoint "GET" "/" Authenticated
-    endpoint "POST" "/access/checkPermission" Authenticated
-    endpoint "POST" "/access/grantRole" Authenticated
-    endpoint "POST" "/access/listPathPermissions" Authenticated
-    endpoint "POST" "/access/listRoleAssignments" Authenticated
-    endpoint "GET" "/access/listRoles" Authenticated
-    endpoint "POST" "/access/removePathPermission" Authenticated
-    endpoint "POST" "/access/revokeRole" Authenticated
-    endpoint "POST" "/access/upsertPathPermission" Authenticated
+    endpoint "POST" "/authorize/check-permission" Authenticated
+    endpoint "POST" "/authorize/grant-role" (Authorized(SystemAdmin, System))
+    endpoint "POST" "/authorize/list-path-permissions" (Authorized(RepositoryAdmin, Repository))
+    endpoint "POST" "/authorize/list-role-assignments" (Authorized(SystemAdmin, System))
+    endpoint "GET" "/authorize/list-roles" Authenticated
+    endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
+    endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+    endpoint "POST" "/authorize/show" Authenticated
+    endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
     endpoint "POST" "/admin/deleteAllFromCosmosDB" Authenticated
     endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" Authenticated
-    endpoint "GET" "/auth/login" Authenticated
-    endpoint "GET" "/auth/login/%s" Authenticated
-    endpoint "GET" "/auth/logout" Authenticated
-    endpoint "GET" "/auth/me" Authenticated
-    endpoint "GET" "/auth/oidc/config" Authenticated
-    endpoint "POST" "/auth/token/create" Authenticated
-    endpoint "POST" "/auth/token/list" Authenticated
-    endpoint "POST" "/auth/token/revoke" Authenticated
+    endpoint "GET" "/authenticate/login" AllowAnonymous
+    endpoint "GET" "/authenticate/login/%s" AllowAnonymous
+    endpoint "GET" "/authenticate/logout" Authenticated
+    endpoint "GET" "/authenticate/me" Authenticated
+    endpoint "GET" "/authenticate/oidc/config" AllowAnonymous
+    endpoint "POST" "/authenticate/token/create" Authenticated
+    endpoint "POST" "/authenticate/token/list" Authenticated
+    endpoint "POST" "/authenticate/token/revoke" Authenticated
     endpoint "POST" "/branch/assign" Authenticated
     endpoint "POST" "/branch/checkpoint" Authenticated
     endpoint "POST" "/branch/commit" Authenticated

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -116,7 +116,11 @@ Approval-specific role IDs:
 
 | Scope | Role ID | Allows |
 | ----- | ------- | ------ |
-| Repository or branch | `ApprovalResponder` | Read and respond to approval requests |
+| Repository | `RepositoryApprovalResponder` | Read and respond to repository approval requests |
+| Branch | `BranchApprovalResponder` | Read and respond to branch approval requests |
+
+`role:ApprovalResponder` remains a legacy approval selector compatibility alias. Do not use `ApprovalResponder` as a
+grantable role ID.
 
 ### Scope creation and creator-admin grants
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -36,8 +36,8 @@ export GRACE_SERVER_URI="http://localhost:5000"
 
 1. **Login via the CLI**:
 
-   * `grace auth login` — Interactive login (tries PKCE first, then falls back to Device Code).
-   * `grace auth whoami` — Verifies your identity against the running server.
+   * `grace authenticate login` — Interactive login (tries PKCE first, then falls back to Device Code).
+   * `grace authenticate whoami` — Verifies your identity against the running server.
 
 ---
 
@@ -82,7 +82,7 @@ export grace__authz__bootstrap__system_admin_users="auth0|abc123"
 ## Authorization roles and creation boundaries
 
 Authentication identifies the caller. Authorization decides whether that caller can act at a system, owner,
-organization, repository, branch, or path scope. Use `grace access list-roles` for the live role catalog, and use the
+organization, repository, branch, or path scope. Use `grace authorize list-roles` for the live role catalog, and use the
 full role IDs shown here when granting roles.
 
 ### System support roles
@@ -227,9 +227,9 @@ PowerShell:
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 bash / zsh:
@@ -237,13 +237,13 @@ bash / zsh:
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
 unset GRACE_TOKEN
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
-`grace auth whoami` proves authentication. `grace auth token create` requires an authenticated principal that maps to a
-Grace User; it does not require an RBAC role before token creation.
+`grace authenticate whoami` proves authentication. `grace authenticate token create` requires an authenticated
+principal that maps to a Grace User; it does not require an RBAC role before token creation.
 
 MSA/OIDC authentication alone does not authorize first-time scope creation or other protected operations. For a fresh
 local/debug environment, seed the first admin through `grace__authz__bootstrap__system_admin_users` or use an existing
@@ -363,22 +363,22 @@ The CLI can authenticate in multiple ways. The first matching mode “wins”:
 
 Because `GRACE_TOKEN` wins before M2M and interactive login, a stale or revoked PAT can mask a fresh interactive
 OIDC/MSA login. Unset `GRACE_TOKEN` when you want the CLI to use cached interactive credentials, and use
-`grace auth token status --output Verbose` or `grace doctor --check Authentication` when the active auth source is
+`grace authenticate token status --output Verbose` or `grace doctor --check Authentication` when the active auth source
 unclear.
 
 ### Primary CLI commands
 
-* `grace auth login [--auth pkce|device]`
+* `grace authenticate login [--auth pkce|device]`
   Interactive login to Auth0; stores access/refresh tokens in the OS secure store. If `--auth` is not
   specified, the CLI attempts PKCE and falls back to Device Code.
 
-* `grace auth status`
+* `grace authenticate status`
   Shows whether the CLI currently has usable credentials (PAT, M2M, or interactive).
 
-* `grace auth whoami`
+* `grace authenticate whoami`
   Calls the server and prints the authenticated identity information.
 
-* `grace auth logout`
+* `grace authenticate logout`
   Clears the cached interactive token from the secure store.
 
 * `grace doctor --check Authentication`
@@ -409,13 +409,13 @@ only through Grace's normal authorization checks.
 
 #### CLI (recommended)
 
-* `grace auth token create --name "<token-name>"`
+* `grace authenticate token create --name "<token-name>"`
   Creates a PAT with the server-default lifetime.
 
-* `grace auth token create --name "<token-name>" --expires-in 30d`
+* `grace authenticate token create --name "<token-name>" --expires-in 30d`
   Creates a PAT that expires after the given duration. Supported suffixes: `s`, `m`, `h`, `d`.
 
-* `grace auth token create --name "<token-name>" --no-expiry`
+* `grace authenticate token create --name "<token-name>" --no-expiry`
   Creates a non-expiring PAT **only if** the server allows it.
 
 #### Notes
@@ -447,16 +447,16 @@ If you are calling the HTTP API directly, use the standard Authorization header:
 
 ### Listing and revoking PATs
 
-* `grace auth token list`
+* `grace authenticate token list`
   Lists active PATs for the current principal.
 
-* `grace auth token list --all`
+* `grace authenticate token list --all`
   Lists active + expired + revoked tokens.
 
-* `grace auth token revoke <token-id>`
+* `grace authenticate token revoke <token-id>`
   Revokes a PAT by token ID (GUID). Revoked tokens are no longer accepted.
 
-* `grace auth token status`
+* `grace authenticate token status`
   Shows whether the current `GRACE_TOKEN` is present and parseable.
 
 ### How PAT “permissions” work in Grace
@@ -483,28 +483,28 @@ granting/revoking roles and path permissions for that principal.
 
 Primary CLI commands for authorization management:
 
-* `grace access grant-role ...`
+* `grace authorize grant-role ...`
   Grants a role to a principal at a scope (Owner/Organization/Repository/Branch/System).
 
-* `grace access revoke-role ...`
+* `grace authorize revoke-role ...`
   Revokes a role from a principal at a scope.
 
-* `grace access list-role-assignments ...`
+* `grace authorize list-role-assignments ...`
   Lists role assignments at a scope (optionally filtered by principal).
 
-* `grace access upsert-path-permission ...`
+* `grace authorize upsert-path-permission ...`
   Sets or updates a path permission entry in a repository.
 
-* `grace access remove-path-permission ...`
+* `grace authorize remove-path-permission ...`
   Removes a path permission entry.
 
-* `grace access list-path-permissions ...`
+* `grace authorize list-path-permissions ...`
   Lists path permissions, optionally scoped to a path prefix.
 
-* `grace access check ...`
+* `grace authorize check ...`
   Asks the server “would this principal be allowed to do operation X on resource Y?”
 
-> For detailed role IDs and operations, use `grace access list-roles` and consult the authorization types
+> For detailed role IDs and operations, use `grace authorize list-roles` and consult the authorization types
 > in `Grace.Types.Authorization`.
 
 ---
@@ -603,11 +603,11 @@ server env vars below).
 
 1. Login:
 
-   * `grace auth login` — Interactive Auth0 login (tries PKCE, then device flow).
+   * `grace authenticate login` — Interactive Auth0 login (tries PKCE, then device flow).
 
 1. Verify:
 
-   * `grace auth whoami` — Calls the server and prints the authenticated identity.
+   * `grace authenticate whoami` — Calls the server and prints the authenticated identity.
 
 ##### Server-side requirements for auto-configuration
 
@@ -674,11 +674,11 @@ not expose `/auth/oidc/config`), you can configure the CLI directly via environm
 
 1. Login:
 
-   * `grace auth login` — Interactive Auth0 login (tries PKCE, then device flow).
+   * `grace authenticate login` — Interactive Auth0 login (tries PKCE, then device flow).
 
 1. Verify:
 
-   * `grace auth whoami` — Calls the server and prints the authenticated identity.
+   * `grace authenticate whoami` — Calls the server and prints the authenticated identity.
 
 ---
 
@@ -732,7 +732,7 @@ export grace__auth__oidc__m2m_scopes="read:foo write:bar"
 
 * `GRACE_TOKEN` (optional)
   **No default.**
-  Source: output from `grace auth token create`.
+  Source: output from `grace authenticate token create`.
   Must be a Grace PAT (prefix `grace_pat_v1_`). If set, this overrides interactive login and M2M. Unset stale or
   revoked values before troubleshooting interactive OIDC/MSA login.
 
@@ -823,7 +823,7 @@ You can create Auth0 resources non-interactively.
 
 ## Troubleshooting
 
-### `grace auth login` fails and mentions refresh tokens
+### `grace authenticate login` fails and mentions refresh tokens
 
 Ensure:
 
@@ -846,16 +846,16 @@ Quick checks:
 PowerShell:
 
 ```powershell
-grace auth status --output Verbose
-grace auth token status --output Verbose
+grace authenticate status --output Verbose
+grace authenticate token status --output Verbose
 grace status --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
-grace auth status --output Verbose
-grace auth token status --output Verbose
+grace authenticate status --output Verbose
+grace authenticate token status --output Verbose
 grace status --output Verbose
 ```
 
@@ -864,17 +864,17 @@ If `GRACE_TOKEN` is false and interactive token is false, authenticate first:
 PowerShell:
 
 ```powershell
-grace auth login --auth device
+grace authenticate login --auth device
 # or
-grace auth login --auth pkce
+grace authenticate login --auth pkce
 ```
 
 bash / zsh:
 
 ```bash
-grace auth login --auth device
+grace authenticate login --auth device
 # or
-grace auth login --auth pkce
+grace authenticate login --auth pkce
 ```
 
 If you are using a PAT:
@@ -883,14 +883,14 @@ PowerShell:
 
 ```powershell
 $env:GRACE_TOKEN="grace_pat_v1_..."
-grace auth token status --output Verbose
+grace authenticate token status --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
 export GRACE_TOKEN="grace_pat_v1_..."
-grace auth token status --output Verbose
+grace authenticate token status --output Verbose
 ```
 
 If you are trying to use interactive OIDC/MSA login, make sure a stale PAT is not taking precedence:
@@ -899,16 +899,16 @@ PowerShell:
 
 ```powershell
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth status --output Verbose
-grace auth whoami --output Verbose
+grace authenticate status --output Verbose
+grace authenticate whoami --output Verbose
 ```
 
 bash / zsh:
 
 ```bash
 unset GRACE_TOKEN
-grace auth status --output Verbose
-grace auth whoami --output Verbose
+grace authenticate status --output Verbose
+grace authenticate whoami --output Verbose
 ```
 
 Why logs may look empty:
@@ -928,11 +928,11 @@ Also note:
 * During development, TestAuth may be available. See this file for setup details:
   `docs/Authentication.md` -> **Development without Auth0 (TestAuth)**.
 
-### You can see `SystemAdmin` in Cosmos, but `grace access check` says denied
+### You can see `SystemAdmin` in Cosmos, but `grace authorize check` says denied
 
-If `grace auth whoami` shows your expected `GraceUserId`, but:
+If `grace authenticate whoami` shows your expected `GraceUserId`, but:
 
-* `grace access check --operation SystemAdmin --resource system --output Json`
+* `grace authorize check --operation SystemAdmin --resource system --output Json`
   returns `Denied: missing permission SystemAdmin.`,
 
 and you can also see a `SystemAdmin` assignment document in Cosmos, the most common cause is a **runtime context
@@ -955,15 +955,15 @@ What to verify first:
 PowerShell:
 
 ```powershell
-grace auth whoami --output Json
-grace access check --operation SystemAdmin --resource system --output Json
+grace authenticate whoami --output Json
+grace authorize check --operation SystemAdmin --resource system --output Json
 ```
 
 bash / zsh:
 
 ```bash
-grace auth whoami --output Json
-grace access check --operation SystemAdmin --resource system --output Json
+grace authenticate whoami --output Json
+grace authorize check --operation SystemAdmin --resource system --output Json
 ```
 
 Then verify server configuration:
@@ -978,7 +978,7 @@ Recommended recovery steps:
 2. Re-run the two checks above.
 3. Re-open Cosmos and confirm the `system` AccessControl actor document for the active service context
    contains your user principal.
-4. If needed, use a current `SystemAdmin` principal to grant your role again via `grace access grant-role`.
+4. If needed, use a current `SystemAdmin` principal to grant your role again via `grace authorize grant-role`.
 
 ### Headless environments / CI
 
@@ -986,4 +986,4 @@ Use:
 
 * M2M auth (client credentials env vars), or
 * PATs (`GRACE_TOKEN`), or
-* `grace auth login --auth device` if interactive login is still acceptable.
+* `grace authenticate login --auth device` if interactive login is still acceptable.

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -63,7 +63,7 @@ Set one or both of these environment variables (semicolon-delimited list):
 
 * The values must be **principal IDs**, not emails or display names.
 * For Auth0/OIDC, the user principal ID is taken from the `sub` claim (exposed as `grace_user_id`).
-* You can confirm the user ID with `GET /auth/me` (`GraceUserId` in the response).
+* You can confirm the user ID with `GET /authenticate/me` (`GraceUserId` in the response).
 
 PowerShell:
 
@@ -194,13 +194,13 @@ When enabled, Grace authenticates requests using headers:
    PowerShell:
 
    ```powershell
-   Invoke-RestMethod "http://localhost:5000/auth/me" -Headers @{ "x-grace-user-id" = "dev-scott" }
+   Invoke-RestMethod "http://localhost:5000/authenticate/me" -Headers @{ "x-grace-user-id" = "dev-scott" }
    ```
 
    bash / zsh:
 
    ```bash
-   curl -H "x-grace-user-id: dev-scott" "http://localhost:5000/auth/me"
+   curl -H "x-grace-user-id: dev-scott" "http://localhost:5000/authenticate/me"
    ```
 
 On first activation (with no existing assignments), Grace will seed `SystemAdmin` for `dev-scott`.
@@ -221,8 +221,9 @@ pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -Sk
 ```
 
 `-SkipAuthProbe` is required for the true zero-OIDC bootstrap path because the default auth probe checks
-`/auth/oidc/config` before TestAuth PAT creation. Omit `-SkipAuthProbe` when OIDC/MSA settings are configured and you
-want the startup helper to verify both `/auth/oidc/config` and `/auth/me` before creating the PAT.
+`/authenticate/oidc/config` before TestAuth PAT creation. Omit `-SkipAuthProbe` when OIDC/MSA settings are configured
+and you want the startup helper to verify both `/authenticate/oidc/config` and `/authenticate/me` before creating the
+PAT.
 
 If OIDC/MSA is configured instead, use the interactive CLI path:
 
@@ -372,6 +373,10 @@ unclear.
 
 ### Primary CLI commands
 
+The canonical command groups are `grace authenticate` and `grace authorize`. The CLI also accepts short aliases:
+`grace authn` for authentication commands, `grace authz` for authorization commands, and root `grace login` /
+`grace logout` aliases for the common interactive sign-in and sign-out flows.
+
 * `grace authenticate login [--auth pkce|device]`
   Interactive login to Auth0; stores access/refresh tokens in the OS secure store. If `--auth` is not
   specified, the CLI attempts PKCE and falls back to Device Code.
@@ -384,6 +389,13 @@ unclear.
 
 * `grace authenticate logout`
   Clears the cached interactive token from the secure store.
+
+Equivalent aliases:
+
+* `grace authn status`
+* `grace authn whoami`
+* `grace login`
+* `grace logout`
 
 * `grace doctor --check Authentication`
   Produces a read-only diagnostic report for local authentication environment checks. Doctor parses
@@ -508,6 +520,8 @@ Primary CLI commands for authorization management:
 * `grace authorize check ...`
   Asks the server “would this principal be allowed to do operation X on resource Y?”
 
+Equivalent short forms use the `authz` alias, for example `grace authz check ...`.
+
 > For detailed role IDs and operations, use `grace authorize list-roles` and consult the authorization types
 > in `Grace.Types.Authorization`.
 
@@ -555,7 +569,7 @@ These variables enable Auth0 JWT authentication on the server.
 
 Recommended (for CLI auto-config):
 
-* `grace__auth__oidc__cli_client_id` (optional for server auth; required for `/auth/oidc/config`)
+* `grace__auth__oidc__cli_client_id` (optional for server auth; required for `/authenticate/oidc/config`)
   **No default.**
   Source: Auth0 Native app Client ID.
 
@@ -582,7 +596,7 @@ If you set only:
 
 …then the CLI can fetch the OIDC configuration automatically by calling:
 
-* `GET /auth/oidc/config` — Returns the server’s OIDC settings needed for interactive login.
+* `GET /authenticate/oidc/config` — Returns the server’s OIDC settings needed for interactive login.
 
 This works **only if** the server is configured with OIDC and has the values needed to publish them (see
 server env vars below).
@@ -615,7 +629,7 @@ server env vars below).
 
 ##### Server-side requirements for auto-configuration
 
-For `GET /auth/oidc/config` to return useful values, the server must be configured with:
+For `GET /authenticate/oidc/config` to return useful values, the server must be configured with:
 
 * `grace__auth__oidc__authority` — `https://<tenant-domain>/`
 * `grace__auth__oidc__audience` — Auth0 API Identifier
@@ -629,7 +643,7 @@ supply the client ID locally (see Advanced).
 #### Advanced: set OIDC settings on the client
 
 If you cannot use server auto-configuration (for example, you are testing against an endpoint that does
-not expose `/auth/oidc/config`), you can configure the CLI directly via environment variables.
+not expose `/authenticate/oidc/config`), you can configure the CLI directly via environment variables.
 
 ##### Required
 

--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -166,7 +166,7 @@ The v1 catalog contains 27 check IDs:
 | `server.connectivity` | Server | No | No | Reserved compatibility catalog entry. |
 | `server.healthz.reachable` | Server | No | No | Probes `/healthz` with a short timeout. |
 | `server.lifecycle.headers` | Server | No | No | Surfaces Grace SDK lifecycle response headers from `/healthz`. |
-| `server.auth-principal.available` | Server | No | No | Probes `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present. |
+| `server.auth-principal.available` | Server | No | No | Probes `/authenticate/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present. |
 
 ## Working Tree Scan
 
@@ -196,7 +196,8 @@ Doctor can help explain local authentication setup without exposing secrets:
 - `GRACE_TOKEN_FILE` is reported as unsupported; set `GRACE_TOKEN` instead.
 - OIDC M2M and CLI environment completeness is checked without token requests, browser/device-code flow, refresh,
   secure-store reads, or provider validation.
-- `server.auth-principal.available` calls `/auth/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is present.
+- `server.auth-principal.available` calls `/authenticate/me` only when a valid non-refreshing `GRACE_TOKEN` PAT is
+  present.
 
 Do not paste doctor JSON into public places without reviewing paths and environment names. The report is designed to
 avoid raw secrets, but summaries may include local file paths or configured server URIs.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -20,8 +20,8 @@ PowerShell:
 
 ```powershell
 grace --output Json auth logout
-grace auth logout --schema
-grace auth logout --examples
+grace authenticate logout --schema
+grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
 ```
@@ -30,8 +30,8 @@ bash / zsh:
 
 ```bash
 grace --output Json auth logout
-grace auth logout --schema
-grace auth logout --examples
+grace authenticate logout --schema
+grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
 ```
@@ -78,7 +78,7 @@ An error emits a `GraceError` document:
   "Kind": "schema",
   "ContractVersion": "cli-json-v1",
   "Command": {
-    "Id": "auth.logout",
+    "Id": "authenticate.logout",
     "Path": [
       "auth",
       "logout"

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -129,8 +129,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `203`
-- JSON-ready routed commands: `182`
+- Total leaf commands: `205`
+- JSON-ready routed commands: `184`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -19,7 +19,7 @@ The contract version is `cli-json-v1`. The charter is recorded in
 PowerShell:
 
 ```powershell
-grace --output Json auth logout
+grace --output Json authenticate logout
 grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
@@ -29,7 +29,7 @@ grace --output Json doctor --select Status
 bash / zsh:
 
 ```bash
-grace --output Json auth logout
+grace --output Json authenticate logout
 grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
@@ -80,11 +80,11 @@ An error emits a `GraceError` document:
   "Command": {
     "Id": "authenticate.logout",
     "Path": [
-      "auth",
+      "authenticate",
       "logout"
     ],
     "GroupPath": [
-      "auth"
+      "authenticate"
     ],
     "Name": "logout"
   },

--- a/scripts/start-debuglocal.ps1
+++ b/scripts/start-debuglocal.ps1
@@ -281,8 +281,8 @@ function Invoke-AuthProbe(
 ) {
   Write-Step "Running auth readiness probe." "Green"
 
-  $oidcConfigUri = "$GraceServerUri/auth/oidc/config"
-  $authMeUri = "$GraceServerUri/auth/me"
+  $oidcConfigUri = "$GraceServerUri/authenticate/oidc/config"
+  $authMeUri = "$GraceServerUri/authenticate/me"
   $headers = @{ "x-grace-user-id" = $BootstrapUserId }
 
   Write-Detail "Probe 1/2: GET $oidcConfigUri"
@@ -292,7 +292,7 @@ function Invoke-AuthProbe(
     $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "auth probe" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
     Set-LastFailureInfo -FailureInfo $failure
     $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
-    throw "Auth probe failed at /auth/oidc/config (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
+    throw "Auth probe failed at /authenticate/oidc/config (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
   }
 
   Write-Detail "Probe 2/2: GET $authMeUri (x-grace-user-id=$BootstrapUserId)"
@@ -302,7 +302,7 @@ function Invoke-AuthProbe(
     $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "auth probe" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
     Set-LastFailureInfo -FailureInfo $failure
     $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
-    throw "Auth probe failed at /auth/me (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
+    throw "Auth probe failed at /authenticate/me (classification=$($failure.Classification), status=$statusSegment). $($failure.Hint)"
   }
 
   Write-Detail "Auth readiness probe passed." "Green"
@@ -315,7 +315,7 @@ function Invoke-TokenBootstrapWithRetry(
   [int] $MaxAttempts,
   [int] $InitialBackoffSeconds
 ) {
-  $tokenUri = "$GraceServerUri/auth/token/create"
+  $tokenUri = "$GraceServerUri/authenticate/token/create"
   $headers = @{ "x-grace-user-id" = $BootstrapUserId }
   $safeMaxAttempts = [Math]::Max($MaxAttempts, 1)
   $safeInitialBackoff = [Math]::Max($InitialBackoffSeconds, 1)

--- a/skills/grace/references/public-surfaces.md
+++ b/skills/grace/references/public-surfaces.md
@@ -56,8 +56,8 @@ Rules:
 
 Current high-signal command groups:
 
-- `grace auth` for login, status, whoami, PAT create/list/revoke/status.
-- `grace access` for role assignments and path permissions.
+- `grace authenticate` with alias `authn` for login, status, whoami, PAT create/list/revoke/status.
+- `grace authorize` with alias `authz` for role assignments and path permissions.
 - `grace workitem` with aliases `work`, `work-item`, and `wi`.
 - `grace review` for candidate review operations and review report output.
 - `grace candidate` for candidate-first reviewer projections.

--- a/skills/grace/references/security-and-auth.md
+++ b/skills/grace/references/security-and-auth.md
@@ -38,9 +38,9 @@ security-sensitive logging, or review of public access boundaries.
 
 ## Authentication
 
-- PATs use the `GracePat` auth scheme and `/auth/token/*` endpoints.
+- PATs use the `GracePat` auth scheme and `/authenticate/token/*` endpoints.
 - `GRACE_TOKEN` accepts Grace PATs only.
-- OIDC configuration is exposed through `/auth/oidc/config`.
+- OIDC configuration is exposed through `/authenticate/oidc/config`.
 - Auth0/OIDC settings use `grace__auth__oidc__*` environment keys.
 - TestAuth is controlled through local/test configuration; verify `GRACE_TESTING=1` before assuming it is available.
 - Local token files are disabled in the CLI. Do not re-enable local token persistence without a current product decision.

--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -17,6 +17,7 @@ type AuthorizationSemanticsTests() =
 
     let principal = { PrincipalType = PrincipalType.User; PrincipalId = "user-1" }
     let otherPrincipal = { PrincipalType = PrincipalType.User; PrincipalId = "user-2" }
+    let groupPrincipal = { PrincipalType = PrincipalType.Group; PrincipalId = "group-1" }
 
     let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
     let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
@@ -88,7 +89,8 @@ type AuthorizationSemanticsTests() =
                 "BranchAdmin"
                 "BranchWriter"
                 "BranchReader"
-                "ApprovalResponder"
+                "RepositoryApprovalResponder"
+                "BranchApprovalResponder"
             ]
 
         let actualRoleIds = roleCatalog |> List.map (fun role -> role.RoleId)
@@ -105,6 +107,7 @@ type AuthorizationSemanticsTests() =
                 "RepoAdmin"
                 "RepoContributor"
                 "RepoReader"
+                "ApprovalResponder"
                 "rEpOrEaDeR"
                 "oRgAdMiN"
             ]
@@ -139,6 +142,34 @@ type AuthorizationSemanticsTests() =
         Assert.That(repositoryAdmin.AllowedOperations.Contains BranchAdmin, Is.True)
 
     [<Test>]
+    member _.EveryRoleMapsToExactlyOneAssignmentScope() =
+        for role in roleCatalog do
+            Assert.That(role.AppliesTo.Count, Is.EqualTo(1), $"Role '{role.RoleId}' must map to exactly one assignment scope.")
+
+            RoleCatalog.tryGetSingleScopeKind role.RoleId
+            |> Option.isSome
+            |> fun hasScope -> Assert.That(hasScope, Is.True, $"Role '{role.RoleId}' should expose a derived assignment scope.")
+
+    [<Test>]
+    member _.SelfAssignmentQueriesUseOnlyEffectiveCallerPrincipalsAcrossScopeLadder() =
+        let resource = Resource.Repository(ownerId, organizationId, repositoryId)
+
+        let queries = Grace.Server.Access.selfAssignmentQueriesForResource [ principal; groupPrincipal; principal ] resource
+
+        let expectedScopes = scopesForResource resource
+        let actualScopes = queries |> List.map fst |> List.distinct
+        Assert.That((actualScopes = expectedScopes), Is.True)
+
+        let actualPrincipals = queries |> List.map snd |> Set.ofList
+        Assert.That((actualPrincipals = Set.ofList [ principal; groupPrincipal ]), Is.True)
+
+        queries
+        |> List.exists (fun (_, queryPrincipal) -> queryPrincipal = otherPrincipal)
+        |> fun containsOtherPrincipal -> Assert.That(containsOtherPrincipal, Is.False)
+
+        Assert.That(queries.Length, Is.EqualTo(expectedScopes.Length * 2))
+
+    [<Test>]
     member _.ApprovalOperationsUseConservativeRoleGrants() =
         let repositoryAdmin =
             roleCatalog
@@ -152,9 +183,13 @@ type AuthorizationSemanticsTests() =
             roleCatalog
             |> List.find (fun role -> role.RoleId.Equals("RepositoryContributor", StringComparison.OrdinalIgnoreCase))
 
-        let responder =
+        let repositoryResponder =
             roleCatalog
-            |> List.find (fun role -> role.RoleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase))
+            |> List.find (fun role -> role.RoleId.Equals("RepositoryApprovalResponder", StringComparison.OrdinalIgnoreCase))
+
+        let branchResponder =
+            roleCatalog
+            |> List.find (fun role -> role.RoleId.Equals("BranchApprovalResponder", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalPolicyManage, Is.True)
         Assert.That(repositoryAdmin.AllowedOperations.Contains ApprovalRequestRead, Is.True)
@@ -166,11 +201,15 @@ type AuthorizationSemanticsTests() =
         Assert.That(repositoryReader.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
         Assert.That(repositoryContributor.AllowedOperations.Contains ApprovalRequestRespond, Is.False)
 
-        Assert.That(responder.AppliesTo.Contains("repository"), Is.True)
-        Assert.That(responder.AppliesTo.Contains("branch"), Is.True)
-        Assert.That(responder.AllowedOperations.Count, Is.EqualTo(2))
-        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
-        Assert.That(responder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+        Assert.That(repositoryResponder.AppliesTo, Is.EquivalentTo([ "repository" ]))
+        Assert.That(repositoryResponder.AllowedOperations.Count, Is.EqualTo(2))
+        Assert.That(repositoryResponder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(repositoryResponder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
+
+        Assert.That(branchResponder.AppliesTo, Is.EquivalentTo([ "branch" ]))
+        Assert.That(branchResponder.AllowedOperations.Count, Is.EqualTo(2))
+        Assert.That(branchResponder.AllowedOperations.Contains ApprovalRequestRead, Is.True)
+        Assert.That(branchResponder.AllowedOperations.Contains ApprovalRequestRespond, Is.True)
 
     [<Test>]
     member _.SystemOperatorHasDescendantAdminWriteReadButNoSystemAdmin() =

--- a/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
+++ b/src/Grace.Authorization.Tests/AuthorizationSemantics.Tests.fs
@@ -116,6 +116,39 @@ type AuthorizationSemanticsTests() =
             Assert.That(RoleCatalog.tryGet roleId |> Option.isNone, Is.True, $"Old role ID '{roleId}' should not be accepted.")
 
     [<Test>]
+    member _.LegacyApprovalResponderAssignmentsGrantOnlyApprovalResponseOperations() =
+        let repositoryScope = Scope.Repository(ownerId, organizationId, repositoryId)
+        let repositoryResource = Resource.Repository(ownerId, organizationId, repositoryId)
+        let branchScope = Scope.Branch(ownerId, organizationId, repositoryId, branchId)
+        let branchResource = Resource.Branch(ownerId, organizationId, repositoryId, branchId)
+        let ownerScope = Scope.Owner ownerId
+        let ownerResource = Resource.Owner ownerId
+
+        let legacyRepositoryAssignment = createAssignment repositoryScope "ApprovalResponder"
+        let legacyBranchAssignment = createAssignment branchScope "ApprovalResponder"
+        let legacyOwnerAssignment = createAssignment ownerScope "ApprovalResponder"
+
+        let repositoryRead = checkPermission roleCatalog [ legacyRepositoryAssignment ] [] [ principal ] Set.empty ApprovalRequestRead repositoryResource
+
+        let repositoryRespond = checkPermission roleCatalog [ legacyRepositoryAssignment ] [] [ principal ] Set.empty ApprovalRequestRespond repositoryResource
+
+        let repositoryPolicyManage =
+            checkPermission roleCatalog [ legacyRepositoryAssignment ] [] [ principal ] Set.empty ApprovalPolicyManage repositoryResource
+
+        let repositoryWrite = checkPermission roleCatalog [ legacyRepositoryAssignment ] [] [ principal ] Set.empty RepositoryWrite repositoryResource
+
+        let branchRespond = checkPermission roleCatalog [ legacyBranchAssignment ] [] [ principal ] Set.empty ApprovalRequestRespond branchResource
+
+        let ownerRespond = checkPermission roleCatalog [ legacyOwnerAssignment ] [] [ principal ] Set.empty ApprovalRequestRespond ownerResource
+
+        assertAllowed repositoryRead
+        assertAllowed repositoryRespond
+        assertDenied repositoryPolicyManage
+        assertDenied repositoryWrite
+        assertAllowed branchRespond
+        assertDenied ownerRespond
+
+    [<Test>]
     member _.RoleCatalogMatrixMatchesPermissionChecks() =
         for role in roleCatalog do
             for resource in resources do

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -270,6 +270,7 @@ type EndpointAuthorizationManifestTests() =
         [
             "GET", "/authorize/list-roles"
             "POST", "/authorize/check-permission"
+            "POST", "/authorize/show"
         ]
         |> assertRoutesUseSecurity Authenticated
 

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -266,22 +266,58 @@ type EndpointAuthorizationManifestTests() =
         |> assertRoutesUseSecurity (Authorized(Operation.WebhookDeliveryRead, ResourceKind.Repository))
 
     [<Test>]
+    member _.AuthorizationRoutesUseExpectedAuthenticatedAndAdminPolicies() =
+        [
+            "GET", "/authorize/list-roles"
+            "POST", "/authorize/check-permission"
+        ]
+        |> assertRoutesUseSecurity Authenticated
+
+        [
+            "POST", "/authorize/grant-role"
+            "POST", "/authorize/list-role-assignments"
+            "POST", "/authorize/revoke-role"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.SystemAdmin, ResourceKind.System))
+
+        [
+            "POST", "/authorize/list-path-permissions"
+            "POST", "/authorize/remove-path-permission"
+            "POST", "/authorize/upsert-path-permission"
+        ]
+        |> assertRoutesUseSecurity (Authorized(Operation.RepositoryAdmin, ResourceKind.Repository))
+
+    [<Test>]
     member _.AuthRoutesUseExpectedAnonymousAndAuthenticatedPolicies() =
         [
-            "GET", "/auth/login"
-            "GET", "/auth/login/%s"
-            "GET", "/auth/oidc/config"
+            "GET", "/authenticate/login"
+            "GET", "/authenticate/login/%s"
+            "GET", "/authenticate/oidc/config"
         ]
         |> assertRoutesUseSecurity AllowAnonymous
 
         [
-            "GET", "/auth/logout"
-            "GET", "/auth/me"
-            "POST", "/auth/token/create"
-            "POST", "/auth/token/list"
-            "POST", "/auth/token/revoke"
+            "GET", "/authenticate/logout"
+            "GET", "/authenticate/me"
+            "POST", "/authenticate/token/create"
+            "POST", "/authenticate/token/list"
+            "POST", "/authenticate/token/revoke"
         ]
         |> assertRoutesUseSecurity Authenticated
+
+    [<Test>]
+    member _.AuthenticationAndAuthorizationRoutesDoNotKeepLegacyPrefixes() =
+        let legacyRoutes =
+            definitions
+            |> List.filter (fun definition ->
+                definition.Path.StartsWith("/auth/", StringComparison.Ordinal)
+                || definition.Path.StartsWith("/access/", StringComparison.Ordinal))
+
+        if not legacyRoutes.IsEmpty then
+            legacyRoutes
+            |> List.map (fun definition -> $"{definition.Method} {definition.Path}")
+            |> String.concat Environment.NewLine
+            |> fun routes -> Assert.Fail($"Legacy auth/access routes must not remain in EndpointAuthorizationManifest:{Environment.NewLine}{routes}")
 
     [<Test>]
     member _.MetricsAndManualRoutesUseExpectedPolicies() =

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -229,7 +229,7 @@ module AuthTests =
         clearOidcEnv (fun () ->
             withEnv Constants.EnvironmentVariables.GraceToken (Some token) (fun () ->
                 let exitCode, standardOut, standardError =
-                    runWithCapturedStdoutAndStderr [| "auth"
+                    runWithCapturedStdoutAndStderr [| "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -264,7 +264,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Json"
-                                                      "auth"
+                                                      "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -310,7 +310,7 @@ module AuthTests =
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
                                                   "Json"
-                                                  "auth"
+                                                  "authenticate"
                                                   "status" |]
 
             exitCode |> should equal 0
@@ -352,7 +352,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Json"
-                                                      "auth"
+                                                      "authenticate"
                                                       "status" |]
 
                 exitCode |> should equal 0
@@ -394,7 +394,7 @@ module AuthTests =
                                 let exitCode, standardOut, standardError =
                                     runWithCapturedStdoutAndStderr [| "--output"
                                                                       "Json"
-                                                                      "auth"
+                                                                      "authenticate"
                                                                       "status" |]
 
                                 exitCode |> should equal 0
@@ -567,7 +567,7 @@ module AuthTests =
                 let exitCode, standardOut, standardError =
                     runWithCapturedStdoutAndStderr [| "--output"
                                                       "Verbose"
-                                                      "auth"
+                                                      "authenticate"
                                                       "whoami" |]
 
                 exitCode |> should not' (equal 0)
@@ -592,7 +592,7 @@ module AuthTests =
                     let exitCode, standardOut, standardError =
                         runWithCapturedStdoutAndStderr [| "--output"
                                                           "Verbose"
-                                                          "auth"
+                                                          "authenticate"
                                                           "token"
                                                           "create"
                                                           "--name"

--- a/src/Grace.CLI.Tests/Auth.Tests.fs
+++ b/src/Grace.CLI.Tests/Auth.Tests.fs
@@ -572,7 +572,7 @@ module AuthTests =
 
                 exitCode |> should not' (equal 0)
                 standardOut |> should contain "401 Unauthorized"
-                standardOut |> should contain "auth/me"
+                standardOut |> should contain "authenticate/me"
 
                 standardOut
                 |> should not' (contain "JsonException")
@@ -602,7 +602,9 @@ module AuthTests =
 
                     exitCode |> should not' (equal 0)
                     standardOut |> should contain "401 Unauthorized"
-                    standardOut |> should contain "auth/token/create"
+
+                    standardOut
+                    |> should contain "authenticate/token/create"
 
                     standardOut
                     |> should not' (contain "JsonException")

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -82,6 +82,8 @@ module CommandOutputContractRegistryTests =
 
     let private argumentPlaceholder argumentName =
         match argumentName with
+        | "action" -> "read"
+        | "resource" -> "repo"
         | "query" -> "example"
         | name when name.Contains("number", StringComparison.OrdinalIgnoreCase) -> "123"
         | name when name.Contains("work", StringComparison.OrdinalIgnoreCase) -> "123"
@@ -213,16 +215,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 203
+        |> should equal 205
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 194
+        |> should equal 196
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 182
+        |> should equal 184
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -263,7 +265,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 182
+        jsonReady |> should equal 184
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -286,7 +288,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.routedEntries
             |> List.map (fun entry -> entry.Identity.CommandId)
 
-        discovered.Length |> should equal 194
+        discovered.Length |> should equal 196
 
         discovered.Length
         |> should equal (discovered |> List.distinct |> List.length)
@@ -409,7 +411,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 182
+        commonEntries.Length |> should equal 184
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -426,7 +428,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 182
+        commonEntries.Length |> should equal 184
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -587,7 +587,7 @@ module CommandOutputContractRegistryTests =
 
     [<Test>]
     let ``schema ready registry entries describe success and error envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+        let identity = CommandOutputContract.commandIdentity [ "authenticate" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -595,7 +595,8 @@ module CommandOutputContractRegistryTests =
 
             document.Kind |> should equal "schema"
 
-            document.Command.Id |> should equal "auth.logout"
+            document.Command.Id
+            |> should equal "authenticate.logout"
 
             match document.Schema with
             | Some schema ->
@@ -655,7 +656,7 @@ module CommandOutputContractRegistryTests =
                     .GetString()
                 |> should equal "string"
             | None -> Assert.Fail("Schema introspection should include a schema document.")
-        | None -> Assert.Fail("auth.logout should have a registry entry.")
+        | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
     [<Test>]
     let ``maintenance registry entries expose schema ready local dto metadata`` () =
@@ -781,7 +782,7 @@ module CommandOutputContractRegistryTests =
             [
                 CommandOutputContract.commandIdentity [ "repository" ] "get", "RepositoryDto metadata is incomplete"
                 CommandOutputContract.commandIdentity [ "workitem" ] "show", "WorkItemDto metadata is incomplete"
-                CommandOutputContract.commandIdentity [ "access" ] "check", "PermissionCheckResult metadata is incomplete"
+                CommandOutputContract.commandIdentity [ "authorize" ] "check", "PermissionCheckResult metadata is incomplete"
             ]
 
         for identity, expectedNote in cases do
@@ -810,7 +811,7 @@ module CommandOutputContractRegistryTests =
 
     [<Test>]
     let ``examples for schema ready commands parse as Grace envelopes`` () =
-        let identity = CommandOutputContract.commandIdentity [ "auth" ] "logout"
+        let identity = CommandOutputContract.commandIdentity [ "authenticate" ] "logout"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
@@ -848,7 +849,7 @@ module CommandOutputContractRegistryTests =
 
             errorRoot.GetProperty("CorrelationId").GetString()
             |> should equal "correlation-id"
-        | None -> Assert.Fail("auth.logout should have a registry entry.")
+        | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
     [<Test>]
     let ``all registry schema and example documents serialize as json`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -1092,7 +1092,7 @@ module DoctorCliTests =
                             principalRequests.Count |> should equal 1
 
                             principalRequests[0].RelativePath
-                            |> should equal "auth/me"
+                            |> should equal "authenticate/me"
 
                             principalRequests[0].BearerToken
                             |> should equal (Some token)))))

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -73,8 +73,6 @@ module CommandParsingTests =
         [|
             "authorize"
             "grant-role"
-            "--scope"
-            "repo"
             "--principal-type"
             "User"
             "--principal-id"
@@ -87,8 +85,6 @@ module CommandParsingTests =
         [|
             "authorize"
             "revoke-role"
-            "--scope"
-            "repo"
             "--principal-type"
             "User"
             "--principal-id"
@@ -113,7 +109,8 @@ module CommandParsingTests =
     [<TestCase("BranchAdmin")>]
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
-    [<TestCase("ApprovalResponder")>]
+    [<TestCase("RepositoryApprovalResponder")>]
+    [<TestCase("BranchApprovalResponder")>]
     let ``authorize role commands accept canonical role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 0
@@ -129,15 +126,38 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
+    [<TestCase("ApprovalResponder")>]
     let ``authorize grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
     [<TestCase("OrgAdmin")>]
-    [<TestCase("RepositoryReader")>]
-    let ``authorize revoke role accepts raw role ids for cleanup`` roleId =
+    [<TestCase("ApprovalResponder")>]
+    let ``authorize revoke role rejects non-catalog role ids`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
+        revokeParseResult.Errors.Count |> should equal 1
+
+    [<Test>]
+    let ``authorize grant and revoke derive scope from role without scope option`` () =
+        let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs "RepositoryReader")
+        grantParseResult.Errors.Count |> should equal 0
+
+        let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs "RepositoryReader")
         revokeParseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize grant no longer accepts explicit scope option`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    yield! grantRoleArgs "RepositoryReader"
+                    "--scope"
+                    "repo"
+                |]
+            )
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
 
     [<Test>]
     let ``authenticate command group accepts authn alias`` () =
@@ -153,6 +173,30 @@ module CommandParsingTests =
             )
 
         parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize show command parses through authz alias`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "authz"; "show" |])
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize can command parses user oriented repo and path checks`` () =
+        let readRepo = GraceCommand.rootCommand.Parse([| "authz"; "can"; "read"; "repo" |])
+        readRepo.Errors.Count |> should equal 0
+
+        let pathRead =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "authz"
+                    "can"
+                    "read"
+                    "path"
+                    "--path"
+                    "src/Grace.CLI/Program.CLI.fs"
+                |]
+            )
+
+        pathRead.Errors.Count |> should equal 0
 
     [<TestCase("auth", "status")>]
     [<TestCase("access", "list-roles")>]
@@ -357,6 +401,87 @@ module HelpDoesNotReadConfigTests =
             (Guid.Parse("22222222-2222-2222-2222-222222222222"))
             (Guid.Parse("33333333-3333-3333-3333-333333333333"))
             (Guid.Parse("44444444-4444-4444-4444-444444444444"))
+
+    [<Test>]
+    let ``authz show explicit repository scope does not include configured branch`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedRepositoryId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+
+            writeValidConfig root ownerId organizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "show"
+                        "--repository-id"
+                        requestedRepositoryId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Access.normalizeShowRoleAssignmentIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal organizationId
+
+            graceIds.RepositoryId
+            |> should equal requestedRepositoryId
+
+            graceIds.RepositoryIdString
+            |> should equal (requestedRepositoryId.ToString())
+
+            graceIds.BranchId |> should equal BranchId.Empty
+
+            graceIds.BranchIdString
+            |> should equal String.Empty
+
+            graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authz show explicit owner scope does not include configured child ids`` () =
+        withTempDir (fun root ->
+            let configuredOwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let configuredOrganizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedOwnerId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+
+            writeValidConfig root configuredOwnerId configuredOrganizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "show"
+                        "--owner-id"
+                        requestedOwnerId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Access.normalizeShowRoleAssignmentIds parseResult
+
+            graceIds.OwnerId |> should equal requestedOwnerId
+
+            graceIds.OrganizationId
+            |> should equal OrganizationId.Empty
+
+            graceIds.RepositoryId
+            |> should equal RepositoryId.Empty
+
+            graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasOrganization |> should equal false
+            graceIds.HasRepository |> should equal false
+            graceIds.HasBranch |> should equal false)
 
     let private addLifecycleHeaders
         (response: HttpResponseMessage)

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -71,7 +71,7 @@ module CommandParsingTests =
 
     let private grantRoleArgs roleId =
         [|
-            "access"
+            "authorize"
             "grant-role"
             "--scope"
             "repo"
@@ -85,7 +85,7 @@ module CommandParsingTests =
 
     let private revokeRoleArgs roleId =
         [|
-            "access"
+            "authorize"
             "revoke-role"
             "--scope"
             "repo"
@@ -114,7 +114,7 @@ module CommandParsingTests =
     [<TestCase("BranchWriter")>]
     [<TestCase("BranchReader")>]
     [<TestCase("ApprovalResponder")>]
-    let ``access role commands accept canonical role ids`` roleId =
+    let ``authorize role commands accept canonical role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 0
 
@@ -129,15 +129,38 @@ module CommandParsingTests =
     [<TestCase("RepoReader")>]
     [<TestCase("rEpOaDmIn")>]
     [<TestCase("oRgReAdEr")>]
-    let ``access grant role rejects stale short role ids`` roleId =
+    let ``authorize grant role rejects stale short role ids`` roleId =
         let grantParseResult = GraceCommand.rootCommand.Parse(grantRoleArgs roleId)
         grantParseResult.Errors.Count |> should equal 1
 
     [<TestCase("OrgAdmin")>]
     [<TestCase("RepositoryReader")>]
-    let ``access revoke role accepts raw role ids for cleanup`` roleId =
+    let ``authorize revoke role accepts raw role ids for cleanup`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
         revokeParseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authenticate command group accepts authn alias`` () =
+        let parseResult = GraceCommand.rootCommand.Parse([| "authn"; "status" |])
+        parseResult.Errors.Count |> should equal 0
+
+    [<Test>]
+    let ``authorize command group accepts authz alias`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                grantRoleArgs "RepositoryReader"
+                |> Array.updateAt 0 "authz"
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+    [<TestCase("auth", "status")>]
+    [<TestCase("access", "list-roles")>]
+    let ``old auth and access command groups are not accepted`` commandGroup commandName =
+        let parseResult = GraceCommand.rootCommand.Parse([| commandGroup; commandName |])
+
+        parseResult.Errors.Count
+        |> should be (greaterThan 0)
 
 
 namespace Grace.CLI.Tests
@@ -376,7 +399,7 @@ module HelpDoesNotReadConfigTests =
             writeInvalidConfig root
 
             let exitCode, _ =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -386,7 +409,7 @@ module HelpDoesNotReadConfigTests =
     let ``help works without config`` () =
         withTempDir (fun _ ->
             let exitCode, _ =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -396,7 +419,7 @@ module HelpDoesNotReadConfigTests =
     let ``help shows symbolic defaults`` () =
         withTempDir (fun _ ->
             let exitCode, output =
-                runWithCapturedOutput [| "access"
+                runWithCapturedOutput [| "authorize"
                                          "grant-role"
                                          "-h" |]
 
@@ -497,7 +520,7 @@ module HelpDoesNotReadConfigTests =
             let exitCode, output =
                 runWithCapturedOutput [| "--output"
                                          "Json"
-                                         "auth"
+                                         "authenticate"
                                          "logout"
                                          "--examples" |]
 
@@ -513,7 +536,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Command")
                 .GetProperty("Id")
                 .GetString()
-            |> should equal "auth.logout"
+            |> should equal "authenticate.logout"
 
             let examples = rootElement.GetProperty("Examples")
             examples.GetArrayLength() |> should equal 2
@@ -523,6 +546,73 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("ReturnValue")
                 .GetString()
             |> should equal "Signed out.")
+
+    [<Test>]
+    let ``root login alias emits schema introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "login"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.login")
+
+    [<Test>]
+    let ``root login alias preserves preceding global options for schema introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "login"
+                                         "--schema" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "schema"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.login")
+
+    [<Test>]
+    let ``root logout alias preserves preceding global options for examples introspection`` () =
+        withTempDir (fun _ ->
+            let exitCode, output =
+                runWithCapturedOutput [| "--output"
+                                         "Json"
+                                         "logout"
+                                         "--examples" |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal "examples"
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "authenticate.logout")
 
     [<Test>]
     let ``examples for missing dto metadata emit explicit unsupported document`` () =
@@ -1049,7 +1139,7 @@ module HelpDoesNotReadConfigTests =
         let parseResult =
             GraceCommand.rootCommand.Parse(
                 [|
-                    "auth"
+                    "authenticate"
                     "logout"
                     "--select"
                     "Value"
@@ -1440,7 +1530,7 @@ module HelpDoesNotReadConfigTests =
             let exitCode, standardOut, standardError =
                 runWithCapturedStdoutAndStderr [| "--output"
                                                   "Json"
-                                                  "access"
+                                                  "authorize"
                                                   "list-roles" |]
 
             exitCode |> should equal -1
@@ -1487,7 +1577,7 @@ module HelpDoesNotReadConfigTests =
             let branchId = Guid.NewGuid()
             writeValidConfig root ownerId orgId repoId branchId
 
-            let parseResult = GraceCommand.rootCommand.Parse([| "access"; "grant-role" |])
+            let parseResult = GraceCommand.rootCommand.Parse([| "authorize"; "grant-role" |])
 
             let output = captureOutput (fun () -> Common.printParseResult parseResult)
 
@@ -1506,7 +1596,7 @@ module HelpDoesNotReadConfigTests =
             let branchId = Guid.NewGuid()
             writeValidConfig root ownerId orgId repoId branchId
 
-            let parseResult = GraceCommand.rootCommand.Parse([| "access"; "grant-role" |])
+            let parseResult = GraceCommand.rootCommand.Parse([| "authorize"; "grant-role" |])
             let graceIds = Services.getNormalizedIdsAndNames parseResult
 
             graceIds.OwnerId |> should equal ownerId
@@ -1632,15 +1722,19 @@ module RootHelpGroupingTests =
             output |> should contain "Review and promotion:"
 
             output
-            |> should contain "Administration and access:"
+            |> should contain "Administration and authorization:"
 
             output |> should contain "Local utilities:"
 
             let gettingStarted = sliceBetween output "Getting started:" "Day-to-day development:"
 
-            gettingStarted |> should contain "auth"
+            gettingStarted |> should contain "authenticate"
             gettingStarted |> should contain "connect"
             gettingStarted |> should contain "config"
+
+            gettingStarted
+            |> should not' (contain $"{Environment.NewLine}    auth ")
+
             gettingStarted |> should not' (contain "branch")
 
             let dayToDay = sliceBetween output "Day-to-day development:" "Review and promotion:"
@@ -1651,7 +1745,7 @@ module RootHelpGroupingTests =
             dayToDay |> should contain "watch"
             dayToDay |> should not' (contain "work")
 
-            let reviewAndPromotion = sliceBetween output "Review and promotion:" "Administration and access:"
+            let reviewAndPromotion = sliceBetween output "Review and promotion:" "Administration and authorization:"
 
             reviewAndPromotion |> should contain "workitem"
             reviewAndPromotion |> should contain "review"
@@ -1662,7 +1756,14 @@ module RootHelpGroupingTests =
             reviewAndPromotion |> should contain "webhook"
 
             reviewAndPromotion
-            |> should contain "promotion-set")
+            |> should contain "promotion-set"
+
+            let administration = sliceBetween output "Administration and authorization:" "Local utilities:"
+
+            administration |> should contain "authorize"
+
+            administration
+            |> should not' (contain $"{Environment.NewLine}    access "))
 
     [<Test>]
     let ``subcommand help is not grouped`` () =
@@ -1681,7 +1782,7 @@ module RootHelpGroupingTests =
             |> should not' (contain "Review and promotion:")
 
             output
-            |> should not' (contain "Administration and access:")
+            |> should not' (contain "Administration and authorization:")
 
             output |> should not' (contain "Local utilities:"))
 

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -93,6 +93,8 @@ module CommandParsingTests =
             roleId
         |]
 
+    let private revokeRoleArgsWithScope roleId scopeArgs = Array.append (revokeRoleArgs roleId) scopeArgs
+
     [<TestCase("SystemAdmin")>]
     [<TestCase("SystemOperator")>]
     [<TestCase("SystemReader")>]
@@ -133,9 +135,34 @@ module CommandParsingTests =
 
     [<TestCase("OrgAdmin")>]
     [<TestCase("ApprovalResponder")>]
-    let ``authorize revoke role rejects non-catalog role ids`` roleId =
+    let ``authorize revoke role allows stale role ids when explicit scope is supplied`` roleId =
+        let repositoryId = Guid.NewGuid()
+
+        let revokeParseResult =
+            GraceCommand.rootCommand.Parse(
+                revokeRoleArgsWithScope
+                    roleId
+                    [|
+                        "--repository-id"
+                        repositoryId.ToString()
+                    |]
+            )
+
+        revokeParseResult.Errors.Count |> should equal 0
+
+        match Command.Access.deriveScopeKindForRevoke revokeParseResult roleId with
+        | Ok scopeKind -> scopeKind |> should equal "repository"
+        | Error error -> Assert.Fail($"Expected stale role revoke scope derivation to succeed, but got {error}.")
+
+    [<TestCase("OrgAdmin")>]
+    [<TestCase("ApprovalResponder")>]
+    let ``authorize revoke role rejects stale role ids without explicit scope`` roleId =
         let revokeParseResult = GraceCommand.rootCommand.Parse(revokeRoleArgs roleId)
-        revokeParseResult.Errors.Count |> should equal 1
+        revokeParseResult.Errors.Count |> should equal 0
+
+        match Command.Access.deriveScopeKindForRevoke revokeParseResult roleId with
+        | Ok scopeKind -> Assert.Fail($"Expected stale role revoke without explicit scope to fail, but got {scopeKind}.")
+        | Error error -> error.Error |> should contain "explicit scope"
 
     [<Test>]
     let ``authorize grant and revoke derive scope from role without scope option`` () =
@@ -482,6 +509,211 @@ module HelpDoesNotReadConfigTests =
             graceIds.HasOrganization |> should equal false
             graceIds.HasRepository |> should equal false
             graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authorize revoke role rejects stale role ids with only configured scope`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let roleId = "OrgAdmin"
+
+            let revokeParseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authorize"
+                        "revoke-role"
+                        "--principal-type"
+                        "User"
+                        "--principal-id"
+                        "user-1"
+                        "--role"
+                        roleId
+                    |]
+                )
+
+            revokeParseResult.Errors.Count |> should equal 0
+
+            match Command.Access.deriveScopeKindForRevoke revokeParseResult roleId with
+            | Ok scopeKind -> Assert.Fail($"Expected stale role revoke with only configured scope to fail, but got {scopeKind}.")
+            | Error error -> error.Error |> should contain "explicit scope")
+
+    [<Test>]
+    let ``authz can explicit owner scope does not include configured child ids`` () =
+        withTempDir (fun root ->
+            let configuredOwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let configuredOrganizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedOwnerId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+
+            writeValidConfig root configuredOwnerId configuredOrganizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "can"
+                        "read"
+                        "branch"
+                        "--owner-id"
+                        requestedOwnerId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCanPermissionIds parseResult
+
+            graceIds.OwnerId |> should equal requestedOwnerId
+
+            graceIds.OrganizationId
+            |> should equal OrganizationId.Empty
+
+            graceIds.RepositoryId
+            |> should equal RepositoryId.Empty
+
+            graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasOrganization |> should equal false
+            graceIds.HasRepository |> should equal false
+            graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authz can explicit organization scope does not include configured repository or branch`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let configuredOrganizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedOrganizationId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+
+            writeValidConfig root ownerId configuredOrganizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "can"
+                        "read"
+                        "branch"
+                        "--organization-id"
+                        requestedOrganizationId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCanPermissionIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal requestedOrganizationId
+
+            graceIds.RepositoryId
+            |> should equal RepositoryId.Empty
+
+            graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasRepository |> should equal false
+            graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authz can explicit repository scope does not include configured branch`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let configuredRepositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedRepositoryId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+
+            writeValidConfig root ownerId organizationId configuredRepositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "can"
+                        "read"
+                        "branch"
+                        "--repository-id"
+                        requestedRepositoryId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCanPermissionIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal organizationId
+
+            graceIds.RepositoryId
+            |> should equal requestedRepositoryId
+
+            graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasBranch |> should equal false)
+
+    [<Test>]
+    let ``authz can explicit branch scope keeps configured parent ids`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let configuredBranchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let requestedBranchId = Guid.Parse("88888888-8888-8888-8888-888888888888")
+
+            writeValidConfig root ownerId organizationId repositoryId configuredBranchId
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authz"
+                        "can"
+                        "read"
+                        "branch"
+                        "--branch-id"
+                        requestedBranchId.ToString()
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCanPermissionIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal organizationId
+
+            graceIds.RepositoryId |> should equal repositoryId
+
+            graceIds.BranchId
+            |> should equal requestedBranchId)
+
+    [<Test>]
+    let ``authz can config-only branch scope keeps configured branch id`` () =
+        withTempDir (fun root ->
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let branchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+
+            writeValidConfig root ownerId organizationId repositoryId branchId
+
+            let parseResult = GraceCommand.rootCommand.Parse([| "authz"; "can"; "read"; "branch" |])
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCanPermissionIds parseResult
+
+            graceIds.OwnerId |> should equal ownerId
+
+            graceIds.OrganizationId
+            |> should equal organizationId
+
+            graceIds.RepositoryId |> should equal repositoryId
+            graceIds.BranchId |> should equal branchId)
 
     let private addLifecycleHeaders
         (response: HttpResponseMessage)

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -810,7 +810,8 @@ module Access =
             |> addOption Options.repositoryId
             |> addOption Options.branchId
 
-        let accessCommand = new Command("access", Description = "Manages access control and permissions.")
+        let accessCommand = new Command("authorize", Description = "Manages access control and permissions.")
+        accessCommand.Aliases.Add("authz")
 
         let grantRoleCommand =
             new Command("grant-role", Description = "Grants a role to a principal at a scope.")

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -26,6 +26,12 @@ open System.Threading.Tasks
 
 module Access =
 
+    type private ExplicitShowScope =
+        | Owner
+        | Organization
+        | Repository
+        | Branch
+
     module private Options =
         let ownerId =
             new Option<OwnerId>(
@@ -124,6 +130,15 @@ module Access =
 
         let revokeRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
 
+        revokeRoleId.Validators.Add (fun optionResult ->
+            let roleId = optionResult.GetValueOrDefault<string>()
+            let allowedRoleIds = String.Join(", ", canonicalRoleIds)
+
+            if canonicalRoleIds
+               |> List.exists (fun canonicalRoleId -> canonicalRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+               |> not then
+                optionResult.AddError($"{OptionName.RoleId} only accepts one of these values: {allowedRoleIds}"))
+
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 
         let sourceDetail =
@@ -159,6 +174,28 @@ module Access =
             (new Option<string>(OptionName.Operation, Required = true, Description = "Operation to check.", Arity = ArgumentArity.ExactlyOne))
                 .AcceptOnlyFromAmong(listCases<Operation> ())
 
+        let canAction =
+            (new Argument<string>("action", Description = "Capability action (read, write, administer).", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    [|
+                        "read"
+                        "write"
+                        "admin"
+                        "administer"
+                    |]
+                )
+
+        let canResource =
+            (new Argument<string>("resource", Description = "Capability resource (repo, branch, path).", Arity = ArgumentArity.ExactlyOne))
+                .AcceptOnlyFromAmong(
+                    [|
+                        "repo"
+                        "repository"
+                        "branch"
+                        "path"
+                    |]
+                )
+
         let resourceKindRequired =
             (new Option<string>(
                 OptionName.ResourceKind,
@@ -178,6 +215,47 @@ module Access =
                         "path"
                     |]
                 )
+
+    let internal normalizeShowRoleAssignmentIds (parseResult: ParseResult) =
+        let graceIds = parseResult |> getNormalizedIdsAndNames
+
+        let isExplicit optionName =
+            isOptionPresent parseResult optionName
+            && not
+               <| isOptionResultImplicit parseResult optionName
+
+        let explicitScope =
+            if isExplicit OptionName.BranchId then Some Branch
+            elif isExplicit OptionName.RepositoryId then Some Repository
+            elif isExplicit OptionName.OrganizationId then Some Organization
+            elif isExplicit OptionName.OwnerId then Some Owner
+            else None
+
+        match explicitScope with
+        | Some Owner ->
+            { graceIds with
+                OrganizationId = OrganizationId.Empty
+                OrganizationIdString = String.Empty
+                RepositoryId = RepositoryId.Empty
+                RepositoryIdString = String.Empty
+                BranchId = BranchId.Empty
+                BranchIdString = String.Empty
+                HasOrganization = false
+                HasRepository = false
+                HasBranch = false
+            }
+        | Some Organization ->
+            { graceIds with
+                RepositoryId = RepositoryId.Empty
+                RepositoryIdString = String.Empty
+                BranchId = BranchId.Empty
+                BranchIdString = String.Empty
+                HasRepository = false
+                HasBranch = false
+            }
+        | Some Repository -> { graceIds with BranchId = BranchId.Empty; BranchIdString = String.Empty; HasBranch = false }
+        | Some Branch
+        | None -> graceIds
 
     let private formatScope (scope: Scope) =
         match scope with
@@ -290,6 +368,48 @@ module Access =
             | Allowed reason -> AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Allowed[/]: {Markup.Escape(reason)}")
             | Denied reason -> AnsiConsole.MarkupLine($"[{Colors.Error}]Denied[/]: {Markup.Escape(reason)}")
 
+    let private deriveScopeKindForRole (parseResult: ParseResult) (roleId: string) =
+        let correlationId = getCorrelationId parseResult
+
+        if String.IsNullOrWhiteSpace roleId then
+            Error(GraceError.Create "RoleId is required." correlationId)
+        else
+            match Authorization.RoleCatalog.tryGet roleId with
+            | None -> Error(GraceError.Create $"Unknown RoleId '{roleId}'." correlationId)
+            | Some roleDefinition when roleDefinition.AppliesTo.Count = 1 -> Ok(roleDefinition.AppliesTo |> Seq.exactlyOne)
+            | Some _ -> Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
+
+    let private tryMapCapability (parseResult: ParseResult) (action: string) (resource: string) (pathValue: string) =
+        let correlationId = getCorrelationId parseResult
+        let normalizedAction = action.Trim().ToLowerInvariant()
+        let normalizedResource = resource.Trim().ToLowerInvariant()
+
+        match normalizedAction, normalizedResource with
+        | "read",
+          ("repo"
+          | "repository") -> Ok("RepositoryRead", "repository")
+        | "write",
+          ("repo"
+          | "repository") -> Ok("RepositoryWrite", "repository")
+        | ("admin"
+          | "administer"),
+          ("repo"
+          | "repository") -> Ok("RepositoryAdmin", "repository")
+        | "read", "branch" -> Ok("BranchRead", "branch")
+        | "write", "branch" -> Ok("BranchWrite", "branch")
+        | ("admin"
+          | "administer"),
+          "branch" -> Ok("BranchAdmin", "branch")
+        | "read", "path" when not (String.IsNullOrWhiteSpace pathValue) -> Ok("PathRead", "path")
+        | "write", "path" when not (String.IsNullOrWhiteSpace pathValue) -> Ok("PathWrite", "path")
+        | ("read"
+          | "write"),
+          "path" -> Error(GraceError.Create "Path is required for Path resources." correlationId)
+        | ("admin"
+          | "administer"),
+          "path" -> Error(GraceError.Create "Path does not support administer checks; use read or write." correlationId)
+        | _ -> Error(GraceError.Create $"Unsupported authorization capability '{action} {resource}'." correlationId)
+
     let private validateClaimPermissions (parseResult: ParseResult) =
         let correlationId = getCorrelationId parseResult
         let claims = parseResult.GetValue(Options.claim)
@@ -348,42 +468,47 @@ module Access =
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        let parameters =
-                            GrantRoleParameters(
-                                OwnerId = graceIds.OwnerIdString,
-                                OrganizationId = graceIds.OrganizationIdString,
-                                RepositoryId = graceIds.RepositoryIdString,
-                                BranchId = graceIds.BranchIdString,
-                                PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
-                                PrincipalId = parseResult.GetValue(Options.principalIdRequired),
-                                ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.grantRoleId),
-                                Source = parseResult.GetValue(Options.source),
-                                SourceDetail = parseResult.GetValue(Options.sourceDetail),
-                                CorrelationId = getCorrelationId parseResult
-                            )
+                        let roleId = parseResult.GetValue(Options.grantRoleId)
 
-                        let! result =
-                            if parseResult |> hasOutput then
-                                progress
-                                    .Columns(progressColumns)
-                                    .StartAsync(fun progressContext ->
-                                        task {
-                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
-                                            let! response = Access.GrantRole(parameters)
-                                            t0.Increment(100.0)
-                                            return response
-                                        })
-                            else
-                                Access.GrantRole(parameters)
+                        match deriveScopeKindForRole parseResult roleId with
+                        | Error error -> return Error error |> renderOutput parseResult
+                        | Ok scopeKind ->
+                            let parameters =
+                                GrantRoleParameters(
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    BranchId = graceIds.BranchIdString,
+                                    PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
+                                    PrincipalId = parseResult.GetValue(Options.principalIdRequired),
+                                    ScopeKind = scopeKind,
+                                    RoleId = roleId,
+                                    Source = parseResult.GetValue(Options.source),
+                                    SourceDetail = parseResult.GetValue(Options.sourceDetail),
+                                    CorrelationId = getCorrelationId parseResult
+                                )
 
-                        match result with
-                        | Ok graceReturnValue ->
-                            renderAssignments parseResult graceReturnValue.ReturnValue
-                            return result |> renderOutput parseResult
-                        | Error error ->
-                            logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
-                            return result |> renderOutput parseResult
+                            let! result =
+                                if parseResult |> hasOutput then
+                                    progress
+                                        .Columns(progressColumns)
+                                        .StartAsync(fun progressContext ->
+                                            task {
+                                                let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
+                                                let! response = Access.GrantRole(parameters)
+                                                t0.Increment(100.0)
+                                                return response
+                                            })
+                                else
+                                    Access.GrantRole(parameters)
+
+                            match result with
+                            | Ok graceReturnValue ->
+                                renderAssignments parseResult graceReturnValue.ReturnValue
+                                return result |> renderOutput parseResult
+                            | Error error ->
+                                logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                                return result |> renderOutput parseResult
                     | Error error -> return Error error |> renderOutput parseResult
                 with
                 | ex ->
@@ -406,16 +531,73 @@ module Access =
 
                     match validateIncomingParameters with
                     | Ok _ ->
+                        let roleId = parseResult.GetValue(Options.revokeRoleId)
+
+                        match deriveScopeKindForRole parseResult roleId with
+                        | Error error -> return Error error |> renderOutput parseResult
+                        | Ok scopeKind ->
+                            let parameters =
+                                RevokeRoleParameters(
+                                    OwnerId = graceIds.OwnerIdString,
+                                    OrganizationId = graceIds.OrganizationIdString,
+                                    RepositoryId = graceIds.RepositoryIdString,
+                                    BranchId = graceIds.BranchIdString,
+                                    PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
+                                    PrincipalId = parseResult.GetValue(Options.principalIdRequired),
+                                    ScopeKind = scopeKind,
+                                    RoleId = roleId,
+                                    CorrelationId = getCorrelationId parseResult
+                                )
+
+                            let! result =
+                                if parseResult |> hasOutput then
+                                    progress
+                                        .Columns(progressColumns)
+                                        .StartAsync(fun progressContext ->
+                                            task {
+                                                let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
+                                                let! response = Access.RevokeRole(parameters)
+                                                t0.Increment(100.0)
+                                                return response
+                                            })
+                                else
+                                    Access.RevokeRole(parameters)
+
+                            match result with
+                            | Ok graceReturnValue ->
+                                renderAssignments parseResult graceReturnValue.ReturnValue
+                                return result |> renderOutput parseResult
+                            | Error error ->
+                                logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                                return result |> renderOutput parseResult
+                    | Error error -> return Error error |> renderOutput parseResult
+                with
+                | ex ->
+                    return
+                        renderOutput
+                            parseResult
+                            (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
+            }
+
+    type ShowRoleAssignments() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let graceIds = parseResult |> normalizeShowRoleAssignmentIds
+                    let validateIncomingParameters = parseResult |> CommonValidations
+
+                    match validateIncomingParameters with
+                    | Ok _ ->
                         let parameters =
-                            RevokeRoleParameters(
+                            ShowRoleAssignmentsParameters(
                                 OwnerId = graceIds.OwnerIdString,
                                 OrganizationId = graceIds.OrganizationIdString,
                                 RepositoryId = graceIds.RepositoryIdString,
                                 BranchId = graceIds.BranchIdString,
-                                PrincipalType = parseResult.GetValue(Options.principalTypeRequired),
-                                PrincipalId = parseResult.GetValue(Options.principalIdRequired),
-                                ScopeKind = parseResult.GetValue(Options.scopeKindRequired),
-                                RoleId = parseResult.GetValue(Options.revokeRoleId),
                                 CorrelationId = getCorrelationId parseResult
                             )
 
@@ -425,13 +607,13 @@ module Access =
                                     .Columns(progressColumns)
                                     .StartAsync(fun progressContext ->
                                         task {
-                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Sending command to the server.[/]")
-                                            let! response = Access.RevokeRole(parameters)
+                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Loading my role assignments.[/]")
+                                            let! response = Access.ShowRoleAssignments(parameters)
                                             t0.Increment(100.0)
                                             return response
                                         })
                             else
-                                Access.RevokeRole(parameters)
+                                Access.ShowRoleAssignments(parameters)
 
                         match result with
                         | Ok graceReturnValue ->
@@ -763,6 +945,76 @@ module Access =
                             (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
             }
 
+    type Can() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let graceIds = parseResult |> getNormalizedIdsAndNames
+
+                    let pathValue =
+                        parseResult.GetValue(Options.pathOptional)
+                        |> Option.ofObj
+                        |> Option.defaultValue ""
+
+                    let mapped = tryMapCapability parseResult (parseResult.GetValue(Options.canAction)) (parseResult.GetValue(Options.canResource)) pathValue
+
+                    let validateIncomingParameters =
+                        parseResult
+                        |> CommonValidations
+                        >>= (fun _ -> mapped |> Result.map (fun _ -> parseResult))
+
+                    match validateIncomingParameters with
+                    | Ok _ ->
+                        let operation, resourceKind =
+                            mapped
+                            |> Result.defaultWith (fun error -> raise (InvalidOperationException(error.Error)))
+
+                        let parameters =
+                            CheckPermissionParameters(
+                                OwnerId = graceIds.OwnerIdString,
+                                OrganizationId = graceIds.OrganizationIdString,
+                                RepositoryId = graceIds.RepositoryIdString,
+                                BranchId = graceIds.BranchIdString,
+                                Operation = operation,
+                                ResourceKind = resourceKind,
+                                Path = pathValue,
+                                CorrelationId = getCorrelationId parseResult
+                            )
+
+                        let! result =
+                            if parseResult |> hasOutput then
+                                progress
+                                    .Columns(progressColumns)
+                                    .StartAsync(fun progressContext ->
+                                        task {
+                                            let t0 = progressContext.AddTask($"[{Color.DodgerBlue1}]Checking permission.[/]")
+                                            let! response = Access.CheckPermission(parameters)
+                                            t0.Increment(100.0)
+                                            return response
+                                        })
+                            else
+                                Access.CheckPermission(parameters)
+
+                        match result with
+                        | Ok graceReturnValue ->
+                            renderPermissionCheck parseResult graceReturnValue.ReturnValue
+                            return result |> renderOutput parseResult
+                        | Error error ->
+                            logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))
+                            return result |> renderOutput parseResult
+                    | Error error -> return Error error |> renderOutput parseResult
+                with
+                | ex ->
+                    return
+                        renderOutput
+                            parseResult
+                            (GraceResult.Error(GraceError.Create $"{Utilities.ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)))
+            }
+
     type ListRoles() =
         inherit AsynchronousCommandLineAction()
 
@@ -816,7 +1068,6 @@ module Access =
         let grantRoleCommand =
             new Command("grant-role", Description = "Grants a role to a principal at a scope.")
             |> addScopeOptions
-            |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
             |> addOption Options.grantRoleId
@@ -829,7 +1080,6 @@ module Access =
         let revokeRoleCommand =
             new Command("revoke-role", Description = "Revokes a role from a principal at a scope.")
             |> addScopeOptions
-            |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeRequired
             |> addOption Options.principalIdRequired
             |> addOption Options.revokeRoleId
@@ -838,7 +1088,7 @@ module Access =
         accessCommand.Subcommands.Add(revokeRoleCommand)
 
         let listRoleAssignmentsCommand =
-            new Command("list-role-assignments", Description = "Lists role assignments at a scope.")
+            new Command("list-role-assignments", Description = "Lists all role assignments at a scope. Requires scope admin permission.")
             |> addScopeOptions
             |> addOption Options.scopeKindRequired
             |> addOption Options.principalTypeOptional
@@ -846,6 +1096,13 @@ module Access =
 
         listRoleAssignmentsCommand.Action <- new ListRoleAssignments()
         accessCommand.Subcommands.Add(listRoleAssignmentsCommand)
+
+        let showRoleAssignmentsCommand =
+            new Command("show", Description = "Display my role assignments")
+            |> addScopeOptions
+
+        showRoleAssignmentsCommand.Action <- new ShowRoleAssignments()
+        accessCommand.Subcommands.Add(showRoleAssignmentsCommand)
 
         let upsertPathPermissionCommand =
             new Command("upsert-path-permission", Description = "Upserts repository path permissions.")
@@ -884,6 +1141,16 @@ module Access =
 
         checkPermissionCommand.Action <- new CheckPermission()
         accessCommand.Subcommands.Add(checkPermissionCommand)
+
+        let canCommand =
+            new Command("can", Description = "Checks whether I can perform an action on a resource.")
+            |> addScopeOptions
+            |> addOption Options.pathOptional
+
+        canCommand.Arguments.Add(Options.canAction)
+        canCommand.Arguments.Add(Options.canResource)
+        canCommand.Action <- new Can()
+        accessCommand.Subcommands.Add(canCommand)
 
         let listRolesCommand = new Command("list-roles", Description = "Lists available roles.")
 

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -130,15 +130,6 @@ module Access =
 
         let revokeRoleId = new Option<string>(OptionName.RoleId, Required = true, Description = "Role identifier.", Arity = ArgumentArity.ExactlyOne)
 
-        revokeRoleId.Validators.Add (fun optionResult ->
-            let roleId = optionResult.GetValueOrDefault<string>()
-            let allowedRoleIds = String.Join(", ", canonicalRoleIds)
-
-            if canonicalRoleIds
-               |> List.exists (fun canonicalRoleId -> canonicalRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
-               |> not then
-                optionResult.AddError($"{OptionName.RoleId} only accepts one of these values: {allowedRoleIds}"))
-
         let source = new Option<string>(OptionName.Source, Required = false, Description = "Optional role assignment source.", Arity = ArgumentArity.ZeroOrOne)
 
         let sourceDetail =
@@ -216,13 +207,16 @@ module Access =
                     |]
                 )
 
-    let internal normalizeShowRoleAssignmentIds (parseResult: ParseResult) =
-        let graceIds = parseResult |> getNormalizedIdsAndNames
-
+    let private isExplicitScopeOption (parseResult: ParseResult) optionName =
         let isExplicit optionName =
             isOptionPresent parseResult optionName
             && not
                <| isOptionResultImplicit parseResult optionName
+
+        isExplicit optionName
+
+    let private getExplicitScope (parseResult: ParseResult) =
+        let isExplicit = isExplicitScopeOption parseResult
 
         let explicitScope =
             if isExplicit OptionName.BranchId then Some Branch
@@ -231,31 +225,60 @@ module Access =
             elif isExplicit OptionName.OwnerId then Some Owner
             else None
 
+        explicitScope
+
+    let private clearBranch (graceIds: GraceIds) = { graceIds with BranchId = BranchId.Empty; BranchIdString = String.Empty; HasBranch = false }
+
+    let private clearRepository (graceIds: GraceIds) =
+        { clearBranch graceIds with RepositoryId = RepositoryId.Empty; RepositoryIdString = String.Empty; HasRepository = false }
+
+    let private clearOrganization (graceIds: GraceIds) =
+        { clearRepository graceIds with OrganizationId = OrganizationId.Empty; OrganizationIdString = String.Empty; HasOrganization = false }
+
+    let private clearImplicitChildScopeIds (parseResult: ParseResult) (graceIds: GraceIds) =
+        let clearBranchIfImplicit current =
+            if isExplicitScopeOption parseResult OptionName.BranchId then
+                current
+            else
+                clearBranch current
+
+        let clearRepositoryIfImplicit current =
+            if isExplicitScopeOption parseResult OptionName.RepositoryId then
+                current
+            else
+                clearRepository current
+
+        let clearOrganizationIfImplicit current =
+            if isExplicitScopeOption parseResult OptionName.OrganizationId then
+                current
+            else
+                clearOrganization current
+
+        let explicitScope = getExplicitScope parseResult
+
         match explicitScope with
         | Some Owner ->
-            { graceIds with
-                OrganizationId = OrganizationId.Empty
-                OrganizationIdString = String.Empty
-                RepositoryId = RepositoryId.Empty
-                RepositoryIdString = String.Empty
-                BranchId = BranchId.Empty
-                BranchIdString = String.Empty
-                HasOrganization = false
-                HasRepository = false
-                HasBranch = false
-            }
+            graceIds
+            |> clearOrganizationIfImplicit
+            |> clearRepositoryIfImplicit
+            |> clearBranchIfImplicit
         | Some Organization ->
-            { graceIds with
-                RepositoryId = RepositoryId.Empty
-                RepositoryIdString = String.Empty
-                BranchId = BranchId.Empty
-                BranchIdString = String.Empty
-                HasRepository = false
-                HasBranch = false
-            }
-        | Some Repository -> { graceIds with BranchId = BranchId.Empty; BranchIdString = String.Empty; HasBranch = false }
+            graceIds
+            |> clearRepositoryIfImplicit
+            |> clearBranchIfImplicit
+        | Some Repository -> graceIds |> clearBranchIfImplicit
         | Some Branch
         | None -> graceIds
+
+    let internal normalizeShowRoleAssignmentIds (parseResult: ParseResult) =
+        parseResult
+        |> getNormalizedIdsAndNames
+        |> clearImplicitChildScopeIds parseResult
+
+    let internal normalizeCanPermissionIds (parseResult: ParseResult) =
+        parseResult
+        |> getNormalizedIdsAndNames
+        |> clearImplicitChildScopeIds parseResult
 
     let private formatScope (scope: Scope) =
         match scope with
@@ -378,6 +401,22 @@ module Access =
             | None -> Error(GraceError.Create $"Unknown RoleId '{roleId}'." correlationId)
             | Some roleDefinition when roleDefinition.AppliesTo.Count = 1 -> Ok(roleDefinition.AppliesTo |> Seq.exactlyOne)
             | Some _ -> Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
+
+    let internal deriveScopeKindForRevoke (parseResult: ParseResult) (roleId: string) =
+        match deriveScopeKindForRole parseResult roleId with
+        | Ok scopeKind -> Ok scopeKind
+        | Error _ ->
+            match getExplicitScope parseResult with
+            | Some Owner -> Ok "owner"
+            | Some Organization -> Ok "organization"
+            | Some Repository -> Ok "repository"
+            | Some Branch -> Ok "branch"
+            | None ->
+                Error(
+                    GraceError.Create
+                        $"Unknown RoleId '{roleId}'. Supply an explicit scope option when revoking a stale or deleted role."
+                        (getCorrelationId parseResult)
+                )
 
     let private tryMapCapability (parseResult: ParseResult) (action: string) (resource: string) (pathValue: string) =
         let correlationId = getCorrelationId parseResult
@@ -526,14 +565,14 @@ module Access =
                 try
                     if parseResult |> verbose then printParseResult parseResult
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
+                    let graceIds = parseResult |> normalizeShowRoleAssignmentIds
                     let validateIncomingParameters = parseResult |> CommonValidations
 
                     match validateIncomingParameters with
                     | Ok _ ->
                         let roleId = parseResult.GetValue(Options.revokeRoleId)
 
-                        match deriveScopeKindForRole parseResult roleId with
+                        match deriveScopeKindForRevoke parseResult roleId with
                         | Error error -> return Error error |> renderOutput parseResult
                         | Ok scopeKind ->
                             let parameters =
@@ -953,7 +992,7 @@ module Access =
                 try
                     if parseResult |> verbose then printParseResult parseResult
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
+                    let graceIds = parseResult |> normalizeCanPermissionIds
 
                     let pathValue =
                         parseResult.GetValue(Options.pathOptional)

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -830,7 +830,7 @@ module Auth =
     let private tryRefreshTokenAsync (config: OidcCliConfig) (bundle: TokenBundle) =
         task {
             if String.IsNullOrWhiteSpace bundle.RefreshToken then
-                return Error "Refresh token missing. Run 'grace auth login' again."
+                return Error "Refresh token missing. Run 'grace authenticate login' again."
             else
                 let endpoint = buildEndpoint config.Authority "oauth/token"
 
@@ -1161,7 +1161,7 @@ module Auth =
 
     let private authDevelopmentGuidance = "During development, TestAuth may be available. See docs/Authentication.md for details."
 
-    let private authenticationRequiredMessage = $"Authentication required. Run 'grace auth login' and try again. {authDevelopmentGuidance}"
+    let private authenticationRequiredMessage = $"Authentication required. Run 'grace authenticate login' and try again. {authDevelopmentGuidance}"
 
     let private addAuthDevelopmentGuidance (message: string) =
         if String.IsNullOrWhiteSpace message then
@@ -1677,7 +1677,8 @@ module Auth =
             }
 
     let Build =
-        let authCommand = new Command("auth", Description = "Authenticate with Grace.")
+        let authCommand = new Command("authenticate", Description = "Authenticate with Grace.")
+        authCommand.Aliases.Add("authn")
 
         let loginCommand = new Command("login", Description = "Sign in with Auth0 (PKCE or device flow).")
         loginCommand.Options.Add(LoginOptions.auth)

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -1444,7 +1444,7 @@ module Auth =
             task {
                 let correlationId = parseResult |> getCorrelationId
                 let parameters = CommonParameters(CorrelationId = correlationId)
-                let! result = Grace.SDK.Common.getServer<CommonParameters, AuthInfo> (parameters, "auth/me")
+                let! result = Grace.SDK.Common.getServer<CommonParameters, AuthInfo> (parameters, "authenticate/me")
 
                 match result with
                 | Ok graceReturnValue ->

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -367,7 +367,7 @@ module Doctor =
                 Id = ServerAuthPrincipalAvailableCheckId
                 Category = "Server"
                 Title = "Grace authenticated principal"
-                Description = "Optionally probes /auth/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
+                Description = "Optionally probes /authenticate/me only when a valid non-refreshing GRACE_TOKEN PAT is present."
                 DefaultEnabled = false
                 SupportsOffline = false
             }
@@ -928,15 +928,15 @@ module Doctor =
                 | Some token ->
                     let effectiveServerUri = resolveEffectiveServerUri context.ConfigurationState context.EnvironmentServerUri
 
-                    match probeServer "auth/me" (Some token) effectiveServerUri
+                    match probeServer "authenticate/me" (Some token) effectiveServerUri
                           |> fun task -> task.GetAwaiter().GetResult()
                         with
                     | ServerProbeSucceeded response when isSuccessfulHttpStatus response.StatusCode ->
                         ok
-                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
+                            $"Authenticated principal endpoint /authenticate/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase} using the non-refreshing {Constants.EnvironmentVariables.GraceToken} PAT source."
                     | ServerProbeSucceeded response ->
                         failed
-                            $"Authenticated principal endpoint /auth/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
+                            $"Authenticated principal endpoint /authenticate/me returned HTTP {(int response.StatusCode)} {response.ReasonPhrase}; verify the PAT, claims, and server authentication configuration."
                     | ServerProbeTimedOut message -> failed $"{message} Check the effective server URI, network path, proxy settings, or server startup state."
                     | ServerProbeTlsFailed message -> failed $"{message} Verify the server certificate and HTTPS endpoint configuration."
                     | ServerProbeConnectionFailed message -> failed $"{message} Check that the Grace server is running and reachable."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -152,7 +152,8 @@ module Watch =
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
         | Ok (Some token) when not (String.IsNullOrWhiteSpace token) -> Ok token
-        | Ok _ -> Error $"No access token is available. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
+        | Ok _ ->
+            Error $"No access token is available. Run `grace authenticate login` or set {Constants.EnvironmentVariables.GraceToken} before starting watch."
         | Error message -> Error $"Unable to acquire an access token for SignalR notifications: {message}"
 
     let private getSignalRAccessToken () =
@@ -833,7 +834,7 @@ module Watch =
                     && httpEx.StatusCode.Value = HttpStatusCode.Unauthorized
                     ->
                     let message =
-                        $"SignalR negotiation failed with 401 Unauthorized. Run `grace auth login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
+                        $"SignalR negotiation failed with 401 Unauthorized. Run `grace authenticate login` or set {Constants.EnvironmentVariables.GraceToken}, then retry `grace watch`."
 
                     if parseResult |> json then
                         return renderJsonError parseResult message

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -611,11 +611,11 @@ module CommandOutputContract =
             incompleteReturnValueContract
                 "WorkItemDto"
                 "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | "access.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | "authorize.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "PermissionCheckResult"
                 "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
-        | "auth.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | "authenticate.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             supportedReturnValueContract
                 "string"
                 "GraceReturnValue<string>"
@@ -887,14 +887,30 @@ module CommandOutputContract =
 
     let entries =
         [
-            row [ "access" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-role-assignments" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "list-roles" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "remove-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "access" ] "upsert-path-permission" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-role-assignments" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "list-roles" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "authorize" ]
+                "remove-path-permission"
+                true
+                true
+                common_renderOutput_envelope
+                mutating_state_transition
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row
+                [ "authorize" ]
+                "upsert-path-permission"
+                true
+                true
+                common_renderOutput_envelope
+                mutating_state_transition
+                server_via_sdk
+                ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "admin"; "reminder" ] "get" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -921,16 +937,16 @@ module CommandOutputContract =
             row [ "approval"; "request" ] "reject" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "request" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "approval"; "request" ] "wait" true true common_renderOutput_envelope workflow_accepted_operation server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "login" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "logout" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "clear" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "revoke" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "auth" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "login" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "logout" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "clear" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "revoke" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "set" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate"; "token" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authenticate" ] "whoami" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "annotate" true true common_renderOutput_envelope mutating_state_transition composite_local_server ReuseExistingApiOrSdkDto
             row [ "branch" ] "assign" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "checkpoint" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -611,7 +611,9 @@ module CommandOutputContract =
             incompleteReturnValueContract
                 "WorkItemDto"
                 "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | "authorize.check", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
+        | ("authorize.can"
+          | "authorize.check"),
+          ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
             incompleteReturnValueContract
                 "PermissionCheckResult"
                 "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
@@ -887,6 +889,7 @@ module CommandOutputContract =
 
     let entries =
         [
+            row [ "authorize" ] "can" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "list-path-permissions" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
@@ -902,6 +905,7 @@ module CommandOutputContract =
                 server_via_sdk
                 ReuseExistingApiOrSdkDto
             row [ "authorize" ] "revoke-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "authorize" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row
                 [ "authorize" ]
                 "upsert-path-permission"

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -73,6 +73,8 @@ module GraceCommand =
         aliases.Add("commit", [ "branch"; "commit" ])
         aliases.Add("commits", [ "branch"; "get-commits" ])
         aliases.Add("dir", [ "maint"; "list-contents" ])
+        aliases.Add("login", [ "authenticate"; "login" ])
+        aliases.Add("logout", [ "authenticate"; "logout" ])
         aliases.Add("ls", [ "maint"; "list-contents" ])
         aliases.Add("promote", [ "branch"; "promote" ])
         aliases.Add("promotions", [ "branch"; "get-promotions" ])
@@ -473,7 +475,7 @@ module GraceCommand =
 
     let private rootHelpSections =
         [
-            { Heading = "Getting started"; CommandNames = [ "auth"; "connect"; "config" ] }
+            { Heading = "Getting started"; CommandNames = [ "authenticate"; "connect"; "config" ] }
             {
                 Heading = "Day-to-day development"
                 CommandNames =
@@ -499,13 +501,13 @@ module GraceCommand =
                     ]
             }
             {
-                Heading = "Administration and access"
+                Heading = "Administration and authorization"
                 CommandNames =
                     [
                         "owner"
                         "organization"
                         "repository"
-                        "access"
+                        "authorize"
                         "admin"
                     ]
             }
@@ -1009,8 +1011,6 @@ module GraceCommand =
             if args.Length = 0 then
                 Array.empty<string>
             else
-                let firstToken = if isCaseInsensitive then args[ 0 ].ToLowerInvariant() else args[0]
-
                 let normalizeOutputEqualsToken (arg: string) =
                     let outputEqualsPrefix = $"{OptionName.Output}="
 
@@ -1018,6 +1018,37 @@ module GraceCommand =
                         $"{OptionName.Output}={arg.Substring(outputEqualsPrefix.Length)}"
                     else
                         arg
+
+                let tryFindTopLevelCommandIndex (args: string array) =
+                    let comparison =
+                        if isCaseInsensitive then
+                            StringComparison.InvariantCultureIgnoreCase
+                        else
+                            StringComparison.InvariantCulture
+
+                    let isOptionWithValue (token: string) =
+                        token.Equals(OptionName.Output, comparison)
+                        || token.Equals("-o", comparison)
+                        || token.Equals(OptionName.CorrelationId, comparison)
+                        || token.Equals("-c", comparison)
+                        || token.Equals(OptionName.Source, comparison)
+                        || token.Equals(OptionName.Select, comparison)
+
+                    let rec loop index =
+                        if index >= args.Length then
+                            None
+                        else
+                            let token = args[index]
+
+                            if token = "--" then
+                                if index + 1 < args.Length then Some(index + 1) else None
+                            elif token.StartsWith("-", StringComparison.Ordinal) then
+                                let nextIndex = if isOptionWithValue token then index + 2 else index + 1
+                                loop nextIndex
+                            else
+                                Some index
+
+                    loop 0
 
                 let properCasedArgs =
                     args
@@ -1043,18 +1074,30 @@ module GraceCommand =
                         else
                             normalizedArg)
 
-                if aliases.ContainsKey(firstToken) then
-                    let newArgs = List<string>()
+                match tryFindTopLevelCommandIndex args with
+                | Some commandIndex ->
+                    let aliasToken =
+                        if isCaseInsensitive then
+                            args[ commandIndex ].ToLowerInvariant()
+                        else
+                            args[commandIndex]
 
-                    for token in aliases[ firstToken ].Reverse() do
-                        newArgs.Insert(0, token)
+                    if aliases.ContainsKey(aliasToken) then
+                        let newArgs = List<string>()
 
-                    for token in properCasedArgs[1..] do
-                        newArgs.Add(token)
+                        for token in properCasedArgs[0 .. commandIndex - 1] do
+                            newArgs.Add(token)
 
-                    newArgs.ToArray()
-                else
-                    properCasedArgs
+                        for token in aliases[aliasToken] do
+                            newArgs.Add(token)
+
+                        for token in properCasedArgs[commandIndex + 1 ..] do
+                            newArgs.Add(token)
+
+                        newArgs.ToArray()
+                    else
+                        properCasedArgs
+                | None -> properCasedArgs
 
         let mutable argvNormalized = normalizeArgsForHistory args
 
@@ -1368,7 +1411,7 @@ module GraceCommand =
                             [
                                 "config"
                                 "history"
-                                "auth"
+                                "authenticate"
                                 "connect"
                                 "alias"
                                 "doctor"

--- a/src/Grace.SDK/Access.SDK.fs
+++ b/src/Grace.SDK/Access.SDK.fs
@@ -10,38 +10,32 @@ type Access() =
 
     /// Grants a role to a principal at a scope.
     static member public GrantRole(parameters: GrantRoleParameters) =
-        postServer<GrantRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.GrantRole)}")
+        postServer<GrantRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/grant-role")
 
     /// Revokes a role from a principal at a scope.
     static member public RevokeRole(parameters: RevokeRoleParameters) =
-        postServer<RevokeRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.RevokeRole)}")
+        postServer<RevokeRoleParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/revoke-role")
 
     /// Lists role assignments at a scope, optionally filtered by principal.
     static member public ListRoleAssignments(parameters: ListRoleAssignmentsParameters) =
-        postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.ListRoleAssignments)}")
+        postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-role-assignments")
 
     /// Upserts a repository path permission.
     static member public UpsertPathPermission(parameters: UpsertPathPermissionParameters) =
-        postServer<UpsertPathPermissionParameters, PathPermission list> (
-            parameters |> ensureCorrelationIdIsSet,
-            $"access/{nameof (Access.UpsertPathPermission)}"
-        )
+        postServer<UpsertPathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/upsert-path-permission")
 
     /// Removes a repository path permission.
     static member public RemovePathPermission(parameters: RemovePathPermissionParameters) =
-        postServer<RemovePathPermissionParameters, PathPermission list> (
-            parameters |> ensureCorrelationIdIsSet,
-            $"access/{nameof (Access.RemovePathPermission)}"
-        )
+        postServer<RemovePathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/remove-path-permission")
 
     /// Lists repository path permissions.
     static member public ListPathPermissions(parameters: ListPathPermissionsParameters) =
-        postServer<ListPathPermissionsParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.ListPathPermissions)}")
+        postServer<ListPathPermissionsParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-path-permissions")
 
     /// Checks a permission against the current or specified principal.
     static member public CheckPermission(parameters: CheckPermissionParameters) =
-        postServer<CheckPermissionParameters, PermissionCheckResult> (parameters |> ensureCorrelationIdIsSet, $"access/{nameof (Access.CheckPermission)}")
+        postServer<CheckPermissionParameters, PermissionCheckResult> (parameters |> ensureCorrelationIdIsSet, "authorize/check-permission")
 
     /// Lists the configured roles.
     static member public ListRoles(parameters: CommonParameters) =
-        getServer<CommonParameters, RoleDefinition list> (parameters |> ensureCorrelationIdIsSet, "access/listRoles")
+        getServer<CommonParameters, RoleDefinition list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-roles")

--- a/src/Grace.SDK/Access.SDK.fs
+++ b/src/Grace.SDK/Access.SDK.fs
@@ -20,6 +20,10 @@ type Access() =
     static member public ListRoleAssignments(parameters: ListRoleAssignmentsParameters) =
         postServer<ListRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/list-role-assignments")
 
+    /// Displays role assignments for the current authenticated principal set.
+    static member public ShowRoleAssignments(parameters: ShowRoleAssignmentsParameters) =
+        postServer<ShowRoleAssignmentsParameters, RoleAssignment list> (parameters |> ensureCorrelationIdIsSet, "authorize/show")
+
     /// Upserts a repository path permission.
     static member public UpsertPathPermission(parameters: UpsertPathPermissionParameters) =
         postServer<UpsertPathPermissionParameters, PathPermission list> (parameters |> ensureCorrelationIdIsSet, "authorize/upsert-path-permission")

--- a/src/Grace.SDK/Auth.SDK.fs
+++ b/src/Grace.SDK/Auth.SDK.fs
@@ -76,7 +76,7 @@ module Auth =
                 let startTime = getCurrentInstant ()
 
                 let graceServerUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
-                let serverUri = Uri($"{graceServerUri}/auth/oidc/config")
+                let serverUri = Uri($"{graceServerUri}/authenticate/oidc/config")
 
                 let! response = Constants.DefaultAsyncRetryPolicy.ExecuteAsync(fun _ -> httpClient.GetAsync(serverUri))
                 let endTime = getCurrentInstant ()
@@ -89,7 +89,7 @@ module Auth =
                         |> enhance "ServerResponseTime" $"{(endTime - startTime).TotalMilliseconds:F3} ms"
                         |> ClientIdentity.enhanceWithLifecycleDiagnostics response
                 else
-                    let! graceError = ResponseErrors.fromResponse correlationId "auth/oidc/config" response
+                    let! graceError = ResponseErrors.fromResponse correlationId "authenticate/oidc/config" response
 
                     return
                         Error graceError

--- a/src/Grace.SDK/PersonalAccessToken.SDK.fs
+++ b/src/Grace.SDK/PersonalAccessToken.SDK.fs
@@ -64,10 +64,10 @@ module PersonalAccessToken =
         }
 
     let Create (parameters: CreatePersonalAccessTokenParameters) =
-        postServerWithEnv<CreatePersonalAccessTokenParameters, PersonalAccessTokenCreated> (parameters, "auth/token/create")
+        postServerWithEnv<CreatePersonalAccessTokenParameters, PersonalAccessTokenCreated> (parameters, "authenticate/token/create")
 
     let List (parameters: ListPersonalAccessTokensParameters) =
-        postServerWithEnv<ListPersonalAccessTokensParameters, PersonalAccessTokenSummary list> (parameters, "auth/token/list")
+        postServerWithEnv<ListPersonalAccessTokensParameters, PersonalAccessTokenSummary list> (parameters, "authenticate/token/list")
 
     let Revoke (parameters: RevokePersonalAccessTokenParameters) =
-        postServerWithEnv<RevokePersonalAccessTokenParameters, PersonalAccessTokenSummary> (parameters, "auth/token/revoke")
+        postServerWithEnv<RevokePersonalAccessTokenParameters, PersonalAccessTokenSummary> (parameters, "authenticate/token/revoke")

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -910,6 +910,46 @@ type AccessControl() =
         }
 
     [<Test>]
+    member _.AccessGrantRoleRejectsConflictingRequestedScopeKind() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+            let! repositoryId = createRepositoryAsync Client organizationId
+
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.ScopeKind <- "owner"
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- $"{Guid.NewGuid()}"
+            parameters.RoleId <- "RepositoryReader"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessRevokeRoleRejectsConflictingRequestedScopeKind() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+            let! repositoryId = createRepositoryAsync Client organizationId
+
+            let parameters = Parameters.Access.RevokeRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.ScopeKind <- "owner"
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- $"{Guid.NewGuid()}"
+            parameters.RoleId <- "RepositoryReader"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
     member _.BootstrapSeedsSystemAdmin() =
         task {
             let parameters = Parameters.Access.ListRoleAssignmentsParameters()
@@ -929,6 +969,80 @@ type AccessControl() =
                     && assignment.Source = "bootstrap")
 
             Assert.That(seeded, Is.True)
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsWithoutOwnerShowsOnlyCurrentPrincipalSystemAssignments() =
+        task {
+            let currentUserId = $"{Guid.NewGuid()}"
+            let otherUserId = $"{Guid.NewGuid()}"
+
+            do! grantRoleAsync Client "" "" "" "system" "SystemReader" currentUserId
+            do! grantRoleAsync Client "" "" "" "system" "SystemOperator" otherUserId
+
+            use currentClient = createClientWithUserId currentUserId
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = currentClient.PostAsync("/authorize/show", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+
+            let returnValue = deserialize<GraceReturnValue<RoleAssignment list>> responseText
+            let assignments = returnValue.ReturnValue
+
+            Assert.That(
+                assignments
+                |> List.exists (fun assignment ->
+                    assignment.Principal.PrincipalId = currentUserId
+                    && assignment.RoleId = "SystemReader"
+                    && assignment.Scope = Scope.System),
+                Is.True
+            )
+
+            Assert.That(
+                assignments
+                |> List.exists (fun assignment -> assignment.Principal.PrincipalId = otherUserId),
+                Is.False
+            )
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsRepositoryWithoutOrganization() =
+        task {
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.RepositoryId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsBranchWithoutRepository() =
+        task {
+            let! organizationId = createOrganizationAsync Client
+
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.BranchId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<Test>]
+    member _.AccessShowRoleAssignmentsRejectsChildScopeWithoutOwner() =
+        task {
+            let parameters = Parameters.Access.ShowRoleAssignmentsParameters()
+            parameters.RepositoryId <- $"{Guid.NewGuid()}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/show", createJsonContent parameters)
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Access.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Access.Server.Tests.fs
@@ -48,7 +48,7 @@ type AccessBootstrapEnabledTests() =
             let! _ownerId = createOwner client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
@@ -104,7 +104,7 @@ type AccessBootstrapTests() =
             let! _ownerId = createOwner Client
 
             let parameters = createGrantRoleParameters "SystemAdmin" $"{Guid.NewGuid()}"
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
@@ -147,7 +147,7 @@ type AccessCheckPermissionTests() =
             parameters.PrincipalId <- principalId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/checkPermission", createJsonContent parameters)
+            return! client.PostAsync("/authorize/check-permission", createJsonContent parameters)
         }
 
     [<Test>]
@@ -230,7 +230,7 @@ type AccessControlSecurityTests() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let revokeRoleAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId principalId roleId =
@@ -246,7 +246,7 @@ type AccessControlSecurityTests() =
             parameters.RoleId <- roleId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/revokeRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
         }
 
     let listRoleAssignmentsAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId =
@@ -259,7 +259,7 @@ type AccessControlSecurityTests() =
             parameters.ScopeKind <- scopeKind
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            return! client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
         }
 
     [<Test>]
@@ -523,7 +523,7 @@ type AccessControl() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -542,7 +542,7 @@ type AccessControl() =
                 claimPermission.DirectoryPermission <- permission
                 parameters.ClaimPermissions.Add(claimPermission)
 
-            let! response = client.PostAsync("/access/upsertPathPermission", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/upsert-path-permission", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -557,7 +557,7 @@ type AccessControl() =
             parameters.Path <- path
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/check-permission", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PermissionCheckResult>> response
             return returnValue.ReturnValue
@@ -575,7 +575,7 @@ type AccessControl() =
             parameters.RoleId <- roleId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/revokeRole", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/revoke-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 
@@ -588,7 +588,7 @@ type AccessControl() =
             parameters.ScopeKind <- scopeKind
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             let! responseText = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
             let returnValue = deserialize<GraceReturnValue<RoleAssignment list>> responseText
@@ -876,7 +876,7 @@ type AccessControl() =
             parameters.RoleId <- "SystemAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -890,7 +890,7 @@ type AccessControl() =
             parameters.RoleId <- "NotARealRole"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -905,7 +905,7 @@ type AccessControl() =
             parameters.RoleId <- "RepositoryAdmin"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -916,7 +916,7 @@ type AccessControl() =
             parameters.ScopeKind <- "system"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<RoleAssignment list>> response
@@ -942,7 +942,7 @@ type AccessControl() =
             parameters.ScopeKind <- "owner"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/listRoleAssignments", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/list-role-assignments", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -962,7 +962,7 @@ type AccessControl() =
             parameters.PrincipalId <- "other-user"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/check-permission", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden))
         }
 
@@ -982,7 +982,7 @@ type AccessControl() =
             parameters.PrincipalId <- nonAdminUserId
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = nonAdminClient.PostAsync("/access/checkPermission", createJsonContent parameters)
+            let! response = nonAdminClient.PostAsync("/authorize/check-permission", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK))
         }
 
@@ -1028,7 +1028,7 @@ type EndpointAuthorizationTests() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let getDefaultBranchAsync (repositoryId: string) =
@@ -1217,13 +1217,13 @@ type EndpointAuthorizationTests() =
             let! healthResponse = client.GetAsync("/healthz")
             Assert.That(healthResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! configResponse = client.GetAsync("/auth/oidc/config")
+            let! configResponse = client.GetAsync("/authenticate/oidc/config")
             Assert.That(configResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! loginResponse = client.GetAsync("/auth/login")
+            let! loginResponse = client.GetAsync("/authenticate/login")
             Assert.That(loginResponse.StatusCode, Is.AnyOf(HttpStatusCode.OK, HttpStatusCode.Redirect))
 
-            let! providerLoginResponse = client.GetAsync("/auth/login/test")
+            let! providerLoginResponse = client.GetAsync("/authenticate/login/test")
             Assert.That(providerLoginResponse.StatusCode, Is.AnyOf(HttpStatusCode.OK, HttpStatusCode.Redirect, HttpStatusCode.NotFound))
         }
 

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -73,7 +73,7 @@ module private ApprovalTestHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let createPolicyParameters (repositoryId: string) (branchId: string) =

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -285,7 +285,8 @@ type ApprovalApiIntegrationTests() =
             let! grantAdmin = ApprovalTestHelpers.grantRoleAsync Client "repo" ownerId organizationId repositoryId "" adminUser "RepositoryAdmin"
             Assert.That(grantAdmin.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "ApprovalResponder"
+            let! grantResponder =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId adminUser "BranchApprovalResponder"
 
             Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
@@ -507,7 +508,8 @@ type ApprovalApiIntegrationTests() =
             let! allowedRequestId = ApprovalTestHelpers.seedRequest repositoryId allowedBranchId $"user:{userId}"
             let! otherRequestId = ApprovalTestHelpers.seedRequest repositoryId otherBranchId $"user:{Guid.NewGuid()}"
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+            let! grantReader =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "BranchApprovalResponder"
 
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
@@ -564,7 +566,7 @@ type ApprovalApiIntegrationTests() =
 
             Assert.That(staleAttempt.ApprovalRequestId, Is.Not.EqualTo(first.ApprovalRequestId))
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -622,7 +624,7 @@ type ApprovalApiIntegrationTests() =
 
             Assert.That(nextAttempt.ApprovalRequestId, Is.Not.EqualTo(requestIds[0]))
 
-            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantReader = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -670,7 +672,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -678,6 +680,54 @@ type ApprovalApiIntegrationTests() =
             let! response = client.PostAsync("/approval/request/reject", createJsonContent parameters)
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+        }
+
+    [<TestCase("role:BranchApprovalResponder", "branch", "BranchApprovalResponder", true)>]
+    [<TestCase("role:RepositoryApprovalResponder", "repo", "RepositoryApprovalResponder", false)>]
+    [<TestCase("role:ApprovalResponder", "branch", "BranchApprovalResponder", true)>]
+    member _.ResponseAcceptsApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string, grantAtBranch: bool) =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
+
+            let grantBranchId = if grantAtBranch then branchId else ""
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client scopeKind ownerId organizationId repositoryId grantBranchId userId roleId
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+        }
+
+    [<TestCase("role:RepositoryApprovalResponder", "branch", "BranchApprovalResponder")>]
+    [<TestCase("role:BranchApprovalResponder", "repo", "RepositoryApprovalResponder")>]
+    member _.ResponseRejectsMismatchedSplitApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string) =
+        task {
+            let repositoryId = repositoryIds[0]
+            let branchId = repositoryDefaultBranchIds[0]
+            let userId = $"{Guid.NewGuid()}"
+            let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
+
+            let grantBranchId =
+                if scopeKind.Equals("branch", StringComparison.OrdinalIgnoreCase) then
+                    branchId
+                else
+                    ""
+
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client scopeKind ownerId organizationId repositoryId grantBranchId userId roleId
+            Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use client = ApprovalTestHelpers.createAuthenticatedClient userId
+            let parameters = ApprovalTestHelpers.requestParameters<Parameters.Approval.ApproveApprovalRequestParameters> repositoryId branchId requestId
+            let! response = client.PostAsync("/approval/request/approve", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseText)
         }
 
     [<Test>]
@@ -689,7 +739,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId allowedBranchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -708,7 +758,7 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grant = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
             Assert.That(grant.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId
@@ -729,7 +779,9 @@ type ApprovalApiIntegrationTests() =
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
-            let! grantResponder = ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "ApprovalResponder"
+            let! grantResponder =
+                ApprovalTestHelpers.grantRoleAsync Client "branch" ownerId organizationId repositoryId branchId userId "BranchApprovalResponder"
+
             Assert.That(grantResponder.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
             use client = ApprovalTestHelpers.createAuthenticatedClient userId

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -24,7 +24,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.LoginPageShowsNoProvidersWhenNotConfigured() =
         task {
-            let! response = Client.GetAsync("/auth/login")
+            let! response = Client.GetAsync("/authenticate/login")
             response.EnsureSuccessStatusCode() |> ignore
             Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("text/html"))
             let! body = response.Content.ReadAsStringAsync()
@@ -37,7 +37,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.LoginProviderReturnsNotFoundWhenNotConfigured() =
         task {
-            let! response = Client.GetAsync("/auth/login/microsoft")
+            let! response = Client.GetAsync("/authenticate/login/microsoft")
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound))
             Assert.That(body, Does.Contain("Login provider not available."))
@@ -67,7 +67,7 @@ type AuthEndpoints() =
             use unauthenticatedClient = new HttpClient()
             unauthenticatedClient.BaseAddress <- Client.BaseAddress
 
-            let! response = unauthenticatedClient.GetAsync("/auth/oidc/config")
+            let! response = unauthenticatedClient.GetAsync("/authenticate/oidc/config")
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<OidcClientConfig>> response
@@ -80,7 +80,7 @@ type AuthEndpoints() =
     [<Test>]
     member _.AuthMeReturnsGraceUserId() =
         task {
-            let! response = Client.GetAsync("/auth/me")
+            let! response = Client.GetAsync("/authenticate/me")
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<AuthInfo>> response
             Assert.That(returnValue.ReturnValue.GraceUserId, Is.EqualTo(testUserId))
@@ -93,7 +93,7 @@ type AuthEndpoints() =
         task {
             use unauthenticatedClient = new HttpClient()
             unauthenticatedClient.BaseAddress <- Client.BaseAddress
-            let! response = unauthenticatedClient.GetAsync("/auth/me")
+            let! response = unauthenticatedClient.GetAsync("/authenticate/me")
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
         }
 
@@ -102,7 +102,7 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
 
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
@@ -112,7 +112,7 @@ type AuthEndpoints() =
             patClient.BaseAddress <- Client.BaseAddress
             patClient.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", token)
 
-            let! meResponse = patClient.GetAsync("/auth/me")
+            let! meResponse = patClient.GetAsync("/authenticate/me")
             meResponse.EnsureSuccessStatusCode() |> ignore
 
             let! meValue = deserializeContent<GraceReturnValue<AuthInfo>> meResponse
@@ -124,20 +124,20 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             let created = returnValue.ReturnValue
 
             let revokeParameters = Grace.Shared.Parameters.Auth.RevokePersonalAccessTokenParameters()
             revokeParameters.TokenId <- created.Summary.TokenId
-            let! revokeResponse = Client.PostAsync("/auth/token/revoke", createJsonContent revokeParameters)
+            let! revokeResponse = Client.PostAsync("/authenticate/token/revoke", createJsonContent revokeParameters)
             revokeResponse.EnsureSuccessStatusCode() |> ignore
 
             use patClient = new HttpClient()
             patClient.BaseAddress <- Client.BaseAddress
             patClient.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", created.Token)
-            let! meResponse = patClient.GetAsync("/auth/me")
+            let! meResponse = patClient.GetAsync("/authenticate/me")
             Assert.That(meResponse.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
         }
 
@@ -147,7 +147,7 @@ type AuthEndpoints() =
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
             parameters.ExpiresInSeconds <- 400L * 86400L
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
         }
 
@@ -156,12 +156,12 @@ type AuthEndpoints() =
         task {
             let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
             parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! createdReturn = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
 
             let listParameters = Grace.Shared.Parameters.Auth.ListPersonalAccessTokensParameters()
-            let! listResponse = Client.PostAsync("/auth/token/list", createJsonContent listParameters)
+            let! listResponse = Client.PostAsync("/authenticate/token/list", createJsonContent listParameters)
             listResponse.EnsureSuccessStatusCode() |> ignore
             let! listReturn = deserializeContent<GraceReturnValue<PersonalAccessTokenSummary list>> listResponse
 
@@ -175,12 +175,12 @@ type AuthEndpoints() =
 
             let revokeParameters = Grace.Shared.Parameters.Auth.RevokePersonalAccessTokenParameters()
             revokeParameters.TokenId <- createdId
-            let! revokeResponse = Client.PostAsync("/auth/token/revoke", createJsonContent revokeParameters)
+            let! revokeResponse = Client.PostAsync("/authenticate/token/revoke", createJsonContent revokeParameters)
             revokeResponse.EnsureSuccessStatusCode() |> ignore
 
             let listWithRevoked = Grace.Shared.Parameters.Auth.ListPersonalAccessTokensParameters()
             listWithRevoked.IncludeRevoked <- true
-            let! revokedResponse = Client.PostAsync("/auth/token/list", createJsonContent listWithRevoked)
+            let! revokedResponse = Client.PostAsync("/authenticate/token/list", createJsonContent listWithRevoked)
 
             revokedResponse.EnsureSuccessStatusCode()
             |> ignore

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -31,7 +31,7 @@ type AuthEndpoints() =
             Assert.That(body, Does.StartWith("<!doctype html>"))
             Assert.That(body, Does.Contain("<title>Grace Login</title>"))
             Assert.That(body, Does.Contain("Interactive browser login is not available on the server in this phase."))
-            Assert.That(body, Does.Contain("grace auth login"))
+            Assert.That(body, Does.Contain("grace authenticate login"))
         }
 
     [<Test>]

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -356,7 +356,7 @@ module BranchServerTestHelpers =
             parameters.TokenName <- $"branch-sdk-{Guid.NewGuid():N}"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             return returnValue.ReturnValue.Token

--- a/src/Grace.Server.Tests/Repository.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Repository.Server.Tests.fs
@@ -41,7 +41,7 @@ type Repository() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
         }
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -153,7 +153,7 @@ type StorageContentBlockSasRoutes() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let setContentBlockParameters (parameters: Parameters.Storage.StorageParameters) repositoryId =
@@ -262,7 +262,7 @@ type StorageContentBlockDiscoveryRoutes() =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let createDiscoveryJson repositoryId (keyChunkAddresses: string array) =

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -61,7 +61,7 @@ module private WebhookTestHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            return! client.PostAsync("/access/grantRole", createJsonContent parameters)
+            return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
     let ruleParameters (repositoryId: string) (branchId: string) =

--- a/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/WorkItem.Integration.Server.Tests.fs
@@ -43,7 +43,7 @@ module private WorkItemIntegrationHelpers =
             parameters.Source <- "test"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/access/grantRole", createJsonContent parameters)
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
         }
@@ -513,7 +513,7 @@ module private WorkItemIntegrationHelpers =
             parameters.TokenName <- $"workitem-sdk-{Guid.NewGuid():N}"
             parameters.CorrelationId <- generateCorrelationId ()
 
-            let! response = Client.PostAsync("/auth/token/create", createJsonContent parameters)
+            let! response = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
             response.EnsureSuccessStatusCode() |> ignore
             let! returnValue = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> response
             return returnValue.ReturnValue.Token

--- a/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Authorization.Unit.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Shared.Authorization
+open Grace.Shared.Parameters.Access
 open Grace.Shared.Utilities
 open Grace.Types.Authorization
 open Grace.Types.Common
@@ -15,6 +16,13 @@ type AuthorizationUnit() =
 
     let createAssignment principal scope roleId =
         { Principal = principal; Scope = scope; RoleId = roleId; Source = "test"; SourceDetail = None; CreatedAt = getCurrentInstant () }
+
+    let createRepositoryParameters ownerId organizationId repositoryId =
+        let parameters = AccessParameters()
+        parameters.OwnerId <- string ownerId
+        parameters.OrganizationId <- string organizationId
+        parameters.RepositoryId <- string repositoryId
+        parameters
 
     let assertAllowed result =
         match result with
@@ -163,3 +171,56 @@ type AuthorizationUnit() =
             |> List.find (fun role -> role.RoleId.Equals("RepositoryAdmin", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(repoAdmin.AllowedOperations.Contains Operation.BranchAdmin, Is.True)
+
+    [<Test>]
+    member _.RevokeScopeParsingAllowsExplicitScopeForNonCatalogRoleIds() =
+        let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+        let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+        let parameters = createRepositoryParameters ownerId organizationId repositoryId
+
+        let result = Grace.Server.Access.parseRevokeRoleScope "DeletedRole" "repository" parameters (string (Guid.NewGuid()))
+
+        match result with
+        | Ok (Scope.Repository (parsedOwnerId, parsedOrganizationId, parsedRepositoryId)) ->
+            Assert.That(parsedOwnerId, Is.EqualTo(ownerId))
+            Assert.That(parsedOrganizationId, Is.EqualTo(organizationId))
+            Assert.That(parsedRepositoryId, Is.EqualTo(repositoryId))
+        | Ok scope -> Assert.Fail($"Expected repository scope but got {scope}.")
+        | Error error -> Assert.Fail($"Expected stale role revocation scope to parse but got {error.Error}.")
+
+    [<Test>]
+    member _.RevokeScopeParsingRequiresExplicitScopeForNonCatalogRoleIds() =
+        let ownerId = Guid.NewGuid()
+        let organizationId = Guid.NewGuid()
+        let repositoryId = Guid.NewGuid()
+        let parameters = createRepositoryParameters ownerId organizationId repositoryId
+
+        let result = Grace.Server.Access.parseRevokeRoleScope "DeletedRole" String.Empty parameters (string (Guid.NewGuid()))
+
+        match result with
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ScopeKind is required when revoking an unknown RoleId."))
+        | Ok scope -> Assert.Fail($"Expected missing scope kind to fail but got {scope}.")
+
+    [<Test>]
+    member _.RevokeScopeParsingStillUsesCatalogScopeInferenceForCurrentRoleIds() =
+        let ownerId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        let organizationId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        let repositoryId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        let parameters = createRepositoryParameters ownerId organizationId repositoryId
+
+        let inferredResult = Grace.Server.Access.parseRevokeRoleScope "RepositoryReader" String.Empty parameters (string (Guid.NewGuid()))
+
+        match inferredResult with
+        | Ok (Scope.Repository (parsedOwnerId, parsedOrganizationId, parsedRepositoryId)) ->
+            Assert.That(parsedOwnerId, Is.EqualTo(ownerId))
+            Assert.That(parsedOrganizationId, Is.EqualTo(organizationId))
+            Assert.That(parsedRepositoryId, Is.EqualTo(repositoryId))
+        | Ok scope -> Assert.Fail($"Expected repository scope but got {scope}.")
+        | Error error -> Assert.Fail($"Expected catalog role revocation scope to parse but got {error.Error}.")
+
+        let conflictingResult = Grace.Server.Access.parseRevokeRoleScope "RepositoryReader" "branch" parameters (string (Guid.NewGuid()))
+
+        match conflictingResult with
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ScopeKind 'branch' conflicts with role 'RepositoryReader' assignment scope 'repository'."))
+        | Ok scope -> Assert.Fail($"Expected conflicting scope kind to fail but got {scope}.")

--- a/src/Grace.Server/AGENTS.md
+++ b/src/Grace.Server/AGENTS.md
@@ -24,7 +24,7 @@ code.
   should be intentional and well documented here.
 - Coordinate contracts and message flows with `Grace.Actors`, `Grace.SDK`, and
   `Grace.Types` so that clients and grain logic remain in sync.
-- Personal access tokens (PATs) use the `GracePat` auth scheme, `/auth/token/*`
+- Personal access tokens (PATs) use the `GracePat` auth scheme, `/authenticate/token/*`
   endpoints, and are governed by `grace__auth__pat__*` lifetime policies.
   Authorization headers are redacted in request logging.
 - Auth0 JWT bearer validation is configured via

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -314,6 +314,18 @@ module Access =
                         )
                     | Error requestedScopeKind -> Error(GraceError.Create $"Invalid ScopeKind '{requestedScopeKind}'." correlationId)
 
+    let parseRevokeRoleScope (roleId: string) (requestedScopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace roleId then
+            Error(GraceError.Create "RoleId is required." correlationId)
+        else
+            match Authorization.RoleCatalog.tryGet roleId with
+            | Some _ -> parseRoleScope roleId requestedScopeKind parameters correlationId
+            | None ->
+                match normalizeScopeKind requestedScopeKind with
+                | Ok "" -> Error(GraceError.Create "ScopeKind is required when revoking an unknown RoleId." correlationId)
+                | Ok scopeKind -> parseScope scopeKind parameters correlationId
+                | Error scopeKind -> Error(GraceError.Create $"Invalid ScopeKind '{scopeKind}'." correlationId)
+
     let selfAssignmentQueriesForResource (principals: Principal list) (resource: Resource) =
         let distinctPrincipals = principals |> List.distinct
 
@@ -387,7 +399,7 @@ module Access =
                 let! parameters = context |> parse<RevokeRoleParameters>
                 let correlationId = parameters.CorrelationId
 
-                match parseRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
+                match parseRevokeRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok scope ->
                     match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with

--- a/src/Grace.Server/Access.Server.fs
+++ b/src/Grace.Server/Access.Server.fs
@@ -113,28 +113,40 @@ module Access =
             | Some parsed -> Ok { PrincipalType = parsed; PrincipalId = principalId }
             | None -> Error(GraceError.Create $"Invalid PrincipalType '{principalType}'." correlationId)
 
-    let private parseScope (scopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
-        let normalized =
+    let private normalizeScopeKind (scopeKind: string) =
+        let value =
             if String.IsNullOrWhiteSpace scopeKind then
                 String.Empty
             else
                 scopeKind.Trim().ToLowerInvariant()
 
+        match value with
+        | "" -> Ok String.Empty
+        | "system" -> Ok "system"
+        | "owner" -> Ok "owner"
+        | "org"
+        | "organization" -> Ok "organization"
+        | "repo"
+        | "repository" -> Ok "repository"
+        | "branch" -> Ok "branch"
+        | other -> Error other
+
+    let private parseScope (scopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+        let normalized = normalizeScopeKind scopeKind
+
         match normalized with
-        | "" -> Error(GraceError.Create "ScopeKind is required." correlationId)
-        | "system" -> Ok Scope.System
-        | "owner" ->
+        | Ok "" -> Error(GraceError.Create "ScopeKind is required." correlationId)
+        | Ok "system" -> Ok Scope.System
+        | Ok "owner" ->
             parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId
             |> Result.map (fun ownerId -> Scope.Owner ownerId)
-        | "org"
-        | "organization" ->
+        | Ok "organization" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
                 parseGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId
                 |> Result.map (fun organizationId -> Scope.Organization(ownerId, organizationId))
-        | "repo"
-        | "repository" ->
+        | Ok "repository" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
@@ -143,7 +155,7 @@ module Access =
                 | Ok organizationId ->
                     parseGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId
                     |> Result.map (fun repositoryId -> Scope.Repository(ownerId, organizationId, repositoryId))
-        | "branch" ->
+        | Ok "branch" ->
             match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
             | Error error -> Error error
             | Ok ownerId ->
@@ -155,7 +167,8 @@ module Access =
                     | Ok repositoryId ->
                         parseGuid parameters.BranchId (nameof parameters.BranchId) correlationId
                         |> Result.map (fun branchId -> Scope.Branch(ownerId, organizationId, repositoryId, branchId))
-        | other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
+        | Ok other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
+        | Error other -> Error(GraceError.Create $"Invalid ScopeKind '{other}'." correlationId)
 
     let private tryParseRepositoryResource (parameters: AccessParameters) (correlationId: CorrelationId) =
         match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
@@ -167,6 +180,51 @@ module Access =
                 match parseGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
                 | Error error -> Error error
                 | Ok repositoryId -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
+
+    let private parseOptionalGuid (value: string) (fieldName: string) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace value then
+            Ok None
+        else
+            let mutable parsed = Guid.Empty
+
+            if Guid.TryParse(value, &parsed) then
+                if parsed = Guid.Empty then Ok None else Ok(Some parsed)
+            else
+                Error(GraceError.Create $"{fieldName} must be a valid Guid." correlationId)
+
+    let private tryParseCurrentContextResource (parameters: AccessParameters) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace parameters.OwnerId then
+            if String.IsNullOrWhiteSpace parameters.OrganizationId
+               && String.IsNullOrWhiteSpace parameters.RepositoryId
+               && String.IsNullOrWhiteSpace parameters.BranchId then
+                Ok Resource.System
+            else
+                Error(GraceError.Create $"{nameof parameters.OwnerId} is required." correlationId)
+        else
+            match parseGuid parameters.OwnerId (nameof parameters.OwnerId) correlationId with
+            | Error error -> Error error
+            | Ok ownerId ->
+                match parseOptionalGuid parameters.OrganizationId (nameof parameters.OrganizationId) correlationId with
+                | Error error -> Error error
+                | Ok None ->
+                    if String.IsNullOrWhiteSpace parameters.RepositoryId
+                       && String.IsNullOrWhiteSpace parameters.BranchId then
+                        Ok(Resource.Owner ownerId)
+                    else
+                        Error(GraceError.Create $"{nameof parameters.OrganizationId} is required." correlationId)
+                | Ok (Some organizationId) ->
+                    match parseOptionalGuid parameters.RepositoryId (nameof parameters.RepositoryId) correlationId with
+                    | Error error -> Error error
+                    | Ok None ->
+                        if String.IsNullOrWhiteSpace parameters.BranchId then
+                            Ok(Resource.Organization(ownerId, organizationId))
+                        else
+                            Error(GraceError.Create $"{nameof parameters.RepositoryId} is required." correlationId)
+                    | Ok (Some repositoryId) ->
+                        match parseOptionalGuid parameters.BranchId (nameof parameters.BranchId) correlationId with
+                        | Error error -> Error error
+                        | Ok None -> Ok(Resource.Repository(ownerId, organizationId, repositoryId))
+                        | Ok (Some branchId) -> Ok(Resource.Branch(ownerId, organizationId, repositoryId, branchId))
 
     let private parseResource (resourceKind: string) (parameters: CheckPermissionParameters) (correlationId: CorrelationId) =
         let normalized =
@@ -232,6 +290,38 @@ module Access =
             | Some parsed -> Ok parsed
             | None -> Error(GraceError.Create $"Invalid Operation '{operation}'." correlationId)
 
+    let private parseRoleScope (roleId: string) (requestedScopeKind: string) (parameters: AccessParameters) (correlationId: CorrelationId) =
+        if String.IsNullOrWhiteSpace roleId then
+            Error(GraceError.Create "RoleId is required." correlationId)
+        else
+            match Authorization.RoleCatalog.tryGet roleId with
+            | None -> Error(GraceError.Create $"Unknown RoleId '{roleId}'." correlationId)
+            | Some roleDefinition ->
+                if roleDefinition.AppliesTo.Count <> 1 then
+                    Error(GraceError.Create $"Role '{roleId}' does not map to exactly one assignment scope." correlationId)
+                else
+                    let roleScopeKind = roleDefinition.AppliesTo |> Seq.exactlyOne
+
+                    match normalizeScopeKind requestedScopeKind with
+                    | Ok "" -> parseScope roleScopeKind parameters correlationId
+                    | Ok requestedScopeKind when requestedScopeKind.Equals(roleScopeKind, StringComparison.OrdinalIgnoreCase) ->
+                        parseScope roleScopeKind parameters correlationId
+                    | Ok requestedScopeKind ->
+                        Error(
+                            GraceError.Create
+                                $"ScopeKind '{requestedScopeKind}' conflicts with role '{roleId}' assignment scope '{roleScopeKind}'."
+                                correlationId
+                        )
+                    | Error requestedScopeKind -> Error(GraceError.Create $"Invalid ScopeKind '{requestedScopeKind}'." correlationId)
+
+    let selfAssignmentQueriesForResource (principals: Principal list) (resource: Resource) =
+        let distinctPrincipals = principals |> List.distinct
+
+        Authorization.scopesForResource resource
+        |> List.collect (fun scope ->
+            distinctPrincipals
+            |> List.map (fun principal -> scope, principal))
+
     let private tryParsePrincipalFilter (principalType: string) (principalId: string) (correlationId: CorrelationId) =
         if String.IsNullOrWhiteSpace principalType
            && String.IsNullOrWhiteSpace principalId then
@@ -250,25 +340,12 @@ module Access =
                 let correlationId = parameters.CorrelationId
 
                 let validationResult =
-                    match parseScope parameters.ScopeKind parameters correlationId with
+                    match parseRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
                     | Error error -> Error error
                     | Ok scope ->
                         match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with
                         | Error error -> Error error
-                        | Ok principal ->
-                            if String.IsNullOrWhiteSpace parameters.RoleId then
-                                Error(GraceError.Create "RoleId is required." correlationId)
-                            else
-                                match Authorization.RoleCatalog.tryGet parameters.RoleId with
-                                | None -> Error(GraceError.Create $"Unknown RoleId '{parameters.RoleId}'." correlationId)
-                                | Some roleDefinition ->
-                                    if
-                                        not
-                                        <| roleDefinition.AppliesTo.Contains(scopeKind scope)
-                                    then
-                                        Error(GraceError.Create $"Role '{parameters.RoleId}' does not apply to scope '{scopeKind scope}'." correlationId)
-                                    else
-                                        Ok(scope, principal)
+                        | Ok principal -> Ok(scope, principal)
 
                 match validationResult with
                 | Error error -> return! context |> result400BadRequest error
@@ -310,7 +387,7 @@ module Access =
                 let! parameters = context |> parse<RevokeRoleParameters>
                 let correlationId = parameters.CorrelationId
 
-                match parseScope parameters.ScopeKind parameters correlationId with
+                match parseRoleScope parameters.RoleId parameters.ScopeKind parameters correlationId with
                 | Error error -> return! context |> result400BadRequest error
                 | Ok scope ->
                     match parsePrincipal parameters.PrincipalType parameters.PrincipalId correlationId with
@@ -332,6 +409,52 @@ module Access =
                                 match! actorProxy.Handle (AccessControlCommand.RevokeRole(principal, parameters.RoleId)) (createMetadata context) with
                                 | Ok returnValue -> return! context |> result200Ok returnValue
                                 | Error error -> return! context |> result400BadRequest error
+            })
+
+    let ShowRoleAssignments: HttpHandler =
+        requireGraceUser (fun next context ->
+            task {
+                let! parameters = context |> parse<ShowRoleAssignmentsParameters>
+                let correlationId = parameters.CorrelationId
+
+                match tryParseCurrentContextResource parameters correlationId with
+                | Error error -> return! context |> result400BadRequest error
+                | Ok resource ->
+                    let principals = PrincipalMapper.getPrincipals context.User
+
+                    if principals.IsEmpty then
+                        return!
+                            context
+                            |> result400BadRequest (GraceError.Create "Authenticated user principal is required." correlationId)
+                    else
+                        let metadata = createMetadata context
+                        let assignments = ResizeArray<RoleAssignment>()
+                        let mutable queryError: GraceError option = None
+
+                        let queries = selfAssignmentQueriesForResource principals resource
+                        let mutable queryIndex = 0
+
+                        while queryIndex < queries.Length && queryError.IsNone do
+                            let scope, principal = queries[queryIndex]
+                            let scopeKey = AccessControl.getScopeKey scope
+                            let actorProxy = ActorProxy.AccessControl.CreateActorProxy scopeKey correlationId
+
+                            match! actorProxy.Handle (AccessControlCommand.ListAssignments(Some principal)) metadata with
+                            | Ok returnValue -> assignments.AddRange(returnValue.ReturnValue)
+                            | Error error -> queryError <- Some error
+
+                            queryIndex <- queryIndex + 1
+
+                        match queryError with
+                        | Some error -> return! context |> result400BadRequest error
+                        | None ->
+                            let returnValue =
+                                assignments
+                                |> Seq.distinct
+                                |> Seq.toList
+                                |> fun values -> GraceReturnValue.Create values correlationId
+
+                            return! context |> result200Ok returnValue
             })
 
     let ListRoleAssignments: HttpHandler =

--- a/src/Grace.Server/ApprovalRequest.Server.fs
+++ b/src/Grace.Server/ApprovalRequest.Server.fs
@@ -7,6 +7,7 @@ open Grace.Shared.Parameters.Approval
 open Grace.Shared.Utilities
 open Grace.Types
 open Grace.Types.Authorization
+open Grace.Types.Common
 open Grace.Types.Webhooks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
@@ -71,6 +72,47 @@ module ApprovalRequest =
                 | None -> Error(error context "Approval request was not found.")
         }
 
+    type private ApprovalResponderRoleSelector =
+        | LegacyApprovalResponder
+        | RepositoryApprovalResponder
+        | BranchApprovalResponder
+
+    let private tryGetApprovalResponderRoleSelector (selector: string) =
+        if selector.StartsWith("role:", StringComparison.OrdinalIgnoreCase) then
+            let roleId = selector.Substring("role:".Length)
+
+            if roleId.Equals("ApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some LegacyApprovalResponder
+            elif roleId.Equals("RepositoryApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some RepositoryApprovalResponder
+            elif roleId.Equals("BranchApprovalResponder", StringComparison.OrdinalIgnoreCase) then
+                Some BranchApprovalResponder
+            else
+                None
+        else
+            None
+
+    let private splitResponderRoleAssignment selector (scope: ApprovalScope) =
+        match selector with
+        | LegacyApprovalResponder -> None
+        | RepositoryApprovalResponder -> Some(Scope.Repository(scope.OwnerId, scope.OrganizationId, scope.RepositoryId), "RepositoryApprovalResponder")
+        | BranchApprovalResponder ->
+            if scope.TargetBranchId = BranchId.Empty then
+                None
+            else
+                Some(Scope.Branch(scope.OwnerId, scope.OrganizationId, scope.RepositoryId, scope.TargetBranchId), "BranchApprovalResponder")
+
+    let private hasSplitResponderRole (principals: Principal list) scope roleId =
+        let assignments =
+            PermissionEvaluatorDefaults.getAssignmentsForScope (scope, generateCorrelationId ())
+            |> fun getAssignments -> getAssignments.GetAwaiter().GetResult()
+
+        assignments
+        |> List.exists (fun assignment ->
+            principals |> List.contains assignment.Principal
+            && assignment.Scope = scope
+            && assignment.RoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+
     let private selectorMatches (context: HttpContext) (request: ApprovalRequest) =
         let selector =
             if isNull request.RequiredResponder then
@@ -95,20 +137,25 @@ module ApprovalRequest =
             |> List.exists (fun principal ->
                 principal.PrincipalType = PrincipalType.Group
                 && principal.PrincipalId.Equals(expected, StringComparison.OrdinalIgnoreCase))
-        elif selector.Equals("role:ApprovalResponder", StringComparison.OrdinalIgnoreCase) then
-            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
-
-            let decision =
-                evaluator
-                    .CheckAsync(principals, claims, Operation.ApprovalRequestRespond, resourceFromApprovalScope request.Scope)
-                    .GetAwaiter()
-                    .GetResult()
-
-            match decision with
-            | Allowed _ -> true
-            | Denied _ -> false
         else
-            false
+            match tryGetApprovalResponderRoleSelector selector with
+            | Some LegacyApprovalResponder ->
+                let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+                let decision =
+                    evaluator
+                        .CheckAsync(principals, claims, Operation.ApprovalRequestRespond, resourceFromApprovalScope request.Scope)
+                        .GetAwaiter()
+                        .GetResult()
+
+                match decision with
+                | Allowed _ -> true
+                | Denied _ -> false
+            | Some roleSelector ->
+                match splitResponderRoleAssignment roleSelector request.Scope with
+                | Some (scope, roleId) -> hasSplitResponderRole principals scope roleId
+                | None -> false
+            | None -> false
 
     let private respond decision approvalRequestId reason clientDecisionId fallbackScope : HttpHandler =
         fun _ context ->

--- a/src/Grace.Server/Auth.Server.fs
+++ b/src/Grace.Server/Auth.Server.fs
@@ -53,7 +53,7 @@ module Auth =
         |> ignore
 
         builder.AppendLine(
-            "<p>Interactive browser login is not available on the server in this phase. Use the CLI (grace auth login) or provide GRACE_TOKEN / Auth0 M2M credentials.</p>"
+            "<p>Interactive browser login is not available on the server in this phase. Use the CLI (grace authenticate login) or provide GRACE_TOKEN / Auth0 M2M credentials.</p>"
         )
         |> ignore
 

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -33,6 +33,7 @@ module EndpointAuthorizationManifest =
             endpoint "GET" "/authorize/list-roles" Authenticated
             endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/show" Authenticated
             endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -26,14 +26,14 @@ module EndpointAuthorizationManifest =
     let definitions: EndpointSecurityDefinition list =
         [
             endpoint "GET" "/" AllowAnonymous
-            endpoint "POST" "/access/checkPermission" Authenticated
-            endpoint "POST" "/access/grantRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/listPathPermissions" (Authorized(RepositoryAdmin, Repository))
-            endpoint "POST" "/access/listRoleAssignments" (Authorized(SystemAdmin, System))
-            endpoint "GET" "/access/listRoles" Authenticated
-            endpoint "POST" "/access/removePathPermission" (Authorized(RepositoryAdmin, Repository))
-            endpoint "POST" "/access/revokeRole" (Authorized(SystemAdmin, System))
-            endpoint "POST" "/access/upsertPathPermission" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/check-permission" Authenticated
+            endpoint "POST" "/authorize/grant-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/list-path-permissions" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/list-role-assignments" (Authorized(SystemAdmin, System))
+            endpoint "GET" "/authorize/list-roles" Authenticated
+            endpoint "POST" "/authorize/remove-path-permission" (Authorized(RepositoryAdmin, Repository))
+            endpoint "POST" "/authorize/revoke-role" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
@@ -60,14 +60,14 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/webhook/rule/test" (Authorized(WebhookManage, Repository))
             endpoint "POST" "/webhook/delivery/list" (Authorized(WebhookDeliveryRead, Repository))
             endpoint "POST" "/webhook/delivery/show" (Authorized(WebhookDeliveryRead, Repository))
-            endpoint "GET" "/auth/login" AllowAnonymous
-            endpoint "GET" "/auth/login/%s" AllowAnonymous
-            endpoint "GET" "/auth/logout" Authenticated
-            endpoint "GET" "/auth/me" Authenticated
-            endpoint "GET" "/auth/oidc/config" AllowAnonymous
-            endpoint "POST" "/auth/token/create" Authenticated
-            endpoint "POST" "/auth/token/list" Authenticated
-            endpoint "POST" "/auth/token/revoke" Authenticated
+            endpoint "GET" "/authenticate/login" AllowAnonymous
+            endpoint "GET" "/authenticate/login/%s" AllowAnonymous
+            endpoint "GET" "/authenticate/logout" Authenticated
+            endpoint "GET" "/authenticate/me" Authenticated
+            endpoint "GET" "/authenticate/oidc/config" AllowAnonymous
+            endpoint "POST" "/authenticate/token/create" Authenticated
+            endpoint "POST" "/authenticate/token/list" Authenticated
+            endpoint "POST" "/authenticate/token/revoke" Authenticated
             endpoint "POST" "/agent/session/active" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/listActive" (Authorized(RepositoryRead, Repository))
             endpoint "POST" "/agent/session/start" (Authorized(RepositoryWrite, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1578,32 +1578,32 @@ module Application =
                                |> addMetadata typeof<Storage.GetUploadUriParameters> ]
                     ]
                 subRoute
-                    "/access"
+                    "/authorize"
                     [
-                        POST [ route "/grantRole" Access.GrantRole
+                        POST [ route "/grant-role" Access.GrantRole
                                |> addMetadata typeof<Access.GrantRoleParameters>
 
-                               route "/revokeRole" Access.RevokeRole
+                               route "/revoke-role" Access.RevokeRole
                                |> addMetadata typeof<Access.RevokeRoleParameters>
 
-                               route "/listRoleAssignments" Access.ListRoleAssignments
+                               route "/list-role-assignments" Access.ListRoleAssignments
                                |> addMetadata typeof<Access.ListRoleAssignmentsParameters>
 
-                               route "/upsertPathPermission" Access.UpsertPathPermission
+                               route "/upsert-path-permission" Access.UpsertPathPermission
                                |> addMetadata typeof<Access.UpsertPathPermissionParameters>
 
-                               route "/removePathPermission" Access.RemovePathPermission
+                               route "/remove-path-permission" Access.RemovePathPermission
                                |> addMetadata typeof<Access.RemovePathPermissionParameters>
 
-                               route "/listPathPermissions" Access.ListPathPermissions
+                               route "/list-path-permissions" Access.ListPathPermissions
                                |> addMetadata typeof<Access.ListPathPermissionsParameters>
 
-                               route "/checkPermission" Access.CheckPermission
+                               route "/check-permission" Access.CheckPermission
                                |> addMetadata typeof<Access.CheckPermissionParameters> ]
-                        GET [ route "/listRoles" Access.ListRoles ]
+                        GET [ route "/list-roles" Access.ListRoles ]
                     ]
                 subRoute
-                    "/auth"
+                    "/authenticate"
                     [
                         GET [ route "/me" Auth.Me
                               route "/oidc/config" (Auth.OidcConfig configuration)

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1589,6 +1589,9 @@ module Application =
                                route "/list-role-assignments" Access.ListRoleAssignments
                                |> addMetadata typeof<Access.ListRoleAssignmentsParameters>
 
+                               route "/show" Access.ShowRoleAssignments
+                               |> addMetadata typeof<Access.ShowRoleAssignmentsParameters>
+
                                route "/upsert-path-permission" Access.UpsertPathPermission
                                |> addMetadata typeof<Access.UpsertPathPermissionParameters>
 

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -188,6 +188,8 @@ module Authorization =
             set [ ApprovalRequestRead
                   ApprovalRequestRespond ]
 
+        let private legacyApprovalResponderRoleId = "ApprovalResponder"
+
         let private roles: RoleDefinition list =
             [
                 { RoleId = "SystemAdmin"; AllowedOperations = systemAdminOperations; AppliesTo = Set.ofList [ scopeSystem ] }
@@ -222,6 +224,16 @@ module Authorization =
                     role.AppliesTo |> Seq.exactlyOne |> Some
                 else
                     None)
+
+        let tryGetLegacyAssignmentRole (roleId: RoleId) (assignmentScopeKind: string) =
+            if
+                legacyApprovalResponderRoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase)
+                && (assignmentScopeKind.Equals(scopeRepository, StringComparison.OrdinalIgnoreCase)
+                    || assignmentScopeKind.Equals(scopeBranch, StringComparison.OrdinalIgnoreCase))
+            then
+                Some { RoleId = legacyApprovalResponderRoleId; AllowedOperations = approvalResponderOperations; AppliesTo = Set.ofList [ assignmentScopeKind ] }
+            else
+                None
 
     let scopesForResource (resource: Resource) =
         match resource with
@@ -278,6 +290,7 @@ module Authorization =
                 |> List.tryFind (fun role ->
                     role.RoleId.Equals(assignment.RoleId, StringComparison.OrdinalIgnoreCase)
                     && role.AppliesTo.Contains scopeKind)
+                |> Option.orElseWith (fun () -> RoleCatalog.tryGetLegacyAssignmentRole assignment.RoleId scopeKind)
             else
                 None)
         |> List.collect (fun role -> role.AllowedOperations |> Set.toList)

--- a/src/Grace.Shared/Authorization.Shared.fs
+++ b/src/Grace.Shared/Authorization.Shared.fs
@@ -205,13 +205,8 @@ module Authorization =
                 { RoleId = "BranchAdmin"; AllowedOperations = branchAdminOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchWriter"; AllowedOperations = branchWriterOperations; AppliesTo = Set.ofList [ scopeBranch ] }
                 { RoleId = "BranchReader"; AllowedOperations = branchReaderOperations; AppliesTo = Set.ofList [ scopeBranch ] }
-                {
-                    RoleId = "ApprovalResponder"
-                    AllowedOperations = approvalResponderOperations
-                    AppliesTo =
-                        Set.ofList [ scopeRepository
-                                     scopeBranch ]
-                }
+                { RoleId = "RepositoryApprovalResponder"; AllowedOperations = approvalResponderOperations; AppliesTo = Set.ofList [ scopeRepository ] }
+                { RoleId = "BranchApprovalResponder"; AllowedOperations = approvalResponderOperations; AppliesTo = Set.ofList [ scopeBranch ] }
             ]
 
         let getAll () = roles
@@ -219,6 +214,14 @@ module Authorization =
         let tryGet (roleId: RoleId) =
             roles
             |> List.tryFind (fun role -> role.RoleId.Equals(roleId, StringComparison.OrdinalIgnoreCase))
+
+        let tryGetSingleScopeKind (roleId: RoleId) =
+            tryGet roleId
+            |> Option.bind (fun role ->
+                if role.AppliesTo.Count = 1 then
+                    role.AppliesTo |> Seq.exactlyOne |> Some
+                else
+                    None)
 
     let scopesForResource (resource: Resource) =
         match resource with

--- a/src/Grace.Shared/Parameters/Access.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Access.Parameters.fs
@@ -35,6 +35,9 @@ module Access =
         member val public PrincipalId = String.Empty with get, set
         member val public ScopeKind = String.Empty with get, set
 
+    type ShowRoleAssignmentsParameters() =
+        inherit AccessParameters()
+
     type ClaimPermissionParameters() =
         member val public Claim = String.Empty with get, set
         member val public DirectoryPermission = String.Empty with get, set

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -45,14 +45,14 @@
       "reason": "Access-control administration and permission-inspection routes are internal authorization operations, not public OpenAPI expansion targets for this slice.",
       "traceIds": [ "B-020", "B-024", "B-041", "surf-startup-admin" ],
       "routes": [
-        { "method": "GET", "path": "/access/listRoles" },
-        { "method": "POST", "path": "/access/checkPermission" },
-        { "method": "POST", "path": "/access/grantRole" },
-        { "method": "POST", "path": "/access/listPathPermissions" },
-        { "method": "POST", "path": "/access/listRoleAssignments" },
-        { "method": "POST", "path": "/access/removePathPermission" },
-        { "method": "POST", "path": "/access/revokeRole" },
-        { "method": "POST", "path": "/access/upsertPathPermission" }
+        { "method": "GET", "path": "/authorize/list-roles" },
+        { "method": "POST", "path": "/authorize/check-permission" },
+        { "method": "POST", "path": "/authorize/grant-role" },
+        { "method": "POST", "path": "/authorize/list-path-permissions" },
+        { "method": "POST", "path": "/authorize/list-role-assignments" },
+        { "method": "POST", "path": "/authorize/remove-path-permission" },
+        { "method": "POST", "path": "/authorize/revoke-role" },
+        { "method": "POST", "path": "/authorize/upsert-path-permission" }
       ]
     },
     {
@@ -60,14 +60,14 @@
       "reason": "Authentication, personal access token, and OIDC bootstrap routes are server identity flows kept outside the current public OpenAPI route expansion.",
       "traceIds": [ "B-020", "B-024", "drift-003", "surf-host" ],
       "routes": [
-        { "method": "GET", "path": "/auth/login" },
-        { "method": "GET", "path": "/auth/login/%s" },
-        { "method": "GET", "path": "/auth/logout" },
-        { "method": "GET", "path": "/auth/me" },
-        { "method": "GET", "path": "/auth/oidc/config" },
-        { "method": "POST", "path": "/auth/token/create" },
-        { "method": "POST", "path": "/auth/token/list" },
-        { "method": "POST", "path": "/auth/token/revoke" }
+        { "method": "GET", "path": "/authenticate/login" },
+        { "method": "GET", "path": "/authenticate/login/%s" },
+        { "method": "GET", "path": "/authenticate/logout" },
+        { "method": "GET", "path": "/authenticate/me" },
+        { "method": "GET", "path": "/authenticate/oidc/config" },
+        { "method": "POST", "path": "/authenticate/token/create" },
+        { "method": "POST", "path": "/authenticate/token/list" },
+        { "method": "POST", "path": "/authenticate/token/revoke" }
       ]
     },
     {

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -52,6 +52,7 @@
         { "method": "POST", "path": "/authorize/list-role-assignments" },
         { "method": "POST", "path": "/authorize/remove-path-permission" },
         { "method": "POST", "path": "/authorize/revoke-role" },
+        { "method": "POST", "path": "/authorize/show" },
         { "method": "POST", "path": "/authorize/upsert-path-permission" }
       ]
     },

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -76,8 +76,8 @@ pwsh ./scripts/start-debuglocal.ps1 --GraceServerUri "http://localhost:5000" -Sk
 
 The script creates a PAT through explicit TestAuth headers so the first local SystemAdmin can get started without an
 OIDC tenant. `-SkipAuthProbe` is required for this true zero-OIDC path because the default preflight checks
-`/auth/oidc/config` before TestAuth PAT creation. Omit it when OIDC/MSA settings are configured and you want the script
-to verify `/auth/oidc/config` and `/auth/me` before creating the PAT.
+`/authenticate/oidc/config` before TestAuth PAT creation. Omit it when OIDC/MSA settings are configured and you want
+the script to verify `/authenticate/oidc/config` and `/authenticate/me` before creating the PAT.
 
 Use this path when the server has OIDC/MSA settings and you want normal interactive auth:
 
@@ -126,7 +126,7 @@ grants.
 
 These are script parameters (not environment variables):
 
-- `-SkipAuthProbe`: skip auth preflight (`/auth/oidc/config`, `/auth/me`).
+- `-SkipAuthProbe`: skip auth preflight (`/authenticate/oidc/config`, `/authenticate/me`).
 - `-NoTokenBootstrap`: skip PAT creation.
 - `-TokenBootstrapMaxAttempts`: set max token bootstrap attempts.
 - `-TokenBootstrapInitialBackoffSeconds`: set initial retry backoff.

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -86,9 +86,9 @@ PowerShell:
 ```powershell
 $env:GRACE_SERVER_URI="http://localhost:5000"
 Remove-Item Env:GRACE_TOKEN -ErrorAction SilentlyContinue
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 bash / zsh:
@@ -96,9 +96,9 @@ bash / zsh:
 ```bash
 export GRACE_SERVER_URI="http://localhost:5000"
 unset GRACE_TOKEN
-grace auth login
-grace auth whoami --output Verbose
-grace auth token create --name "local-dev" --expires-in 30d --output Verbose
+grace authenticate login
+grace authenticate whoami --output Verbose
+grace authenticate token create --name "local-dev" --expires-in 30d --output Verbose
 ```
 
 Authentication proves the caller identity. The first authenticated OIDC/MSA caller still needs authorization: seed a
@@ -107,7 +107,7 @@ role before protected operations will succeed. An authenticated caller that maps
 RBAC grants; that PAT still authorizes protected operations only through Grace's normal authorization checks.
 
 `GRACE_TOKEN` takes precedence over M2M and interactive credentials. Clear stale or revoked PAT values before testing
-interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace auth login` succeeds.
+interactive OIDC/MSA login, otherwise the CLI may keep sending the stale PAT even after `grace authenticate login` succeeds.
 
 Scope creation uses normal authorization in DebugLocal and production:
 


### PR DESCRIPTION
## Summary

- Renames the Grace authentication surface from `auth` to `authenticate`, with `authn` as the command alias.
- Adds root `grace login` and `grace logout` aliases for `grace authenticate login/logout`.
- Renames the Grace authorization surface from `access` to `authorize`, with `authz` as the command alias.
- Moves server API paths from `/auth/*` and `/access/*` to `/authenticate/*` and `/authorize/*` as one clean breaking stack-wide change.
- Adds `grace authz show` / `/authorize/show` for self-service role assignment display.
- Adds `grace authz can` / `/authorize/can` as the user-oriented permission check surface.
- Derives grant/revoke scope from `--role` and rejects conflicting legacy `ScopeKind` values.
- Preserves effective authorization for persisted legacy `ApprovalResponder` assignments without restoring grant/catalog compatibility.
- Allows server and CLI revocation of stale/non-catalog role assignments when callers provide an explicit scope.
- Clears inherited child scope context for `authz can` when a caller explicitly overrides a parent scope.
- Updates docs, scripts, skill references, endpoint manifest, OpenAPI classification, SDK calls, and tests to the final authn/authz surface.

## Child PRs

- #419: Server API, SDK, manifest, OpenAPI route rename. Merged to epic at `c30aa27`.
- #420: CLI authenticate/authorize command rename and aliases. Merged to epic at `9fc9a9d`.
- #421: authz show/can and role-derived grant/revoke scope. Merged to epic at `f66d1b3`.
- #422: docs, examples, static surface audit, and final child validation. Merged to epic at `70ed04c`.

## Validation

- Final release-candidate gate before PR open from `C:\Source\Grace-epic-414`: `pwsh ./scripts/validate.ps1 -Fast` passed on `70ed04c00baefe74fbee08ef04fabafd76d9177c`.
- Final pre-fix gate build: succeeded with 0 warnings and 0 errors.
- Final pre-fix gate tests:
  - `Grace.Types.Tests`: 96 passed.
  - `Grace.Authorization.Tests`: 52 passed.
  - `Grace.Server.Unit.Tests`: 512 passed.
  - `Grace.CLI.Tests`: 551 passed, 1 skipped.
- Bot-fix validation on `2cedbe736e7230d3d318fd3b5f36c7e697f7419f`:
  - Fantomas passed on touched F# files.
  - Focused legacy approval responder authorization test passed, 1/1.
  - Focused stale-role revoke parsing tests passed, 3/3.
  - Full `Grace.Authorization.Tests` passed, 53/53.
  - `pwsh ./scripts/validate.ps1 -Fast` passed: `Grace.Types.Tests` 96/96, `Grace.Authorization.Tests` 53/53, `Grace.Server.Unit.Tests` 515/515, `Grace.CLI.Tests` 551 passed / 1 skipped.
  - `git diff --check` passed.
- CLI bot-fix validation on `7f4cb1879bf1438d69ab87bc7299521cb10e193b`:
  - Fantomas check passed on touched CLI F# files after formatting.
  - `Grace.CLI.Tests` Release build passed.
  - Focused CLI test selection `FullyQualifiedName~CommandParsingTests|FullyQualifiedName~HelpDoesNotReadConfigTests` passed, 197/197.
  - `pwsh ./scripts/validate.ps1 -Fast` passed.
  - `git diff --check` passed.
- Child PR #422: GitHub Actions `full` passed on `994319dabca8278c90fc04fa0f7ba864aebbd827`.
- Child PR #422: CLI help smoke checks passed for `authenticate`, `authn`, `login`, `logout`, `authorize`, and `authz`.
- Child PR #422: touched-file MarkdownLint passed; broad MarkdownLint still has unrelated pre-existing failures in older docs.
- Child PR #422: stale-surface audit completed; remaining exceptions are documented in the PR body.
- Child PR #422: `pwsh ./src/OpenAPI/prove-openapi.ps1 -Check All -AllowPending` still fails in the generated-client matrix proof outside this authn/authz docs patch. The failing proof reported the generated-client accepted-tier/Rust probe mismatch. Earlier route-focused OpenAPI proof passed in the API slice.
- Final PR #423: GitHub Actions `full` passed on `70ed04c00baefe74fbee08ef04fabafd76d9177c` and `2cedbe736e7230d3d318fd3b5f36c7e697f7419f`; the check is running again for `7f4cb1879bf1438d69ab87bc7299521cb10e193b`.

## Review Status

- #419: Codex Code Review Bot thumbs-up and `full` passed before merge.
- #420: Codex Code Review Bot thumbs-up and `full` passed before merge.
- #421: All actual Codex Code Review Bot findings were fixed and threads resolved; `full` passed on latest head. The bot remained on a stale eyes reaction after an explicit review request, which is recorded in #421 before merge.
- #422: Codex Code Review Bot thumbs-up and `full` passed before merge.
- #423 review on `70ed04c00baefe74fbee08ef04fabafd76d9177c` reported two findings:
  - Persisted `ApprovalResponder` grants became inert. Fixed in `2cedbe736e7230d3d318fd3b5f36c7e697f7419f`; thread replied and resolved. Prevention: auth / materialization / traversal ordering gap; coverage now includes persisted legacy-role effective authorization without restoring grant/catalog compatibility.
  - Revocation rejected stale/non-catalog role IDs. Fixed in `2cedbe736e7230d3d318fd3b5f36c7e697f7419f`; thread replied and resolved. Prevention: auth / materialization / traversal ordering gap; coverage now distinguishes grant catalog validation from stale-role revocation.
- #423 review on `2cedbe736e7230d3d318fd3b5f36c7e697f7419f` reported two findings:
  - CLI revoke rejected stale/non-catalog role IDs. Fixed in `7f4cb1879bf1438d69ab87bc7299521cb10e193b`; thread replied and resolved. Prevention: stale identity assumption; no process/template update needed for this ordinary implementation gap.
  - `authz can` inherited branch config under explicit parent overrides. Fixed in `7f4cb1879bf1438d69ab87bc7299521cb10e193b`; thread replied and resolved. Prevention: stale config inheritance gap; no process/template update needed for this ordinary implementation gap.
- Final PR #423 is awaiting Codex Code Review Bot and GitHub Actions on head `7f4cb1879bf1438d69ab87bc7299521cb10e193b`.

## Docs Impact

- Public docs and Grace skill references now use `authenticate`/`authn`, `authorize`/`authz`, and root `login`/`logout` aliases.
- Authentication route examples now use `/authenticate/*`.
- Authorization route/static endpoint surfaces now use `/authorize/*`.
- `grace authz list-role-assignments` remains documented as an admin inventory command, while `grace authz show` is documented as self-service role assignment display.

## Residual Risk

- This is intentionally a breaking command/API rename with no legacy `auth`/`access` command or route compatibility aliases.
- Legacy `ApprovalResponder` compatibility is authorization-only for persisted repository/branch assignments and does not restore the role as grantable in the current catalog.
- Revoking stale/non-catalog roles now requires an explicit `ScopeKind` because the catalog cannot infer a scope for deleted role IDs.
- OpenAPI generated-client matrix proof still has an unrelated generated-client/Rust probe failure. The route rename/static contract work has focused proof and test coverage, and final `validate -Fast` passed.
- Broad MarkdownLint still has unrelated pre-existing doc failures. Touched docs are lint-clean.

Closes #414
