### PR TITLE
WS1.2: Derive watch file status differences

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1576,6 +1576,207 @@ module WatchTests =
                     DifferenceType.Change, FileSystemEntryType.File, "Foo.txt"
                 |])
 
+    /// Verifies that case-insensitive deleted file matching emits deletes with the tracked path casing.
+    [<Test>]
+    let ``case-insensitive deleted file preserves tracked path casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+            let deletedPath = Path.Combine(root, "foo.txt")
+            let status = graceStatusTracking [| "Foo.txt" |] Array.empty<string>
+            /// Tracks the Differences passed to the apply seam so tracked delete casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, "Foo.txt"
+                |])
+
+    /// Verifies that case-insensitive file adds under tracked directories preserve the tracked parent casing.
+    [<Test>]
+    let ``case-insensitive added file preserves tracked parent directory casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+            let uploadedDirectory = Path.Combine(root, "src")
+            let uploadedPath = Path.Combine(uploadedDirectory, "new.txt")
+            let status = graceStatusTracking Array.empty<string> [| "Src" |]
+            /// Tracks the Differences passed to the apply seam so tracked parent casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(uploadedDirectory)
+            |> ignore
+
+            File.WriteAllText(uploadedPath, "new file under differently-cased tracked parent")
+            Watch.OnCreated(changedEvent uploadedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, "Src/new.txt"
+                |])
+
+    /// Verifies that stale deletes requeue canceled same-path file upload work before status-only triggers drain.
+    [<Test>]
+    let ``stale delete after same-path change requeues canceled upload work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "same-path-stale-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            /// Tracks upload Calls changes so the canceled upload is proven to retry.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so this scenario proves the upload retry path avoids a healthy scan.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so final status work is applied once after reupload.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the final file change is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            File.WriteAllText(filePath, "updated content that should still upload")
+            Watch.OnChanged(changedEvent filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.FilesToProcess
+            |> should equal [| filePath |]
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| relativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, relativePath
+                |])
+
     /// Verifies that a pending uploaded file addition is rescanned and cleared when a later delete removes the file.
     [<Test>]
     let ``delete after failed uploaded add rescans and clears stale pending file difference`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -225,6 +225,15 @@ module WatchTests =
     /// Produces an empty difference list for watch tests that do not exercise a scan path.
     let private scanForNoDifferences _ = Task.FromResult(List<FileSystemDifference>())
 
+    /// Records the uploaded identity that the real watch upload path would cache for status application.
+    let private recordUploadedFileVersion fullPath =
+        match (Services.createLocalFileVersion (FileInfo(fullPath)))
+            .GetAwaiter()
+            .GetResult()
+            with
+        | Some localFileVersion -> Watch.recordUploadedFileVersionForWatchTests localFileVersion.ToFileVersion
+        | None -> Assert.Fail($"Expected a local file version for {fullPath}.")
+
     /// Builds process pending watch work for test test data used to exercise CLI watch behavior.
     let private processPendingWatchWorkForTest () =
         let status = GraceStatus.Default
@@ -237,8 +246,12 @@ module WatchTests =
         let readStatus () = Task.FromResult(status)
 
         /// Builds upload test data used to exercise CLI watch behavior.
-        let upload _ _ =
+        let upload _ filePath =
             uploadCalls <- uploadCalls + 1
+            let fullPath = $"{filePath}"
+
+            if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
             Task.FromResult(())
 
         /// Builds update grace status test data used to exercise CLI watch behavior.
@@ -269,13 +282,64 @@ module WatchTests =
 
         updateCalls, uploadCalls
 
+    /// Builds process pending watch work with an explicit GraceStatus for test data used to exercise CLI watch behavior.
+    let private processPendingWatchWorkForTestWithStatus status =
+        /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
+        let mutable updateCalls = 0
+        /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
+        let mutable uploadCalls = 0
+        /// Reads status needed by the test scenario.
+        let readStatus () = Task.FromResult(status)
+
+        /// Builds upload test data used to exercise CLI watch behavior.
+        let upload _ filePath =
+            uploadCalls <- uploadCalls + 1
+            let fullPath = $"{filePath}"
+
+            if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+            Task.FromResult(())
+
+        /// Builds update grace status test data used to exercise CLI watch behavior.
+        let updateGraceStatus status _ =
+            updateCalls <- updateCalls + 1
+            Task.FromResult(Some status)
+
+        /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+        let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
+        /// Builds apply incremental test data used to exercise CLI watch behavior.
+        let applyIncremental _ _ _ = Task.FromResult(())
+        /// Builds update ipc test data used to exercise CLI watch behavior.
+        let updateIpc _ _ = Task.FromResult(())
+
+        (Watch.processChangedFilesWithClients
+            readStatus
+            readStatus
+            upload
+            updateGraceStatus
+            scanForNoDifferences
+            updateGraceStatusFromDifferences
+            applyIncremental
+            updateIpc)
+            .GetAwaiter()
+            .GetResult()
+
+        updateCalls, uploadCalls
+
     /// Builds process pending watch work with status clients test data used to exercise CLI watch behavior.
     let private processPendingWatchWorkWithStatusClients readStatusFile updateGraceStatus =
         let status = GraceStatus.Default
         /// Reads status meta needed by the test scenario.
         let readStatusMeta () = Task.FromResult(status)
+
         /// Builds upload test data used to exercise CLI watch behavior.
-        let upload _ _ = Task.FromResult(())
+        let upload _ filePath =
+            let fullPath = $"{filePath}"
+
+            if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+            Task.FromResult(())
+
         /// Builds update grace status from differences test data used to exercise CLI watch behavior.
         let updateGraceStatusFromDifferences status _ _ = updateGraceStatus status CorrelationId.Empty
         /// Builds apply incremental test data used to exercise CLI watch behavior.
@@ -365,6 +429,34 @@ module WatchTests =
             RootDirectoryBlake3Hash = root.Blake3Hash
         }
 
+    /// Builds GraceStatus around explicit file versions so tests can model content-equivalent uploads.
+    let private graceStatusTrackingFileVersions (trackedFiles: LocalFileVersion array) =
+        let rootDirectoryId = Guid.NewGuid()
+        let index = GraceIndex()
+
+        let root =
+            LocalDirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "root-sha")
+                (Blake3Hash "root-blake3")
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>(trackedFiles))
+                1L
+                DateTime.UtcNow
+
+        index.TryAdd(rootDirectoryId, root) |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     /// Verifies that resolve signal r access token result returns token when present.
     [<Test>]
     let ``resolveSignalRAccessTokenResult returns token when present`` () =
@@ -415,7 +507,7 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             /// Builds update calls test data used to exercise CLI watch behavior.
-            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let updateCalls, uploadCalls = processPendingWatchWorkForTestWithStatus (graceStatusTracking [| "deleted.txt" |] Array.empty<string>)
 
             updateCalls |> should equal 1
             uploadCalls |> should equal 0
@@ -488,7 +580,8 @@ module WatchTests =
             |> should equal [| "deleted-while-upload-pending.txt" |]
 
             /// Builds success calls test data used to exercise CLI watch behavior.
-            let successCalls, successfulUploadCalls = processPendingWatchWorkForTest ()
+            let successCalls, successfulUploadCalls =
+                processPendingWatchWorkForTestWithStatus (graceStatusTracking [| "deleted-while-upload-pending.txt" |] Array.empty<string>)
 
             successCalls |> should equal 1
             successfulUploadCalls |> should equal 1
@@ -518,12 +611,14 @@ module WatchTests =
             let readStatus () = Task.FromResult(GraceStatus.Default)
 
             /// Builds upload test data used to exercise CLI watch behavior.
-            let upload _ _ =
+            let upload _ filePath =
                 uploadCalls <- uploadCalls + 1
 
                 if uploadCalls = 1 then
                     File.WriteAllText(changedFilePath, "second payload")
                     Watch.OnChanged(changedEvent changedFilePath)
+                else
+                    recordUploadedFileVersion $"{filePath}"
 
                 Task.FromResult(())
 
@@ -600,7 +695,7 @@ module WatchTests =
             |> should equal [| "queued-then-deleted.txt" |]
 
             /// Builds update calls test data used to exercise CLI watch behavior.
-            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let updateCalls, uploadCalls = processPendingWatchWorkForTestWithStatus (graceStatusTracking [| "queued-then-deleted.txt" |] Array.empty<string>)
 
             updateCalls |> should equal 1
             uploadCalls |> should equal 0)
@@ -637,6 +732,7 @@ module WatchTests =
     let ``status-only triggers remain pending when status update returns none`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "retry-delete.txt")
+            let status = graceStatusTracking [| "retry-delete.txt" |] Array.empty<string>
             /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable updateCalls = 0
 
@@ -647,7 +743,7 @@ module WatchTests =
                 updateCalls <- updateCalls + 1
                 Task.FromResult(None)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             updateCalls |> should equal 1
 
@@ -657,7 +753,7 @@ module WatchTests =
             |> should equal [| "retry-delete.txt" |]
 
             /// Builds success calls test data used to exercise CLI watch behavior.
-            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let successCalls, uploadCalls = processPendingWatchWorkForTestWithStatus status
 
             successCalls |> should equal 1
             uploadCalls |> should equal 0
@@ -672,6 +768,14 @@ module WatchTests =
     let ``status-only triggers remain pending when scan failure is swallowed as unchanged status`` () =
         withTempRepo (fun root ->
             let filePath = Path.Combine(root, "swallowed-scan-failure-delete.txt")
+
+            let status =
+                graceStatusTracking
+                    [|
+                        "swallowed-scan-failure-delete.txt"
+                    |]
+                    Array.empty<string>
+
             /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable updateCalls = 0
 
@@ -683,26 +787,16 @@ module WatchTests =
                 Services.setLastScanForDifferencesSuccessfulForWatchTests false
                 Task.FromResult(Some status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             updateCalls |> should equal 1
 
-            let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
+            let afterStatusUpdate = Watch.pendingWatchWorkSnapshotForTests ()
 
-            afterFailure.StatusUpdateTriggers
-            |> should
-                equal
-                [|
-                    "swallowed-scan-failure-delete.txt"
-                |]
+            afterStatusUpdate.StatusUpdateTriggers
+            |> should equal Array.empty<string>
 
-            Services.setLastScanForDifferencesSuccessfulForWatchTests true
-
-            /// Builds success calls test data used to exercise CLI watch behavior.
-            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
-
-            successCalls |> should equal 1
-            uploadCalls |> should equal 0)
+            Services.setLastScanForDifferencesSuccessfulForWatchTests true)
 
     /// Verifies that status only triggers added during status update remain pending for next pass.
     [<Test>]
@@ -710,6 +804,15 @@ module WatchTests =
         withTempRepo (fun root ->
             let beforeUpdatePath = Path.Combine(root, "before-update-delete.txt")
             let duringUpdatePath = Path.Combine(root, "during-update-delete.txt")
+
+            let status =
+                graceStatusTracking
+                    [|
+                        "before-update-delete.txt"
+                        "during-update-delete.txt"
+                    |]
+                    Array.empty<string>
+
             /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable updateCalls = 0
 
@@ -723,7 +826,7 @@ module WatchTests =
 
                 Task.FromResult(Some status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             updateCalls |> should equal 1
 
@@ -733,7 +836,7 @@ module WatchTests =
             |> should equal [| "during-update-delete.txt" |]
 
             /// Builds success calls test data used to exercise CLI watch behavior.
-            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let successCalls, uploadCalls = processPendingWatchWorkForTestWithStatus status
 
             successCalls |> should equal 1
             uploadCalls |> should equal 0
@@ -748,6 +851,7 @@ module WatchTests =
     let ``same status-only trigger added during status update remains pending for next pass`` () =
         withTempRepo (fun root ->
             let deletedPath = Path.Combine(root, "same-path-delete.txt")
+            let status = graceStatusTracking [| "same-path-delete.txt" |] Array.empty<string>
             /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable updateCalls = 0
 
@@ -761,7 +865,7 @@ module WatchTests =
 
                 Task.FromResult(Some status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             updateCalls |> should equal 1
 
@@ -771,7 +875,7 @@ module WatchTests =
             |> should equal [| "same-path-delete.txt" |]
 
             /// Builds success calls test data used to exercise CLI watch behavior.
-            let successCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let successCalls, uploadCalls = processPendingWatchWorkForTestWithStatus status
 
             successCalls |> should equal 1
             uploadCalls |> should equal 0
@@ -814,13 +918,14 @@ module WatchTests =
         withTempRepo (fun root ->
             let oldPath = Path.Combine(root, "old-status-only-name.txt")
             let ignoredNewPath = Path.Combine(root, "new-status-only-name.gracetmp")
+            let status = graceStatusTracking [| "old-status-only-name.txt" |] Array.empty<string>
 
             Watch.OnRenamed(renamedEvent oldPath ignoredNewPath)
 
             /// Builds update grace status test data used to exercise CLI watch behavior.
             let updateGraceStatus _ _ = Task.FromException<GraceStatus option>(InvalidOperationException("transient status update failure"))
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
 
@@ -1135,7 +1240,7 @@ module WatchTests =
             |> should equal [| "duplicate-delete.txt" |]
 
             /// Builds update calls test data used to exercise CLI watch behavior.
-            let updateCalls, uploadCalls = processPendingWatchWorkForTest ()
+            let updateCalls, uploadCalls = processPendingWatchWorkForTestWithStatus (graceStatusTracking [| "duplicate-delete.txt" |] Array.empty<string>)
 
             updateCalls |> should equal 1
             uploadCalls |> should equal 0
@@ -1144,6 +1249,272 @@ module WatchTests =
 
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that healthy file add change and delete derive status differences without scanning.
+    [<Test>]
+    let ``healthy file events derive status differences without scan`` () =
+        withTempRepo (fun root ->
+            let addedPath = Path.Combine(root, "added.txt")
+            let changedPath = Path.Combine(root, "changed.txt")
+            let deletedPath = Path.Combine(root, "deleted.txt")
+            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanCalls = 0
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so this scenario can assert event-derived status work.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(addedPath, "new file content")
+            File.WriteAllText(changedPath, "changed file content")
+
+            Watch.OnCreated(changedEvent addedPath)
+            Watch.OnChanged(changedEvent changedPath)
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| "changed.txt"; "deleted.txt" |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.sortBy (fun (_, _, relativePath) -> relativePath)
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, "added.txt"
+                    DifferenceType.Change, FileSystemEntryType.File, "changed.txt"
+                    DifferenceType.Delete, FileSystemEntryType.File, "deleted.txt"
+                |])
+
+    /// Verifies that content-equivalent changed observations do not apply a Save-producing difference.
+    [<Test>]
+    let ``content-equivalent changed file derives no status difference`` () =
+        withTempRepo (fun root ->
+            let changedPath = Path.Combine(root, "equivalent.txt")
+            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the no-save behavior.
+            let mutable applyFromDifferencesCalls = 0
+
+            File.WriteAllText(changedPath, "same content")
+
+            let trackedFile =
+                (Services.createLocalFileVersion (FileInfo(changedPath)))
+                    .GetAwaiter()
+                    .GetResult()
+                    .Value
+
+            Watch.OnChanged(changedEvent changedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTrackingFileVersions [| trackedFile |])
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that recreated paths invalidate stale startup deletes before status apply.
+    [<Test>]
+    let ``recreated path invalidates stale startup delete before apply`` () =
+        withTempRepo (fun root ->
+            let relativePath = "recreated.txt"
+            let fullPath = Path.Combine(root, relativePath)
+            /// Tracks scan-oriented update Calls changes so this scenario can assert the no-scan-update behavior.
+            let mutable scanOrientedUpdateCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert no stale delete was applied.
+            let mutable applyFromDifferencesCalls = 0
+
+            Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
+            File.WriteAllText(fullPath, "recreated equivalent content")
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| relativePath |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ =
+                scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                differences
+                |> Seq.exists (fun difference -> difference.DifferenceType = DifferenceType.Delete)
+                |> should equal false
+
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanOrientedUpdateCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that startup rescan changes do not apply a stale delete for the same recreated path.
+    [<Test>]
+    let ``startup rescan change suppresses stale delete for same path`` () =
+        withTempRepo (fun root ->
+            let relativePath = "recreated-with-change.txt"
+            let fullPath = Path.Combine(root, relativePath)
+            let staleDelete = FileSystemDifference.Create Delete FileSystemEntryType.File relativePath
+            let liveChange = FileSystemDifference.Create Change FileSystemEntryType.File relativePath
+            /// Tracks scan Calls changes so this scenario can assert the startup fallback still runs when required.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert the applied action set.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the test fails on Delete plus Change.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.queueStartupDifferenceForWatch staleDelete
+            File.WriteAllText(fullPath, "recreated changed content")
+            Watch.OnChanged(changedEvent fullPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| relativePath |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>([ liveChange ]))
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.toArray
+            |> should equal [| liveChange |])
 
     /// Verifies that renamed file queues old path status trigger and new path upload work.
     [<Test>]
@@ -1244,6 +1615,7 @@ module WatchTests =
         withTempRepo (fun root ->
             let deletedFilePath = Path.Combine(root, "delete-before-race.txt")
             let createdFilePath = Path.Combine(root, "created-during-status-update.txt")
+            let status = graceStatusTracking [| "delete-before-race.txt" |] Array.empty<string>
             /// Tracks update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable updateCalls = 0
 
@@ -1259,7 +1631,7 @@ module WatchTests =
 
                 Task.FromResult(Some status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(GraceStatus.Default)) updateGraceStatus
+            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
 
             updateCalls |> should equal 1
 
@@ -1311,8 +1683,12 @@ module WatchTests =
             let readStatus () = Task.FromResult(GraceStatus.Default)
 
             /// Builds upload test data used to exercise CLI watch behavior.
-            let upload _ _ =
+            let upload _ filePath =
                 uploadCalls <- uploadCalls + 1
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
                 Task.FromResult(())
 
             /// Builds scan-oriented update test data used to exercise CLI watch behavior.
@@ -1635,13 +2011,22 @@ module WatchTests =
             let updateGraceStatusFromDifferences status differences _ =
                 applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
 
-                differences
-                |> Seq.toArray
-                |> should equal [| startupDifference |]
-
                 if applyFromDifferencesCalls = 1 then
+                    differences
+                    |> Seq.toArray
+                    |> should equal [| startupDifference |]
+
                     File.WriteAllText(createdDuringApplyPath, "created during apply")
                     Watch.OnChanged(changedEvent createdDuringApplyPath)
+                else
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Add, FileSystemEntryType.File, "created-during-apply.txt"
+                        |]
 
                 Task.FromResult(Some status)
 
@@ -1673,7 +2058,7 @@ module WatchTests =
             processPendingWork ()
 
             uploadCalls |> should equal 1
-            scanOrientedUpdateCalls |> should equal 1
+            scanOrientedUpdateCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 1)
 
     /// Verifies that startup apply does not drain unrelated status-only work queued before the same pass.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1690,6 +1690,67 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.File, "Src/new.txt"
                 |])
 
+    /// Verifies that nested file adds preserve the tracked ancestor directory casing for all derived add paths.
+    [<Test>]
+    let ``case-insensitive nested added file preserves tracked ancestor directory casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+            let uploadedDirectory = Path.Combine(root, "src", "newdir")
+            let uploadedPath = Path.Combine(uploadedDirectory, "a.txt")
+            let status = graceStatusTracking Array.empty<string> [| "Src" |]
+            /// Tracks the Differences passed to the apply seam so nested tracked ancestor casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(uploadedDirectory)
+            |> ignore
+
+            File.WriteAllText(uploadedPath, "new file under a nested differently-cased tracked ancestor")
+            Watch.OnCreated(changedEvent uploadedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, "Src/newdir"
+                    DifferenceType.Add, FileSystemEntryType.File, "Src/newdir/a.txt"
+                |])
+
     /// Verifies that stale deletes requeue canceled same-path file upload work before status-only triggers drain.
     [<Test>]
     let ``stale delete after same-path change requeues canceled upload work`` () =
@@ -1777,6 +1838,91 @@ module WatchTests =
                     DifferenceType.Change, FileSystemEntryType.File, relativePath
                 |])
 
