### PR TITLE
CAS-04: Prove ContentBlock URI StoragePool routing

### DIFF
--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -48,20 +48,30 @@ module private StoragePlacementTestHelpers =
             || IPAddress.TryParse(blobUriWithSasToken.Host)
                |> fst
 
+        let accountFragment = fragmentParameter "graceStorageAccount" blobUriWithSasToken
+
         let accountName =
-            if isPathStyleAzurite && pathSegments.Length >= 3 then
-                pathSegments[0]
-            else if (fragmentParameter "graceStorageAccount" blobUriWithSasToken)
-                .IsSome then
-                (fragmentParameter "graceStorageAccount" blobUriWithSasToken)
-                    .Value
-            else
+            match accountFragment with
+            | Some accountName -> accountName
+            | None when isPathStyleAzurite && pathSegments.Length >= 3 -> pathSegments[0]
+            | None ->
                 let host = blobUriWithSasToken.Host
                 let firstDot = host.IndexOf('.')
 
                 if firstDot > 0 then host.Substring(0, firstDot) else host
 
-        let containerIndex = if isPathStyleAzurite then 1 else 0
+        let containerIndex =
+            match accountFragment with
+            | Some accountName when
+                isPathStyleAzurite
+                && pathSegments.Length >= 3
+                && pathSegments[0]
+                    .Equals(accountName, StringComparison.OrdinalIgnoreCase)
+                ->
+                1
+            | Some _ -> 0
+            | None when isPathStyleAzurite -> 1
+            | None -> 0
 
         {
             StorageAccountName = accountName
@@ -396,6 +406,35 @@ type StorageContentBlockSasRoutes() =
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
             Assert.That(body, Does.Contain(expected))
         }
+
+    [<Test>]
+    member _.ContentBlockPlacementParserUsesShardFragmentForIpHostCustomEndpoint() =
+        let contentBlockAddress = ContentBlockAddress "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+        let objectKey = StorageKeys.contentBlockObjectKey contentBlockAddress
+        let uri = Uri($"http://127.0.0.1:10000/grace-cas/{objectKey}?sv=test#graceStorageAccount=cas-shard-a")
+
+        let placement = StoragePlacementTestHelpers.contentBlockPlacementFromUri uri (Some "etag-ip-shard")
+
+        Assert.That(placement.StorageAccountName, Is.EqualTo("cas-shard-a"))
+        Assert.That(placement.StorageAccountName, Is.Not.EqualTo("grace-cas"))
+        Assert.That(placement.StorageContainerName, Is.EqualTo(StorageContainerName "grace-cas"))
+        Assert.That(placement.StorageContainerName, Is.Not.EqualTo(StorageContainerName "cas"))
+        Assert.That(placement.ObjectKey, Is.EqualTo(objectKey))
+        Assert.That(placement.ETag, Is.EqualTo(Some "etag-ip-shard"))
+
+    [<Test>]
+    member _.ContentBlockPlacementParserKeepsAzuritePathStyleWhenFragmentNamesSameAccount() =
+        let contentBlockAddress = ContentBlockAddress "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+        let objectKey = StorageKeys.contentBlockObjectKey contentBlockAddress
+        let uri = Uri($"http://127.0.0.1:10000/devstoreaccount1/grace-cas/{objectKey}?sv=test#graceStorageAccount=devstoreaccount1")
+
+        let placement = StoragePlacementTestHelpers.contentBlockPlacementFromUri uri None
+
+        Assert.That(placement.StorageAccountName, Is.EqualTo("devstoreaccount1"))
+        Assert.That(placement.StorageContainerName, Is.EqualTo(StorageContainerName "grace-cas"))
+        Assert.That(placement.ObjectKey, Is.EqualTo(objectKey))
 
     [<Test>]
     member _.ContentBlockUploadUriRequiresPathWriteAndFailsClosedWithoutUploadSessionIntent() =
@@ -1188,6 +1227,17 @@ type StorageManifestUploadSessionRoutes() =
                 confirmResult.ReturnValue.Session.ConfirmedBlockUploads[0]
                     .StoragePlacement
 
