### PR TITLE
CAS-05: Prove upload-session StoragePool identity

### DIFF
--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -866,8 +866,33 @@ type StorageManifestUploadSessionRoutes() =
 
     let encodeBlock bytes = encodeBlockAt 0L bytes
 
-    let manifestForStoragePool storagePoolId (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
-        let contentBlock = ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+    let encodeChunkedBlock (chunks: byte array array) =
+        let mutable physicalOffset = 0L
+
+        let inputChunks =
+            chunks
+            |> Array.map (fun chunk ->
+                let input: ContentBlockFormat.ContentBlockInputChunk = { PhysicalOffset = physicalOffset; Bytes = chunk }
+                physicalOffset <- physicalOffset + int64 chunk.Length
+                input)
+
+        match ContentBlockFormat.encode inputChunks with
+        | Ok block -> block
+        | Error error ->
+            Assert.Fail($"Expected chunked test ContentBlock to encode, got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    let chunkedPayload label chunkCount =
+        [|
+            for index in 0 .. chunkCount - 1 do
+                Encoding.UTF8.GetBytes($"{label}-chunk-{index:D2}-{Guid.NewGuid():N}-{String('x', 256)}")
+        |]
+
+    let manifestForBlocks storagePoolId bytes (blocks: (ContentBlockFormat.EncodedContentBlock * int64 * int64) array) =
+        let contentBlocks =
+            blocks
+            |> Array.map (fun (block, offset, length) -> ContentBlock.Create(block.Address, offset, length))
+            |> Array.toList
 
         let manifest =
             FileManifest.Create(
@@ -876,10 +901,13 @@ type StorageManifestUploadSessionRoutes() =
                 FileContentHash(ContentAddress.computeBlake3Hex bytes),
                 int64 bytes.Length,
                 storagePoolId,
-                [ contentBlock ]
+                contentBlocks
             )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let manifestForStoragePool storagePoolId (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
+        manifestForBlocks storagePoolId bytes [| block, 0L, int64 bytes.Length |]
 
     let manifestFor bytes block = manifestForStoragePool (StoragePoolId Constants.DefaultStoragePoolId) bytes block
 
@@ -1138,6 +1166,82 @@ type StorageManifestUploadSessionRoutes() =
             return body
         }
 
+    let startManifestUploadSession repositoryId correlationId sessionId authorizedScope operationId manifest samplingPolicySnapshot =
+        task {
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- sessionId
+            start.AuthorizedScope <- authorizedScope
+            start.FileContentHash <- manifest.FileContentHash
+            start.ExpectedSize <- manifest.Size
+            start.ChunkingSuiteId <- manifest.ChunkingSuiteId
+            start.SamplingPolicySnapshot <- samplingPolicySnapshot
+            start.OperationId <- operationId
+
+            return! postUploadSessionDecision "/storage/startManifestUploadSession" start
+        }
+
+    let confirmUploadedBlock
+        repositoryId
+        correlationId
+        sessionId
+        authorizedScope
+        (block: ContentBlockFormat.EncodedContentBlock)
+        logicalOffset
+        logicalLength
+        registerOperationId
+        confirmOperationId
+        =
+        task {
+            let register = Parameters.Storage.RegisterContentBlockUploadParameters()
+            setStorageParameters register repositoryId correlationId
+            register.UploadSessionId <- sessionId
+            register.AuthorizedScope <- authorizedScope
+            register.OperationId <- registerOperationId
+            register.ContentBlockAddress <- block.Address
+            register.LogicalOffset <- logicalOffset
+            register.LogicalLength <- logicalLength
+            register.ExpectedPayloadLength <- int64 block.Payload.Length
+
+            let! _ = postUploadSessionDecision "/storage/registerContentBlockUpload" register
+
+            let uploadUriParameters = Parameters.Storage.GetContentBlockUploadUriParameters()
+            setStorageParameters uploadUriParameters repositoryId correlationId
+            uploadUriParameters.UploadSessionId <- sessionId
+            uploadUriParameters.ContentBlockAddress <- block.Address
+            uploadUriParameters.AuthorizedScope <- authorizedScope
+
+            let! uploadUriResponse = Client.PostAsync("/storage/getContentBlockUploadUri", createJsonContent uploadUriParameters)
+            let! uploadUriBody = uploadUriResponse.Content.ReadAsStringAsync()
+            Assert.That(uploadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadUriBody)
+
+            let uploadUri = Uri uploadUriBody
+            let! uploadETag = uploadContentBlockWithSas block.Payload uploadUri
+
+            let confirm = Parameters.Storage.ConfirmContentBlockUploadParameters()
+            setStorageParameters confirm repositoryId correlationId
+            confirm.UploadSessionId <- sessionId
+            confirm.AuthorizedScope <- authorizedScope
+            confirm.OperationId <- confirmOperationId
+            confirm.ContentBlockAddress <- block.Address
+            confirm.Payload <- block.Payload
+            confirm.StoragePlacement <- StoragePlacementTestHelpers.contentBlockPlacementFromUri uploadUri (Some uploadETag)
+
+            return! postUploadSessionDecision "/storage/confirmContentBlockUpload" confirm
+        }
+
+    let finalizeManifestUpload repositoryId correlationId sessionId authorizedScope operationId manifest =
+        task {
+            let finalize = Parameters.Storage.FinalizeManifestUploadParameters()
+            setStorageParameters finalize repositoryId correlationId
+            finalize.UploadSessionId <- sessionId
+            finalize.AuthorizedScope <- authorizedScope
+            finalize.OperationId <- operationId
+            finalize.Manifest <- manifest
+
+            return! postUploadSessionDecision "/storage/finalizeManifestUpload" finalize
+        }
+
     [<Test>]
     member _.LargeManifestUploadCanUploadBlobConfirmFinalizeAndDownloadContentBlock() =
         task {
@@ -1288,6 +1392,92 @@ type StorageManifestUploadSessionRoutes() =
                 with
             | Ok reconstructedBytes -> Assert.That(Convert.ToHexString(reconstructedBytes), Is.EqualTo(Convert.ToHexString(payload)))
             | Error error -> Assert.Fail($"Expected downloaded ContentBlock to reconstruct the manifest bytes, got {error}.")
+        }
+
+    [<Test>]
+    member _.FinalizedUploadMetadataAuthorizesOnlyRecordedSessionStoragePool() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let otherRepositoryId = repositoryIds[1]
+            let correlationId = generateCorrelationId ()
+            let sessionId = Guid.NewGuid()
+            let authorizedScope = exactUploadScope sessionId
+            let chunks = chunkedPayload $"recorded-pool-upload-{sessionId:N}" 12
+            let payload = Array.concat chunks
+            let block = encodeChunkedBlock chunks
+            let manifestForStart = manifestFor payload block
+
+            let! startResult =
+                startManifestUploadSession repositoryId correlationId sessionId authorizedScope "start-recorded-pool" manifestForStart "sdk-recorded-pool-proof"
+
+            let recordedPoolId = startResult.ReturnValue.Session.StoragePoolId
+            let manifest = manifestForStoragePool recordedPoolId payload block
+
+            Assert.That(recordedPoolId, Is.Not.EqualTo(StoragePoolId Constants.DefaultStoragePoolId))
+
+            let! _ =
+                confirmUploadedBlock
+                    repositoryId
+                    correlationId
+                    sessionId
+                    authorizedScope
+                    block
+                    0L
+                    (int64 payload.Length)
+                    "register-recorded-pool"
+                    "confirm-recorded-pool"
+
+            let! finalizeResult = finalizeManifestUpload repositoryId correlationId sessionId authorizedScope "finalize-recorded-pool" manifest
+            Assert.That(finalizeResult.ReturnValue.Session.StoragePoolId, Is.EqualTo(recordedPoolId))
+            Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+
+            let wrongPoolDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
+            setStorageParameters wrongPoolDownload repositoryId correlationId
+            wrongPoolDownload.AuthorizedScope <- authorizedScope
+            wrongPoolDownload.ContentBlockAddress <- block.Address
+            wrongPoolDownload.StoragePoolId <- StoragePoolId Constants.DefaultStoragePoolId
+            wrongPoolDownload.ManifestAddress <- manifest.ManifestAddress
+
+            let! wrongPoolDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent wrongPoolDownload)
+            let! wrongPoolDownloadBody = wrongPoolDownloadResponse.Content.ReadAsStringAsync()
+            Assert.That(wrongPoolDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), wrongPoolDownloadBody)
+            Assert.That(wrongPoolDownloadBody, Does.Contain("storage pool"))
+
+            let crossRepositoryDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
+            setStorageParameters crossRepositoryDownload otherRepositoryId correlationId
+            crossRepositoryDownload.AuthorizedScope <- authorizedScope
+            crossRepositoryDownload.ContentBlockAddress <- block.Address
+            crossRepositoryDownload.StoragePoolId <- recordedPoolId
+            crossRepositoryDownload.ManifestAddress <- manifest.ManifestAddress
+
+            let! crossRepositoryDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent crossRepositoryDownload)
+            let! crossRepositoryDownloadBody = crossRepositoryDownloadResponse.Content.ReadAsStringAsync()
+            Assert.That(crossRepositoryDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), crossRepositoryDownloadBody)
+            Assert.That(crossRepositoryDownloadBody, Does.Contain("repository, storage pool, and authorized scope"))
+
+            let correctDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
+            setStorageParameters correctDownload repositoryId correlationId
+            correctDownload.AuthorizedScope <- authorizedScope
+            correctDownload.ContentBlockAddress <- block.Address
+            correctDownload.StoragePoolId <- recordedPoolId
+            correctDownload.ManifestAddress <- manifest.ManifestAddress
+
+            let! correctDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent correctDownload)
+            let! correctDownloadBody = correctDownloadResponse.Content.ReadAsStringAsync()
+            Assert.That(correctDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), correctDownloadBody)
+
+            let! downloadedPayload = downloadContentBlockWithSas (Uri correctDownloadBody)
+
+            match
+                ManifestValidation.validate
+                    RabinChunking.SuiteName
+                    manifest
+                    [
+                        ManifestValidation.createBlockPayload block.Address downloadedPayload
+                    ]
+                with
+            | Ok reconstructedBytes -> Assert.That(Convert.ToHexString(reconstructedBytes), Is.EqualTo(Convert.ToHexString(payload)))
+            | Error error -> Assert.Fail($"Expected recorded-pool ContentBlock to reconstruct the manifest bytes, got {error}.")
         }
 
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs
@@ -482,6 +482,81 @@ type DedupeIndexServerTests() =
         Assert.That(result.CandidateContentBlocks[0].MetadataVersion, Is.EqualTo(localMetadata.MetadataVersion))
 
     [<Test>]