+    /// Verifies that stale deletes requeue canceled same-path upload work for files not already tracked in GraceStatus.
+    [<Test>]
+    let ``stale delete after untracked add requeues canceled upload work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "same-path-stale-add.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so the untracked add retry is proven.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so this scenario proves the upload retry path avoids a healthy scan.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so final status work is applied once after reupload.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the final file add is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(filePath, "new content that should still upload")
+            Watch.OnChanged(changedEvent filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.FilesToProcess
+            |> should equal [| filePath |]
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| relativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |])
+
     /// Verifies that a pending uploaded file addition is rescanned and cleared when a later delete removes the file.
     [<Test>]
     let ``delete after failed uploaded add rescans and clears stale pending file difference`` () =
@@ -1835,6 +1981,96 @@ module WatchTests =
             applyFromDifferencesCalls |> should equal 1
 
             File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            processPendingWork ()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRetry.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterRetry.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that stale parent directory adds are cleared when their child file add disappears before retry.
+    [<Test>]
+    let ``delete after failed nested uploaded add clears stale parent directory difference`` () =
+        withTempRepo (fun root ->
+            let relativePath = "new-parent/deleted-before-retry.txt"
+            let parentPath = Path.Combine(root, "new-parent")
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks scan Calls changes so this scenario proves stale parent cleanup uses the retry rescan.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the stale parent add is not applied on retry.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the first failed parent-plus-file add is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(parentPath) |> ignore
+
+            File.WriteAllText(filePath, "transient nested upload content")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(None)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, "new-parent"
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |]
+
+            File.Delete(filePath)
+            Directory.Delete(parentPath)
             Watch.OnDeleted(deletedEvent filePath)
 
             processPendingWork ()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1612,6 +1612,92 @@ module WatchTests =
             appliedSnapshot.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that uploaded adds retry when final content no longer matches the uploaded identity.
+    [<Test>]
+    let ``uploaded add retries when final content changes after upload`` () =
+        withTempRepo (fun root ->
+            let relativePath = "retry-rewritten-add.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so this scenario can assert the retry side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the stale upload identity does not clear the add.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the retried add is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(filePath, "content captured by the first upload")
+            Watch.OnCreated(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+
+                if uploadCalls = 1 then
+                    File.WriteAllText($"{pendingFilePath}", "rewritten content with no newer watcher event")
+
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            /// Runs one watch processing pass with the rewritten-content test clients.
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            let retrySnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            retrySnapshot.FilesToProcess
+            |> should equal [| filePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |]
+
+            let appliedSnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            appliedSnapshot.FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that case-sensitive watch comparison does not collapse distinct tracked and uploaded file paths.
     [<Test>]
     let ``case-sensitive tracked file matching preserves distinct uploaded path`` () =
@@ -2986,8 +3072,12 @@ module WatchTests =
             let readStatus () = Task.FromResult(GraceStatus.Default)
 
             /// Builds upload test data used to exercise CLI watch behavior.
-            let upload _ _ =
+            let upload _ filePath =
                 uploadCalls <- uploadCalls + 1
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
                 Task.FromResult(())
 
             /// Builds scan-oriented update test data used to exercise CLI watch behavior.
@@ -3069,8 +3159,12 @@ module WatchTests =
             let readStatus () = Task.FromResult(GraceStatus.Default)
 
             /// Builds upload test data used to exercise CLI watch behavior.
-            let upload _ _ =
+            let upload _ filePath =
                 uploadCalls <- uploadCalls + 1
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
                 Task.FromResult(())
 
             /// Builds scan-oriented update test data used to exercise CLI watch behavior.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -763,6 +763,101 @@ module WatchTests =
             afterSuccess.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
+    /// Verifies that a stale status only delete requeues recreated content without a canceled upload marker.
+    [<Test>]
+    let ``stale status-only delete requeues recreated changed tracked file without canceled upload`` () =
+        withTempRepo (fun root ->
+            let relativePath = "stale-delete-recreated.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so this scenario can assert the requeued upload happened.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the changed content reaches status application.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the stale delete becomes a file change.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(filePath, "tracked content")
+
+            let trackedFile =
+                (Services.createLocalFileVersion (FileInfo(filePath)))
+                    .GetAwaiter()
+                    .GetResult()
+                    .Value
+
+            File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+            File.WriteAllText(filePath, "recreated changed content")
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTrackingFileVersions [| trackedFile |])
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 0
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| relativePath |]
+
+            afterRequeue.FilesToProcess
+            |> should equal [| filePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, relativePath
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that status only triggers remain pending when scan failure is swallowed as unchanged status.
     [<Test>]
     let ``status-only triggers remain pending when scan failure is swallowed as unchanged status`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1466,6 +1466,91 @@ module WatchTests =
                     for index in 1..fileCount -> $"batch-{index:D2}.txt"
                 |])
 
+    /// Verifies that uploaded adds retry when the final file cannot be hashed during status derivation.
+    [<Test>]
+    let ``uploaded add retries when final hashing is unavailable`` () =
+        withTempRepo (fun root ->
+            let relativePath = "retry-unhashed-add.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so this scenario can assert the retry side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the unavailable hash pass does not clear the add.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the retried add is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(filePath, "content that cannot be hashed during the first status pass")
+            Watch.OnCreated(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            Watch.setCreateLocalFileVersionForWatchTests (fun _ -> Task.FromResult<LocalFileVersion option>(None))
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            let retrySnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            retrySnapshot.FilesToProcess
+            |> should equal [| filePath |]
+
+            Watch.setCreateLocalFileVersionForWatchTests Services.createLocalFileVersion
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |]
+
+            let appliedSnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            appliedSnapshot.FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that case-sensitive watch comparison does not collapse distinct tracked and uploaded file paths.
     [<Test>]
     let ``case-sensitive tracked file matching preserves distinct uploaded path`` () =
@@ -1585,6 +1670,60 @@ module WatchTests =
             let deletedPath = Path.Combine(root, "foo.txt")
             let status = graceStatusTracking [| "Foo.txt" |] Array.empty<string>
             /// Tracks the Differences passed to the apply seam so tracked delete casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, "Foo.txt"
+                |])
+
+    /// Verifies that delete classification stays case-insensitive even when other watch matching is case-sensitive.
+    [<Test>]
+    let ``case-sensitive watch comparison still preserves tracked delete casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.Ordinal
+
+            let deletedPath = Path.Combine(root, "foo.txt")
+            let status = graceStatusTracking [| "Foo.txt" |] Array.empty<string>
+            /// Tracks the Differences passed to the apply seam so legacy delete casing is proven.
             let mutable observedDifferences = List<FileSystemDifference>()
 
             Watch.setGraceStatusForWatchTests status

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1698,6 +1698,105 @@ module WatchTests =
             appliedSnapshot.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that mixed uploaded adds wait for rewritten uploads before applying status.
+    [<Test>]
+    let ``mixed uploaded adds defer status while rewritten upload requeues`` () =
+        withTempRepo (fun root ->
+            let readyRelativePath = "ready-add.txt"
+            let rewrittenRelativePath = "retry-rewritten-add.txt"
+            let readyFilePath = Path.Combine(root, readyRelativePath)
+            let rewrittenFilePath = Path.Combine(root, rewrittenRelativePath)
+            /// Tracks upload Calls changes so this scenario can detect redundant ready-file retries.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls so partial status application is rejected.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply path once every upload has final content.
+            let mutable observedDifferences = List<FileSystemDifference>()
+            /// Tracks whether the rewritten file already changed after its first uploaded identity was recorded.
+            let mutable rewrittenAfterFirstUpload = false
+
+            File.WriteAllText(readyFilePath, "ready content")
+            File.WriteAllText(rewrittenFilePath, "content captured by the first upload")
+            Watch.OnCreated(changedEvent readyFilePath)
+            Watch.OnCreated(changedEvent rewrittenFilePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                let fullPath = $"{pendingFilePath}"
+                recordUploadedFileVersion fullPath
+
+                if
+                    not rewrittenAfterFirstUpload
+                    && String.Equals(Path.GetFileName(fullPath), rewrittenRelativePath, StringComparison.Ordinal)
+                then
+                    rewrittenAfterFirstUpload <- true
+                    File.WriteAllText(fullPath, "rewritten content with no newer watcher event")
+
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            /// Runs one watch processing pass with the mixed uploaded-file test clients.
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 0
+
+            let retrySnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            retrySnapshot.FilesToProcess
+            |> should equal [| rewrittenFilePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 3
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.sortBy (fun (_, _, relativePath) -> relativePath)
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, readyRelativePath
+                    DifferenceType.Add, FileSystemEntryType.File, rewrittenRelativePath
+                |]
+
+            let appliedSnapshot = Watch.pendingWatchWorkSnapshotForTests ()
+
+            appliedSnapshot.FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that case-sensitive watch comparison does not collapse distinct tracked and uploaded file paths.
     [<Test>]
     let ``case-sensitive tracked file matching preserves distinct uploaded path`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -675,6 +675,93 @@ module WatchTests =
             afterSecondUpload.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that a concurrent file event does not leave already-applied upload paths waiting for status.
+    [<Test>]
+    let ``processed upload path clears when file event arrives during status apply`` () =
+        withTempRepo (fun root ->
+            let appliedRelativePath = "already-applied.txt"
+            let appliedFilePath = Path.Combine(root, appliedRelativePath)
+            let createdDuringApplyRelativePath = "created-during-upload-apply.txt"
+            let createdDuringApplyPath = Path.Combine(root, createdDuringApplyRelativePath)
+            /// Tracks upload Calls changes so the test proves old applied content is not retried.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the race and retry passes are explicit.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the latest Differences passed to the apply seam.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(appliedFilePath, "already uploaded content")
+            Watch.OnChanged(changedEvent appliedFilePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+
+                if applyFromDifferencesCalls = 1 then
+                    File.WriteAllText(createdDuringApplyPath, "created while status was saving")
+                    Watch.OnChanged(changedEvent createdDuringApplyPath)
+
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            /// Runs one watch processing pass with the status-apply race test clients.
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterRace = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRace.FilesToProcess
+            |> should equal [| createdDuringApplyPath |]
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal Array.empty<string>
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 2
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, createdDuringApplyRelativePath
+                |])
+
     /// Verifies that deleted file cancels same path pending upload work before status rescan.
     [<Test>]
     let ``deleted file cancels same-path pending upload work before status rescan`` () =
@@ -856,6 +943,108 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that a stale delete requeue prevents applying unrelated ready uploads in the same pass.
+    [<Test>]
+    let ``mixed ready upload defers while stale status-only delete requeues`` () =
+        withTempRepo (fun root ->
+            let readyRelativePath = "ready-before-stale-delete.txt"
+            let readyFilePath = Path.Combine(root, readyRelativePath)
+            let staleDeleteRelativePath = "stale-delete-requeued.txt"
+            let staleDeletePath = Path.Combine(root, staleDeleteRelativePath)
+            /// Tracks upload Calls changes so the ready file is not redundantly uploaded.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so partial status application is rejected.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam after the stale delete reupload completes.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(readyFilePath, "ready content")
+            Watch.OnChanged(changedEvent readyFilePath)
+
+            File.WriteAllText(staleDeletePath, "tracked stale-delete content")
+
+            let trackedFile =
+                (Services.createLocalFileVersion (FileInfo(staleDeletePath)))
+                    .GetAwaiter()
+                    .GetResult()
+                    .Value
+
+            File.Delete(staleDeletePath)
+            Watch.OnDeleted(deletedEvent staleDeletePath)
+            File.WriteAllText(staleDeletePath, "changed content after stale delete")
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTrackingFileVersions [| trackedFile |])
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            /// Runs one watch processing pass with mixed ready and stale-delete work.
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.FilesToProcess
+            |> should equal [| staleDeletePath |]
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| staleDeleteRelativePath |]
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal [| readyRelativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.sortBy (fun (_, _, relativePath) -> relativePath)
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, readyRelativePath
+                    DifferenceType.Change, FileSystemEntryType.File, staleDeleteRelativePath
+                |]
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
             |> should equal Array.empty<string>)
 
     /// Verifies that status only triggers remain pending when scan failure is swallowed as unchanged status.
@@ -2035,6 +2224,11 @@ module WatchTests =
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
                 observedDifferences <- differences
+
+                Watch.uploadedFileVersionRelativePathsForWatchTests ()
+                |> Array.contains "Foo.txt"
+                |> should equal true
+
                 Task.FromResult(Some status)
 
             /// Builds apply incremental test data used to exercise CLI watch behavior.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1330,6 +1330,324 @@ module WatchTests =
                     DifferenceType.Delete, FileSystemEntryType.File, "deleted.txt"
                 |])
 
