### PR TITLE
CAS-03G: Materialize annotations from stored CAS placement

### DIFF
--- a/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs
@@ -3,6 +3,7 @@ namespace Grace.Server.Tests
 open Grace.Server
 open Grace.Shared
 open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Common
 open NUnit.Framework
 open System
@@ -35,12 +36,64 @@ type AnnotationMaterializationServerTests() =
 
     let fileVersion relativePath isBinary (bytes: byte array) = FileVersion.Create relativePath (sha256Hex bytes) String.Empty isBinary (int64 bytes.Length)
 
-    let readerFrom (objects: IDictionary<string, byte array>) : AnnotationMaterialization.ObjectPayloadReader =
+    let wholeFileReaderFrom (objects: IDictionary<string, byte array>) : AnnotationMaterialization.ObjectPayloadReader =
         fun objectKey correlationId _ ->
             task {
                 match objects.TryGetValue objectKey with
                 | true, payload -> return Ok payload
                 | false, _ -> return Error(GraceError.Create $"missing object {objectKey}" correlationId)
+            }
+
+    let failingWholeFileReader: AnnotationMaterialization.ObjectPayloadReader =
+        fun objectKey correlationId _ -> task { return Error(GraceError.Create $"whole-file reader should not be called for {objectKey}" correlationId) }
+
+    let placementFor storagePoolId address =
+        {
+            StorageAccountName = $"account-{storagePoolId}"
+            StorageContainerName = StorageContainerName $"container-{storagePoolId}"
+            ObjectKey = $"stored/{storagePoolId}/{StorageKeys.contentBlockObjectKey address}"
+            ETag = Some $"etag-{address}"
+        }
+
+    let metadataFor storagePoolId (block: ContentBlock) placement =
+        { ContentBlockMetadata.Empty with
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = block.Address
+            BlockFormatVersion = 1s
+            StoragePlacement = placement
+            Ranges =
+                [|
+                    { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 1; PhysicalOffset = 0L; PhysicalLength = block.Size }
+                |]
+        }
+
+    let metadataResolverFrom
+        (metadata: IDictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>)
+        : AnnotationMaterialization.ContentBlockMetadataResolver
+        =
+        fun manifest contentBlockAddress correlationId _ ->
+            task {
+                let key = (manifest.StoragePoolId, manifest.ManifestAddress, contentBlockAddress)
+
+                match metadata.TryGetValue key with
+                | true, value -> return Ok value
+                | false, _ ->
+                    return
+                        Error(GraceError.Create $"missing metadata for {manifest.StoragePoolId}/{manifest.ManifestAddress}/{contentBlockAddress}" correlationId)
+            }
+
+    let contentBlockReaderFrom
+        (objects: IDictionary<string, byte array>)
+        (readPlacements: ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>)
+        : AnnotationMaterialization.ContentBlockPlacementPayloadReader
+        =
+        fun placement contentBlockAddress correlationId _ ->
+            task {
+                readPlacements.Add(contentBlockAddress, placement)
+
+                match objects.TryGetValue placement.ObjectKey with
+                | true, payload -> return Ok payload
+                | false, _ -> return Error(GraceError.Create $"missing placement object {placement.ObjectKey}" correlationId)
             }
 
     let expectOk result =
