### PR TITLE
Finish Grace Watch delete capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,16 @@ so links stay traceable without relying on epic-branch auto-close behavior.
   top-level PR comments alone; inspect review comments attached to the bot review before merging. For high-risk slices,
   the orchestrator may assign a fresh pre-PR review worker before opening or updating the PR when that is cheaper than a
   likely bot/fix/re-review loop; this does not replace the bot as the blocking review gate.
+- For Grace PR review-fix routing, wait for Codex Code Review Bot to finish on the latest head before deciding the
+  next fix action set. A fresh finding is one that belongs to the completed bot review for the current head commit, or
+  is repeated after that review completes. Review threads from earlier review passes are stale when a newer head exists,
+  even if GitHub still maps the thread onto the current diff. Do not assign workers, make code changes, or post fix
+  evidence for stale findings; close them only as stale when the maintainer directs that disposition, and say that no
+  code change addressed them.
+- Serialize review-fix workers for a single Grace pull request unless the completed latest-head review contains multiple
+  fresh findings with provably disjoint write sets. Do not overlap workers that touch the same branch, files, tests, or
+  review surface. After a fix worker pushes, reply to and resolve only the fresh findings it addressed, update
+  `Review Status`, then wait for Codex Code Review Bot to finish on the new head before assigning another fix worker.
 - Never manually trigger Codex Code Review Bot while 👀 is present for the current pull request head. A manual trigger is
   allowed only through the documented missed-ack exception after verifying that no 👀, no 👍🏻, no bot review, and no bot
   comment exists for the current head commit.

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -576,6 +576,35 @@ The orchestrator must verify that the bot signal applies to the latest pushed co
 complete. Do not merge, close, or call a task review-complete while the latest bot state is still 👀, while a bot comment
 is unresolved, or while the bot has not yet reacted to the current head commit.
 
+### Review Freshness and Fix Serialization
+
+Review-fix routing starts from a frozen action set. The orchestrator must wait for Codex Code Review Bot to finish on
+the latest head commit, then classify findings before assigning any fix worker.
+
+- A fresh finding belongs to the completed bot review for the current head commit, or is repeated after that review
+  completes.
+- A previous-pass finding is stale when a newer head exists and the completed latest-head review does not repeat it.
+  GitHub can keep mapping old review threads onto the current diff, so do not use `isOutdated = false`, the current
+  line number, or the thread's displayed commit alone as proof that the finding is fresh.
+- Do not assign a worker, edit code, or post fix evidence for stale findings. When the maintainer directs stale
+  findings to be closed, reply with a stale disposition, say that no code change addressed the thread, resolve it, and
+  keep the current action set limited to fresh latest-review findings.
+- If the bot has acknowledged the current head with 👀 but has not yet submitted its completed review or no-issues
+  result, continue waiting. Do not infer the action set from early inline threads.
+
+Review-fix workers on a single pull request are serialized by default. A review-fix worker may cover multiple fresh
+findings from the same completed latest-head review when they share a write set or behavior surface. Do not start
+another fix worker for that pull request until the active worker has handed off, pushed its commit, and the orchestrator
+has replied to and resolved the fresh findings it addressed. Parallel fix workers are allowed only when all of these are
+true:
+
+- the findings come from the same completed latest-head review
+- the write sets, tests, and review surfaces are provably disjoint
+- the worker prompts name the disjoint owned and forbidden paths
+- the orchestrator can merge the results without predictable branch churn or conflicting review replies
+
+After every review-fix push, wait for Codex Code Review Bot to finish on the new head before assigning more fix work.
+
 ### Manual Codex Review Trigger Lock
 
 The manual Codex review trigger lock prevents duplicate review requests while Codex Code Review Bot is already working
@@ -651,9 +680,9 @@ The review loop is blocking:
    wait for 👍🏻 or findings.
 3. If the bot switches the PR-body reaction to 👍🏻 and there are no unresolved bot review comments for the current head,
    record that no-issues state in `Review Status` and continue toward merge readiness.
-4. If the bot writes a top-level PR comment or inline pull-request-review comment with findings, update
-   `Review Status`, then send the findings to a fresh implementation subagent to address in the issue-owned
-   branch/worktree.
+4. If the completed latest-head bot review contains fresh findings, update `Review Status`, then send the frozen fresh
+   action set to a fresh implementation subagent to address in the issue-owned branch/worktree. Do not include stale
+   previous-pass findings unless the latest completed review repeats them.
 5. If the review finds a missing acceptance-criterion class, adversarial case, contract-propagation requirement, stale
    validation evidence, repeated trap, or issue-template gap that could affect active or future workers, amend the
    active and future sibling issues before spawning more workers. Update the issue template or agent docs when the trap

--- a/docs/What grace watch does.md
+++ b/docs/What grace watch does.md
@@ -49,6 +49,17 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
   - Update the local Grace Status file with the new directory versions.
   - Upload those recomputed directory versions to Grace Server.
   - Create a Save reference by calling Grace Server's `/branch/createSave` endpoint.
+- When a tracked file or directory is deleted, `grace watch` will:
+  - Queue a status update without trying to upload file content for the deleted path.
+  - Rescan the working directory against the local Grace Status file.
+  - Recompute the required directory versions from the nearest changed parent up to the root directory.
+  - Upload those recomputed directory versions to Grace Server.
+  - Create a normal Save reference by calling Grace Server's `/branch/createSave` endpoint.
+  - Update the local Grace Status file only after Grace Server creates the Save reference successfully.
+  - Use a Save message such as `Delete src/old-file.txt` for deleted files. Directory-only deletes can create a
+    Save with an empty message because the changed root directory version is the durable record of the directory change.
+- In V1, renames are captured as the old path being deleted plus the new path being added or changed. Grace does not
+  assign rename identity, tombstones, or a durable "same file moved" relationship for V1 rename capture.
 - When a promotion event from your parent branch is sent to `grace watch` by the server, `grace watch` will run auto-rebase.
 - Every 4.8 minutes, `grace watch` will recompute and rewrite the Grace interprocess-communication (IPC) file, which requires reading and deserializing the local Grace Status file. The size of the IPC file is under 1K for small repos, and scales with the number of directories in the repo. A repo with 275 directories would fit in a 10K IPC file, and a repo with 2,750 directories would fit in a 100K IPC file. They're usually very small.
   > Long story about why we rewrite the file: Imagine that you're at the command line, and you run `grace checkpoint -m ...`. That instance of Grace uses the existence of the IPC file as proof that `grace watch` is running in a separate process. `grace watch` writes the IPC file as soon as it starts, and, deletes it in a `try...finally` clause when it exits. In other words: in any normal exit, including exits caused by unhandled exceptions, the IPC file will be deleted when `grace watch` exits. However: it's possible that `grace watch` could be killed before it has a chance to execute that `finally` clause. For instance, in Windows, if I open Task Manager, right-click on the `grace watch` process, and hit `End Task`, the process dies immediately, and does not execute the `finally` clause. To ensure that there's not a stale IPC file laying around, Grace checks the value of the UpdatedAt field; if it's more than 5 minutes old, Grace will ignore the IPC file and assume that `grace watch` isn't running. So: *that's* why the IPC file gets refreshed every 4.8 minutes: it resets the UpdatedAt field so the file stays under 5 minutes old.

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -704,6 +704,197 @@ module CurrentStateCaptureCliTests =
         | Error error -> Assert.Fail($"Expected auto-save success, got: {error.Error}")
 
     [<Test>]
+    let ``delete-only file changes create save after directory upload and then apply local status`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-delete-sha"
+        let createdSaveId = Guid.NewGuid()
+        let saveMessage = "Delete deleted.txt"
+        let operationOrder = ResizeArray<string>()
+        let mutable uploadedFileVersions = Seq.empty<LocalFileVersion>
+        let mutable savedDirectoryVersions = List<DirectoryVersion>()
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+        let mutable createdSaveMessage = String.Empty
+        let mutable appliedStatus = GraceStatus.Default
+        let mutable appliedDirectoryVersions = Seq.empty<LocalDirectoryVersion>
+        let mutable appliedDifferences = Seq.empty<FileSystemDifference>
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "deleted.txt")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions =
+                    fun fileVersions ->
+                        uploadedFileVersions <- fileVersions |> Seq.toArray
+                        Task.FromResult(Ok Array.empty<FileVersion>)
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        operationOrder.Add("upload-directories")
+                        savedDirectoryVersions <- directoryVersions
+                        Task.FromResult(Ok())
+                CreateSaveReference =
+                    fun rootDirectoryVersion message ->
+                        operationOrder.Add("create-save")
+                        createdSaveRoot <- rootDirectoryVersion
+                        createdSaveMessage <- message
+                        Task.FromResult(Ok(createdSaveId))
+                ApplyGraceStatusIncremental =
+                    fun status directoryVersions applied ->
+                        operationOrder.Add("apply-status")
+                        appliedStatus <- status
+                        appliedDirectoryVersions <- directoryVersions |> Seq.toArray
+                        appliedDifferences <- applied |> Seq.toArray
+                        Task.FromResult(())
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None saveMessage correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.Source |> should equal CreatedSave
+
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
+            uploadedFileVersions
+            |> Seq.isEmpty
+            |> should equal true
+
+            savedDirectoryVersions.Count |> should equal 1
+
+            savedDirectoryVersions[0].DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveRoot.DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveMessage |> should equal saveMessage
+
+            appliedStatus.RootDirectoryId
+            |> should equal updatedRootId
+
+            appliedDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+            |> should equal [| updatedRootId |]
+
+            appliedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, difference.RelativePath)
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, RelativePath "deleted.txt"
+                |]
+
+            operationOrder
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    "upload-directories"
+                    "create-save"
+                    "apply-status"
+                |]
+        | Error error -> Assert.Fail($"Expected delete-only auto-save success, got: {error.Error}")
+
+    [<Test>]
+    let ``directory-only deletes still create save with updated root directory version`` () =
+        let updatedRootId = Guid.NewGuid()
+        let updatedRootSha = Sha256Hash "updated-root-directory-delete-sha"
+        let createdSaveId = Guid.NewGuid()
+        let operationOrder = ResizeArray<string>()
+        let mutable createdSaveRoot = Unchecked.defaultof<LocalDirectoryVersion>
+        let mutable createdSaveMessage = "not-empty"
+        let mutable appliedStatus = GraceStatus.Default
+
+        let differences =
+            List<FileSystemDifference>(
+                [|
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "empty")
+                |]
+            )
+
+        let updatedStatus = graceStatus updatedRootId updatedRootSha
+        let updatedRoot = rootDirectoryVersion updatedRootId updatedRootSha
+
+        let operations =
+            { defaultOperations (branch true ReferenceDto.Default) with
+                ScanForDifferences = fun _ -> Task.FromResult(differences)
+                BuildUpdatedGraceStatus = fun _ _ -> Task.FromResult(updatedStatus, List<LocalDirectoryVersion>([| updatedRoot |]))
+                UploadFileVersions =
+                    fun fileVersions ->
+                        fileVersions |> Seq.isEmpty |> should equal true
+                        Task.FromResult(Ok Array.empty<FileVersion>)
+                UploadDirectoryVersions =
+                    fun directoryVersions ->
+                        operationOrder.Add("upload-directories")
+                        directoryVersions.Count |> should equal 1
+
+                        directoryVersions[0].DirectoryVersionId
+                        |> should equal updatedRootId
+
+                        Task.FromResult(Ok())
+                CreateSaveReference =
+                    fun rootDirectoryVersion message ->
+                        operationOrder.Add("create-save")
+                        createdSaveRoot <- rootDirectoryVersion
+                        createdSaveMessage <- message
+                        Task.FromResult(Ok(createdSaveId))
+                ApplyGraceStatusIncremental =
+                    fun status _ _ ->
+                        operationOrder.Add("apply-status")
+                        appliedStatus <- status
+                        Task.FromResult(())
+            }
+
+        let result =
+            (resolveCliCurrentStateTargetReference operations None String.Empty correlationId)
+                .Result
+
+        match result with
+        | Ok captured ->
+            captured.TargetReferenceId
+            |> should equal createdSaveId
+
+            captured.Source |> should equal CreatedSave
+
+            captured.RootDirectoryId
+            |> should equal updatedRootId
+
+            createdSaveRoot.DirectoryVersionId
+            |> should equal updatedRootId
+
+            createdSaveMessage |> should equal String.Empty
+
+            appliedStatus.RootDirectoryId
+            |> should equal updatedRootId
+
+            operationOrder
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    "upload-directories"
+                    "create-save"
+                    "apply-status"
+                |]
+        | Error error -> Assert.Fail($"Expected directory-only delete auto-save success, got: {error.Error}")
+
+    [<Test>]
     let ``changed file upload selection comes from updated directory versions`` () =
         let changedPath = RelativePath "src/cached-large.bin"
         let unchangedPath = RelativePath "src/unchanged-large.bin"

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -58,6 +58,58 @@ module CurrentStateCaptureCliTests =
 
     let private graceStatus directoryVersionId sha256Hash = graceStatusWithRootBlake3 directoryVersionId sha256Hash rootBlake3
 
+    let private sha256Hash (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+    let private directoryVersion
+        (configuration: GraceConfiguration)
+        (directoryVersionId: DirectoryVersionId)
+        (relativePath: RelativePath)
+        (directoryIds: DirectoryVersionId seq)
+        (files: LocalFileVersion seq)
+        =
+        LocalDirectoryVersion.CreateWithHashes
+            directoryVersionId
+            configuration.OwnerId
+            configuration.OrganizationId
+            configuration.RepositoryId
+            relativePath
+            (Sha256Hash $"sha-{directoryVersionId:N}")
+            (Blake3Hash $"blake3-{directoryVersionId:N}")
+            (List<DirectoryVersionId>(directoryIds))
+            (List<LocalFileVersion>(files))
+            (files |> Seq.sumBy (fun file -> int64 file.Size))
+            DateTime.UtcNow
+
+    let private fileVersion (relativePath: RelativePath) (contents: string) =
+        let bytes = Encoding.UTF8.GetBytes(contents)
+
+        LocalFileVersion.CreateWithHashes
+            relativePath
+            (sha256Hash bytes)
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            false
+            (int64 bytes.Length)
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    let private graceStatusFromDirectories (root: LocalDirectoryVersion) (directories: LocalDirectoryVersion seq) =
+        let index = GraceIndex()
+
+        for directoryVersion in directories do
+            index.TryAdd(directoryVersion.DirectoryVersionId, directoryVersion)
+            |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = root.DirectoryVersionId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     let private referenceDto referenceId directoryVersionId sha256Hash =
         { ReferenceDto.Default with
             ReferenceId = referenceId
@@ -70,11 +122,6 @@ module CurrentStateCaptureCliTests =
 
     let private branch saveEnabled latestReference =
         { BranchDto.Default with BranchId = currentBranchId; SaveEnabled = saveEnabled; LatestReference = latestReference; LatestSave = latestReference }
-
-    let private sha256Hash (bytes: byte array) =
-        SHA256.HashData(bytes)
-        |> Convert.ToHexString
-        |> fun value -> Sha256Hash(value.ToLowerInvariant())
 
     let private manifestReferenceFor bytes =
         let blockAddress = ContentBlockAddress(ContentAddress.computeBlake3Hex bytes)
@@ -112,13 +159,16 @@ module CurrentStateCaptureCliTests =
         let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-{Guid.NewGuid():N}")
         let previousDirectory = Environment.CurrentDirectory
         let previousConfiguration = if configurationFileExists () then Some(Current()) else None
+        let previousParseResult = parseResult
 
         try
             Directory.CreateDirectory(root) |> ignore
             Environment.CurrentDirectory <- root
+            parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
             let configuration = configureForRoot root
             action root configuration
         finally
+            parseResult <- previousParseResult
             Environment.CurrentDirectory <- previousDirectory
 
             match previousConfiguration with
@@ -126,6 +176,180 @@ module CurrentStateCaptureCliTests =
             | None -> resetConfiguration ()
 
             if Directory.Exists(root) then Directory.Delete(root, true)
+
+    [<Test>]
+    let ``directory delete removes subtree reference from nearest surviving parent`` () =
+        withTempRepo (fun root configuration ->
+            Directory.CreateDirectory(Path.Combine(root, "src"))
+            |> ignore
+
+            let rootId = Guid.NewGuid()
+            let srcId = Guid.NewGuid()
+            let deletedId = Guid.NewGuid()
+            let nestedDeletedId = Guid.NewGuid()
+            let deletedFile = fileVersion (RelativePath "src/old/file.txt") "deleted file"
+            let nestedDeleted = directoryVersion configuration nestedDeletedId (RelativePath "src/old/nested") Seq.empty Seq.empty
+            let deleted = directoryVersion configuration deletedId (RelativePath "src/old") [| nestedDeletedId |] [| deletedFile |]
+            let src = directoryVersion configuration srcId (RelativePath "src") [| deletedId |] Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| srcId |] Seq.empty
+
+            let previousStatus =
+                graceStatusFromDirectories
+                    previousRoot
+                    [|
+                        previousRoot
+                        src
+                        deleted
+                        nestedDeleted
+                    |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "src/old/file.txt")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/old/nested")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/old")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/old")
+            |> should equal false
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/old/nested")
+            |> should equal false
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Directories.Count |> should equal 1
+
+            let updatedSrc = updatedStatus.Index[updatedRoot.Directories[0]]
+
+            updatedSrc.RelativePath
+            |> should equal (RelativePath "src")
+
+            updatedSrc.DirectoryVersionId
+            |> should not' (equal srcId)
+
+            updatedSrc.Directories
+            |> Seq.exists (fun directoryId ->
+                directoryId = deletedId
+                || directoryId = nestedDeletedId)
+            |> should equal false
+
+            newDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> should
+                equivalent
+                [
+                    RelativePath "src"
+                    Constants.RootDirectoryPath
+                ])
+
+    [<Test>]
+    let ``directory delete for unknown path is ignored without changing root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath Seq.empty Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "missing")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.RootDirectoryId
+            |> should equal previousStatus.RootDirectoryId
+
+            updatedStatus.RootDirectorySha256Hash
+            |> should equal previousStatus.RootDirectorySha256Hash
+
+            updatedStatus.RootDirectoryBlake3Hash
+            |> should equal previousStatus.RootDirectoryBlake3Hash
+
+            updatedStatus.Index.Count
+            |> should equal previousStatus.Index.Count
+
+            newDirectoryVersions.Count |> should equal 0)
+
+    [<Test>]
+    let ``file delete still removes file reference and rebuilds root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let deletedFile = fileVersion (RelativePath "deleted.txt") "deleted file"
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath Seq.empty [| deletedFile |]
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath "deleted.txt")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Files.Count |> should equal 0
+            newDirectoryVersions.Count |> should equal 1
+
+            newDirectoryVersions[0].RelativePath
+            |> should equal Constants.RootDirectoryPath)
+
+    [<Test>]
+    let ``empty directory delete removes child reference from root`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let emptyId = Guid.NewGuid()
+            let empty = directoryVersion configuration emptyId (RelativePath "empty") Seq.empty Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| emptyId |] Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot; empty |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "empty")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "empty")
+            |> should equal false
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.DirectoryVersionId
+            |> should not' (equal rootId)
+
+            updatedRoot.Directories.Count |> should equal 0
+            newDirectoryVersions.Count |> should equal 1
+
+            newDirectoryVersions[0].RelativePath
+            |> should equal Constants.RootDirectoryPath)
 
     let private defaultOperations branchDto =
         {

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -255,6 +255,78 @@ module CurrentStateCaptureCliTests =
                 ])
 
     [<Test>]