+    /// Verifies that a file addition under new directories includes the directory additions needed to link the file.
+    [<Test>]
+    let ``new file under untracked directories derives parent directory additions`` () =
+        withTempRepo (fun root ->
+            let nestedDirectory = Path.Combine(root, "new-parent", "nested")
+
+            Directory.CreateDirectory(nestedDirectory)
+            |> ignore
+
+            let addedPath = Path.Combine(nestedDirectory, "added.txt")
+            /// Tracks the Differences passed to the apply seam so parent directory additions are proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(addedPath, "new nested file content")
+            Watch.OnCreated(changedEvent addedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking Array.empty<string> Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, "new-parent"
+                    DifferenceType.Add, FileSystemEntryType.Directory, "new-parent/nested"
+                    DifferenceType.Add, FileSystemEntryType.File, "new-parent/nested/added.txt"
+                |])
+
+    /// Verifies that uploaded paths are retained across 50-file batches until status application drains the full queue.
+    [<Test>]
+    let ``uploaded file paths survive across watch batches before status apply`` () =
+        withTempRepo (fun root ->
+            let fileCount = 55
+            /// Tracks upload Calls changes so this scenario can assert the batched side effect explicitly.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so this scenario can assert status applies once after drain.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so all uploaded files are represented.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            for index in 1..fileCount do
+                let filePath = Path.Combine(root, $"batch-{index:D2}.txt")
+                File.WriteAllText(filePath, $"batch payload {index}")
+                Watch.OnChanged(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForNoDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 50
+            applyFromDifferencesCalls |> should equal 0
+
+            processPendingWork ()
+
+            uploadCalls |> should equal fileCount
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.filter (fun difference ->
+                difference.DifferenceType = DifferenceType.Add
+                && difference.FileSystemEntryType = FileSystemEntryType.File)
+            |> Seq.map (fun difference -> $"{difference.RelativePath}")
+            |> Seq.sort
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    for index in 1..fileCount -> $"batch-{index:D2}.txt"
+                |])
+
+    /// Verifies that case-sensitive watch comparison does not collapse distinct tracked and uploaded file paths.
+    [<Test>]
+    let ``case-sensitive tracked file matching preserves distinct uploaded path`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.Ordinal
+
+            let uploadedPath = Path.Combine(root, "foo.txt")
+            /// Tracks the Differences passed to the apply seam so case-sensitive matching is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(uploadedPath, "uploaded lowercase content")
+            Watch.OnChanged(changedEvent uploadedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| "Foo.txt" |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, "foo.txt"
+                |])
+
+    /// Verifies that a pending uploaded file addition is rescanned and cleared when a later delete removes the file.
+    [<Test>]
+    let ``delete after failed uploaded add rescans and clears stale pending file difference`` () =
+        withTempRepo (fun root ->
+            let relativePath = "deleted-before-retry.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks scan Calls changes so this scenario can assert stale pending work is rescanned.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so only the failed add attempt reached status apply.
+            let mutable applyFromDifferencesCalls = 0
+
+            File.WriteAllText(filePath, "transient uploaded content")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(None)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            applyFromDifferencesCalls |> should equal 1
+
+            File.Delete(filePath)
+            Watch.OnDeleted(deletedEvent filePath)
+
+            processPendingWork ()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRetry.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterRetry.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that replacing a tracked file with a directory preserves the file delete half of the replacement.
+    [<Test>]
+    let ``tracked file replaced by directory still derives file delete`` () =
+        withTempRepo (fun root ->
+            let relativePath = "replaced-path"
+            let replacementDirectory = Path.Combine(root, relativePath)
+            /// Tracks the Differences passed to the apply seam so the replaced file delete is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(replacementDirectory)
+            |> ignore
+
+            Watch.OnDeleted(deletedEvent replacementDirectory)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| relativePath |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                |])
+
     /// Verifies that content-equivalent changed observations do not apply a Save-producing difference.
     [<Test>]
     let ``content-equivalent changed file derives no status difference`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1041,6 +1041,67 @@ module WatchTests =
             pending.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that case-sensitive delete derivation removes the exact tracked casing when a case-colliding file remains.
+    [<Test>]
+    let ``case-sensitive delete uses exact tracked file before ignore-case fallback`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.Ordinal
+
+            let status = graceStatusTracking [| "Foo.txt"; "foo.txt" |] Array.empty<string>
+
+            Watch.setGraceStatusForWatchTests status
+
+            Watch.setFinalPathExistsForWatchTests
+                (fun fullPath -> String.Equals(Path.GetFileName(fullPath), "Foo.txt", StringComparison.Ordinal))
+                (fun _ -> false)
+
+            let deletedPath = Path.Combine(root, "foo.txt")
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            /// Tracks event-derived Differences changes so this scenario can assert the exact delete casing.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            /// Reads status metadata needed by the test scenario.
+            let readStatusMeta () = Task.FromResult(GraceStatus.Default)
+            /// Reads status file needed by the test scenario.
+            let readStatusFile () = Task.FromResult(status)
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+            /// Builds scan-oriented status update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status (differences: List<FileSystemDifference>) _ =
+                observedDifferences <- List<FileSystemDifference>(differences)
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatusMeta
+                readStatusFile
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, "foo.txt"
+                |])
+
     /// Verifies that status reload failure keeps ignored looking delete queued for retry.
     [<Test>]
     let ``status reload failure keeps ignored-looking delete queued for retry`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1606,6 +1606,67 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.File, "foo.txt"
                 |])
 
+    /// Verifies that repository case detection can make default matching case-insensitive without a test override.
+    [<Test>]
+    let ``case-insensitive repository default preserves tracked file casing`` () =
+        withTempRepo (fun root ->
+            let uploadedPath = Path.Combine(root, "foo.txt")
+            /// Tracks probe Calls changes so the test proves repository case behavior configures watch matching.
+            let mutable probeCalls = 0
+            /// Tracks the Differences passed to the apply seam so default tracked casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setRepositoryPathCaseInsensitiveLookupForWatchTests (fun _ ->
+                probeCalls <- probeCalls + 1
+                true)
+
+            File.WriteAllText(uploadedPath, "uploaded lowercase content")
+            Watch.OnChanged(changedEvent uploadedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| "Foo.txt" |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            probeCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, "Foo.txt"
+                |])
+
     /// Verifies that case-insensitive tracked file matching emits changes with the tracked path casing.
     [<Test>]
     let ``case-insensitive changed file preserves tracked path casing`` () =
@@ -1714,6 +1775,66 @@ module WatchTests =
                 [|
                     DifferenceType.Delete, FileSystemEntryType.File, "Foo.txt"
                 |])
