### PR TITLE
Watch: fix directory delete tree updates

### DIFF
--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -58,6 +58,58 @@ module CurrentStateCaptureCliTests =
 
     let private graceStatus directoryVersionId sha256Hash = graceStatusWithRootBlake3 directoryVersionId sha256Hash rootBlake3
 
+    let private sha256Hash (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+    let private directoryVersion
+        (configuration: GraceConfiguration)
+        (directoryVersionId: DirectoryVersionId)
+        (relativePath: RelativePath)
+        (directoryIds: DirectoryVersionId seq)
+        (files: LocalFileVersion seq)
+        =
+        LocalDirectoryVersion.CreateWithHashes
+            directoryVersionId
+            configuration.OwnerId
+            configuration.OrganizationId
+            configuration.RepositoryId
+            relativePath
+            (Sha256Hash $"sha-{directoryVersionId:N}")
+            (Blake3Hash $"blake3-{directoryVersionId:N}")
+            (List<DirectoryVersionId>(directoryIds))
+            (List<LocalFileVersion>(files))
+            (files |> Seq.sumBy (fun file -> int64 file.Size))
+            DateTime.UtcNow
+
+    let private fileVersion (relativePath: RelativePath) (contents: string) =
+        let bytes = Encoding.UTF8.GetBytes(contents)
+
+        LocalFileVersion.CreateWithHashes
+            relativePath
+            (sha256Hash bytes)
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            false
+            (int64 bytes.Length)
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    let private graceStatusFromDirectories (root: LocalDirectoryVersion) (directories: LocalDirectoryVersion seq) =
+        let index = GraceIndex()
+
+        for directoryVersion in directories do
+            index.TryAdd(directoryVersion.DirectoryVersionId, directoryVersion)
+            |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = root.DirectoryVersionId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     let private referenceDto referenceId directoryVersionId sha256Hash =
         { ReferenceDto.Default with
             ReferenceId = referenceId
@@ -70,11 +122,6 @@ module CurrentStateCaptureCliTests =
 
     let private branch saveEnabled latestReference =
         { BranchDto.Default with BranchId = currentBranchId; SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
-
-    let private sha256Hash (bytes: byte array) =
-        SHA256.HashData(bytes)
-        |> Convert.ToHexString
-        |> fun value -> Sha256Hash(value.ToLowerInvariant())
 
     let private manifestReferenceFor bytes =
         let blockAddress = ContentBlockAddress(ContentAddress.computeBlake3Hex bytes)
@@ -112,13 +159,16 @@ module CurrentStateCaptureCliTests =
         let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-{Guid.NewGuid():N}")
         let previousDirectory = Environment.CurrentDirectory
         let previousConfiguration = if configurationFileExists () then Some(Current()) else None
+        let previousParseResult = parseResult
 
         try
             Directory.CreateDirectory(root) |> ignore
             Environment.CurrentDirectory <- root
+            parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
             let configuration = configureForRoot root
             action root configuration
         finally
+            parseResult <- previousParseResult
             Environment.CurrentDirectory <- previousDirectory
 
             match previousConfiguration with
@@ -126,6 +176,180 @@ module CurrentStateCaptureCliTests =
             | None -> resetConfiguration ()
 
             if Directory.Exists(root) then Directory.Delete(root, true)
+
+    [<Test>]
+    let ``directory delete removes subtree reference from nearest surviving parent`` () =
+        withTempRepo (fun root configuration ->
+            Directory.CreateDirectory(Path.Combine(root, "src"))
+            |> ignore
+
+            let rootId = Guid.NewGuid()
+            let srcId = Guid.NewGuid()
+            let deletedId = Guid.NewGuid()
+            let nestedDeletedId = Guid.NewGuid()
+            let deletedFile = fileVersion (RelativePath "src/old/file.txt") "deleted file"
+            let nestedDeleted = directoryVersion configuration nestedDeletedId (RelativePath "src/old/nested") Seq.empty Seq.empty
+            let deleted = directoryVersion configuration deletedId (RelativePath "src/old") [| nestedDeletedId |] [| deletedFile |]
+            let src = directoryVersion configuration srcId (RelativePath "src") [| deletedId |] Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| srcId |] Seq.empty
+
+            let previousStatus =
+                graceStatusFromDirectories
+                    previousRoot
+                    [|
+                        previousRoot
+                        src
+                        deleted
+                        nestedDeleted
+                    |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "src/old/file.txt")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/old/nested")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/old")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/old")
+            |> should equal false
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/old/nested")
+            |> should equal false
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Directories.Count |> should equal 1
+
+            let updatedSrc = updatedStatus.Index[updatedRoot.Directories[0]]
+
+            updatedSrc.RelativePath
+            |> should equal (RelativePath "src")
+
+            updatedSrc.DirectoryVersionId
+            |> should not' (equal srcId)
+
+            updatedSrc.Directories
+            |> Seq.exists (fun directoryId ->
+                directoryId = deletedId
+                || directoryId = nestedDeletedId)
+            |> should equal false
+
+            newDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> should
+                equivalent
+                [
+                    RelativePath "src"
+                    Constants.RootDirectoryPath
+                ])
+
+    [<Test>]
+    let ``directory delete for unknown path is ignored without changing root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath Seq.empty Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "missing")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.RootDirectoryId
+            |> should equal previousStatus.RootDirectoryId
+
+            updatedStatus.RootDirectorySha256Hash
+            |> should equal previousStatus.RootDirectorySha256Hash
+
+            updatedStatus.RootDirectoryBlake3Hash
+            |> should equal previousStatus.RootDirectoryBlake3Hash
+
+            updatedStatus.Index.Count
+            |> should equal previousStatus.Index.Count
+
+            newDirectoryVersions.Count |> should equal 0)
+
+    [<Test>]
+    let ``file delete still removes file reference and rebuilds root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let deletedFile = fileVersion (RelativePath "deleted.txt") "deleted file"
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath Seq.empty [| deletedFile |]
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "deleted.txt")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Files.Count |> should equal 0
+            newDirectoryVersions.Count |> should equal 1
+
+            newDirectoryVersions[0].RelativePath
+            |> should equal Constants.RootDirectoryPath)
+
+    [<Test>]
+    let ``empty directory delete removes child reference from root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let emptyId = Guid.NewGuid()
+            let empty = directoryVersion configuration emptyId (RelativePath "empty") Seq.empty Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| emptyId |] Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot; empty |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "empty")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "empty")
+            |> should equal false
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Directories.Count |> should equal 0
+            newDirectoryVersions.Count |> should equal 1
+
+            newDirectoryVersions[0].RelativePath
+            |> should equal Constants.RootDirectoryPath)
 
     let private defaultOperations branchDto =
         {

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -255,6 +255,78 @@ module CurrentStateCaptureCliTests =
                 ])
 
     [<Test>]
