### PR TITLE
CAS-03E: Authorize shared CAS downloads with scoped manifest evidence

### DIFF
--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -378,6 +378,10 @@ type StorageContentBlockSasRoutes() =
             Assert.That(body, Does.Contain("64-character hexadecimal BLAKE3"))
         }
 
+    let assertJsonContent (response: HttpResponseMessage) =
+        Assert.That(response.Content.Headers.ContentType, Is.Not.Null)
+        Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/json"))
+
     let assertSuccessSasForContentBlock (response: HttpResponseMessage) (contentBlockAddress: ContentBlockAddress) =
         task {
             let! body = response.Content.ReadAsStringAsync()
@@ -523,6 +527,49 @@ type StorageContentBlockSasRoutes() =
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
             Assert.That(body, Does.Contain("AuthorizedScope"))
+            Assert.That(body, Does.Not.Contain("cas/content/"))
+        }
+
+    [<Test>]
+    member _.ContentBlockDownloadUriRejectsNullAuthorizedScopeBeforePathAuthorization() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathReader = $"{Guid.NewGuid()}"
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use readerClient = createClientWithUserId pathReader
+
+            let contentBlockAddress = ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"content-block-{Guid.NewGuid():N}")
+            let manifestAddress = ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"manifest-{Guid.NewGuid():N}")
+            let correlationId = generateCorrelationId ()
+
+            let requestBody =
+                String.Join(
+                    Environment.NewLine,
+                    [|
+                        "{"
+                        $"  \"OwnerId\": \"{ownerId}\","
+                        $"  \"OrganizationId\": \"{organizationId}\","
+                        $"  \"RepositoryId\": \"{repositoryId}\","
+                        $"  \"CorrelationId\": \"{correlationId}\","
+                        $"  \"ContentBlockAddress\": \"{contentBlockAddress}\","
+                        $"  \"ManifestAddress\": \"{manifestAddress}\","
+                        "  \"StoragePoolId\": \"pool-null-scope\","
+                        "  \"AuthorizedScope\": null"
+                        "}"
+                    |]
+                )
+
+            use content = new StringContent(requestBody, Encoding.UTF8, "application/json")
+            let! response = readerClient.PostAsync("/storage/getContentBlockDownloadUri", content)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            assertJsonContent response
+            Assert.That(body, Does.Contain("AuthorizedScope"))
+            Assert.That(body, Does.Not.Contain("InternalServerError"))
+            Assert.That(body, Does.Not.Contain("Error in /storage/getContentBlockDownloadUri"))
             Assert.That(body, Does.Not.Contain("cas/content/"))
         }
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -493,6 +493,7 @@ type StorageContentBlockSasRoutes() =
             use unprivilegedClient = createClientWithUserId $"{Guid.NewGuid()}"
 
             let parameters = createContentBlockDownloadParameters repositoryId
+            parameters.AuthorizedScope <- "/download/requires-finalized-manifest.bin"
 
             let! unauthDownload = unauthClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
             Assert.That(unauthDownload.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized))
@@ -502,6 +503,27 @@ type StorageContentBlockSasRoutes() =
 
             let! allowedDownload = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
             do! assertBadRequestContains "ManifestAddress" allowedDownload
+        }
+
+    [<Test>]
+    member _.ContentBlockDownloadUriRejectsAddressOnlyRequestBeforeSharedCasPlacementLookup() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let pathReader = $"{Guid.NewGuid()}"
+
+            let! grantReader = grantRoleAsync Client "repo" ownerId organizationId repositoryId "" pathReader "RepositoryReader"
+            Assert.That(grantReader.StatusCode, Is.EqualTo(HttpStatusCode.OK))
+
+            use readerClient = createClientWithUserId pathReader
+            let parameters = createContentBlockDownloadParameters repositoryId
+            parameters.StoragePoolId <- "pool-address-only"
+            parameters.ManifestAddress <- ManifestAddress(ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"manifest-{Guid.NewGuid():N}"))
+
+            let! response = readerClient.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
+            Assert.That(body, Does.Contain("AuthorizedScope"))
+            Assert.That(body, Does.Not.Contain("cas/content/"))
         }
 
     [<Test>]