+    let ``directory delete preserves sibling that differs only by case`` () =
+        withTempRepo (fun root configuration ->
+            Directory.CreateDirectory(Path.Combine(root, "src"))
+            |> ignore
+
+            let rootId = Guid.NewGuid()
+            let srcId = Guid.NewGuid()
+            let deletedId = Guid.NewGuid()
+            let deletedNestedId = Guid.NewGuid()
+            let survivingId = Guid.NewGuid()
+            let deletedNested = directoryVersion configuration deletedNestedId (RelativePath "src/Foo/nested") Seq.empty Seq.empty
+            let deleted = directoryVersion configuration deletedId (RelativePath "src/Foo") [| deletedNestedId |] Seq.empty
+            let surviving = directoryVersion configuration survivingId (RelativePath "src/foo") Seq.empty Seq.empty
+            let src = directoryVersion configuration srcId (RelativePath "src") [| deletedId; survivingId |] Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| srcId |] Seq.empty
+
+            let previousStatus =
+                graceStatusFromDirectories
+                    previousRoot
+                    [|
+                        previousRoot
+                        src
+                        deleted
+                        deletedNested
+                        surviving
+                    |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/Foo/nested")
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath "src/Foo")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/Foo")
+            |> should equal false
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "src/Foo/nested")
+            |> should equal false
+
+            updatedStatus.Index.ContainsKey(survivingId)
+            |> should equal true
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+            updatedRoot.Directories.Count |> should equal 1
+
+            let updatedSrc = updatedStatus.Index[updatedRoot.Directories[0]]
+
+            updatedSrc.RelativePath
+            |> should equal (RelativePath "src")
+
+            updatedSrc.Directories
+            |> Seq.map (fun directoryId -> updatedStatus.Index[directoryId].RelativePath)
+            |> should equivalent [ RelativePath "src/foo" ]
+
+            newDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> should
+                equivalent
+                [
+                    RelativePath "src"
+                    Constants.RootDirectoryPath
+                ])
+
+    [<Test>]
     let ``directory delete for unknown path is ignored without changing root`` () =
         withTempRepo (fun _ configuration ->
             let rootId = Guid.NewGuid()

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -127,6 +127,25 @@ module LocalStateDbTests =
         cmd.CommandText <- sql
         cmd.ExecuteScalar() |> Convert.ToInt32
 
+    let private executeScalarIntWithTextParameter (connection: SqliteConnection) (sql: string) parameterName parameterValue =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- sql
+
+        cmd.Parameters.AddWithValue(parameterName, parameterValue)
+        |> ignore
+
+        cmd.ExecuteScalar() |> Convert.ToInt32
+
+    let private countStatusFileRows connection relativePath =
+        executeScalarIntWithTextParameter connection "SELECT COUNT(*) FROM status_files WHERE relative_path = $relative_path;" "$relative_path" relativePath
+
+    let private countStatusDirectoryRows connection relativePath =
+        executeScalarIntWithTextParameter
+            connection
+            "SELECT COUNT(*) FROM status_directories WHERE relative_path = $relative_path;"
+            "$relative_path"
+            relativePath
+
     let private executeScalarInt64 (connection: SqliteConnection) (sql: string) =
         use cmd = connection.CreateCommand()
         cmd.CommandText <- sql
@@ -2023,7 +2042,7 @@ module LocalStateDbTests =
             })
 
     [<Test>]
-    let ``applyStatusIncremental delete file removes the row`` () =
+    let ``applyStatusIncremental delete file removes only the matching status file row`` () =
         withTempDir (fun _ configuration ->
             task {
                 let now = Instant.FromUnixTimeTicks(6000L)
@@ -2031,9 +2050,19 @@ module LocalStateDbTests =
                 let rootId = Guid.NewGuid()
                 let srcId = Guid.NewGuid()
 
-                let file = createFileVersion "src/delete-me.txt" "hash" false 1L now lastWrite
+                let deletedFile = createFileVersion "src/delete-me.txt" "hash-delete" false 1L now lastWrite
+                let siblingFile = createFileVersion "src/delete-me-too.txt" "hash-keep" false 2L now lastWrite
 
-                let srcDir = createDirectoryVersion configuration srcId "src" "src-hash" [||] [| file |] file.Size lastWrite
+                let srcDir =
+                    createDirectoryVersion
+                        configuration
+                        srcId
+                        "src"
+                        "src-hash"
+                        [||]
+                        [| deletedFile; siblingFile |]
+                        (deletedFile.Size + siblingFile.Size)
+                        lastWrite
 
                 let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [| srcId |] [||] 0L lastWrite
 
@@ -2059,32 +2088,41 @@ module LocalStateDbTests =
                         Seq.empty
                         [
                             FileSystemDifference.Create Delete FileSystemEntryType.File "src/delete-me.txt"
+                            FileSystemDifference.Create Delete FileSystemEntryType.File "src/delete-me.txt"
+                            FileSystemDifference.Create Delete FileSystemEntryType.File "src/unknown.txt"
                         ]
 
-                let! readBack = LocalStateDb.readStatusSnapshot configuration.GraceStatusFile
+                use connection = openRawConnection configuration.GraceStatusFile
 
-                readBack.Index.Values
-                |> Seq.collect (fun dv -> dv.Files)
-                |> Seq.exists (fun f -> f.RelativePath = "src/delete-me.txt")
-                |> should equal false
+                countStatusFileRows connection "src/delete-me.txt"
+                |> should equal 0
+
+                countStatusFileRows connection "src/delete-me-too.txt"
+                |> should equal 1
+
+                countStatusDirectoryRows connection "src"
+                |> should equal 1
             })
 
     [<Test>]