+
+    /// Verifies that a differently-cased delete event does not delete a tracked file that still exists.
+    [<Test>]
+    let ``matched delete checks tracked path before deleting tracked file`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.Ordinal
+
+            let trackedRelativePath = "Foo.txt"
+            let deletedEventRelativePath = "foo.txt"
+            let trackedPath = Path.Combine(root, trackedRelativePath)
+            let deletedEventPath = Path.Combine(root, deletedEventRelativePath)
+            let status = graceStatusTracking [| trackedRelativePath |] Array.empty<string>
+            /// Tracks apply-from-differences Calls changes so stale delete suppression is proven.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the test fails if Foo.txt is deleted.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+
+            Watch.setFinalPathExistsForWatchTests (fun fullPath -> String.Equals(fullPath, trackedPath, StringComparison.Ordinal)) (fun _ -> false)
+
+            Watch.OnDeleted(deletedEvent deletedEventPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 0
+
+            observedDifferences
+            |> Seq.toArray
+            |> should equal Array.empty<FileSystemDifference>)
 
     /// Verifies that delete classification stays case-insensitive even when other watch matching is case-sensitive.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1521,6 +1521,61 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.File, "foo.txt"
                 |])
 
+    /// Verifies that case-insensitive tracked file matching emits changes with the tracked path casing.
+    [<Test>]
+    let ``case-insensitive changed file preserves tracked path casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+            let uploadedPath = Path.Combine(root, "foo.txt")
+            /// Tracks the Differences passed to the apply seam so tracked casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(uploadedPath, "uploaded lowercase content")
+            Watch.OnChanged(changedEvent uploadedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| "Foo.txt" |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, "Foo.txt"
+                |])
+
     /// Verifies that a pending uploaded file addition is rescanned and cleared when a later delete removes the file.
     [<Test>]
     let ``delete after failed uploaded add rescans and clears stale pending file difference`` () =
@@ -1581,6 +1636,100 @@ module WatchTests =
             File.Delete(filePath)
             Watch.OnDeleted(deletedEvent filePath)
 
+            processPendingWork ()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRetry.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterRetry.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that a clean retry drops a stale uploaded file change after the file returns to tracked content.
+    [<Test>]
+    let ``clean rescan after reverted upload clears stale pending change`` () =
+        withTempRepo (fun root ->
+            let relativePath = "reverted-before-retry.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks scan Calls changes so this scenario can assert the clean retry path was used.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so stale changes are not re-applied.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the first failed change is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            File.WriteAllText(filePath, "tracked content")
+
+            let trackedFile =
+                (Services.createLocalFileVersion (FileInfo(filePath)))
+                    .GetAwaiter()
+                    .GetResult()
+                    .Value
+
+            File.WriteAllText(filePath, "changed content")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(graceStatusTrackingFileVersions [| trackedFile |])
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(None)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, relativePath
+                |]
+
+            File.WriteAllText(filePath, "tracked content")
+            Watch.OnChanged(changedEvent filePath)
+
+            processPendingWork ()
             processPendingWork ()
 
             scanCalls |> should equal 1

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1689,8 +1689,7 @@ module Watch =
                         let! uploadedFileDifferences, unresolvedUploadedFilePaths =
                             deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
 
-                        reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
-                        |> ignore
+                        let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
 
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
                         let eventDerivedDifferences = mergeStatusDifferences uploadedFileDifferences deleteDifferences
@@ -1714,6 +1713,12 @@ module Watch =
                                 logToAnsiConsole
                                     Colors.Important
                                     $"Grace Status pending startup differences need a successful rescan before status application; status-only triggers will retry."
+
+                                Task.FromResult(None)
+                            elif requeuedUnresolvedUploadedFilePaths.Count > 0 then
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Status uploaded file differences include unresolved final content; requeued uploads will finish before status application."
 
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -620,7 +620,12 @@ module Watch =
 
             match trackedDeletedPathKind status statusTrigger.RelativePath with
             | DeletedFile ->
-                match tryFindTrackedFileWithComparison deletedPathComparison status relativePath with
+                let trackedFile =
+                    match tryFindTrackedFileWithComparison StringComparison.Ordinal status relativePath with
+                    | Some exactTrackedFile -> Some exactTrackedFile
+                    | None -> tryFindTrackedFileWithComparison deletedPathComparison status relativePath
+
+                match trackedFile with
                 | Some trackedFile ->
                     if not (finalPathMatchesEntryType FileSystemEntryType.File trackedFile.RelativePath) then
                         differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -361,20 +361,34 @@ module Watch =
         status.Index.Values
         |> Seq.tryFind (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, watchPathComparison))
 
-    /// Uses the tracked parent directory casing before status application performs exact path lookups.
-    let private preserveTrackedParentCasingForFileAdd (status: GraceStatus) (relativePath: RelativePath) =
+    /// Uses the longest tracked ancestor casing before status application performs exact path lookups.
+    let private canonicalizeTrackedAncestorCasing (status: GraceStatus) (relativePath: RelativePath) =
         let normalizedRelativePath = normalizeRelativePath relativePath
         let segments = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
+        let mutable canonicalRelativePath = relativePath
+        let mutable foundTrackedAncestor = false
 
-        if segments.Length <= 1 then
-            relativePath
-        else
-            let parentRelativePath = RelativePath(String.Join("/", segments[0 .. segments.Length - 2]))
-            let fileName = segments[segments.Length - 1]
+        if segments.Length > 0 then
+            for prefixLength in segments.Length .. -1 .. 1 do
+                if not foundTrackedAncestor then
+                    let ancestorRelativePath = RelativePath(String.Join("/", segments[0 .. prefixLength - 1]))
 
-            match tryFindTrackedDirectory status parentRelativePath with
-            | Some trackedParentDirectory -> RelativePath($"{trackedParentDirectory.RelativePath}/{fileName}")
-            | None -> relativePath
+                    match tryFindTrackedDirectory status ancestorRelativePath with
+                    | Some trackedAncestorDirectory ->
+                        let trackedAncestorPath = normalizeRelativePath trackedAncestorDirectory.RelativePath
+
+                        let canonicalPath =
+                            if prefixLength = segments.Length then
+                                trackedAncestorPath
+                            else
+                                let suffixPath = String.Join("/", segments[prefixLength..])
+                                $"{trackedAncestorPath}/{suffixPath}"
+
+                        canonicalRelativePath <- RelativePath canonicalPath
+                        foundTrackedAncestor <- true
+                    | None -> ()
+
+        canonicalRelativePath
 
     /// Checks whether the uploaded file identity would change the tracked GraceStatus file content.
     let private uploadedFileContentChanged (trackedFile: LocalFileVersion) (uploadedFile: FileVersion) =
@@ -432,6 +446,7 @@ module Watch =
         if segments.Length > 1 then
             for index in 0 .. segments.Length - 2 do
                 let parentRelativePath = RelativePath(String.Join("/", segments[0..index]))
+                let parentDifferenceRelativePath = canonicalizeTrackedAncestorCasing status parentRelativePath
                 let parentFullPath = Path.Combine(Current().RootDirectory, $"{parentRelativePath}")
 
                 let alreadyAdded =
@@ -439,14 +454,14 @@ module Watch =
                     |> Seq.exists (fun difference ->
                         difference.FileSystemEntryType = FileSystemEntryType.Directory
                         && difference.DifferenceType = Add
-                        && String.Equals(normalizeRelativePath difference.RelativePath, normalizeRelativePath parentRelativePath, watchPathComparison))
+                        && String.Equals(normalizeRelativePath difference.RelativePath, normalizeRelativePath parentDifferenceRelativePath, watchPathComparison))
 
                 if
                     not alreadyAdded
-                    && not (isTrackedDirectory status parentRelativePath)
+                    && not (isTrackedDirectory status parentDifferenceRelativePath)
                     && Directory.Exists(parentFullPath)
                 then
-                    differences.Add(FileSystemDifference.Create Add FileSystemEntryType.Directory parentRelativePath)
+                    differences.Add(FileSystemDifference.Create Add FileSystemEntryType.Directory parentDifferenceRelativePath)
 
         differences
 
@@ -466,7 +481,7 @@ module Watch =
                     | Some _ -> ()
                     | None ->
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
-                        let addRelativePath = preserveTrackedParentCasingForFileAdd status uploadedFileVersion.RelativePath
+                        let addRelativePath = canonicalizeTrackedAncestorCasing status uploadedFileVersion.RelativePath
                         differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File addRelativePath)
                 | None -> ()
 
@@ -504,6 +519,13 @@ module Watch =
             || difference.DifferenceType = Change)
         && finalPathKind difference.RelativePath
            <> FinalPathFile
+
+    /// Checks whether a pending parent directory add no longer exists in final path state.
+    let private isStaleParentDirectoryAddDifference (difference: FileSystemDifference) =
+        difference.FileSystemEntryType = FileSystemEntryType.Directory
+        && difference.DifferenceType = Add
+        && finalPathKind difference.RelativePath
+           <> FinalPathDirectory
 
     /// Checks whether a status-only trigger covers the same path as a pending file difference.
     let private hasMatchingStatusTrigger (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (difference: FileSystemDifference) =
@@ -556,6 +578,8 @@ module Watch =
                 resolved.Add(difference)
             elif isStaleUploadedFileDifference difference
                  && hasMatchingStatusTrigger statusTriggerSnapshot difference then
+                resolved.Add(difference)
+            elif isStaleParentDirectoryAddDifference difference then
                 resolved.Add(difference)
             else
                 applicable.Add(difference)
@@ -651,9 +675,9 @@ module Watch =
         else
             false
 
-    /// Requeues a same-path upload when a stale delete had canceled upload work for a tracked file that exists again.
+    /// Requeues a same-path upload when a stale delete had canceled upload work for a final file that exists again.
     let private reenqueueCanceledUploadsForResolvedFileDeletes
-        (status: GraceStatus)
+        (_status: GraceStatus)
         (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
         (canceledRelativePaths: List<RelativePath>)
         =
@@ -667,12 +691,10 @@ module Watch =
                 |> Seq.exists (fun canceledPath -> String.Equals(normalizeRelativePath canceledPath, normalizeRelativePath relativePath, watchPathComparison))
 
             if uploadWasCanceled then
-                match tryFindTrackedFile status relativePath with
-                | Some _ when finalPathMatchesEntryType FileSystemEntryType.File relativePath ->
+                if finalPathMatchesEntryType FileSystemEntryType.File relativePath then
                     let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
-                    enqueueFileUpload fullPath |> ignore
-                    requeuedRelativePaths.Add(relativePath)
-                | _ -> ()
+
+                    if enqueueFileUpload fullPath then requeuedRelativePaths.Add(relativePath)
 
         clearCanceledFileUploadDeleteRelativePaths requeuedRelativePaths
         requeuedRelativePaths
@@ -831,7 +853,15 @@ module Watch =
                     |> Seq.exists (statusDifferenceMatches startupDifference)
                 )
 
-            if not isSupersededUploadedFileDifference then
+            let isSupersededParentDirectoryAdd =
+                isStaleParentDirectoryAddDifference startupDifference
+                && not (
+                    rescannedDifferences
+                    |> Seq.exists (statusDifferenceMatches startupDifference)
+                )
+
+            if not isSupersededUploadedFileDifference
+               && not isSupersededParentDirectoryAdd then
                 retainedStartupDifferences.Add(startupDifference)
 
         mergeStatusDifferences retainedStartupDifferences rescannedDifferences

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -54,6 +54,10 @@ module Watch =
 
     let private processedFileRelativePathsPendingStatus = List<RelativePath>()
 
+    let private canceledFileUploadDeleteRelativePathsLock = obj ()
+
+    let private canceledFileUploadDeleteRelativePaths = List<RelativePath>()
+
     /// Removes uploaded identities after their matching watch work is either applied or proven content-equivalent.
     let private removeUploadedFileVersionsForPaths (relativePaths: seq<RelativePath>) =
         let normalizedPaths =
@@ -350,6 +354,28 @@ module Watch =
         status.Index.Values
         |> Seq.exists (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, watchPathComparison))
 
+    /// Finds the tracked directory entry that owns a repository-relative path in GraceStatus.
+    let private tryFindTrackedDirectory (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        status.Index.Values
+        |> Seq.tryFind (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, watchPathComparison))
+
+    /// Uses the tracked parent directory casing before status application performs exact path lookups.
+    let private preserveTrackedParentCasingForFileAdd (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+        let segments = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+        if segments.Length <= 1 then
+            relativePath
+        else
+            let parentRelativePath = RelativePath(String.Join("/", segments[0 .. segments.Length - 2]))
+            let fileName = segments[segments.Length - 1]
+
+            match tryFindTrackedDirectory status parentRelativePath with
+            | Some trackedParentDirectory -> RelativePath($"{trackedParentDirectory.RelativePath}/{fileName}")
+            | None -> relativePath
+
     /// Checks whether the uploaded file identity would change the tracked GraceStatus file content.
     let private uploadedFileContentChanged (trackedFile: LocalFileVersion) (uploadedFile: FileVersion) =
         uploadedFile.Sha256Hash <> trackedFile.Sha256Hash
@@ -440,7 +466,8 @@ module Watch =
                     | Some _ -> ()
                     | None ->
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
-                        differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File uploadedFileVersion.RelativePath)
+                        let addRelativePath = preserveTrackedParentCasingForFileAdd status uploadedFileVersion.RelativePath
+                        differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File addRelativePath)
                 | None -> ()
 
             return differences
@@ -456,7 +483,9 @@ module Watch =
             match trackedDeletedPathKind status statusTrigger.RelativePath with
             | DeletedFile ->
                 if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
-                    differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
+                    match tryFindTrackedFile status relativePath with
+                    | Some trackedFile -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)
+                    | None -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
             | DeletedDirectory ->
                 if not (finalPathMatchesEntryType FileSystemEntryType.Directory relativePath) then
                     differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
@@ -481,6 +510,32 @@ module Watch =
         statusTriggerSnapshot
         |> Array.exists (fun statusTrigger ->
             String.Equals(normalizeRelativePath statusTrigger.RelativePath, normalizeRelativePath difference.RelativePath, watchPathComparison))
+
+    /// Records a delete-triggered cancellation that may need the final file re-uploaded if the delete proves stale.
+    let private addCanceledFileUploadDeleteRelativePath (relativePath: RelativePath) =
+        lock canceledFileUploadDeleteRelativePathsLock (fun () ->
+            let normalizedRelativePath = normalizeRelativePath relativePath
+
+            let alreadyRecorded =
+                canceledFileUploadDeleteRelativePaths
+                |> Seq.exists (fun existing -> String.Equals(normalizeRelativePath existing, normalizedRelativePath, watchPathComparison))
+
+            if not alreadyRecorded then
+                canceledFileUploadDeleteRelativePaths.Add(relativePath))
+
+    /// Captures delete-triggered upload cancellations waiting for final path resolution.
+    let private canceledFileUploadDeleteRelativePathsSnapshot () =
+        lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.ToList())
+
+    /// Clears delete-triggered upload cancellations after they are requeued or their status trigger drains.
+    let private clearCanceledFileUploadDeleteRelativePaths (relativePaths: seq<RelativePath>) =
+        lock canceledFileUploadDeleteRelativePathsLock (fun () ->
+            for relativePath in relativePaths do
+                let normalizedRelativePath = normalizeRelativePath relativePath
+
+                canceledFileUploadDeleteRelativePaths.RemoveAll (fun existing ->
+                    String.Equals(normalizeRelativePath existing, normalizedRelativePath, watchPathComparison))
+                |> ignore)
 
     /// Checks whether pending uploaded file work needs a final-state rescan before applying status differences.
     let private staleUploadedFileDifferencesNeedRescan (differences: List<FileSystemDifference>) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
@@ -596,19 +651,44 @@ module Watch =
         else
             false
 
+    /// Requeues a same-path upload when a stale delete had canceled upload work for a tracked file that exists again.
+    let private reenqueueCanceledUploadsForResolvedFileDeletes
+        (status: GraceStatus)
+        (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
+        (canceledRelativePaths: List<RelativePath>)
+        =
+        let requeuedRelativePaths = List<RelativePath>()
+
+        for statusTrigger in statusTriggerSnapshot do
+            let relativePath = RelativePath statusTrigger.RelativePath
+
+            let uploadWasCanceled =
+                canceledRelativePaths
+                |> Seq.exists (fun canceledPath -> String.Equals(normalizeRelativePath canceledPath, normalizeRelativePath relativePath, watchPathComparison))
+
+            if uploadWasCanceled then
+                match tryFindTrackedFile status relativePath with
+                | Some _ when finalPathMatchesEntryType FileSystemEntryType.File relativePath ->
+                    let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+                    enqueueFileUpload fullPath |> ignore
+                    requeuedRelativePaths.Add(relativePath)
+                | _ -> ()
+
+        clearCanceledFileUploadDeleteRelativePaths requeuedRelativePaths
+        requeuedRelativePaths
+
     /// Reads remove pending file upload data needed by the command workflow without changing remote state.
     let private removePendingFileUpload filePath =
         let mutable generation = 0L
 
         filesToProcess.TryRemove(filePath, &generation)
-        |> ignore
 
     /// Reads cancel pending uploads for deleted path data needed by the command workflow without changing remote state.
     let private cancelPendingUploadsForDeletedPath fullPath =
-        removePendingFileUpload fullPath
+        let mutable canceledExactFileUpload = removePendingFileUpload fullPath
 
         match repositoryRelativePath fullPath with
-        | Some relativePath -> removePendingFileUpload relativePath
+        | Some relativePath -> if removePendingFileUpload relativePath then canceledExactFileUpload <- true
         | None -> ()
 
         let normalizedFullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(fullPath))
@@ -623,20 +703,31 @@ module Watch =
             | None -> None
 
         for queuedFile in filesToProcess.Keys.ToArray() do
-            let removeQueuedFile =
-                let normalizedQueuedFile =
-                    try
-                        Path.GetFullPath(queuedFile)
-                    with
-                    | _ -> queuedFile
+            let normalizedQueuedFile =
+                try
+                    Path.GetFullPath(queuedFile)
+                with
+                | _ -> queuedFile
 
+            let removeQueuedFile =
                 normalizedQueuedFile.Equals(normalizedFullPath, watchPathComparison)
                 || normalizedQueuedFile.StartsWith(fullPathPrefix, watchPathComparison)
                 || (match relativePathPrefix with
                     | Some prefix -> queuedFile.StartsWith(prefix, watchPathComparison)
                     | None -> false)
 
-            if removeQueuedFile then removePendingFileUpload queuedFile
+            if removeQueuedFile then
+                let queuedExactPathMatched =
+                    normalizedQueuedFile.Equals(normalizedFullPath, watchPathComparison)
+                    || (match repositoryRelativePath fullPath with
+                        | Some relativePath -> String.Equals(normalizeRelativePath queuedFile, normalizeRelativePath relativePath, watchPathComparison)
+                        | None -> false)
+
+                if removePendingFileUpload queuedFile
+                   && queuedExactPathMatched then
+                    canceledExactFileUpload <- true
+
+        canceledExactFileUpload
 
     /// Records an already-derived filesystem difference so status application can retry without duplicating work.
     let private addPendingStatusDifference (difference: FileSystemDifference) =
@@ -752,6 +843,7 @@ module Watch =
         statusUpdateTriggers.Clear()
         uploadedFileVersions.Clear()
         lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
+        lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.Clear())
         clearPendingStatusDifferencesForTests ()
 
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
@@ -975,9 +1067,14 @@ module Watch =
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
         if updateNotInProgress () then
-            cancelPendingUploadsForDeletedPath args.FullPath
+            let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
 
             if enqueueStatusUpdateTrigger args.FullPath then
+                if canceledFileUpload then
+                    match repositoryRelativePath args.FullPath with
+                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
+                    | None -> ()
+
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
 
             if (isGraceStatusArtifact args.FullPath)
@@ -989,11 +1086,16 @@ module Watch =
         if updateNotInProgress () then
             let newPathIsDirectory = Directory.Exists(args.FullPath)
 
-            cancelPendingUploadsForDeletedPath args.OldFullPath
+            let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
 
             let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
 
             if oldPathStatusQueued then
+                if canceledFileUpload then
+                    match repositoryRelativePath args.OldFullPath with
+                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
+                    | None -> ()
+
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
             if newPathIsDirectory then
@@ -1374,6 +1476,11 @@ module Watch =
                         let fileWorkGenerationBeforeStatusUpdate = Volatile.Read(&fileUploadWorkGeneration)
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
+                        let canceledFileUploadDeleteRelativePathsForStatus = canceledFileUploadDeleteRelativePathsSnapshot ()
+
+                        reenqueueCanceledUploadsForResolvedFileDeletes graceStatus statusTriggerSnapshot canceledFileUploadDeleteRelativePathsForStatus
+                        |> ignore
+
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
                         let processedFileRelativePathsForStatus = processedFileRelativePathsPendingStatusSnapshot ()
@@ -1439,6 +1546,17 @@ module Watch =
                                     drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                                 else
                                     drainAppliedStatusWork directorySnapshot statusTriggerSnapshot statusDifferencesForApply.Resolved
+
+                                let canceledFileUploadDeletePathsToClear =
+                                    if startupPendingDifferences.Count = 0 then
+                                        statusTriggerSnapshot
+                                        |> Seq.map (fun statusTrigger -> RelativePath statusTrigger.RelativePath)
+                                    else
+                                        statusDifferencesForApply.Resolved
+                                        |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.File)
+                                        |> Seq.map (fun difference -> difference.RelativePath)
+
+                                clearCanceledFileUploadDeleteRelativePaths canceledFileUploadDeletePathsToClear
 
                                 clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -663,6 +663,42 @@ module Watch =
         |> Array.exists (fun statusTrigger ->
             String.Equals(normalizeRelativePath statusTrigger.RelativePath, normalizeRelativePath difference.RelativePath, watchPathComparison))
 
+    /// Checks whether a completed file upload already waits for status application on this path.
+    let private hasProcessedFileRelativePath (processedRelativePaths: List<RelativePath>) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        processedRelativePaths
+        |> Seq.exists (fun processedPath -> String.Equals(normalizeRelativePath processedPath, normalizedRelativePath, watchPathComparison))
+
+    /// Checks whether startup recovery already owns the stale delete decision for this path.
+    let private hasMatchingStartupFileDeleteDifference (startupPendingDifferences: List<FileSystemDifference>) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        startupPendingDifferences
+        |> Seq.exists (fun difference ->
+            difference.DifferenceType = DifferenceType.Delete
+            && difference.FileSystemEntryType = FileSystemEntryType.File
+            && String.Equals(normalizeRelativePath difference.RelativePath, normalizedRelativePath, watchPathComparison))
+
+    /// Finds the GraceStatus file entry represented by a status-only trigger.
+    let private tryFindTrackedFileForStatusTrigger (status: GraceStatus) (relativePath: RelativePath) =
+        match tryFindTrackedFileWithComparison StringComparison.Ordinal status relativePath with
+        | Some exactTrackedFile -> Some exactTrackedFile
+        | None -> tryFindTrackedFileWithComparison deletedPathComparison status relativePath
+
+    /// Checks whether a stale delete trigger's final file content differs from GraceStatus.
+    let private finalFileContentChangedFromTrackedStatus (status: GraceStatus) (relativePath: RelativePath) =
+        task {
+            match tryFindTrackedFileForStatusTrigger status relativePath with
+            | Some trackedFile when finalPathMatchesEntryType FileSystemEntryType.File relativePath ->
+                let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+
+                match! createLocalFileVersionForWatchStatus (FileInfo(fullPath)) with
+                | Some finalFileVersion -> return uploadedFileContentChanged trackedFile finalFileVersion.ToFileVersion
+                | None -> return false
+            | _ -> return false
+        }
+
     /// Records a delete-triggered cancellation that may need the final file re-uploaded if the delete proves stale.
     let private addCanceledFileUploadDeleteRelativePath (relativePath: RelativePath) =
         lock canceledFileUploadDeleteRelativePathsLock (fun () ->
@@ -822,29 +858,46 @@ module Watch =
 
         requeuedRelativePaths
 
-    /// Requeues a same-path upload when a stale delete had canceled upload work for a final file that exists again.
-    let private reenqueueCanceledUploadsForResolvedFileDeletes
-        (_status: GraceStatus)
+    /// Requeues a same-path upload when a stale delete resolves to changed final file content.
+    let private reenqueueUploadsForResolvedFileDeletes
+        (status: GraceStatus)
         (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
         (canceledRelativePaths: List<RelativePath>)
+        (processedRelativePaths: List<RelativePath>)
+        (startupPendingDifferences: List<FileSystemDifference>)
         =
-        let requeuedRelativePaths = List<RelativePath>()
+        task {
+            let requeuedRelativePaths = List<RelativePath>()
+            let mutable index = 0
 
-        for statusTrigger in statusTriggerSnapshot do
-            let relativePath = RelativePath statusTrigger.RelativePath
+            while index < statusTriggerSnapshot.Length do
+                let statusTrigger = statusTriggerSnapshot[index]
+                let relativePath = RelativePath statusTrigger.RelativePath
 
-            let uploadWasCanceled =
-                canceledRelativePaths
-                |> Seq.exists (fun canceledPath -> String.Equals(normalizeRelativePath canceledPath, normalizeRelativePath relativePath, watchPathComparison))
+                if not (hasProcessedFileRelativePath processedRelativePaths relativePath) then
+                    let uploadWasCanceled =
+                        canceledRelativePaths
+                        |> Seq.exists (fun canceledPath ->
+                            String.Equals(normalizeRelativePath canceledPath, normalizeRelativePath relativePath, watchPathComparison))
 
-            if uploadWasCanceled then
-                if finalPathMatchesEntryType FileSystemEntryType.File relativePath then
-                    let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+                    let! finalFileContentChanged =
+                        if uploadWasCanceled
+                           || hasMatchingStartupFileDeleteDifference startupPendingDifferences relativePath then
+                            Task.FromResult(false)
+                        else
+                            finalFileContentChangedFromTrackedStatus status relativePath
 
-                    if enqueueFileUpload fullPath then requeuedRelativePaths.Add(relativePath)
+                    if (uploadWasCanceled || finalFileContentChanged)
+                       && finalPathMatchesEntryType FileSystemEntryType.File relativePath then
+                        let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
-        clearCanceledFileUploadDeleteRelativePaths requeuedRelativePaths
-        requeuedRelativePaths
+                        if enqueueFileUpload fullPath then requeuedRelativePaths.Add(relativePath)
+
+                index <- index + 1
+
+            clearCanceledFileUploadDeleteRelativePaths requeuedRelativePaths
+            return requeuedRelativePaths
+        }
 
     /// Reads remove pending file upload data needed by the command workflow without changing remote state.
     let private removePendingFileUpload filePath =
@@ -1662,13 +1715,18 @@ module Watch =
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
                         let canceledFileUploadDeleteRelativePathsForStatus = canceledFileUploadDeleteRelativePathsSnapshot ()
+                        let processedFileRelativePathsForStatus = processedFileRelativePathsPendingStatusSnapshot ()
+                        let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
 
-                        reenqueueCanceledUploadsForResolvedFileDeletes graceStatus statusTriggerSnapshot canceledFileUploadDeleteRelativePathsForStatus
-                        |> ignore
+                        let! _ =
+                            reenqueueUploadsForResolvedFileDeletes
+                                graceStatus
+                                statusTriggerSnapshot
+                                canceledFileUploadDeleteRelativePathsForStatus
+                                processedFileRelativePathsForStatus
+                                startupPendingDifferences
 
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
-                        let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
-                        let processedFileRelativePathsForStatus = processedFileRelativePathsPendingStatusSnapshot ()
 
                         let pendingDifferencesNeedRescan =
                             startupPendingDifferences.Count > 0

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -550,8 +550,7 @@ module Watch =
     let private isStaleParentDirectoryAddDifference (difference: FileSystemDifference) =
         difference.FileSystemEntryType = FileSystemEntryType.Directory
         && difference.DifferenceType = Add
-        && finalPathKind difference.RelativePath
-           <> FinalPathDirectory
+        && not (directoryExistsUsingWatchPathComparison difference.RelativePath)
 
     /// Checks whether a status-only trigger covers the same path as a pending file difference.
     let private hasMatchingStatusTrigger (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (difference: FileSystemDifference) =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -417,6 +417,35 @@ module Watch =
         | FileSystemEntryType.Directory, FinalPathDirectory -> true
         | _ -> false
 
+    /// Checks directory existence using the active watch path comparison so case-insensitive event paths still match disk.
+    let private directoryExistsUsingWatchPathComparison (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+        let fullPath = Path.Combine(Current().RootDirectory, normalizedRelativePath)
+
+        if Directory.Exists(fullPath) then
+            true
+        else
+            let segments = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
+            let mutable currentDirectory = Path.GetFullPath(Current().RootDirectory)
+            let mutable exists = segments.Length > 0
+            let mutable index = 0
+
+            while exists && index < segments.Length do
+                if Directory.Exists(currentDirectory) then
+                    let matchingDirectory =
+                        Directory.EnumerateDirectories(currentDirectory)
+                        |> Seq.tryFind (fun candidate -> String.Equals(Path.GetFileName(candidate), segments[index], watchPathComparison))
+
+                    match matchingDirectory with
+                    | Some directory ->
+                        currentDirectory <- directory
+                        index <- index + 1
+                    | None -> exists <- false
+                else
+                    exists <- false
+
+            exists
+
     /// Finds the uploaded identity that matches the final file content for a processed watch path.
     let private tryFindUploadedFinalFileVersion (relativePath: RelativePath) =
         task {
@@ -447,7 +476,6 @@ module Watch =
             for index in 0 .. segments.Length - 2 do
                 let parentRelativePath = RelativePath(String.Join("/", segments[0..index]))
                 let parentDifferenceRelativePath = canonicalizeTrackedAncestorCasing status parentRelativePath
-                let parentFullPath = Path.Combine(Current().RootDirectory, $"{parentRelativePath}")
 
                 let alreadyAdded =
                     differences
@@ -456,11 +484,9 @@ module Watch =
                         && difference.DifferenceType = Add
                         && String.Equals(normalizeRelativePath difference.RelativePath, normalizeRelativePath parentDifferenceRelativePath, watchPathComparison))
 
-                if
-                    not alreadyAdded
-                    && not (isTrackedDirectory status parentDifferenceRelativePath)
-                    && Directory.Exists(parentFullPath)
-                then
+                if not alreadyAdded
+                   && not (isTrackedDirectory status parentDifferenceRelativePath)
+                   && directoryExistsUsingWatchPathComparison parentDifferenceRelativePath then
                     differences.Add(FileSystemDifference.Create Add FileSystemEntryType.Directory parentDifferenceRelativePath)
 
         differences

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -259,19 +259,35 @@ module Watch =
 
     let mutable private watchPathComparison = defaultWatchPathComparison ()
 
+    /// Compares delete-trigger paths against GraceStatus with the legacy status delete semantics.
+    let private deletedPathComparison = StringComparison.OrdinalIgnoreCase
+
+    /// Finds the tracked file entry that owns a repository-relative path with the requested comparison.
+    let private tryFindTrackedFileWithComparison (comparison: StringComparison) (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        status.Index.Values
+        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+        |> Seq.tryFind (fun fileVersion -> String.Equals(normalizeRelativePath fileVersion.RelativePath, normalizedRelativePath, comparison))
+
+    /// Finds the tracked directory entry that owns a repository-relative path with the requested comparison.
+    let private tryFindTrackedDirectoryWithComparison (comparison: StringComparison) (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        status.Index.Values
+        |> Seq.tryFind (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, comparison))
+
     /// Coordinates tracked deleted path kind behavior for this CLI command path.
     let private trackedDeletedPathKind (status: GraceStatus) (relativePath: string) =
-        let deletedRelativePath = normalizeRelativePath relativePath
+        let deletedRelativePath = RelativePath(normalizeRelativePath relativePath)
 
         let isTrackedFile =
-            status.Index.Values
-            |> Seq.exists (fun directoryVersion ->
-                directoryVersion.Files
-                |> Seq.exists (fun fileVersion -> String.Equals(normalizeRelativePath fileVersion.RelativePath, deletedRelativePath, watchPathComparison)))
+            tryFindTrackedFileWithComparison deletedPathComparison status deletedRelativePath
+            |> Option.isSome
 
         let isTrackedDirectory =
-            status.Index.Values
-            |> Seq.exists (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, deletedRelativePath, watchPathComparison))
+            tryFindTrackedDirectoryWithComparison deletedPathComparison status deletedRelativePath
+            |> Option.isSome
 
         match isTrackedFile, isTrackedDirectory with
         | true, _ -> DeletedFile
@@ -340,12 +356,7 @@ module Watch =
     let internal setWatchPathComparisonForWatchTests comparison = watchPathComparison <- comparison
 
     /// Finds the tracked file entry that owns a repository-relative path in GraceStatus.
-    let private tryFindTrackedFile (status: GraceStatus) (relativePath: RelativePath) =
-        let normalizedRelativePath = normalizeRelativePath relativePath
-
-        status.Index.Values
-        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
-        |> Seq.tryFind (fun fileVersion -> String.Equals(normalizeRelativePath fileVersion.RelativePath, normalizedRelativePath, watchPathComparison))
+    let private tryFindTrackedFile (status: GraceStatus) (relativePath: RelativePath) = tryFindTrackedFileWithComparison watchPathComparison status relativePath
 
     /// Checks whether GraceStatus already tracks a repository-relative directory path.
     let private isTrackedDirectory (status: GraceStatus) (relativePath: RelativePath) =
@@ -356,10 +367,7 @@ module Watch =
 
     /// Finds the tracked directory entry that owns a repository-relative path in GraceStatus.
     let private tryFindTrackedDirectory (status: GraceStatus) (relativePath: RelativePath) =
-        let normalizedRelativePath = normalizeRelativePath relativePath
-
-        status.Index.Values
-        |> Seq.tryFind (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, watchPathComparison))
+        tryFindTrackedDirectoryWithComparison watchPathComparison status relativePath
 
     /// Uses the longest tracked ancestor casing before status application performs exact path lookups.
     let private canonicalizeTrackedAncestorCasing (status: GraceStatus) (relativePath: RelativePath) =
@@ -446,25 +454,37 @@ module Watch =
 
             exists
 
+    /// Describes whether a completed upload can be matched against the current final path content.
+    type private UploadedFinalFileVersionResolution =
+        | UploadedFinalFileVersionFound of FileVersion
+        | UploadedFinalFileVersionUnavailable
+        | UploadedFinalFileVersionUnmatched
+        | UploadedFinalFileVersionMissing
+
+    let mutable private createLocalFileVersionForWatchStatus = createLocalFileVersion
+
     /// Finds the uploaded identity that matches the final file content for a processed watch path.
     let private tryFindUploadedFinalFileVersion (relativePath: RelativePath) =
         task {
             let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
             if File.Exists(fullPath) then
-                match! createLocalFileVersion (FileInfo(fullPath)) with
+                match! createLocalFileVersionForWatchStatus (FileInfo(fullPath)) with
                 | Some localFileVersion ->
                     let identity = (localFileVersion.RelativePath, localFileVersion.Sha256Hash, localFileVersion.Blake3Hash)
                     let mutable uploadedFileVersion = Unchecked.defaultof<FileVersion>
 
                     if uploadedFileVersions.TryGetValue(identity, &uploadedFileVersion) then
-                        return Some uploadedFileVersion
+                        return UploadedFinalFileVersionFound uploadedFileVersion
                     else
-                        return None
-                | None -> return None
+                        return UploadedFinalFileVersionUnmatched
+                | None -> return UploadedFinalFileVersionUnavailable
             else
-                return None
+                return UploadedFinalFileVersionMissing
         }
+
+    /// Installs the local file-version reader used by watch status derivation tests.
+    let internal setCreateLocalFileVersionForWatchTests createLocalFileVersionClient = createLocalFileVersionForWatchStatus <- createLocalFileVersionClient
 
     /// Lists missing parent directories that must be added before a new uploaded file can link into GraceStatus.
     let private deriveParentDirectoryAddDifferences (status: GraceStatus) (relativePath: RelativePath) =
@@ -495,12 +515,13 @@ module Watch =
     let private deriveUploadedFileDifferences (status: GraceStatus) (processedFilePaths: seq<RelativePath>) =
         task {
             let differences = List<FileSystemDifference>()
+            let unresolvedFilePaths = List<RelativePath>()
 
             for relativePath in
                 processedFilePaths
                 |> Seq.distinctBy normalizeRelativePath do
                 match! tryFindUploadedFinalFileVersion relativePath with
-                | Some uploadedFileVersion ->
+                | UploadedFinalFileVersionFound uploadedFileVersion ->
                     match tryFindTrackedFile status uploadedFileVersion.RelativePath with
                     | Some trackedFile when uploadedFileContentChanged trackedFile uploadedFileVersion ->
                         differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File trackedFile.RelativePath)
@@ -509,9 +530,11 @@ module Watch =
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
                         let addRelativePath = canonicalizeTrackedAncestorCasing status uploadedFileVersion.RelativePath
                         differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File addRelativePath)
-                | None -> ()
+                | UploadedFinalFileVersionUnavailable -> unresolvedFilePaths.Add(relativePath)
+                | UploadedFinalFileVersionUnmatched -> ()
+                | UploadedFinalFileVersionMissing -> ()
 
-            return differences
+            return differences, unresolvedFilePaths
         }
 
     /// Derives delete differences from GraceStatus while rejecting stale deletes for paths that exist again.
@@ -524,7 +547,7 @@ module Watch =
             match trackedDeletedPathKind status statusTrigger.RelativePath with
             | DeletedFile ->
                 if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
-                    match tryFindTrackedFile status relativePath with
+                    match tryFindTrackedFileWithComparison deletedPathComparison status relativePath with
                     | Some trackedFile -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)
                     | None -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
             | DeletedDirectory ->
@@ -699,6 +722,23 @@ module Watch =
             true
         else
             false
+
+    /// Requeues uploaded paths whose final content could not be hashed during status derivation.
+    let private reenqueueUnresolvedUploadedFinalFileVersions (relativePaths: seq<RelativePath>) =
+        let requeuedRelativePaths = List<RelativePath>()
+
+        for relativePath in
+            relativePaths
+            |> Seq.distinctBy normalizeRelativePath do
+            let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+
+            if
+                File.Exists(fullPath)
+                && enqueueFileUpload fullPath
+            then
+                requeuedRelativePaths.Add(relativePath)
+
+        requeuedRelativePaths
 
     /// Requeues a same-path upload when a stale delete had canceled upload work for a final file that exists again.
     let private reenqueueCanceledUploadsForResolvedFileDeletes
@@ -912,6 +952,7 @@ module Watch =
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         watchPathComparison <- defaultWatchPathComparison ()
+        createLocalFileVersionForWatchStatus <- createLocalFileVersion
         setLastScanForDifferencesSuccessfulForWatchTests true
 
     /// Coordinates pending watch work snapshot for tests behavior for this CLI command path.
@@ -1556,7 +1597,12 @@ module Watch =
                             else
                                 Task.FromResult(startupPendingDifferences)
 
-                        let! uploadedFileDifferences = deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
+                        let! uploadedFileDifferences, unresolvedUploadedFilePaths =
+                            deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
+
+                        reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
+                        |> ignore
+
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
                         let eventDerivedDifferences = mergeStatusDifferences uploadedFileDifferences deleteDifferences
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -436,7 +436,7 @@ module Watch =
                 | Some uploadedFileVersion ->
                     match tryFindTrackedFile status uploadedFileVersion.RelativePath with
                     | Some trackedFile when uploadedFileContentChanged trackedFile uploadedFileVersion ->
-                        differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File uploadedFileVersion.RelativePath)
+                        differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File trackedFile.RelativePath)
                     | Some _ -> ()
                     | None ->
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
@@ -695,6 +695,55 @@ module Watch =
             addIfMissing difference
 
         merged
+
+    /// Checks whether two status differences represent the same repository path observation.
+    let private statusDifferenceMatches (left: FileSystemDifference) (right: FileSystemDifference) =
+        left.DifferenceType = right.DifferenceType
+        && left.FileSystemEntryType = right.FileSystemEntryType
+        && String.Equals(normalizeRelativePath left.RelativePath, normalizeRelativePath right.RelativePath, watchPathComparison)
+
+    /// Checks whether a difference came from uploaded file work that a successful rescan can supersede.
+    let private isUploadedFileAddOrChangeDifference (difference: FileSystemDifference) =
+        difference.FileSystemEntryType = FileSystemEntryType.File
+        && (difference.DifferenceType = DifferenceType.Add
+            || difference.DifferenceType = DifferenceType.Change)
+
+    /// Checks whether uploaded identity data exists for a repository-relative path.
+    let private hasUploadedFileVersionForPath (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        uploadedFileVersions.Values
+        |> Seq.exists (fun uploadedFileVersion ->
+            String.Equals(normalizeRelativePath uploadedFileVersion.RelativePath, normalizedRelativePath, watchPathComparison))
+
+    /// Revalidates pending uploaded file differences against a successful rescan before retrying status application.
+    let private mergeRescannedStartupDifferences
+        (processedFilePaths: RelativePath seq)
+        (startupDifferences: List<FileSystemDifference>)
+        (rescannedDifferences: List<FileSystemDifference>)
+        =
+        let retainedStartupDifferences = List<FileSystemDifference>()
+
+        let processedUploadedPaths =
+            processedFilePaths
+            |> Seq.map normalizeRelativePath
+            |> Seq.toArray
+
+        for startupDifference in startupDifferences do
+            let isSupersededUploadedFileDifference =
+                isUploadedFileAddOrChangeDifference startupDifference
+                && hasUploadedFileVersionForPath startupDifference.RelativePath
+                && processedUploadedPaths
+                   |> Array.exists (fun processedPath -> String.Equals(normalizeRelativePath startupDifference.RelativePath, processedPath, watchPathComparison))
+                && not (
+                    rescannedDifferences
+                    |> Seq.exists (statusDifferenceMatches startupDifference)
+                )
+
+            if not isSupersededUploadedFileDifference then
+                retainedStartupDifferences.Add(startupDifference)
+
+        mergeStatusDifferences retainedStartupDifferences rescannedDifferences
 
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
@@ -1339,7 +1388,8 @@ module Watch =
                             if pendingDifferencesNeedRescan then
                                 task {
                                     let! rescannedDifferences = scanForDifferencesClient graceStatus
-                                    return mergeStatusDifferences startupPendingDifferences rescannedDifferences
+
+                                    return mergeRescannedStartupDifferences processedFileRelativePathsForStatus startupPendingDifferences rescannedDifferences
                                 }
                             else
                                 Task.FromResult(startupPendingDifferences)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -50,6 +50,24 @@ module Watch =
     /// Reads uploaded file version identity data needed by the command workflow without changing remote state.
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
+    /// Removes uploaded identities after their matching watch work is either applied or proven content-equivalent.
+    let private removeUploadedFileVersionsForPaths (relativePaths: seq<RelativePath>) =
+        let normalizedPaths =
+            relativePaths
+            |> Seq.map normalizeFilePath
+            |> HashSet
+
+        for uploadedFileVersion in uploadedFileVersions.Values.ToArray() do
+            if normalizedPaths.Contains(normalizeFilePath $"{uploadedFileVersion.RelativePath}") then
+                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity uploadedFileVersion, &removedFileVersion)
+                |> ignore
+
+    /// Records uploaded file identity data for watch tests that replace the storage upload client.
+    let internal recordUploadedFileVersionForWatchTests (fileVersion: FileVersion) =
+        uploadedFileVersions[uploadedFileVersionIdentity fileVersion] <- fileVersion
+
     /// Defines the options parsed by the watch command handlers.
     module private Options =
         let ownerId =
@@ -149,10 +167,10 @@ module Watch =
     /// Defines structured data exchanged by CLI helpers.
     type private StatusUpdateTriggerSnapshot = { RelativePath: string; Generation: int64 }
 
-    /// Holds a list of repo-relative paths that should trigger a Grace Status scan without uploading file content.
+    /// Holds a list of repo-relative paths that should trigger a Grace Status update without uploading file content.
     ///
-    /// FileSystemWatcher delete and rename-old events do not have durable file content to upload. They only need to
-    /// wake the timer loop so updateGraceStatus can run scanForDifferences against the current working tree.
+    /// FileSystemWatcher delete and rename-old events do not have durable file content to upload. They wake the timer
+    /// loop so status application can derive delete differences from GraceStatus and final path state.
     let mutable private statusUpdateTriggerGeneration = 0L
 
     let private statusUpdateTriggers = ConcurrentDictionary<string, int64>()
@@ -289,6 +307,102 @@ module Watch =
     /// Coordinates set watch path comparison for watch tests behavior for this CLI command path.
     let internal setWatchPathComparisonForWatchTests comparison = watchPathComparison <- comparison
 
+    /// Finds the tracked file entry that owns a repository-relative path in GraceStatus.
+    let private tryFindTrackedFile (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        status.Index.Values
+        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+        |> Seq.tryFind (fun fileVersion ->
+            String.Equals(normalizeRelativePath fileVersion.RelativePath, normalizedRelativePath, StringComparison.InvariantCultureIgnoreCase))
+
+    /// Checks whether the uploaded file identity would change the tracked GraceStatus file content.
+    let private uploadedFileContentChanged (trackedFile: LocalFileVersion) (uploadedFile: FileVersion) =
+        uploadedFile.Sha256Hash <> trackedFile.Sha256Hash
+        || (trackedFile.Blake3Hash <> Blake3Hash String.Empty
+            && uploadedFile.Blake3Hash <> trackedFile.Blake3Hash)
+
+    /// Checks whether a stale delete should be ignored because the path exists again before status application.
+    let private finalPathExists (relativePath: RelativePath) =
+        let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+
+        File.Exists(fullPath)
+        || Directory.Exists(fullPath)
+
+    /// Finds the uploaded identity that matches the final file content for a processed watch path.
+    let private tryFindUploadedFinalFileVersion (relativePath: RelativePath) =
+        task {
+            let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+
+            if File.Exists(fullPath) then
+                match! createLocalFileVersion (FileInfo(fullPath)) with
+                | Some localFileVersion ->
+                    let identity = (localFileVersion.RelativePath, localFileVersion.Sha256Hash, localFileVersion.Blake3Hash)
+                    let mutable uploadedFileVersion = Unchecked.defaultof<FileVersion>
+
+                    if uploadedFileVersions.TryGetValue(identity, &uploadedFileVersion) then
+                        return Some uploadedFileVersion
+                    else
+                        return None
+                | None -> return None
+            else
+                return None
+        }
+
+    /// Derives add and change differences from uploads already completed by the watch loop.
+    let private deriveUploadedFileDifferences (status: GraceStatus) (processedFilePaths: seq<RelativePath>) =
+        task {
+            let differences = List<FileSystemDifference>()
+
+            for relativePath in
+                processedFilePaths
+                |> Seq.distinctBy normalizeRelativePath do
+                match! tryFindUploadedFinalFileVersion relativePath with
+                | Some uploadedFileVersion ->
+                    match tryFindTrackedFile status uploadedFileVersion.RelativePath with
+                    | Some trackedFile when uploadedFileContentChanged trackedFile uploadedFileVersion ->
+                        differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File uploadedFileVersion.RelativePath)
+                    | Some _ -> ()
+                    | None -> differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File uploadedFileVersion.RelativePath)
+                | None -> ()
+
+            return differences
+        }
+
+    /// Derives delete differences from GraceStatus while rejecting stale deletes for paths that exist again.
+    let private deriveDeleteDifferences (status: GraceStatus) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
+        let differences = List<FileSystemDifference>()
+
+        for statusTrigger in statusTriggerSnapshot do
+            let relativePath = RelativePath statusTrigger.RelativePath
+
+            if not (finalPathExists relativePath) then
+                match trackedDeletedPathKind status statusTrigger.RelativePath with
+                | DeletedFile -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
+                | DeletedDirectory -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
+                | DeletedPathKindUnknown
+                | DeletedPathStatusUnavailable -> ()
+
+        differences
+
+    /// Models the differences that can be applied and the queued work they resolve.
+    type private StatusDifferencesForApply = { Applicable: List<FileSystemDifference>; Resolved: List<FileSystemDifference> }
+
+    /// Removes stale delete differences when final path state proves the path exists again.
+    let private splitApplicableStatusDifferences (differences: List<FileSystemDifference>) =
+        let applicable = List<FileSystemDifference>()
+        let resolved = List<FileSystemDifference>()
+
+        for difference in differences do
+            if difference.DifferenceType = Delete
+               && finalPathExists difference.RelativePath then
+                resolved.Add(difference)
+            else
+                applicable.Add(difference)
+                resolved.Add(difference)
+
+        { Applicable = applicable; Resolved = resolved }
+
     /// Coordinates should ignore deleted path behavior for this CLI command path.
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
         let configuration = Current()
@@ -419,8 +533,15 @@ module Watch =
 
             if removeQueuedFile then removePendingFileUpload queuedFile
 
-    /// Records an already-derived filesystem difference so status application can run without rescanning.
-    let private addPendingStatusDifference difference = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Add(difference))
+    /// Records an already-derived filesystem difference so status application can retry without duplicating work.
+    let private addPendingStatusDifference (difference: FileSystemDifference) =
+        lock pendingStatusDifferencesLock (fun () ->
+            if not
+               <| pendingStatusDifferences.Exists (fun (existing: FileSystemDifference) ->
+                   existing.RelativePath = difference.RelativePath
+                   && existing.DifferenceType = difference.DifferenceType
+                   && existing.FileSystemEntryType = difference.FileSystemEntryType) then
+                pendingStatusDifferences.Add(difference))
 
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
@@ -475,6 +596,7 @@ module Watch =
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
+        uploadedFileVersions.Clear()
         clearPendingStatusDifferencesForTests ()
 
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
@@ -1037,7 +1159,7 @@ module Watch =
         readGraceStatusMetaClient
         readGraceStatusFileClient
         copyFileToObjectDirectoryAndUploadToStorageClient
-        updateGraceStatusClient
+        _updateGraceStatusClient
         scanForDifferencesClient
         updateGraceStatusFromDifferencesClient
         applyGraceStatusIncrementalClient
@@ -1053,6 +1175,7 @@ module Watch =
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
+                    let processedFileRelativePaths = List<RelativePath>()
 
                     // Loop through no more than 50 files. Copy them to the objects directory, and upload them to storage.
                     //   In the incredibly rare event that more than 50 files have changed, we'll get 50-per-timer-tick,
@@ -1081,6 +1204,10 @@ module Watch =
                                 .Remove(pendingPair)
                             |> ignore
 
+                            match repositoryRelativePath pendingFile.FullPath with
+                            | Some relativePath -> processedFileRelativePaths.Add(RelativePath relativePath)
+                            | None -> ()
+
                             processedAnyFile <- true
                             lastFileUploadInstant <- getCurrentInstant ()
 
@@ -1096,25 +1223,35 @@ module Watch =
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
                         graceStatus <- graceStatusSnapshot
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
-                        let pendingDifferences = pendingStatusDifferencesSnapshot ()
+                        let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
 
                         let pendingDifferencesNeedRescan =
-                            processedAnyFile
-                            || pendingStatusDifferencesRequireRescanRetrySnapshot ()
+                            startupPendingDifferences.Count > 0
+                            && (processedAnyFile
+                                || pendingStatusDifferencesRequireRescanRetrySnapshot ())
 
-                        let! differencesToApply =
-                            if pendingDifferences.Count > 0
-                               && pendingDifferencesNeedRescan then
+                        let! startupDifferences =
+                            if pendingDifferencesNeedRescan then
                                 task {
                                     let! rescannedDifferences = scanForDifferencesClient graceStatus
-                                    return mergeStatusDifferences pendingDifferences rescannedDifferences
+                                    return mergeStatusDifferences startupPendingDifferences rescannedDifferences
                                 }
                             else
-                                Task.FromResult(pendingDifferences)
+                                Task.FromResult(startupPendingDifferences)
+
+                        let! uploadedFileDifferences = deriveUploadedFileDifferences graceStatus processedFileRelativePaths
+                        let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
+                        let eventDerivedDifferences = mergeStatusDifferences uploadedFileDifferences deleteDifferences
+
+                        for eventDerivedDifference in (eventDerivedDifferences :> seq<FileSystemDifference>) do
+                            addPendingStatusDifference eventDerivedDifference
+
+                        let pendingDifferencesToClear = mergeStatusDifferences startupPendingDifferences eventDerivedDifferences
+                        let statusDifferencesForApply = splitApplicableStatusDifferences (mergeStatusDifferences startupDifferences eventDerivedDifferences)
 
                         let! statusUpdateResult =
                             if
-                                pendingDifferences.Count > 0
+                                startupPendingDifferences.Count > 0
                                 && pendingDifferencesNeedRescan
                                 && not (wasLastScanForDifferencesSuccessful ())
                             then
@@ -1125,27 +1262,32 @@ module Watch =
                                     $"Grace Status pending startup differences need a successful rescan before status application; status-only triggers will retry."
 
                                 Task.FromResult(None)
-                            elif differencesToApply.Count > 0 then
-                                updateGraceStatusFromDifferencesClient graceStatus differencesToApply correlationId
+                            elif statusDifferencesForApply.Applicable.Count > 0 then
+                                updateGraceStatusFromDifferencesClient graceStatus statusDifferencesForApply.Applicable correlationId
                             else
-                                updateGraceStatusClient graceStatus correlationId
+                                Task.FromResult(Some graceStatus)
 
                         match statusUpdateResult with
                         | Some newGraceStatus ->
                             let statusUpdateCanCommit =
                                 filesToProcess.IsEmpty
                                 && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
-                                && (pendingDifferences.Count > 0
-                                    && not pendingDifferencesNeedRescan
+                                && (not pendingDifferencesNeedRescan
                                     || wasLastScanForDifferencesSuccessful ())
 
                             if statusUpdateCanCommit then
                                 graceStatus <- newGraceStatus
-                                drainAppliedStatusWork directorySnapshot statusTriggerSnapshot pendingDifferences
-                                clearPendingStatusDifferences pendingDifferences
+
+                                if startupPendingDifferences.Count = 0 then
+                                    drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
+                                else
+                                    drainAppliedStatusWork directorySnapshot statusTriggerSnapshot statusDifferencesForApply.Resolved
+
+                                clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
+                                removeUploadedFileVersionsForPaths processedFileRelativePaths
                             else
                                 if wasLastScanForDifferencesSuccessful () then
-                                    clearPendingStatusDifferences pendingDifferences
+                                    clearPendingStatusDifferences pendingDifferencesToClear
 
                                 logToAnsiConsole
                                     Colors.Important
@@ -1188,7 +1330,7 @@ module Watch =
             updateGraceWatchInterprocessFile
 
     /// Coordinates queue startup difference for watch behavior for this CLI command path.
-    let internal queueStartupDifferenceForWatch difference =
+    let internal queueStartupDifferenceForWatch (difference: FileSystemDifference) =
         addPendingStatusDifference difference
 
         match difference.FileSystemEntryType, difference.DifferenceType with

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -250,7 +250,7 @@ module Watch =
             .Replace(Path.DirectorySeparatorChar, '/')
             .Replace(Path.AltDirectorySeparatorChar, '/')
 
-    /// Coordinates default watch path comparison behavior for this CLI command path.
+    /// Provides the fallback path comparison until the repository volume can be probed.
     let private defaultWatchPathComparison () =
         if OperatingSystem.IsWindows() then
             StringComparison.OrdinalIgnoreCase
@@ -258,6 +258,64 @@ module Watch =
             StringComparison.Ordinal
 
     let mutable private watchPathComparison = defaultWatchPathComparison ()
+    let mutable private watchPathComparisonOverride: StringComparison option = None
+    let mutable private watchPathComparisonConfiguredRoot: string option = None
+
+    /// Checks whether the repository volume resolves differently-cased names to the same file.
+    let private detectRepositoryPathCaseInsensitiveLookup (rootDirectory: string) =
+        let mutable probePath = String.Empty
+        let mutable alternateProbePath = String.Empty
+
+        try
+            try
+                let probeDirectory =
+                    let graceDirectory = Current().GraceDirectory
+
+                    if String.IsNullOrWhiteSpace(graceDirectory) then
+                        Path.Combine(rootDirectory, Constants.GraceConfigDirectory)
+                    else
+                        graceDirectory
+
+                Directory.CreateDirectory(probeDirectory)
+                |> ignore
+
+                let probeName = $"grace-watch-case-probe-{Guid.NewGuid():N}"
+                probePath <- Path.Combine(probeDirectory, probeName.ToLowerInvariant())
+                alternateProbePath <- Path.Combine(probeDirectory, probeName.ToUpperInvariant())
+
+                File.WriteAllText(probePath, String.Empty)
+                File.Exists(alternateProbePath)
+            with
+            | _ -> OperatingSystem.IsWindows()
+        finally
+            for path in [| probePath; alternateProbePath |] do
+                try
+                    if
+                        not (String.IsNullOrWhiteSpace(path))
+                        && File.Exists(path)
+                    then
+                        File.Delete(path)
+                with
+                | _ -> ()
+
+    let mutable private repositoryPathCaseInsensitiveLookupForWatch = detectRepositoryPathCaseInsensitiveLookup
+
+    /// Aligns watch path matching with the active repository volume's case behavior.
+    let private configureWatchPathComparisonForCurrentRepository () =
+        match watchPathComparisonOverride with
+        | Some comparison -> watchPathComparison <- comparison
+        | None ->
+            let normalizedRoot = Path.GetFullPath(Current().RootDirectory)
+
+            if watchPathComparisonConfiguredRoot
+               <> Some normalizedRoot then
+                watchPathComparison <-
+                    if repositoryPathCaseInsensitiveLookupForWatch normalizedRoot then
+                        StringComparison.OrdinalIgnoreCase
+                    else
+                        StringComparison.Ordinal
+
+                watchPathComparisonConfiguredRoot <- Some normalizedRoot
 
     /// Compares delete-trigger paths against GraceStatus with the legacy status delete semantics.
     let private deletedPathComparison = StringComparison.OrdinalIgnoreCase
@@ -352,8 +410,16 @@ module Watch =
     let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
     /// Reads set enumerate files for directory upload for watch tests data needed by the command workflow without changing remote state.
     let internal setEnumerateFilesForDirectoryUploadForWatchTests enumerateFiles = enumerateFilesForDirectoryUpload <- enumerateFiles
+
     /// Coordinates set watch path comparison for watch tests behavior for this CLI command path.
-    let internal setWatchPathComparisonForWatchTests comparison = watchPathComparison <- comparison
+    let internal setWatchPathComparisonForWatchTests comparison =
+        watchPathComparison <- comparison
+        watchPathComparisonOverride <- Some comparison
+
+    /// Installs the repository case-sensitivity detector used by watch tests.
+    let internal setRepositoryPathCaseInsensitiveLookupForWatchTests detector =
+        repositoryPathCaseInsensitiveLookupForWatch <- detector
+        watchPathComparisonConfiguredRoot <- None
 
     /// Finds the tracked file entry that owns a repository-relative path in GraceStatus.
     let private tryFindTrackedFile (status: GraceStatus) (relativePath: RelativePath) = tryFindTrackedFileWithComparison watchPathComparison status relativePath
@@ -410,13 +476,21 @@ module Watch =
         | FinalPathFile
         | FinalPathDirectory
 
+    let mutable private fileExistsForWatchFinalPath = File.Exists
+    let mutable private directoryExistsForWatchFinalPath = Directory.Exists
+
     /// Reads the final filesystem kind for a repository-relative path.
     let private finalPathKind (relativePath: RelativePath) =
         let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
-        if File.Exists(fullPath) then FinalPathFile
-        elif Directory.Exists(fullPath) then FinalPathDirectory
+        if fileExistsForWatchFinalPath fullPath then FinalPathFile
+        elif directoryExistsForWatchFinalPath fullPath then FinalPathDirectory
         else FinalPathMissing
+
+    /// Installs final path existence readers used by watch classification tests.
+    let internal setFinalPathExistsForWatchTests fileExists directoryExists =
+        fileExistsForWatchFinalPath <- fileExists
+        directoryExistsForWatchFinalPath <- directoryExists
 
     /// Checks whether final path state still has the same kind as a delete difference.
     let private finalPathMatchesEntryType entryType relativePath =
@@ -546,10 +620,13 @@ module Watch =
 
             match trackedDeletedPathKind status statusTrigger.RelativePath with
             | DeletedFile ->
-                if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
-                    match tryFindTrackedFileWithComparison deletedPathComparison status relativePath with
-                    | Some trackedFile -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)
-                    | None -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
+                match tryFindTrackedFileWithComparison deletedPathComparison status relativePath with
+                | Some trackedFile ->
+                    if not (finalPathMatchesEntryType FileSystemEntryType.File trackedFile.RelativePath) then
+                        differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)
+                | None ->
+                    if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
+                        differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
             | DeletedDirectory ->
                 if not (finalPathMatchesEntryType FileSystemEntryType.Directory relativePath) then
                     differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
@@ -952,6 +1029,11 @@ module Watch =
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         watchPathComparison <- defaultWatchPathComparison ()
+        watchPathComparisonOverride <- None
+        watchPathComparisonConfiguredRoot <- None
+        repositoryPathCaseInsensitiveLookupForWatch <- detectRepositoryPathCaseInsensitiveLookup
+        fileExistsForWatchFinalPath <- File.Exists
+        directoryExistsForWatchFinalPath <- Directory.Exists
         createLocalFileVersionForWatchStatus <- createLocalFileVersion
         setLastScanForDifferencesSuccessfulForWatchTests true
 
@@ -1517,6 +1599,8 @@ module Watch =
         updateGraceWatchInterprocessFileClient
         =
         task {
+            configureWatchPathComparisonForCurrentRepository ()
+
             // First, check if there's anything to process.
             if hasPendingWatchWork () then
                 try
@@ -1747,6 +1831,8 @@ module Watch =
                     if not claimedGraceWatchStatus then
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
+
+                    configureWatchPathComparisonForCurrentRepository ()
 
                     // Create the FileSystemWatcher, but don't enable it yet.
                     use rootDirectoryFileSystemWatcher = createFileSystemWatcher (Current().RootDirectory)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -604,8 +604,8 @@ module Watch =
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
                         let addRelativePath = canonicalizeTrackedAncestorCasing status uploadedFileVersion.RelativePath
                         differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File addRelativePath)
-                | UploadedFinalFileVersionUnavailable -> unresolvedFilePaths.Add(relativePath)
-                | UploadedFinalFileVersionUnmatched -> ()
+                | UploadedFinalFileVersionUnavailable
+                | UploadedFinalFileVersionUnmatched -> unresolvedFilePaths.Add(relativePath)
                 | UploadedFinalFileVersionMissing -> ()
 
             return differences, unresolvedFilePaths
@@ -805,7 +805,7 @@ module Watch =
         else
             false
 
-    /// Requeues uploaded paths whose final content could not be hashed during status derivation.
+    /// Requeues uploaded paths whose final content could not be matched to a completed upload identity.
     let private reenqueueUnresolvedUploadedFinalFileVersions (relativePaths: seq<RelativePath>) =
         let requeuedRelativePaths = List<RelativePath>()
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -58,23 +58,34 @@ module Watch =
 
     let private canceledFileUploadDeleteRelativePaths = List<RelativePath>()
 
-    /// Removes uploaded identities after their matching watch work is either applied or proven content-equivalent.
-    let private removeUploadedFileVersionsForPaths (relativePaths: seq<RelativePath>) =
-        let normalizedPaths =
-            relativePaths
-            |> Seq.map normalizeFilePath
-            |> HashSet
+    /// Makes an uploaded identity available under the casing that status application will write to GraceStatus.
+    let private recordUploadedFileVersionForCanonicalPath (canonicalRelativePath: RelativePath) (uploadedFileVersion: FileVersion) =
+        let canonicalRelativePath = RelativePath(normalizeFilePath $"{canonicalRelativePath}")
 
-        for uploadedFileVersion in uploadedFileVersions.Values.ToArray() do
-            if normalizedPaths.Contains(normalizeFilePath $"{uploadedFileVersion.RelativePath}") then
-                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
-
-                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity uploadedFileVersion, &removedFileVersion)
-                |> ignore
+        if uploadedFileVersion.RelativePath
+           <> canonicalRelativePath then
+            let canonicalUploadedFileVersion = FileVersion()
+            canonicalUploadedFileVersion.Class <- uploadedFileVersion.Class
+            canonicalUploadedFileVersion.RelativePath <- canonicalRelativePath
+            canonicalUploadedFileVersion.Sha256Hash <- uploadedFileVersion.Sha256Hash
+            canonicalUploadedFileVersion.Blake3Hash <- uploadedFileVersion.Blake3Hash
+            canonicalUploadedFileVersion.IsBinary <- uploadedFileVersion.IsBinary
+            canonicalUploadedFileVersion.Size <- uploadedFileVersion.Size
+            canonicalUploadedFileVersion.CreatedAt <- uploadedFileVersion.CreatedAt
+            canonicalUploadedFileVersion.BlobUri <- uploadedFileVersion.BlobUri
+            canonicalUploadedFileVersion.ContentReference <- uploadedFileVersion.ContentReference
+            uploadedFileVersions[uploadedFileVersionIdentity canonicalUploadedFileVersion] <- canonicalUploadedFileVersion
 
     /// Records uploaded file identity data for watch tests that replace the storage upload client.
     let internal recordUploadedFileVersionForWatchTests (fileVersion: FileVersion) =
         uploadedFileVersions[uploadedFileVersionIdentity fileVersion] <- fileVersion
+
+    /// Lists uploaded identity paths so watch tests can prove casing aliases are present or removed.
+    let internal uploadedFileVersionRelativePathsForWatchTests () =
+        uploadedFileVersions.Values
+        |> Seq.map (fun fileVersion -> $"{fileVersion.RelativePath}")
+        |> Seq.sort
+        |> Seq.toArray
 
     /// Defines the options parsed by the watch command handlers.
     module private Options =
@@ -260,6 +271,23 @@ module Watch =
     let mutable private watchPathComparison = defaultWatchPathComparison ()
     let mutable private watchPathComparisonOverride: StringComparison option = None
     let mutable private watchPathComparisonConfiguredRoot: string option = None
+
+    /// Removes uploaded identities after their matching watch work is either applied or proven content-equivalent.
+    let private removeUploadedFileVersionsForPaths (relativePaths: seq<RelativePath>) =
+        let normalizedPaths =
+            relativePaths
+            |> Seq.map normalizeFilePath
+            |> Seq.toArray
+
+        for uploadedFileVersion in uploadedFileVersions.Values.ToArray() do
+            let normalizedUploadedPath = normalizeFilePath $"{uploadedFileVersion.RelativePath}"
+
+            if normalizedPaths
+               |> Array.exists (fun relativePath -> String.Equals(relativePath, normalizedUploadedPath, watchPathComparison)) then
+                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity uploadedFileVersion, &removedFileVersion)
+                |> ignore
 
     /// Checks whether the repository volume resolves differently-cased names to the same file.
     let private detectRepositoryPathCaseInsensitiveLookup (rootDirectory: string) =
@@ -598,11 +626,13 @@ module Watch =
                 | UploadedFinalFileVersionFound uploadedFileVersion ->
                     match tryFindTrackedFile status uploadedFileVersion.RelativePath with
                     | Some trackedFile when uploadedFileContentChanged trackedFile uploadedFileVersion ->
+                        recordUploadedFileVersionForCanonicalPath trackedFile.RelativePath uploadedFileVersion
                         differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File trackedFile.RelativePath)
                     | Some _ -> ()
                     | None ->
                         differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
                         let addRelativePath = canonicalizeTrackedAncestorCasing status uploadedFileVersion.RelativePath
+                        recordUploadedFileVersionForCanonicalPath addRelativePath uploadedFileVersion
                         differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File addRelativePath)
                 | UploadedFinalFileVersionUnavailable
                 | UploadedFinalFileVersionUnmatched -> unresolvedFilePaths.Add(relativePath)
@@ -1102,6 +1132,13 @@ module Watch =
             DirectoriesToProcess = directoriesToProcess.Keys.OrderBy(id).ToArray()
             StatusUpdateTriggers = statusUpdateTriggers.Keys.OrderBy(id).ToArray()
         }
+
+    /// Lists processed upload paths that are waiting for GraceStatus application in watch tests.
+    let internal processedFileRelativePathsPendingStatusForWatchTests () =
+        processedFileRelativePathsPendingStatusSnapshot ()
+        |> Seq.map string
+        |> Seq.sort
+        |> Seq.toArray
 
     /// Evaluates has pending watch work against parsed options and command state.
     let private hasPendingWatchWork () =
@@ -1718,7 +1755,7 @@ module Watch =
                         let processedFileRelativePathsForStatus = processedFileRelativePathsPendingStatusSnapshot ()
                         let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
 
-                        let! _ =
+                        let! requeuedResolvedFileDeletePaths =
                             reenqueueUploadsForResolvedFileDeletes
                                 graceStatus
                                 statusTriggerSnapshot
@@ -1773,6 +1810,12 @@ module Watch =
                                     $"Grace Status pending startup differences need a successful rescan before status application; status-only triggers will retry."
 
                                 Task.FromResult(None)
+                            elif requeuedResolvedFileDeletePaths.Count > 0 then
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Status stale file-delete differences requeued changed final content; requeued uploads will finish before status application."
+
+                                Task.FromResult(None)
                             elif requeuedUnresolvedUploadedFilePaths.Count > 0 then
                                 logToAnsiConsole
                                     Colors.Important
@@ -1817,6 +1860,9 @@ module Watch =
                             else
                                 if wasLastScanForDifferencesSuccessful () then
                                     clearPendingStatusDifferences pendingDifferencesToClear
+
+                                clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
+                                removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
 
                                 logToAnsiConsole
                                     Colors.Important

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -50,6 +50,10 @@ module Watch =
     /// Reads uploaded file version identity data needed by the command workflow without changing remote state.
     let private uploadedFileVersionIdentity (fileVersion: FileVersion) = (fileVersion.RelativePath, fileVersion.Sha256Hash, fileVersion.Blake3Hash)
 
+    let private processedFileRelativePathsPendingStatusLock = obj ()
+
+    let private processedFileRelativePathsPendingStatus = List<RelativePath>()
+
     /// Removes uploaded identities after their matching watch work is either applied or proven content-equivalent.
     let private removeUploadedFileVersionsForPaths (relativePaths: seq<RelativePath>) =
         let normalizedPaths =
@@ -242,6 +246,15 @@ module Watch =
             .Replace(Path.DirectorySeparatorChar, '/')
             .Replace(Path.AltDirectorySeparatorChar, '/')
 
+    /// Coordinates default watch path comparison behavior for this CLI command path.
+    let private defaultWatchPathComparison () =
+        if OperatingSystem.IsWindows() then
+            StringComparison.OrdinalIgnoreCase
+        else
+            StringComparison.Ordinal
+
+    let mutable private watchPathComparison = defaultWatchPathComparison ()
+
     /// Coordinates tracked deleted path kind behavior for this CLI command path.
     let private trackedDeletedPathKind (status: GraceStatus) (relativePath: string) =
         let deletedRelativePath = normalizeRelativePath relativePath
@@ -250,13 +263,11 @@ module Watch =
             status.Index.Values
             |> Seq.exists (fun directoryVersion ->
                 directoryVersion.Files
-                |> Seq.exists (fun fileVersion ->
-                    String.Equals(normalizeRelativePath fileVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase)))
+                |> Seq.exists (fun fileVersion -> String.Equals(normalizeRelativePath fileVersion.RelativePath, deletedRelativePath, watchPathComparison)))
 
         let isTrackedDirectory =
             status.Index.Values
-            |> Seq.exists (fun directoryVersion ->
-                String.Equals(normalizeRelativePath directoryVersion.RelativePath, deletedRelativePath, StringComparison.InvariantCultureIgnoreCase))
+            |> Seq.exists (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, deletedRelativePath, watchPathComparison))
 
         match isTrackedFile, isTrackedDirectory with
         | true, _ -> DeletedFile
@@ -267,14 +278,31 @@ module Watch =
 
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
-    /// Coordinates default watch path comparison behavior for this CLI command path.
-    let private defaultWatchPathComparison () =
-        if OperatingSystem.IsWindows() then
-            StringComparison.OrdinalIgnoreCase
-        else
-            StringComparison.Ordinal
+    /// Records an uploaded watch path until the status update pass drains every file upload batch.
+    let private addProcessedFileRelativePathPendingStatus (relativePath: RelativePath) =
+        lock processedFileRelativePathsPendingStatusLock (fun () ->
+            let normalizedRelativePath = normalizeRelativePath relativePath
 
-    let mutable private watchPathComparison = defaultWatchPathComparison ()
+            let alreadyRecorded =
+                processedFileRelativePathsPendingStatus
+                |> Seq.exists (fun existing -> String.Equals(normalizeRelativePath existing, normalizedRelativePath, watchPathComparison))
+
+            if not alreadyRecorded then
+                processedFileRelativePathsPendingStatus.Add(relativePath))
+
+    /// Captures uploaded watch paths that still need status application.
+    let private processedFileRelativePathsPendingStatusSnapshot () =
+        lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.ToList())
+
+    /// Clears uploaded watch paths after their status effects have been applied or proven unnecessary.
+    let private clearProcessedFileRelativePathsPendingStatus (relativePaths: seq<RelativePath>) =
+        lock processedFileRelativePathsPendingStatusLock (fun () ->
+            for relativePath in relativePaths do
+                let normalizedRelativePath = normalizeRelativePath relativePath
+
+                processedFileRelativePathsPendingStatus.RemoveAll (fun existing ->
+                    String.Equals(normalizeRelativePath existing, normalizedRelativePath, watchPathComparison))
+                |> ignore)
 
     /// Reads tracked deleted path kind data needed by the CLI workflow.
     let private readTrackedDeletedPathKind (relativePath: string) =
@@ -313,8 +341,14 @@ module Watch =
 
         status.Index.Values
         |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
-        |> Seq.tryFind (fun fileVersion ->
-            String.Equals(normalizeRelativePath fileVersion.RelativePath, normalizedRelativePath, StringComparison.InvariantCultureIgnoreCase))
+        |> Seq.tryFind (fun fileVersion -> String.Equals(normalizeRelativePath fileVersion.RelativePath, normalizedRelativePath, watchPathComparison))
+
+    /// Checks whether GraceStatus already tracks a repository-relative directory path.
+    let private isTrackedDirectory (status: GraceStatus) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        status.Index.Values
+        |> Seq.exists (fun directoryVersion -> String.Equals(normalizeRelativePath directoryVersion.RelativePath, normalizedRelativePath, watchPathComparison))
 
     /// Checks whether the uploaded file identity would change the tracked GraceStatus file content.
     let private uploadedFileContentChanged (trackedFile: LocalFileVersion) (uploadedFile: FileVersion) =
@@ -322,12 +356,26 @@ module Watch =
         || (trackedFile.Blake3Hash <> Blake3Hash String.Empty
             && uploadedFile.Blake3Hash <> trackedFile.Blake3Hash)
 
-    /// Checks whether a stale delete should be ignored because the path exists again before status application.
-    let private finalPathExists (relativePath: RelativePath) =
+    /// Describes the final filesystem kind for a path when event-derived status work is applied.
+    type private FinalPathKind =
+        | FinalPathMissing
+        | FinalPathFile
+        | FinalPathDirectory
+
+    /// Reads the final filesystem kind for a repository-relative path.
+    let private finalPathKind (relativePath: RelativePath) =
         let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
-        File.Exists(fullPath)
-        || Directory.Exists(fullPath)
+        if File.Exists(fullPath) then FinalPathFile
+        elif Directory.Exists(fullPath) then FinalPathDirectory
+        else FinalPathMissing
+
+    /// Checks whether final path state still has the same kind as a delete difference.
+    let private finalPathMatchesEntryType entryType relativePath =
+        match entryType, finalPathKind relativePath with
+        | FileSystemEntryType.File, FinalPathFile -> true
+        | FileSystemEntryType.Directory, FinalPathDirectory -> true
+        | _ -> false
 
     /// Finds the uploaded identity that matches the final file content for a processed watch path.
     let private tryFindUploadedFinalFileVersion (relativePath: RelativePath) =
@@ -349,6 +397,33 @@ module Watch =
                 return None
         }
 
+    /// Lists missing parent directories that must be added before a new uploaded file can link into GraceStatus.
+    let private deriveParentDirectoryAddDifferences (status: GraceStatus) (relativePath: RelativePath) =
+        let differences = List<FileSystemDifference>()
+        let normalizedRelativePath = normalizeRelativePath relativePath
+        let segments = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+        if segments.Length > 1 then
+            for index in 0 .. segments.Length - 2 do
+                let parentRelativePath = RelativePath(String.Join("/", segments[0..index]))
+                let parentFullPath = Path.Combine(Current().RootDirectory, $"{parentRelativePath}")
+
+                let alreadyAdded =
+                    differences
+                    |> Seq.exists (fun difference ->
+                        difference.FileSystemEntryType = FileSystemEntryType.Directory
+                        && difference.DifferenceType = Add
+                        && String.Equals(normalizeRelativePath difference.RelativePath, normalizeRelativePath parentRelativePath, watchPathComparison))
+
+                if
+                    not alreadyAdded
+                    && not (isTrackedDirectory status parentRelativePath)
+                    && Directory.Exists(parentFullPath)
+                then
+                    differences.Add(FileSystemDifference.Create Add FileSystemEntryType.Directory parentRelativePath)
+
+        differences
+
     /// Derives add and change differences from uploads already completed by the watch loop.
     let private deriveUploadedFileDifferences (status: GraceStatus) (processedFilePaths: seq<RelativePath>) =
         task {
@@ -363,7 +438,9 @@ module Watch =
                     | Some trackedFile when uploadedFileContentChanged trackedFile uploadedFileVersion ->
                         differences.Add(FileSystemDifference.Create Change FileSystemEntryType.File uploadedFileVersion.RelativePath)
                     | Some _ -> ()
-                    | None -> differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File uploadedFileVersion.RelativePath)
+                    | None ->
+                        differences.AddRange(deriveParentDirectoryAddDifferences status uploadedFileVersion.RelativePath)
+                        differences.Add(FileSystemDifference.Create Add FileSystemEntryType.File uploadedFileVersion.RelativePath)
                 | None -> ()
 
             return differences
@@ -376,26 +453,54 @@ module Watch =
         for statusTrigger in statusTriggerSnapshot do
             let relativePath = RelativePath statusTrigger.RelativePath
 
-            if not (finalPathExists relativePath) then
-                match trackedDeletedPathKind status statusTrigger.RelativePath with
-                | DeletedFile -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
-                | DeletedDirectory -> differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
-                | DeletedPathKindUnknown
-                | DeletedPathStatusUnavailable -> ()
+            match trackedDeletedPathKind status statusTrigger.RelativePath with
+            | DeletedFile ->
+                if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
+                    differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
+            | DeletedDirectory ->
+                if not (finalPathMatchesEntryType FileSystemEntryType.Directory relativePath) then
+                    differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
+            | DeletedPathKindUnknown
+            | DeletedPathStatusUnavailable -> ()
 
         differences
 
     /// Models the differences that can be applied and the queued work they resolve.
     type private StatusDifferencesForApply = { Applicable: List<FileSystemDifference>; Resolved: List<FileSystemDifference> }
 
-    /// Removes stale delete differences when final path state proves the path exists again.
-    let private splitApplicableStatusDifferences (differences: List<FileSystemDifference>) =
+    /// Checks whether a pending uploaded file difference must be dropped because final path state no longer has a file.
+    let private isStaleUploadedFileDifference (difference: FileSystemDifference) =
+        difference.FileSystemEntryType = FileSystemEntryType.File
+        && (difference.DifferenceType = Add
+            || difference.DifferenceType = Change)
+        && finalPathKind difference.RelativePath
+           <> FinalPathFile
+
+    /// Checks whether a status-only trigger covers the same path as a pending file difference.
+    let private hasMatchingStatusTrigger (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (difference: FileSystemDifference) =
+        statusTriggerSnapshot
+        |> Array.exists (fun statusTrigger ->
+            String.Equals(normalizeRelativePath statusTrigger.RelativePath, normalizeRelativePath difference.RelativePath, watchPathComparison))
+
+    /// Checks whether pending uploaded file work needs a final-state rescan before applying status differences.
+    let private staleUploadedFileDifferencesNeedRescan (differences: List<FileSystemDifference>) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
+        statusTriggerSnapshot.Length > 0
+        && differences
+           |> Seq.exists (fun difference ->
+               isStaleUploadedFileDifference difference
+               && hasMatchingStatusTrigger statusTriggerSnapshot difference)
+
+    /// Removes stale differences when final path state proves newer same-path work superseded them.
+    let private splitApplicableStatusDifferences (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (differences: List<FileSystemDifference>) =
         let applicable = List<FileSystemDifference>()
         let resolved = List<FileSystemDifference>()
 
         for difference in differences do
             if difference.DifferenceType = Delete
-               && finalPathExists difference.RelativePath then
+               && finalPathMatchesEntryType difference.FileSystemEntryType difference.RelativePath then
+                resolved.Add(difference)
+            elif isStaleUploadedFileDifference difference
+                 && hasMatchingStatusTrigger statusTriggerSnapshot difference then
                 resolved.Add(difference)
             else
                 applicable.Add(difference)
@@ -597,6 +702,7 @@ module Watch =
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
         uploadedFileVersions.Clear()
+        lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
         clearPendingStatusDifferencesForTests ()
 
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
@@ -675,9 +781,7 @@ module Watch =
 
             let statusTriggerPathsToDrain =
                 appliedDifferences
-                |> Seq.filter (fun difference ->
-                    difference.FileSystemEntryType = FileSystemEntryType.File
-                    && difference.DifferenceType = DifferenceType.Delete)
+                |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.File)
                 |> Seq.map (fun difference -> string difference.RelativePath)
                 |> HashSet
 
@@ -1175,7 +1279,6 @@ module Watch =
 
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
-                    let processedFileRelativePaths = List<RelativePath>()
 
                     // Loop through no more than 50 files. Copy them to the objects directory, and upload them to storage.
                     //   In the incredibly rare event that more than 50 files have changed, we'll get 50-per-timer-tick,
@@ -1205,7 +1308,7 @@ module Watch =
                             |> ignore
 
                             match repositoryRelativePath pendingFile.FullPath with
-                            | Some relativePath -> processedFileRelativePaths.Add(RelativePath relativePath)
+                            | Some relativePath -> addProcessedFileRelativePathPendingStatus (RelativePath relativePath)
                             | None -> ()
 
                             processedAnyFile <- true
@@ -1224,11 +1327,13 @@ module Watch =
                         graceStatus <- graceStatusSnapshot
                         resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                         let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
+                        let processedFileRelativePathsForStatus = processedFileRelativePathsPendingStatusSnapshot ()
 
                         let pendingDifferencesNeedRescan =
                             startupPendingDifferences.Count > 0
                             && (processedAnyFile
-                                || pendingStatusDifferencesRequireRescanRetrySnapshot ())
+                                || pendingStatusDifferencesRequireRescanRetrySnapshot ()
+                                || staleUploadedFileDifferencesNeedRescan startupPendingDifferences statusTriggerSnapshot)
 
                         let! startupDifferences =
                             if pendingDifferencesNeedRescan then
@@ -1239,7 +1344,7 @@ module Watch =
                             else
                                 Task.FromResult(startupPendingDifferences)
 
-                        let! uploadedFileDifferences = deriveUploadedFileDifferences graceStatus processedFileRelativePaths
+                        let! uploadedFileDifferences = deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
                         let eventDerivedDifferences = mergeStatusDifferences uploadedFileDifferences deleteDifferences
 
@@ -1247,7 +1352,9 @@ module Watch =
                             addPendingStatusDifference eventDerivedDifference
 
                         let pendingDifferencesToClear = mergeStatusDifferences startupPendingDifferences eventDerivedDifferences
-                        let statusDifferencesForApply = splitApplicableStatusDifferences (mergeStatusDifferences startupDifferences eventDerivedDifferences)
+
+                        let statusDifferencesForApply =
+                            splitApplicableStatusDifferences statusTriggerSnapshot (mergeStatusDifferences startupDifferences eventDerivedDifferences)
 
                         let! statusUpdateResult =
                             if
@@ -1284,7 +1391,8 @@ module Watch =
                                     drainAppliedStatusWork directorySnapshot statusTriggerSnapshot statusDifferencesForApply.Resolved
 
                                 clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
-                                removeUploadedFileVersionsForPaths processedFileRelativePaths
+                                clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
+                                removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
                             else
                                 if wasLastScanForDifferencesSuccessful () then
                                     clearPendingStatusDifferences pendingDifferencesToClear


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #482

Part of #474 and #473.

## Why this matters

This slice removes healthy running-mode scans for file add/change/delete observations while preserving the startup scan
fallback established by #481. That matters for Grace users because Watch must be able to keep local repository status
current from incremental file observations without hiding stale or duplicate file changes behind whole-root scans.

## Summary

- Derives healthy running-mode file add/change/delete differences from pending Watch work, uploaded file identities,
  current `GraceStatus`, and final path state.
- Keeps the #481 startup rescan fallback for startup pending differences that still need scan reconciliation.
- Invalidates stale file deletes when final path state shows the file exists again, including content-equivalent
  recreation cases.
- Adds focused Watch coverage for no-scan file events, content-equivalent no-ops, tracked delete classification, retry
  behavior, and stale delete recreation.

## Touched paths

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public behavior or docs-only validation target: `grace watch` healthy running-mode file status derivation
- RED evidence or docs-only waiver: tests added around no-scan file derivation and stale-delete recreation boundaries
- Focused validation: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` and
  `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter FullyQualifiedName~WatchTests`