@@ -1951,7 +1973,7 @@ type StorageManifestUploadSessionRoutes() =
             let! downloadUriBody = downloadUriResponse.Content.ReadAsStringAsync()
             Assert.That(downloadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), downloadUriBody)
             assertJsonContent downloadUriResponse
-            Assert.That(downloadUriBody, Does.Contain("ManifestAddress"))
+            Assert.That(downloadUriBody, Does.Contain("AuthorizedScope"))
 
             let! discoveryResponse =
                 postDiscoveryAsync

--- a/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
@@ -188,10 +188,126 @@ type StorageContentBlockSdkContract() =
 
         Assert.That(rejected, Is.EqualTo(None))
 
+        let blankScopeRejected = Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId "   " manifestAddress contentBlockAddress state
+
+        Assert.That(blankScopeRejected, Is.EqualTo(None))
+
+        let wrongManifestRejected =
+            Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope "manifest-other" contentBlockAddress state
+
+        Assert.That(wrongManifestRejected, Is.EqualTo(None))
+
+        let wrongPoolRejected =
+            Storage.tryFindFinalizedScopedContentBlockMetadata "pool-other" repositoryId authorizedScope manifestAddress contentBlockAddress state
+
+        Assert.That(wrongPoolRejected, Is.EqualTo(None))
+
         let crossRepositoryRejected =
             Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId otherRepositoryId authorizedScope manifestAddress contentBlockAddress state
 
         Assert.That(crossRepositoryRejected, Is.EqualTo(None))
+
+    [<Test>]
+    member _.DownloadPlacementResolutionKeepsHistoricalPathManifestEvidenceAfterReplacement() =
+        let repositoryId = Guid.Parse("2cd698a1-8642-4e0d-a963-e76f48afec1e")
+        let authorizedScope = "/download/history-replaced.bin"
+        let storagePoolId = StoragePoolId "pool-history"
+        let otherStoragePoolId = StoragePoolId "pool-history-other"
+        let oldManifestAddress = ManifestAddress "manifest-history-old"
+        let newManifestAddress = ManifestAddress "manifest-history-new"
+        let oldContentBlockAddress = ContentBlockAddress "1111111111111111111111111111111111111111111111111111111111111111"
+        let newContentBlockAddress = ContentBlockAddress "2222222222222222222222222222222222222222222222222222222222222222"
+
+        let metadata
+            (storagePoolId: StoragePoolId)
+            (contentBlockAddress: ContentBlockAddress)
+            (account: StorageAccountName)
+            (container: string)
+            objectKey
+            version
+            : ContentBlockMetadata
+            =
+            { ContentBlockMetadata.Empty with
+                StoragePoolId = storagePoolId
+                ContentBlockAddress = contentBlockAddress
+                StoragePlacement =
+                    {
+                        StorageAccountName = account
+                        StorageContainerName = StorageContainerName container
+                        ObjectKey = objectKey
+                        ETag = Some $"etag-{version}"
+                    }
+                MetadataVersion = version
+            }
+
+        let registration
+            (storagePoolId: StoragePoolId)
+            (manifestAddress: ManifestAddress)
+            (contentBlockAddress: ContentBlockAddress)
+            : DedupeIndex.RuntimeFinalizedManifestRegistration
+            =
+            {
+                StoragePoolId = storagePoolId
+                Session = { UploadSessionDto.Default with RepositoryId = repositoryId; AuthorizedScope = authorizedScope }
+                ManifestAddress = manifestAddress
+                Blocks =
+                    [|
+                        { Address = contentBlockAddress; ChunkAddresses = Array.empty }
+                    |]
+            }
+
+        let oldMetadata = metadata storagePoolId oldContentBlockAddress "old-account" "old-container" "historical/cas/content/old" 11L
+
+        let replacementMetadata = metadata storagePoolId newContentBlockAddress "new-account" "new-container" "historical/cas/content/new" 12L
+
+        let otherPoolMetadata = metadata otherStoragePoolId oldContentBlockAddress "other-pool-account" "other-pool-container" "other-pool/cas/content/old" 21L
+
+        let state =
+            { DedupeIndex.DedupeIndexState.Empty with
+                FinalizedManifests =
+                    [|
+                        registration storagePoolId oldManifestAddress oldContentBlockAddress
+                        registration storagePoolId newManifestAddress newContentBlockAddress
+                        registration otherStoragePoolId oldManifestAddress oldContentBlockAddress
+                    |]
+                MetadataRecords =
+                    [|
+                        oldMetadata
+                        replacementMetadata
+                        otherPoolMetadata
+                    |]
+            }
+
+        let oldSelection =
+            Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope oldManifestAddress oldContentBlockAddress state
+
+        Assert.That(oldSelection, Is.EqualTo(Some oldMetadata))
+
+        let replacementSelection =
+            Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope newManifestAddress newContentBlockAddress state
+
+        Assert.That(replacementSelection, Is.EqualTo(Some replacementMetadata))
+
+        let otherPoolSelection =
+            Storage.tryFindFinalizedScopedContentBlockMetadata otherStoragePoolId repositoryId authorizedScope oldManifestAddress oldContentBlockAddress state
+
+        Assert.That(otherPoolSelection, Is.EqualTo(Some otherPoolMetadata))
+
+        let mismatchedPathSelection =
+            Storage.tryFindFinalizedScopedContentBlockMetadata
+                storagePoolId
+                repositoryId
+                "/download/other-path.bin"
+                oldManifestAddress
+                oldContentBlockAddress
+                state
+
+        Assert.That(mismatchedPathSelection, Is.EqualTo(None))
+
+        let mismatchedBlockSelection =
+            Storage.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope oldManifestAddress newContentBlockAddress state
+
+        Assert.That(mismatchedBlockSelection, Is.EqualTo(None))
 
     [<Test>]
     member _.DefaultRepositoryDedupePoolResolutionUsesRepositoryScopedPool() =

