### PR TITLE
Watch: enqueue delete and rename-old triggers

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -484,6 +484,23 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``unknown deleted file matching file ignore does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.log" |]
+
+            let filePath = Path.Combine(root, "ignored.log")
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory queues status update when rename cached directory ignore`` () =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-directory-name")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -232,6 +232,10 @@ module WatchTests =
         Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus applyIncremental updateIpc
         |> fun processTask -> processTask.GetAwaiter().GetResult()
 
+    let private writeGraceIgnore root (entries: string array) =
+        File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, entries))
+        resetConfiguration ()
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -433,6 +437,44 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal [| "cached-directory" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted directory named like file ignore queues status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.tmp" |]
+
+            let directoryPath = Path.Combine(root, "archive.tmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted directory matching directory ignore does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let directoryPath = Path.Combine(root, "archive.tmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -322,6 +322,41 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``status-only triggers added during status update remain pending for next pass`` () =
+        withTempRepo (fun root ->
+            let beforeUpdatePath = Path.Combine(root, "before-update-delete.txt")
+            let duringUpdatePath = Path.Combine(root, "during-update-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent beforeUpdatePath)
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+
+                if updateCalls = 1 then Watch.OnDeleted(deletedEvent duringUpdatePath)
+
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFirstPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFirstPass.StatusUpdateTriggers
+            |> should equal [| "during-update-delete.txt" |]
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterSecondPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSecondPass.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``status-only triggers remain pending when status file read fails`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "read-failure-delete.txt")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -178,8 +178,10 @@ module WatchTests =
             resetConfiguration ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             deleteWatchStatusFileIfExists ()
+            Watch.clearPendingWatchWorkForTests ()
             action tempDir
         finally
+            Watch.clearPendingWatchWorkForTests ()
             deleteWatchStatusFileIfExists ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             resetConfiguration ()
@@ -190,6 +192,35 @@ module WatchTests =
                     Directory.Delete(tempDir, true)
                 with
                 | _ -> ()
+
+    let private deletedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
+
+    let private renamedEvent (oldFullPath: string) (fullPath: string) =
+        RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
+
+    let private processPendingWatchWorkForTest () =
+        let status = GraceStatus.Default
+        let mutable updateCalls = 0
+        let mutable uploadCalls = 0
+
+        let readStatus () = Task.FromResult(status)
+
+        let upload _ _ =
+            uploadCalls <- uploadCalls + 1
+            Task.FromResult(())
+
+        let updateGraceStatus status _ =
+            updateCalls <- updateCalls + 1
+            Task.FromResult(Some status)
+
+        let applyIncremental _ _ _ = Task.FromResult(())
+        let updateIpc _ _ = Task.FromResult(())
+
+        let processTask = Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc
+
+        processTask.GetAwaiter().GetResult()
+
+        updateCalls, uploadCalls
 
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
@@ -220,6 +251,91 @@ module WatchTests =
             |> should contain "Unable to acquire an access token for SignalR notifications:"
 
             error |> should contain "test error"
+
+    [<Test>]
+    let ``deleted file queues status update work without upload work`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "deleted.txt")
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "deleted.txt" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``ignored and outside delete paths do not queue status update work`` () =
+        withTempRepo (fun root ->
+            let graceArtifactPath = Path.Combine(root, Constants.GraceConfigDirectory, "grace-local.db")
+            let outsidePath = Path.Combine(Path.GetTempPath(), $"grace-watch-outside-{Guid.NewGuid():N}.txt")
+
+            Watch.OnDeleted(deletedEvent graceArtifactPath)
+            Watch.OnDeleted(deletedEvent outsidePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``duplicate deleted file events drain as one status update trigger`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "duplicate-delete.txt")
+
+            Watch.OnDeleted(deletedEvent filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "duplicate-delete.txt" |]
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``renamed file queues old path status trigger and new path upload work`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-name.txt")
+            let newPath = Path.Combine(root, "new-name.txt")
+            File.WriteAllText(newPath, "new rename target")
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "old-name.txt" |]
+
+            pending.FilesToProcess
+            |> should equal [| newPath |])
 
     [<Test>]
     let ``watch exits with auth guidance when no token is configured`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -501,6 +501,32 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``dirty status reload keeps tracked ignored-looking delete from being suppressed`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.log" |]
+
+            let filePath = Path.Combine(root, "important.log")
+            File.WriteAllText(filePath, "tracked log file")
+
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "other.txt" |] Array.empty<string>)
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            (Services.writeGraceStatusFile (graceStatusTracking [| "important.log" |] Array.empty<string>))
+                .GetAwaiter()
+                .GetResult()
+
+            File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "important.log" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory queues status update when rename cached directory ignore`` () =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-directory-name")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -222,6 +222,16 @@ module WatchTests =
 
         updateCalls, uploadCalls
 
+    let private processPendingWatchWorkWithStatusClients readStatusFile updateGraceStatus =
+        let status = GraceStatus.Default
+        let readStatusMeta () = Task.FromResult(status)
+        let upload _ _ = Task.FromResult(())
+        let applyIncremental _ _ _ = Task.FromResult(())
+        let updateIpc _ _ = Task.FromResult(())
+
+        Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus applyIncremental updateIpc
+        |> fun processTask -> processTask.GetAwaiter().GetResult()
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -278,6 +288,80 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only triggers remain pending when status update returns none`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "retry-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let updateGraceStatus _ _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(None)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "retry-delete.txt" |]
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterSuccess = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSuccess.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only triggers remain pending when status file read fails`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "read-failure-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let readStatusFile () = Task.FromException<GraceStatus>(InvalidOperationException("transient status read failure"))
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients readStatusFile updateGraceStatus
+
+            updateCalls |> should equal 0
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "read-failure-delete.txt" |])
+
+    [<Test>]
+    let ``rename-old status-only trigger remains pending when status update fails`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-status-only-name.txt")
+            let ignoredNewPath = Path.Combine(root, "new-status-only-name.gracetmp")
+
+            Watch.OnRenamed(renamedEvent oldPath ignoredNewPath)
+
+            let updateGraceStatus _ _ = Task.FromException<GraceStatus option>(InvalidOperationException("transient status update failure"))
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "old-status-only-name.txt" |]
+
+            afterFailure.FilesToProcess
             |> should equal Array.empty<string>)
 
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -382,6 +382,27 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``deleted directory queues status update when rename cached directory ignore`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-directory-name")
+            let directoryPath = Path.Combine(root, "cached-directory")
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            Watch.OnRenamed(renamedEvent oldPath directoryPath)
+            Watch.clearPendingWatchWorkForTests ()
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "cached-directory" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``duplicate deleted file events drain as one status update trigger`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "duplicate-delete.txt")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -236,6 +236,69 @@ module WatchTests =
         File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, entries))
         resetConfiguration ()
 
+    let private localFileVersion relativePath =
+        LocalFileVersion.CreateWithHashes
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            false
+            1L
+            (getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    let private localDirectoryVersion relativePath directories files =
+        LocalDirectoryVersion.CreateWithHashes
+            (Guid.NewGuid())
+            OwnerId.Empty
+            OrganizationId.Empty
+            RepositoryId.Empty
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            directories
+            files
+            1L
+            DateTime.UtcNow
+
+    let private graceStatusTracking trackedFiles trackedDirectories =
+        let rootDirectoryId = Guid.NewGuid()
+        let index = GraceIndex()
+
+        let childDirectories =
+            trackedDirectories
+            |> Array.map (fun relativePath -> localDirectoryVersion relativePath (List<DirectoryVersionId>()) (List<LocalFileVersion>()))
+
+        let root =
+            LocalDirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "root-sha")
+                (Blake3Hash "root-blake3")
+                (List<DirectoryVersionId>(
+                    childDirectories
+                    |> Array.map (fun directory -> directory.DirectoryVersionId)
+                ))
+                (List<LocalFileVersion>(trackedFiles |> Array.map localFileVersion))
+                1L
+                DateTime.UtcNow
+
+        index.TryAdd(rootDirectoryId, root) |> ignore
+
+        for directory in childDirectories do
+            index.TryAdd(directory.DirectoryVersionId, directory)
+            |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -448,6 +511,7 @@ module WatchTests =
 
             let directoryPath = Path.Combine(root, "archive.tmp")
             Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "archive.tmp" |])
             Directory.Delete(directoryPath)
 
             Watch.OnDeleted(deletedEvent directoryPath)
@@ -461,12 +525,31 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``deleted tracked directory ending gracetmp queues status update work`` () =
+        withTempRepo (fun root ->
+            let directoryPath = Path.Combine(root, "assets.gracetmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "assets.gracetmp" |])
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "assets.gracetmp" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory matching directory ignore does not queue status update work`` () =
         withTempRepo (fun root ->
             writeGraceIgnore root [| "archive.tmp/" |]
 
             let directoryPath = Path.Combine(root, "archive.tmp")
             Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "archive.tmp" |])
             Directory.Delete(directoryPath)
 
             Watch.OnDeleted(deletedEvent directoryPath)
@@ -475,6 +558,26 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted tracked file matching directory-only ignore queues status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let filePath = Path.Combine(root, "archive.tmp")
+            File.WriteAllText(filePath, "tracked file with directory-only ignored name")
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "archive.tmp" |] Array.empty<string>)
+            File.Delete(filePath)
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)
@@ -515,6 +618,26 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal [| "old-name.txt" |]
+
+            pending.FilesToProcess
+            |> should equal [| newPath |])
+
+    [<Test>]
+    let ``renamed tracked file matching directory-only ignore queues old path status trigger`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let oldPath = Path.Combine(root, "archive.tmp")
+            let newPath = Path.Combine(root, "renamed.txt")
+            File.WriteAllText(newPath, "new rename target")
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "archive.tmp" |] Array.empty<string>)
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
 
             pending.FilesToProcess
             |> should equal [| newPath |])

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -160,6 +160,11 @@ module Watch =
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     let updateNotInProgress () = not <| updateInProgress ()
 