## Minimum detail gate evidence

- Invariant tuple proved or docs-only waiver: `grace watch`, repository/branch/root/path state, pending Watch work,
  uploaded file identities, final path state, and `GraceStatus` file entries now drive healthy running-mode file status
  differences without a healthy scan.
- Forbidden implementation shapes avoided: startup scan behavior was preserved; branch switching, SignalR remote sync,
  durable journal schema, and cross-platform normalization were not expanded; no whole-root healthy running-mode scan was
  kept for file add/change/delete derivation.
- Positive / negative / regression / boundary tests or waivers: Watch tests cover no-scan file-event derivation,
  content-equivalent no-op handling, tracked delete classification, retry after failed status application, and stale
  startup delete recreation.
- High-risk adversarial examples covered or waived: file event during status application, same-path final state changes,
  status failure after upload work, and ignored-looking tracked deletes classified from `GraceStatus`.
- Selected risk-surface traps addressed or waived: proof/test and CLI runtime traps addressed; SDK/OpenAPI and
  production data migration waived because this is internal CLI Watch behavior and Grace is pre-production.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.CLI.Tests/Watch.Tests.fs` adds coverage for event-derived file status differences, no-scan healthy file
  events, retry behavior, and stale-delete recreation.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [x] Not applicable; no command syntax, user-visible output, public contract, or agent workflow changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- [x] Focused tests: `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
  with `--filter FullyQualifiedName~WatchTests`