--- a/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
@@ -90,13 +90,24 @@ type StorageAuthorizationResourcesTests() =
         assertPathResource (StorageKeys.contentBlockObjectKey "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") resource
 
     [<Test>]
-    member _.ContentBlockDownloadUsesContentBlockObjectKey() =
+    member _.ContentBlockDownloadUsesExplicitAuthorizedScope() =
         let parameters = Storage.GetContentBlockDownloadUriParameters()
         parameters.ContentBlockAddress <- "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        parameters.AuthorizedScope <- "manifest/download.bin"
 
         let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
 
-        assertPathResource (StorageKeys.contentBlockObjectKey "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc") resource
+        assertPathResource "manifest/download.bin" resource
+
+    [<Test>]
+    member _.ContentBlockDownloadDoesNotAuthorizeByContentBlockObjectKeyWhenScopeIsBlank() =
+        let parameters = Storage.GetContentBlockDownloadUriParameters()
+        parameters.ContentBlockAddress <- "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        parameters.AuthorizedScope <- "   "
+
+        let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
+
+        assertPathResource "   " resource
 
     [<Test>]
     member _.UploadSessionStorageUsesAuthorizedScope() =

--- a/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs
@@ -28,6 +28,17 @@ type StorageAuthorizationResourcesTests() =
             Assert.That(actualPath, Is.EqualTo(expectedPath))
         | other -> Assert.Fail($"Expected Resource.Path but received {other}.")
 
+    let assertMissingDownloadScope (authorizedScope: RelativePath) =
+        let parameters = Storage.GetContentBlockDownloadUriParameters()
+        parameters.ContentBlockAddress <- "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        parameters.AuthorizedScope <- authorizedScope
+
+        let result = StorageAuthorizationResources.tryContentBlockDownloadResource "unit-test-correlation" ownerId organizationId repositoryId parameters
+
+        match result with
+        | Error error -> Assert.That(error.Error, Is.EqualTo("AuthorizedScope is required for ContentBlock manifest download authorization."))
+        | Ok resource -> Assert.Fail($"Expected missing AuthorizedScope to be rejected but received {resource}.")
+
     [<Test>]
     member _.UploadMetadataFileVersionsMapToPathResources() =
         let parameters = Storage.GetUploadMetadataForFilesParameters()