-    let ``applyStatusIncremental delete directory removes the directory row`` () =
+    let ``applyStatusIncremental delete directory removes only the matching status directory row`` () =
         withTempDir (fun _ configuration ->
             task {
                 let now = Instant.FromUnixTimeTicks(7000L)
                 let lastWrite = DateTime(2022, 1, 2, 3, 4, 5, DateTimeKind.Utc)
                 let rootId = Guid.NewGuid()
                 let srcId = Guid.NewGuid()
+                let srcOldId = Guid.NewGuid()
 
                 let srcDir = createDirectoryVersion configuration srcId "src" "src-hash" [||] [||] 0L lastWrite
+                let srcOldDir = createDirectoryVersion configuration srcOldId "src-old" "src-old-hash" [||] [||] 0L lastWrite
 
-                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [| srcId |] [||] 0L lastWrite
+                let rootDir = createDirectoryVersion configuration rootId Constants.RootDirectoryPath "root-hash" [| srcId; srcOldId |] [||] 0L lastWrite
 
                 let index = GraceIndex()
                 index.TryAdd(rootId, rootDir) |> ignore
                 index.TryAdd(srcId, srcDir) |> ignore
+                index.TryAdd(srcOldId, srcOldDir) |> ignore
 
                 let status =
                     { GraceStatus.Default with
@@ -2104,13 +2142,103 @@ module LocalStateDbTests =
                         Seq.empty
                         [
                             FileSystemDifference.Create Delete FileSystemEntryType.Directory "src"
+                            FileSystemDifference.Create Delete FileSystemEntryType.Directory "src"
+                            FileSystemDifference.Create Delete FileSystemEntryType.Directory "src-missing"
                         ]
 
-                let! readBack = LocalStateDb.readStatusSnapshot configuration.GraceStatusFile
+                use connection = openRawConnection configuration.GraceStatusFile
 
-                readBack.Index.Values
-                |> Seq.exists (fun dv -> dv.RelativePath = "src")
-                |> should equal false
+                countStatusDirectoryRows connection "src"
+                |> should equal 0
+
+                countStatusDirectoryRows connection "src-old"
+                |> should equal 1
+
+                countStatusDirectoryRows connection Constants.RootDirectoryPath
+                |> should equal 1
+            })
+
+    [<Test>]
+    let ``applyStatusIncremental subtree delete differences remove descendant status rows and preserve prefix siblings`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(8000L)
+                let lastWrite = DateTime(2022, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+                let srcId = Guid.NewGuid()
+                let nestedId = Guid.NewGuid()
+                let srcOldId = Guid.NewGuid()
+
+                let srcFile = createFileVersion "src/delete-me.txt" "src-delete-hash" false 1L now lastWrite
+                let nestedFile = createFileVersion "src/nested/delete-me.txt" "nested-delete-hash" false 2L now lastWrite
+                let prefixSiblingFile = createFileVersion "src-old/keep-me.txt" "src-old-keep-hash" false 3L now lastWrite
+
+                let nestedDir = createDirectoryVersion configuration nestedId "src/nested" "nested-hash" [||] [| nestedFile |] nestedFile.Size lastWrite
+
+                let srcDir = createDirectoryVersion configuration srcId "src" "src-hash" [| nestedId |] [| srcFile |] (srcFile.Size + nestedDir.Size) lastWrite
+
+                let srcOldDir =
+                    createDirectoryVersion configuration srcOldId "src-old" "src-old-hash" [||] [| prefixSiblingFile |] prefixSiblingFile.Size lastWrite
+
+                let rootDir =
+                    createDirectoryVersion
+                        configuration
+                        rootId
+                        Constants.RootDirectoryPath
+                        "root-hash"
+                        [| srcId; srcOldId |]
+                        [||]
+                        (srcDir.Size + srcOldDir.Size)
+                        lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, rootDir) |> ignore
+                index.TryAdd(srcId, srcDir) |> ignore
+                index.TryAdd(nestedId, nestedDir) |> ignore
+                index.TryAdd(srcOldId, srcOldDir) |> ignore
+
+                let status =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootDir.Sha256Hash
+                        LastSuccessfulFileUpload = now
+                        LastSuccessfulDirectoryVersionUpload = now
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile status
+
+                do!
+                    LocalStateDb.applyStatusIncremental
+                        configuration.GraceStatusFile
+                        status
+                        Seq.empty
+                        [
+                            FileSystemDifference.Create Delete FileSystemEntryType.File "src/nested/delete-me.txt"
+                            FileSystemDifference.Create Delete FileSystemEntryType.Directory "src"
+                            FileSystemDifference.Create Delete FileSystemEntryType.File "src/delete-me.txt"
+                            FileSystemDifference.Create Delete FileSystemEntryType.Directory "src/nested"
+                        ]
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                countStatusDirectoryRows connection "src"
+                |> should equal 0
+
+                countStatusDirectoryRows connection "src/nested"
+                |> should equal 0
+
+                countStatusFileRows connection "src/delete-me.txt"
+                |> should equal 0
+
+                countStatusFileRows connection "src/nested/delete-me.txt"
+                |> should equal 0
+
+                countStatusDirectoryRows connection "src-old"
+                |> should equal 1
+
+                countStatusFileRows connection "src-old/keep-me.txt"
+                |> should equal 1
             })
 
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -484,6 +484,23 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``unknown deleted file matching file ignore does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.log" |]
+
+            let filePath = Path.Combine(root, "ignored.log")
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory queues status update when rename cached directory ignore`` () =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-directory-name")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -232,6 +232,10 @@ module WatchTests =
         Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus applyIncremental updateIpc
         |> fun processTask -> processTask.GetAwaiter().GetResult()
 
+    let private writeGraceIgnore root (entries: string array) =
+        File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, entries))
+        resetConfiguration ()
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -433,6 +437,44 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal [| "cached-directory" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted directory named like file ignore queues status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.tmp" |]
+
+            let directoryPath = Path.Combine(root, "archive.tmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted directory matching directory ignore does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let directoryPath = Path.Combine(root, "archive.tmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -688,13 +688,32 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
-    let ``deleted directory matching directory ignore does not queue status update work`` () =
+    let ``deleted tracked directory matching directory ignore queues status update work`` () =
         withTempRepo (fun root ->
             writeGraceIgnore root [| "archive.tmp/" |]
 
             let directoryPath = Path.Combine(root, "archive.tmp")
             Directory.CreateDirectory(directoryPath) |> ignore
             Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "archive.tmp" |])
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``unknown deleted directory matching directory ignore does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let directoryPath = Path.Combine(root, "archive.tmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
             Directory.Delete(directoryPath)
 
             Watch.OnDeleted(deletedEvent directoryPath)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -172,19 +172,24 @@ module WatchTests =
         File.WriteAllText(configPath, "{}")
 
         let originalDir = Environment.CurrentDirectory
+        let originalParseResult = Services.parseResult
 
         try
             Environment.CurrentDirectory <- tempDir
+            Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
             resetConfiguration ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
+            Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
             deleteWatchStatusFileIfExists ()
             Watch.clearPendingWatchWorkForTests ()
             action tempDir
         finally
             Watch.clearPendingWatchWorkForTests ()
+            Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
             deleteWatchStatusFileIfExists ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             resetConfiguration ()
+            Services.parseResult <- originalParseResult
             Environment.CurrentDirectory <- originalDir
 
             if Directory.Exists(tempDir) then
@@ -525,6 +530,62 @@ module WatchTests =
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status reload failure keeps ignored-looking delete queued for retry`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.log" |]
+
+            let filePath = Path.Combine(root, "important.log")
+
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromException<GraceStatus>(InvalidOperationException("transient status reload failure")))
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "important.log" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only delete rescan clears stale working tree scan cache`` () =
+        withTempRepo (fun root ->
+            let relativePath = "stale-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            File.WriteAllText(filePath, "tracked content before delete")
+
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+
+            (Services.scanForDifferences status)
+                .GetAwaiter()
+                .GetResult()
+            |> ignore
+
+            File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            let updateGraceStatus status _ =
+                task {
+                    let! differences = Services.scanForDifferences status
+                    observedDifferences <- differences
+                    return Some status
+                }
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
+
+            observedDifferences
+            |> Seq.exists (fun difference ->
+                difference.DifferenceType = DifferenceType.Delete
+                && difference.FileSystemEntryType = FileSystemEntryType.File
+                && difference.RelativePath = RelativePath relativePath)
+            |> should equal true)
 
     [<Test>]
     let ``deleted directory queues status update when rename cached directory ignore`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -493,6 +493,32 @@ module WatchTests =
             uploadCalls |> should equal 0)
 
     [<Test>]
+    let ``ignored delete uses filesystem casing when cancelling pending upload work`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.Ordinal
+
+            let queuedDirectory = Path.Combine(root, "src", "Foo")
+
+            Directory.CreateDirectory(queuedDirectory)
+            |> ignore
+
+            let queuedFilePath = Path.Combine(queuedDirectory, "pending.txt")
+            File.WriteAllText(queuedFilePath, "queued payload")
+            Watch.OnChanged(changedEvent queuedFilePath)
+            writeGraceIgnore root [| "src/foo/" |]
+
+            let ignoredDeletedDirectory = Path.Combine(root, "src", "foo")
+            Watch.OnDeleted(deletedEvent ignoredDeletedDirectory)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| queuedFilePath |]
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``status-only triggers remain pending when status update returns none`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "retry-delete.txt")
@@ -984,6 +1010,26 @@ module WatchTests =
             |> should equal [| newPath |])
 
     [<Test>]
+    let ``renamed file cancels old path pending upload before queuing new path`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "queued-old-name.txt")
+            let newPath = Path.Combine(root, "queued-new-name.txt")
+
+            File.WriteAllText(oldPath, "payload before rename")
+            Watch.OnChanged(changedEvent oldPath)
+            File.Move(oldPath, newPath)
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "queued-old-name.txt" |]
+
+            pending.FilesToProcess
+            |> should equal [| newPath |])
+
+    [<Test>]
     let ``renamed directory queues old path status trigger and new contents upload work`` () =
         withTempRepo (fun root ->
             writeGraceIgnore root [| "*.tmp" |]
@@ -1016,7 +1062,7 @@ module WatchTests =
             updateCalls |> should equal 1)
 
     [<Test>]
-    let ``renamed directory enumeration failure removes status-only trigger and stays in callback`` () =
+    let ``renamed directory enumeration failure keeps old path trigger for retry`` () =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-enumeration-name")
             let newPath = Path.Combine(root, "new-enumeration-name")
@@ -1029,7 +1075,7 @@ module WatchTests =
             let pending = Watch.pendingWatchWorkSnapshotForTests ()
 
             pending.StatusUpdateTriggers
-            |> should equal Array.empty<string>
+            |> should equal [| "old-enumeration-name" |]
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -322,6 +322,41 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``status-only triggers added during status update remain pending for next pass`` () =
+        withTempRepo (fun root ->
+            let beforeUpdatePath = Path.Combine(root, "before-update-delete.txt")
+            let duringUpdatePath = Path.Combine(root, "during-update-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent beforeUpdatePath)
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+
+                if updateCalls = 1 then Watch.OnDeleted(deletedEvent duringUpdatePath)
+
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFirstPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFirstPass.StatusUpdateTriggers
+            |> should equal [| "during-update-delete.txt" |]
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterSecondPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSecondPass.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``status-only triggers remain pending when status file read fails`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "read-failure-delete.txt")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -178,8 +178,10 @@ module WatchTests =
             resetConfiguration ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             deleteWatchStatusFileIfExists ()
+            Watch.clearPendingWatchWorkForTests ()
             action tempDir
         finally
+            Watch.clearPendingWatchWorkForTests ()
             deleteWatchStatusFileIfExists ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             resetConfiguration ()
@@ -190,6 +192,35 @@ module WatchTests =
                     Directory.Delete(tempDir, true)
                 with
                 | _ -> ()
+
+    let private deletedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
+
+    let private renamedEvent (oldFullPath: string) (fullPath: string) =
+        RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
+
+    let private processPendingWatchWorkForTest () =
+        let status = GraceStatus.Default
+        let mutable updateCalls = 0
+        let mutable uploadCalls = 0
+
+        let readStatus () = Task.FromResult(status)
+
+        let upload _ _ =
+            uploadCalls <- uploadCalls + 1
+            Task.FromResult(())
+
+        let updateGraceStatus status _ =
+            updateCalls <- updateCalls + 1
+            Task.FromResult(Some status)
+
+        let applyIncremental _ _ _ = Task.FromResult(())
+        let updateIpc _ _ = Task.FromResult(())
+
+        let processTask = Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc
+
+        processTask.GetAwaiter().GetResult()
+
+        updateCalls, uploadCalls
 
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
@@ -220,6 +251,91 @@ module WatchTests =
             |> should contain "Unable to acquire an access token for SignalR notifications:"
 
             error |> should contain "test error"
+
+    [<Test>]
+    let ``deleted file queues status update work without upload work`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "deleted.txt")
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "deleted.txt" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``ignored and outside delete paths do not queue status update work`` () =
+        withTempRepo (fun root ->
+            let graceArtifactPath = Path.Combine(root, Constants.GraceConfigDirectory, "grace-local.db")
+            let outsidePath = Path.Combine(Path.GetTempPath(), $"grace-watch-outside-{Guid.NewGuid():N}.txt")
+
+            Watch.OnDeleted(deletedEvent graceArtifactPath)
+            Watch.OnDeleted(deletedEvent outsidePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``duplicate deleted file events drain as one status update trigger`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "duplicate-delete.txt")
+
+            Watch.OnDeleted(deletedEvent filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "duplicate-delete.txt" |]
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``renamed file queues old path status trigger and new path upload work`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-name.txt")
+            let newPath = Path.Combine(root, "new-name.txt")
+            File.WriteAllText(newPath, "new rename target")
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "old-name.txt" |]
+
+            pending.FilesToProcess
+            |> should equal [| newPath |])
 
     [<Test>]
     let ``watch exits with auth guidance when no token is configured`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -506,6 +506,47 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``unknown deleted file under ignored parent directory does not queue status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "logs/" |]
+
+            let logsDirectory = Path.Combine(root, "logs")
+            Directory.CreateDirectory(logsDirectory) |> ignore
+            let filePath = Path.Combine(logsDirectory, "ignored.txt")
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted tracked file under ignored parent directory queues status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "logs/" |]
+
+            let logsDirectory = Path.Combine(root, "logs")
+            Directory.CreateDirectory(logsDirectory) |> ignore
+            let filePath = Path.Combine(logsDirectory, "tracked.txt")
+            File.WriteAllText(filePath, "tracked log content")
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "logs/tracked.txt" |] Array.empty<string>)
+            File.Delete(filePath)
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "logs/tracked.txt" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``dirty status reload keeps tracked ignored-looking delete from being suppressed`` () =
         withTempRepo (fun root ->
             writeGraceIgnore root [| "*.log" |]
@@ -725,6 +766,56 @@ module WatchTests =
 
             pending.FilesToProcess
             |> should equal [| newPath |])
+
+    [<Test>]
+    let ``renamed directory queues old path status trigger and new contents upload work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.tmp" |]
+
+            let oldPath = Path.Combine(root, "old-assets")
+            let newPath = Path.Combine(root, "new-assets")
+            let nestedPath = Path.Combine(newPath, "nested")
+            Directory.CreateDirectory(nestedPath) |> ignore
+
+            let rootFile = Path.Combine(newPath, "asset.txt")
+            let nestedFile = Path.Combine(nestedPath, "nested.txt")
+            let ignoredFile = Path.Combine(nestedPath, "ignored.tmp")
+            File.WriteAllText(rootFile, "root asset")
+            File.WriteAllText(nestedFile, "nested asset")
+            File.WriteAllText(ignoredFile, "ignored asset")
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "old-assets" |]
+
+            pending.FilesToProcess
+            |> should equal ([| rootFile; nestedFile |] |> Array.sort)
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            uploadCalls |> should equal 2
+            updateCalls |> should equal 1)
+
+    [<Test>]
+    let ``startup deleted file difference queues status-only work without upload work`` () =
+        withTempRepo (fun _ ->
+            Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create Delete FileSystemEntryType.File "offline-delete.txt")
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "offline-delete.txt" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0)
 
     [<Test>]
     let ``renamed tracked file matching directory-only ignore queues old path status trigger`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -501,6 +501,32 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``dirty status reload keeps tracked ignored-looking delete from being suppressed`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "*.log" |]
+
+            let filePath = Path.Combine(root, "important.log")
+            File.WriteAllText(filePath, "tracked log file")
+
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "other.txt" |] Array.empty<string>)
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            (Services.writeGraceStatusFile (graceStatusTracking [| "important.log" |] Array.empty<string>))
+                .GetAwaiter()
+                .GetResult()
+
+            File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "important.log" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory queues status update when rename cached directory ignore`` () =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-directory-name")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -222,6 +222,16 @@ module WatchTests =
 
         updateCalls, uploadCalls
 
+    let private processPendingWatchWorkWithStatusClients readStatusFile updateGraceStatus =
+        let status = GraceStatus.Default
+        let readStatusMeta () = Task.FromResult(status)
+        let upload _ _ = Task.FromResult(())
+        let applyIncremental _ _ _ = Task.FromResult(())
+        let updateIpc _ _ = Task.FromResult(())
+
+        Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus applyIncremental updateIpc
+        |> fun processTask -> processTask.GetAwaiter().GetResult()
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -278,6 +288,80 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only triggers remain pending when status update returns none`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "retry-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let updateGraceStatus _ _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(None)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "retry-delete.txt" |]
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterSuccess = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSuccess.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only triggers remain pending when status file read fails`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "read-failure-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let readStatusFile () = Task.FromException<GraceStatus>(InvalidOperationException("transient status read failure"))
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients readStatusFile updateGraceStatus
+
+            updateCalls |> should equal 0
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "read-failure-delete.txt" |])
+
+    [<Test>]
+    let ``rename-old status-only trigger remains pending when status update fails`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-status-only-name.txt")
+            let ignoredNewPath = Path.Combine(root, "new-status-only-name.gracetmp")
+
+            Watch.OnRenamed(renamedEvent oldPath ignoredNewPath)
+
+            let updateGraceStatus _ _ = Task.FromException<GraceStatus option>(InvalidOperationException("transient status update failure"))
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "old-status-only-name.txt" |]
+
+            afterFailure.FilesToProcess
             |> should equal Array.empty<string>)
 
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -382,6 +382,27 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``deleted directory queues status update when rename cached directory ignore`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-directory-name")
+            let directoryPath = Path.Combine(root, "cached-directory")
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            Watch.OnRenamed(renamedEvent oldPath directoryPath)
+            Watch.clearPendingWatchWorkForTests ()
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "cached-directory" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``duplicate deleted file events drain as one status update trigger`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "duplicate-delete.txt")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -418,6 +418,81 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``same-path change during upload remains queued for a newer upload`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "changed-during-upload.txt")
+            let mutable uploadCalls = 0
+            let mutable updateCalls = 0
+
+            File.WriteAllText(changedFilePath, "first payload")
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+
+                if uploadCalls = 1 then
+                    File.WriteAllText(changedFilePath, "second payload")
+                    Watch.OnChanged(changedEvent changedFilePath)
+
+                Task.FromResult(())
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(Some status)
+
+            let applyIncremental _ _ _ = Task.FromResult(())
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            updateCalls |> should equal 0
+
+            let afterFirstUpload = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFirstUpload.FilesToProcess
+            |> should equal [| changedFilePath |]
+
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 2
+            updateCalls |> should equal 1
+
+            let afterSecondUpload = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSecondUpload.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted file cancels same-path pending upload work before status rescan`` () =
+        withTempRepo (fun root ->
+            let deletedFilePath = Path.Combine(root, "queued-then-deleted.txt")
+
+            File.WriteAllText(deletedFilePath, "payload before delete")
+            Watch.OnChanged(changedEvent deletedFilePath)
+            File.Delete(deletedFilePath)
+            Watch.OnDeleted(deletedEvent deletedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "queued-then-deleted.txt" |]
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            updateCalls |> should equal 1
+            uploadCalls |> should equal 0)
+
+    [<Test>]
     let ``status-only triggers remain pending when status update returns none`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "retry-delete.txt")
