### PR TITLE
CAS-06 plan manifest contributions recursively

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -57,6 +57,38 @@ module DirectoryVersion =
         | MissingInStorage of fileVersion: FileVersion * elapsedMs: float
         | ValidationError of fileVersion: FileVersion * errorMessage: string * elapsedMs: float
 
+    let validateRecursiveDirectoryVersionsComplete rootDirectoryVersionId (directoryVersionDtos: DirectoryVersionDto seq) correlationId =
+        let directoryVersionDtoArray = directoryVersionDtos |> Seq.toArray
+
+        let directoryVersionIds =
+            HashSet<DirectoryVersionId>(
+                directoryVersionDtoArray
+                |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId)
+            )
+
+        if not (directoryVersionIds.Contains rootDirectoryVersionId) then
+            Error(
+                (GraceError.Create "Recursive directory traversal did not include the root DirectoryVersion." correlationId)
+                    .enhance (nameof DirectoryVersionId, rootDirectoryVersionId)
+            )
+        else
+            let missingChild =
+                directoryVersionDtoArray
+                |> Seq.collect (fun directoryVersionDto ->
+                    directoryVersionDto.DirectoryVersion.Directories
+                    |> Seq.map (fun childDirectoryVersionId -> directoryVersionDto.DirectoryVersion, childDirectoryVersionId))
+                |> Seq.tryFind (fun (_, childDirectoryVersionId) -> not (directoryVersionIds.Contains childDirectoryVersionId))
+
+            match missingChild with
+            | Some (parentDirectoryVersion, childDirectoryVersionId) ->
+                Error(
+                    (GraceError.Create "Recursive directory traversal did not include a declared child DirectoryVersion." correlationId)
+                        .enhance(nameof DirectoryVersionId, rootDirectoryVersionId)
+                        .enhance("ParentDirectoryVersionId", parentDirectoryVersion.DirectoryVersionId)
+                        .enhance ("ChildDirectoryVersionId", childDirectoryVersionId)
+                )
+            | None -> Ok directoryVersionDtoArray
+
     /// Validates a single file's version hashes by downloading from storage and computing.
     /// Note: Non-binary files are stored as GZip-compressed streams, so we need to decompress them first.
     let validateFileSha256 (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (correlationId: CorrelationId) =
@@ -964,79 +996,90 @@ module DirectoryVersion =
                                     .OrderBy(fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.RelativePath)
                                     .ToArray()
 
-                            // Save the recursive results to Azure Blob Storage.
-                            let repositoryActorProxy =
-                                Repository.CreateActorProxy
-                                    directoryVersionDto.DirectoryVersion.OrganizationId
-                                    directoryVersionDto.DirectoryVersion.RepositoryId
-                                    correlationId
+                            match validateRecursiveDirectoryVersionsComplete directoryVersion.DirectoryVersionId subdirectoryVersionsList correlationId with
+                            | Error graceError ->
+                                log.LogWarning(
+                                    "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}): Skipping recursive directory version cache write because traversal was incomplete. Error: {error}",
+                                    getCurrentInstantExtended (),
+                                    getMachineName,
+                                    correlationId,
+                                    this.GetPrimaryKey(),
+                                    graceError
+                                )
+                            | Ok completeSubdirectoryVersionsList ->
+                                // Save the recursive results to Azure Blob Storage only after completeness is known.
+                                let repositoryActorProxy =
+                                    Repository.CreateActorProxy
+                                        directoryVersionDto.DirectoryVersion.OrganizationId
+                                        directoryVersionDto.DirectoryVersion.RepositoryId
+                                        correlationId
 
-                            let! repositoryDto = repositoryActorProxy.Get correlationId
+                                let! repositoryDto = repositoryActorProxy.Get correlationId
 
-                            let tags = Dictionary<string, string>()
-                            tags.Add(nameof OwnerId, $"{repositoryDto.OwnerId}")
-                            tags.Add(nameof OrganizationId, $"{repositoryDto.OrganizationId}")
-                            tags.Add(nameof RepositoryId, $"{repositoryDto.RepositoryId}")
-                            tags.Add(nameof DirectoryVersionId, $"{directoryVersionDto.DirectoryVersion.DirectoryVersionId}")
-                            tags.Add(nameof RelativePath, $"{directoryVersionDto.DirectoryVersion.RelativePath}")
-                            tags.Add(nameof Sha256Hash, $"{directoryVersionDto.DirectoryVersion.Sha256Hash}")
-                            tags.Add("RecursiveSize", $"{directoryVersionDto.RecursiveSize}")
+                                let tags = Dictionary<string, string>()
+                                tags.Add(nameof OwnerId, $"{repositoryDto.OwnerId}")
+                                tags.Add(nameof OrganizationId, $"{repositoryDto.OrganizationId}")
+                                tags.Add(nameof RepositoryId, $"{repositoryDto.RepositoryId}")
+                                tags.Add(nameof DirectoryVersionId, $"{directoryVersionDto.DirectoryVersion.DirectoryVersionId}")
+                                tags.Add(nameof RelativePath, $"{directoryVersionDto.DirectoryVersion.RelativePath}")
+                                tags.Add(nameof Sha256Hash, $"{directoryVersionDto.DirectoryVersion.Sha256Hash}")
+                                tags.Add("RecursiveSize", $"{directoryVersionDto.RecursiveSize}")
 
-                            // Write the JSON using MessagePack serialization for efficiency.
-                            let blockBlobOpenWriteOptions =
-                                BlockBlobOpenWriteOptions(Tags = tags, HttpHeaders = BlobHttpHeaders(ContentType = "application/msgpack"))
+                                // Write the JSON using MessagePack serialization for efficiency.
+                                let blockBlobOpenWriteOptions =
+                                    BlockBlobOpenWriteOptions(Tags = tags, HttpHeaders = BlobHttpHeaders(ContentType = "application/msgpack"))
 
-                            let conditionsSummary =
-                                let conditionsProperty = typeof<BlockBlobOpenWriteOptions>.GetProperty ("Conditions")
+                                let conditionsSummary =
+                                    let conditionsProperty = typeof<BlockBlobOpenWriteOptions>.GetProperty ("Conditions")
 
-                                if isNull conditionsProperty then
-                                    "not supported"
-                                else
-                                    let conditionsValue = conditionsProperty.GetValue(blockBlobOpenWriteOptions)
-
-                                    if isNull conditionsValue then
-                                        "null"
+                                    if isNull conditionsProperty then
+                                        "not supported"
                                     else
-                                        let conditionProperties = conditionsValue.GetType().GetProperties()
+                                        let conditionsValue = conditionsProperty.GetValue(blockBlobOpenWriteOptions)
 
-                                        conditionProperties
-                                        |> Seq.map (fun propertyInfo ->
-                                            let value = propertyInfo.GetValue(conditionsValue)
-                                            $"{propertyInfo.Name}={value}")
-                                        |> String.concat "; "
+                                        if isNull conditionsValue then
+                                            "null"
+                                        else
+                                            let conditionProperties = conditionsValue.GetType().GetProperties()
 
-                            log.LogDebug(
-                                "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Blob write conditions: {conditionsSummary}.",
-                                this.GetPrimaryKey(),
-                                conditionsSummary
-                            )
+                                            conditionProperties
+                                            |> Seq.map (fun propertyInfo ->
+                                                let value = propertyInfo.GetValue(conditionsValue)
+                                                $"{propertyInfo.Name}={value}")
+                                            |> String.concat "; "
 
-                            use! blobStream = directoryVersionBlobClient.OpenWriteAsync(overwrite = true, options = blockBlobOpenWriteOptions)
-                            do! MessagePackSerializer.SerializeAsync(blobStream, subdirectoryVersionsList, messagePackSerializerOptions)
-                            do! blobStream.DisposeAsync()
+                                log.LogDebug(
+                                    "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Blob write conditions: {conditionsSummary}.",
+                                    this.GetPrimaryKey(),
+                                    conditionsSummary
+                                )
 
-                            log.LogDebug(
-                                "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Saving cached list of directory versions. RelativePath: {relativePath}.",
-                                this.GetPrimaryKey(),
-                                directoryVersionDto.DirectoryVersion.RelativePath
-                            )
+                                use! blobStream = directoryVersionBlobClient.OpenWriteAsync(overwrite = true, options = blockBlobOpenWriteOptions)
+                                do! MessagePackSerializer.SerializeAsync(blobStream, completeSubdirectoryVersionsList, messagePackSerializerOptions)
+                                do! blobStream.DisposeAsync()
 
-                            // Create a reminder to delete the cached state after the configured number of cache days.
-                            let deletionReminderState: PhysicalDeletionReminderState =
-                                { DeleteReason = getDiscriminatedUnionCaseName ReminderTypes.DeleteCachedState; CorrelationId = correlationId }
+                                log.LogDebug(
+                                    "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Saving cached list of directory versions. RelativePath: {relativePath}.",
+                                    this.GetPrimaryKey(),
+                                    directoryVersionDto.DirectoryVersion.RelativePath
+                                )
 
-                            do!
-                                (this :> IGraceReminderWithGuidKey)
-                                    .ScheduleReminderAsync
-                                    ReminderTypes.DeleteCachedState
-                                    (Duration.FromDays(float repositoryDto.DirectoryVersionCacheDays))
-                                    (ReminderState.DirectoryVersionDeleteCachedState deletionReminderState)
-                                    correlationId
+                                // Create a reminder to delete the cached state after the configured number of cache days.
+                                let deletionReminderState: PhysicalDeletionReminderState =
+                                    { DeleteReason = getDiscriminatedUnionCaseName ReminderTypes.DeleteCachedState; CorrelationId = correlationId }
 
-                            log.LogDebug(
-                                "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Delete cached state reminder was set.",
-                                this.GetPrimaryKey()
-                            )
+                                do!
+                                    (this :> IGraceReminderWithGuidKey)
+                                        .ScheduleReminderAsync
+                                        ReminderTypes.DeleteCachedState
+                                        (Duration.FromDays(float repositoryDto.DirectoryVersionCacheDays))
+                                        (ReminderState.DirectoryVersionDeleteCachedState deletionReminderState)
+                                        correlationId
+
+                                log.LogDebug(
+                                    "In DirectoryVersionActor.GetRecursiveDirectoryVersions({id}); Delete cached state reminder was set.",
+                                    this.GetPrimaryKey()
+                                )
 
                             return subdirectoryVersionsList
                     with

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -569,7 +569,7 @@ module Reference =
                                             referenceId
                                             physicalDeletionReminderState.DirectoryVersionId
                                             referenceDto
-                                            (fun () -> directoryVersionActorProxy.GetRecursiveDirectoryVersions false this.correlationId)
+                                            (fun () -> directoryVersionActorProxy.GetRecursiveDirectoryVersions true this.correlationId)
                                             this.correlationId
                                         with
                                     | Error graceError -> return Error graceError
@@ -799,7 +799,7 @@ module Reference =
                                 return Ok()
                             else
                                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
-                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
+                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions true metadata.CorrelationId
 
                                 match
                                     planManifestSaveBoundaryForRecursiveDirectoryVersions
@@ -820,7 +820,7 @@ module Reference =
                                 return Ok()
                             else
                                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
-                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
+                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions true metadata.CorrelationId
 
                                 match!
                                     planManifestSaveExpiryBoundaryForReferenceDirectoryVersions

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -127,6 +127,43 @@ module Reference =
         | Some graceError -> Error graceError
         | None -> Ok(planManifestReferences repositoryId referenceId manifestReferences)
 
+    let validateRecursiveDirectoryVersionsComplete rootDirectoryVersionId (directoryVersions: DirectoryVersion seq) correlationId =
+        let directoryVersionArray = directoryVersions |> Seq.toArray
+
+        let directoryVersionIds =
+            HashSet<DirectoryVersionId>(
+                directoryVersionArray
+                |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+            )
+
+        if not (directoryVersionIds.Contains rootDirectoryVersionId) then
+            Error(
+                (GraceError.Create "Recursive directory traversal did not include the root DirectoryVersion." correlationId)
+                    .enhance (nameof DirectoryVersionId, rootDirectoryVersionId)
+            )
+        else
+            let missingChild =
+                directoryVersionArray
+                |> Seq.collect (fun directoryVersion ->
+                    directoryVersion.Directories
+                    |> Seq.map (fun childDirectoryVersionId -> directoryVersion, childDirectoryVersionId))
+                |> Seq.tryFind (fun (_, childDirectoryVersionId) -> not (directoryVersionIds.Contains childDirectoryVersionId))
+
+            match missingChild with
+            | Some (parentDirectoryVersion, childDirectoryVersionId) ->
+                Error(
+                    (GraceError.Create "Recursive directory traversal did not include a declared child DirectoryVersion." correlationId)
+                        .enhance(nameof DirectoryVersionId, rootDirectoryVersionId)
+                        .enhance("ParentDirectoryVersionId", parentDirectoryVersion.DirectoryVersionId)
+                        .enhance ("ChildDirectoryVersionId", childDirectoryVersionId)
+                )
+            | None -> Ok directoryVersionArray
+
+    let planManifestSaveBoundaryForRecursiveDirectoryVersions repositoryId referenceId rootDirectoryVersionId directoryVersions correlationId =
+        match validateRecursiveDirectoryVersionsComplete rootDirectoryVersionId directoryVersions correlationId with
+        | Error graceError -> Error graceError
+        | Ok completeDirectoryVersions -> planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId completeDirectoryVersions correlationId
+
     let planManifestSaveBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
         planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId [ directoryVersion ] correlationId
 
@@ -151,6 +188,50 @@ module Reference =
     let shouldApplyManifestExpiryBoundary (referenceDto: ReferenceDto) =
         referenceDto.ReferenceId <> ReferenceId.Empty
         && referenceDto.ReferenceType = ReferenceType.Save
+
+    let planManifestSaveExpiryBoundaryForReferenceDirectoryVersions
+        repositoryId
+        referenceId
+        rootDirectoryVersionId
+        (referenceDto: ReferenceDto)
+        (getRecursiveDirectoryVersions: unit -> Task<Grace.Types.DirectoryVersion.DirectoryVersionDto array>)
+        correlationId
+        =
+        task {
+            if shouldApplyManifestExpiryBoundary referenceDto then
+                let! directoryVersionDtos = getRecursiveDirectoryVersions ()
+
+                match
+                    planManifestSaveBoundaryForRecursiveDirectoryVersions
+                        repositoryId
+                        referenceId
+                        rootDirectoryVersionId
+                        (directoryVersionDtos
+                         |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                        correlationId
+                    with
+                | Error graceError -> return Error graceError
+                | Ok plans ->
+                    return
+                        plans
+                        |> List.map (fun plan ->
+                            let operationId =
+                                RepositoryContentCounterOperationId
+                                    $"reference-expiry:{referenceId:N}:{plan.Manifest.StoragePoolId}:{plan.Manifest.ManifestAddress}"
+
+                            { plan with
+                                CounterCommand =
+                                    RepositoryContentCounterCommand.RemoveReference(
+                                        operationId,
+                                        repositoryId,
+                                        plan.Manifest.StoragePoolId,
+                                        plan.Manifest.ManifestAddress
+                                    )
+                            })
+                        |> Ok
+            else
+                return Ok []
+        }
 
     let validateReferenceRootDirectoryVersionHashes correlationId repositoryId directoryId sha256Hash blake3Hash (directoryVersion: DirectoryVersion) =
         let rootRelativePath = directoryVersion.RelativePath
@@ -473,23 +554,22 @@ module Reference =
                             else
                                 referenceDto.ReferenceId
 
-                        let directoryVersionActorProxy =
-                            DirectoryVersion.CreateActorProxy
-                                physicalDeletionReminderState.DirectoryVersionId
-                                physicalDeletionReminderState.RepositoryId
-                                this.correlationId
-
-                        let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false this.correlationId
-
                         let! boundaryResult =
                             task {
                                 if shouldApplyManifestExpiryBoundary referenceDto then
-                                    match
-                                        planManifestSaveExpiryBoundaryForDirectoryVersions
+                                    let directoryVersionActorProxy =
+                                        DirectoryVersion.CreateActorProxy
+                                            physicalDeletionReminderState.DirectoryVersionId
+                                            physicalDeletionReminderState.RepositoryId
+                                            this.correlationId
+
+                                    match!
+                                        planManifestSaveExpiryBoundaryForReferenceDirectoryVersions
                                             physicalDeletionReminderState.RepositoryId
                                             referenceId
-                                            (directoryVersionDtos
-                                             |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                                            physicalDeletionReminderState.DirectoryVersionId
+                                            referenceDto
+                                            (fun () -> directoryVersionActorProxy.GetRecursiveDirectoryVersions false this.correlationId)
                                             this.correlationId
                                         with
                                     | Error graceError -> return Error graceError
@@ -722,9 +802,10 @@ module Reference =
                                 let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
 
                                 match
-                                    planManifestSaveBoundaryForDirectoryVersions
+                                    planManifestSaveBoundaryForRecursiveDirectoryVersions
                                         repositoryId
                                         referenceId
+                                        directoryId
                                         (directoryVersionDtos
                                          |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
                                         metadata.CorrelationId
@@ -741,12 +822,13 @@ module Reference =
                                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
                                 let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
 
-                                match
-                                    planManifestSaveExpiryBoundaryForDirectoryVersions
+                                match!
+                                    planManifestSaveExpiryBoundaryForReferenceDirectoryVersions
                                         repositoryId
                                         referenceId
-                                        (directoryVersionDtos
-                                         |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                                        directoryId
+                                        referenceDto
+                                        (fun () -> Task.FromResult directoryVersionDtos)
                                         metadata.CorrelationId
                                     with
                                 | Error graceError -> return Error graceError

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -88,29 +88,52 @@ module Reference =
                 Ranges = plan.WorkflowRanges
             }
 
+    let private planManifestReferences
+        repositoryId
+        referenceId
+        (manifestReferences: DirectoryVersion.ManifestReferenceForSaveBoundary seq)
+        : ManifestSaveContributionPlan list
+        =
+        manifestReferences
+        |> Seq.distinctBy (fun manifestReference -> manifestReference.Manifest.StoragePoolId, manifestReference.Manifest.ManifestAddress)
+        |> Seq.map (fun manifestReference -> manifestReference.Manifest)
+        |> Seq.toList
+        |> List.map (fun manifest ->
+            let operationId = manifestContributionOperationId referenceId manifest.StoragePoolId manifest.ManifestAddress
+
+            {
+                RepositoryId = repositoryId
+                ReferenceId = referenceId
+                Manifest = manifest
+                CounterCommand = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, manifest.StoragePoolId, manifest.ManifestAddress)
+                WorkflowRanges = workflowRangesForManifest manifest
+            })
+
+    let planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId (directoryVersions: DirectoryVersion seq) correlationId =
+        let directoryVersionArray = directoryVersions |> Seq.toArray
+        let manifestReferences = ResizeArray<DirectoryVersion.ManifestReferenceForSaveBoundary>()
+        let mutable index = 0
+        let mutable error: GraceError option = None
+
+        while index < directoryVersionArray.Length
+              && error.IsNone do
+            match DirectoryVersion.getManifestReferencesForSaveBoundary directoryVersionArray[index] correlationId with
+            | Error graceError -> error <- Some graceError
+            | Ok directoryManifestReferences -> manifestReferences.AddRange directoryManifestReferences
+
+            index <- index + 1
+
+        match error with
+        | Some graceError -> Error graceError
+        | None -> Ok(planManifestReferences repositoryId referenceId manifestReferences)
+
     let planManifestSaveBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
-        match DirectoryVersion.getManifestReferencesForSaveBoundary directoryVersion correlationId with
+        planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId [ directoryVersion ] correlationId
+
+    let planManifestSaveExpiryBoundaryForDirectoryVersions repositoryId referenceId directoryVersions correlationId =
+        match planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId directoryVersions correlationId with
         | Error graceError -> Error graceError
-        | Ok manifestReferences ->
-            manifestReferences
-            |> Seq.distinctBy (fun manifestReference -> manifestReference.Manifest.StoragePoolId, manifestReference.Manifest.ManifestAddress)
-            |> Seq.map (fun manifestReference -> manifestReference.Manifest)
-            |> Seq.toList
-            |> List.map (fun manifest ->
-                let operationId = manifestContributionOperationId referenceId manifest.StoragePoolId manifest.ManifestAddress
-
-                {
-                    RepositoryId = repositoryId
-                    ReferenceId = referenceId
-                    Manifest = manifest
-                    CounterCommand = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, manifest.StoragePoolId, manifest.ManifestAddress)
-                    WorkflowRanges = workflowRangesForManifest manifest
-                })
-            |> Ok
-
-    let planManifestSaveExpiryBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
-        planManifestSaveBoundary repositoryId referenceId directoryVersion correlationId
-        |> Result.map (fun plans ->
+        | Ok plans ->
             plans
             |> List.map (fun plan ->
                 let operationId =
@@ -119,7 +142,11 @@ module Reference =
                 { plan with
                     CounterCommand =
                         RepositoryContentCounterCommand.RemoveReference(operationId, repositoryId, plan.Manifest.StoragePoolId, plan.Manifest.ManifestAddress)
-                }))
+                })
+            |> Ok
+
+    let planManifestSaveExpiryBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
+        planManifestSaveExpiryBoundaryForDirectoryVersions repositoryId referenceId [ directoryVersion ] correlationId
 
     let shouldApplyManifestExpiryBoundary (referenceDto: ReferenceDto) =
         referenceDto.ReferenceId <> ReferenceId.Empty
@@ -452,16 +479,17 @@ module Reference =
                                 physicalDeletionReminderState.RepositoryId
                                 this.correlationId
 
-                        let! directoryVersionDto = directoryVersionActorProxy.Get this.correlationId
+                        let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false this.correlationId
 
                         let! boundaryResult =
                             task {
                                 if shouldApplyManifestExpiryBoundary referenceDto then
                                     match
-                                        planManifestSaveExpiryBoundary
+                                        planManifestSaveExpiryBoundaryForDirectoryVersions
                                             physicalDeletionReminderState.RepositoryId
                                             referenceId
-                                            directoryVersionDto.DirectoryVersion
+                                            (directoryVersionDtos
+                                             |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
                                             this.correlationId
                                         with
                                     | Error graceError -> return Error graceError
@@ -691,9 +719,16 @@ module Reference =
                                 return Ok()
                             else
                                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
-                                let! directoryVersionDto = directoryVersionActorProxy.Get metadata.CorrelationId
+                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
 
-                                match planManifestSaveBoundary repositoryId referenceId directoryVersionDto.DirectoryVersion metadata.CorrelationId with
+                                match
+                                    planManifestSaveBoundaryForDirectoryVersions
+                                        repositoryId
+                                        referenceId
+                                        (directoryVersionDtos
+                                         |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                                        metadata.CorrelationId
+                                    with
                                 | Error graceError -> return Error graceError
                                 | Ok plans -> return! applyManifestContributionBoundary plans metadata
                         }
@@ -704,9 +739,16 @@ module Reference =
                                 return Ok()
                             else
                                 let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId metadata.CorrelationId
-                                let! directoryVersionDto = directoryVersionActorProxy.Get metadata.CorrelationId
+                                let! directoryVersionDtos = directoryVersionActorProxy.GetRecursiveDirectoryVersions false metadata.CorrelationId
 
-                                match planManifestSaveExpiryBoundary repositoryId referenceId directoryVersionDto.DirectoryVersion metadata.CorrelationId with
+                                match
+                                    planManifestSaveExpiryBoundaryForDirectoryVersions
+                                        repositoryId
+                                        referenceId
+                                        (directoryVersionDtos
+                                         |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                                        metadata.CorrelationId
+                                    with
                                 | Error graceError -> return Error graceError
                                 | Ok plans -> return! applyManifestContributionBoundary plans metadata
                         }

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -378,3 +378,41 @@ type ReferenceActorHashValidationTests() =
         Assert.That(predicateSource, Does.Contain("referenceType = ReferenceType.Save"))
         Assert.That(predicateSource, Does.Not.Contain("ReferenceType.Commit"))
         Assert.That(predicateSource, Does.Not.Contain("ReferenceType.Checkpoint"))
+
+    [<Test>]
+    member _.ManifestContributionBoundaryTraversalsForceRegenerationInsteadOfCachedRecursiveResults() =
+        let actorPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Actors", "Reference.Actor.fs"))
+        let actorSource = File.ReadAllText actorPath
+
+        let assertBoundaryForcesRegeneration (boundaryStartText: string) (boundaryEndText: string) =
+            let boundaryStart = actorSource.IndexOf(boundaryStartText, StringComparison.Ordinal)
+
+            Assert.That(boundaryStart, Is.GreaterThanOrEqualTo(0), $"Expected ReferenceActor boundary `{boundaryStartText}` to be present.")
+
+            let boundaryEnd = actorSource.IndexOf(boundaryEndText, boundaryStart, StringComparison.Ordinal)
+
+            Assert.That(boundaryEnd, Is.GreaterThan(boundaryStart), $"Expected ReferenceActor boundary `{boundaryStartText}` to have a bounded source slice.")
+
+            let boundarySource = actorSource.Substring(boundaryStart, boundaryEnd - boundaryStart)
+
+            Assert.That(
+                boundarySource,
+                Does.Contain("GetRecursiveDirectoryVersions true"),
+                $"Expected ReferenceActor boundary `{boundaryStartText}` to bypass cached partial recursive directory results."
+            )
+
+            Assert.That(
+                boundarySource,
+                Does.Not.Contain("GetRecursiveDirectoryVersions false"),
+                $"ReferenceActor boundary `{boundaryStartText}` must not trust cached partial recursive directory results."
+            )
+
+        assertBoundaryForcesRegeneration "let! boundaryResult =" "match boundaryResult with"
+
+        assertBoundaryForcesRegeneration
+            "let applyReferenceManifestBoundary referenceId repositoryId directoryId referenceType ="
+            "let applyReferenceManifestExpiryBoundary referenceId repositoryId directoryId referenceType ="
+
+        assertBoundaryForcesRegeneration
+            "let applyReferenceManifestExpiryBoundary referenceId repositoryId directoryId referenceType ="
+            "let existingReferenceReturnValue () ="

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -9,6 +9,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.IO
 open System.Text
 open System.Threading.Tasks
 
@@ -1134,3 +1135,50 @@ type SaveBoundaryActorTests() =
 
             Assert.That(fetchCalled, Is.False)
         }
+
+    [<Test>]
+    member _.RecursiveDirectoryTraversalCompletenessRejectsMissingDeclaredChildBeforeCacheWrite() =
+        let rootDirectory =
+            DirectoryVersion.CreateWithHashes
+                directoryVersionId
+                ownerId
+                organizationId
+                repositoryId
+                (RelativePath ".")
+                (Sha256Hash "root-sha256")
+                (Blake3Hash "root-blake3")
+                (List<DirectoryVersionId>([ childDirectoryVersionId ]))
+                (List<FileVersion>())
+                0L
+
+        let rootDto = { Grace.Types.DirectoryVersion.DirectoryVersionDto.Default with DirectoryVersion = rootDirectory }
+
+        match DirectoryVersionActor.validateRecursiveDirectoryVersionsComplete directoryVersionId [ rootDto ] "corr-cache-poison-missing-child" with
+        | Ok _ -> Assert.Fail("Expected incomplete recursive traversal to be rejected before cache write.")
+        | Error error ->
+            Assert.That(error.Error, Does.Contain("declared child DirectoryVersion"))
+            Assert.That(error.Properties["ParentDirectoryVersionId"], Is.EqualTo(string directoryVersionId))
+            Assert.That(error.Properties["ChildDirectoryVersionId"], Is.EqualTo(string childDirectoryVersionId))
+
+    [<Test>]
+    member _.RecursiveDirectoryVersionsCachesOnlyCompleteTraversalResults() =
+        let actorPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Actors", "DirectoryVersion.Actor.fs"))
+        let actorSource = File.ReadAllText actorPath
+
+        let traversalListStart = actorSource.IndexOf("let subdirectoryVersionsList =", StringComparison.Ordinal)
+
+        Assert.That(traversalListStart, Is.GreaterThanOrEqualTo(0), "Expected recursive traversal list assembly to exist.")
+
+        let validationStart = actorSource.IndexOf("match validateRecursiveDirectoryVersionsComplete", traversalListStart, StringComparison.Ordinal)
+
+        Assert.That(validationStart, Is.GreaterThan(traversalListStart), "Expected cache writes to be gated by traversal completeness.")
+
+        let cacheWriteStart = actorSource.IndexOf("OpenWriteAsync", validationStart, StringComparison.Ordinal)
+
+        Assert.That(cacheWriteStart, Is.GreaterThan(validationStart), "Expected recursive cache write to remain present.")
+
+        let guardedSlice = actorSource.Substring(validationStart, cacheWriteStart - validationStart)
+
+        Assert.That(guardedSlice, Does.Contain("| Error graceError ->"))
+        Assert.That(guardedSlice, Does.Contain("Skipping recursive directory version cache write"))
+        Assert.That(guardedSlice, Does.Contain("| Ok completeSubdirectoryVersionsList ->"))

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -711,6 +711,59 @@ type SaveBoundaryActorTests() =
         | _ -> Assert.Fail("Expected nested child manifest planning to add stored-pool manifest ownership.")
 
     [<Test>]
+    member _.RecursiveSaveBoundaryPlanningRejectsMissingRootDirectoryVersion() =
+        let childManifest = finalizedManifestInPool archiveStoragePoolId
+
+        let childDirectory =
+            hashedDirectory
+                childDirectoryVersionId
+                (RelativePath "/src/")
+                []
+                [
+                    manifestFileAt "/src/large.bin" childManifest
+                ]
+
+        let result =
+            ReferenceActor.planManifestSaveBoundaryForRecursiveDirectoryVersions
+                repositoryId
+                referenceId
+                directoryVersionId
+                [ childDirectory ]
+                "corr-recursive-missing-root"
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected recursive save boundary planning to reject traversal results without the root directory.")
+        | Error error -> Assert.That(error.Error, Does.Contain("did not include the root DirectoryVersion"))
+
+    [<Test>]
+    member _.RecursiveSaveBoundaryPlanningRejectsDeclaredChildMissingFromTraversal() =
+        let rootManifest = finalizedManifest ()
+        let childManifest = finalizedManifestInPool archiveStoragePoolId
+
+        let childDirectory =
+            hashedDirectory
+                childDirectoryVersionId
+                (RelativePath "/src/")
+                []
+                [
+                    manifestFileAt "/src/large.bin" childManifest
+                ]
+
+        let rootDirectory = hashedDirectory directoryVersionId (RelativePath "/") [ childDirectory ] [ manifestFile rootManifest ]
+
+        let result =
+            ReferenceActor.planManifestSaveBoundaryForRecursiveDirectoryVersions
+                repositoryId
+                referenceId
+                directoryVersionId
+                [ rootDirectory ]
+                "corr-recursive-missing-child"
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected recursive save boundary planning to reject traversal results missing a declared child directory.")
+        | Error error -> Assert.That(error.Error, Does.Contain("did not include a declared child DirectoryVersion"))
+
+    [<Test>]
     member _.ReferenceBoundaryDeduplicatesRecursiveManifestReferencesByStoredPoolAndManifestAddress() =
         let manifest = finalizedManifestInPool archiveStoragePoolId
 
@@ -1056,3 +1109,28 @@ type SaveBoundaryActorTests() =
         Assert.That(ReferenceActor.shouldApplyManifestExpiryBoundary (referenceDto ReferenceType.Commit), Is.False)
         Assert.That(ReferenceActor.shouldApplyManifestExpiryBoundary (referenceDto ReferenceType.Checkpoint), Is.False)
         Assert.That(ReferenceActor.shouldApplyManifestExpiryBoundary Grace.Types.Reference.ReferenceDto.Default, Is.False)
+
+    [<Test>]
+    member _.SaveExpiryReferencePlanningSkipsRecursiveFetchForCheckpointReferences() =
+        task {
+            let mutable fetchCalled = false
+
+            let getRecursiveDirectoryVersions () =
+                fetchCalled <- true
+                Task.FromResult Array.empty<Grace.Types.DirectoryVersion.DirectoryVersionDto>
+
+            let! result =
+                ReferenceActor.planManifestSaveExpiryBoundaryForReferenceDirectoryVersions
+                    repositoryId
+                    referenceId
+                    directoryVersionId
+                    (referenceDto ReferenceType.Checkpoint)
+                    getRecursiveDirectoryVersions
+                    "corr-checkpoint-expiry-skip"
+
+            match result with
+            | Error error -> Assert.Fail($"Expected checkpoint expiry planning to skip manifest traversal, got {error.Error}.")
+            | Ok plans -> Assert.That(plans, Is.Empty)
+
+            Assert.That(fetchCalled, Is.False)
+        }

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -25,6 +25,7 @@ type SaveBoundaryActorTests() =
     let organizationId = Guid.Parse("5a602145-3f0a-47c8-bc7c-f6618425c07f")
     let repositoryId = Guid.Parse("e34f8949-6306-4fb1-89ca-e9eb831022b0")
     let directoryVersionId = Guid.Parse("29e93e9b-3e5f-4b6e-b8c3-2a964d8d33f3")
+    let childDirectoryVersionId = Guid.Parse("599af9a9-cb67-49cb-a6df-7a2b5b63ff78")
     let referenceId = Guid.Parse("9b26f91a-fd44-46b3-9cc7-17645bb388a2")
     let storagePoolId = StoragePoolId Constants.DefaultStoragePoolId
     let archiveStoragePoolId = StoragePoolId "pool-archive"
@@ -67,10 +68,12 @@ type SaveBoundaryActorTests() =
 
     let finalizedManifestInPool storagePoolId = { finalizedManifest () with StoragePoolId = storagePoolId }
 
-    let manifestFile (manifest: FileManifest) =
-        let fileVersion = FileVersion.Create "/large.bin" "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" String.Empty true manifest.Size
+    let manifestFileAt relativePath (manifest: FileManifest) =
+        let fileVersion = FileVersion.Create relativePath "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" String.Empty true manifest.Size
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
         fileVersion
+
+    let manifestFile (manifest: FileManifest) = manifestFileAt "/large.bin" manifest
 
     let manifestReference (manifest: FileManifest) : DirectoryVersionActor.ManifestReferenceForSaveBoundary =
         { Manifest = manifest; AuthorizedScope = RelativePath "/large.bin" }
@@ -135,6 +138,13 @@ type SaveBoundaryActorTests() =
         | Error error ->
             Assert.Fail($"Expected save boundary plan to succeed, got {error.Error}.")
             Unchecked.defaultof<ReferenceActor.ManifestSaveContributionPlan>
+
+    let expectPlans result =
+        match result with
+        | Ok plans -> plans |> List.toArray
+        | Error error ->
+            Assert.Fail($"Expected save boundary plans to succeed, got {error.Error}.")
+            Array.empty
 
     [<Test>]
     member _.SaveBoundaryRejectsUnfinalizedManifestReferences() =
@@ -648,6 +658,132 @@ type SaveBoundaryActorTests() =
             Assert.That(commandStoragePoolId, Is.EqualTo(storagePoolId))
             Assert.That(manifestAddress, Is.EqualTo(manifest.ManifestAddress))
         | _ -> Assert.Fail("Expected checkpoint expiry planning to remove manifest ownership.")
+
+    [<Test>]
+    member _.ReferenceBoundaryPlansNestedChildDirectoryManifestOwnershipByStoredPool() =
+        let rootManifest = finalizedManifest ()
+        let childManifest = finalizedManifestInPool archiveStoragePoolId
+
+        let childDirectory =
+            hashedDirectory
+                childDirectoryVersionId
+                (RelativePath "/src/")
+                []
+                [
+                    manifestFileAt "/src/large.bin" childManifest
+                ]
+
+        let rootDirectory = hashedDirectory directoryVersionId (RelativePath "/") [ childDirectory ] [ manifestFile rootManifest ]
+
+        let plans =
+            ReferenceActor.planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId [ rootDirectory; childDirectory ] "corr-recursive-plan"
+            |> expectPlans
+
+        Assert.That(plans, Has.Length.EqualTo(2))
+
+        Assert.That(
+            plans
+            |> Seq.map (fun plan -> plan.Manifest.StoragePoolId, plan.Manifest.ManifestAddress),
+            Is.EquivalentTo(
+                [
+                    storagePoolId, rootManifest.ManifestAddress
+                    archiveStoragePoolId, childManifest.ManifestAddress
+                ]
+            )
+        )
+
+        let childPlan =
+            plans
+            |> Seq.find (fun plan -> plan.Manifest.ManifestAddress = childManifest.ManifestAddress)
+
+        Assert.That(childPlan.Manifest.StoragePoolId, Is.EqualTo(archiveStoragePoolId))
+
+        Assert.That(
+            childPlan.WorkflowRanges
+            |> Seq.forall (fun range -> range.StoragePoolId = archiveStoragePoolId),
+            Is.True
+        )
+
+        match childPlan.CounterCommand with
+        | RepositoryContentCounterCommand.AddReference (_, _, commandStoragePoolId, manifestAddress) ->
+            Assert.That(commandStoragePoolId, Is.EqualTo(archiveStoragePoolId))
+            Assert.That(manifestAddress, Is.EqualTo(childManifest.ManifestAddress))
+        | _ -> Assert.Fail("Expected nested child manifest planning to add stored-pool manifest ownership.")
+
+    [<Test>]
+    member _.ReferenceBoundaryDeduplicatesRecursiveManifestReferencesByStoredPoolAndManifestAddress() =
+        let manifest = finalizedManifestInPool archiveStoragePoolId
+
+        let childDirectory =
+            hashedDirectory
+                childDirectoryVersionId
+                (RelativePath "/src/")
+                []
+                [
+                    manifestFileAt "/src/large.bin" manifest
+                ]
+
+        let rootDirectory = hashedDirectory directoryVersionId (RelativePath "/") [ childDirectory ] [ manifestFile manifest ]
+
+        let plans =
+            ReferenceActor.planManifestSaveBoundaryForDirectoryVersions
+                repositoryId
+                referenceId
+                [ rootDirectory; childDirectory ]
+                "corr-recursive-duplicate-plan"
+            |> expectPlans
+
+        Assert.That(plans, Has.Length.EqualTo(1))
+        Assert.That(plans[0].Manifest.StoragePoolId, Is.EqualTo(archiveStoragePoolId))
+        Assert.That(plans[0].Manifest.ManifestAddress, Is.EqualTo(manifest.ManifestAddress))
+
+    [<Test>]
+    member _.SaveExpiryPlanningMatchesRecursiveSaveManifestKeysByStoredPool() =
+        let rootManifest = finalizedManifest ()
+        let childManifest = finalizedManifestInPool archiveStoragePoolId
+
+        let childDirectory =
+            hashedDirectory
+                childDirectoryVersionId
+                (RelativePath "/src/")
+                []
+                [
+                    manifestFileAt "/src/large.bin" childManifest
+                ]
+
+        let rootDirectory = hashedDirectory directoryVersionId (RelativePath "/") [ childDirectory ] [ manifestFile rootManifest ]
+        let recursiveDirectoryVersions = [ rootDirectory; childDirectory ]
+
+        let savePlans =
+            ReferenceActor.planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId recursiveDirectoryVersions "corr-recursive-save-plan"
+            |> expectPlans
+
+        let expiryPlans =
+            ReferenceActor.planManifestSaveExpiryBoundaryForDirectoryVersions repositoryId referenceId recursiveDirectoryVersions "corr-recursive-expiry-plan"
+            |> expectPlans
+
+        let saveKeys =
+            savePlans
+            |> Seq.map (fun plan -> plan.Manifest.StoragePoolId, plan.Manifest.ManifestAddress)
+            |> Seq.toArray
+
+        let expiryKeys =
+            expiryPlans
+            |> Seq.map (fun plan -> plan.Manifest.StoragePoolId, plan.Manifest.ManifestAddress)
+            |> Seq.toArray
+
+        Assert.That(expiryKeys, Is.EquivalentTo(saveKeys))
+
+        Assert.That(
+            expiryPlans
+            |> Seq.forall (fun plan ->
+                match plan.CounterCommand with
+                | RepositoryContentCounterCommand.RemoveReference (_, _, commandStoragePoolId, manifestAddress) ->
+                    commandStoragePoolId = plan.Manifest.StoragePoolId
+                    && manifestAddress = plan.Manifest.ManifestAddress
+                | _ -> false),
+            Is.True
+        )
 
     [<Test>]
     member _.SaveBoundaryStartsContributionWorkflowForRepeatedManifestBlockOccurrences() =


### PR DESCRIPTION
# CAS-06: Recursive manifest save-boundary validation

Part of #424.

Related to #429.

## Branch flow

This PR targets `epic/424-storagepool-cas`, not `main`. The #424 CAS integration branch is intentionally based on
`origin/epic/343-blake3-sha256-version-hashes`, and child PRs merge back to the CAS integration branch before the final
CAS handoff into #343.

## Summary

- Plans manifest-backed save-boundary contributions from recursive `DirectoryVersion` children, not only the root
  directory.
- Keeps manifest contribution identity keyed by stored `StoragePoolId` plus manifest address.
- Uses the same recursive manifest planning path for save-expiry and physical deletion decrement/removal behavior.
- Adds focused unit coverage for nested child directory manifests, duplicate references, and save-expiry symmetry.

## Review Status

- First-pass bot-prevention self-review: complete in worker handoff.
- Prevention line: recursive manifest ownership now uses stored-pool manifest identity instead of current route or
  address-only contribution planning; fix passes also fail closed on incomplete recursive traversal, skip recursive
  expiry fetches for non-Save references, force recursive regeneration for manifest contribution boundaries, and prevent
  incomplete recursive traversals from writing recursive cache entries.
- Codex Code Review Bot: first pass on `54415266068ef85112a5b1f100e45a38ad0f9c65` found two actionable findings;
  fixes are pushed in `272475627b652ae39b3c183a1d29536d5116b026`. Second pass on that head found one additional
  cache-bypass finding; fix is pushed in `fca46fbefa10098d56b835e7040ce421a188b30c`. Third pass found one additional
  cache-poisoning finding; fix is pushed in `64b924bcff0f34cf3e9e43e5cfdf29d4842a256d`.
- Codex Code Review Bot final state: 👍 on `64b924bcff0f34cf3e9e43e5cfdf29d4842a256d` with no unresolved review
  threads.
- Review threads: all bot threads have fix replies and are resolved.

## Validation

Worker validation on `agent/429-directory-manifest-storagepool-validation`:

```powershell
dotnet tool run fantomas src\Grace.Actors\Reference.Actor.fs src\Grace.Server.Unit.Tests\SaveBoundary.Actor.Tests.fs
dotnet build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj
dotnet test --configuration Release --no-build src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj
git diff --check
```

Results:

- Targeted Fantomas passed.
- `dotnet build` passed with 0 warnings and 0 errors.
- `dotnet test` passed: 686/686.
- `git diff --check` passed.

Focused Server.Unit validation was used instead of `pwsh ./scripts/validate.ps1 -Fast` because this slice is pure actor
contribution-planning logic with direct unit coverage, and `validate -Fast` would add broad unrelated suites after the
same Release build path.

## Deferred Scope

- #430 owns normal file download and materialization from stored manifest CAS blocks.
- #431 owns large binary watch/save lifecycle proof.
- #432 owns final CAS placement contract, SDK, and documentation refresh.
- #433 owns cross-repository StoragePool dedupe proof.