+            Assert.That(confirmedPlacement.ObjectKey, Is.EqualTo(StorageKeys.contentBlockObjectKey block.Address))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain("cas/content-blocks"))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain("staging/repositories"))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain(repositoryId.ToString()))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain(sessionId.ToString("N")))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain(exactUploadScope sessionId))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain("ContentBlockAddress"))
+            Assert.That(confirmedPlacement.ObjectKey, Does.Not.Contain("content-block-"))
+            Assert.That(confirmedPlacement.StorageContainerName, Is.EqualTo(StorageContainerName Constants.DefaultCasStorageContainerName))
+            Assert.That(confirmedPlacement.StorageContainerName, Is.Not.EqualTo(StorageContainerName $"{repositoryId}"))
+
             let finalize = Parameters.Storage.FinalizeManifestUploadParameters()
             setStorageParameters finalize repositoryId correlationId
             finalize.UploadSessionId <- sessionId
@@ -1217,6 +1267,14 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(downloadPlacement.ObjectKey, Is.EqualTo(confirmedPlacement.ObjectKey))
             Assert.That(downloadPlacement.StorageAccountName, Is.EqualTo(confirmedPlacement.StorageAccountName))
             Assert.That(downloadPlacement.StorageContainerName, Is.EqualTo(confirmedPlacement.StorageContainerName))
+            Assert.That(downloadPlacement.ObjectKey, Is.EqualTo(StorageKeys.contentBlockObjectKey block.Address))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain("cas/content-blocks"))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain("staging/repositories"))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain(repositoryId.ToString()))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain(sessionId.ToString("N")))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain(exactUploadScope sessionId))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain("ContentBlockAddress"))
+            Assert.That(downloadPlacement.ObjectKey, Does.Not.Contain("content-block-"))
 
             Assert.That(Convert.ToHexString(downloadedPayload), Is.EqualTo(Convert.ToHexString(block.Payload)))
 

--- a/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
@@ -899,6 +899,37 @@ type StorageContentBlockSdkContract() =
         Assert.That(storageServerSource, Does.Not.Contain("SnapshotState correlationId"))
 
     [<Test>]
+    member _.ContentBlockDownloadSasUsesFinalizedPlacementInsteadOfCurrentRoute() =
+        let storageServerPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Storage.Server.fs"))
+        let storageServerSource = File.ReadAllText(storageServerPath)
+        let handlerStart = storageServerSource.IndexOf("let GetContentBlockDownloadUri: HttpHandler =", StringComparison.Ordinal)
+        let handlerEnd = storageServerSource.IndexOf("/// Discovers reusable ContentBlocks", handlerStart, StringComparison.Ordinal)
+
+        Assert.That(handlerStart, Is.GreaterThanOrEqualTo(0))
+        Assert.That(handlerEnd, Is.GreaterThan(handlerStart))
+
+        let handlerSource = storageServerSource.Substring(handlerStart, handlerEnd - handlerStart)
+        let compactedSource = String.Join(" ", handlerSource.Split([| '\r'; '\n'; '\t'; ' ' |], StringSplitOptions.RemoveEmptyEntries))
+
+        Assert.That(
+            compactedSource,
+            Does.Contain("Ok storagePlacement -> match! createAzureContentBlockSasUriForPlacement storagePlacement azureBlobReadPermissions correlationId"),
+            "Download URI generation must use the finalized ContentBlockMetadata.StoragePlacement returned by the DedupeIndex lookup."
+        )
+
+        Assert.That(
+            handlerSource,
+            Does.Not.Contain("expectedContentBlockStoragePlacement"),
+            "Download URI generation must not recompute the CAS object key from the current route after finalization."
+        )
+
+        Assert.That(
+            handlerSource,
+            Does.Not.Contain("resolveUploadSessionStoragePoolRoute"),
+            "Download URI generation must not follow upload-session/current route state after finalized placement is recorded."
+        )
+
+    [<Test>]
     member _.UploadSessionBackedSasUsesRecordedSessionPoolRoute() =
         let storageServerPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Storage.Server.fs"))
         let storageServerSource = File.ReadAllText(storageServerPath)


### PR DESCRIPTION
# CAS-04: Prove ContentBlock URIs use finalized StoragePool routing

## Linked issue