@@ -447,6 +522,39 @@ module WatchTests =
 
             afterSuccess.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``status-only triggers remain pending when scan failure is swallowed as unchanged status`` () =
+        withTempRepo (fun root ->
+            let filePath = Path.Combine(root, "swallowed-scan-failure-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+                Services.setLastScanForDifferencesSuccessfulForWatchTests false
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.StatusUpdateTriggers
+            |> should
+                equal
+                [|
+                    "swallowed-scan-failure-delete.txt"
+                |]
+
+            Services.setLastScanForDifferencesSuccessfulForWatchTests true
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0)
 
     [<Test>]
     let ``status-only triggers added during status update remain pending for next pass`` () =
@@ -906,6 +1014,55 @@ module WatchTests =
 
             uploadCalls |> should equal 2
             updateCalls |> should equal 1)
+
+    [<Test>]
+    let ``renamed directory enumeration failure removes status-only trigger and stays in callback`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-enumeration-name")
+            let newPath = Path.Combine(root, "new-enumeration-name")
+            Directory.CreateDirectory(newPath) |> ignore
+
+            Watch.setEnumerateFilesForDirectoryUploadForWatchTests (fun _ -> raise (UnauthorizedAccessException("blocked enumeration")))
+
+            Assert.DoesNotThrow(Action(fun () -> Watch.OnRenamed(renamedEvent oldPath newPath)))
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``file event during status-only update keeps trigger pending for upload-first retry`` () =
+        withTempRepo (fun root ->
+            let deletedFilePath = Path.Combine(root, "delete-before-race.txt")
+            let createdFilePath = Path.Combine(root, "created-during-status-update.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent deletedFilePath)
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+
+                if updateCalls = 1 then
+                    File.WriteAllText(createdFilePath, "created during status-only rescan")
+                    Watch.OnChanged(changedEvent createdFilePath)
+
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterRace = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRace.StatusUpdateTriggers
+            |> should equal [| "delete-before-race.txt" |]
+
+            afterRace.FilesToProcess
+            |> should equal [| createdFilePath |])
 
     [<Test>]
     let ``startup deleted file difference queues status-only work without upload work`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -236,6 +236,69 @@ module WatchTests =
         File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, entries))
         resetConfiguration ()
 
+    let private localFileVersion relativePath =
+        LocalFileVersion.CreateWithHashes
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            false
+            1L
+            (getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    let private localDirectoryVersion relativePath directories files =
+        LocalDirectoryVersion.CreateWithHashes
+            (Guid.NewGuid())
+            OwnerId.Empty
+            OrganizationId.Empty
+            RepositoryId.Empty
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            directories
+            files
+            1L
+            DateTime.UtcNow
+
+    let private graceStatusTracking trackedFiles trackedDirectories =
+        let rootDirectoryId = Guid.NewGuid()
+        let index = GraceIndex()
+
+        let childDirectories =
+            trackedDirectories
+            |> Array.map (fun relativePath -> localDirectoryVersion relativePath (List<DirectoryVersionId>()) (List<LocalFileVersion>()))
+
+        let root =
+            LocalDirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "root-sha")
+                (Blake3Hash "root-blake3")
+                (List<DirectoryVersionId>(
+                    childDirectories
+                    |> Array.map (fun directory -> directory.DirectoryVersionId)
+                ))
+                (List<LocalFileVersion>(trackedFiles |> Array.map localFileVersion))
+                1L
+                DateTime.UtcNow
+
+        index.TryAdd(rootDirectoryId, root) |> ignore
+
+        for directory in childDirectories do
+            index.TryAdd(directory.DirectoryVersionId, directory)
+            |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
         let result = Watch.resolveSignalRAccessTokenResult (Ok(Some "token-value"))
@@ -448,6 +511,7 @@ module WatchTests =
 
             let directoryPath = Path.Combine(root, "archive.tmp")
             Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "archive.tmp" |])
             Directory.Delete(directoryPath)
 
             Watch.OnDeleted(deletedEvent directoryPath)
@@ -461,12 +525,31 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``deleted tracked directory ending gracetmp queues status update work`` () =
+        withTempRepo (fun root ->
+            let directoryPath = Path.Combine(root, "assets.gracetmp")
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "assets.gracetmp" |])
+            Directory.Delete(directoryPath)
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "assets.gracetmp" |]
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``deleted directory matching directory ignore does not queue status update work`` () =
         withTempRepo (fun root ->
             writeGraceIgnore root [| "archive.tmp/" |]
 
             let directoryPath = Path.Combine(root, "archive.tmp")
             Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setGraceStatusForWatchTests (graceStatusTracking Array.empty<string> [| "archive.tmp" |])
             Directory.Delete(directoryPath)
 
             Watch.OnDeleted(deletedEvent directoryPath)
@@ -475,6 +558,26 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``deleted tracked file matching directory-only ignore queues status update work`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let filePath = Path.Combine(root, "archive.tmp")
+            File.WriteAllText(filePath, "tracked file with directory-only ignored name")
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "archive.tmp" |] Array.empty<string>)
+            File.Delete(filePath)
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
 
             pending.FilesToProcess
             |> should equal Array.empty<string>)
@@ -515,6 +618,26 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal [| "old-name.txt" |]
+
+            pending.FilesToProcess
+            |> should equal [| newPath |])
+
+    [<Test>]
+    let ``renamed tracked file matching directory-only ignore queues old path status trigger`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "archive.tmp/" |]
+
+            let oldPath = Path.Combine(root, "archive.tmp")
+            let newPath = Path.Combine(root, "renamed.txt")
+            File.WriteAllText(newPath, "new rename target")
+            Watch.setGraceStatusForWatchTests (graceStatusTracking [| "archive.tmp" |] Array.empty<string>)
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "archive.tmp" |]
 
             pending.FilesToProcess
             |> should equal [| newPath |])

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -200,6 +200,8 @@ module WatchTests =
 
     let private deletedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
+    let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
+
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
 
@@ -363,6 +365,59 @@ module WatchTests =
             |> should equal Array.empty<string>)
 
     [<Test>]
+    let ``failed upload remains queued and blocks status-only rescan until upload succeeds`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "changed.txt")
+            let deletedFilePath = Path.Combine(root, "deleted-while-upload-pending.txt")
+            let mutable uploadCalls = 0
+            let mutable updateCalls = 0
+
+            File.WriteAllText(changedFilePath, "changed payload")
+            Watch.OnChanged(changedEvent changedFilePath)
+            Watch.OnDeleted(deletedEvent deletedFilePath)
+
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            let failingUpload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromException<unit>(InvalidOperationException("transient upload failure"))
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+                Task.FromResult(Some status)
+
+            let applyIncremental _ _ _ = Task.FromResult(())
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients readStatus readStatus failingUpload updateGraceStatus applyIncremental updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            updateCalls |> should equal 0
+
+            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFailure.FilesToProcess
+            |> should equal [| changedFilePath |]
+
+            afterFailure.StatusUpdateTriggers
+            |> should equal [| "deleted-while-upload-pending.txt" |]
+
+            let successCalls, successfulUploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            successfulUploadCalls |> should equal 1
+
+            let afterSuccess = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSuccess.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterSuccess.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
     let ``status-only triggers remain pending when status update returns none`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "retry-delete.txt")
@@ -417,6 +472,40 @@ module WatchTests =
 
             afterFirstPass.StatusUpdateTriggers
             |> should equal [| "during-update-delete.txt" |]
