### PR TITLE
CAS-07 materialize stored-manifest normal downloads

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />
     <Compile Include="AnnotationMaterialization.Server.Tests.fs" />
+    <Compile Include="NormalFileMaterialization.Server.Tests.fs" />
     <Compile Include="StoragePoolRouting.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/NormalFileMaterialization.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/NormalFileMaterialization.Server.Tests.fs
@@ -1,0 +1,453 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.ContentBlockMetadata
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+
+[<Parallelizable(ParallelScope.All)>]
+type NormalFileMaterializationServerTests() =
+
+    let correlationId = "corr-normal-file-materialization"
+
+    let bytes (text: string) = Encoding.UTF8.GetBytes text
+
+    let sha256Hex (payload: byte array) =
+        SHA256.HashData(payload)
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let expectEncodedOk result =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected ContentBlockFormat.encode Ok but got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    let encodeBlock payload =
+        ContentBlockFormat.encode [ ContentBlockFormat.createChunk 0L payload ]
+        |> expectEncodedOk
+
+    let fileVersion (relativePath: string) (payload: byte array) =
+        FileVersion.CreateWithHashes
+            (RelativePath relativePath)
+            (Sha256Hash(sha256Hex payload))
+            (Blake3Hash(ContentAddress.computeBlake3Hex payload))
+            String.Empty
+            true
+            (int64 payload.Length)
+
+    let manifestForBlocks (storagePoolId: StoragePoolId) (payload: byte array) (blocks: (ContentBlockFormat.EncodedContentBlock * int64 * int64) array) =
+        let manifestBlocks =
+            blocks
+            |> Array.map (fun (block, offset, size) -> ContentBlock.Create(block.Address, offset, size))
+            |> Array.toList
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                RabinChunking.SuiteName,
+                FileContentHash(ContentAddress.computeBlake3Hex payload),
+                int64 payload.Length,
+                storagePoolId,
+                manifestBlocks
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let manifestFile (relativePath: string) (storagePoolId: StoragePoolId) (payload: byte array) =
+        let block = encodeBlock payload
+        let manifest = manifestForBlocks storagePoolId payload [| block, 0L, int64 payload.Length |]
+        let fileVersion = fileVersion relativePath payload
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+        fileVersion, manifest, [| block |]
+
+    let placementFor (storagePoolId: StoragePoolId) (address: ContentBlockAddress) (objectKey: string) =
+        {
+            StorageAccountName = $"account-{storagePoolId}"
+            StorageContainerName = StorageContainerName $"container-{storagePoolId}"
+            ObjectKey = objectKey
+            ETag = Some $"etag-{address}"
+        }
+
+    let metadataFor (storagePoolId: StoragePoolId) (block: ContentBlock) (placement: ContentBlockStoragePlacement) =
+        { ContentBlockMetadata.Empty with
+            StoragePoolId = storagePoolId
+            ContentBlockAddress = block.Address
+            BlockFormatVersion = 1s
+            StoragePlacement = placement
+            Ranges =
+                [|
+                    { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 1; PhysicalOffset = 0L; PhysicalLength = block.Size }
+                |]
+        }
+
+    let metadataResolverFrom
+        (metadata: IDictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>)
+        (requests: ResizeArray<ContentBlockAddress array>)
+        : NormalFileMaterialization.ContentBlockMetadataBatchResolver
+        =
+        fun manifest addresses correlationId _ ->
+            task {
+                requests.Add(Array.copy addresses)
+                let records = ResizeArray<ContentBlockMetadata>()
+                let mutable error = None
+                let mutable index = 0
+
+                while index < addresses.Length && Option.isNone error do
+                    let key = (manifest.StoragePoolId, manifest.ManifestAddress, addresses[index])
+
+                    match metadata.TryGetValue key with
+                    | true, value -> records.Add value
+                    | false, _ ->
+                        error <-
+                            Some(GraceError.Create $"missing metadata for {manifest.StoragePoolId}/{manifest.ManifestAddress}/{addresses[index]}" correlationId)
+
+                    index <- index + 1
+
+                match error with
+                | Some error -> return Error error
+                | None -> return Ok(records.ToArray())
+            }
+
+    let contentBlockReaderFrom
+        (objects: IDictionary<string, byte array>)
+        (readPlacements: ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>)
+        : NormalFileMaterialization.ContentBlockPlacementPayloadReader
+        =
+        fun placement contentBlockAddress correlationId _ ->
+            task {
+                readPlacements.Add(contentBlockAddress, placement)
+
+                match objects.TryGetValue placement.ObjectKey with
+                | true, payload -> return Ok payload
+                | false, _ -> return Error(GraceError.Create $"missing placement object {placement.ObjectKey}" correlationId)
+            }
+
+    let wholeFileReaderFrom (objects: IDictionary<string, byte array>) : NormalFileMaterialization.ObjectPayloadReader =
+        fun objectKey correlationId _ ->
+            task {
+                match objects.TryGetValue objectKey with
+                | true, payload -> return Ok payload
+                | false, _ -> return Error(GraceError.Create $"missing object {objectKey}" correlationId)
+            }
+
+    let failingWholeFileReader: NormalFileMaterialization.ObjectPayloadReader =
+        fun objectKey correlationId _ -> task { return Error(GraceError.Create $"whole-file reader should not be called for {objectKey}" correlationId) }
+
+    let writerTo (objects: IDictionary<string, byte array>) (writes: ResizeArray<string * byte array>) : NormalFileMaterialization.ObjectPayloadWriter =
+        fun objectKey payload _ _ ->
+            task {
+                writes.Add(objectKey, Array.copy payload)
+                objects[objectKey] <- Array.copy payload
+                return Ok()
+            }
+
+    let materializeBytes wholeFileReader metadataResolver contentBlockReader fileVersion objectKey =
+        NormalFileMaterialization.materializeBytesWithReaders
+            wholeFileReader
+            metadataResolver
+            contentBlockReader
+            fileVersion
+            objectKey
+            correlationId
+            CancellationToken.None
+        |> fun operation -> operation.GetAwaiter().GetResult()
+
+    let materializeForDownload wholeFileReader writer metadataResolver contentBlockReader fileVersion objectKey =
+        NormalFileMaterialization.materializeForDownloadWithReaders
+            wholeFileReader
+            writer
+            metadataResolver
+            contentBlockReader
+            fileVersion
+            objectKey
+            correlationId
+            CancellationToken.None
+        |> fun operation -> operation.GetAwaiter().GetResult()
+
+    let expectOk result =
+        match result with
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Expected normal file materialization to succeed, got {error.Error}.")
+            Unchecked.defaultof<byte array>
+
+    let expectUnitOk result =
+        match result with
+        | Ok () -> ()
+        | Error error -> Assert.Fail($"Expected normal file materialization to succeed, got {error.Error}.")
+
+    let expectErrorContains expected result =
+        match result with
+        | Ok _ -> Assert.Fail("Expected normal file materialization to fail.")
+        | Error error -> Assert.That(error.Error, Does.Contain(expected))
+
+    let addMetadata
+        (metadata: IDictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>)
+        (manifest: FileManifest)
+        (storagePoolId: StoragePoolId)
+        (block: ContentBlock)
+        (placement: ContentBlockStoragePlacement)
+        =
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, block.Address)] <- metadataFor storagePoolId block placement
+
+    [<Test>]
+    member _.WholeFileContentMaterializesRepositoryObjectIncludingEmptyFile() =
+        let payload = Array.empty<byte>
+        let target = fileVersion "/empty.bin" payload
+        let objectKey = StorageKeys.wholeFileContentObjectKey target
+        let objects = Dictionary<string, byte array>()
+        objects[objectKey] <- payload
+        let metadataRequests = ResizeArray<ContentBlockAddress array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        let result =
+            materializeBytes
+                (wholeFileReaderFrom objects)
+                (metadataResolverFrom (Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()) metadataRequests)
+                (contentBlockReaderFrom objects readPlacements)
+                target
+                objectKey
+            |> expectOk
+
+        Assert.That(result, Is.Empty)
+        Assert.That(metadataRequests, Is.Empty)
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadPublishesBytesFromStoredPlacement() =
+        let payload = bytes "manifest normal download bytes"
+        let target, manifest, blocks = manifestFile "/nested/historical/file.bin" (StoragePoolId "pool-download") payload
+        let objectKey = "normal/materialized/historical-file.bin"
+        let recordedPlacement = placementFor manifest.StoragePoolId blocks[0].Address "recorded/compacted/block"
+        let addressOnlyPlacement = placementFor manifest.StoragePoolId blocks[0].Address (StorageKeys.contentBlockObjectKey blocks[0].Address)
+        let objects = Dictionary<string, byte array>()
+        objects[recordedPlacement.ObjectKey] <- blocks[0].Payload
+        objects[addressOnlyPlacement.ObjectKey] <- bytes "address-only fallback must not be read"
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        addMetadata metadata manifest manifest.StoragePoolId manifest.Blocks[0] recordedPlacement
+        let metadataRequests = ResizeArray<ContentBlockAddress array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+        let writes = ResizeArray<string * byte array>()
+
+        materializeForDownload
+            failingWholeFileReader
+            (writerTo objects writes)
+            (metadataResolverFrom metadata metadataRequests)
+            (contentBlockReaderFrom objects readPlacements)
+            target
+            objectKey
+        |> expectUnitOk
+
+        Assert.That(writes, Has.Count.EqualTo(1))
+        Assert.That(fst writes[0], Is.EqualTo(objectKey))
+        Assert.That(((snd writes[0]) = payload), Is.True)
+        Assert.That(readPlacements, Has.Count.EqualTo(1))
+        Assert.That(snd readPlacements[0], Is.EqualTo(recordedPlacement))
+        Assert.That(metadataRequests, Has.Count.EqualTo(1))
+        Assert.That((metadataRequests[0] = [| blocks[0].Address |]), Is.True)
+
+    [<Test>]
+    member _.ManifestBackedMultiBlockDownloadBatchesMetadataAndReadsEachDistinctBlockOnce() =
+        let first = bytes "first block "
+        let second = bytes "second block "
+        let payload = Array.concat [ first; second; first ]
+        let firstBlock = encodeBlock first
+        let secondBlock = encodeBlock second
+        let storagePoolId = StoragePoolId "pool-multi"
+
+        let manifest =
+            manifestForBlocks
+                storagePoolId
+                payload
+                [|
+                    firstBlock, 0L, int64 first.Length
+                    secondBlock, int64 first.Length, int64 second.Length
+                    firstBlock, int64 first.Length + int64 second.Length, int64 first.Length
+                |]
+
+        let target = fileVersion "/history/repeated.bin" payload
+        target.ContentReference <- FileContentReference.FileManifest manifest
+        let firstPlacement = placementFor storagePoolId firstBlock.Address "recorded/first"
+        let secondPlacement = placementFor storagePoolId secondBlock.Address "recorded/second"
+        let objects = Dictionary<string, byte array>()
+        objects[firstPlacement.ObjectKey] <- firstBlock.Payload
+        objects[secondPlacement.ObjectKey] <- secondBlock.Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        addMetadata metadata manifest storagePoolId manifest.Blocks[0] firstPlacement
+        addMetadata metadata manifest storagePoolId manifest.Blocks[1] secondPlacement
+        let metadataRequests = ResizeArray<ContentBlockAddress array>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        let result =
+            materializeBytes
+                failingWholeFileReader
+                (metadataResolverFrom metadata metadataRequests)
+                (contentBlockReaderFrom objects readPlacements)
+                target
+                "normal/repeated.bin"
+            |> expectOk
+
+        Assert.That((result = payload), Is.True)
+        Assert.That(metadataRequests, Has.Count.EqualTo(1))
+
+        let expectedMetadataRequest =
+            [|
+                firstBlock.Address
+                secondBlock.Address
+            |]
+
+        Assert.That((metadataRequests[0] = expectedMetadataRequest), Is.True)
+
+        Assert.That(readPlacements, Has.Count.EqualTo(2))
+
+        let expectedReadAddresses =
+            [|
+                firstBlock.Address
+                secondBlock.Address
+            |]
+
+        Assert.That(((readPlacements |> Seq.map fst |> Seq.toArray) = expectedReadAddresses), Is.True)
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsWrongPoolMetadata() =
+        let payload = bytes "wrong pool"
+        let target, manifest, blocks = manifestFile "/wrong-pool.bin" (StoragePoolId "pool-correct") payload
+        let wrongPool = StoragePoolId "pool-wrong"
+        let placement = placementFor wrongPool blocks[0].Address "wrong-pool/object"
+        let objects = Dictionary<string, byte array>()
+        objects[placement.ObjectKey] <- blocks[0].Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        addMetadata metadata manifest wrongPool manifest.Blocks[0] placement
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom metadata (ResizeArray<ContentBlockAddress array>()))
+            (contentBlockReaderFrom objects readPlacements)
+            target
+            "normal/wrong-pool.bin"
+        |> expectErrorContains "StoragePoolId does not match FileManifest.StoragePoolId"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsMissingBlockMetadata() =
+        let payload = bytes "missing metadata"
+        let target, _, _ = manifestFile "/missing.bin" (StoragePoolId "pool-missing") payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        let readPlacements = ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom metadata (ResizeArray<ContentBlockAddress array>()))
+            (contentBlockReaderFrom (Dictionary<string, byte array>()) readPlacements)
+            target
+            "normal/missing.bin"
+        |> expectErrorContains "missing metadata"
+
+        Assert.That(readPlacements, Is.Empty)
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsWrongBlockHash() =
+        let payload = bytes "expected payload"
+        let target, manifest, blocks = manifestFile "/wrong-hash.bin" (StoragePoolId "pool-hash") payload
+        let otherBlock = encodeBlock (bytes "different valid block")
+        let placement = placementFor manifest.StoragePoolId blocks[0].Address "stored/wrong-hash"
+        let objects = Dictionary<string, byte array>()
+        objects[placement.ObjectKey] <- otherBlock.Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        addMetadata metadata manifest manifest.StoragePoolId manifest.Blocks[0] placement
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom metadata (ResizeArray<ContentBlockAddress array>()))
+            (contentBlockReaderFrom objects (ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()))
+            target
+            "normal/wrong-hash.bin"
+        |> expectErrorContains "Invalid manifest reconstruction"
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsInvalidRangeOrder() =
+        let first = bytes "first"
+        let second = bytes "second"
+        let payload = Array.concat [ first; second ]
+        let firstBlock = encodeBlock first
+        let secondBlock = encodeBlock second
+        let storagePoolId = StoragePoolId "pool-range-order"
+
+        let manifest =
+            manifestForBlocks
+                storagePoolId
+                payload
+                [|
+                    firstBlock, 0L, int64 first.Length
+                    secondBlock, 99L, int64 second.Length
+                |]
+
+        let target = fileVersion "/invalid-range.bin" payload
+        target.ContentReference <- FileContentReference.FileManifest manifest
+        let firstPlacement = placementFor storagePoolId firstBlock.Address "stored/range/first"
+        let secondPlacement = placementFor storagePoolId secondBlock.Address "stored/range/second"
+        let objects = Dictionary<string, byte array>()
+        objects[firstPlacement.ObjectKey] <- firstBlock.Payload
+        objects[secondPlacement.ObjectKey] <- secondBlock.Payload
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        addMetadata metadata manifest storagePoolId manifest.Blocks[0] firstPlacement
+        addMetadata metadata manifest storagePoolId manifest.Blocks[1] secondPlacement
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom metadata (ResizeArray<ContentBlockAddress array>()))
+            (contentBlockReaderFrom objects (ResizeArray<ContentBlockAddress * ContentBlockStoragePlacement>()))
+            target
+            "normal/invalid-range.bin"
+        |> expectErrorContains "BlockRangeOutOfOrder"
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsSizeMismatch() =
+        let payload = bytes "size mismatch"
+        let target, manifest, _ = manifestFile "/size-mismatch.bin" (StoragePoolId "pool-size") payload
+        let mismatchedManifest = { manifest with Size = manifest.Size + 1L }
+        target.ContentReference <- FileContentReference.FileManifest mismatchedManifest
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom (Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()) (ResizeArray()))
+            (contentBlockReaderFrom (Dictionary<string, byte array>()) (ResizeArray()))
+            target
+            "normal/size-mismatch.bin"
+        |> expectErrorContains "FileManifest.Size"
+
+    [<Test>]
+    member _.ManifestBackedNormalDownloadRejectsStaleActiveRangeEvidence() =
+        let payload = bytes "stale placement range"
+        let target, manifest, blocks = manifestFile "/stale-range.bin" (StoragePoolId "pool-stale") payload
+        let placement = placementFor manifest.StoragePoolId blocks[0].Address "recorded/stale-range"
+
+        let staleMetadata =
+            { metadataFor manifest.StoragePoolId manifest.Blocks[0] placement with
+                Ranges =
+                    [|
+                        { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 0; PhysicalOffset = 0L; PhysicalLength = manifest.Blocks[0].Size }
+                    |]
+            }
+
+        let metadata = Dictionary<StoragePoolId * ManifestAddress * ContentBlockAddress, ContentBlockMetadata>()
+        metadata[(manifest.StoragePoolId, manifest.ManifestAddress, blocks[0].Address)] <- staleMetadata
+
+        materializeBytes
+            failingWholeFileReader
+            (metadataResolverFrom metadata (ResizeArray<ContentBlockAddress array>()))
+            (contentBlockReaderFrom (Dictionary<string, byte array>()) (ResizeArray()))
+            target
+            "normal/stale-range.bin"
+        |> expectErrorContains "active ranges do not cover"

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -103,6 +103,7 @@
                 <Compile Include="Eventing.Server.fs" />
 		<Compile Include="DirectoryVersion.Server.fs" />
 		<Compile Include="Diff.Server.fs" />
