### PR TITLE
Watch: prove delete-only Save flow and docs

### DIFF
--- a/docs/What grace watch does.md
+++ b/docs/What grace watch does.md
@@ -49,6 +49,17 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
   - Update the local Grace Status file with the new directory versions.
   - Upload those recomputed directory versions to Grace Server.
   - Create a Save reference by calling Grace Server's `/branch/createSave` endpoint.
+- When a tracked file or directory is deleted, `grace watch` will:
+  - Queue a status update without trying to upload file content for the deleted path.
+  - Rescan the working directory against the local Grace Status file.
+  - Recompute the required directory versions from the nearest changed parent up to the root directory.
+  - Upload those recomputed directory versions to Grace Server.
+  - Create a normal Save reference by calling Grace Server's `/branch/createSave` endpoint.
+  - Update the local Grace Status file only after Grace Server creates the Save reference successfully.
+  - Use a Save message such as `Delete src/old-file.txt` for deleted files. Directory-only deletes can create a
+    Save with an empty message because the changed root directory version is the durable record of the directory change.
+- In V1, renames are captured as the old path being deleted plus the new path being added or changed. Grace does not
+  assign rename identity, tombstones, or a durable "same file moved" relationship for V1 rename capture.
 - When a promotion event from your parent branch is sent to `grace watch` by the server, `grace watch` will run auto-rebase.
 - Every 4.8 minutes, `grace watch` will recompute and rewrite the Grace interprocess-communication (IPC) file, which requires reading and deserializing the local Grace Status file. The size of the IPC file is under 1K for small repos, and scales with the number of directories in the repo. A repo with 275 directories would fit in a 10K IPC file, and a repo with 2,750 directories would fit in a 100K IPC file. They're usually very small.
   > Long story about why we rewrite the file: Imagine that you're at the command line, and you run `grace checkpoint -m ...`. That instance of Grace uses the existence of the IPC file as proof that `grace watch` is running in a separate process. `grace watch` writes the IPC file as soon as it starts, and, deletes it in a `try...finally` clause when it exits. In other words: in any normal exit, including exits caused by unhandled exceptions, the IPC file will be deleted when `grace watch` exits. However: it's possible that `grace watch` could be killed before it has a chance to execute that `finally` clause. For instance, in Windows, if I open Task Manager, right-click on the `grace watch` process, and hit `End Task`, the process dies immediately, and does not execute the `finally` clause. To ensure that there's not a stale IPC file laying around, Grace checks the value of the UpdatedAt field; if it's more than 5 minutes old, Grace will ignore the IPC file and assume that `grace watch` isn't running. So: *that's* why the IPC file gets refreshed every 4.8 minutes: it resets the UpdatedAt field so the file stays under 5 minutes old.

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -704,6 +704,197 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``delete-only file changes create save after directory upload and then apply local status`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-delete-sha"
+        let createdSaveId = Guid.NewGuid()
+        let saveMessage = "Delete deleted.txt"
+        let operationOrder = ResizeArray<string>()
+        let mutable uploadedFileVersions = Seq.empty<LocalFileVersion>
+        let mutable savedDirectoryVersions = List<DirectoryVersion>()
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+        let mutable createdSaveMessage = String.Empty
+        let mutable appliedStatus = GraceStatus.Default
+        let mutable appliedDirectoryVersions = Seq.empty<LocalDirectoryVersion>
+        let mutable appliedDifferences = Seq.empty<FileSystemDifference>
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "deleted.txt")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions =
+                    fun fileVersions ->
+                        uploadedFileVersions <- fileVersions |> Seq.toArray
+                        Task.FromResult(Ok Array.empty<FileVersion>)
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        operationOrder.Add("upload-directories")
+                        savedDirectoryVersions <- directoryVersions
+                        Task.FromResult(Ok())
+                CreateSaveReference =
+                    fun rootDirectoryVersion message ->
+                        operationOrder.Add("create-save")
+                        createdSaveRoot <- rootDirectoryVersion
+                        createdSaveMessage <- message
+                        Task.FromResult(Ok(createdSaveId))
+                ApplyGraceStatusIncremental =
+                    fun status directoryVersions applied ->
+                        operationOrder.Add("apply-status")
+                        appliedStatus <- status
+                        appliedDirectoryVersions <- directoryVersions |> Seq.toArray
+                        appliedDifferences <- applied |> Seq.toArray
+                        Task.FromResult(())
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None saveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.Source |> should equal CreatedSave
+
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
+            uploadedFileVersions
+            |> Seq.isEmpty
+            |> should equal true
+
+            savedDirectoryVersions.Count |> should equal 1
+
+            savedDirectoryVersions[0].DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveRoot.DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveMessage |> should equal saveMessage
+
+            appliedStatus.RootDirectoryId
+            |> should equal updatedRootId
+
+            appliedDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+            |> should equal [| updatedRootId |]
+
+            appliedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, difference.RelativePath)
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, RelativePath "deleted.txt"
+                |]
+
+            operationOrder
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    "upload-directories"
+                    "create-save"
+                    "apply-status"
+                |]
+        | Error error -> Assert.Fail($"Expected delete-only auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``directory-only deletes still create save with updated root directory version`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-directory-delete-sha"
+        let createdSaveId = Guid.NewGuid()
+        let operationOrder = ResizeArray<string>()
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+        let mutable createdSaveMessage = "not-empty"
+        let mutable appliedStatus = GraceStatus.Default
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "empty")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions =
+                    fun fileVersions ->
+                        fileVersions |> Seq.isEmpty |> should equal true
+                        Task.FromResult(Ok Array.empty<FileVersion>)
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        operationOrder.Add("upload-directories")
+                        directoryVersions.Count |> should equal 1
+
+                        directoryVersions[0].DirectoryVersionId
+                        |> should equal updatedRootId
+
+                        Task.FromResult(Ok())
+                CreateSaveReference =
+                    fun rootDirectoryVersion message ->
+                        operationOrder.Add("create-save")
+                        createdSaveRoot <- rootDirectoryVersion
+                        createdSaveMessage <- message
+                        Task.FromResult(Ok(createdSaveId))
+                ApplyGraceStatusIncremental =
+                    fun status _ _ ->
+                        operationOrder.Add("apply-status")
+                        appliedStatus <- status
+                        Task.FromResult(())
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None String.Empty correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.Source |> should equal CreatedSave
+
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
+            createdSaveRoot.DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveMessage |> should equal String.Empty
+
+            appliedStatus.RootDirectoryId
+            |> should equal updatedRootId
+
+            operationOrder
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    "upload-directories"
+                    "create-save"
+                    "apply-status"
+                |]
+        | Error error -> Assert.Fail($"Expected directory-only delete auto-save success, got: {error.Error}")
+
+    [<Test>]
     let ``changed file upload selection comes from updated directory versions`` () =
         let changedPath = RelativePath "src/cached-large.bin"
         let unchangedPath = RelativePath "src/unchanged-large.bin"