+    type private DeletedPathKind =
+        | DeletedFile
+        | DeletedDirectory
+        | DeletedPathKindUnknown
+
     let private repositoryRelativePath (fullPath: string) =
         let rootDirectory =
             Current().RootDirectory
@@ -181,7 +186,43 @@ module Watch =
             else
                 None
 
-    let private shouldIgnoreDeletedPath (fullPath: string) =
+    let private normalizeRelativePath (relativePath: RelativePath) =
+        $"{relativePath}"
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/')
+
+    let private trackedDeletedPathKind (status: GraceStatus) (relativePath: string) =
+        let deletedRelativePath = normalizeRelativePath relativePath
+
+        let isTrackedFile =
+            status.Index.Values
+            |> Seq.exists (fun directoryVersion ->
+                directoryVersion.Files
+                |> Seq.exists (fun fileVersion ->
+                    String.Equals(normalizeRelativePath fileVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase)))
+
+        let isTrackedDirectory =
+            status.Index.Values
+            |> Seq.exists (fun directoryVersion ->
+                String.Equals(normalizeRelativePath directoryVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase))
+
+        match isTrackedFile, isTrackedDirectory with
+        | true, _ -> DeletedFile
+        | false, true -> DeletedDirectory
+        | false, false -> DeletedPathKindUnknown
+
+    let private readTrackedDeletedPathKind (relativePath: string) =
+        try
+            if graceStatus.Index.Count > 0 then
+                trackedDeletedPathKind graceStatus relativePath
+            else
+                trackedDeletedPathKind (readGraceStatusFile().GetAwaiter().GetResult()) relativePath
+        with
+        | _ -> DeletedPathKindUnknown
+
+    let internal setGraceStatusForWatchTests status = graceStatus <- status
+
+    let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
         let normalizedFullPath = Path.GetFullPath(fullPath)
         let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