+		<Compile Include="NormalFileMaterialization.Server.fs" />
 		<Compile Include="Storage.Server.fs" />
 		<Compile Include="Access.Server.fs" />
 		<Compile Include="Auth.Server.fs" />

--- a/src/Grace.Server/NormalFileMaterialization.Server.fs
+++ b/src/Grace.Server/NormalFileMaterialization.Server.fs
@@ -1,0 +1,532 @@
+namespace Grace.Server
+
+open Azure
+open Azure.Storage.Blobs.Models
+open Grace.Actors
+open Grace.Actors.Extensions.ActorProxy
+open Grace.Actors.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.Repository
+open System
+open System.Collections.Generic
+open System.IO
+open System.Linq
+open System.Security.Cryptography
+open System.Threading
+open System.Threading.Tasks
+
+module internal NormalFileMaterialization =
+
+    type ObjectPayloadReader = string -> CorrelationId -> CancellationToken -> Task<Result<byte array, GraceError>>
+
+    type ObjectPayloadWriter = string -> byte array -> CorrelationId -> CancellationToken -> Task<Result<unit, GraceError>>
+
+    type ContentBlockMetadataBatchResolver =
+        FileManifest -> ContentBlockAddress array -> CorrelationId -> CancellationToken -> Task<Result<ContentBlockMetadata array, GraceError>>
+
+    type ContentBlockPlacementPayloadReader =
+        ContentBlockStoragePlacement -> ContentBlockAddress -> CorrelationId -> CancellationToken -> Task<Result<byte array, GraceError>>
+
+    let private error correlationId message = GraceError.Create message correlationId
+
+    let private copyBytes (bytes: byte array) =
+        let copy = Array.zeroCreate<byte> bytes.Length
+        Array.Copy(bytes, copy, bytes.Length)
+        copy
+
+    let private sha256Hex (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    let private blake3Hex (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
+
+    let private completeContentBlockStoragePlacement (placement: ContentBlockStoragePlacement) =
+        not (isNull (box placement))
+        && not (String.IsNullOrWhiteSpace placement.StorageAccountName)
+        && not (String.IsNullOrWhiteSpace placement.StorageContainerName)
+        && not (String.IsNullOrWhiteSpace placement.ObjectKey)
+
+    let private validateFileVersionShape (fileVersion: FileVersion) correlationId =
+        if isNull (box fileVersion) then
+            Error(error correlationId "Normal file download FileVersion is required.")
+        elif fileVersion.Size < 0L then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' has an invalid negative size.")
+        elif isNull (box fileVersion.ContentReference) then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' has no ContentReference.")
+        else
+            Ok()
+
+    let private validateExactFileBytes (fileVersion: FileVersion) (bytes: byte array) correlationId =
+        if isNull bytes then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' materialized null bytes.")
+        elif int64 bytes.Length <> fileVersion.Size then
+            Error(
+                error
+                    correlationId
+                    $"Normal file download target '{fileVersion.RelativePath}' materialized {bytes.Length} bytes, but FileVersion.Size is {fileVersion.Size} bytes."
+            )
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Sha256Hash)
+            && not (String.Equals(sha256Hex bytes, fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase))
+        then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Sha256Hash.")
+        elif
+            not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+            && not (String.Equals(blake3Hex bytes, fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase))
+        then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' materialized bytes do not match FileVersion.Blake3Hash.")
+        else
+            Ok(copyBytes bytes)
+
+    let private describeManifestValidationError validationError = $"Invalid manifest reconstruction: {validationError}."
+
+    let private validateManifestStoragePool (fileVersion: FileVersion) (manifest: FileManifest) correlationId =
+        if String.IsNullOrWhiteSpace manifest.StoragePoolId then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' FileManifest StoragePoolId is required.")
+        else
+            Ok()
+
+    let private manifestBlockAddresses (manifest: FileManifest) =
+        let addresses = ResizeArray<ContentBlockAddress>()
+        let seen = HashSet<ContentBlockAddress>()
+
+        if
+            not (isNull (box manifest))
+            && not (isNull manifest.Blocks)
+        then
+            let mutable index = 0
+
+            while index < manifest.Blocks.Count do
+                let block = manifest.Blocks[index]
+
+                if not (isNull (box block)) && seen.Add block.Address then
+                    addresses.Add block.Address
+
+                index <- index + 1
+
+        addresses.ToArray()
+
+    let private manifestBlocksByAddress (manifest: FileManifest) =
+        let blocks = Dictionary<ContentBlockAddress, ResizeArray<ContentBlock>>()
+
+        if
+            not (isNull (box manifest))
+            && not (isNull manifest.Blocks)
+        then
+            let mutable index = 0
+
+            while index < manifest.Blocks.Count do
+                let block = manifest.Blocks[index]
+
+                if not (isNull (box block)) then
+                    match blocks.TryGetValue block.Address with
+                    | true, existing -> existing.Add block
+                    | false, _ ->
+                        let values = ResizeArray<ContentBlock>()
+                        values.Add block
+                        blocks[block.Address] <- values
+
+                index <- index + 1
+
+        blocks
+
+    let private hasActivePhysicalRangeCover expectedLength (metadata: ContentBlockMetadata) =
+        if expectedLength <= 0L || isNull metadata.Ranges then
+            false
+        else
+            let ranges =
+                metadata.Ranges
+                |> Array.filter (fun range ->
+                    not (isNull (box range))
+                    && range.ActiveManifestCount > 0
+                    && range.OrdinalStart >= 0
+                    && range.OrdinalCount > 0
+                    && range.PhysicalOffset >= 0L
+                    && range.PhysicalLength > 0L)
+                |> Array.sortBy (fun range -> range.OrdinalStart, range.PhysicalOffset)
+
+            let mutable coveredLength = 0L
+            let mutable expectedOrdinal = 0
+            let mutable error = false
+            let mutable index = 0
+
+            while index < ranges.Length
+                  && not error
+                  && coveredLength < expectedLength do
+                let range = ranges[index]
+
+                if range.OrdinalStart <> expectedOrdinal then
+                    error <- true
+                else
+                    coveredLength <- coveredLength + range.PhysicalLength
+                    expectedOrdinal <- expectedOrdinal + range.OrdinalCount
+
+                    if coveredLength > expectedLength then error <- true
+
+                index <- index + 1
+
+            not error && coveredLength = expectedLength
+
+    let private validateManifestBlockMetadata
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (blocksForAddress: IDictionary<ContentBlockAddress, ResizeArray<ContentBlock>>)
+        (metadata: ContentBlockMetadata)
+        correlationId
+        =
+        if isNull (box metadata) then
+            Error(error correlationId $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata is absent.")
+        elif metadata.StoragePoolId <> manifest.StoragePoolId then
+            Error(
+                error
+                    correlationId
+                    $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata StoragePoolId does not match FileManifest.StoragePoolId for {metadata.ContentBlockAddress}."
+            )
+        elif not (blocksForAddress.ContainsKey metadata.ContentBlockAddress) then
+            Error(
+                error
+                    correlationId
+                    $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata ContentBlockAddress is not referenced by FileManifest."
+            )
+        elif metadata.BlockFormatVersion <= 0s then
+            Error(
+                error
+                    correlationId
+                    $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata BlockFormatVersion is required for manifest block {metadata.ContentBlockAddress}."
+            )
+        elif not (completeContentBlockStoragePlacement metadata.StoragePlacement) then
+            Error(
+                error
+                    correlationId
+                    $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata StoragePlacement is incomplete for manifest block {metadata.ContentBlockAddress}."
+            )
+        else
+            let blocks = blocksForAddress[metadata.ContentBlockAddress]
+            let mutable blockIndex = 0
+            let mutable missingRangeCover = false
+
+            while blockIndex < blocks.Count && not missingRangeCover do
+                missingRangeCover <- not (hasActivePhysicalRangeCover blocks[blockIndex].Size metadata)
+                blockIndex <- blockIndex + 1
+
+            if missingRangeCover then
+                Error(
+                    error
+                        correlationId
+                        $"Normal file download target '{fileVersion.RelativePath}' ContentBlockMetadata active ranges do not cover manifest block {metadata.ContentBlockAddress}."
+                )
+            else
+                Ok metadata.StoragePlacement
+
+    let private materializeWholeFileBytes
+        (fileVersion: FileVersion)
+        (objectKey: string)
+        (readObjectPayload: ObjectPayloadReader)
+        correlationId
+        cancellationToken
+        =
+        task {
+            match! readObjectPayload objectKey correlationId cancellationToken with
+            | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+            | Error readError -> return Error readError
+        }
+
+    let private manifestPayloads
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (resolveContentBlockMetadata: ContentBlockMetadataBatchResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let blockAddresses = manifestBlockAddresses manifest
+            let blocksByAddress = manifestBlocksByAddress manifest
+
+            match! resolveContentBlockMetadata manifest blockAddresses correlationId cancellationToken with
+            | Error metadataError -> return Error metadataError
+            | Ok metadataRecords ->
+                let metadataByAddress = Dictionary<ContentBlockAddress, ContentBlockMetadata>()
+                let mutable metadataError = None
+                let mutable metadataIndex = 0
+
+                while metadataIndex < metadataRecords.Length
+                      && Option.isNone metadataError do
+                    let metadata = metadataRecords[metadataIndex]
+
+                    if isNull (box metadata) then
+                        metadataError <-
+                            Some(error correlationId $"Normal file download target '{fileVersion.RelativePath}' resolved null ContentBlockMetadata.")
+                    else
+                        match validateManifestBlockMetadata fileVersion manifest blocksByAddress metadata correlationId with
+                        | Error validationError -> metadataError <- Some validationError
+                        | Ok _ -> metadataByAddress[metadata.ContentBlockAddress] <- metadata
+
+                    metadataIndex <- metadataIndex + 1
+
+                match metadataError with
+                | Some validationError -> return Error validationError
+                | None ->
+                    let payloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
+                    let mutable readError = None
+                    let mutable blockIndex = 0
+
+                    while blockIndex < blockAddresses.Length
+                          && Option.isNone readError do
+                        let address = blockAddresses[blockIndex]
+
+                        match metadataByAddress.TryGetValue address with
+                        | false, _ ->
+                            readError <-
+                                Some(
+                                    error
+                                        correlationId
+                                        $"Normal file download target '{fileVersion.RelativePath}' has no finalized StoragePool placement evidence for FileManifest block {address}."
+                                )
+                        | true, metadata ->
+                            match validateManifestBlockMetadata fileVersion manifest blocksByAddress metadata correlationId with
+                            | Error validationError -> readError <- Some validationError
+                            | Ok placement ->
+                                match! readContentBlockPayload placement address correlationId cancellationToken with
+                                | Ok payload -> payloads.Add(ManifestValidation.createBlockPayload address payload)
+                                | Error payloadError -> readError <- Some payloadError
+
+                        blockIndex <- blockIndex + 1
+
+                    match readError with
+                    | Some error -> return Error error
+                    | None -> return Ok(payloads.ToArray())
+        }
+
+    let private materializeManifestBytes
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (resolveContentBlockMetadata: ContentBlockMetadataBatchResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
+        correlationId
+        cancellationToken
+        =
+        task {
+            if isNull (box manifest) then
+                return
+                    Error(
+                        error correlationId $"Normal file download target '{fileVersion.RelativePath}' FileManifest ContentReference is missing its manifest."
+                    )
+            elif manifest.Size <> fileVersion.Size then
+                return
+                    Error(
+                        error
+                            correlationId
+                            $"Normal file download target '{fileVersion.RelativePath}' FileManifest.Size {manifest.Size} does not match FileVersion.Size {fileVersion.Size}."
+                    )
+            else
+                match validateManifestStoragePool fileVersion manifest correlationId with
+                | Error validationError -> return Error validationError
+                | Ok () ->
+                    match! manifestPayloads fileVersion manifest resolveContentBlockMetadata readContentBlockPayload correlationId cancellationToken with
+                    | Error readError -> return Error readError
+                    | Ok payloads ->
+                        match ManifestValidation.validate RabinChunking.SuiteName manifest payloads with
+                        | Ok bytes -> return validateExactFileBytes fileVersion bytes correlationId
+                        | Error validationError ->
+                            return
+                                Error(
+                                    error
+                                        correlationId
+                                        $"Normal file download target '{fileVersion.RelativePath}' {describeManifestValidationError validationError}"
+                                )
+        }
+
+    let materializeBytesWithReaders
+        (readWholeFileObjectPayload: ObjectPayloadReader)
+        (resolveContentBlockMetadata: ContentBlockMetadataBatchResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
+        (fileVersion: FileVersion)
+        objectKey
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            match validateFileVersionShape fileVersion correlationId with
+            | Error validationError -> return Error validationError
+            | Ok () ->
+                match fileVersion.ContentReference.ReferenceType with
+                | FileContentReferenceType.WholeFileContent ->
+                    return! materializeWholeFileBytes fileVersion objectKey readWholeFileObjectPayload correlationId cancellationToken
+                | FileContentReferenceType.FileManifest ->
+                    match fileVersion.ContentReference.Manifest with
+                    | Some manifest ->
+                        return!
+                            materializeManifestBytes fileVersion manifest resolveContentBlockMetadata readContentBlockPayload correlationId cancellationToken
+                    | None ->
+                        return
+                            Error(
+                                error
+                                    correlationId
+                                    $"Normal file download target '{fileVersion.RelativePath}' FileManifest ContentReference is missing its manifest."
+                            )
+                | unsupported ->
+                    return
+                        Error(
+                            error
+                                correlationId
+                                $"Normal file download target '{fileVersion.RelativePath}' has unsupported ContentReference type '{unsupported}'."
+                        )
+        }
+
+    let materializeForDownloadWithReaders
+        (readWholeFileObjectPayload: ObjectPayloadReader)
+        (writeWholeFileObjectPayload: ObjectPayloadWriter)
+        (resolveContentBlockMetadata: ContentBlockMetadataBatchResolver)
+        (readContentBlockPayload: ContentBlockPlacementPayloadReader)
+        (fileVersion: FileVersion)
+        objectKey
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            match!
+                materializeBytesWithReaders
+                    readWholeFileObjectPayload
+                    resolveContentBlockMetadata
+                    readContentBlockPayload
+                    fileVersion
+                    objectKey
+                    correlationId
+                    cancellationToken
+                with
+            | Error materializationError -> return Error materializationError
+            | Ok bytes ->
+                match fileVersion.ContentReference.ReferenceType with
+                | FileContentReferenceType.WholeFileContent -> return Ok()
+                | FileContentReferenceType.FileManifest -> return! writeWholeFileObjectPayload objectKey bytes correlationId cancellationToken
+                | unsupported ->
+                    return
+                        Error(
+                            error
+                                correlationId
+                                $"Normal file download target '{fileVersion.RelativePath}' has unsupported ContentReference type '{unsupported}'."
+                        )
+        }
+
+    let private azureObjectPayloadReader (repositoryDto: RepositoryDto) objectKey correlationId (cancellationToken: CancellationToken) =
+        task {
+            match repositoryDto.ObjectStorageProvider with
+            | AzureBlobStorage ->
+                try
+                    let! blobClient = getAzureBlobClient repositoryDto objectKey correlationId
+                    let! download = blobClient.DownloadContentAsync(cancellationToken)
+                    return Ok(download.Value.Content.ToArray())
+                with
+                | :? RequestFailedException as ex ->
+                    return Error(error correlationId $"Normal file content object '{objectKey}' could not be read from object storage: {ex.Message}")
+            | AWSS3 -> return Error(error correlationId "Normal file content materialization is not implemented for AWS S3 object storage.")
+            | GoogleCloudStorage -> return Error(error correlationId "Normal file content materialization is not implemented for Google Cloud Storage.")
+            | ObjectStorageProvider.Unknown ->
+                return Error(error correlationId "Normal file content materialization cannot use an unknown object storage provider.")
+        }
+
+    let private azureObjectPayloadWriter (repositoryDto: RepositoryDto) objectKey (bytes: byte array) correlationId (cancellationToken: CancellationToken) =
+        task {
+            match repositoryDto.ObjectStorageProvider with
+            | AzureBlobStorage ->
+                try
+                    let! blobClient = getAzureBlobClient repositoryDto objectKey correlationId
+                    use payloadStream = new MemoryStream(bytes, writable = false)
+                    let uploadOptions = BlobUploadOptions()
+                    let! _ = blobClient.UploadAsync(payloadStream, uploadOptions, cancellationToken)
+                    return Ok()
+                with
+                | :? RequestFailedException as ex ->
+                    return Error(error correlationId $"Normal file content object '{objectKey}' could not be written to object storage: {ex.Message}")
+            | AWSS3 -> return Error(error correlationId "Normal file content materialization is not implemented for AWS S3 object storage.")
+            | GoogleCloudStorage -> return Error(error correlationId "Normal file content materialization is not implemented for Google Cloud Storage.")
+            | ObjectStorageProvider.Unknown ->
+                return Error(error correlationId "Normal file content materialization cannot use an unknown object storage provider.")
+        }
+
+    let private azureContentBlockPlacementPayloadReader
+        (placement: ContentBlockStoragePlacement)
+        (contentBlockAddress: ContentBlockAddress)
+        correlationId
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            try
+                match! getAzureContentBlockClientForPlacement placement correlationId with
+                | Error error -> return Error error
+                | Ok blobClient ->
+                    let! download = blobClient.DownloadContentAsync(cancellationToken)
+                    return Ok(download.Value.Content.ToArray())
+            with
+            | :? RequestFailedException as ex ->
+                return
+                    Error(
+                        error
+                            correlationId
+                            $"Normal file ContentBlock payload '{contentBlockAddress}' could not be read from stored CAS placement: {ex.Message}"
+                    )
+        }
+
+    let private finalizedManifestMetadataResolver
+        (repositoryDto: RepositoryDto)
+        (authorizedScope: string)
+        (manifest: FileManifest)
+        (contentBlockAddresses: ContentBlockAddress array)
+        correlationId
+        _
+        =
+        task {
+            let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+            let metadata = ResizeArray<ContentBlockMetadata>()
+            let mutable firstError = None
+            let mutable index = 0
+
+            while index < contentBlockAddresses.Length
+                  && Option.isNone firstError do
+                let contentBlockAddress = contentBlockAddresses[index]
+
+                match!
+                    dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata
+                        (
+                            manifest.StoragePoolId,
+                            repositoryDto.RepositoryId,
+                            authorizedScope,
+                            manifest.ManifestAddress,
+                            contentBlockAddress,
+                            correlationId
+                        )
+                    with
+                | Some record -> metadata.Add record
+                | None ->
+                    firstError <-
+                        Some(
+                            error
+                                correlationId
+                                $"Normal file download has no finalized StoragePool placement evidence for FileManifest block {contentBlockAddress}."
+                        )
+
+                index <- index + 1
+
+            match firstError with
+            | Some error -> return Error error
+            | None -> return Ok(metadata.ToArray())
+        }
+
+    let materializeForDownload (repositoryDto: RepositoryDto) (authorizedScope: string) (fileVersion: FileVersion) objectKey correlationId cancellationToken =
+        let metadataResolver manifest contentBlockAddresses correlationId cancellationToken =
+            finalizedManifestMetadataResolver repositoryDto authorizedScope manifest contentBlockAddresses correlationId cancellationToken
+
+        materializeForDownloadWithReaders
+            (azureObjectPayloadReader repositoryDto)
+            (azureObjectPayloadWriter repositoryDto)
+            metadataResolver
+            azureContentBlockPlacementPayloadReader
+            fileVersion
+            objectKey
+            correlationId
+            cancellationToken

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -1447,11 +1447,40 @@ module Storage =
                     let repositoryActor = Repository.CreateActorProxy organizationId repositoryId correlationId
                     let! repositoryDto = repositoryActor.Get correlationId
 
-                    let! blobName = getReadableWholeFileContentObjectKey repositoryDto parameters.FileVersion correlationId
-                    let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
-                    context.SetStatusCode StatusCodes.Status200OK
-                    //log.LogTrace("fileVersion: {fileVersion.RelativePath}; downloadUri: {downloadUri}", [| parameters.FileVersion.RelativePath, downloadUri |])
-                    return! context.WriteStringAsync $"{downloadUri}"
+                    match validateRepositoryExistsForStorageRequest repositoryId repositoryDto correlationId with
+                    | Error error -> return! context |> result400BadRequest error
+                    | Ok () ->
+                        let contentReference =
+                            if isNull (box parameters.FileVersion.ContentReference) then
+                                FileContentReference.WholeFileContent
+                            else
+                                parameters.FileVersion.ContentReference
+
+                        let blobName = StorageKeys.wholeFileContentObjectKey parameters.FileVersion
+
+                        let! materializationResult =
+                            match contentReference.ReferenceType with
+                            | FileContentReferenceType.WholeFileContent -> Task.FromResult(Ok())
+                            | FileContentReferenceType.FileManifest ->
+                                NormalFileMaterialization.materializeForDownload
+                                    repositoryDto
+                                    $"{parameters.FileVersion.RelativePath}"
+                                    parameters.FileVersion
+                                    blobName
+                                    correlationId
+                                    context.RequestAborted
+                            | unsupported ->
+                                Task.FromResult(
+                                    Error(GraceError.Create $"Unsupported file content reference type for download URI: {unsupported}." correlationId)
+                                )
+
+                        match materializationResult with
+                        | Error error -> return! context |> result400BadRequest error
+                        | Ok () ->
+                            let! downloadUri = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
+                            context.SetStatusCode StatusCodes.Status200OK
+                            //log.LogTrace("fileVersion: {fileVersion.RelativePath}; downloadUri: {downloadUri}", [| parameters.FileVersion.RelativePath, downloadUri |])
+                            return! context.WriteStringAsync $"{downloadUri}"
                 with
                 | ex ->
                     context.SetStatusCode StatusCodes.Status500InternalServerError


### PR DESCRIPTION
# CAS-07: Materialize stored-manifest normal downloads

Part of #424.

Related to #430.

## Branch flow

This PR targets `epic/424-storagepool-cas`, not `main`. The #424 CAS integration branch is intentionally based on
`origin/epic/343-blake3-sha256-version-hashes`, and child PRs merge back to the CAS integration branch before the final
CAS handoff into #343.

## Summary

- Adds bytes-only normal-file materialization for manifest-backed `FileContentReference` values.
- Reconstructs bytes from the stored `FileManifest`, stored `StoragePoolId`, and authoritative
  `ContentBlockMetadata.StoragePlacement` evidence.
- Preserves the existing whole-file download URI path for repository-scoped whole-file content.
- Wires `/storage/getDownloadUri` so manifest-backed normal downloads materialize validated bytes before returning a
  normal download URI.
- Adds focused unit coverage for stored placement, wrong pool, missing metadata, wrong hash, invalid range order, size
  mismatch, repeated blocks, nested or historical paths, and distinct-block batching behavior.

## Review Status

- First-pass bot-prevention self-review: complete in worker handoff.
- Prevention line: manifest-backed normal downloads now use stored manifest pool and recorded block placement evidence,
  not whole-file fallback, current-route recomputation, address-only CAS reads, or per-block download URI loops.
- Codex Code Review Bot final state: 👍 on `36f0ddbec0cfee797cd96251fc0c50f483917bb7` with no review threads.
- Review threads: none.

## Validation

Worker validation on `agent/430-stored-manifest-downloads`:

```powershell
dotnet tool run fantomas -- `
  "C:\Source\Grace-gh-430\src\Grace.Server\NormalFileMaterialization.Server.fs" `
  "C:\Source\Grace-gh-430\src\Grace.Server\Storage.Server.fs" `
  "C:\Source\Grace-gh-430\src\Grace.Server.Unit.Tests\NormalFileMaterialization.Server.Tests.fs"
dotnet test --configuration Release `
  "C:\Source\Grace-gh-430\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj" `
  --filter "FullyQualifiedName~NormalFileMaterializationServerTests"
pwsh ./scripts/validate.ps1 -Fast
git diff --check
```

Results:

- Targeted Fantomas passed.
- Focused `NormalFileMaterializationServerTests` passed: 9/9.
- `validate -Fast` passed after the worker self-review fix.
- Fast gate totals: `Grace.Types.Tests` 129 passed, `Grace.Authorization.Tests` 53 passed,
  `Grace.Server.Unit.Tests` 701 passed, `Grace.CLI.Tests` 642 passed and 1 skipped.
- `git diff --check` passed.

`validate -Full` was not run. The slice keeps the existing `/storage/getDownloadUri` response shape and covers the new
storage behavior through injectable no-Aspire readers.

## Public Contract Notes

No SDK/OpenAPI response-shape update is included. `/storage/getDownloadUri` still returns the existing raw URI string.
Any final public contract and documentation refresh remains deferred to #432 unless review identifies a required shape
change in this PR.

## Deferred Scope

- #431 owns large binary watch/save lifecycle proof.
- #432 owns final CAS placement contract, SDK, and documentation refresh.
- #433 owns cross-repository StoragePool dedupe proof.
- #434 owns final CAS integration audit and #343 handoff.