+    let ``directory delete preserves sibling that differs only by case`` () =
+        withTempRepo (fun root configuration ->
+            Directory.CreateDirectory(Path.Combine(root, "src"))
+            |> ignore
+
+            let rootId = Guid.NewGuid()
+            let srcId = Guid.NewGuid()
+            let deletedId = Guid.NewGuid()
+            let deletedNestedId = Guid.NewGuid()
+            let survivingId = Guid.NewGuid()
+            let deletedNested = directoryVersion configuration deletedNestedId (RelativePath "src/Foo/nested") Seq.empty Seq.empty
+            let deleted = directoryVersion configuration deletedId (RelativePath "src/Foo") [| deletedNestedId |] Seq.empty
+            let surviving = directoryVersion configuration survivingId (RelativePath "src/foo") Seq.empty Seq.empty
+            let src = directoryVersion configuration srcId (RelativePath "src") [| deletedId; survivingId |] Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| srcId |] Seq.empty
+
+            let previousStatus =
+                graceStatusFromDirectories
+                    previousRoot
+                    [|
+                        previousRoot
+                        src
+                        deleted
+                        deletedNested
+                        surviving
+                    |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/Foo/nested")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/Foo")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/Foo")
+            |> should equal false
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/Foo/nested")
+            |> should equal false
+
+            updatedStatus.Index.ContainsKey(survivingId)
+            |> should equal true
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+            updatedRoot.Directories.Count |> should equal 1
+
+            let updatedSrc = updatedStatus.Index[updatedRoot.Directories[0]]
+
+            updatedSrc.RelativePath
+            |> should equal (RelativePath "src")
+
+            updatedSrc.Directories
+            |> Seq.map (fun directoryId -> updatedStatus.Index[directoryId].RelativePath)
+            |> should equivalent [ RelativePath "src/foo" ]
+
+            newDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> should
+                equivalent
+                [
+                    RelativePath "src"
+                    Constants.RootDirectoryPath
+                ])
+
+    [<Test>]
     let ``directory delete for unknown path is ignored without changing root`` () =
         withTempRepo (fun _ configuration ->
             let rootId = Guid.NewGuid()

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1663,6 +1663,120 @@ module Services =
                     processChangedDirectoriesBottomUp newGraceStatus changedDirectoryVersions newDirectoryVersions
                 | None -> ()
 
+    let private normalizeDirectoryDifferencePath (relativePath: RelativePath) =
+        let normalized = normalizeFilePath $"{relativePath}"
+
+        if normalized = Constants.RootDirectoryPath then
+            Constants.RootDirectoryPath
+        else
+            normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+    let private isDirectoryPathInSubtree (subtreeRoot: RelativePath) (candidate: RelativePath) =
+        let normalizedSubtreeRoot = normalizeDirectoryDifferencePath subtreeRoot
+        let normalizedCandidate = normalizeDirectoryDifferencePath candidate
+
+        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.OrdinalIgnoreCase)
+        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.OrdinalIgnoreCase)
+
+    let private selectTopLevelDeletedDirectories (differences: IEnumerable<FileSystemDifference>) =
+        let topLevelDeletedDirectories = List<RelativePath>()
+
+        let deletedDirectories =
+            differences
+                .Where(fun difference ->
+                    isDirectoryChange difference
+                    && difference.DifferenceType = Delete)
+                .Select(fun difference -> normalizeDirectoryDifferencePath difference.RelativePath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(fun relativePath -> countSegments relativePath)
+
+        for deletedDirectory in deletedDirectories do
+            let ancestorAlreadyDeleted =
+                topLevelDeletedDirectories
+                |> Seq.exists (fun existingDeletedDirectory ->
+                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.OrdinalIgnoreCase))
+                    && isDirectoryPathInSubtree existingDeletedDirectory deletedDirectory)
+
+            if not ancestorAlreadyDeleted then
+                topLevelDeletedDirectories.Add(deletedDirectory)
+
+        topLevelDeletedDirectories
+
+    let private tryFindSurvivingDirectoryVersion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        let mutable changedDirectoryVersion = LocalDirectoryVersion.Default
+
+        if changedDirectoryVersions.TryGetValue(relativePath, &changedDirectoryVersion) then
+            Some changedDirectoryVersion
+        else
+            let directoryVersion = newGraceStatus.Index.Values.FirstOrDefault((fun dv -> dv.RelativePath = relativePath), LocalDirectoryVersion.Default)
+
+            if directoryVersion.DirectoryVersionId <> Guid.Empty then
+                Some directoryVersion
+            else
+                None
+
+    let rec private tryFindNearestSurvivingParentDirectoryVersion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        match getParentPath relativePath with
+        | None -> None
+        | Some parentPath ->
+            match tryFindSurvivingDirectoryVersion changedDirectoryVersions newGraceStatus parentPath with
+            | Some parentDirectoryVersion -> Some parentDirectoryVersion
+            | None -> tryFindNearestSurvivingParentDirectoryVersion changedDirectoryVersions newGraceStatus parentPath
+
+    let private processDirectoryDeletion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        if relativePath = Constants.RootDirectoryPath then
+            ()
+        else
+            let deletedDirectoryVersions =
+                newGraceStatus
+                    .Index
+                    .Values
+                    .Where(fun dv -> isDirectoryPathInSubtree relativePath dv.RelativePath)
+                    .ToList()
+
+            let deletedDirectoryVersion = deletedDirectoryVersions.FirstOrDefault((fun dv -> dv.RelativePath = relativePath), LocalDirectoryVersion.Default)
+
+            if deletedDirectoryVersion.DirectoryVersionId
+               <> Guid.Empty then
+                for deletedDirectoryVersion in deletedDirectoryVersions do
+                    let mutable removedDirectoryVersion = LocalDirectoryVersion.Default
+
+                    newGraceStatus.Index.TryRemove(deletedDirectoryVersion.DirectoryVersionId, &removedDirectoryVersion)
+                    |> ignore
+
+                    let mutable changedRemovedDirectoryVersion = LocalDirectoryVersion.Default
+
+                    changedDirectoryVersions.TryRemove(deletedDirectoryVersion.RelativePath, &changedRemovedDirectoryVersion)
+                    |> ignore
+
+                match tryFindNearestSurvivingParentDirectoryVersion changedDirectoryVersions newGraceStatus relativePath with
+                | Some parentDirectoryVersion ->
+                    parentDirectoryVersion.Directories.Remove(deletedDirectoryVersion.DirectoryVersionId)
+                    |> ignore
+
+                    changedDirectoryVersions.AddOrUpdate(
+                        parentDirectoryVersion.RelativePath,
+                        (fun _ -> parentDirectoryVersion),
+                        (fun _ _ -> parentDirectoryVersion)
+                    )
+                    |> ignore
+                | None -> ()
+
     /// Main refactored function
     let getNewGraceStatusAndDirectoryVersions (previousGraceStatus: GraceStatus) (differences: IEnumerable<FileSystemDifference>) =
         task {
@@ -1703,11 +1817,10 @@ module Services =
                             changedDirectoryVersions.AddOrUpdate(difference.RelativePath, (fun _ -> newDirectoryVersion), (fun _ _ -> newDirectoryVersion))
                             |> ignore
                     | None -> ()
-                | Delete ->
-                    let mutable directoryVersion = newGraceStatus.Index.Values.First(fun dv -> dv.RelativePath = difference.RelativePath)
+                | Delete -> ()
 
-                    newGraceStatus.Index.TryRemove(directoryVersion.DirectoryVersionId, &directoryVersion)
-                    |> ignore
+            for deletedDirectory in selectTopLevelDeletedDirectories differences do
+                processDirectoryDeletion changedDirectoryVersions newGraceStatus deletedDirectory
 
             // Process file changes (Add/Change/Delete)
             for difference in differences.Where(fun d -> isFileChange d) do

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1675,8 +1675,8 @@ module Services =
         let normalizedSubtreeRoot = normalizeDirectoryDifferencePath subtreeRoot
         let normalizedCandidate = normalizeDirectoryDifferencePath candidate
 
-        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.OrdinalIgnoreCase)
-        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.OrdinalIgnoreCase)
+        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.Ordinal)
+        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.Ordinal)
 
     let private selectTopLevelDeletedDirectories (differences: IEnumerable<FileSystemDifference>) =
         let topLevelDeletedDirectories = List<RelativePath>()
