### PR TITLE
CAS-02: Implement four-level CAS content key fanout

### DIFF
--- a/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestUpload.SDK.Tests.fs
@@ -238,7 +238,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded =
@@ -350,7 +350,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
@@ -517,7 +517,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded =
@@ -621,7 +621,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded =
@@ -685,7 +685,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
@@ -773,7 +773,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
@@ -862,7 +862,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded = fun parameters -> ManifestUploadSdkTests.Decision correlationId parameters.UploadSessionId parameters.OperationId
@@ -918,7 +918,7 @@ type ManifestUploadSdkTests() =
                             fun parameters _payload ->
                                 Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
 
-                                let placement = { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = None }
+                                let placement = { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = None }
 
                                 existingPlacements.Add(placement)
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
@@ -985,7 +985,7 @@ type ManifestUploadSdkTests() =
                                 uploadedBlocks[parameters.ContentBlockAddress] <- payload
 
                                 let placement =
-                                    { ObjectKey = $"cas/content-blocks/{parameters.ContentBlockAddress}"; ETag = Some $"etag-{uploadedBlocks.Count}" }
+                                    { ObjectKey = StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress; ETag = Some $"etag-{uploadedBlocks.Count}" }
 
                                 Task.FromResult(Ok(GraceReturnValue.Create placement correlationId))
                         ConfirmBlockUploaded =

--- a/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
@@ -239,7 +239,7 @@ module private RestartDurabilityHelpers =
             confirm.OperationId <- "confirm-0"
             confirm.ContentBlockAddress <- block.Address
             confirm.Payload <- block.Payload
-            confirm.StoragePlacement <- { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some uploadETag }
+            confirm.StoragePlacement <- { ObjectKey = StorageKeys.contentBlockObjectKey block.Address; ETag = Some uploadETag }
 
             let! confirmResult = postUploadSessionDecisionAsync "/storage/confirmContentBlockUpload" confirm
             Assert.That(confirmResult.ReturnValue.Session.ConfirmedBlockUploads.Length, Is.EqualTo(1))

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -274,6 +274,8 @@ type StorageContentBlockSasRoutes() =
         client.BaseAddress <- Client.BaseAddress
         client
 
+    let createMalformedJsonContent () = new StringContent("{", Encoding.UTF8, "application/json")
+
     let grantRoleAsync (client: HttpClient) scopeKind ownerId organizationId repositoryId branchId principalId roleId =
         task {
             let parameters = Parameters.Access.GrantRoleParameters()
@@ -308,6 +310,14 @@ type StorageContentBlockSasRoutes() =
         setContentBlockParameters parameters repositoryId
         parameters.ContentBlockAddress <- ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray())
         parameters
+
+    let malformedContentBlockAddress () = ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+
+    let assertUnauthorized (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), body)
+        }
 
     let assertBadRequestForMalformedContentBlockAddress (response: HttpResponseMessage) =
         task {
@@ -351,7 +361,7 @@ type StorageContentBlockSasRoutes() =
         }
 
     [<Test>]
-    member _.ContentBlockUploadUriReturnsBadRequestForMalformedContentBlockAddressBeforeAuthorizationResource() =
+    member _.ContentBlockUploadUriChecksPrincipalBeforeBodyValidationAndReturnsBadRequestAfterAuthentication() =
         task {
             let repositoryId = repositoryIds[0]
             let pathWriter = $"{Guid.NewGuid()}"
@@ -359,10 +369,18 @@ type StorageContentBlockSasRoutes() =
             let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
             Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
+            use unauthClient = createUnauthenticatedClient ()
             use writerClient = createClientWithUserId pathWriter
             let parameters = createContentBlockUploadParameters repositoryId
 
-            parameters.ContentBlockAddress <- ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+            parameters.ContentBlockAddress <- malformedContentBlockAddress ()
+
+            let! unauthInvalidUpload = unauthClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            do! assertUnauthorized unauthInvalidUpload
+
+            use malformedJson = createMalformedJsonContent ()
+            let! unauthMalformedUpload = unauthClient.PostAsync("/storage/getContentBlockUploadUri", malformedJson)
+            do! assertUnauthorized unauthMalformedUpload
 
             let! malformedUpload = writerClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
             do! assertBadRequestForMalformedContentBlockAddress malformedUpload
@@ -399,7 +417,7 @@ type StorageContentBlockSasRoutes() =
         }
 
     [<Test>]
-    member _.ContentBlockDownloadUriReturnsBadRequestForMalformedContentBlockAddressBeforeAuthorizationResource() =
+    member _.ContentBlockDownloadUriChecksPrincipalBeforeBodyValidationAndReturnsBadRequestAfterAuthentication() =
         task {
             let repositoryId = repositoryIds[0]
             let pathReader = $"{Guid.NewGuid()}"
@@ -407,10 +425,18 @@ type StorageContentBlockSasRoutes() =
             let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
             Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
+            use unauthClient = createUnauthenticatedClient ()
             use readerClient = createClientWithUserId pathReader
             let parameters = createContentBlockDownloadParameters repositoryId
 
-            parameters.ContentBlockAddress <- ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+            parameters.ContentBlockAddress <- malformedContentBlockAddress ()
+
+            let! unauthInvalidDownload = unauthClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            do! assertUnauthorized unauthInvalidDownload
+
+            use malformedJson = createMalformedJsonContent ()
+            let! unauthMalformedDownload = unauthClient.PostAsync("/storage/getContentBlockDownloadUri", malformedJson)
+            do! assertUnauthorized unauthMalformedDownload
 
             let! malformedDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
             do! assertBadRequestForMalformedContentBlockAddress malformedDownload

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -300,20 +300,20 @@ type StorageContentBlockSasRoutes() =
     let createContentBlockUploadParameters repositoryId =
         let parameters = Parameters.Storage.GetContentBlockUploadUriParameters()
         setContentBlockParameters parameters repositoryId
-        parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
+        parameters.ContentBlockAddress <- ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray())
         parameters
 
     let createContentBlockDownloadParameters repositoryId =
         let parameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
         setContentBlockParameters parameters repositoryId
-        parameters.ContentBlockAddress <- $"content-block-{Guid.NewGuid():N}"
+        parameters.ContentBlockAddress <- ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray())
         parameters
 
     let assertSuccessSasForContentBlock (response: HttpResponseMessage) (contentBlockAddress: ContentBlockAddress) =
         task {
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
-            Assert.That(body, Does.Contain("cas/content-blocks"))
+            Assert.That(body, Does.Contain("cas/content/"))
             Assert.That(body, Does.Contain(contentBlockAddress))
         }
 
@@ -760,7 +760,7 @@ type StorageManifestUploadSessionRoutes() =
 
             let! uploadETag = uploadContentBlockWithSas block.Payload uploadUri
 
-            let storagePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some uploadETag }
+            let storagePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey block.Address; ETag = Some uploadETag }
 
             Assert.That(storagePlacement.ETag, Is.Not.EqualTo(None))
 
@@ -834,7 +834,7 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(uploadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadUriBody)
             assertRawStringContent uploadUriResponse
             Assert.That(uploadUriBody, Does.StartWith("http"))
-            Assert.That(uploadUriBody, Does.Contain("cas/content-blocks"))
+            Assert.That(uploadUriBody, Does.Contain("cas/content/"))
             Assert.That(uploadUriBody, Does.Not.StartWith("{"))
 
             let downloadUriParameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