+
+            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+
+            successCalls |> should equal 1
+            uploadCalls |> should equal 0
+
+            let afterSecondPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterSecondPass.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    [<Test>]
+    let ``same status-only trigger added during status update remains pending for next pass`` () =
+        withTempRepo (fun root ->
+            let deletedPath = Path.Combine(root, "same-path-delete.txt")
+            let mutable updateCalls = 0
+
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            let updateGraceStatus status _ =
+                updateCalls <- updateCalls + 1
+
+                if updateCalls = 1 then Watch.OnDeleted(deletedEvent deletedPath)
+
+                Task.FromResult(Some status)
+
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+
+            updateCalls |> should equal 1
+
+            let afterFirstPass = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterFirstPass.StatusUpdateTriggers
+            |> should equal [| "same-path-delete.txt" |]
 
             let successCalls, uploadCalls = processPendingWatchWorkForTest ()
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1663,6 +1663,120 @@ module Services =
                     processChangedDirectoriesBottomUp newGraceStatus changedDirectoryVersions newDirectoryVersions
                 | None -> ()
 
+    let private normalizeDirectoryDifferencePath (relativePath: RelativePath) =
+        let normalized = normalizeFilePath $"{relativePath}"
+
+        if normalized = Constants.RootDirectoryPath then
+            Constants.RootDirectoryPath
+        else
+            normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+    let private isDirectoryPathInSubtree (subtreeRoot: RelativePath) (candidate: RelativePath) =
+        let normalizedSubtreeRoot = normalizeDirectoryDifferencePath subtreeRoot
+        let normalizedCandidate = normalizeDirectoryDifferencePath candidate
+
+        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.OrdinalIgnoreCase)
+        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.OrdinalIgnoreCase)
+
+    let private selectTopLevelDeletedDirectories (differences: IEnumerable<FileSystemDifference>) =
+        let topLevelDeletedDirectories = List<RelativePath>()
+
+        let deletedDirectories =
+            differences
+                .Where(fun difference ->
+                    isDirectoryChange difference
+                    && difference.DifferenceType = Delete)
+                .Select(fun difference -> normalizeDirectoryDifferencePath difference.RelativePath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(fun relativePath -> countSegments relativePath)
+
+        for deletedDirectory in deletedDirectories do
+            let ancestorAlreadyDeleted =
+                topLevelDeletedDirectories
+                |> Seq.exists (fun existingDeletedDirectory ->
+                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.OrdinalIgnoreCase))
+                    && isDirectoryPathInSubtree existingDeletedDirectory deletedDirectory)
+
+            if not ancestorAlreadyDeleted then
+                topLevelDeletedDirectories.Add(deletedDirectory)
+
+        topLevelDeletedDirectories
+
+    let private tryFindSurvivingDirectoryVersion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        let mutable changedDirectoryVersion = LocalDirectoryVersion.Default
+
+        if changedDirectoryVersions.TryGetValue(relativePath, &changedDirectoryVersion) then
+            Some changedDirectoryVersion
+        else
+            let directoryVersion = newGraceStatus.Index.Values.FirstOrDefault((fun dv -> dv.RelativePath = relativePath), LocalDirectoryVersion.Default)
+
+            if directoryVersion.DirectoryVersionId <> Guid.Empty then
+                Some directoryVersion
+            else
+                None
+
+    let rec private tryFindNearestSurvivingParentDirectoryVersion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        match getParentPath relativePath with
+        | None -> None
+        | Some parentPath ->
+            match tryFindSurvivingDirectoryVersion changedDirectoryVersions newGraceStatus parentPath with
+            | Some parentDirectoryVersion -> Some parentDirectoryVersion
+            | None -> tryFindNearestSurvivingParentDirectoryVersion changedDirectoryVersions newGraceStatus parentPath
+
+    let private processDirectoryDeletion
+        (changedDirectoryVersions: ConcurrentDictionary<RelativePath, LocalDirectoryVersion>)
+        (newGraceStatus: GraceStatus)
+        (relativePath: RelativePath)
+        =
+
+        if relativePath = Constants.RootDirectoryPath then
+            ()
+        else
+            let deletedDirectoryVersions =
+                newGraceStatus
+                    .Index
+                    .Values
+                    .Where(fun dv -> isDirectoryPathInSubtree relativePath dv.RelativePath)
+                    .ToList()
+
+            let deletedDirectoryVersion = deletedDirectoryVersions.FirstOrDefault((fun dv -> dv.RelativePath = relativePath), LocalDirectoryVersion.Default)
+
+            if deletedDirectoryVersion.DirectoryVersionId
+               <> Guid.Empty then
+                for deletedDirectoryVersion in deletedDirectoryVersions do
+                    let mutable removedDirectoryVersion = LocalDirectoryVersion.Default
+
+                    newGraceStatus.Index.TryRemove(deletedDirectoryVersion.DirectoryVersionId, &removedDirectoryVersion)
+                    |> ignore
+
+                    let mutable changedRemovedDirectoryVersion = LocalDirectoryVersion.Default
+
+                    changedDirectoryVersions.TryRemove(deletedDirectoryVersion.RelativePath, &changedRemovedDirectoryVersion)
+                    |> ignore
+
+                match tryFindNearestSurvivingParentDirectoryVersion changedDirectoryVersions newGraceStatus relativePath with
+                | Some parentDirectoryVersion ->
+                    parentDirectoryVersion.Directories.Remove(deletedDirectoryVersion.DirectoryVersionId)
+                    |> ignore
+
+                    changedDirectoryVersions.AddOrUpdate(
+                        parentDirectoryVersion.RelativePath,
+                        (fun _ -> parentDirectoryVersion),
+                        (fun _ _ -> parentDirectoryVersion)
+                    )
+                    |> ignore
+                | None -> ()
+
     /// Main refactored function
     let getNewGraceStatusAndDirectoryVersions (previousGraceStatus: GraceStatus) (differences: IEnumerable<FileSystemDifference>) =
         task {
@@ -1703,11 +1817,10 @@ module Services =
                             changedDirectoryVersions.AddOrUpdate(difference.RelativePath, (fun _ -> newDirectoryVersion), (fun _ _ -> newDirectoryVersion))
                             |> ignore
                     | None -> ()
-                | Delete ->
-                    let mutable directoryVersion = newGraceStatus.Index.Values.First(fun dv -> dv.RelativePath = difference.RelativePath)
+                | Delete -> ()
 
-                    newGraceStatus.Index.TryRemove(directoryVersion.DirectoryVersionId, &directoryVersion)
-                    |> ignore
+            for deletedDirectory in selectTopLevelDeletedDirectories differences do
+                processDirectoryDeletion changedDirectoryVersions newGraceStatus deletedDirectory
 
             // Process file changes (Add/Change/Delete)
             for difference in differences.Where(fun d -> isFileChange d) do

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -535,6 +535,12 @@ module Services =
 
     let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
 
+    let mutable private lastScanForDifferencesSucceeded = true
+
+    let internal wasLastScanForDifferencesSuccessful () = lastScanForDifferencesSucceeded
+
+    let internal setLastScanForDifferencesSuccessfulForWatchTests succeeded = lastScanForDifferencesSucceeded <- succeeded
+
     let internal clearWorkingDirectoryWriteTimesForWatchRescan () = localWriteTimes.Clear()
 
     /// Gets a dictionary of local paths and their last write times.
@@ -688,9 +694,11 @@ module Services =
 
                         differences.Push(FileSystemDifference.Create Delete fileSystemEntryType relativePath)
 
+                lastScanForDifferencesSucceeded <- true
                 return differences.ToList()
             with
             | ex ->
+                lastScanForDifferencesSucceeded <- false
                 logToAnsiConsole Colors.Error $"{ExceptionResponse.Create ex}"
                 return List<FileSystemDifference>()
         }

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -535,6 +535,8 @@ module Services =
 
     let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
 
+    let internal clearWorkingDirectoryWriteTimesForWatchRescan () = localWriteTimes.Clear()
+
     /// Gets a dictionary of local paths and their last write times.
     let rec getWorkingDirectoryWriteTimes (directoryInfo: DirectoryInfo) =
         if shouldNotIgnoreDirectory directoryInfo.FullName then

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1675,8 +1675,8 @@ module Services =
         let normalizedSubtreeRoot = normalizeDirectoryDifferencePath subtreeRoot
         let normalizedCandidate = normalizeDirectoryDifferencePath candidate
 
-        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.OrdinalIgnoreCase)
-        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.OrdinalIgnoreCase)
+        normalizedCandidate.Equals(normalizedSubtreeRoot, StringComparison.Ordinal)
+        || normalizedCandidate.StartsWith($"{normalizedSubtreeRoot}/", StringComparison.Ordinal)
 
     let private selectTopLevelDeletedDirectories (differences: IEnumerable<FileSystemDifference>) =
         let topLevelDeletedDirectories = List<RelativePath>()
@@ -1687,14 +1687,14 @@ module Services =
                     isDirectoryChange difference
                     && difference.DifferenceType = Delete)
                 .Select(fun difference -> normalizeDirectoryDifferencePath difference.RelativePath)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Distinct(StringComparer.Ordinal)
                 .OrderBy(fun relativePath -> countSegments relativePath)
 
         for deletedDirectory in deletedDirectories do
             let ancestorAlreadyDeleted =
                 topLevelDeletedDirectories
                 |> Seq.exists (fun existingDeletedDirectory ->
-                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.OrdinalIgnoreCase))
+                    not (existingDeletedDirectory.Equals(deletedDirectory, StringComparison.Ordinal))
                     && isDirectoryPathInSubtree existingDeletedDirectory deletedDirectory)
 
             if not ancestorAlreadyDeleted then

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -160,6 +160,11 @@ module Watch =
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     let updateNotInProgress () = not <| updateInProgress ()
 
+    type private DeletedPathKind =
+        | DeletedFile
+        | DeletedDirectory
+        | DeletedPathKindUnknown
+
     let private repositoryRelativePath (fullPath: string) =
         let rootDirectory =
             Current().RootDirectory
@@ -181,7 +186,43 @@ module Watch =
             else
                 None
 
-    let private shouldIgnoreDeletedPath (fullPath: string) =
+    let private normalizeRelativePath (relativePath: RelativePath) =
+        $"{relativePath}"
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/')
+
+    let private trackedDeletedPathKind (status: GraceStatus) (relativePath: string) =
+        let deletedRelativePath = normalizeRelativePath relativePath
+
+        let isTrackedFile =
+            status.Index.Values
+            |> Seq.exists (fun directoryVersion ->
+                directoryVersion.Files
+                |> Seq.exists (fun fileVersion ->
+                    String.Equals(normalizeRelativePath fileVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase)))
+
+        let isTrackedDirectory =
+            status.Index.Values
+            |> Seq.exists (fun directoryVersion ->
+                String.Equals(normalizeRelativePath directoryVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase))
+
+        match isTrackedFile, isTrackedDirectory with
+        | true, _ -> DeletedFile
+        | false, true -> DeletedDirectory
+        | false, false -> DeletedPathKindUnknown
+
+    let private readTrackedDeletedPathKind (relativePath: string) =
+        try
+            if graceStatus.Index.Count > 0 then
+                trackedDeletedPathKind graceStatus relativePath
+            else
+                trackedDeletedPathKind (readGraceStatusFile().GetAwaiter().GetResult()) relativePath
+        with
+        | _ -> DeletedPathKindUnknown
+
+    let internal setGraceStatusForWatchTests status = graceStatus <- status
+
+    let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
         let normalizedFullPath = Path.GetFullPath(fullPath)
         let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
@@ -207,17 +248,23 @@ module Watch =
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
         || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
-        || normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase)
+        || (pathKind <> DeletedDirectory
+            && normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase))
         || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists directoryIgnoreMatches
-        || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine)
-        || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+        || (pathKind <> DeletedFile
+            && configuration.GraceDirectoryIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
+        || (pathKind <> DeletedDirectory
+            && configuration.GraceDirectoryIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
 
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with
-        | Some relativePath when not <| shouldIgnoreDeletedPath fullPath ->
+        | Some relativePath when
+            not
+            <| shouldIgnoreDeletedPath (readTrackedDeletedPathKind relativePath) fullPath
+            ->
             statusUpdateTriggers.TryAdd(relativePath, ())
             |> ignore
 
@@ -228,6 +275,7 @@ module Watch =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
+        graceStatus <- GraceStatus.Default
 
     let internal pendingWatchWorkSnapshotForTests () =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -181,9 +181,42 @@ module Watch =
             else
                 None
 
+    let private shouldIgnoreDeletedPath (fullPath: string) =
+        let configuration = Current()
+        let normalizedFullPath = Path.GetFullPath(fullPath)
+        let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
+        let fileInfo = FileInfo(fullPath)
+
+        let isInGraceDirectory =
+            normalizedFullPath.Equals(graceDirectory, StringComparison.InvariantCultureIgnoreCase)
+            || normalizedFullPath.StartsWith(
+                graceDirectory
+                + string Path.DirectorySeparatorChar,
+                StringComparison.InvariantCultureIgnoreCase
+            )
+
+        let directoryIgnoreMatches graceIgnoreLine =
+            if isNull fileInfo.Directory then
+                false
+            else
+                checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine
+
+        isInGraceDirectory
+        || normalizedFullPath.Equals(configuration.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
+        || normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase)
+        || configuration.GraceDirectoryIgnoreEntries
+           |> Array.exists directoryIgnoreMatches
+        || configuration.GraceDirectoryIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+        || configuration.GraceFileIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
+
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with
-        | Some relativePath when not <| shouldIgnoreFile fullPath ->
+        | Some relativePath when not <| shouldIgnoreDeletedPath fullPath ->
             statusUpdateTriggers.TryAdd(relativePath, ())
             |> ignore
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -271,8 +271,9 @@ module Watch =
 
             (pathKind <> DeletedDirectory
              && normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase))
-            || configuration.GraceDirectoryIgnoreEntries
-               |> Array.exists directoryIgnoreMatches
+            || (pathKind = DeletedPathKindUnknown
+                && configuration.GraceDirectoryIgnoreEntries
+                   |> Array.exists directoryIgnoreMatches)
             || (pathKind <> DeletedFile
                 && configuration.GraceDirectoryIgnoreEntries
                    |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
@@ -429,6 +430,23 @@ module Watch =
                 graceStatusHasChanged <- true
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
+    let private enqueueFileUpload fullPath =
+        let shouldIgnore = shouldIgnoreFile fullPath
+
+        if not shouldIgnore then
+            filesToProcess.TryAdd(fullPath, ()) |> ignore
+            true
+        else
+            false
+
+    let private enqueueDirectoryContentsForUpload directoryPath =
+        if
+            Directory.Exists(directoryPath)
+            && shouldNotIgnoreDirectory directoryPath
+        then
+            for filePath in Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories) do
+                enqueueFileUpload filePath |> ignore
+
     let OnDeleted (args: FileSystemEventArgs) =
         if updateNotInProgress () then
             if enqueueStatusUpdateTrigger args.FullPath then
@@ -440,14 +458,15 @@ module Watch =
 
     let OnRenamed (args: RenamedEventArgs) =
         if updateNotInProgress () then
-            let shouldIgnoreNewFile = shouldIgnoreFile args.FullPath
+            let newPathIsDirectory = Directory.Exists(args.FullPath)
 
             if enqueueStatusUpdateTrigger args.OldFullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
-            if not <| shouldIgnoreNewFile then
+            if newPathIsDirectory then
+                enqueueDirectoryContentsForUpload args.FullPath
+            elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                filesToProcess.TryAdd(args.FullPath, ()) |> ignore
 
     let OnError (args: ErrorEventArgs) =
         let correlationId = generateCorrelationId ()
@@ -792,6 +811,18 @@ module Watch =
             applyGraceStatusIncremental
             updateGraceWatchInterprocessFile
 
+    let internal queueStartupDifferenceForWatch difference =
+        match difference.FileSystemEntryType, difference.DifferenceType with
+        | Directory, _ ->
+            directoriesToProcess.TryAdd(difference.RelativePath, ())
+            |> ignore
+        | File, Delete ->
+            statusUpdateTriggers.TryAdd(difference.RelativePath, ())
+            |> ignore
+        | File, _ ->
+            filesToProcess.TryAdd(difference.RelativePath, ())
+            |> ignore
+
     type Watch() =
         inherit AsynchronousCommandLineAction()
 
@@ -1043,13 +1074,7 @@ module Watch =
                         logToAnsiConsole Colors.Verbose $"Found {differences.Count} differences."
 
                     for difference in differences do
-                        match difference.FileSystemEntryType with
-                        | Directory ->
-                            directoriesToProcess.TryAdd(difference.RelativePath, ())
-                            |> ignore
-                        | File ->
-                            filesToProcess.TryAdd(difference.RelativePath, ())
-                            |> ignore
+                        queueStartupDifferenceForWatch difference
 
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -136,11 +136,15 @@ module Watch =
     /// Note: We're using ConcurrentDictionary because it's safe for multithreading, doesn't allow us to insert the same key twice, and for its algorithms. We're not using the values of the ConcurrentDictionary here, only the keys.
     let private directoriesToProcess = ConcurrentDictionary<string, unit>()
 
+    type private StatusUpdateTriggerSnapshot = { RelativePath: string; Generation: int64 }
+
     /// Holds a list of repo-relative paths that should trigger a Grace Status scan without uploading file content.
     ///
     /// FileSystemWatcher delete and rename-old events do not have durable file content to upload. They only need to
     /// wake the timer loop so updateGraceStatus can run scanForDifferences against the current working tree.
-    let private statusUpdateTriggers = ConcurrentDictionary<string, unit>()
+    let mutable private statusUpdateTriggerGeneration = 0L
+
+    let private statusUpdateTriggers = ConcurrentDictionary<string, int64>()
 
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
 
@@ -290,7 +294,9 @@ module Watch =
             not
             <| shouldIgnoreDeletedPath (readTrackedDeletedPathKind relativePath) fullPath
             ->
-            statusUpdateTriggers.TryAdd(relativePath, ())
+            let generation = Interlocked.Increment(&statusUpdateTriggerGeneration)
+
+            statusUpdateTriggers.AddOrUpdate(relativePath, generation, (fun _ _ -> generation))
             |> ignore
 
             true
@@ -300,6 +306,10 @@ module Watch =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
+
+        Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
+        |> ignore
+
         graceStatus <- GraceStatus.Default
         graceStatusHasChanged <- false
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
@@ -318,14 +328,19 @@ module Watch =
             && statusUpdateTriggers.IsEmpty
         )
 