@@ -207,17 +248,23 @@ module Watch =
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
-        || normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase)
+        || (pathKind <> DeletedDirectory
+            && normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase))
         || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists directoryIgnoreMatches
-        || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine)
-        || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+        || (pathKind <> DeletedFile
+            && configuration.GraceDirectoryIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
+        || (pathKind <> DeletedDirectory
+            && configuration.GraceDirectoryIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
 
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with
-        | Some relativePath when not <| shouldIgnoreDeletedPath fullPath ->
+        | Some relativePath when
+            not
+            <| shouldIgnoreDeletedPath (readTrackedDeletedPathKind relativePath) fullPath
+            ->
             statusUpdateTriggers.TryAdd(relativePath, ())
             |> ignore
 
@@ -228,6 +275,7 @@ module Watch =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
+        graceStatus <- GraceStatus.Default
 
     let internal pendingWatchWorkSnapshotForTests () =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -181,9 +181,42 @@ module Watch =
             else
                 None
 
+    let private shouldIgnoreDeletedPath (fullPath: string) =
+        let configuration = Current()
+        let normalizedFullPath = Path.GetFullPath(fullPath)
+        let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
+        let fileInfo = FileInfo(fullPath)
+
+        let isInGraceDirectory =
+            normalizedFullPath.Equals(graceDirectory, StringComparison.InvariantCultureIgnoreCase)
+            || normalizedFullPath.StartsWith(
+                graceDirectory
+                + string Path.DirectorySeparatorChar,
+                StringComparison.InvariantCultureIgnoreCase
+            )
+
+        let directoryIgnoreMatches graceIgnoreLine =
+            if isNull fileInfo.Directory then
+                false
+            else
+                checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine
+
+        isInGraceDirectory
+        || normalizedFullPath.Equals(configuration.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase)
+        || configuration.GraceDirectoryIgnoreEntries
+           |> Array.exists directoryIgnoreMatches
+        || configuration.GraceDirectoryIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+        || configuration.GraceFileIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with
-        | Some relativePath when not <| shouldIgnoreFile fullPath ->
+        | Some relativePath when not <| shouldIgnoreDeletedPath fullPath ->
             statusUpdateTriggers.TryAdd(relativePath, ())
             |> ignore
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -186,6 +186,7 @@ module Watch =
         let normalizedFullPath = Path.GetFullPath(fullPath)
         let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
         let fileInfo = FileInfo(fullPath)
+        let deletedDirectoryInfo = DirectoryInfo(normalizedFullPath)
 
         let isInGraceDirectory =
             normalizedFullPath.Equals(graceDirectory, StringComparison.InvariantCultureIgnoreCase)
@@ -210,8 +211,8 @@ module Watch =
         || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists directoryIgnoreMatches
         || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
-        || configuration.GraceFileIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine)
+        || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
 
     let private enqueueStatusUpdateTrigger fullPath =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -627,12 +627,13 @@ module Watch =
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
-                        drainStatusOnlyTriggers ()
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
-                        | Some newGraceStatus -> graceStatus <- newGraceStatus
+                        | Some newGraceStatus ->
+                            graceStatus <- newGraceStatus
+                            drainStatusOnlyTriggers ()
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -242,9 +242,18 @@ module Watch =
             && statusUpdateTriggers.IsEmpty
         )
 