@@ -846,7 +846,7 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(downloadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), downloadUriBody)
             assertRawStringContent downloadUriResponse
             Assert.That(downloadUriBody, Does.StartWith("http"))
-            Assert.That(downloadUriBody, Does.Contain("cas/content-blocks"))
+            Assert.That(downloadUriBody, Does.Contain("cas/content/"))
             Assert.That(downloadUriBody, Does.Not.StartWith("{"))
 
             let! discoveryResponse =
@@ -1319,7 +1319,11 @@ type StorageManifestUploadSessionRoutes() =
             confirm.ContentBlockAddress <- block.Address
             confirm.Payload <- block.Payload
 
-            confirm.StoragePlacement <- { ObjectKey = $"cas/content-blocks/missing-{Guid.NewGuid():N}"; ETag = Some "etag-missing-block" }
+            confirm.StoragePlacement <-
+                {
+                    ObjectKey = StorageKeys.contentBlockObjectKey (ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray()))
+                    ETag = Some "etag-missing-block"
+                }
 
             let! _ = postUploadSessionDecision "/storage/confirmContentBlockUpload" confirm
 
@@ -1405,7 +1409,7 @@ type StorageManifestUploadSessionRoutes() =
             confirm.OperationId <- "confirm-0"
             confirm.ContentBlockAddress <- block.Address
             confirm.Payload <- block.Payload
-            confirm.StoragePlacement <- { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some uploadETag }
+            confirm.StoragePlacement <- { ObjectKey = StorageKeys.contentBlockObjectKey block.Address; ETag = Some uploadETag }
 
             let! _ = postUploadSessionDecision "/storage/confirmContentBlockUpload" confirm
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -309,6 +309,14 @@ type StorageContentBlockSasRoutes() =
         parameters.ContentBlockAddress <- ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray())
         parameters
 
+    let assertBadRequestForMalformedContentBlockAddress (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain("ContentBlockAddress"))
+            Assert.That(body, Does.Contain("64-character hexadecimal BLAKE3"))
+        }
+
     let assertSuccessSasForContentBlock (response: HttpResponseMessage) (contentBlockAddress: ContentBlockAddress) =
         task {
             let! body = response.Content.ReadAsStringAsync()
@@ -343,6 +351,29 @@ type StorageContentBlockSasRoutes() =
         }
 
     [<Test>]
+    member _.ContentBlockUploadUriReturnsBadRequestForMalformedContentBlockAddressBeforeAuthorizationResource() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathWriter = $"{Guid.NewGuid()}"
+
+            let! grantWriter = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathWriter "RepositoryContributor"
+            Assert.That(grantWriter.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use writerClient = createClientWithUserId pathWriter
+            let parameters = createContentBlockUploadParameters repositoryId
+
+            parameters.ContentBlockAddress <- ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+
+            let! malformedUpload = writerClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            do! assertBadRequestForMalformedContentBlockAddress malformedUpload
+
+            parameters.ContentBlockAddress <- ContentBlockAddress String.Empty
+
+            let! emptyUpload = writerClient.PostAsync("/storage/getContentBlockUploadUri", createJsonContent parameters)
+            do! assertBadRequestForMalformedContentBlockAddress emptyUpload
+        }
+
+    [<Test>]
     member _.ContentBlockDownloadUriRequiresPathReadAndDoesNotProbeBlockExistence() =
         task {
             let repositoryId = repositoryIds[0]
@@ -365,6 +396,29 @@ type StorageContentBlockSasRoutes() =
 
             let! allowedDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
             do! assertSuccessSasForContentBlock allowedDownload parameters.ContentBlockAddress
+        }
+
+    [<Test>]
+    member _.ContentBlockDownloadUriReturnsBadRequestForMalformedContentBlockAddressBeforeAuthorizationResource() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathReader = $"{Guid.NewGuid()}"
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use readerClient = createClientWithUserId pathReader
+            let parameters = createContentBlockDownloadParameters repositoryId
+
+            parameters.ContentBlockAddress <- ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+
+            let! malformedDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            do! assertBadRequestForMalformedContentBlockAddress malformedDownload
+
+            parameters.ContentBlockAddress <- ContentBlockAddress String.Empty
+
+            let! emptyDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            do! assertBadRequestForMalformedContentBlockAddress emptyDownload
         }
 
 [<NonParallelizable>]
@@ -822,7 +876,7 @@ type StorageManifestUploadSessionRoutes() =
         task {
             let repositoryId = repositoryIds[0]
             let correlationId = generateCorrelationId ()
-            let contentBlockAddress = ContentBlockAddress $"content-block-contract-{Guid.NewGuid():N}"
+            let contentBlockAddress = ContentBlockAddress(ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"content-block-contract-{Guid.NewGuid():N}"))
 
             let uploadUriParameters = Parameters.Storage.GetContentBlockUploadUriParameters()
             setStorageParameters uploadUriParameters repositoryId correlationId

--- a/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Actors
+open Grace.Shared
 open Grace.Types.ContentBlockMetadata
 open Grace.Types.Common
 open NodaTime
@@ -27,7 +28,8 @@ type ContentBlockMetadataActorTests() =
         }
 
     let storagePoolId = StoragePoolId "pool-main"
-    let contentBlockAddress = ContentBlockAddress "block-blake3-0001"
+    let contentBlockAddress = ContentBlockAddress "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    let contentBlockObjectKey = StorageKeys.contentBlockObjectKey contentBlockAddress
 
     let activeRange = { OrdinalStart = 0; OrdinalCount = 8; ActiveManifestCount = 2; PhysicalOffset = 0L; PhysicalLength = 1024L }
 
@@ -39,7 +41,7 @@ type ContentBlockMetadataActorTests() =
             StoragePoolId = storagePoolId
             ContentBlockAddress = contentBlockAddress
             BlockFormatVersion = 1s
-            StoragePlacement = { ObjectKey = "cas/content-blocks/block-blake3-0001"; ETag = Some "etag-1" }
+            StoragePlacement = { ObjectKey = contentBlockObjectKey; ETag = Some "etag-1" }
             Ranges = ranges
             TotalPhysicalBytes = 1536L
             ActivePhysicalBytes = 1024L
@@ -71,7 +73,7 @@ type ContentBlockMetadataActorTests() =
 
     let mergeWithObjectKey operationId objectKey ranges = mergeWithPlacement operationId { ObjectKey = objectKey; ETag = Some "etag-1" } ranges
 
-    let merge operationId ranges = mergeWithObjectKey operationId "cas/content-blocks/block-blake3-0001" ranges
+    let merge operationId ranges = mergeWithObjectKey operationId contentBlockObjectKey ranges
 
     let compact operationId expectedMetadataVersion placement ranges context =
         ContentBlockMetadataCommand.CompactPhysicalRanges
@@ -267,7 +269,7 @@ type ContentBlockMetadataActorTests() =
             }
 
         let compactedRange = { active with PhysicalOffset = 0L }
-        let compactedPlacement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let compactedPlacement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
 
         let result =
             ContentBlockMetadataActor.decideCommand
@@ -318,7 +320,7 @@ type ContentBlockMetadataActorTests() =
                 HasActiveCompaction = false
             }
 
-        let placement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let placement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
         let changedLogicalRange = { active with OrdinalCount = active.OrdinalCount + 1; PhysicalOffset = 0L }
 
         let changedLogicalResult =