-    let private statusOnlyTriggerSnapshot () = directoriesToProcess.Keys.ToArray(), statusUpdateTriggers.Keys.ToArray()
+    let private statusOnlyTriggerSnapshot () =
+        directoriesToProcess.Keys.ToArray(),
+        statusUpdateTriggers
+            .ToArray()
+            .Select(fun trigger -> { RelativePath = trigger.Key; Generation = trigger.Value })
+            .ToArray()
 
-    let private resetWorkingTreeScanCacheForStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
+    let private resetWorkingTreeScanCacheForStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
         if directorySnapshot.Length > 0
            || statusTriggerSnapshot.Length > 0 then
             clearWorkingDirectoryWriteTimesForWatchRescan ()
 
-    let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
+    let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
         let mutable unitValue = ()
 
         for directory in directorySnapshot do
@@ -333,7 +348,10 @@ module Watch =
             |> ignore
 
         for statusTrigger in statusTriggerSnapshot do
-            statusUpdateTriggers.TryRemove(statusTrigger, &unitValue)
+            let pair = KeyValuePair(statusTrigger.RelativePath, statusTrigger.Generation)
+
+            (statusUpdateTriggers :> ICollection<KeyValuePair<string, int64>>)
+                .Remove(pair)
             |> ignore
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
@@ -755,9 +773,13 @@ module Watch =
                         )
 
                     for fileName in filesToProcess.Keys.Take(50) do
-                        if filesToProcess.TryRemove(fileName, &unitValue) then
+                        if filesToProcess.ContainsKey(fileName) then
                             logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
                             do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath fileName)
+
+                            filesToProcess.TryRemove(fileName, &unitValue)
+                            |> ignore
+
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
@@ -817,7 +839,9 @@ module Watch =
             directoriesToProcess.TryAdd(difference.RelativePath, ())
             |> ignore
         | File, Delete ->
-            statusUpdateTriggers.TryAdd(difference.RelativePath, ())
+            let generation = Interlocked.Increment(&statusUpdateTriggerGeneration)
+
+            statusUpdateTriggers.AddOrUpdate(difference.RelativePath, generation, (fun _ _ -> generation))
             |> ignore
         | File, _ ->
             filesToProcess.TryAdd(difference.RelativePath, ())

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -274,7 +274,7 @@ module Watch =
             || (pathKind = DeletedPathKindUnknown
                 && configuration.GraceDirectoryIgnoreEntries
                    |> Array.exists directoryIgnoreMatches)
-            || (pathKind <> DeletedFile
+            || (pathKind = DeletedPathKindUnknown
                 && configuration.GraceDirectoryIgnoreEntries
                    |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
             || (pathKind <> DeletedDirectory

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -186,6 +186,7 @@ module Watch =
         let normalizedFullPath = Path.GetFullPath(fullPath)
         let graceDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(configuration.GraceDirectory))
         let fileInfo = FileInfo(fullPath)
+        let deletedDirectoryInfo = DirectoryInfo(normalizedFullPath)
 
         let isInGraceDirectory =
             normalizedFullPath.Equals(graceDirectory, StringComparison.InvariantCultureIgnoreCase)
@@ -210,8 +211,8 @@ module Watch =
         || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists directoryIgnoreMatches
         || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
-        || configuration.GraceFileIgnoreEntries
+           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine)
+        || configuration.GraceDirectoryIgnoreEntries
            |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine)
 
     let private enqueueStatusUpdateTrigger fullPath =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -627,12 +627,13 @@ module Watch =
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
-                        drainStatusOnlyTriggers ()
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
-                        | Some newGraceStatus -> graceStatus <- newGraceStatus
+                        | Some newGraceStatus ->
+                            graceStatus <- newGraceStatus
+                            drainStatusOnlyTriggers ()
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -242,9 +242,18 @@ module Watch =
             && statusUpdateTriggers.IsEmpty
         )
 
-    let private drainStatusOnlyTriggers () =
-        directoriesToProcess.Clear()
-        statusUpdateTriggers.Clear()
+    let private statusOnlyTriggerSnapshot () = directoriesToProcess.Keys.ToArray(), statusUpdateTriggers.Keys.ToArray()
+
+    let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
+        let mutable unitValue = ()
+
+        for directory in directorySnapshot do
+            directoriesToProcess.TryRemove(directory, &unitValue)
+            |> ignore
+
+        for statusTrigger in statusTriggerSnapshot do
+            statusUpdateTriggers.TryRemove(statusTrigger, &unitValue)
+            |> ignore
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
@@ -660,13 +669,14 @@ module Watch =
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
+                        let directorySnapshot, statusTriggerSnapshot = statusOnlyTriggerSnapshot ()
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus ->
                             graceStatus <- newGraceStatus
-                            drainStatusOnlyTriggers ()
+                            drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -126,10 +126,15 @@ module Watch =
 
     let isCheckRequested (parseResult: ParseResult) = parseResult.GetValue(Options.check)
 
+    type private PendingFileWorkSnapshot = { FullPath: string; Generation: int64 }
+
     /// Holds a list of the created or changed files that we need to process, as determined by the FileSystemWatcher.
     ///
-    /// Note: We're using ConcurrentDictionary because it's safe for multithreading, doesn't allow us to insert the same key twice, and for its algorithms. We're not using the values of the ConcurrentDictionary here, only the keys.
-    let private filesToProcess = ConcurrentDictionary<string, unit>()
+    /// The generation lets a same-path change observed during an upload remain queued after the upload removes only
+    /// the snapshot it processed.
+    let private filesToProcess = ConcurrentDictionary<string, int64>()
+
+    let mutable private fileUploadWorkGeneration = 0L
 
     /// Holds a list of the created or changed directories that we need to process, as determined by the FileSystemWatcher.
     ///
@@ -218,6 +223,8 @@ module Watch =
 
     let mutable private readGraceStatusFileForDeletedPathClassification = readGraceStatusFile
 
+    let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
+
     let private readTrackedDeletedPathKind (relativePath: string) =
         try
             let status =
@@ -240,6 +247,7 @@ module Watch =
     let internal setGraceStatusForWatchTests status = graceStatus <- status
     let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
     let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
+    let internal setEnumerateFilesForDirectoryUploadForWatchTests enumerateFiles = enumerateFilesForDirectoryUpload <- enumerateFiles
 
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -302,6 +310,68 @@ module Watch =
             true
         | _ -> false
 
+    let private removeStatusUpdateTrigger fullPath =
+        match repositoryRelativePath fullPath with
+        | Some relativePath ->
+            let mutable generation = 0L
+
+            statusUpdateTriggers.TryRemove(relativePath, &generation)
+            |> ignore
+        | _ -> ()
+
+    let private enqueueFileUpload fullPath =
+        let shouldIgnore = shouldIgnoreFile fullPath
+
+        if not shouldIgnore then
+            let generation = Interlocked.Increment(&fileUploadWorkGeneration)
+
+            filesToProcess.AddOrUpdate(fullPath, generation, (fun _ _ -> generation))
+            |> ignore
+
+            true
+        else
+            false
+
+    let private removePendingFileUpload filePath =
+        let mutable generation = 0L
+
+        filesToProcess.TryRemove(filePath, &generation)
+        |> ignore
+
+    let private cancelPendingUploadsForDeletedPath fullPath =
+        removePendingFileUpload fullPath
+
+        match repositoryRelativePath fullPath with
+        | Some relativePath -> removePendingFileUpload relativePath
+        | None -> ()
+
+        let normalizedFullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(fullPath))
+
+        let fullPathPrefix =
+            normalizedFullPath
+            + string Path.DirectorySeparatorChar
+
+        let relativePathPrefix =
+            match repositoryRelativePath fullPath with
+            | Some relativePath -> Some(relativePath.TrimEnd('/') + "/")
+            | None -> None
+
+        for queuedFile in filesToProcess.Keys.ToArray() do
+            let removeQueuedFile =
+                let normalizedQueuedFile =
+                    try
+                        Path.GetFullPath(queuedFile)
+                    with
+                    | _ -> queuedFile
+
+                normalizedQueuedFile.Equals(normalizedFullPath, StringComparison.InvariantCultureIgnoreCase)
+                || normalizedQueuedFile.StartsWith(fullPathPrefix, StringComparison.InvariantCultureIgnoreCase)
+                || (match relativePathPrefix with
+                    | Some prefix -> queuedFile.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
+                    | None -> false)
+
+            if removeQueuedFile then removePendingFileUpload queuedFile
+
     let internal clearPendingWatchWorkForTests () =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
@@ -310,9 +380,14 @@ module Watch =
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
         |> ignore
 
+        Interlocked.Exchange(&fileUploadWorkGeneration, 0L)
+        |> ignore
+
         graceStatus <- GraceStatus.Default
         graceStatusHasChanged <- false
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
+        enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
+        setLastScanForDifferencesSuccessfulForWatchTests true
 
     let internal pendingWatchWorkSnapshotForTests () =
         {
@@ -425,7 +500,7 @@ module Watch =
 
             if not <| shouldIgnore then
                 logToAnsiConsole Colors.Added $"I saw that {args.FullPath} was created."
-                filesToProcess.TryAdd(args.FullPath, ()) |> ignore
+                enqueueFileUpload args.FullPath |> ignore
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -439,7 +514,7 @@ module Watch =
 
             if not <| shouldIgnore then
                 logToAnsiConsole Colors.Changed $"I saw that {args.FullPath} changed."
-                filesToProcess.TryAdd(args.FullPath, ()) |> ignore
+                enqueueFileUpload args.FullPath |> ignore
 
             // Special handling for the Grace status file; if that is the changed file, we'll set this flag so we reload it in OnWatch() in the main loop
             if (isGraceStatusArtifact args.FullPath)
@@ -448,25 +523,30 @@ module Watch =
                 graceStatusHasChanged <- true
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
-    let private enqueueFileUpload fullPath =
-        let shouldIgnore = shouldIgnoreFile fullPath
-
-        if not shouldIgnore then
-            filesToProcess.TryAdd(fullPath, ()) |> ignore
-            true
-        else
-            false
-
     let private enqueueDirectoryContentsForUpload directoryPath =
         if
             Directory.Exists(directoryPath)
             && shouldNotIgnoreDirectory directoryPath
         then
-            for filePath in Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories) do
-                enqueueFileUpload filePath |> ignore
+            try
+                for filePath in enumerateFilesForDirectoryUpload directoryPath do
+                    enqueueFileUpload filePath |> ignore
+
+                true
+            with
+            | ex ->
+                logToAnsiConsole
+                    Colors.Error
+                    $"Unable to enumerate renamed directory {directoryPath}; status update will retry after file uploads can be queued. {Markup.Escape(ex.Message)}"
+
+                false
+        else
+            true
 
     let OnDeleted (args: FileSystemEventArgs) =
         if updateNotInProgress () then
+            cancelPendingUploadsForDeletedPath args.FullPath
+
             if enqueueStatusUpdateTrigger args.FullPath then
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
 
@@ -478,11 +558,14 @@ module Watch =
         if updateNotInProgress () then
             let newPathIsDirectory = Directory.Exists(args.FullPath)
 
-            if enqueueStatusUpdateTrigger args.OldFullPath then
+            let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
+
+            if oldPathStatusQueued then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
             if newPathIsDirectory then
-                enqueueDirectoryContentsForUpload args.FullPath
+                if not (enqueueDirectoryContentsForUpload args.FullPath) then
+                    removeStatusUpdateTrigger args.OldFullPath
             elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
@@ -558,85 +641,124 @@ module Watch =
                 |> Seq.filter (fun fileVersion -> fileIdentities.Contains(uploadedFileVersionIdentity fileVersion))
                 |> Seq.toArray
 
-            let! savedDirectoryVersionsResult = getSavedDirectoryVersionsForRootDirectory graceStatus.RootDirectoryId correlationId
+            let uploadedFileVersionIdentities =
+                directoryUploadedFileVersions
+                |> Seq.map uploadedFileVersionIdentity
+                |> HashSet
 
-            match savedDirectoryVersionsResult with
-            | Error error ->
-                logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
-                return None
-            | Ok savedDirectoryVersions ->
-                // Upload the new directory versions.
-                let directoryVersionsToSave =
-                    applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
-                        directoryUploadedFileVersions
-                        savedDirectoryVersions
-                        newDirectoryVersions
+            let newFileVersionsByPath = Dictionary<RelativePath, LocalFileVersion>()
 