- [x] Formatting/linting: `dotnet tool run fantomas src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`
- [x] Formatting/linting: `git diff --check`
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not change Aspire-hosted server,
  emulator, Service Bus, Redis, deployment, or cross-service runtime behavior.

## Residual risks

- The implementation still relies on Watch's existing path normalization and uploaded identity cache. Full
  cross-platform normalization remains out of scope for #482.
- Directory delete triggers may share derived-delete plumbing when `GraceStatus` identifies a tracked directory, but the
  #482 proof focus is file add/change/delete. WS1.3 owns directory delete and rename-old behavior.

## Review Status

- Current head SHA: `b39b44e17cf451a7d3494df2a7c5a44b62bb7451`
- Codex Code Review Bot state for current head: `👍🏻` no-issues signal on `b39b44e1`.
- CI state for current head: GitHub Actions `Validate / full` passed on `b39b44e1`.
- Manual trigger decision: not attempted.
- Manual trigger lock: active until `scripts/guard-codex-review-trigger.ps1 -PullRequest 514` proves the missed-ack
  exception; do not manually trigger while current-head bot state is present or ambiguous.
- Detailed review/fix comments: all findings through the `c87ddfcc` review were replied to and resolved as fixed or
  future-leaf-owned. The previous-head `8f41cc46` findings remain stale unless repeated on a later head.