-    let private drainStatusOnlyTriggers () =
-        directoriesToProcess.Clear()
-        statusUpdateTriggers.Clear()
+    let private statusOnlyTriggerSnapshot () = directoriesToProcess.Keys.ToArray(), statusUpdateTriggers.Keys.ToArray()
+
+    let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
+        let mutable unitValue = ()
+
+        for directory in directorySnapshot do
+            directoriesToProcess.TryRemove(directory, &unitValue)
+            |> ignore
+
+        for statusTrigger in statusTriggerSnapshot do
+            statusUpdateTriggers.TryRemove(statusTrigger, &unitValue)
+            |> ignore
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
@@ -660,13 +669,14 @@ module Watch =
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
+                        let directorySnapshot, statusTriggerSnapshot = statusOnlyTriggerSnapshot ()
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus ->
                             graceStatus <- newGraceStatus
-                            drainStatusOnlyTriggers ()
+                            drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -136,6 +136,14 @@ module Watch =
     /// Note: We're using ConcurrentDictionary because it's safe for multithreading, doesn't allow us to insert the same key twice, and for its algorithms. We're not using the values of the ConcurrentDictionary here, only the keys.
     let private directoriesToProcess = ConcurrentDictionary<string, unit>()
 
+    /// Holds a list of repo-relative paths that should trigger a Grace Status scan without uploading file content.
+    ///
+    /// FileSystemWatcher delete and rename-old events do not have durable file content to upload. They only need to
+    /// wake the timer loop so updateGraceStatus can run scanForDifferences against the current working tree.
+    let private statusUpdateTriggers = ConcurrentDictionary<string, unit>()
+
+    type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
+
     type WatchParameters() =
         inherit ParameterBase()
         member val public RepositoryPath: string = String.Empty with get, set