@@ -371,7 +373,7 @@ type ContentBlockMetadataActorTests() =
                 HasActiveCompaction = false
             }
 
-        let placement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let placement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
         let nonCompactingRange = { active with PhysicalOffset = minimumReclaimableBytes; PhysicalLength = 8192L }
 
         let result =
@@ -407,7 +409,7 @@ type ContentBlockMetadataActorTests() =
                 HasActiveCompaction = false
             }
 
-        let placement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let placement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
 
         let futureBypassResult =
             ContentBlockMetadataActor.decideCommand
@@ -477,7 +479,7 @@ type ContentBlockMetadataActorTests() =
                 HasActiveCompaction = true
             }
 
-        let placement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let placement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
 
         let result =
             ContentBlockMetadataActor.decideCommand
@@ -535,7 +537,7 @@ type ContentBlockMetadataActorTests() =
                 HasActiveCompaction = false
             }
 
-        let placement = { ObjectKey = "cas/content-blocks/block-blake3-0001.compacted"; ETag = Some "etag-compact" }
+        let placement = { ObjectKey = $"{contentBlockObjectKey}.compacted"; ETag = Some "etag-compact" }
 
         let result =
             ContentBlockMetadataActor.decideCommand
@@ -787,7 +789,10 @@ type ContentBlockMetadataActorTests() =
             ContentBlockMetadataActor.decideCommand
                 createdEvents
                 createdDto
-                (mergeWithObjectKey "op-moved" "cas/content-blocks/other-object" [| reclaimableRange |])
+                (mergeWithObjectKey
+                    "op-moved"
+                    (StorageKeys.contentBlockObjectKey "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+                    [| reclaimableRange |])
                 (metadata "corr-moved")
 
         match changedPlacement with
@@ -798,7 +803,7 @@ type ContentBlockMetadataActorTests() =
     member _.MetadataActorUsesOneCompositeStringKeyAndDoesNotIntroduceChunkActorState() =
         let key = ContentBlockMetadataActorKey.Create storagePoolId contentBlockAddress
 
-        Assert.That(key, Is.EqualTo("pool-main|block-blake3-0001"))
+        Assert.That(key, Is.EqualTo($"pool-main|{contentBlockAddress}"))
 
         let repoRoot =
             DirectoryInfo(

--- a/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
@@ -26,11 +26,13 @@ type DedupeIndexServerTests() =
         let mutable physicalOffset = 0L
 
         let chunks =
-            [| for index in 0 .. chunkCount - 1 do
-                   let chunkBytes = bytes $"{name}-chunk-{index:D2}-{String('x', 128)}"
-                   let input: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = physicalOffset; Bytes = chunkBytes }
-                   physicalOffset <- physicalOffset + int64 chunkBytes.Length
-                   input |]
+            [|
+                for index in 0 .. chunkCount - 1 do
+                    let chunkBytes = bytes $"{name}-chunk-{index:D2}-{String('x', 128)}"
+                    let input: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = physicalOffset; Bytes = chunkBytes }
+                    physicalOffset <- physicalOffset + int64 chunkBytes.Length
+                    input
+            |]
 
         match ContentBlockFormat.encode chunks with
         | Ok block -> block
@@ -38,15 +40,27 @@ type DedupeIndexServerTests() =
             Assert.Fail($"Expected test content block to encode, got {error}.")
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
-    let decodedChunkAddresses (block: ContentBlockFormat.EncodedContentBlock) = block.Chunks |> Array.map (fun chunk -> chunk.Address)
+    let decodedChunkAddresses (block: ContentBlockFormat.EncodedContentBlock) =
+        block.Chunks
+        |> Array.map (fun chunk -> chunk.Address)
 
     let manifestFor (block: ContentBlockFormat.EncodedContentBlock) =
-        let size = block.Chunks |> Array.sumBy (fun chunk -> int64 chunk.Length)
+        let size =
+            block.Chunks
+            |> Array.sumBy (fun chunk -> int64 chunk.Length)
 
         let fileHash = FileContentHash(ContentAddress.computeBlake3Hex block.Payload)
 
         let manifest =
-            FileManifest.Create(ManifestAddress String.Empty, RabinChunking.SuiteName, fileHash, size, [ ContentBlock.Create(block.Address, 0L, size) ])
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                fileHash,
+                size,
+                [
+                    ContentBlock.Create(block.Address, 0L, size)
+                ]
+            )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
 
@@ -54,30 +68,38 @@ type DedupeIndexServerTests() =
         { UploadSessionDto.Default with
             RepositoryId = repositoryId
             LifecycleState = UploadSessionLifecycleState.RetentionPending
-            FinalizedManifestAddress = Some manifest.ManifestAddress }
+            FinalizedManifestAddress = Some manifest.ManifestAddress
+        }
 
     let nonFinalizedSession () =
         { UploadSessionDto.Default with
             RepositoryId = repositoryId
             LifecycleState = UploadSessionLifecycleState.UploadingBlocks
-            FinalizedManifestAddress = None }
+            FinalizedManifestAddress = None
+        }
 
     let metadataFor activeManifestCount metadataVersion (block: ContentBlockFormat.EncodedContentBlock) =
-        { Class = nameof ContentBlockMetadata
-          StoragePoolId = storagePoolId
-          ContentBlockAddress = block.Address
-          BlockFormatVersion = 1s
-          StoragePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some $"etag-{metadataVersion}" }
-          Ranges =
-            [| { OrdinalStart = 0
-                 OrdinalCount = block.Chunks.Length
-                 ActiveManifestCount = activeManifestCount
-                 PhysicalOffset = 0L
-                 PhysicalLength = block.Payload.LongLength } |]
-          TotalPhysicalBytes = block.Payload.LongLength
-          ActivePhysicalBytes = if activeManifestCount > 0 then block.Payload.LongLength else 0L
-          MetadataVersion = metadataVersion
-          UpdatedAt = timestamp }
+        {
+            Class = nameof ContentBlockMetadata
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = block.Address
+            BlockFormatVersion = 1s
+            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey block.Address; ETag = Some $"etag-{metadataVersion}" }
+            Ranges =
+                [|
+                    {
+                        OrdinalStart = 0
+                        OrdinalCount = block.Chunks.Length
+                        ActiveManifestCount = activeManifestCount
+                        PhysicalOffset = 0L
+                        PhysicalLength = block.Payload.LongLength
+                    }
+                |]
+            TotalPhysicalBytes = block.Payload.LongLength
+            ActivePhysicalBytes = if activeManifestCount > 0 then block.Payload.LongLength else 0L
+            MetadataVersion = metadataVersion
+            UpdatedAt = timestamp
+        }
 
     let payloadFor (block: ContentBlockFormat.EncodedContentBlock) : FinalizeManifestBlockPayload = { Address = block.Address; Payload = block.Payload }
 
@@ -153,15 +175,23 @@ type DedupeIndexServerTests() =
             let tail = bytes $"limit-tail-{index}-{String('y', 128)}"
 
             let chunks: ContentBlockFormat.ContentBlockInputChunk array =
-                [| let firstChunk: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = 0L; Bytes = sharedChunkBytes }
-                   firstChunk
+                [|
+                    let firstChunk: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = 0L; Bytes = sharedChunkBytes }
+                    firstChunk
 