@@ -1687,14 +1687,14 @@ module Services =
                     isDirectoryChange difference
                     && difference.DifferenceType = Delete)
                 .Select(fun difference -> normalizeDirectoryDifferencePath difference.RelativePath)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Distinct(StringComparer.Ordinal)
                 .OrderBy(fun relativePath -> countSegments relativePath)
 
         for deletedDirectory in deletedDirectories do
             let ancestorAlreadyDeleted =
                 topLevelDeletedDirectories
                 |> Seq.exists (fun existingDeletedDirectory ->
-                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.OrdinalIgnoreCase))
+                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.Ordinal))
                     && isDirectoryPathInSubtree existingDeletedDirectory deletedDirectory)
 
             if not ancestorAlreadyDeleted then


### PR DESCRIPTION
## Summary

Part of #467.

This PR fixes directory delete tree mutation in `getNewGraceStatusAndDirectoryVersions`. Directory deletes now remove the
child DirectoryVersion reference from the nearest surviving parent, collapse descendant delete differences into the
owning deleted subtree, and let the existing bottom-up rebuild produce a new root that omits the deleted subtree.

## Why This Matters

Grace Watch delete capture is only correct if the saved root DirectoryVersion reflects the current working tree. Removing
local status rows is not enough: future connects, diffs, and materializations must not be able to reach a deleted
subtree through the old parent/root graph.