Related to #427.

Part of #424.

This PR intentionally targets `epic/424-storagepool-cas`, not `main`. Parent epic #424 intentionally deviates from the
standard branch rule: the CAS integration branch was based on `origin/epic/343-blake3-sha256-version-hashes`, and child
issue PRs target `epic/424-storagepool-cas`.

## Summary

- Adds proof that finalized ContentBlock download URIs use recorded final CAS placement rather than current-route
  recomputation.
- Strengthens the manifest-backed upload/download integration flow to assert final CAS keys use
  `StorageKeys.contentBlockObjectKey` and reject old `cas/content-blocks` proof.
- Verifies repository id, upload session id, authorized file path, typed-address text, and `content-block-` do not leak
  into final CAS blob keys.
- Fixes the integration-test URI placement parser so shard fragment evidence wins for IP-host custom endpoints while
  Azurite path-style URIs still parse correctly.
- Adds focused parser coverage for IP-host custom endpoints and Azurite path-style endpoints.

## Production and contract impact

This is a proof/coverage slice. No production behavior changed.

The existing production handler already uses `TryGetFinalizedScopedContentBlockMetadata` and
`createAzureContentBlockSasUriForPlacement` for download URI generation. No public DTO, endpoint shape, generated
OpenAPI, SDK, or docs behavior changed.

## Review-prevention evidence

- Invariant tuple covered: `(RepositoryId, StoragePoolId, ContentBlockId, UriKind, PhysicalBlobKey)`.
- Recorded placement vs current route: covered by a unit guard and integration placement equality assertions.
- Address-only reads: existing bad-request coverage remains; no address-only production lookup was added.
- Endpoint rewriting: existing private-link host tests remain, and new IP-host fragment parser proof covers the custom
  endpoint evidence gap.
- Route drift/default fallback: the download handler guard prevents recomputing from route state after finalization.
- Old key shape: final placement and download placement assert no `cas/content-blocks`.
- Repository/session/path/typed-address leakage: final CAS key assertions cover repository id, session id, authorized
  scope path, `ContentBlockAddress`, and `content-block-`.
- Generated contract drift: waived because no public contract changed.
- Production migration: N/A because Grace has no production users or production data for this epic.

## Validation

- `dotnet tool run fantomas -- "Grace.Server.Tests/Storage.Server.Tests.fs" "Grace.Server.Unit.Tests/Storage.Server.Tests.fs"`:
  passed.
- `dotnet test --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~ContentBlockDownloadSasUsesFinalizedPlacementInsteadOfCurrentRoute"`:
  passed `1/1`.
- `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~ContentBlockPlacementParser|FullyQualifiedName~LargeManifestUploadCanUploadBlobConfirmFinalizeAndDownloadContentBlock"`:
  passed `3/3` before the final addendum.
- `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~LargeManifestUploadCanUploadBlobConfirmFinalizeAndDownloadContentBlock"`:
  passed `1/1` after the typed-address leakage addendum.
- `pwsh ./scripts/validate.ps1 -Full`: passed after the final addendum.
  - `Grace.Types.Tests`: `129/129` passed.
  - `Grace.Authorization.Tests`: `53/53` passed.
  - `Grace.Server.Unit.Tests`: `682/682` passed.
  - `Grace.CLI.Tests`: `642/643` passed, `1` skipped.
  - `Grace.Server.Tests`: `231/231` passed.
- `git diff --check`: passed.

## Residual risks and waivers

- Non-default configured StoragePool route execution remains mostly proven by existing routing unit tests and
  source-shape guards; this slice does not introduce a second routing implementation.
- OpenAPI, generated SDKs, docs, and public contracts are waived because this proof slice does not change endpoint
  shape or client-visible behavior.

## Final merge-readiness

- `Validate / full` passed on PR head `7cbc857fa5fd8388950c32665bc81b122091a7da` in run 27919032322.
- Codex Code Review Bot reacted with thumbs-up on the latest head; no review threads were opened.
- Final audit: `git rev-list --left-right --count origin/epic/424-storagepool-cas...origin/agent/427-contentblock-uri-routing`
  returned `0 1`, merge state was `CLEAN`, and the scoped diff had no deletions.