-                   for ordinal in 1..11 do
-                       let chunk: ContentBlockFormat.ContentBlockInputChunk =
-                           { PhysicalOffset = int64 (sharedChunkBytes.Length + (ordinal - 1) * tail.Length)
-                             Bytes = bytes $"limit-{index}-{ordinal}-{String('z', 128)}" }
+                    for ordinal in 1..11 do
+                        let chunk: ContentBlockFormat.ContentBlockInputChunk =
+                            {
+                                PhysicalOffset =
+                                    int64 (
+                                        sharedChunkBytes.Length
+                                        + (ordinal - 1) * tail.Length
+                                    )
+                                Bytes = bytes $"limit-{index}-{ordinal}-{String('z', 128)}"
+                            }
 
-                       chunk |]
+                        chunk
+                |]
 
             match ContentBlockFormat.encode chunks with
             | Ok block -> block
@@ -170,10 +200,12 @@ type DedupeIndexServerTests() =
                 Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
         let records =
-            [| for index in 0 .. MaxCandidateWindowsPerKeyChunk + 2 do
-                   let block = createBlock index
-                   let manifest = manifestFor block
-                   DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block (metadataFor 1 (int64 index + 1L) block)) |]
+            [|
+                for index in 0 .. MaxCandidateWindowsPerKeyChunk + 2 do
+                    let block = createBlock index
+                    let manifest = manifestFor block
+                    DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block (metadataFor 1 (int64 index + 1L) block))
+            |]
             |> Array.concat
 
         let requestedChunk = (decodedChunkAddresses firstBlock)[0]
@@ -188,11 +220,13 @@ type DedupeIndexServerTests() =
         let matchingChunk = (decodedChunkAddresses duplicateBlock)[0]
 
         let requested =
-            [| yield matchingChunk
-               yield matchingChunk
-               yield String.Empty
-               for index in 0 .. MaxDiscoveryKeyChunkAddresses + 10 do
-                   yield $"missing-key-{index:D3}" |]
+            [|
+                yield matchingChunk
+                yield matchingChunk
+                yield String.Empty
+                for index in 0 .. MaxDiscoveryKeyChunkAddresses + 10 do
+                    yield $"missing-key-{index:D3}"
+            |]
 
         let result = discover Array.empty requested
 
@@ -207,8 +241,13 @@ type DedupeIndexServerTests() =
     [<Test>]
     member _.DiscoveryResponseBudgetTruncatesProtectedWindowsAndMarksPartial() =
         let blocks =
-            [| for index in 0 .. MaxResponseProtectedChunks / MinimumAcceptedReuseRunLength + 8 do
-                   encodedBlock $"budget-{index:D4}" MinimumAcceptedReuseRunLength |]
+            [|
+                for index in
+                    0 .. MaxResponseProtectedChunks
+                         / MinimumAcceptedReuseRunLength
+                         + 8 do
+                    encodedBlock $"budget-{index:D4}" MinimumAcceptedReuseRunLength
+            |]
 
         let records =
             blocks
@@ -218,7 +257,9 @@ type DedupeIndexServerTests() =
                 DedupeIndex.recordsAfterFinalize (sourceFor (finalizedSession manifest) manifest block metadata))
             |> Array.concat
 
-        let requested = blocks |> Array.map (fun block -> (decodedChunkAddresses block)[0])
+        let requested =
+            blocks
+            |> Array.map (fun block -> (decodedChunkAddresses block)[0])
 
         let result = discover records requested
 
@@ -248,31 +289,41 @@ type DedupeIndexServerTests() =
         let authoritativeMetadata =
             { metadataFor 1 8L block with
                 Ranges =
-                    [| { OrdinalStart = candidate.OrdinalStart
-                         OrdinalCount = candidate.OrdinalCount
-                         ActiveManifestCount = 1
-                         PhysicalOffset = 0L
-                         PhysicalLength = block.Payload.LongLength } |] }
+                    [|
+                        {
+                            OrdinalStart = candidate.OrdinalStart
+                            OrdinalCount = candidate.OrdinalCount
+                            ActiveManifestCount = 1
+                            PhysicalOffset = 0L
+                            PhysicalLength = block.Payload.LongLength
+                        }
+                    |]
+            }
 
         let discovery =
             UploadSessionCommand.IssueDedupeDiscovery
-                { OperationId = "op-discovery"
-                  ExpiresAt = timestamp.Plus(Duration.FromMinutes(5L))
-                  MinimumReuseRunLength = MinimumAcceptedReuseRunLength
-                  Hints = [| hint |] }
+                {
+                    OperationId = "op-discovery"
+                    ExpiresAt = timestamp.Plus(Duration.FromMinutes(5L))
+                    MinimumReuseRunLength = MinimumAcceptedReuseRunLength
+                    Hints = [| hint |]
+                }
 
         let started =
             { UploadSessionDto.Default with
                 UploadSessionId = Guid.NewGuid()
                 RepositoryId = repositoryId
-                LifecycleState = UploadSessionLifecycleState.Started }
+                LifecycleState = UploadSessionLifecycleState.Started
+            }
 
         let eventMetadata =
-            { Timestamp = timestamp
-              CorrelationId = "corr-stale-candidate"
-              Principal = "tester"
-              ClientType = Microsoft.FSharp.Core.Option.None
-              Properties = Dictionary<string, string>() }
+            {
+                Timestamp = timestamp
+                CorrelationId = "corr-stale-candidate"
+                Principal = "tester"
+                ClientType = Microsoft.FSharp.Core.Option.None
+                Properties = Dictionary<string, string>()
+            }
 
         let issued =
             match Grace.Actors.UploadSession.decideCommand [] started discovery eventMetadata with
@@ -285,7 +336,14 @@ type DedupeIndexServerTests() =
 
         let claim =
             UploadSessionCommand.ClaimReuseRanges
-                { OperationId = "op-claim"; DiscoveryOperationId = "op-discovery"; Ranges = [| { Hint = hint; Metadata = authoritativeMetadata } |] }
+                {
+                    OperationId = "op-claim"
+                    DiscoveryOperationId = "op-discovery"
+                    Ranges =
+                        [|
+                            { Hint = hint; Metadata = authoritativeMetadata }
+                        |]
+                }
 
         match Grace.Actors.UploadSession.decideCommand discoveryEvents discoveredSession claim eventMetadata with
         | Ok _ -> Assert.Fail("Expected stale index candidate to be rejected by authoritative metadata at claim time.")
@@ -303,10 +361,14 @@ type DedupeIndexServerTests() =
         let requested = [| (decodedChunkAddresses block)[0] |]
 
         let incrementalCandidates =
-            (discover incremental requested).CandidateContentBlocks
+            (discover incremental requested)
+                .CandidateContentBlocks
             |> Array.map candidateShape
 
-        let rebuiltCandidates = (discover rebuilt requested).CandidateContentBlocks |> Array.map candidateShape
+        let rebuiltCandidates =
+            (discover rebuilt requested)
+                .CandidateContentBlocks
+            |> Array.map candidateShape
 
         Assert.That(rebuiltCandidates.Length, Is.EqualTo(incrementalCandidates.Length))
 
@@ -321,9 +383,8 @@ type DedupeIndexServerTests() =
         let newerMetadata = metadataFor 1 11L block
 
         let rebuilt =