@@ -95,19 +106,17 @@ type StorageAuthorizationResourcesTests() =
         parameters.ContentBlockAddress <- "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
         parameters.AuthorizedScope <- "manifest/download.bin"
 
-        let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
+        let result = StorageAuthorizationResources.tryContentBlockDownloadResource "unit-test-correlation" ownerId organizationId repositoryId parameters
 
-        assertPathResource "manifest/download.bin" resource
+        match result with
+        | Ok resource -> assertPathResource "manifest/download.bin" resource
+        | Error error -> Assert.Fail($"Expected explicit AuthorizedScope to create a path resource but received {error.Error}.")
 
     [<Test>]
-    member _.ContentBlockDownloadDoesNotAuthorizeByContentBlockObjectKeyWhenScopeIsBlank() =
-        let parameters = Storage.GetContentBlockDownloadUriParameters()
-        parameters.ContentBlockAddress <- "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-        parameters.AuthorizedScope <- "   "
-
-        let resource = StorageAuthorizationResources.contentBlockDownloadResource ownerId organizationId repositoryId parameters
-
-        assertPathResource "   " resource
+    member _.ContentBlockDownloadRejectsMissingAuthorizedScopeBeforePathResourceCreation() =
+        assertMissingDownloadScope null
+        assertMissingDownloadScope String.Empty
+        assertMissingDownloadScope "   "
 
     [<Test>]
     member _.UploadSessionStorageUsesAuthorizedScope() =

--- a/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
+++ b/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
@@ -32,13 +32,7 @@ module internal StorageAuthorizationResources =
         pathResource ownerId organizationId repositoryId path
 
     let contentBlockDownloadResource ownerId organizationId repositoryId (parameters: Storage.GetContentBlockDownloadUriParameters) =
-        let path =
-            if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
-                StorageKeys.contentBlockObjectKey parameters.ContentBlockAddress
-            else
-                parameters.AuthorizedScope
-
-        pathResource ownerId organizationId repositoryId path
+        pathResource ownerId organizationId repositoryId parameters.AuthorizedScope
 
     let uploadSessionResource ownerId organizationId repositoryId (parameters: Storage.UploadSessionStorageParameters) =
         pathResource ownerId organizationId repositoryId parameters.AuthorizedScope

--- a/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
+++ b/src/Grace.Server/Security/StorageAuthorizationResources.Server.fs
@@ -31,8 +31,14 @@ module internal StorageAuthorizationResources =
 
         pathResource ownerId organizationId repositoryId path
 
-    let contentBlockDownloadResource ownerId organizationId repositoryId (parameters: Storage.GetContentBlockDownloadUriParameters) =
+    let private contentBlockDownloadResource ownerId organizationId repositoryId (parameters: Storage.GetContentBlockDownloadUriParameters) =
         pathResource ownerId organizationId repositoryId parameters.AuthorizedScope
+
+    let tryContentBlockDownloadResource correlationId ownerId organizationId repositoryId (parameters: Storage.GetContentBlockDownloadUriParameters) =
+        if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
+            Error(GraceError.Create "AuthorizedScope is required for ContentBlock manifest download authorization." correlationId)
+        else
+            Ok(contentBlockDownloadResource ownerId organizationId repositoryId parameters)
 
     let uploadSessionResource ownerId organizationId repositoryId (parameters: Storage.UploadSessionStorageParameters) =
         pathResource ownerId organizationId repositoryId parameters.AuthorizedScope

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -278,11 +278,16 @@ module Application =
                 | Ok contentBlockAddress ->
                     parameters.ContentBlockAddress <- contentBlockAddress
 
