### PR TITLE
WS1.1: Extract watch status apply seam

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -243,12 +243,16 @@ module WatchTests =
             updateCalls <- updateCalls + 1
             Task.FromResult(Some status)
 
+        /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+        let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
+
         /// Builds apply incremental test data used to exercise CLI watch behavior.
         let applyIncremental _ _ _ = Task.FromResult(())
         /// Builds update ipc test data used to exercise CLI watch behavior.
         let updateIpc _ _ = Task.FromResult(())
 
-        let processTask = Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc
+        let processTask =
+            Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc
 
         processTask.GetAwaiter().GetResult()
 
@@ -261,12 +265,14 @@ module WatchTests =
         let readStatusMeta () = Task.FromResult(status)
         /// Builds upload test data used to exercise CLI watch behavior.
         let upload _ _ = Task.FromResult(())
+        /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+        let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
         /// Builds apply incremental test data used to exercise CLI watch behavior.
         let applyIncremental _ _ _ = Task.FromResult(())
         /// Builds update ipc test data used to exercise CLI watch behavior.
         let updateIpc _ _ = Task.FromResult(())
 
-        Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus applyIncremental updateIpc
+        Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc
         |> fun processTask -> processTask.GetAwaiter().GetResult()
 
     /// Writes grace ignore needed by the test scenario.
@@ -431,12 +437,22 @@ module WatchTests =
                 updateCalls <- updateCalls + 1
                 Task.FromResult(Some status)
 
+            /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
+
             /// Builds apply incremental test data used to exercise CLI watch behavior.
             let applyIncremental _ _ _ = Task.FromResult(())
             /// Builds update ipc test data used to exercise CLI watch behavior.
             let updateIpc _ _ = Task.FromResult(())
 
-            (Watch.processChangedFilesWithClients readStatus readStatus failingUpload updateGraceStatus applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                failingUpload
+                updateGraceStatus
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -496,12 +512,15 @@ module WatchTests =
                 updateCalls <- updateCalls + 1
                 Task.FromResult(Some status)
 
+            /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
+
             /// Builds apply incremental test data used to exercise CLI watch behavior.
             let applyIncremental _ _ _ = Task.FromResult(())
             /// Builds update ipc test data used to exercise CLI watch behavior.
             let updateIpc _ _ = Task.FromResult(())
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -513,7 +532,7 @@ module WatchTests =
             afterFirstUpload.FilesToProcess
             |> should equal [| changedFilePath |]
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -1235,6 +1254,174 @@ module WatchTests =
 
             updateCalls |> should equal 1
             uploadCalls |> should equal 0)