-            DedupeIndex.rebuild
-                [| sourceFor (finalizedSession manifest) manifest block olderMetadata
-                   sourceFor (finalizedSession manifest) manifest block newerMetadata |]
+            DedupeIndex.rebuild [| sourceFor (finalizedSession manifest) manifest block olderMetadata
+                                   sourceFor (finalizedSession manifest) manifest block newerMetadata |]
 
         let matchingRecords =
             rebuilt
@@ -415,7 +476,8 @@ type DedupeIndexServerTests() =
         let registration: DedupeIndex.FinalizedManifestRegistration =
             { StoragePoolId = storagePoolId; Session = finalizedSession manifest; Manifest = manifest; BlockPayloads = [| payloadFor block |] }
 
-        DedupeIndex.registerFinalizedManifest registration |> ignore
+        DedupeIndex.registerFinalizedManifest registration
+        |> ignore
 
         let firstRecords = DedupeIndex.writeAfterAuthoritativeMetadata firstMetadata
         let secondRecords = DedupeIndex.writeAfterAuthoritativeMetadata secondMetadata
@@ -509,6 +571,14 @@ type DedupeIndexServerTests() =
 
         Assert.That(result.CandidateContentBlocks[0].MetadataVersion, Is.EqualTo(5L))
 
-        Assert.That(matchingSnapshot |> Array.exists (fun record -> record.MetadataVersion = 1L), Is.False)
+        Assert.That(
+            matchingSnapshot
+            |> Array.exists (fun record -> record.MetadataVersion = 1L),
+            Is.False
+        )
 
-        Assert.That(matchingSnapshot |> Array.exists (fun record -> record.MetadataVersion = 5L), Is.True)
+        Assert.That(
+            matchingSnapshot
+            |> Array.exists (fun record -> record.MetadataVersion = 5L),
+            Is.True
+        )

--- a/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
@@ -72,7 +72,7 @@ type StorageAuthorizationResourcesTests() =
     [<Test>]
     member _.ContentBlockUploadHonorsExplicitAuthorizedScope() =
         let parameters = Storage.GetContentBlockUploadUriParameters()
-        parameters.ContentBlockAddress <- "sha256-explicit"
+        parameters.ContentBlockAddress <- "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         parameters.AuthorizedScope <- "manifest/file.bin"
 
         let resource = StorageAuthorizationResources.contentBlockUploadResource ownerId organizationId repositoryId parameters
@@ -82,21 +82,21 @@ type StorageAuthorizationResourcesTests() =
     [<Test>]
     member _.ContentBlockUploadFallsBackToContentBlockObjectKeyWhenScopeIsBlank() =
         let parameters = Storage.GetContentBlockUploadUriParameters()
-        parameters.ContentBlockAddress <- "sha256-blank-scope"
+        parameters.ContentBlockAddress <- "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         parameters.AuthorizedScope <- "   "
 
         let resource = StorageAuthorizationResources.contentBlockUploadResource ownerId organizationId repositoryId parameters
 
-        assertPathResource (StorageKeys.contentBlockObjectKey "sha256-blank-scope") resource
+        assertPathResource (StorageKeys.contentBlockObjectKey "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") resource
 
     [<Test>]
     member _.ContentBlockDownloadUsesContentBlockObjectKey() =
         let parameters = Storage.GetContentBlockDownloadUriParameters()
-        parameters.ContentBlockAddress <- "sha256-download"
+        parameters.ContentBlockAddress <- "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 
         let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
 
-        assertPathResource (StorageKeys.contentBlockObjectKey "sha256-download") resource
+        assertPathResource (StorageKeys.contentBlockObjectKey "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc") resource
 
     [<Test>]
     member _.UploadSessionStorageUsesAuthorizedScope() =

--- a/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
@@ -80,7 +80,7 @@ type UploadSessionActorTests() =
             OperationId = operationId
             ContentBlockAddress = blockAddress
             Payload = payload
-            StoragePlacement = { ObjectKey = $"cas/content-blocks/{blockAddress}"; ETag = Some "etag-confirmed" }
+            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey blockAddress; ETag = Some "etag-confirmed" }
         }
 
     let confirmWithPlacement operationId blockAddress payload placement : ConfirmBlockUploaded =
@@ -111,7 +111,7 @@ type UploadSessionActorTests() =
         UploadSessionCommand.FinalizeManifest { OperationId = operationId; Manifest = manifest; BlockPayloads = payloads }
 
     let storagePoolId = StoragePoolId "pool-main"
-    let reuseBlockAddress = ContentBlockAddress "block-blake3-reuse"
+    let reuseBlockAddress = ContentBlockAddress "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     let discoveryExpiresAt = timestamp.Plus(Duration.FromMinutes(10L))
     let minimumReuseRunLength = 4
 
@@ -123,7 +123,7 @@ type UploadSessionActorTests() =
             StoragePoolId = storagePoolId
             ContentBlockAddress = reuseBlockAddress
             BlockFormatVersion = 1s
-            StoragePlacement = { ObjectKey = $"cas/content-blocks/{reuseBlockAddress}"; ETag = Some "etag-reuse" }
+            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey reuseBlockAddress; ETag = Some "etag-reuse" }
             Ranges = ranges
             TotalPhysicalBytes = 4096L
             ActivePhysicalBytes = 0L
@@ -134,7 +134,7 @@ type UploadSessionActorTests() =
     let reuseMetadataFor contentBlockAddress metadataVersion ranges : ContentBlockMetadata =
         { reuseMetadata metadataVersion ranges with
             ContentBlockAddress = contentBlockAddress
-            StoragePlacement = { ObjectKey = $"cas/content-blocks/{contentBlockAddress}"; ETag = Some "etag-reuse" }
+            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey contentBlockAddress; ETag = Some "etag-reuse" }
         }
 
     let reuseHint =