+    member _.IdenticalContentBlocksRemainReusableOnlyInsideTheSameStoragePool() =
+        let block = encodedBlock "identical-cross-pool" 12
+        let poolA = StoragePoolId "pool-a"
+        let poolB = StoragePoolId "pool-b"
+
+        let manifestForPool storagePoolId =
+            let size =
+                block.Chunks
+                |> Array.sumBy (fun chunk -> int64 chunk.Length)
+
+            let manifest =
+                FileManifest.Create(
+                    ManifestAddress String.Empty,
+                    RabinChunking.SuiteName,
+                    FileContentHash(ContentAddress.computeBlake3Hex block.Payload),
+                    size,
+                    storagePoolId,
+                    [
+                        ContentBlock.Create(block.Address, 0L, size)
+                    ]
+                )
+
+            { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+        let sessionFor storagePoolId manifest =
+            { finalizedSession manifest with StoragePoolId = storagePoolId; FinalizedManifestAddress = Some manifest.ManifestAddress }
+
+        let metadataForPool storagePoolId metadataVersion =
+            { metadataFor 1 metadataVersion block with
+                StoragePoolId = storagePoolId
+                StoragePlacement =
+                    {
+                        StorageAccountName = $"cas-{storagePoolId}"
+                        StorageContainerName = StorageContainerName $"cas-{storagePoolId}"
+                        ObjectKey = $"{storagePoolId}/{StorageKeys.contentBlockObjectKey block.Address}"
+                        ETag = Some $"etag-{metadataVersion}"
+                    }
+            }
+
+        let registrationFor storagePoolId manifest : DedupeIndex.FinalizedManifestRegistration =
+            { StoragePoolId = storagePoolId; Session = sessionFor storagePoolId manifest; Manifest = manifest; BlockPayloads = [| payloadFor block |] }
+
+        let manifestA = manifestForPool poolA
+        let manifestB = manifestForPool poolB
+
+        let stateAfterPoolARegistration, _ = DedupeIndex.registerFinalizedManifestInState DedupeIndex.DedupeIndexState.Empty (registrationFor poolA manifestA)
+
+        let stateAfterPoolAMetadata, _ = DedupeIndex.writeAfterAuthoritativeMetadataInState stateAfterPoolARegistration (metadataForPool poolA 31L)
+
+        let stateAfterPoolBRegistration, _ = DedupeIndex.registerFinalizedManifestInState stateAfterPoolAMetadata (registrationFor poolB manifestB)
+        let stateAfterBothPools, _ = DedupeIndex.writeAfterAuthoritativeMetadataInState stateAfterPoolBRegistration (metadataForPool poolB 41L)
+
+        let requestedChunk = (decodedChunkAddresses block)[0]
+        let poolAResult = DedupeIndex.discover poolA [| requestedChunk |] timestamp stateAfterBothPools.Records
+        let poolBResult = DedupeIndex.discover poolB [| requestedChunk |] timestamp stateAfterBothPools.Records
+        let defaultPoolResult = DedupeIndex.discover storagePoolId [| requestedChunk |] timestamp stateAfterBothPools.Records
+
+        let poolACandidate =
+            poolAResult.CandidateContentBlocks
+            |> Array.exactlyOne
+
+        let poolBCandidate =
+            poolBResult.CandidateContentBlocks
+            |> Array.exactlyOne
+
+        Assert.That(defaultPoolResult.CandidateContentBlocks, Is.Empty)
+        Assert.That(poolACandidate.StoragePoolId, Is.EqualTo(poolA))
+        Assert.That(poolACandidate.ManifestAddress, Is.EqualTo(manifestA.ManifestAddress))
+        Assert.That(poolACandidate.ContentBlockAddress, Is.EqualTo(block.Address))
+        Assert.That(poolBCandidate.StoragePoolId, Is.EqualTo(poolB))
+        Assert.That(poolBCandidate.ManifestAddress, Is.EqualTo(manifestB.ManifestAddress))
+        Assert.That(poolBCandidate.ContentBlockAddress, Is.EqualTo(block.Address))
+        Assert.That(poolACandidate.ProtectedChunkAddresses[0], Is.Not.EqualTo(poolBCandidate.ProtectedChunkAddresses[0]))
+
+    [<Test>]
     member _.NewerNonAuthoritativeMetadataEvictsOlderCandidateWindows() =
         let block = encodedBlock "metadata-evict" 12
         let manifest = manifestFor block


### PR DESCRIPTION
# CAS-05: Prove upload-session StoragePool identity

## Linked issue

Related to #428.

Part of #424.

This PR intentionally targets `epic/424-storagepool-cas`, not `main`. Parent epic #424 intentionally deviates from the
standard branch rule: the CAS integration branch was based on `origin/epic/343-blake3-sha256-version-hashes`, and child
issue PRs target `epic/424-storagepool-cas`.

## Summary

- Adds proof that identical ContentBlocks with identical chunk hashes are discoverable only within the same
  `StoragePoolId`.
- Adds server integration coverage proving finalized upload metadata authorizes by the upload session's recorded
  `StoragePoolId`.
- Verifies wrong-pool/default-pool downloads and cross-repository claims are rejected while the correct repository,
  scope, and pool still succeed.
- Adds local test helpers for chunked upload-session setup, upload confirmation, and finalization inside the existing
  storage route test fixture.

## Production and contract impact

This is tests-only proof coverage. No production behavior, public contract, docs, OpenAPI, or SDK files changed.

Contract/docs waiver: no public shape changed and no generated output was expected.

## Review-prevention evidence

- Invariant tuple covered: `(UploadSessionId, RepositoryId, StoragePoolId, ContentBlockId, DedupeIdentity)`.
- StoragePool-scoped dedupe identity is covered by a unit test using identical content and chunk hashes across different
  pools.
- Recorded session pool vs caller-supplied/current pool is covered by server integration assertions that reject wrong
  pool/default pool authorization after finalization.
- Cross-repository authority is covered by the server proof rejecting a different repository for the finalized content.
- Existing #426 upload-session claimed metadata tests remain the deeper claimed-reuse actor coverage; this slice adds
  direct dedupe identity coverage plus finalized-upload server authorization coverage.
- Generated contract drift is waived because no public contract changed.
- Production migration and old actor-key readers are N/A because Grace has no production users or production data for
  this epic.

## Validation

- `dotnet tool run fantomas -- src/Grace.Server.Tests/Storage.Server.Tests.fs`: passed.
- `dotnet tool run fantomas -- src/Grace.Server.Unit.Tests/DedupeIndex.Server.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~DedupeIndexServerTests.IdenticalContentBlocksRemainReusableOnlyInsideTheSameStoragePool"`:
  passed.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~StorageManifestUploadSessionRoutes.FinalizedUploadMetadataAuthorizesOnlyRecordedSessionStoragePool"`:
  passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed, including `Grace.Server.Tests` `232/232`.
- `git diff --check`: passed.

## Residual risks and waivers

- Repository route-mutation integration is waived because the current repository actor still fails closed for non-default
  configured storage-pool route changes. The added server proof verifies finalized metadata is usable only through the
  recorded session pool and rejects wrong-pool and cross-repository authority.
- Claimed-reuse public end-to-end behavior was not changed. Existing #426 upload-session claimed metadata tests remain
  the deeper claimed-reuse actor coverage.

## Final merge-readiness

- `Validate / full` passed on PR head `4e7025c2817ba4d4ed9bfcf87971af846096d355` in run 27919756756.
- Codex Code Review Bot reacted with thumbs-up on the latest head; no review threads were opened.
- Final audit: `git rev-list --left-right --count origin/epic/424-storagepool-cas...origin/agent/428-upload-session-pool-identity`
  returned `0 1`, merge state was `CLEAN`, and the scoped diff had no deletions.