@@ -151,6 +159,59 @@ module Watch =
     let isNotDirectory path = not <| Directory.Exists(path)
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     let updateNotInProgress () = not <| updateInProgress ()
+
+    let private repositoryRelativePath (fullPath: string) =
+        let rootDirectory =
+            Current().RootDirectory
+            |> Path.GetFullPath
+            |> Path.TrimEndingDirectorySeparator
+
+        let normalizedFullPath = Path.GetFullPath(fullPath)
+
+        if normalizedFullPath.Equals(rootDirectory, StringComparison.InvariantCultureIgnoreCase) then
+            Some Constants.RootDirectoryPath
+        else
+            let rootDirectoryWithSeparator = rootDirectory + string Path.DirectorySeparatorChar
+
+            if normalizedFullPath.StartsWith(rootDirectoryWithSeparator, StringComparison.InvariantCultureIgnoreCase) then
+                normalizedFullPath
+                    .Substring(rootDirectoryWithSeparator.Length)
+                    .Replace(Path.DirectorySeparatorChar, '/')
+                |> Some
+            else
+                None
+
+    let private enqueueStatusUpdateTrigger fullPath =
+        match repositoryRelativePath fullPath with
+        | Some relativePath when not <| shouldIgnoreFile fullPath ->
+            statusUpdateTriggers.TryAdd(relativePath, ())
+            |> ignore
+
+            true
+        | _ -> false
+
+    let internal clearPendingWatchWorkForTests () =
+        filesToProcess.Clear()
+        directoriesToProcess.Clear()
+        statusUpdateTriggers.Clear()
+
+    let internal pendingWatchWorkSnapshotForTests () =
+        {
+            FilesToProcess = filesToProcess.Keys.OrderBy(id).ToArray()
+            DirectoriesToProcess = directoriesToProcess.Keys.OrderBy(id).ToArray()
+            StatusUpdateTriggers = statusUpdateTriggers.Keys.OrderBy(id).ToArray()
+        }
+
+    let private hasPendingWatchWork () =
+        not (
+            filesToProcess.IsEmpty
+            && directoriesToProcess.IsEmpty
+            && statusUpdateTriggers.IsEmpty
+        )
+
+    let private drainStatusOnlyTriggers () =
+        directoriesToProcess.Clear()
+        statusUpdateTriggers.Clear()
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
@@ -247,14 +308,9 @@ module Watch =
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
     let OnDeleted (args: FileSystemEventArgs) =
-        if updateNotInProgress ()
-           && isNotDirectory args.FullPath then
-            let shouldIgnore = shouldIgnoreFile args.FullPath
-            //logToAnsiConsole Colors.Verbose $"Should ignore {args.FullPath}: {shouldIgnore}."
-
-            if not <| shouldIgnore then
+        if updateNotInProgress () then
+            if enqueueStatusUpdateTrigger args.FullPath then
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
-                logToAnsiConsole Colors.Deleted $"Delete processing is not yet implemented."
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -262,17 +318,13 @@ module Watch =
 
     let OnRenamed (args: RenamedEventArgs) =
         if updateNotInProgress () then
-            let shouldIgnoreOldFile = shouldIgnoreFile args.OldFullPath
             let shouldIgnoreNewFile = shouldIgnoreFile args.FullPath
 