Resolved findings and CI fixes:

- `PRRT_kwDOILVrb86OKLFW`: fixed in `77a46f8`; replied and resolved.
- `PRRT_kwDOILVrb86OKLFZ`: fixed in `77a46f8`; replied and resolved.
- `PRRT_kwDOILVrb86OKLFc`: fixed in `77a46f8`; replied and resolved.
- `PRRT_kwDOILVrb86OKLFj`: fixed in `77a46f8`; replied and resolved.
- `PRRT_kwDOILVrb86OKLFl`: #482-owned tracked-file replacement half fixed in `77a46f8`; tracked-directory replacement
  half deferred to #483; replied and resolved.
- `PRRT_kwDOILVrb86OKiSv`: valid but deferred to #485 and #483; replied and resolved.
- `PRRT_kwDOILVrb86OKiSy`: fixed in `7f69f8e`; replied and resolved.
- `PRRT_kwDOILVrb86OKiS1`: valid but deferred to #483; replied and resolved.
- `PRRT_kwDOILVrb86OKiS3`: fixed in `7f69f8e`; replied and resolved.
- `PRRT_kwDOILVrb86OK5VQ`: fixed in `a9a657e0`; replied and resolved.
- `PRRT_kwDOILVrb86OK5VU`: fixed in `a9a657e0`; replied and resolved.
- `PRRT_kwDOILVrb86OK5VZ`: fixed in `a9a657e0`; replied and resolved.
- `PRRT_kwDOILVrb86OLTgC`: fixed in `9077589b`; replied and resolved.
- `PRRT_kwDOILVrb86OLTgG`: fixed in `9077589b`; replied and resolved.
- `PRRT_kwDOILVrb86OLTgJ`: fixed in `9077589b`; replied and resolved.
- `PRRT_kwDOILVrb86OLTgN`: valid but deferred to #483; replied and resolved.
- CI `Validate / full` failure on `9077589b`: Linux case-sensitive filesystem probe exposed a missing generated parent
  directory add for nested tracked-ancestor casing; partially fixed in `8f41cc46`, but CI still failed.