@@ -697,7 +697,7 @@ type UploadSessionActorTests() =
                         {
                             ContentBlockAddress = firstBlock.Address
                             PayloadLength = firstBlock.Payload.LongLength
-                            StoragePlacement = { ObjectKey = $"cas/content-blocks/{firstBlock.Address}"; ETag = Some "etag-first" }
+                            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey firstBlock.Address; ETag = Some "etag-first" }
                             Ranges =
                                 [|
                                     {
@@ -713,7 +713,7 @@ type UploadSessionActorTests() =
                         {
                             ContentBlockAddress = secondBlock.Address
                             PayloadLength = secondBlock.Payload.LongLength
-                            StoragePlacement = { ObjectKey = $"cas/content-blocks/{secondBlock.Address}"; ETag = Some "etag-second" }
+                            StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey secondBlock.Address; ETag = Some "etag-second" }
                             Ranges =
                                 [|
                                     {
@@ -748,8 +748,8 @@ type UploadSessionActorTests() =
                 Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
             | _ -> Assert.Fail("Expected uploaded block finalization to create ContentBlockMetadata MergePhysicalRanges commands.")
 
-        assertMerge commands[0] firstBlock.Address $"cas/content-blocks/{firstBlock.Address}"
-        assertMerge commands[1] secondBlock.Address $"cas/content-blocks/{secondBlock.Address}"
+        assertMerge commands[0] firstBlock.Address (StorageKeys.contentBlockObjectKey firstBlock.Address)
+        assertMerge commands[1] secondBlock.Address (StorageKeys.contentBlockObjectKey secondBlock.Address)
 
     [<Test>]
     member _.FinalizedUploadRangesIncrementExistingActiveManifestCount() =
@@ -1183,7 +1183,7 @@ type UploadSessionActorTests() =
             {
                 ContentBlockAddress = block.Address
                 PayloadLength = block.Payload.LongLength
-                StoragePlacement = { ObjectKey = $"cas/content-blocks/{block.Address}"; ETag = Some "etag-confirmed" }
+                StoragePlacement = { ObjectKey = StorageKeys.contentBlockObjectKey block.Address; ETag = Some "etag-confirmed" }
                 Ranges =
                     [|
                         { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 0; PhysicalOffset = 0L; PhysicalLength = 11L }

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -272,12 +272,6 @@ module internal AnnotationMaterialization =
 
     let materializeTargetText (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId cancellationToken =
         let reader (objectKey: string) correlationId cancellationToken =
-            let maxPayloadBytes =
-                if objectKey.StartsWith(StorageKeys.contentBlockObjectKey String.Empty, StringComparison.Ordinal) then
-                    MaxContentBlockPayloadBytes
-                else
-                    MaxContentBlockPayloadBytes
-
-            azureObjectPayloadReader repositoryDto maxPayloadBytes objectKey correlationId cancellationToken
+            azureObjectPayloadReader repositoryDto MaxContentBlockPayloadBytes objectKey correlationId cancellationToken
 
         materializeTextWithObjectReader reader fileVersion correlationId cancellationToken

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -231,6 +231,14 @@ module Application =
                     return Ok(Operation.PathRead, Resource.Path(graceIds.OwnerId, graceIds.OrganizationId, graceIds.RepositoryId, normalizedPath))
             }
 
+        let invalidContentBlockAddressError correlationId =
+            GraceError.Create "ContentBlockAddress must be a 64-character hexadecimal BLAKE3 value." correlationId
+
+        let validateContentBlockAddressForResource correlationId contentBlockAddress =
+            match ContentAddress.tryNormalizeBlake3Address contentBlockAddress with
+            | Some normalizedAddress -> Ok normalizedAddress
+            | None -> Error(invalidContentBlockAddressError correlationId)
+
         let contentBlockUploadPathResourceFromContext (context: HttpContext) =
             task {
                 context.Request.EnableBuffering()
@@ -239,9 +247,19 @@ module Application =
                 context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
                 |> ignore
 
+                let correlationId = Services.getCorrelationId context
                 let graceIds = Services.getGraceIds context
 
-                return StorageAuthorizationResources.contentBlockUploadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
+                match validateContentBlockAddressForResource correlationId parameters.ContentBlockAddress with
+                | Error error -> return Error error
+                | Ok contentBlockAddress ->
+                    parameters.ContentBlockAddress <- contentBlockAddress
+
+                    return
+                        Ok(
+                            Operation.PathWrite,
+                            StorageAuthorizationResources.contentBlockUploadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
+                        )
             }
 
         let contentBlockDownloadPathResourceFromContext (context: HttpContext) =
@@ -252,9 +270,19 @@ module Application =
                 context.Request.Body.Seek(0L, IO.SeekOrigin.Begin)
                 |> ignore
 
+                let correlationId = Services.getCorrelationId context
                 let graceIds = Services.getGraceIds context
 
-                return StorageAuthorizationResources.contentBlockDownloadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
+                match validateContentBlockAddressForResource correlationId parameters.ContentBlockAddress with
+                | Error error -> return Error error
+                | Ok contentBlockAddress ->
+                    parameters.ContentBlockAddress <- contentBlockAddress
+
+                    return
+                        Ok(
+                            Operation.PathRead,
+                            StorageAuthorizationResources.contentBlockDownloadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
+                        )
             }
 
         let uploadSessionPathResourceFromContext (context: HttpContext) =
@@ -451,11 +479,10 @@ module Application =
 
         let requireAnnotatePathRead: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved annotatePathResourceFromContext
 
-        let requirePathWriteForContentBlockUploadUri: HttpHandler =
-            AuthorizationMiddleware.requiresPermission Operation.PathWrite contentBlockUploadPathResourceFromContext
+        let requirePathWriteForContentBlockUploadUri: HttpHandler = AuthorizationMiddleware.requiresPermissionResolved contentBlockUploadPathResourceFromContext
 
         let requirePathReadForContentBlockDownloadUri: HttpHandler =
-            AuthorizationMiddleware.requiresPermission Operation.PathRead contentBlockDownloadPathResourceFromContext
+            AuthorizationMiddleware.requiresPermissionResolved contentBlockDownloadPathResourceFromContext
 
         let requirePathWriteForUploadSession: HttpHandler = AuthorizationMiddleware.requiresPermission Operation.PathWrite uploadSessionPathResourceFromContext
 
@@ -1572,18 +1599,12 @@ module Application =
                                route "/getDownloadUri" (composeHandlers requirePathRead Storage.GetDownloadUri)
                                |> addMetadata typeof<Storage.GetDownloadUriParameters>
 
-                               route
-                                   "/getContentBlockUploadUri"
-                                   (composeHandlers
-                                       Storage.ValidateContentBlockUploadUriParameters
-                                       (composeHandlers requirePathWriteForContentBlockUploadUri Storage.GetContentBlockUploadUri))
+                               route "/getContentBlockUploadUri" (composeHandlers requirePathWriteForContentBlockUploadUri Storage.GetContentBlockUploadUri)
                                |> addMetadata typeof<Storage.GetContentBlockUploadUriParameters>
 
                                route
                                    "/getContentBlockDownloadUri"
-                                   (composeHandlers
-                                       Storage.ValidateContentBlockDownloadUriParameters
-                                       (composeHandlers requirePathReadForContentBlockDownloadUri Storage.GetContentBlockDownloadUri))
+                                   (composeHandlers requirePathReadForContentBlockDownloadUri Storage.GetContentBlockDownloadUri)
                                |> addMetadata typeof<Storage.GetContentBlockDownloadUriParameters>
 
                                route "/getUploadUri" (composeHandlers requirePathWriteForUploadUri Storage.GetUploadUris)

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1572,12 +1572,18 @@ module Application =
                                route "/getDownloadUri" (composeHandlers requirePathRead Storage.GetDownloadUri)
                                |> addMetadata typeof<Storage.GetDownloadUriParameters>
 
-                               route "/getContentBlockUploadUri" (composeHandlers requirePathWriteForContentBlockUploadUri Storage.GetContentBlockUploadUri)
+                               route
+                                   "/getContentBlockUploadUri"
+                                   (composeHandlers
+                                       Storage.ValidateContentBlockUploadUriParameters
+                                       (composeHandlers requirePathWriteForContentBlockUploadUri Storage.GetContentBlockUploadUri))
                                |> addMetadata typeof<Storage.GetContentBlockUploadUriParameters>
 
                                route
                                    "/getContentBlockDownloadUri"
-                                   (composeHandlers requirePathReadForContentBlockDownloadUri Storage.GetContentBlockDownloadUri)
+                                   (composeHandlers
+                                       Storage.ValidateContentBlockDownloadUriParameters
+                                       (composeHandlers requirePathReadForContentBlockDownloadUri Storage.GetContentBlockDownloadUri))
                                |> addMetadata typeof<Storage.GetContentBlockDownloadUriParameters>
 
                                route "/getUploadUri" (composeHandlers requirePathWriteForUploadUri Storage.GetUploadUris)

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -61,6 +61,14 @@ module Storage =
 
     let private getContentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = StorageKeys.contentBlockObjectKey contentBlockAddress
 
+    let private invalidContentBlockAddressError correlationId =
+        GraceError.Create "ContentBlockAddress must be a 64-character hexadecimal BLAKE3 value." correlationId
+
+    let private validateContentBlockAddress correlationId (contentBlockAddress: ContentBlockAddress) =
+        match ContentAddress.tryNormalizeBlake3Address contentBlockAddress with
+        | Some _ -> Ok()
+        | None -> Error(invalidContentBlockAddressError correlationId)
+
     let private resolveStorageIds (graceIds: GraceIds) (parameters: StorageParameters) =
         let organizationId =
             if graceIds.OrganizationId <> OrganizationId.Empty then
@@ -420,6 +428,22 @@ module Storage =
             }
 
     /// Gets an upload URI for the specified ContentBlock payload without probing whether the blob already exists.
+    let ValidateContentBlockUploadUriParameters: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<GetContentBlockUploadUriParameters>()
+
+                context.Request.Body.Seek(0L, SeekOrigin.Begin)
+                |> ignore
+
+                match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
+                | Ok () -> return! next context
+                | Error error -> return! context |> result400BadRequest error
+            }
+
     let GetContentBlockUploadUri: HttpHandler =
         fun (next: HttpFunc) (context: HttpContext) ->
             task {
@@ -428,14 +452,18 @@ module Storage =
 
                 try
                     let! parameters = context.BindJsonAsync<GetContentBlockUploadUriParameters>()
-                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
-                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
-                    let! repositoryDto = repositoryActor.Get correlationId
 
-                    let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
-                    let! uploadUri = getUriWithCreateSharedAccessSignature repositoryDto blobName correlationId
-                    context.SetStatusCode StatusCodes.Status200OK
-                    return! context.WriteStringAsync uploadUri.AbsoluteUri
+                    match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
+                    | Error error -> return! context |> result400BadRequest error
+                    | Ok () ->
+                        let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                        let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
+                        let! repositoryDto = repositoryActor.Get correlationId
+
+                        let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
+                        let! uploadUri = getUriWithCreateSharedAccessSignature repositoryDto blobName correlationId
+                        context.SetStatusCode StatusCodes.Status200OK
+                        return! context.WriteStringAsync uploadUri.AbsoluteUri
                 with
                 | ex ->
                     context.SetStatusCode StatusCodes.Status500InternalServerError
@@ -445,6 +473,22 @@ module Storage =
             }
 
     /// Gets a download URI for the specified ContentBlock payload without probing whether the blob already exists.
+    let ValidateContentBlockDownloadUriParameters: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let correlationId = getCorrelationId context
+
+                context.Request.EnableBuffering()
+                let! parameters = context.BindJsonAsync<GetContentBlockDownloadUriParameters>()
+
+                context.Request.Body.Seek(0L, SeekOrigin.Begin)
+                |> ignore
+
+                match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
+                | Ok () -> return! next context
+                | Error error -> return! context |> result400BadRequest error
+            }
+
     let GetContentBlockDownloadUri: HttpHandler =
         fun (next: HttpFunc) (context: HttpContext) ->
             task {
@@ -453,14 +497,18 @@ module Storage =
 
                 try
                     let! parameters = context.BindJsonAsync<GetContentBlockDownloadUriParameters>()
-                    let organizationId, repositoryId = resolveStorageIds graceIds parameters
-                    let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
-                    let! repositoryDto = repositoryActor.Get correlationId
 
-                    let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
-                    let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
-                    context.SetStatusCode StatusCodes.Status200OK
-                    return! context.WriteStringAsync downloadUri.AbsoluteUri
+                    match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
+                    | Error error -> return! context |> result400BadRequest error
+                    | Ok () ->
+                        let organizationId, repositoryId = resolveStorageIds graceIds parameters
+                        let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
+                        let! repositoryDto = repositoryActor.Get correlationId
+
+                        let blobName = getContentBlockObjectKey parameters.ContentBlockAddress
+                        let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
+                        context.SetStatusCode StatusCodes.Status200OK
+                        return! context.WriteStringAsync downloadUri.AbsoluteUri
                 with
                 | ex ->
                     context.SetStatusCode StatusCodes.Status500InternalServerError

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -427,23 +427,6 @@ module Storage =
                     return! context.WriteTextAsync $"Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
             }
 
-    /// Gets an upload URI for the specified ContentBlock payload without probing whether the blob already exists.
-    let ValidateContentBlockUploadUriParameters: HttpHandler =
-        fun (next: HttpFunc) (context: HttpContext) ->
-            task {
-                let correlationId = getCorrelationId context
-
-                context.Request.EnableBuffering()
-                let! parameters = context.BindJsonAsync<GetContentBlockUploadUriParameters>()
-
-                context.Request.Body.Seek(0L, SeekOrigin.Begin)
-                |> ignore
-
-                match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
-                | Ok () -> return! next context
-                | Error error -> return! context |> result400BadRequest error
-            }
-
     let GetContentBlockUploadUri: HttpHandler =
         fun (next: HttpFunc) (context: HttpContext) ->
             task {
@@ -470,23 +453,6 @@ module Storage =
                     logToConsole $"Exception in GetContentBlockUploadUri: {(ExceptionResponse.Create ex)}"
 
                     return! context.WriteTextAsync $"{getCurrentInstantExtended ()} Error in {context.Request.Path} at {DateTime.Now.ToLongTimeString()}."
-            }
-
-    /// Gets a download URI for the specified ContentBlock payload without probing whether the blob already exists.
-    let ValidateContentBlockDownloadUriParameters: HttpHandler =
-        fun (next: HttpFunc) (context: HttpContext) ->
-            task {
-                let correlationId = getCorrelationId context
-
-                context.Request.EnableBuffering()
-                let! parameters = context.BindJsonAsync<GetContentBlockDownloadUriParameters>()
-
-                context.Request.Body.Seek(0L, SeekOrigin.Begin)
-                |> ignore
-
-                match validateContentBlockAddress correlationId parameters.ContentBlockAddress with
-                | Ok () -> return! next context
-                | Error error -> return! context |> result400BadRequest error
             }
 
     let GetContentBlockDownloadUri: HttpHandler =

--- a/src/Grace.Shared/ContentAddress.Shared.fs
+++ b/src/Grace.Shared/ContentAddress.Shared.fs
@@ -23,6 +23,13 @@ module ContentAddress =
             ||| RegexOptions.CultureInvariant
         )
 
+    let private anyCaseAddressRegex =
+        Regex(
+            "^[0-9a-fA-F]{64}$",
+            RegexOptions.Compiled
+            ||| RegexOptions.CultureInvariant
+        )
+
     let private appendLine (builder: StringBuilder) (value: string) = builder.Append(value).Append('\n') |> ignore
 
     let private ensureNonNegative name value =
@@ -55,6 +62,24 @@ module ContentAddress =
     let isValidAddress (address: string) =
         not (String.IsNullOrEmpty(address))
         && lowercaseAddressRegex.IsMatch(address)
+
+    /// Normalizes a 64-hex BLAKE3 address for storage key construction.
+    let tryNormalizeBlake3Address (address: string) =
+        if String.IsNullOrWhiteSpace(address) then
+            None
+        else
+            let candidate = address.Trim()
+
+            if anyCaseAddressRegex.IsMatch(candidate) then
+                Some(candidate.ToLowerInvariant())
+            else
+                None
+
+    /// Requires a 64-hex BLAKE3 address and returns its lowercase storage-key representation.
+    let requireBlake3Address name address =
+        match tryNormalizeBlake3Address address with
+        | Some normalized -> normalized
+        | None -> invalidArg name "Content addresses must be 64-character hexadecimal BLAKE3 values."
 
     /// Computes the content address for one physical chunk payload.
     let computeChunkAddress (bytes: byte array) : ChunkAddress = ChunkAddress(computeBlake3Hex bytes)

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -25,8 +25,8 @@
         <Compile Include="Resources\Utilities.Resources.fs" />
         <Compile Include="Combinators.fs" />
         <Compile Include="Utilities.Shared.fs" />
-        <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="ContentAddress.Shared.fs" />
+        <Compile Include="StorageKeys.Shared.fs" />
         <Compile Include="ContentBlockFormat.Shared.fs" />
         <Compile Include="ManifestValidation.Shared.fs" />
         <Compile Include="RabinChunking.Shared.fs" />

--- a/src/Grace.Shared/StorageKeys.Shared.fs
+++ b/src/Grace.Shared/StorageKeys.Shared.fs
@@ -8,7 +8,7 @@ module StorageKeys =
     let private CasPrefix = "cas"
 
     [<Literal>]
-    let private ContentBlocksPrefix = "content-blocks"
+    let private ContentPrefix = "content"
 
     [<Literal>]
     let private FileManifestsPrefix = "file-manifests"
@@ -34,7 +34,9 @@ module StorageKeys =
         <> legacyWholeFileContentObjectKey fileVersion
 
     /// Builds the StoragePool-scoped object key for a content-addressed ContentBlock payload.
-    let contentBlockObjectKey (contentBlockAddress: ContentBlockAddress) = $"{CasPrefix}/{ContentBlocksPrefix}/{contentBlockAddress}"
+    let contentBlockObjectKey (contentBlockAddress: ContentBlockAddress) =
+        let digest = ContentAddress.requireBlake3Address (nameof contentBlockAddress) contentBlockAddress
+        $"{CasPrefix}/{ContentPrefix}/{digest[0..1]}/{digest[2..3]}/{digest[4..5]}/{digest[6..7]}/{digest}"
 
     /// Builds the StoragePool-scoped object key for a content-addressed FileManifest record.
     let fileManifestObjectKey (manifestAddress: ManifestAddress) = $"{CasPrefix}/{FileManifestsPrefix}/{manifestAddress}"

--- a/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
+++ b/src/Grace.Types.Tests/StorageKeys.Shared.Tests.fs
@@ -64,14 +64,47 @@ type StorageKeysSharedTests() =
         Assert.That(StorageKeys.wholeFileContentObjectKey first, Is.Not.EqualTo(StorageKeys.wholeFileContentObjectKey second))
 
     [<Test>]
-    member _.ContentBlockObjectKeyDependsOnlyOnContentBlockAddress() =
-        let address = ContentBlockAddress "block-blake3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    member _.ContentBlockObjectKeyUsesFourLevelDigestFanout() =
+        let address = ContentBlockAddress "ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
         let firstKey = StorageKeys.contentBlockObjectKey address
         let secondKey = StorageKeys.contentBlockObjectKey address
 
-        Assert.That(firstKey, Is.EqualTo("cas/content-blocks/block-blake3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+        Assert.That(firstKey, Is.EqualTo("cas/content/ab/34/cd/56/ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
         Assert.That(secondKey, Is.EqualTo(firstKey))
+
+    [<Test>]
+    member _.ContentBlockObjectKeyNormalizesUppercaseDigest() =
+        let address = ContentBlockAddress "AB34CD567F43AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+        let key = StorageKeys.contentBlockObjectKey address
+
+        Assert.That(key, Is.EqualTo("cas/content/ab/34/cd/56/ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+
+    [<Test>]
+    member _.ContentBlockObjectKeyDoesNotUseLegacyFlatOrTypedAddressShapes() =
+        let digest = "ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let address = ContentBlockAddress digest
+
+        let key = StorageKeys.contentBlockObjectKey address
+
+        Assert.That(key, Is.Not.EqualTo($"cas/content/{digest}"))
+        Assert.That(key, Is.Not.EqualTo($"cas/content/ab/34/{digest}"))
+        Assert.That(key, Is.Not.EqualTo($"cas/content-blocks/{digest}"))
+        Assert.That(key, Does.Not.Contain("content-blocks"))
+        Assert.That(key, Does.Not.Contain("block-blake3"))
+
+    [<TestCase("block-blake3-ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")>]
+    [<TestCase("ab34cd")>]
+    [<TestCase("ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz")>]
+    [<TestCase("sha256-ab34cd567f43aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")>]
+    member _.ContentBlockObjectKeyRejectsMalformedOrUnsupportedAddresses(address: string) =
+        Assert.Throws<ArgumentException>(
+            Action (fun () ->
+                StorageKeys.contentBlockObjectKey (ContentBlockAddress address)
+                |> ignore)
+        )
+        |> ignore
 
     [<Test>]
     member _.ManifestObjectKeyDependsOnlyOnManifestAddress() =


### PR DESCRIPTION
## Summary

- Implements four-level CAS ContentBlock object key fanout under `cas/content/<aa>/<bb>/<cc>/<dd>/<full-hash>`.
- Makes ContentBlock object key construction validate and normalize raw BLAKE3 digest values before producing physical blob names.
- Updates stale test fixtures and assertions that still constructed or expected `cas/content-blocks` placement.

## Issue Links

Related to #425.
Part of #424.
Blocks #343 and PR #396.

## Required Branch-Flow Exception

This epic intentionally deviates from the standard Grace epic branch rule.

The CAS integration branch is `epic/424-storagepool-cas` and was created from `origin/epic/343-blake3-sha256-version-hashes`, not `origin/main`.

This issue branch remains based on current `origin/epic/424-storagepool-cas`.

This PR targets `epic/424-storagepool-cas`, not `main` and not `epic/343-blake3-sha256-version-hashes`.

The final CAS integration PR will target `epic/343-blake3-sha256-version-hashes` after all CAS child issues land.

## Validation

- `dotnet tool run fantomas -- <touched F# files>`: passed.
- `dotnet test src/Grace.Types.Tests/Grace.Types.Tests.fsproj --configuration Release --filter "FullyQualifiedName~StorageKeysSharedTests"`: passed, 14/14.
- `pwsh ./scripts/validate.ps1 -Fast`: passed on rerun after repairing two introduced test separator typos.
- `git diff --check`: passed.

## Review Status

- Implementation worker: completed in `b735e67a1b58fdb48ec23b89c6f7fca88adc9f34`.
- Bot-prevention self-review: completed; no likely findings left by the worker.
- Codex Code Review Bot: pending review on PR head `b735e67a1b58fdb48ec23b89c6f7fca88adc9f34`.
- Open findings: none known before bot review.

## Docs Impact

- No public docs or generated contract updates in this slice. OpenAPI example URL cleanup is deferred to #432 unless route/model changes expose the helper directly.

## Residual Risk

- Test fixture overlap with #426 exists in `src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs`; merge order should preserve #425 fanout helper behavior and #426 routing identity changes.