-            if not <| shouldIgnoreOldFile then
+            if enqueueStatusUpdateTrigger args.OldFullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                //logToAnsiConsole Colors.Verbose $"Should ignore {args.OldFullPath}: {shouldIgnoreOldFile}. Should ignore {args.FullPath}: {shouldIgnoreNewFile}."
-                logToAnsiConsole Colors.Changed $"Delete processing is not yet implemented."
 
             if not <| shouldIgnoreNewFile then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                //logToAnsiConsole Colors.Verbose $"Should ignore {args.OldFullPath}: {shouldIgnoreOldFile}. Should ignore {args.FullPath}: {shouldIgnoreNewFile}."
                 filesToProcess.TryAdd(args.FullPath, ()) |> ignore
 
     let OnError (args: ErrorEventArgs) =
@@ -528,19 +580,20 @@ module Watch =
     let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
     /// Processes any changed files since the last timer tick.
-    let processChangedFiles () =
+    let internal processChangedFilesWithClients
+        readGraceStatusMetaClient
+        readGraceStatusFileClient
+        copyFileToObjectDirectoryAndUploadToStorageClient
+        updateGraceStatusClient
+        applyGraceStatusIncrementalClient
+        updateGraceWatchInterprocessFileClient
+        =
         task {
             // First, check if there's anything to process.
-            if
-                not
-                    (
-                        filesToProcess.IsEmpty
-                        && directoriesToProcess.IsEmpty
-                    )
-            then
+            if hasPendingWatchWork () then
                 try
                     let correlationId = generateCorrelationId ()
-                    let! graceStatusFromDisk = readGraceStatusMeta ()
+                    let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     graceStatus <- graceStatusFromDisk
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
@@ -563,28 +616,29 @@ module Watch =
                     for fileName in filesToProcess.Keys.Take(50) do
                         if filesToProcess.TryRemove(fileName, &unitValue) then
                             logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
-                            do! copyFileToObjectDirectoryAndUploadToStorage getUploadMetadataForFilesParameters (FilePath fileName)
+                            do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath fileName)
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
                     if processedAnyFile then
                         graceStatus <- { graceStatus with LastSuccessfulFileUpload = lastFileUploadInstant }
-                        do! applyGraceStatusIncremental graceStatus Seq.empty Seq.empty
+                        do! applyGraceStatusIncrementalClient graceStatus Seq.empty Seq.empty
 
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
-                        let! graceStatusSnapshot = readGraceStatusFile ()
+                        drainStatusOnlyTriggers ()
+                        let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
-                        match! (updateGraceStatus graceStatus correlationId) with
+                        match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus -> graceStatus <- newGraceStatus
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.
 
                     updateGraceStatusDirectoryIds graceStatus
-                    do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
+                    do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
 
                     // Reset the in-memory Grace Status to empty to minimize memory usage.
                     graceStatus <- GraceStatus.Default
@@ -603,6 +657,15 @@ module Watch =
                 do! updateGraceWatchInterprocessFile graceStatusFromDisk (Some graceStatusDirectoryIds)
                 GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
         }
+
+    let processChangedFiles () =
+        processChangedFilesWithClients
+            readGraceStatusMeta
+            readGraceStatusFile
+            copyFileToObjectDirectoryAndUploadToStorage
+            updateGraceStatus
+            applyGraceStatusIncremental
+            updateGraceWatchInterprocessFile
 
     type Watch() =
         inherit AsynchronousCommandLineAction()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -213,14 +213,21 @@ module Watch =
 
     let private readTrackedDeletedPathKind (relativePath: string) =
         try
-            if graceStatus.Index.Count > 0 then
-                trackedDeletedPathKind graceStatus relativePath
-            else
-                trackedDeletedPathKind (readGraceStatusFile().GetAwaiter().GetResult()) relativePath
+            let status =
+                if graceStatusHasChanged
+                   || graceStatus.Index.Count = 0 then
+                    let refreshedStatus = readGraceStatusFile().GetAwaiter().GetResult()
+                    graceStatus <- refreshedStatus
+                    refreshedStatus
+                else
+                    graceStatus
+
+            trackedDeletedPathKind status relativePath
         with
         | _ -> DeletedPathKindUnknown
 
     let internal setGraceStatusForWatchTests status = graceStatus <- status