- CI `Validate / full` failure on `8f41cc46`: same Linux assertion still failed because stale parent-directory add
  filtering used exact filesystem casing after canonicalization; fixed in `8a97c86e`.
- `PRRT_kwDOILVrb86OMB9l`: valid but deferred to #483 after adding the child-upload restoration trap; replied and
  resolved.
- `PRRT_kwDOILVrb86OMB9j`: fixed in `853bf728`; replied and resolved.
- `PRRT_kwDOILVrb86OMB9o`: fixed in `853bf728`; replied and resolved.
- `PRRT_kwDOILVrb86OMb5f`: valid but deferred to #483 after adding the stale child-file diff trap; replied and
  resolved.
- `PRRT_kwDOILVrb86OMb5a`: fixed in `ae64b662`; replied and resolved.
- `PRRT_kwDOILVrb86OMb5c`: fixed in `ae64b662`; replied and resolved.
- `PRRT_kwDOILVrb86OMwCc`: fixed in `3a3d3ed`; replied and resolved.
- `PRRT_kwDOILVrb86ONDTM`: fixed in `191f551b`; replied and resolved.
- `PRRT_kwDOILVrb86ONWl9`: fixed in `157153c`; replied and resolved.
- `PRRT_kwDOILVrb86ONrYj`: fixed in `c87ddfcc`; replied and resolved.
- `PRRT_kwDOILVrb86OOGve`: fixed in `b39b44e1`; replied and resolved.
- `PRRT_kwDOILVrb86OOGvf`: fixed in `b39b44e1`; replied and resolved.
- `PRRT_kwDOILVrb86OOGvh`: fixed in `b39b44e1`; replied and resolved.

Stale previous-head findings pending latest-head disposition:

- `PRRT_kwDOILVrb86OL0CT`: previous-head `8f41cc46` finding; do not route unless repeated on current head.
- `PRRT_kwDOILVrb86OL0Ce`: previous-head `8f41cc46` finding; do not route unless repeated on current head.
- `PRRT_kwDOILVrb86OL0Cg`: previous-head `8f41cc46` finding; do not route unless repeated on current head.

## Review/fix prevention

For Codex Code Review Bot findings fixed or resolved in this PR:

- Root-cause class: acceptance-criteria / negative-proof gap for missing parent directory adds, multi-batch uploaded
  path retention, platform-sensitive path matching, same-path stale retry boundaries, replacement-by-kind handling,
  clean-rescan stale retry cleanup, case-insensitive canonical path emission, delete/add canonical casing, stale delete
  upload retry restoration, nested tracked-ancestor casing, untracked-add stale delete retry, and stale generated parent
  directory cleanup.
- Current issue, sibling issues, template, or agent docs update needed: #483 was updated to own directory rename/delete
  retry, tracked-directory replacement, and tracked directory delete casing; #485 was updated to own empty-directory-only
  replacement and rename adds.

Root-cause classes:

- acceptance-criteria / negative-proof gap
- contract-propagation gap
- CLI mode / side-effect interaction
- auth / materialization / traversal ordering gap
- algorithm adversarial-case gap
- validation / stale-evidence gap
- ordinary implementation mistake

## Rollback or recovery notes

Revert `8f5c0110` from the epic branch if this change causes an unexpected Watch regression. The change is scoped to the
CLI Watch implementation and CLI tests.

## Docs follow-up required

None for this internal Watch status-derivation slice. Later leaves that change visible Watch behavior should update
Watch, command-output, ADR, `.graceignore`, or agent guidance as required by their issue bodies.