@@ -62,13 +115,14 @@ type AnnotationMaterializationServerTests() =
             Assert.Fail($"Expected test ContentBlock to encode, got {error}.")
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
-    let manifestFor (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
+    let manifestForWithStoragePool storagePoolId (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
         let manifest =
             FileManifest.Create(
                 ManifestAddress String.Empty,
                 RabinChunking.SuiteName,
                 FileContentHash(ContentAddress.computeBlake3Hex bytes),
                 int64 bytes.Length,
+                storagePoolId,
                 [
                     ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
                 ]
@@ -76,16 +130,31 @@ type AnnotationMaterializationServerTests() =
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
 
+    let manifestFor bytes block = manifestForWithStoragePool (StoragePoolId "pool-annotation") bytes block
+
     let manifestFile relativePath bytes =
         let block = encodeBlock bytes
         let manifest = manifestFor bytes block
         let fileVersion = fileVersion relativePath false bytes
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
-        fileVersion, block
+        fileVersion, block, manifest
 
-    let materialize reader fileVersion =
+    let materializeWithReaders wholeFileReader metadataResolver contentBlockReader fileVersion =
+        AnnotationMaterialization.materializeTextWithReaders
+            wholeFileReader
+            metadataResolver
+            contentBlockReader
+            fileVersion
+            correlationId
+            CancellationToken.None
+        |> fun task -> task.GetAwaiter().GetResult()
+
+    let materializeWholeFile reader fileVersion =
         AnnotationMaterialization.materializeTextWithObjectReader reader fileVersion correlationId CancellationToken.None
         |> fun task -> task.GetAwaiter().GetResult()
+
+    let materializeManifest metadata objects readPlacements fileVersion =
+        materializeWithReaders failingWholeFileReader (metadataResolverFrom metadata) (contentBlockReaderFrom objects readPlacements) fileVersion
 
     [<Test>]
     member _.WholeFileContentMaterializesExactUtf8Text() =
@@ -96,7 +165,7 @@ type AnnotationMaterializationServerTests() =
         objects[objectKey] <- bytes
 
         let result =
-            materialize (readerFrom objects) target
+            materializeWholeFile (wholeFileReaderFrom objects) target
             |> expectOk
 
         Assert.That(result.Text, Is.EqualTo("line one\nline two\n"))
@@ -111,48 +180,142 @@ type AnnotationMaterializationServerTests() =
         objects[objectKey] <- gzipBytes bytes
 
         let result =
-            materialize (readerFrom objects) target
+            materializeWholeFile (wholeFileReaderFrom objects) target
             |> expectOk
 
         Assert.That(result.Text, Is.EqualTo("gzip line one\ngzip line two\n"))
         Assert.That(result.Bytes = bytes, Is.True)
 
     [<Test>]
-    member _.ManifestBackedContentMaterializesExactUtf8Text() =
+    member _.ManifestBackedContentMaterializesExactUtf8TextFromStoredPlacement() =
         let bytes = textBytes "manifest line one\nmanifest line two\n"
-        let target, block = manifestFile "/src/Large.fs" bytes
+        let target, block, manifest = manifestFile "/src/Large.fs" bytes
         target.Blake3Hash <- Blake3Hash(ContentAddress.computeBlake3Hex bytes)
         let objects = Dictionary<string, byte array>()
-        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+        let placement = placementFor manifest.StoragePoolId block.Address
+        objects[placement.ObjectKey] <- block.Payload
+        objects[StorageKeys.contentBlockObjectKey block.Address] <- textBytes "repository fallback must not be read"
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let otherPool = StoragePoolId "pool-other"
+        let otherPlacement = placementFor otherPool block.Address
+        metadata[(otherPool, manifest.ManifestAddress, block.Address)] <- metadataFor otherPool manifest.Blocks[0] otherPlacement
+        objects[otherPlacement.ObjectKey] <- textBytes "same address in another pool must not be read"
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
 
         let result =
-            materialize (readerFrom objects) target
+            materializeManifest metadata objects readPlacements target
             |> expectOk
 
         Assert.That(result.Text, Is.EqualTo("manifest line one\nmanifest line two\n"))
         Assert.That(result.Bytes = bytes, Is.True)
+        Assert.That(readPlacements, Has.Count.EqualTo(1))
+        Assert.That(snd readPlacements[0], Is.EqualTo(placement))
+
+    [<Test>]
+    member _.ManifestBackedContentRejectsMissingFinalizedPlacementEvidence() =
+        let bytes = textBytes "manifest placement evidence"
+        let target, _, _ = manifestFile "/src/MissingPlacement.fs" bytes
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        let objects = Dictionary<string, byte array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeManifest metadata objects readPlacements target
+        |> expectErrorContains "missing metadata"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedContentRejectsBlankStoredPool() =
+        let bytes = textBytes "manifest blank pool"
+        let block = encodeBlock bytes
+        let manifest = manifestForWithStoragePool (StoragePoolId String.Empty) bytes block
+        let target = fileVersion "/src/BlankPool.fs" false bytes
+        target.ContentReference <- FileContentReference.FileManifest manifest
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        let objects = Dictionary<string, byte array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeManifest metadata objects readPlacements target
+        |> expectErrorContains "FileManifest StoragePoolId is required"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedContentRejectsWrongPoolMetadata() =
+        let bytes = textBytes "manifest wrong pool"
+        let target, block, manifest = manifestFile "/src/WrongPool.fs" bytes
+        let placement = placementFor (StoragePoolId "pool-other") block.Address
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor (StoragePoolId "pool-other") manifest.Blocks[0] placement
+        let objects = Dictionary<string, byte array>()
+        objects[placement.ObjectKey] <- block.Payload
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeManifest metadata objects readPlacements target
+        |> expectErrorContains "StoragePoolId does not match FileManifest.StoragePoolId"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedContentRejectsIncompleteStoredPlacement() =
+        let bytes = textBytes "manifest incomplete placement"
+        let target, block, manifest = manifestFile "/src/IncompletePlacement.fs" bytes
+        let placement = { placementFor manifest.StoragePoolId block.Address with ObjectKey = String.Empty }
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let objects = Dictionary<string, byte array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeManifest metadata objects readPlacements target
+        |> expectErrorContains "StoragePlacement is incomplete"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedContentReturnsStoredPlacementReadErrors() =
+        let bytes = textBytes "manifest missing stored blob"
+        let target, block, manifest = manifestFile "/src/MissingStoredBlob.fs" bytes
+        let placement = placementFor manifest.StoragePoolId block.Address
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let objects = Dictionary<string, byte array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeManifest metadata objects readPlacements target
+        |> expectErrorContains "missing placement object"
+
+        Assert.That(readPlacements, Has.Count.EqualTo(1))
 
     [<Test>]
     member _.MaterializationRejectsMismatchedFileBlake3WhenPresent() =
         let bytes = textBytes "manifest blake3 payload"
-        let target, block = manifestFile "/src/Large.fs" bytes
+        let target, block, manifest = manifestFile "/src/Large.fs" bytes
         target.Blake3Hash <- Blake3Hash "wrong-blake3"
         let objects = Dictionary<string, byte array>()
-        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+        let placement = placementFor manifest.StoragePoolId block.Address
+        objects[placement.ObjectKey] <- block.Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
 
-        materialize (readerFrom objects) target
+        materializeManifest metadata objects readPlacements target
         |> expectErrorContains "FileVersion.Blake3Hash"
 
     [<Test>]
     member _.MaterializationAllowsLegacyEmptyFileBlake3() =
         let bytes = textBytes "legacy manifest payload"
-        let target, block = manifestFile "/src/LegacyLarge.fs" bytes
+        let target, block, manifest = manifestFile "/src/LegacyLarge.fs" bytes
         target.Blake3Hash <- Blake3Hash String.Empty
         let objects = Dictionary<string, byte array>()
-        objects[StorageKeys.contentBlockObjectKey block.Address] <- block.Payload
+        let placement = placementFor manifest.StoragePoolId block.Address
+        objects[placement.ObjectKey] <- block.Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
 
         let result =
-            materialize (readerFrom objects) target
+            materializeManifest metadata objects readPlacements target
             |> expectOk
 
         Assert.That(result.Text, Is.EqualTo("legacy manifest payload"))
@@ -163,7 +326,7 @@ type AnnotationMaterializationServerTests() =
         let target = fileVersion "/src/Binary.dat" true bytes
         let reader _ _ _ = task { return Error(GraceError.Create "reader should not be called" correlationId) }
 
-        materialize reader target
+        materializeWholeFile reader target
         |> expectErrorContains "is binary"
 
     [<Test>]
@@ -173,7 +336,7 @@ type AnnotationMaterializationServerTests() =
         let objects = Dictionary<string, byte array>()
         objects[StorageKeys.wholeFileContentObjectKey target] <- bytes
 
-        materialize (readerFrom objects) target
+        materializeWholeFile (wholeFileReaderFrom objects) target
         |> expectErrorContains "not valid UTF-8"
 
     [<Test>]
@@ -189,7 +352,7 @@ type AnnotationMaterializationServerTests() =
 
         let reader _ _ _ = task { return Error(GraceError.Create "reader should not be called" correlationId) }
 
-        materialize reader target
+        materializeWholeFile reader target
         |> expectErrorContains "too large"
 
     [<Test>]
@@ -198,17 +361,21 @@ type AnnotationMaterializationServerTests() =
         let target = fileVersion "/src/Missing.txt" false bytes
         let objects = Dictionary<string, byte array>()
 
-        materialize (readerFrom objects) target
+        materializeWholeFile (wholeFileReaderFrom objects) target
         |> expectErrorContains "missing object"
 
     [<Test>]
     member _.InvalidManifestReconstructionIsRejectedClearly() =
         let bytes = textBytes "manifest payload"
-        let target, block = manifestFile "/src/Manifest.fs" bytes
+        let target, block, manifest = manifestFile "/src/Manifest.fs" bytes
         let objects = Dictionary<string, byte array>()
         let corrupted = Array.copy block.Payload
         corrupted[0] <- corrupted[0] ^^^ 0xffuy
-        objects[StorageKeys.contentBlockObjectKey block.Address] <- corrupted
+        let placement = placementFor manifest.StoragePoolId block.Address
+        objects[placement.ObjectKey] <- corrupted
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor manifest.StoragePoolId manifest.Blocks[0] placement
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
 
-        materialize (readerFrom objects) target
+        materializeManifest metadata objects readPlacements target
         |> expectErrorContains "Invalid manifest reconstruction"

--- a/src/Grace.Server/AnnotationMaterialization.Server.fs
+++ b/src/Grace.Server/AnnotationMaterialization.Server.fs
@@ -4,6 +4,7 @@ open Azure
 open Grace.Actors.Services
 open Grace.Shared
 open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.Common
 open Grace.Types.Repository
 open System
@@ -25,6 +26,12 @@ module internal AnnotationMaterialization =
     type MaterializedTextContent = { FileVersion: FileVersion; Bytes: byte array; Text: string }
 
     type ObjectPayloadReader = string -> CorrelationId -> CancellationToken -> Task<Result<byte array, GraceError>>
+
+    type ContentBlockMetadataResolver =
+        FileManifest -> ContentBlockAddress -> CorrelationId -> CancellationToken -> Task<Result<ContentBlockMetadata, GraceError>>
+
+    type ContentBlockPlacementPayloadReader =
+        ContentBlockStoragePlacement -> ContentBlockAddress -> CorrelationId -> CancellationToken -> Task<Result<byte array, GraceError>>
 
     let private error correlationId message = GraceError.Create message correlationId
 
@@ -124,7 +131,65 @@ module internal AnnotationMaterialization =
 
     let private describeManifestValidationError validationError = $"Invalid manifest reconstruction: {validationError}."
 
-    let private manifestPayloads (manifest: FileManifest) (readObjectPayload: ObjectPayloadReader) correlationId (cancellationToken: CancellationToken) =
+    let private completeContentBlockStoragePlacement (placement: ContentBlockStoragePlacement) =
+        not (isNull (box placement))
+        && not (String.IsNullOrWhiteSpace placement.StorageAccountName)
+        && not (String.IsNullOrWhiteSpace placement.StorageContainerName)
+        && not (String.IsNullOrWhiteSpace placement.ObjectKey)
+
+    let private validateManifestStoragePool (fileVersion: FileVersion) (manifest: FileManifest) correlationId =
+        if String.IsNullOrWhiteSpace manifest.StoragePoolId then
+            Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' FileManifest StoragePoolId is required.")
+        else
+            Ok()
+
+    let private validateManifestBlockMetadata
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (contentBlockAddress: ContentBlockAddress)
+        (metadata: ContentBlockMetadata)
+        correlationId
+        =
+        if isNull (box metadata) then
+            Error(
+                error correlationId $"Annotation target '{fileVersion.RelativePath}' ContentBlockMetadata is absent for manifest block {contentBlockAddress}."
+            )
+        elif metadata.StoragePoolId <> manifest.StoragePoolId then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' ContentBlockMetadata StoragePoolId does not match FileManifest.StoragePoolId for {contentBlockAddress}."
+            )
+        elif metadata.ContentBlockAddress
+             <> contentBlockAddress then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' ContentBlockMetadata ContentBlockAddress does not match FileManifest block {contentBlockAddress}."
+            )
+        elif metadata.BlockFormatVersion <= 0s then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' ContentBlockMetadata BlockFormatVersion is required for manifest block {contentBlockAddress}."
+            )
+        elif not (completeContentBlockStoragePlacement metadata.StoragePlacement) then
+            Error(
+                error
+                    correlationId
+                    $"Annotation target '{fileVersion.RelativePath}' ContentBlockMetadata StoragePlacement is incomplete for manifest block {contentBlockAddress}."
+            )
+        else
+            Ok metadata.StoragePlacement
+
+    let private manifestPayloads
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (resolveContentBlockMetadata: ContentBlockMetadataResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
         task {
             let payloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
 
@@ -143,11 +208,16 @@ module internal AnnotationMaterialization =
             while index < blockAddresses.Length
                   && Option.isNone error do
                 let address = blockAddresses[index]
-                let objectKey = StorageKeys.contentBlockObjectKey address
 
-                match! readObjectPayload objectKey correlationId cancellationToken with
-                | Ok payload -> payloads.Add(ManifestValidation.createBlockPayload address payload)
-                | Error readError -> error <- Some readError
+                match! resolveContentBlockMetadata manifest address correlationId cancellationToken with
+                | Error metadataError -> error <- Some metadataError
+                | Ok metadata ->
+                    match validateManifestBlockMetadata fileVersion manifest address metadata correlationId with
+                    | Error validationError -> error <- Some validationError
+                    | Ok placement ->
+                        match! readContentBlockPayload placement address correlationId cancellationToken with
+                        | Ok payload -> payloads.Add(ManifestValidation.createBlockPayload address payload)
+                        | Error readError -> error <- Some readError
 
                 index <- index + 1
 
@@ -159,7 +229,8 @@ module internal AnnotationMaterialization =
     let private materializeManifestBytes
         (fileVersion: FileVersion)
         (manifest: FileManifest)
-        (readObjectPayload: ObjectPayloadReader)
+        (resolveContentBlockMetadata: ContentBlockMetadataResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
         correlationId
         cancellationToken
         =
@@ -181,14 +252,32 @@ module internal AnnotationMaterialization =
                             $"Annotation target '{fileVersion.RelativePath}' is too large to materialize as text. FileManifest.Size {manifest.Size} bytes exceeds the {MaxMaterializedTextBytes} byte limit."
                     )
             else
-                match! manifestPayloads manifest readObjectPayload correlationId cancellationToken with
-                | Error readError -> return Error readError
-                | Ok payloads ->
-                    match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
-                    | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
-                    | Error validationError ->
-                        return Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}")
+                match validateManifestStoragePool fileVersion manifest correlationId with
+                | Error validationError -> return Error validationError
+                | Ok () ->
+                    match! manifestPayloads fileVersion manifest resolveContentBlockMetadata readContentBlockPayload correlationId cancellationToken with
+                    | Error readError -> return Error readError
+                    | Ok payloads ->
+                        match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
+                        | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+                        | Error validationError ->
+                            return
+                                Error(error correlationId $"Annotation target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}")
         }