## Changed Paths

- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs`

## Validation

- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`: passed, 24 tests.
- Test filter: `FullyQualifiedName~CurrentStateCaptureCliTests`.
- `dotnet tool run fantomas`: passed for `Services.CLI.fs` and `CurrentStateCapture.CLI.Tests.fs`.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Fast test phase passed, including 655 CLI tests.
- `git diff --check`: passed.

## Review Status

- **Current head:** `d67702fdf963187541d1ad53661a7adb90658cb8`
- **Current base:** `8cdf817b7c232e0a46655879d38ee385aa3434f3`
- **Base refresh:** Merged the current epic branch, including #469 Watch trigger work, the BLAKE3 child-prefix test
  stabilization, and the review-freshness agent/process docs.
- **Codex Code Review Bot:** No issues for the refreshed head; the bot posted 👍 at 2026-06-30T01:29:01Z.
- **Review threads:** No unresolved Codex Code Review Bot threads remain.
- **Freshness rule:** Only findings repeated by the completed latest-head review were actionable. Previous-pass threads
  were treated as stale unless the latest review repeated them.
- **Current CI:** `Validate / full` passed for the refreshed head.
- **Manual trigger decision:** Not attempted.
- **Manual trigger lock:** Complete; no manual trigger was needed.
- **Implementation path:** Fresh GPT-5.5 Medium worker implemented the original branch and fix; orchestrator owns review
  replies, conversation resolution, PR-body state, and merge state.

## Docs Impact

No user-facing docs changed in this slice. The final Watch behavior docs are owned by issue #466.

## First-Pass Review Readiness

- Bot-prevention self-review completed by the worker over the actual diff.
- Checked directory delete correctness, descendant ordering, parent/root rebuild behavior, false-positive tests,
  file-delete regression, owned-path scope, contract drift, docs impact, and validation evidence.
- Tests assert the root graph no longer references the deleted child, not just that status rows changed.

## Residual Risk

Root directory deletion remains out of scope per issue guidance. The helper ignores root directory delete rather than
defining new root-deletion semantics. No server/API/SDK/OpenAPI/storage/auth/deployment/docs changes were made.