-                let! result = saveDirectoryVersions directoryVersionsToSave correlationId
+            for directoryVersion in newDirectoryVersions do
+                for fileVersion in directoryVersion.Files do
+                    newFileVersionsByPath[fileVersion.RelativePath] <- fileVersion
 
-                match result with
-                | Ok returnValue ->
-                    let newGraceStatus = syncGraceStatusRootDirectoryHash newGraceStatus
+            let unuploadedFileDifferences =
+                differences
+                    .Where(fun diff ->
+                        diff.FileSystemEntryType = FileSystemEntryType.File
+                        && (diff.DifferenceType = DifferenceType.Add
+                            || diff.DifferenceType = DifferenceType.Change))
+                    .Where(fun diff ->
+                        let mutable fileVersion = Unchecked.defaultof<LocalFileVersion>
 
-                    do! updateObjectCacheFile newDirectoryVersions
-
-                    let fileDifferences =
-                        differences
-                            .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
-                            .ToList()
-
-                    let message =
-                        if fileDifferences |> Seq.isEmpty then
-                            String.Empty
+                        if newFileVersionsByPath.TryGetValue(diff.RelativePath, &fileVersion) then
+                            not
+                            <| uploadedFileVersionIdentities.Contains((fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash))
                         else
-                            let sb = stringBuilderPool.Get()
+                            true)
+                    .ToList()
 
-                            try
-                                for fileDifference in fileDifferences do
-                                    //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
-                                    match fileDifference.DifferenceType with
-                                    | Change ->
-                                        sb.AppendLine($"{fileDifference.RelativePath}")
-                                        |> ignore
-                                    | Add ->
-                                        sb.AppendLine($"Add {fileDifference.RelativePath}")
-                                        |> ignore
-                                    | Delete ->
-                                        sb.AppendLine($"Delete {fileDifference.RelativePath}")
-                                        |> ignore
+            if unuploadedFileDifferences.Count > 0 then
+                for fileDifference in unuploadedFileDifferences do
+                    let fullPath = Path.Combine(Current().RootDirectory, string fileDifference.RelativePath)
 
-                                let saveMessage = sb.ToString()
-                                saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
-                            finally
-                                stringBuilderPool.Return(sb)
+                    enqueueFileUpload fullPath |> ignore
 
-                    // If there are changes either to files or just to directories, create a save reference.
-                    if (differences.Count > 0) then
-                        match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
-                        | Ok returnValue ->
-                            let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
-                            // Apply incremental changes to the Grace Status DB.
-                            do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+                logToAnsiConsole
+                    Colors.Important
+                    $"Grace Status update found {unuploadedFileDifferences.Count} file add/change differences without uploaded file content; file uploads will run before retrying the status update."
 
-                            for fileVersion in directoryUploadedFileVersions do
-                                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+                return None
+            else
+                let! savedDirectoryVersionsResult = getSavedDirectoryVersionsForRootDirectory graceStatus.RootDirectoryId correlationId
 
-                                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
-                                |> ignore
-
-                            //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
-                            graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
-                            return Some newGraceStatusWithUpdatedTime
-                        | Error error ->
-                            logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
-                            return None
-                    else
-                        // There were no changes to process, so just return the existing GraceStatus.
-                        //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
-                        return Some graceStatus
+                match savedDirectoryVersionsResult with
                 | Error error ->
                     logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
                     return None
+                | Ok savedDirectoryVersions ->
+                    // Upload the new directory versions.
+                    let directoryVersionsToSave =
+                        applyUploadedFileVersionsToDirectoryVersionsWithSavedDirectoryVersions
+                            directoryUploadedFileVersions
+                            savedDirectoryVersions
+                            newDirectoryVersions
+
+                    let! result = saveDirectoryVersions directoryVersionsToSave correlationId
+
+                    match result with
+                    | Ok returnValue ->
+                        let newGraceStatus = syncGraceStatusRootDirectoryHash newGraceStatus
+
+                        do! updateObjectCacheFile newDirectoryVersions
+
+                        let fileDifferences =
+                            differences
+                                .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
+                                .ToList()
+
+                        let message =
+                            if fileDifferences |> Seq.isEmpty then
+                                String.Empty
+                            else
+                                let sb = stringBuilderPool.Get()
+
+                                try
+                                    for fileDifference in fileDifferences do
+                                        //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
+                                        match fileDifference.DifferenceType with
+                                        | Change ->
+                                            sb.AppendLine($"{fileDifference.RelativePath}")
+                                            |> ignore
+                                        | Add ->
+                                            sb.AppendLine($"Add {fileDifference.RelativePath}")
+                                            |> ignore
+                                        | Delete ->
+                                            sb.AppendLine($"Delete {fileDifference.RelativePath}")
+                                            |> ignore
+
+                                    let saveMessage = sb.ToString()
+                                    saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
+                                finally
+                                    stringBuilderPool.Return(sb)
+
+                        // If there are changes either to files or just to directories, create a save reference.
+                        if (differences.Count > 0) then
+                            match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
+                            | Ok returnValue ->
+                                let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
+                                // Apply incremental changes to the Grace Status DB.
+                                do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+
+                                for fileVersion in directoryUploadedFileVersions do
+                                    let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                                    uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
+                                    |> ignore
+
+                                //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
+                                graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
+                                return Some newGraceStatusWithUpdatedTime
+                            | Error error ->
+                                logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
+                                return None
+                        else
+                            // There were no changes to process, so just return the existing GraceStatus.
+                            //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
+                            return Some graceStatus
+                    | Error error ->
+                        logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
+                        return None
         }
 
     let private getCachedFileVersionForUploadSkip (fullPath: FilePath) =
@@ -758,9 +880,6 @@ module Watch =
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
 
-                    /// This is just a way to throw away the unit value from the ConcurrentDictionary.
-                    let mutable unitValue = ()
-
                     // Loop through no more than 50 files. Copy them to the objects directory, and upload them to storage.
                     //   In the incredibly rare event that more than 50 files have changed, we'll get 50-per-timer-tick,
                     //   and clear the queue quickly without overwhelming the system.
@@ -772,12 +891,20 @@ module Watch =
                             CorrelationId = correlationId
                         )
 
-                    for fileName in filesToProcess.Keys.Take(50) do
-                        if filesToProcess.ContainsKey(fileName) then
-                            logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
-                            do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath fileName)
+                    for pendingFile in
+                        filesToProcess
+                            .ToArray()
+                            .Take(50)
+                            .Select(fun entry -> { FullPath = entry.Key; Generation = entry.Value }) do
+                        let pendingPair = KeyValuePair(pendingFile.FullPath, pendingFile.Generation)
 
-                            filesToProcess.TryRemove(fileName, &unitValue)
+                        if (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
+                            .Contains(pendingPair) then
+                            logToAnsiConsole Colors.Verbose $"Processing {pendingFile.FullPath}. filesToProcess.Count: {filesToProcess.Count}."
+                            do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath pendingFile.FullPath)
+
+                            (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
+                                .Remove(pendingPair)
                             |> ignore
 
                             processedAnyFile <- true
@@ -791,14 +918,22 @@ module Watch =
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
                         let directorySnapshot, statusTriggerSnapshot = statusOnlyTriggerSnapshot ()
+                        let fileWorkGenerationBeforeStatusUpdate = Volatile.Read(&fileUploadWorkGeneration)
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus ->
-                            graceStatus <- newGraceStatus
-                            drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+                            if wasLastScanForDifferencesSuccessful ()
+                               && filesToProcess.IsEmpty
+                               && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate then
+                                graceStatus <- newGraceStatus
+                                drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+                            else
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Status file update completed while file upload work or a failed scan was pending; status-only triggers will retry."
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.
@@ -844,7 +979,7 @@ module Watch =
             statusUpdateTriggers.AddOrUpdate(difference.RelativePath, generation, (fun _ _ -> generation))
             |> ignore
         | File, _ ->
-            filesToProcess.TryAdd(difference.RelativePath, ())
+            enqueueFileUpload difference.RelativePath
             |> ignore
 
     type Watch() =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -136,6 +136,14 @@ module Watch =
     /// Note: We're using ConcurrentDictionary because it's safe for multithreading, doesn't allow us to insert the same key twice, and for its algorithms. We're not using the values of the ConcurrentDictionary here, only the keys.
     let private directoriesToProcess = ConcurrentDictionary<string, unit>()
 
+    /// Holds a list of repo-relative paths that should trigger a Grace Status scan without uploading file content.
+    ///
+    /// FileSystemWatcher delete and rename-old events do not have durable file content to upload. They only need to
+    /// wake the timer loop so updateGraceStatus can run scanForDifferences against the current working tree.
+    let private statusUpdateTriggers = ConcurrentDictionary<string, unit>()
+
+    type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
+
     type WatchParameters() =
         inherit ParameterBase()
         member val public RepositoryPath: string = String.Empty with get, set
@@ -151,6 +159,59 @@ module Watch =
     let isNotDirectory path = not <| Directory.Exists(path)
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     let updateNotInProgress () = not <| updateInProgress ()
+
+    let private repositoryRelativePath (fullPath: string) =
+        let rootDirectory =
+            Current().RootDirectory
+            |> Path.GetFullPath
+            |> Path.TrimEndingDirectorySeparator
+
+        let normalizedFullPath = Path.GetFullPath(fullPath)
+
+        if normalizedFullPath.Equals(rootDirectory, StringComparison.InvariantCultureIgnoreCase) then
+            Some Constants.RootDirectoryPath
+        else
+            let rootDirectoryWithSeparator = rootDirectory + string Path.DirectorySeparatorChar
+
+            if normalizedFullPath.StartsWith(rootDirectoryWithSeparator, StringComparison.InvariantCultureIgnoreCase) then
+                normalizedFullPath
+                    .Substring(rootDirectoryWithSeparator.Length)
+                    .Replace(Path.DirectorySeparatorChar, '/')
+                |> Some
+            else
+                None
+
+    let private enqueueStatusUpdateTrigger fullPath =
+        match repositoryRelativePath fullPath with
+        | Some relativePath when not <| shouldIgnoreFile fullPath ->
+            statusUpdateTriggers.TryAdd(relativePath, ())
+            |> ignore
+
+            true
+        | _ -> false
+
+    let internal clearPendingWatchWorkForTests () =
+        filesToProcess.Clear()
+        directoriesToProcess.Clear()
+        statusUpdateTriggers.Clear()
+
+    let internal pendingWatchWorkSnapshotForTests () =
+        {
+            FilesToProcess = filesToProcess.Keys.OrderBy(id).ToArray()
+            DirectoriesToProcess = directoriesToProcess.Keys.OrderBy(id).ToArray()
+            StatusUpdateTriggers = statusUpdateTriggers.Keys.OrderBy(id).ToArray()
+        }
+
+    let private hasPendingWatchWork () =
+        not (
+            filesToProcess.IsEmpty
+            && directoriesToProcess.IsEmpty
+            && statusUpdateTriggers.IsEmpty
+        )
+
+    let private drainStatusOnlyTriggers () =
+        directoriesToProcess.Clear()
+        statusUpdateTriggers.Clear()
 
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
         match tokenResult with
@@ -247,14 +308,9 @@ module Watch =
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
     let OnDeleted (args: FileSystemEventArgs) =
-        if updateNotInProgress ()
-           && isNotDirectory args.FullPath then
-            let shouldIgnore = shouldIgnoreFile args.FullPath
-            //logToAnsiConsole Colors.Verbose $"Should ignore {args.FullPath}: {shouldIgnore}."
-
-            if not <| shouldIgnore then
+        if updateNotInProgress () then
+            if enqueueStatusUpdateTrigger args.FullPath then
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
-                logToAnsiConsole Colors.Deleted $"Delete processing is not yet implemented."
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -262,17 +318,13 @@ module Watch =
 
     let OnRenamed (args: RenamedEventArgs) =
         if updateNotInProgress () then
-            let shouldIgnoreOldFile = shouldIgnoreFile args.OldFullPath
             let shouldIgnoreNewFile = shouldIgnoreFile args.FullPath
 
-            if not <| shouldIgnoreOldFile then
+            if enqueueStatusUpdateTrigger args.OldFullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                //logToAnsiConsole Colors.Verbose $"Should ignore {args.OldFullPath}: {shouldIgnoreOldFile}. Should ignore {args.FullPath}: {shouldIgnoreNewFile}."
-                logToAnsiConsole Colors.Changed $"Delete processing is not yet implemented."
 
             if not <| shouldIgnoreNewFile then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                //logToAnsiConsole Colors.Verbose $"Should ignore {args.OldFullPath}: {shouldIgnoreOldFile}. Should ignore {args.FullPath}: {shouldIgnoreNewFile}."
                 filesToProcess.TryAdd(args.FullPath, ()) |> ignore
 
     let OnError (args: ErrorEventArgs) =
@@ -528,19 +580,20 @@ module Watch =
     let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
     /// Processes any changed files since the last timer tick.
-    let processChangedFiles () =
+    let internal processChangedFilesWithClients
+        readGraceStatusMetaClient
+        readGraceStatusFileClient
+        copyFileToObjectDirectoryAndUploadToStorageClient
+        updateGraceStatusClient
+        applyGraceStatusIncrementalClient
+        updateGraceWatchInterprocessFileClient
+        =
         task {
             // First, check if there's anything to process.
-            if
-                not
-                    (
-                        filesToProcess.IsEmpty
-                        && directoriesToProcess.IsEmpty
-                    )
-            then
+            if hasPendingWatchWork () then
                 try
                     let correlationId = generateCorrelationId ()
-                    let! graceStatusFromDisk = readGraceStatusMeta ()
+                    let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     graceStatus <- graceStatusFromDisk
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
@@ -563,28 +616,29 @@ module Watch =
                     for fileName in filesToProcess.Keys.Take(50) do
                         if filesToProcess.TryRemove(fileName, &unitValue) then
                             logToAnsiConsole Colors.Verbose $"Processing {fileName}. filesToProcess.Count: {filesToProcess.Count}."
-                            do! copyFileToObjectDirectoryAndUploadToStorage getUploadMetadataForFilesParameters (FilePath fileName)
+                            do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath fileName)
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
                     if processedAnyFile then
                         graceStatus <- { graceStatus with LastSuccessfulFileUpload = lastFileUploadInstant }
-                        do! applyGraceStatusIncremental graceStatus Seq.empty Seq.empty
+                        do! applyGraceStatusIncrementalClient graceStatus Seq.empty Seq.empty
 
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
                     if filesToProcess.IsEmpty then
-                        let! graceStatusSnapshot = readGraceStatusFile ()
+                        drainStatusOnlyTriggers ()
+                        let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
 
-                        match! (updateGraceStatus graceStatus correlationId) with
+                        match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus -> graceStatus <- newGraceStatus
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.
 
                     updateGraceStatusDirectoryIds graceStatus
-                    do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
+                    do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
 
                     // Reset the in-memory Grace Status to empty to minimize memory usage.
                     graceStatus <- GraceStatus.Default
@@ -603,6 +657,15 @@ module Watch =
                 do! updateGraceWatchInterprocessFile graceStatusFromDisk (Some graceStatusDirectoryIds)
                 GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
         }