+
+    let private unsupportedManifestMetadataResolver (manifest: FileManifest) contentBlockAddress correlationId _ =
+        Task.FromResult(
+            Error(
+                error
+                    correlationId
+                    $"Annotation target FileManifest block {contentBlockAddress} cannot be materialized without finalized StoragePool placement evidence."
+            )
+        )
+
+    let private unsupportedContentBlockPayloadReader placement contentBlockAddress correlationId _ =
+        Task.FromResult(
+            Error(error correlationId $"Annotation target FileManifest block {contentBlockAddress} cannot be read without a ContentBlock placement reader.")
+        )
 
     let private materializeWholeFileBytes (fileVersion: FileVersion) (readObjectPayload: ObjectPayloadReader) correlationId cancellationToken =
         task {
@@ -202,8 +291,10 @@ module internal AnnotationMaterialization =
             | Error readError -> return Error readError
         }
 
-    let materializeTextWithObjectReader
-        (readObjectPayload: ObjectPayloadReader)
+    let materializeTextWithReaders
+        (readWholeFileObjectPayload: ObjectPayloadReader)
+        (resolveContentBlockMetadata: ContentBlockMetadataResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
         (fileVersion: FileVersion)
         correlationId
         (cancellationToken: CancellationToken)
@@ -214,10 +305,12 @@ module internal AnnotationMaterialization =
             | Ok () ->
                 let! bytesResult =
                     match fileVersion.ContentReference.ReferenceType with
-                    | FileContentReferenceType.WholeFileContent -> materializeWholeFileBytes fileVersion readObjectPayload correlationId cancellationToken
+                    | FileContentReferenceType.WholeFileContent ->
+                        materializeWholeFileBytes fileVersion readWholeFileObjectPayload correlationId cancellationToken
                     | FileContentReferenceType.FileManifest ->
                         match fileVersion.ContentReference.Manifest with
-                        | Some manifest -> materializeManifestBytes fileVersion manifest readObjectPayload correlationId cancellationToken
+                        | Some manifest ->
+                            materializeManifestBytes fileVersion manifest resolveContentBlockMetadata readContentBlockPayload correlationId cancellationToken
                         | None ->
                             Task.FromResult(
                                 Error(
@@ -236,6 +329,20 @@ module internal AnnotationMaterialization =
                     | Error decodeError -> return Error decodeError
                     | Ok text -> return Ok { FileVersion = fileVersion; Bytes = bytes; Text = text }
         }
+
+    let materializeTextWithObjectReader
+        (readObjectPayload: ObjectPayloadReader)
+        (fileVersion: FileVersion)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        materializeTextWithReaders
+            readObjectPayload
+            unsupportedManifestMetadataResolver
+            unsupportedContentBlockPayloadReader
+            fileVersion
+            correlationId
+            cancellationToken
 
     let private azureObjectPayloadReader
         (repositoryDto: RepositoryDto)
@@ -270,8 +377,79 @@ module internal AnnotationMaterialization =
                 return Error(error correlationId "Annotation content materialization cannot use an unknown object storage provider.")
         }
 
-    let materializeTargetText (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId cancellationToken =
-        let reader (objectKey: string) correlationId cancellationToken =
+    let private azureContentBlockPlacementPayloadReader
+        maxPayloadBytes
+        (placement: ContentBlockStoragePlacement)
+        (contentBlockAddress: ContentBlockAddress)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            try
+                match! getAzureContentBlockClientForPlacement placement correlationId with
+                | Error error -> return Error error
+                | Ok blobClient ->
+                    let! properties = blobClient.GetPropertiesAsync(cancellationToken = cancellationToken)
+
+                    if properties.Value.ContentLength > maxPayloadBytes then
+                        return
+                            Error(
+                                error
+                                    correlationId
+                                    $"Annotation ContentBlock payload '{contentBlockAddress}' is too large to read. Content length {properties.Value.ContentLength} bytes exceeds the {maxPayloadBytes} byte read limit."
+                            )
+                    else
+                        let! download = blobClient.DownloadContentAsync(cancellationToken)
+                        return Ok(download.Value.Content.ToArray())
+            with
+            | :? RequestFailedException as ex ->
+                return
+                    Error(
+                        error correlationId $"Annotation ContentBlock payload '{contentBlockAddress}' could not be read from stored CAS placement: {ex.Message}"
+                    )
+        }
+
+    let private finalizedManifestMetadataResolver
+        (repositoryDto: RepositoryDto)
+        (fileVersion: FileVersion)
+        (authorizedScope: string)
+        (manifest: FileManifest)
+        contentBlockAddress
+        correlationId
+        _
+        =
+        task {
+            let dedupeIndexActor = Grace.Actors.DedupeIndexActor.CreateActorProxy correlationId
+
+            let! metadata =
+                dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata(
+                    manifest.StoragePoolId,
+                    repositoryDto.RepositoryId,
+                    authorizedScope,
+                    manifest.ManifestAddress,
+                    contentBlockAddress,
+                    correlationId
+                )
+
+            match metadata with
+            | Some metadata -> return Ok metadata
+            | None ->
+                return
+                    Error(
+                        error
+                            correlationId
+                            $"Annotation target '{fileVersion.RelativePath}' has no finalized StoragePool placement evidence for FileManifest block {contentBlockAddress}."
+                    )
+        }
+
+    let materializeTargetText (repositoryDto: RepositoryDto) authorizedScope (fileVersion: FileVersion) correlationId cancellationToken =
+        let wholeFileReader (objectKey: string) correlationId cancellationToken =
             azureObjectPayloadReader repositoryDto MaxContentBlockPayloadBytes objectKey correlationId cancellationToken
 
-        materializeTextWithObjectReader reader fileVersion correlationId cancellationToken
+        let metadataResolver manifest contentBlockAddress correlationId cancellationToken =
+            finalizedManifestMetadataResolver repositoryDto fileVersion authorizedScope manifest contentBlockAddress correlationId cancellationToken
+
+        let contentBlockReader placement contentBlockAddress correlationId cancellationToken =
+            azureContentBlockPlacementPayloadReader MaxContentBlockPayloadBytes placement contentBlockAddress correlationId cancellationToken
+
+        materializeTextWithReaders wholeFileReader metadataResolver contentBlockReader fileVersion correlationId cancellationToken

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -128,7 +128,7 @@ module Branch =
             match tryFindFileVersion path contents with
             | None -> return Ok None
             | Some fileVersion ->
-                match! AnnotationMaterialization.materializeTargetText repositoryDto fileVersion correlationId context.RequestAborted with
+                match! AnnotationMaterialization.materializeTargetText repositoryDto path fileVersion correlationId context.RequestAborted with
                 | Ok materialized ->
                     let document =
                         { SourceReference = toAnnotationSourceReference referenceDto; Path = normalizeAnnotationPath path; Content = materialized.Bytes }


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #443.

Part of #426 and #424.

This PR intentionally targets `epic/426-storagepool-routing`, not `main`, not `epic/424-storagepool-cas`, and not
`epic/343-blake3-sha256-version-hashes`. The sub-issue will be closed manually only after the reviewed slice is merged
into the mini-integration branch.

## Summary

- Materializes FileManifest-backed annotation targets from the manifest's stored CAS pool and finalized placement.
- Keeps whole-file annotation materialization on the existing repository whole-file object path.
- Passes the annotation request path from `Branch.Server` into materialization so scoped metadata is resolved by request
  path instead of inferred file-version state.
- Validates manifest size, pool, metadata placement, reconstructed bytes, SHA-256, BLAKE3, and strict UTF-8 before
  returning annotation text.

## Touched paths

- `src/Grace.Server/AnnotationMaterialization.Server.fs`
- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server.Unit.Tests/AnnotationMaterialization.Server.Tests.fs`

## Validation

- `dotnet tool run fantomas C:\Source\Grace-gh-443\src\Grace.Server\AnnotationMaterialization.Server.fs C:\Source\Grace-gh-443\src\Grace.Server\Branch.Server.fs C:\Source\Grace-gh-443\src\Grace.Server.Unit.Tests\AnnotationMaterialization.Server.Tests.fs`: passed / unchanged after final edits.
- `dotnet test --configuration Release C:\Source\Grace-gh-443\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter AnnotationMaterializationServerTests`: passed, 15/15.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Fast filtered tests passed: Server.Unit 666/666, Types 129/129,
  Authorization 53/53, CLI 642 passed / 1 skipped.
- `git diff --check`: passed.

## Review Status

- Initial worker self-review complete.
- `Validate / full` passed on PR head `c7ce6fbb` in run 27909097502.
- Codex Code Review Bot reacted with 👍 on current head `c7ce6fbb`; no review threads were opened.

## Review-prevention note

Prevention: the manifest path does not use the repository whole-file object reader or current repository route; it reads
from finalized scoped metadata for the stored manifest pool, and tests cover route drift, same-address/two-pool decoys,
wrong-pool metadata, incomplete placement, missing blobs, corrupt blocks, and whole-file compatibility.