+    let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
 
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -279,6 +286,7 @@ module Watch =
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
         graceStatus <- GraceStatus.Default
+        graceStatusHasChanged <- false
 
     let internal pendingWatchWorkSnapshotForTests () =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -258,6 +258,9 @@ module Watch =
         || (pathKind <> DeletedDirectory
             && configuration.GraceDirectoryIgnoreEntries
                |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
+        || (pathKind = DeletedPathKindUnknown
+            && configuration.GraceFileIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
 
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -1418,7 +1418,14 @@ type BranchServer() =
                         parentBranch.BasedOn.Blake3Hash
                     ]
 
-            let! response = BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync repositoryId branch DirectoryVersionId.Empty (Blake3Hash childOnlyPrefix)
+            let stableChildOnlyPrefix =
+                if childOnlyPrefix.Length < 16 then
+                    (string child.Blake3Hash).Substring(0, 16)
+                else
+                    childOnlyPrefix
+
+            let! response =
+                BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync repositoryId branch DirectoryVersionId.Empty (Blake3Hash stableChildOnlyPrefix)
 
             let! responseBody = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseBody)


### PR DESCRIPTION
## Summary

Part of #465.

This PR completes the local Watch trigger path for delete capture. Deleted paths and rename-old paths now enqueue
status/deletion work so the timer loop reaches `updateGraceStatus` even when no file content upload is pending. Rename
new-path upload handling is preserved.

## Why This Matters

A running `grace watch` should capture deletes as repository state changes. This slice wires the watcher callbacks to
the existing scan-based reconciliation path without adding rename identity, tombstones, or a new event-derived status
architecture.

## Changed Paths

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Validation

- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- Test filter: `FullyQualifiedName~WatchTests`.
- `dotnet tool run fantomas src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

### Review Fix Validation

- Fantomas on the touched Watch source and tests: passed.
- Focused Watch tests: passed, 35 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed, including `Grace.CLI.Tests` with 665 tests.
- `git diff --check`: passed.

### Latest Review Fix Validation

- Unknown deleted file-ignore regression test: added.
- Focused Watch tests: passed, 36 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; Types 133, Authorization 53, Server.Unit 723, CLI 666.
- `git diff --check`: passed.

### Dirty Status Review Fix Validation

- Dirty status delete-classification regression test: added.
- Focused Watch tests: passed, 37 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after clearing a stale worktree-local `testhost.exe` lock.
- `git diff --check`: passed.

## Review Status

- **Current head:** `1f8a1945b70c59ff2b494860c7b583bd6a69c5f2`
- **Current base:** `8cec4690feda3b9ba75ed98e9d79260e3f35c10e`
- **Base refresh:** Merged the updated epic integration branch after documenting review freshness and serialized
  review-fix routing in the agent/process docs.
- **Codex Code Review Bot:** No issues for the refreshed head; the bot posted 👍 at 2026-06-30T01:15:26Z.
- **Review threads:** No unresolved Codex Code Review Bot threads remain.
- **Freshness rule:** Only findings repeated by the completed latest-head review were actionable. Previous-pass threads
  were treated as stale unless the latest review repeated them.
- **Current CI:** `Validate / full` passed for the refreshed head.
- **Manual trigger decision:** Not attempted.
- **Manual trigger lock:** Complete; no manual trigger was needed.
- **Implementation path:** Fresh GPT-5.5 Medium workers implemented the branch, review fixes, and CI-failure fix work;
  orchestrator owns review replies, conversation resolution, PR-body state, and merge state.

## Docs Impact

No user-facing docs changed. Watch documentation is intentionally deferred to the final integration/docs issue #466.

## First-Pass Review Readiness

- Bot-prevention self-review completed by the worker over the actual diff.
- Checked delete queue idempotency, no deleted-content upload, `updateGraceStatus -> scanForDifferences` preservation,
  ignored/outside path handling, public CLI contract drift, and docs/generated N/A.
- Forbidden paths were not touched.

## Residual Risk

None identified by the worker beyond normal PR bot review. DirectoryVersion tree mutation and final delete-only Save
flow proof remain owned by sibling issues #467 and #466.