+
+    let processChangedFiles () =
+        processChangedFilesWithClients
+            readGraceStatusMeta
+            readGraceStatusFile
+            copyFileToObjectDirectoryAndUploadToStorage
+            updateGraceStatus
+            applyGraceStatusIncremental
+            updateGraceWatchInterprocessFile
 
     type Watch() =
         inherit AsynchronousCommandLineAction()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -164,6 +164,7 @@ module Watch =
         | DeletedFile
         | DeletedDirectory
         | DeletedPathKindUnknown
+        | DeletedPathStatusUnavailable
 
     let private repositoryRelativePath (fullPath: string) =
         let rootDirectory =
@@ -211,12 +212,18 @@ module Watch =
         | false, true -> DeletedDirectory
         | false, false -> DeletedPathKindUnknown
 
+    let mutable private readGraceStatusFileForDeletedPathClassification = readGraceStatusFile
+
     let private readTrackedDeletedPathKind (relativePath: string) =
         try
             let status =
                 if graceStatusHasChanged
                    || graceStatus.Index.Count = 0 then
-                    let refreshedStatus = readGraceStatusFile().GetAwaiter().GetResult()
+                    let refreshedStatus =
+                        readGraceStatusFileForDeletedPathClassification()
+                            .GetAwaiter()
+                            .GetResult()
+
                     graceStatus <- refreshedStatus
                     refreshedStatus
                 else
@@ -224,10 +231,11 @@ module Watch =
 
             trackedDeletedPathKind status relativePath
         with
-        | _ -> DeletedPathKindUnknown
+        | _ -> DeletedPathStatusUnavailable
 
     let internal setGraceStatusForWatchTests status = graceStatus <- status
     let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
+    let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
 
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -244,30 +252,36 @@ module Watch =
                 StringComparison.InvariantCultureIgnoreCase
             )
 
-        let directoryIgnoreMatches graceIgnoreLine =
-            if isNull fileInfo.Directory then
-                false
-            else
-                checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine
+        let isGraceStatusArtifact =
+            normalizedFullPath.Equals(configuration.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
+            || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+            || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+            || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
 
-        isInGraceDirectory
-        || normalizedFullPath.Equals(configuration.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
-        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
-        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
-        || normalizedFullPath.Equals(configuration.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
-        || (pathKind <> DeletedDirectory
-            && normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase))
-        || configuration.GraceDirectoryIgnoreEntries
-           |> Array.exists directoryIgnoreMatches
-        || (pathKind <> DeletedFile
-            && configuration.GraceDirectoryIgnoreEntries
-               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
-        || (pathKind <> DeletedDirectory
-            && configuration.GraceDirectoryIgnoreEntries
-               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
-        || (pathKind = DeletedPathKindUnknown
-            && configuration.GraceFileIgnoreEntries
-               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
+        if isInGraceDirectory || isGraceStatusArtifact then
+            true
+        elif pathKind = DeletedPathStatusUnavailable then
+            false
+        else
+            let directoryIgnoreMatches graceIgnoreLine =
+                if isNull fileInfo.Directory then
+                    false
+                else
+                    checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine
+
+            (pathKind <> DeletedDirectory
+             && normalizedFullPath.EndsWith(".gracetmp", StringComparison.InvariantCultureIgnoreCase))
+            || configuration.GraceDirectoryIgnoreEntries
+               |> Array.exists directoryIgnoreMatches
+            || (pathKind <> DeletedFile
+                && configuration.GraceDirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
+            || (pathKind <> DeletedDirectory
+                && configuration.GraceDirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
+            || (pathKind = DeletedPathKindUnknown
+                && configuration.GraceFileIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
 
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with
@@ -287,6 +301,7 @@ module Watch =
         statusUpdateTriggers.Clear()
         graceStatus <- GraceStatus.Default
         graceStatusHasChanged <- false
+        readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
 
     let internal pendingWatchWorkSnapshotForTests () =
         {
@@ -303,6 +318,11 @@ module Watch =
         )
 
     let private statusOnlyTriggerSnapshot () = directoriesToProcess.Keys.ToArray(), statusUpdateTriggers.Keys.ToArray()
+
+    let private resetWorkingTreeScanCacheForStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
+        if directorySnapshot.Length > 0
+           || statusTriggerSnapshot.Length > 0 then
+            clearWorkingDirectoryWriteTimesForWatchRescan ()
 
     let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: string array) =
         let mutable unitValue = ()
@@ -732,6 +752,7 @@ module Watch =
                         let directorySnapshot, statusTriggerSnapshot = statusOnlyTriggerSnapshot ()
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
+                        resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
 
                         match! (updateGraceStatusClient graceStatus correlationId) with
                         | Some newGraceStatus ->

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -213,14 +213,21 @@ module Watch =
 
     let private readTrackedDeletedPathKind (relativePath: string) =
         try
-            if graceStatus.Index.Count > 0 then
-                trackedDeletedPathKind graceStatus relativePath
-            else
-                trackedDeletedPathKind (readGraceStatusFile().GetAwaiter().GetResult()) relativePath
+            let status =
+                if graceStatusHasChanged
+                   || graceStatus.Index.Count = 0 then
+                    let refreshedStatus = readGraceStatusFile().GetAwaiter().GetResult()
+                    graceStatus <- refreshedStatus
+                    refreshedStatus
+                else
+                    graceStatus
+
+            trackedDeletedPathKind status relativePath
         with
         | _ -> DeletedPathKindUnknown
 
     let internal setGraceStatusForWatchTests status = graceStatus <- status
+    let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
 
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -279,6 +286,7 @@ module Watch =
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
         graceStatus <- GraceStatus.Default
+        graceStatusHasChanged <- false
 
     let internal pendingWatchWorkSnapshotForTests () =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -225,6 +225,14 @@ module Watch =
 
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
+    let private defaultWatchPathComparison () =
+        if OperatingSystem.IsWindows() then
+            StringComparison.OrdinalIgnoreCase
+        else
+            StringComparison.Ordinal
+
+    let mutable private watchPathComparison = defaultWatchPathComparison ()
+
     let private readTrackedDeletedPathKind (relativePath: string) =
         try
             let status =
@@ -248,6 +256,7 @@ module Watch =
     let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
     let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
     let internal setEnumerateFilesForDirectoryUploadForWatchTests enumerateFiles = enumerateFilesForDirectoryUpload <- enumerateFiles
+    let internal setWatchPathComparisonForWatchTests comparison = watchPathComparison <- comparison
 
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -364,10 +373,10 @@ module Watch =
                     with
                     | _ -> queuedFile
 
-                normalizedQueuedFile.Equals(normalizedFullPath, StringComparison.InvariantCultureIgnoreCase)
-                || normalizedQueuedFile.StartsWith(fullPathPrefix, StringComparison.InvariantCultureIgnoreCase)
+                normalizedQueuedFile.Equals(normalizedFullPath, watchPathComparison)
+                || normalizedQueuedFile.StartsWith(fullPathPrefix, watchPathComparison)
                 || (match relativePathPrefix with
-                    | Some prefix -> queuedFile.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
+                    | Some prefix -> queuedFile.StartsWith(prefix, watchPathComparison)
                     | None -> false)
 
             if removeQueuedFile then removePendingFileUpload queuedFile
@@ -387,6 +396,7 @@ module Watch =
         graceStatusHasChanged <- false
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
+        watchPathComparison <- defaultWatchPathComparison ()
         setLastScanForDifferencesSuccessfulForWatchTests true
 
     let internal pendingWatchWorkSnapshotForTests () =
@@ -558,14 +568,16 @@ module Watch =
         if updateNotInProgress () then
             let newPathIsDirectory = Directory.Exists(args.FullPath)
 
+            cancelPendingUploadsForDeletedPath args.OldFullPath
+
             let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
 
             if oldPathStatusQueued then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
             if newPathIsDirectory then
-                if not (enqueueDirectoryContentsForUpload args.FullPath) then
-                    removeStatusUpdateTrigger args.OldFullPath
+                enqueueDirectoryContentsForUpload args.FullPath
+                |> ignore
             elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -258,6 +258,9 @@ module Watch =
         || (pathKind <> DeletedDirectory
             && configuration.GraceDirectoryIgnoreEntries
                |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
+        || (pathKind = DeletedPathKindUnknown
+            && configuration.GraceFileIgnoreEntries
+               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
 
     let private enqueueStatusUpdateTrigger fullPath =
         match repositoryRelativePath fullPath with

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -1418,7 +1418,14 @@ type BranchServer() =
                         parentBranch.BasedOn.Blake3Hash
                     ]
 
-            let! response = BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync repositoryId branch DirectoryVersionId.Empty (Blake3Hash childOnlyPrefix)
+            let stableChildOnlyPrefix =
+                if childOnlyPrefix.Length < 16 then
+                    (string child.Blake3Hash).Substring(0, 16)
+                else
+                    childOnlyPrefix
+
+            let! response =
+                BranchServerTestHelpers.saveReferenceByBlake3ResponseAsync repositoryId branch DirectoryVersionId.Empty (Blake3Hash stableChildOnlyPrefix)
 
             let! responseBody = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseBody)


### PR DESCRIPTION
## Summary

Closes #463.

This release candidate completes Grace Watch delete capture. A running `grace watch` now captures file deletes,
directory deletes, and V1 renames as old-path delete plus new-path add/change through the existing scan-based Save flow.
The implementation preserves `updateGraceStatus -> scanForDifferences` and does not introduce rename identity,
tombstones, server contracts, storage schema changes, or SDK/OpenAPI changes.

## Why This Matters

Grace users expect Watch to save the current repository state while they edit. Before this epic, delete-only changes
could leave Grace history and future materialization paths pointing at files or directories that no longer existed in the
working tree. This PR makes delete capture trustworthy while keeping the current V1 model clear and documented.

## Child PRs

- #468: local status cleanup proof for file and directory deletes.
- #469: Watch delete and rename-old trigger completion.
- #470: DirectoryVersion tree mutation for directory deletes.
- #471: delete-only Save flow proof and Watch docs.

## Changed Areas

- Watch delete and rename-old event trigger handling.
- Local status cleanup tests for deletes.
- DirectoryVersion parent/root rebuild behavior for directory deletes.
- Current-state Save flow regression tests for delete-only file and directory-only changes.
- Watch docs for delete capture and V1 rename behavior.
- Agent/process docs for fresh review finding routing and serialized review-fix workers.

## Validation

- `npx --yes markdownlint-cli2 "AGENTS.md" "docs/Development process.md" "docs/What grace watch does.md"`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - Build succeeded with 0 warnings and 0 errors.
  - Fast test gate passed: Authorization 53, CLI 674, Types 133, Server.Unit 723.
- `git diff --check origin/main...HEAD`: passed.

## Review Status

- **Current head:** `cca61d6c81c19744daedc125928cba1699136119`
- **Current base:** `7198f835ce7d5f336cad999aed09502c95ee93d6`
- **Codex Code Review Bot:** Gave a current-head no-issues thumbs-up on `cca61d6c`.
- **Latest fresh findings addressed:**
  - `PRRC_kwDOILVrb87QYxhz`: failed directory rename enumeration now keeps
    the old-path retry/status trigger; fixed in `cca61d6c`.
  - `PRRC_kwDOILVrb87QYxh2`: delete cancellation now uses watch path
    comparison semantics instead of unconditional ignore-case matching; fixed in `cca61d6c`.
  - `PRRC_kwDOILVrb87QYxh5`: rename handling now cancels queued
    old-path uploads before queuing old-path status and new-path upload work; fixed in `cca61d6c`.
- **Fix routing:** One fresh GPT-5.5 Medium worker owned all three shared Watch rename/delete queue findings;
  no parallel or overlapping fix workers were used for this review pass.
- **Fix validation:** Targeted Fantomas passed; focused CLI test build passed with 0 warnings and 0 errors;
  focused Watch tests passed 53/53; `git diff --check` passed.
- **Current CI:** `Validate / full` passed on `cca61d6c81c19744daedc125928cba1699136119`.
- **Freshness rule:** Only findings from the completed latest-head review were actionable. Previous-pass threads were
  treated as stale unless the latest review repeated them.
- **Manual trigger decision:** Not attempted.
- **Manual trigger lock:** Honored; no manual trigger was used while current-head eyes acknowledgement existed.
- **Implementation path:** Child issues and final review fixes were implemented by fresh GPT-5.5 Medium workers;
  orchestrator owns final PR, review, merge, and cleanup state.

## Docs Impact

`docs/What grace watch does.md` now describes tracked delete capture, required DirectoryVersion upload before Save,
local status update after Save success, and V1 rename as delete plus add/change.

## Residual Risk

Root directory deletion remains out of scope. V1 rename capture is intentionally path-based: Grace records the old path
as deleted and the new path as added or changed without durable moved-file identity.
