### PR TITLE
WS1.3: Derive watch directory delete status

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3308,6 +3308,543 @@ module WatchTests =
             pending.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that a renamed directory enumeration failure blocks the old-path status trigger from applying.
+    [<Test>]
+    let ``renamed directory enumeration failure keeps old path trigger during processing`` () =
+        withTempRepo (fun root ->
+            let oldPath = Path.Combine(root, "old-enumeration-processing-name")
+            let newPath = Path.Combine(root, "new-enumeration-processing-name")
+            let status = graceStatusTracking Array.empty<string> [| "old-enumeration-processing-name" |]
+            /// Tracks scan Calls changes so failed enumeration does not fall back to a healthy scan.
+            let mutable scanCalls = 0
+            /// Tracks event-derived status apply calls so the old path cannot be deleted before new contents upload.
+            let mutable applyFromDifferencesCalls = 0
+
+            Directory.CreateDirectory(newPath) |> ignore
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setEnumerateFilesForDirectoryUploadForWatchTests (fun _ -> raise (UnauthorizedAccessException("blocked enumeration")))
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "old-enumeration-processing-name" |]
+
+            pending.DirectoriesToProcess
+            |> should equal [| newPath |])
+
+    /// Verifies that directory deletes derive structural delete differences without a whole-root scan.
+    [<Test>]
+    let ``deleted tracked directory derives directory delete without scan`` () =
+        withTempRepo (fun root ->
+            let relativePath = "tracked-assets"
+            let directoryPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking Array.empty<string> [| relativePath |]
+            /// Tracks scan Calls changes so this scenario proves healthy directory delete avoids a scan.
+            let mutable scanCalls = 0
+            /// Tracks event-derived status application so the directory delete is explicit.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so this scenario fails on missing directory delete work.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, relativePath
+                |])
+
+    /// Verifies that unknown directory delete observations do not create Saves.
+    [<Test>]
+    let ``unknown deleted directory derives no save without scan`` () =
+        withTempRepo (fun root ->
+            let directoryPath = Path.Combine(root, "unknown-assets")
+            /// Tracks scan Calls changes so this scenario proves no healthy fallback scan is used.
+            let mutable scanCalls = 0
+            /// Tracks event-derived status application so unknown deletes cannot create Saves.
+            let mutable applyFromDifferencesCalls = 0
+
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that a recreated directory invalidates a stale directory delete before status apply.
+    [<Test>]
+    let ``recreated directory suppresses stale directory delete without scan`` () =
+        withTempRepo (fun root ->
+            let relativePath = "recreated-assets"
+            let directoryPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking Array.empty<string> [| relativePath |]
+            /// Tracks scan Calls changes so final-state invalidation stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks event-derived status application so stale directory deletes do not apply.
+            let mutable applyFromDifferencesCalls = 0
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that a directory replaced by a file emits the directory delete before the file add.
+    [<Test>]
+    let ``tracked directory replaced by file derives delete before add without scan`` () =
+        withTempRepo (fun root ->
+            let relativePath = "kind-replaced"
+            let replacementFilePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking Array.empty<string> [| relativePath |]
+            /// Tracks scan Calls changes so replacement-by-kind stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks the Differences passed to the apply seam so ordering is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            File.WriteAllText(replacementFilePath, "file replacing a tracked directory")
+            Watch.OnDeleted(deletedEvent replacementFilePath)
+            Watch.OnCreated(changedEvent replacementFilePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, relativePath
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |])
+
+    /// Verifies that case-insensitive directory delete emits the tracked directory casing.
+    [<Test>]
+    let ``case-insensitive deleted directory preserves tracked path casing`` () =
+        withTempRepo (fun root ->
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+            let deletedPath = Path.Combine(root, "src")
+            let status = graceStatusTracking Array.empty<string> [| "Src" |]
+            /// Tracks the Differences passed to the apply seam so tracked directory casing is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent deletedPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, "Src"
+                |])
+
+    /// Verifies that a stale directory delete requeues surviving child files after canceling their uploads.
+    [<Test>]
+    let ``stale directory delete requeues canceled child uploads without scan`` () =
+        withTempRepo (fun root ->
+            let directoryRelativePath = "assets"
+            let childRelativePath = "assets/child.txt"
+            let directoryPath = Path.Combine(root, directoryRelativePath)
+            let childPath = Path.Combine(directoryPath, "child.txt")
+
+            let status =
+                graceStatusTracking [| childRelativePath |] [|
+                    directoryRelativePath
+                |]
+
+            /// Tracks upload Calls changes so the canceled child upload retry is proven.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so this stale directory path stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so status waits for requeued upload content.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the surviving child reaches status.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            File.WriteAllText(childPath, "surviving changed child")
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnChanged(changedEvent childPath)
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.FilesToProcess
+            |> should equal [| childPath |]
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| directoryRelativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, childRelativePath
+                |])
+
+    /// Verifies that parent directory delete resolves stale child file work when the child is gone.
+    [<Test>]
+    let ``parent directory delete resolves stale child add without requeueing missing upload`` () =
+        withTempRepo (fun root ->
+            let directoryRelativePath = "transient-parent"
+            let childRelativePath = "transient-parent/child.txt"
+            let directoryPath = Path.Combine(root, directoryRelativePath)
+            let childPath = Path.Combine(directoryPath, "child.txt")
+            /// Tracks scan Calls changes so stale child resolution does not use a healthy scan.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the stale child add is applied only on the failed pass.
+            let mutable applyFromDifferencesCalls = 0
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            File.WriteAllText(childPath, "transient child content")
+            Watch.OnChanged(changedEvent childPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(None)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            applyFromDifferencesCalls |> should equal 1
+
+            File.Delete(childPath)
+            Directory.Delete(directoryPath)
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            processPendingWork ()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that file event during status only update keeps trigger pending for upload first retry.
     [<Test>]
     let ``file event during status-only update keeps trigger pending for upload-first retry`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -527,6 +527,16 @@ module Watch =
         | FileSystemEntryType.Directory, FinalPathDirectory -> true
         | _ -> false
 
+    /// Checks whether a repository-relative path is inside a directory trigger.
+    let private isPathUnderDirectoryTrigger (directoryRelativePath: RelativePath) (candidateRelativePath: RelativePath) =
+        let normalizedDirectoryPath =
+            normalizeRelativePath directoryRelativePath
+            |> fun path -> path.TrimEnd('/')
+
+        let normalizedCandidatePath = normalizeRelativePath candidateRelativePath
+
+        normalizedCandidatePath.StartsWith(normalizedDirectoryPath + "/", watchPathComparison)
+
     /// Checks directory existence using the active watch path comparison so case-insensitive event paths still match disk.
     let private directoryExistsUsingWatchPathComparison (relativePath: RelativePath) =
         let normalizedRelativePath = normalizeRelativePath relativePath
@@ -663,8 +673,16 @@ module Watch =
                     if not (finalPathMatchesEntryType FileSystemEntryType.File relativePath) then
                         differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.File relativePath)
             | DeletedDirectory ->
-                if not (finalPathMatchesEntryType FileSystemEntryType.Directory relativePath) then
-                    differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory relativePath)
+                let trackedDirectoryRelativePath =
+                    match tryFindTrackedDirectoryWithComparison StringComparison.Ordinal status relativePath with
+                    | Some exactTrackedDirectory -> exactTrackedDirectory.RelativePath
+                    | None ->
+                        match tryFindTrackedDirectoryWithComparison deletedPathComparison status relativePath with
+                        | Some trackedDirectory -> trackedDirectory.RelativePath
+                        | None -> relativePath
+
+                if not (finalPathMatchesEntryType FileSystemEntryType.Directory trackedDirectoryRelativePath) then
+                    differences.Add(FileSystemDifference.Create Delete FileSystemEntryType.Directory trackedDirectoryRelativePath)
             | DeletedPathKindUnknown
             | DeletedPathStatusUnavailable -> ()
 
@@ -692,6 +710,11 @@ module Watch =
         statusTriggerSnapshot
         |> Array.exists (fun statusTrigger ->
             String.Equals(normalizeRelativePath statusTrigger.RelativePath, normalizeRelativePath difference.RelativePath, watchPathComparison))
+
+    /// Checks whether a status-only directory trigger covers a pending file difference.
+    let private hasContainingStatusTrigger (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (difference: FileSystemDifference) =
+        statusTriggerSnapshot
+        |> Array.exists (fun statusTrigger -> isPathUnderDirectoryTrigger (RelativePath statusTrigger.RelativePath) difference.RelativePath)
 
     /// Checks whether a completed file upload already waits for status application on this path.
     let private hasProcessedFileRelativePath (processedRelativePaths: List<RelativePath>) (relativePath: RelativePath) =
@@ -773,7 +796,8 @@ module Watch =
                && finalPathMatchesEntryType difference.FileSystemEntryType difference.RelativePath then
                 resolved.Add(difference)
             elif isStaleUploadedFileDifference difference
-                 && hasMatchingStatusTrigger statusTriggerSnapshot difference then
+                 && (hasMatchingStatusTrigger statusTriggerSnapshot difference
+                     || hasContainingStatusTrigger statusTriggerSnapshot difference) then
                 resolved.Add(difference)
             elif isStaleParentDirectoryAddDifference difference then
                 resolved.Add(difference)
@@ -871,6 +895,36 @@ module Watch =
         else
             false
 
+    /// Records a directory whose contents must be enumerated before related status triggers can apply.
+    let private enqueueDirectoryUploadRetry directoryPath =
+        if
+            Directory.Exists(directoryPath)
+            && shouldNotIgnoreDirectory directoryPath
+        then
+            directoriesToProcess.TryAdd(directoryPath, ())
+            |> ignore
+
+    /// Queues every non-ignored file under a directory and reports whether enumeration reached a durable answer.
+    let private tryEnqueueDirectoryContentsForUpload directoryPath =
+        if
+            Directory.Exists(directoryPath)
+            && shouldNotIgnoreDirectory directoryPath
+        then
+            try
+                for filePath in enumerateFilesForDirectoryUpload directoryPath do
+                    enqueueFileUpload filePath |> ignore
+
+                true
+            with
+            | ex ->
+                logToAnsiConsole
+                    Colors.Error
+                    $"Unable to enumerate renamed directory {directoryPath}; status update will retry after file uploads can be queued. {Markup.Escape(ex.Message)}"
+
+                false
+        else
+            true
+
     /// Requeues uploaded paths whose final content could not be matched to a completed upload identity.
     let private reenqueueUnresolvedUploadedFinalFileVersions (relativePaths: seq<RelativePath>) =
         let requeuedRelativePaths = List<RelativePath>()
@@ -888,8 +942,8 @@ module Watch =
 
         requeuedRelativePaths
 
-    /// Requeues a same-path upload when a stale delete resolves to changed final file content.
-    let private reenqueueUploadsForResolvedFileDeletes
+    /// Requeues uploads when stale delete triggers resolve to live final file or directory content.
+    let private reenqueueUploadsForResolvedDeletes
         (status: GraceStatus)
         (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
         (canceledRelativePaths: List<RelativePath>)
@@ -922,6 +976,15 @@ module Watch =
                         let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
                         if enqueueFileUpload fullPath then requeuedRelativePaths.Add(relativePath)
+                    elif uploadWasCanceled
+                         && finalPathMatchesEntryType FileSystemEntryType.Directory relativePath then
+                        let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
+
+                        if tryEnqueueDirectoryContentsForUpload fullPath then
+                            requeuedRelativePaths.Add(relativePath)
+                        else
+                            enqueueDirectoryUploadRetry fullPath
+                            requeuedRelativePaths.Add(relativePath)
 
                 index <- index + 1
 
@@ -935,12 +998,12 @@ module Watch =
 
         filesToProcess.TryRemove(filePath, &generation)
 
-    /// Reads cancel pending uploads for deleted path data needed by the command workflow without changing remote state.
+    /// Cancels pending upload work covered by a delete or rename-old path before status observes the disappearance.
     let private cancelPendingUploadsForDeletedPath fullPath =
-        let mutable canceledExactFileUpload = removePendingFileUpload fullPath
+        let mutable canceledFileUpload = removePendingFileUpload fullPath
 
         match repositoryRelativePath fullPath with
-        | Some relativePath -> if removePendingFileUpload relativePath then canceledExactFileUpload <- true
+        | Some relativePath -> if removePendingFileUpload relativePath then canceledFileUpload <- true
         | None -> ()
 
         let normalizedFullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(fullPath))
@@ -969,17 +1032,9 @@ module Watch =
                     | None -> false)
 
             if removeQueuedFile then
-                let queuedExactPathMatched =
-                    normalizedQueuedFile.Equals(normalizedFullPath, watchPathComparison)
-                    || (match repositoryRelativePath fullPath with
-                        | Some relativePath -> String.Equals(normalizeRelativePath queuedFile, normalizeRelativePath relativePath, watchPathComparison)
-                        | None -> false)
+                if removePendingFileUpload queuedFile then canceledFileUpload <- true
 
-                if removePendingFileUpload queuedFile
-                   && queuedExactPathMatched then
-                    canceledExactFileUpload <- true
-
-        canceledExactFileUpload
+        canceledFileUpload
 
     /// Records an already-derived filesystem difference so status application can retry without duplicating work.
     let private addPendingStatusDifference (difference: FileSystemDifference) =
@@ -1195,7 +1250,6 @@ module Watch =
 
             let statusTriggerPathsToDrain =
                 appliedDifferences
-                |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.File)
                 |> Seq.map (fun difference -> string difference.RelativePath)
                 |> HashSet
 
@@ -1207,7 +1261,16 @@ module Watch =
                     |> ignore
 
             for statusTrigger in statusTriggerSnapshot do
-                if statusTriggerPathsToDrain.Contains(statusTrigger.RelativePath) then
+                let statusTriggerRelativePath = RelativePath statusTrigger.RelativePath
+
+                let statusTriggerResolvedByChild =
+                    appliedDifferences
+                    |> Seq.exists (fun difference -> isPathUnderDirectoryTrigger statusTriggerRelativePath difference.RelativePath)
+
+                if
+                    statusTriggerPathsToDrain.Contains(statusTrigger.RelativePath)
+                    || statusTriggerResolvedByChild
+                then
                     let pair = KeyValuePair(statusTrigger.RelativePath, statusTrigger.Generation)
 
                     (statusUpdateTriggers :> ICollection<KeyValuePair<string, int64>>)
@@ -1317,25 +1380,16 @@ module Watch =
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
-    let private enqueueDirectoryContentsForUpload directoryPath =
-        if
-            Directory.Exists(directoryPath)
-            && shouldNotIgnoreDirectory directoryPath
-        then
-            try
-                for filePath in enumerateFilesForDirectoryUpload directoryPath do
-                    enqueueFileUpload filePath |> ignore
+    let private enqueueDirectoryContentsForUpload directoryPath = tryEnqueueDirectoryContentsForUpload directoryPath
 
-                true
-            with
-            | ex ->
-                logToAnsiConsole
-                    Colors.Error
-                    $"Unable to enumerate renamed directory {directoryPath}; status update will retry after file uploads can be queued. {Markup.Escape(ex.Message)}"
+    /// Retries directory content enumeration before status application consumes directory rename-old triggers.
+    let private retryPendingDirectoryUploads () =
+        let mutable unitValue = ()
 
-                false
-        else
-            true
+        for directoryPath in directoriesToProcess.Keys.ToArray() do
+            if enqueueDirectoryContentsForUpload directoryPath then
+                directoriesToProcess.TryRemove(directoryPath, &unitValue)
+                |> ignore
 
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
@@ -1372,8 +1426,8 @@ module Watch =
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
             if newPathIsDirectory then
-                enqueueDirectoryContentsForUpload args.FullPath
-                |> ignore
+                if not (enqueueDirectoryContentsForUpload args.FullPath) then
+                    enqueueDirectoryUploadRetry args.FullPath
             elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
@@ -1706,6 +1760,8 @@ module Watch =
                     let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
                     let mutable processedAnyFile = false
 
+                    retryPendingDirectoryUploads ()
+
                     // Loop through no more than 50 files. Copy them to the objects directory, and upload them to storage.
                     //   In the incredibly rare event that more than 50 files have changed, we'll get 50-per-timer-tick,
                     //   and clear the queue quickly without overwhelming the system.
@@ -1746,7 +1802,8 @@ module Watch =
 
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
-                    if filesToProcess.IsEmpty then
+                    if filesToProcess.IsEmpty
+                       && directoriesToProcess.IsEmpty then
                         let directorySnapshot, statusTriggerSnapshot = statusOnlyTriggerSnapshot ()
                         let fileWorkGenerationBeforeStatusUpdate = Volatile.Read(&fileUploadWorkGeneration)
                         let! graceStatusSnapshot = readGraceStatusFileClient ()
@@ -1756,7 +1813,7 @@ module Watch =
                         let startupPendingDifferences = pendingStatusDifferencesSnapshot ()
 
                         let! requeuedResolvedFileDeletePaths =
-                            reenqueueUploadsForResolvedFileDeletes
+                            reenqueueUploadsForResolvedDeletes
                                 graceStatus
                                 statusTriggerSnapshot
                                 canceledFileUploadDeleteRelativePathsForStatus
@@ -1787,7 +1844,7 @@ module Watch =
                         let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
 
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
-                        let eventDerivedDifferences = mergeStatusDifferences uploadedFileDifferences deleteDifferences
+                        let eventDerivedDifferences = mergeStatusDifferences deleteDifferences uploadedFileDifferences
 
                         for eventDerivedDifference in (eventDerivedDifferences :> seq<FileSystemDifference>) do
                             addPendingStatusDifference eventDerivedDifference
@@ -1813,7 +1870,7 @@ module Watch =
                             elif requeuedResolvedFileDeletePaths.Count > 0 then
                                 logToAnsiConsole
                                     Colors.Important
-                                    $"Grace Status stale file-delete differences requeued changed final content; requeued uploads will finish before status application."
+                                    $"Grace Status stale delete differences requeued live final content; requeued uploads will finish before status application."
 
                                 Task.FromResult(None)
                             elif requeuedUnresolvedUploadedFilePaths.Count > 0 then


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #483

Part of #474 and #473.

## Why this matters

This slice removes healthy running-mode scans for tracked directory delete and rename-old observations while
preserving the startup scan fallback and deferring full empty-directory add semantics to WS2. That matters for Grace
users because `grace watch` must keep repository status current from incremental structural observations without
relying on a whole-root scan to notice deleted or renamed-away directory subtrees.

## Summary

- Derives event-based tracked directory delete differences from `GraceStatus` for directory delete and rename-old
  triggers.
- Preserves tracked directory casing before status application on case-insensitive observations.
- Orders tracked-directory replacement-by-file as `Delete Directory` before `Add File`.
- Keeps rename-new enumeration failures retryable instead of draining the old-path trigger.
- Requeues surviving child files after stale directory delete or rename-old observations cancel child uploads.
- Resolves stale pending child Add/Change differences when a parent directory delete or rename-old proves the child no
  longer exists.

## Touched paths

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public behavior or docs-only validation target: `grace watch` event-derived directory delete and rename-old status
  derivation
- RED evidence or docs-only waiver: tests added around no-scan directory delete, rename-old, stale final state,
  replacement-by-kind, retry, and stale child upload/diff boundaries
- Focused validation: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` and
  `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter FullyQualifiedName~WatchTests`

## Minimum detail gate evidence

- Invariant tuple proved or docs-only waiver: `grace watch`, repository/branch/root/path state, pending Watch work,
  final path state, and `GraceStatus` directory entries now drive healthy running-mode directory delete and rename-old
  status differences without a healthy scan.
- Forbidden implementation shapes avoided: startup scan behavior was preserved; branch switching, SignalR remote sync,
  durable journal schema, full cross-platform normalization, and full empty-directory add semantics were not expanded.
- Positive / negative / regression / boundary tests or waivers: Watch tests cover tracked directory delete without scan,
  unknown directory delete with no save, stale recreated directory suppression, directory replaced by file ordering,
  case-insensitive tracked directory casing, rename enumeration retry, stale directory child-upload requeue, and parent
  delete resolving stale child work.
- High-risk adversarial examples covered or waived: final path kind mismatch, stale recreated subtree state, rename-new
  enumeration failure, canceled child uploads, stale pending child file work, and case-insensitive directory event casing.
- Selected risk-surface traps addressed or waived: proof/test and async/runtime traps addressed; SDK/OpenAPI and
  production data migration waived because this is internal CLI Watch behavior and Grace is pre-production.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `src/Grace.CLI.Tests/Watch.Tests.fs` adds coverage for tracked directory delete without scan, unknown directory delete
  with no save, stale recreated directory suppression, directory replaced by file ordering, case-insensitive tracked
  directory casing, rename enumeration failure retry, stale directory child-upload requeue, and parent delete resolving
  stale child add work.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Skipped validation is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [ ] Docs impact: None - reason
- [x] Not applicable; no command syntax, user-visible output, public contract, or agent workflow changed.

## Validation run

- [x] `pwsh ./scripts/validate.ps1 -Fast`
- [ ] `pwsh ./scripts/validate.ps1 -Full`
- [x] Focused tests: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
- [x] Focused tests: `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`
  with `--filter FullyQualifiedName~WatchTests`
- [x] Formatting/linting: `dotnet tool run fantomas -- src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`
- [x] Formatting/linting: `git diff --check`
- [ ] Manual validation: command or steps

## Validation not run

- `pwsh ./scripts/validate.ps1 -Full` was not run because this slice does not change Aspire-hosted server, emulator,
  Service Bus, Redis, deployment, or cross-service runtime behavior.

## Validation sequencing note

- `pwsh ./scripts/validate.ps1 -Fast` passed once before the worker added one final self-review test-only regression for
  rename enumeration failure draining.
- After that test-only addition, targeted Fantomas, Release build, focused `WatchTests`, and `git diff --check` passed on
  the final diff.

## Residual risks

- Full empty-directory add/replacement semantics remain intentionally deferred to WS2/#485.
- The new directory retry path is covered at the Watch seam, not with an end-to-end filesystem watcher runtime test.

## Review Status

- Current head SHA: `87183289a77b8643cd8babdfd3b5c2457a94feb9`
- Codex Code Review Bot state for current head: `👍🏻` no-issues signal on `87183289`.
- CI state for current head: GitHub Actions `Validate / full` passed on `87183289`.
- Manual trigger decision: not attempted.
- Manual trigger lock: active until `scripts/guard-codex-review-trigger.ps1 -PullRequest <number>` proves the missed-ack
  exception; do not manually trigger while current-head bot state is present or ambiguous.
- Detailed review/fix comments: none yet.

## Review/fix prevention

For Codex Code Review Bot findings fixed or resolved in this PR:

- Root-cause class: acceptance-criteria / negative-proof gap for directory delete and rename-old final-state,
  retryability, replacement-by-kind, case-insensitive casing, and stale child-work boundaries.
- Current issue, sibling issues, template, or agent docs update needed: none at PR creation; future findings that belong
  to #484 or #485 should be deferred only after those issue bodies are updated with the concrete trap.

Root-cause classes:

- acceptance-criteria / negative-proof gap
- contract-propagation gap
- CLI mode / side-effect interaction
- auth / materialization / traversal ordering gap
- algorithm adversarial-case gap
- validation / stale-evidence gap
- ordinary implementation mistake

## Rollback or recovery notes

Revert `87183289` from the epic branch if this change causes an unexpected Watch regression. The change is scoped to the
CLI Watch implementation and CLI tests.

## Docs follow-up required

None for this internal Watch status-derivation slice. Later leaves that change visible Watch behavior should update
Watch, command-output, ADR, `.graceignore`, or agent guidance as required by their issue bodies.