+
+    /// Verifies that startup-derived file differences use the shared apply seam without rescanning.
+    [<Test>]
+    let ``startup file difference applies pre-derived differences without scan-oriented update`` () =
+        withTempRepo (fun _ ->
+            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "offline-add.txt"
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks the Differences passed to the apply seam so the test fails if startup scan findings are discarded.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.toArray
+            |> should equal [| startupDifference |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that failed startup-derived status application remains retryable without rescanning.
+    [<Test>]
+    let ``startup pre-derived differences retry apply seam after transient status failure`` () =
+        withTempRepo (fun _ ->
+            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "retry-add.txt"
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable uploadCalls = 0
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                if applyFromDifferencesCalls = 1 then
+                    Task.FromResult(None)
+                else
+                    Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 2
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that startup apply does not drain unrelated status-only work queued before the same pass.
+    [<Test>]
+    let ``startup apply preserves unrelated status-only trigger for later scan`` () =
+        withTempRepo (fun root ->
+            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "startup-add.txt"
+            let unrelatedDeletedPath = Path.Combine(root, "unrelated-delete.txt")
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+            Watch.OnDeleted(deletedEvent unrelatedDeletedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal [| "unrelated-delete.txt" |])
 
     /// Verifies that renamed tracked file matching directory only ignore queues old path status trigger.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -222,6 +222,9 @@ module WatchTests =
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
 
+    /// Produces an empty difference list for watch tests that do not exercise a scan path.
+    let private scanForNoDifferences _ = Task.FromResult(List<FileSystemDifference>())
+
     /// Builds process pending watch work for test test data used to exercise CLI watch behavior.
     let private processPendingWatchWorkForTest () =
         let status = GraceStatus.Default
@@ -252,7 +255,15 @@ module WatchTests =
         let updateIpc _ _ = Task.FromResult(())
 
         let processTask =
-            Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc
+            Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc
 
         processTask.GetAwaiter().GetResult()
 
@@ -272,7 +283,15 @@ module WatchTests =
         /// Builds update ipc test data used to exercise CLI watch behavior.
         let updateIpc _ _ = Task.FromResult(())
 
-        Watch.processChangedFilesWithClients readStatusMeta readStatusFile upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc
+        Watch.processChangedFilesWithClients
+            readStatusMeta
+            readStatusFile
+            upload
+            updateGraceStatus
+            scanForNoDifferences
+            updateGraceStatusFromDifferences
+            applyIncremental
+            updateIpc
         |> fun processTask -> processTask.GetAwaiter().GetResult()
 
     /// Writes grace ignore needed by the test scenario.
@@ -450,6 +469,7 @@ module WatchTests =
                 readStatus
                 failingUpload
                 updateGraceStatus
+                scanForNoDifferences
                 updateGraceStatusFromDifferences
                 applyIncremental
                 updateIpc)
@@ -520,7 +540,15 @@ module WatchTests =
             /// Builds update ipc test data used to exercise CLI watch behavior.
             let updateIpc _ _ = Task.FromResult(())
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -532,7 +560,15 @@ module WatchTests =
             afterFirstUpload.FilesToProcess
             |> should equal [| changedFilePath |]
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -1295,7 +1331,15 @@ module WatchTests =
             /// Builds update ipc test data used to exercise CLI watch behavior.
             let updateIpc _ _ = Task.FromResult(())
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
@@ -1306,6 +1350,91 @@ module WatchTests =
             observedDifferences
             |> Seq.toArray
             |> should equal [| startupDifference |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that live uploads drained before startup apply are included by a fresh status scan.
+    [<Test>]
+    let ``startup apply rescans after live upload drains before applying differences`` () =
+        withTempRepo (fun root ->
+            let startupDifference = FileSystemDifference.Create Delete FileSystemEntryType.File "offline-delete.txt"
+            let liveFilePath = Path.Combine(root, "live-upload.txt")
+            let liveUploadDifference = FileSystemDifference.Create Add FileSystemEntryType.File "live-upload.txt"
+            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanCalls = 0
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks the Differences passed to the apply seam so the test fails if live uploads are omitted.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+            File.WriteAllText(liveFilePath, "live content")
+            Watch.OnChanged(changedEvent liveFilePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>([ liveUploadDifference ]))
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            scanCalls |> should equal 1
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    startupDifference
+                    liveUploadDifference
+                |]
 
             let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
 
@@ -1357,7 +1486,15 @@ module WatchTests =
             let updateIpc _ _ = Task.FromResult(())
 
             let processPendingWork () =
-                (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
                     .GetAwaiter()
                     .GetResult()
 
@@ -1375,6 +1512,79 @@ module WatchTests =
 
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that already-applied startup differences are dropped when concurrent file work blocks status commit.
+    [<Test>]
+    let ``startup applied differences are dropped when commit gate loses file-event race`` () =
+        withTempRepo (fun root ->
+            let startupDifference = FileSystemDifference.Create Delete FileSystemEntryType.File "race-delete.txt"
+            let createdDuringApplyPath = Path.Combine(root, "created-during-apply.txt")
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable uploadCalls = 0
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                differences
+                |> Seq.toArray
+                |> should equal [| startupDifference |]
+
+                if applyFromDifferencesCalls = 1 then
+                    File.WriteAllText(createdDuringApplyPath, "created during apply")
+                    Watch.OnChanged(changedEvent createdDuringApplyPath)
+
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            let afterRace = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRace.FilesToProcess
+            |> should equal [| createdDuringApplyPath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            scanOrientedUpdateCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1)
 
     /// Verifies that startup apply does not drain unrelated status-only work queued before the same pass.
     [<Test>]
@@ -1411,7 +1621,15 @@ module WatchTests =
             /// Builds update ipc test data used to exercise CLI watch behavior.
             let updateIpc _ _ = Task.FromResult(())
 
-            (Watch.processChangedFilesWithClients readStatus readStatus upload updateGraceStatus updateGraceStatusFromDifferences applyIncremental updateIpc)
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
                 .GetAwaiter()
                 .GetResult()
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1444,6 +1444,96 @@ module WatchTests =
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
+    /// Verifies that failed startup rescan retries before applying pending startup differences.
+    [<Test>]
+    let ``startup apply retries failed rescan before applying pending differences`` () =
+        withTempRepo (fun root ->
+            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "retry-after-failed-rescan.txt"
+            let liveFilePath = Path.Combine(root, "live-upload-after-failed-rescan.txt")
+            let liveUploadDifference = FileSystemDifference.Create Add FileSystemEntryType.File "live-upload-after-failed-rescan.txt"
+            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks the Differences passed to the apply seam so the test fails if retry skips the failed rescan result.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.queueStartupDifferenceForWatch startupDifference
+            File.WriteAllText(liveFilePath, "live content")
+            Watch.OnChanged(changedEvent liveFilePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Services.setLastScanForDifferencesSuccessfulForWatchTests (scanCalls > 1)
+
+                Task.FromResult(List<FileSystemDifference>([ liveUploadDifference ]))
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            scanCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    startupDifference
+                    liveUploadDifference
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
     /// Verifies that failed startup-derived status application remains retryable without rescanning.
     [<Test>]
     let ``startup pre-derived differences retry apply seam after transient status failure`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -157,6 +157,10 @@ module Watch =
 
     let private statusUpdateTriggers = ConcurrentDictionary<string, int64>()
 
+    let private pendingStatusDifferencesLock = obj ()
+
+    let private pendingStatusDifferences = List<FileSystemDifference>()
+
     /// Defines structured data exchanged by CLI helpers.
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
 
@@ -413,11 +417,31 @@ module Watch =
 
             if removeQueuedFile then removePendingFileUpload queuedFile
 
+    /// Records an already-derived filesystem difference so status application can run without rescanning.
+    let private addPendingStatusDifference difference = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Add(difference))
+
+    /// Captures the already-derived differences waiting for the shared status-application path.
+    let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
+
+    /// Checks whether any pre-derived filesystem differences still need status application.
+    let private hasPendingStatusDifferences () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Count > 0)
+
+    /// Clears only the differences that a successful status update already applied.
+    let private clearPendingStatusDifferences (differences: List<FileSystemDifference>) =
+        lock pendingStatusDifferencesLock (fun () ->
+            for difference in differences do
+                pendingStatusDifferences.Remove(difference)
+                |> ignore)
+
+    /// Clears pre-derived differences when tests reset watch module state.
+    let private clearPendingStatusDifferencesForTests () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Clear())
+
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
+        clearPendingStatusDifferencesForTests ()
 
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
         |> ignore
@@ -446,6 +470,7 @@ module Watch =
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty
             && statusUpdateTriggers.IsEmpty
+            && not (hasPendingStatusDifferences ())
         )
 
     /// Coordinates status only trigger snapshot behavior for this CLI command path.
@@ -476,6 +501,44 @@ module Watch =
             (statusUpdateTriggers :> ICollection<KeyValuePair<string, int64>>)
                 .Remove(pair)
             |> ignore
+
+    /// Drains the watch work proven by either a scan-derived update or the matched pre-derived differences.
+    let private drainAppliedStatusWork
+        (directorySnapshot: string array)
+        (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
+        (appliedDifferences: List<FileSystemDifference>)
+        =
+        if appliedDifferences.Count = 0 then
+            drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+        else
+            let directoryPathsToDrain =
+                appliedDifferences
+                |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.Directory)
+                |> Seq.map (fun difference -> string difference.RelativePath)
+                |> HashSet
+
+            let statusTriggerPathsToDrain =
+                appliedDifferences
+                |> Seq.filter (fun difference ->
+                    difference.FileSystemEntryType = FileSystemEntryType.File
+                    && difference.DifferenceType = DifferenceType.Delete)
+                |> Seq.map (fun difference -> string difference.RelativePath)
+                |> HashSet
+
+            let mutable unitValue = ()
+
+            for directory in directorySnapshot do
+                if directoryPathsToDrain.Contains(directory) then
+                    directoriesToProcess.TryRemove(directory, &unitValue)
+                    |> ignore
+
+            for statusTrigger in statusTriggerSnapshot do
+                if statusTriggerPathsToDrain.Contains(statusTrigger.RelativePath) then
+                    let pair = KeyValuePair(statusTrigger.RelativePath, statusTrigger.Generation)
+
+                    (statusUpdateTriggers :> ICollection<KeyValuePair<string, int64>>)
+                        .Remove(pair)
+                    |> ignore
 
     /// Resolves signal raccess token result from command options, configuration, or local state.
     let resolveSignalRAccessTokenResult (tokenResult: Result<string option, string>) =
@@ -679,11 +742,9 @@ module Watch =
     /// Update the Grace Object Cache file with the new DirectoryVersions.
     let updateObjectCacheFile (newDirectoryVersions: List<LocalDirectoryVersion>) = task { do! upsertObjectCache newDirectoryVersions }
 
-    /// Updates the Grace Status file's Index with updates detected from the file system.
-    let updateGraceStatus graceStatus correlationId =
+    /// Applies already-derived filesystem differences to Grace Status, object cache, and save history.
+    let updateGraceStatusFromDifferences graceStatus (differences: List<FileSystemDifference>) correlationId =
         task {
-            // Get the list of differences between what's in the working directory, and what Grace Index knows about.
-            let! differences = scanForDifferences graceStatus
             printDifferences differences
 
             // Get an updated Grace Index, and any new DirectoryVersions that were needed to build it.
@@ -826,6 +887,14 @@ module Watch =
                         return None
         }
 
+    /// Updates the Grace Status file's Index with updates detected from the file system.
+    let updateGraceStatus graceStatus correlationId =
+        task {
+            // Get the list of differences between what's in the working directory, and what Grace Index knows about.
+            let! differences = scanForDifferences graceStatus
+            return! updateGraceStatusFromDifferences graceStatus differences correlationId
+        }
+
     /// Reads cached file version for upload skip from ParseResult, local configuration, or Grace ids.
     let private getCachedFileVersionForUploadSkip (fullPath: FilePath) =
         task {
@@ -935,6 +1004,7 @@ module Watch =
         readGraceStatusFileClient
         copyFileToObjectDirectoryAndUploadToStorageClient
         updateGraceStatusClient
+        updateGraceStatusFromDifferencesClient
         applyGraceStatusIncrementalClient
         updateGraceWatchInterprocessFileClient
         =
@@ -991,14 +1061,26 @@ module Watch =
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+                        let pendingDifferences = pendingStatusDifferencesSnapshot ()
 
-                        match! (updateGraceStatusClient graceStatus correlationId) with
+                        let! statusUpdateResult =
+                            if pendingDifferences.Count > 0 then
+                                updateGraceStatusFromDifferencesClient graceStatus pendingDifferences correlationId
+                            else
+                                updateGraceStatusClient graceStatus correlationId
+
+                        match statusUpdateResult with
                         | Some newGraceStatus ->
-                            if wasLastScanForDifferencesSuccessful ()
-                               && filesToProcess.IsEmpty
-                               && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate then
+                            let statusUpdateCanCommit =
+                                filesToProcess.IsEmpty
+                                && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
+                                && (pendingDifferences.Count > 0
+                                    || wasLastScanForDifferencesSuccessful ())
+
+                            if statusUpdateCanCommit then
                                 graceStatus <- newGraceStatus
-                                drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+                                drainAppliedStatusWork directorySnapshot statusTriggerSnapshot pendingDifferences
+                                clearPendingStatusDifferences pendingDifferences
                             else
                                 logToAnsiConsole
                                     Colors.Important
@@ -1035,11 +1117,14 @@ module Watch =
             readGraceStatusFile
             copyFileToObjectDirectoryAndUploadToStorage
             updateGraceStatus
+            updateGraceStatusFromDifferences
             applyGraceStatusIncremental
             updateGraceWatchInterprocessFile
 
     /// Coordinates queue startup difference for watch behavior for this CLI command path.
     let internal queueStartupDifferenceForWatch difference =
+        addPendingStatusDifference difference
+
         match difference.FileSystemEntryType, difference.DifferenceType with
         | Directory, _ ->
             directoriesToProcess.TryAdd(difference.RelativePath, ())

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -436,6 +436,26 @@ module Watch =
     /// Clears pre-derived differences when tests reset watch module state.
     let private clearPendingStatusDifferencesForTests () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Clear())
 
+    /// Combines pre-derived and freshly scanned status differences without applying the same filesystem observation twice.
+    let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
+        let merged = List<FileSystemDifference>()
+
+        let addIfMissing (difference: FileSystemDifference) =
+            if not
+               <| merged.Exists (fun existing ->
+                   existing.RelativePath = difference.RelativePath
+                   && existing.DifferenceType = difference.DifferenceType
+                   && existing.FileSystemEntryType = difference.FileSystemEntryType) then
+                merged.Add(difference)
+
+        for difference in first do
+            addIfMissing difference
+
+        for difference in second do
+            addIfMissing difference
+
+        merged
+
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
         filesToProcess.Clear()
@@ -1004,6 +1024,7 @@ module Watch =
         readGraceStatusFileClient
         copyFileToObjectDirectoryAndUploadToStorageClient
         updateGraceStatusClient
+        scanForDifferencesClient
         updateGraceStatusFromDifferencesClient
         applyGraceStatusIncrementalClient
         updateGraceWatchInterprocessFileClient
@@ -1063,9 +1084,18 @@ module Watch =
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         let pendingDifferences = pendingStatusDifferencesSnapshot ()
 
+                        let! differencesToApply =
+                            if pendingDifferences.Count > 0 && processedAnyFile then
+                                task {
+                                    let! rescannedDifferences = scanForDifferencesClient graceStatus
+                                    return mergeStatusDifferences pendingDifferences rescannedDifferences
+                                }
+                            else
+                                Task.FromResult(pendingDifferences)
+
                         let! statusUpdateResult =
-                            if pendingDifferences.Count > 0 then
-                                updateGraceStatusFromDifferencesClient graceStatus pendingDifferences correlationId
+                            if differencesToApply.Count > 0 then
+                                updateGraceStatusFromDifferencesClient graceStatus differencesToApply correlationId
                             else
                                 updateGraceStatusClient graceStatus correlationId
 
@@ -1075,6 +1105,7 @@ module Watch =
                                 filesToProcess.IsEmpty
                                 && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
                                 && (pendingDifferences.Count > 0
+                                    && not processedAnyFile
                                     || wasLastScanForDifferencesSuccessful ())
 
                             if statusUpdateCanCommit then
@@ -1082,6 +1113,8 @@ module Watch =
                                 drainAppliedStatusWork directorySnapshot statusTriggerSnapshot pendingDifferences
                                 clearPendingStatusDifferences pendingDifferences
                             else
+                                clearPendingStatusDifferences pendingDifferences
+
                                 logToAnsiConsole
                                     Colors.Important
                                     $"Grace Status file update completed while file upload work or a failed scan was pending; status-only triggers will retry."
@@ -1117,6 +1150,7 @@ module Watch =
             readGraceStatusFile
             copyFileToObjectDirectoryAndUploadToStorage
             updateGraceStatus
+            scanForDifferences
             updateGraceStatusFromDifferences
             applyGraceStatusIncremental
             updateGraceWatchInterprocessFile

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -161,6 +161,8 @@ module Watch =
 
     let private pendingStatusDifferences = List<FileSystemDifference>()
 
+    let mutable private pendingStatusDifferencesRequireRescanRetry = false
+
     /// Defines structured data exchanged by CLI helpers.
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
 
@@ -423,6 +425,12 @@ module Watch =
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
 
+    /// Checks whether a failed startup rescan left pending differences that must rescan again before applying.
+    let private pendingStatusDifferencesRequireRescanRetrySnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferencesRequireRescanRetry)
+
+    /// Records that pending startup differences still need a successful rescan before they can be applied.
+    let private requirePendingStatusDifferencesRescanRetry () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferencesRequireRescanRetry <- true)
+
     /// Checks whether any pre-derived filesystem differences still need status application.
     let private hasPendingStatusDifferences () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Count > 0)
 
@@ -431,10 +439,16 @@ module Watch =
         lock pendingStatusDifferencesLock (fun () ->
             for difference in differences do
                 pendingStatusDifferences.Remove(difference)
-                |> ignore)
+                |> ignore
+
+            if pendingStatusDifferences.Count = 0 then
+                pendingStatusDifferencesRequireRescanRetry <- false)
 
     /// Clears pre-derived differences when tests reset watch module state.
-    let private clearPendingStatusDifferencesForTests () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Clear())
+    let private clearPendingStatusDifferencesForTests () =
+        lock pendingStatusDifferencesLock (fun () ->
+            pendingStatusDifferences.Clear()
+            pendingStatusDifferencesRequireRescanRetry <- false)
 
     /// Combines pre-derived and freshly scanned status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
@@ -1084,8 +1098,13 @@ module Watch =
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         let pendingDifferences = pendingStatusDifferencesSnapshot ()
 
+                        let pendingDifferencesNeedRescan =
+                            processedAnyFile
+                            || pendingStatusDifferencesRequireRescanRetrySnapshot ()
+
                         let! differencesToApply =
-                            if pendingDifferences.Count > 0 && processedAnyFile then
+                            if pendingDifferences.Count > 0
+                               && pendingDifferencesNeedRescan then
                                 task {
                                     let! rescannedDifferences = scanForDifferencesClient graceStatus
                                     return mergeStatusDifferences pendingDifferences rescannedDifferences
@@ -1094,7 +1113,19 @@ module Watch =
                                 Task.FromResult(pendingDifferences)
 
                         let! statusUpdateResult =
-                            if differencesToApply.Count > 0 then
+                            if
+                                pendingDifferences.Count > 0
+                                && pendingDifferencesNeedRescan
+                                && not (wasLastScanForDifferencesSuccessful ())
+                            then
+                                requirePendingStatusDifferencesRescanRetry ()
+
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Status pending startup differences need a successful rescan before status application; status-only triggers will retry."
+
+                                Task.FromResult(None)
+                            elif differencesToApply.Count > 0 then
                                 updateGraceStatusFromDifferencesClient graceStatus differencesToApply correlationId
                             else
                                 updateGraceStatusClient graceStatus correlationId
@@ -1105,7 +1136,7 @@ module Watch =
                                 filesToProcess.IsEmpty
                                 && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
                                 && (pendingDifferences.Count > 0
-                                    && not processedAnyFile
+                                    && not pendingDifferencesNeedRescan
                                     || wasLastScanForDifferencesSuccessful ())
 
                             if statusUpdateCanCommit then
@@ -1113,7 +1144,8 @@ module Watch =
                                 drainAppliedStatusWork directorySnapshot statusTriggerSnapshot pendingDifferences
                                 clearPendingStatusDifferences pendingDifferences
                             else
-                                clearPendingStatusDifferences pendingDifferences
+                                if wasLastScanForDifferencesSuccessful () then
+                                    clearPendingStatusDifferences pendingDifferences
 
                                 logToAnsiConsole
                                     Colors.Important


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #481

Part of #474 and #473.

## Why this matters

This tracer slice gives `grace watch` one reusable status-application path so startup scans and later
incremental observations can be proven through the same behavior. That matters for Grace users because Watch must stay
trustworthy during local edits without hiding future healthy-mode scans behind existing startup reconciliation code.

## Summary

- Extracted a reusable apply-from-differences path for Watch status updates.
- Preserved startup reconciliation so startup still calls `scanForDifferences`.
- Added false-positive-resistant Watch tests for startup scan preservation, pre-derived difference application, retry
  behavior, stale scan flag interaction, and mixed pending work drain behavior.

## Touched paths

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public behavior or docs-only validation target: `grace watch` startup reconciliation and status application behavior
- RED evidence or docs-only waiver: tests added around the extracted seam and scan-preservation boundaries
- Focused validation: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` and
  `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`

## Minimum detail gate evidence

- Invariant tuple proved or docs-only waiver: `grace watch`, repository/branch/root/path state, pending Watch work,
  startup scan differences, and `GraceStatus` application now share a proofable apply path.
- Forbidden implementation shapes avoided: startup scan was not removed; no durable journal, remote sync, branch-switch,
  or cross-platform normalization behavior was added; scan invocation was not hidden behind a renamed running-mode
  helper.
- Positive / negative / regression / boundary tests or waivers: Watch tests cover startup scan preservation,
  pre-derived application without rescanning, empty/pre-derived retry behavior, stale scan flag interaction, and mixed
  pending work drain behavior.
- High-risk adversarial examples covered or waived: unrelated status-only triggers queued before the same processing
  pass are preserved for later scanning; applying pre-derived startup differences does not drain unrelated scan work.
- Selected risk-surface traps addressed or waived: proof/test and CLI runtime traps addressed; SDK/OpenAPI and
  production data migration waived because this is an internal CLI Watch seam and Grace is pre-production.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.CLI.Tests/Watch.Tests.fs` adds coverage for the extracted apply-from-differences path and startup scan
  preservation.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [x] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- [x] Focused tests: `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- [x] Formatting/linting: `dotnet tool run fantomas -- "src/Grace.CLI/Command/Watch.CLI.fs" "src/Grace.CLI.Tests/Watch.Tests.fs"`
- [x] Formatting/linting: `git diff --check`
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not change Aspire-hosted server,
  emulator, Service Bus, Redis, deployment, or cross-service runtime behavior.

## Residual risks

None known from the implementation worker's self-review. Later WS1 leaves still need to feed healthy running-mode
file and directory observations through this seam.

## Review Status

- Current head SHA: `d8458ba27678998c7123196315b2cd618e232ee7`
- Codex Code Review Bot state for current head: latest-head finding reviewed, replied to, and resolved as
  future-leaf-owned by #482.
- CI state for current head: GitHub Actions `Validate / full` passed on `d8458ba2`.
- Manual trigger decision: not attempted; current-head bot review completed.
- Manual trigger lock: active until `scripts/guard-codex-review-trigger.ps1 -PullRequest 513` proves the missed-ack
  exception; do not manually trigger while current-head bot state is present or ambiguous.
- Detailed review/fix comments: all Codex Code Review Bot findings are resolved as fixed or future-leaf-owned.

Resolved latest-head findings:

- `PRRT_kwDOILVrb86OJLET`: valid but deferred to #482/#483/#484; replied and resolved.
- `PRRT_kwDOILVrb86OJLEU`: fixed in `76a0b0d1`; replied and resolved.
- `PRRT_kwDOILVrb86OJLEW`: valid but deferred to #483/#485+; replied and resolved.
- `PRRT_kwDOILVrb86OJkQt`: valid but deferred to #482; replied and resolved.

## Review/fix prevention

For Codex Code Review Bot findings fixed or resolved in this PR:

- Root-cause class: ordinary implementation mistake for the #481-owned retry-loss fix
- Root-cause class: acceptance-criteria / negative-proof gap for future-leaf-owned stale snapshot and directory-subtree
  invalidation findings
- Current issue, sibling issues, template, or agent docs update needed: future sibling issue detail gates should capture
  stale startup/live merge invalidation, file-delete recreation, directory delete subtree recreation, and empty-directory
  semantics before #482, #483, #484, and #485+ are assigned. Agent docs were updated on the epic integration branch in
  `32f6288e` to document
  future-leaf review finding routing.

Root-cause classes:

- acceptance-criteria / negative-proof gap
- contract-propagation gap
- CLI mode / side-effect interaction
- auth / materialization / traversal ordering gap
- algorithm adversarial-case gap
- validation / stale-evidence gap
- ordinary implementation mistake

## Rollback or recovery notes

Revert `f45898ae` from the epic branch if this seam causes an unexpected Watch regression. The change is scoped to the
CLI Watch implementation and CLI tests.

## Docs follow-up required

None for this internal tracer seam. Later leaves that change visible Watch behavior should update Watch, command-output,
ADR, `.graceignore`, or agent guidance as required by their issue bodies.