-                    return
-                        Ok(
-                            Operation.PathRead,
-                            StorageAuthorizationResources.contentBlockDownloadResource graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId parameters
-                        )
+                    match
+                        StorageAuthorizationResources.tryContentBlockDownloadResource
+                            correlationId
+                            graceIds.OwnerId
+                            graceIds.OrganizationId
+                            graceIds.RepositoryId
+                            parameters
+                        with
+                    | Error error -> return Error error
+                    | Ok resource -> return Ok(Operation.PathRead, resource)
             }
 
         let uploadSessionPathResourceFromContext (context: HttpContext) =

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -1369,33 +1369,36 @@ module Storage =
 
     let private validateManifestForContentBlockDownload repositoryId (parameters: GetContentBlockDownloadUriParameters) correlationId =
         task {
-            match validateManifestAddress correlationId parameters.ManifestAddress with
-            | Error error -> return Error error
-            | Ok () ->
-                if String.IsNullOrWhiteSpace parameters.StoragePoolId then
-                    return Error(GraceError.Create "StoragePoolId is required for ContentBlock manifest download authorization." correlationId)
-                else
-                    let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+            if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
+                return Error(GraceError.Create "AuthorizedScope is required for ContentBlock manifest download authorization." correlationId)
+            else
+                match validateManifestAddress correlationId parameters.ManifestAddress with
+                | Error error -> return Error error
+                | Ok () ->
+                    if String.IsNullOrWhiteSpace parameters.StoragePoolId then
+                        return Error(GraceError.Create "StoragePoolId is required for ContentBlock manifest download authorization." correlationId)
+                    else
+                        let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
 
-                    match!
-                        dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata
-                            (
-                                parameters.StoragePoolId,
-                                repositoryId,
-                                parameters.AuthorizedScope,
-                                parameters.ManifestAddress,
-                                parameters.ContentBlockAddress,
-                                correlationId
-                            )
-                        with
-                    | Some metadata -> return Ok metadata.StoragePlacement
-                    | None ->
-                        return
-                            Error(
-                                GraceError.Create
-                                    $"ContentBlockAddress {parameters.ContentBlockAddress} is not referenced by finalized metadata reachable from this repository, storage pool, and authorized scope."
+                        match!
+                            dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata
+                                (
+                                    parameters.StoragePoolId,
+                                    repositoryId,
+                                    parameters.AuthorizedScope,
+                                    parameters.ManifestAddress,
+                                    parameters.ContentBlockAddress,
                                     correlationId
-                            )
+                                )
+                            with
+                        | Some metadata -> return Ok metadata.StoragePlacement
+                        | None ->
+                            return
+                                Error(
+                                    GraceError.Create
+                                        $"ContentBlockAddress {parameters.ContentBlockAddress} is not referenced by finalized metadata reachable from this repository, storage pool, and authorized scope."
+                                        correlationId
+                                )
         }
 
     /// Gets a download URI for the specified file version that can be used by a Grace client.


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #441.

Part of #426 and #424.

This PR intentionally targets `epic/426-storagepool-routing`, not `main`, not `epic/424-storagepool-cas`, and not
`epic/343-blake3-sha256-version-hashes`. The sub-issue will be closed manually only after the reviewed slice is merged
into the mini-integration branch.

## Summary

Implements CAS-03E by requiring scoped manifest evidence before minting shared CAS read SAS tokens.

Implemented behavior:

- `GetContentBlockDownloadUri` requires explicit path evidence through `AuthorizedScope` for manifest-backed shared CAS
  downloads.
- Download authorization no longer falls back to the content-block object key when scope evidence is blank.
- The server validates block address, `AuthorizedScope`, `ManifestAddress`, and `StoragePoolId` before performing the
  targeted finalized scoped metadata lookup.
- Read SAS issuance uses the stored `ContentBlockStoragePlacement` returned by finalized scoped metadata, preserving
  route-drift and compacted-placement behavior.
- Upload-session mismatched-scope denial remains intact.
- Repository-owned historical semantics are covered by tests for old manifests after replacement, plus denial for wrong
  path, repository, pool, manifest, and block evidence.

## Touched paths

Core implementation:

- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.Server/Security/StorageAuthorizationResources.Server.fs`

Tests:

- `src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs`
- `src/Grace.Server.Unit.Tests/StorageAuthorizationResources.Unit.Tests.fs`
- `src/Grace.Server.Tests/Storage.Server.Tests.fs`

## Owned-path compliance

- [x] Changed paths match the linked issue's owned paths and runtime authorization surface.
- [x] This PR does not implement #443 annotation materialization.
- [x] This PR does not implement #444 final contract/audit work.
- [x] This PR builds on #442 ownership/finalized-scope evidence and does not reimplement save/commit/checkpoint
  ownership registration.

## Contract impact

No request DTO/OpenAPI/SDK/generated-client change was needed. `GetContentBlockDownloadUriParameters` already carries
`AuthorizedScope`, `StoragePoolId`, `ManifestAddress`, and `ContentBlockAddress`; this slice tightens server
validation and authorization for those existing fields.

## Validation run

Implementation worker validation for `622e6baedc72a8037e2a597dbe2bfae984432b29`:

- Targeted Fantomas for touched F# files: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed.
- Focused Server.Unit tests for `StorageContentBlockSdkContract` and `StorageAuthorizationResourcesTests`: passed,
  29/29.
- First `pwsh ./scripts/validate.ps1 -Full`: failed at compile because a new integration test referenced a fixture-local
  helper out of scope; fixed before push.
- `pwsh ./scripts/validate.ps1 -Full`: passed.
  - `Grace.Server.Unit.Tests`: 661 passed.
  - `Grace.Authorization.Tests`: 53 passed.
  - `Grace.Types.Tests`: 129 passed.
  - `Grace.CLI.Tests`: 642 passed, 1 skipped.
  - `Grace.Server.Tests`: 228 passed.
- `git diff --check`: passed.

## Review Status

### Review Fix - 2026-06-21

- Fix worker: GPT-5.5 Medium worker `019eeab0-1e09-7973-91fd-d50fd9b0838e`.
- Fix commit: `bb8528f8effb78e8667dcf22049a1e83c506584f` (`Reject missing CAS download scopes in auth resolver`).
- Codex review source: review on `622e6baedc72a8037e2a597dbe2bfae984432b29`.
- Finding addressed: null, empty, or whitespace `AuthorizedScope` is now rejected before the authorization resolver can
  construct a path resource, preserving fail-closed 400 behavior instead of a middleware exception.
- Fix summary: added checked content-block download resource construction, routed `/storage/getContentBlockDownloadUri`
  through that helper, and kept the raw helper private so downloads cannot accidentally fall back to content-block object
  key authorization.
- Validation: targeted Fantomas passed; Release build for `Grace.Server.Unit.Tests` passed; focused
  `StorageAuthorizationResourcesTests` passed 9/9; Release build for `Grace.Server.Tests` passed; focused
  `ContentBlockDownloadUriRejectsNullAuthorizedScopeBeforePathAuthorization` passed 1/1; `git diff --check` passed.
  Broad `validate -Full` was skipped because the fix is narrow and directly covered by the focused helper plus
  Aspire-backed HTTP regression.
- Prevention: middleware-ordering gap; null scope is rejected before `Resource.Path`, and explicit scope remains required
  for manifest-backed shared CAS downloads.
- Final gate: GitHub `Validate / full` run `27908395238` passed on `bb8528f8effb78e8667dcf22049a1e83c506584f`; Codex Code Review Bot returned 👍 at `2026-06-21T15:12:10Z`; all review threads were answered and resolved.`r`n- Implementation worker: GPT-5.5 Medium worker `019eea9c-5dde-7110-a6dc-b9fad50cd7e5`.
- Current PR head: `622e6baedc72a8037e2a597dbe2bfae984432b29`.
- Worker bot-prevention self-review: completed for authorization/materialization ordering, address-only denial, negative
  test coverage, historical path semantics, stored placement route drift, pool/repository/path/manifest identity,
  contract drift, generated artifact requirements, and validation evidence.
- Prevention: authorization-boundary and route-evidence gap; the server now requires explicit path evidence and targeted
  finalized scoped metadata before minting shared CAS read SAS tokens.
- Open findings: none known before Codex Code Review Bot runs on this PR.
- Next gate: wait for GitHub `Validate / full` and Codex Code Review Bot on the current head, then require no-issues
  evidence or route findings to a fresh fix worker.

## Docs impact

No documentation changes. This PR tightens existing runtime authorization behavior and test coverage without changing
public request shape.

## Residual risk

- #443 owns annotation materialization from stored manifest CAS placement.
- #444 owns the final #426 generated-contract and integration audit.