### PR DESCRIPTION
## Summary

Part of #466.

This PR proves the integrated Watch delete-only Save flow after the trigger, local-status cleanup, and directory-tree
mutation slices merged to the epic branch. It adds regression proof for delete-only file and directory-only delete Save
creation, then updates the Watch user docs for delete capture and V1 rename behavior.

## Why This Matters

Grace Watch delete capture is only complete when a delete-only working-tree change creates a normal Save reference whose
root DirectoryVersion reflects the deleted paths. Users also need the docs to match V1 behavior: renames are captured as
old-path delete plus new-path add/change, not as durable rename identity.

## Changed Paths

- `src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs`
- `docs/What grace watch does.md`

## Validation

- `dotnet tool run fantomas -- src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs`: passed.
- `npx --yes markdownlint-cli2 "docs/What grace watch does.md"`: passed.
- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release`: passed.
- Test filter: `FullyQualifiedName~CurrentStateCaptureCliTests`; 27 tests passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Fast test gate passed: Authorization 53, CLI 674, Types 133, Server.Unit 723.
- `git diff --check`: passed.

## Review Status

- **Current head:** `e23e698124a4a0687c8b386ba64c066849baaa43`
- **Current base:** `c77293806ac5b08a661fa722cffb69d4553d88d6`
- **Codex Code Review Bot:** No issues for the latest head; the bot posted 👍 at 2026-06-30T01:52:51Z.
- **Review threads:** No unresolved Codex Code Review Bot threads remain.
- **Freshness rule:** Only findings from the completed latest-head review were actionable. No fresh findings were raised.
- **Current CI:** `Validate / full` passed for the PR head.
- **Manual trigger decision:** Not attempted.
- **Manual trigger lock:** Complete; no manual trigger was needed.
- **Implementation path:** Fresh GPT-5.5 Medium worker implemented the slice; orchestrator owns PR, review, merge, and
  cleanup state.

## Docs Impact

`docs/What grace watch does.md` now documents tracked delete capture, required DirectoryVersion upload before Save,
local status update after Save success, and V1 rename as delete plus add/change.

## First-Pass Review Readiness

- Bot-prevention self-review completed by the worker over the actual diff.
- Checked false-positive tests, Save/local-status ordering, directory-only delete proof, rename wording, docs accuracy,
  owned-path scope, and validation evidence.
- No production source code changed.

## Residual Risk

The new tests prove the current-state Save flow seam. Watch delete message behavior remains covered by existing
implementation and docs; this PR does not extract a new Watch message-builder seam.
