### PR TITLE
WS1.4: Enforce no-scan watch queue drain

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -225,6 +225,10 @@ module WatchTests =
     /// Produces an empty difference list for watch tests that do not exercise a scan path.
     let private scanForNoDifferences _ = Task.FromResult(List<FileSystemDifference>())
 
+    /// Fails tests that exercise healthy running-mode watch status application through a working-tree scan.
+    let private scannerHostileDifferenceDiscovery _ : Task<List<FileSystemDifference>> =
+        raise (InvalidOperationException("Healthy running-mode watch status application must not scan for differences."))
+
     /// Records the uploaded identity that the real watch upload path would cache for status application.
     let private recordUploadedFileVersion fullPath =
         match (Services.createLocalFileVersion (FileInfo(fullPath)))
@@ -1047,16 +1051,16 @@ module WatchTests =
             Watch.processedFileRelativePathsPendingStatusForWatchTests ()
             |> should equal Array.empty<string>)
 
-    /// Verifies that status only triggers remain pending when scan failure is swallowed as unchanged status.
+    /// Verifies that status only triggers remain pending when status application fails.
     [<Test>]
-    let ``status-only triggers remain pending when scan failure is swallowed as unchanged status`` () =
+    let ``status-only triggers remain pending when status application fails`` () =
         withTempRepo (fun root ->
-            let filePath = Path.Combine(root, "swallowed-scan-failure-delete.txt")
+            let filePath = Path.Combine(root, "failed-status-application-delete.txt")
 
             let status =
                 graceStatusTracking
                     [|
-                        "swallowed-scan-failure-delete.txt"
+                        "failed-status-application-delete.txt"
                     |]
                     Array.empty<string>
 
@@ -1068,19 +1072,30 @@ module WatchTests =
             /// Builds update grace status test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ =
                 updateCalls <- updateCalls + 1
-                Services.setLastScanForDifferencesSuccessfulForWatchTests false
-                Task.FromResult(Some status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
+                if updateCalls = 1 then Task.FromResult(None) else Task.FromResult(Some status)
 
-            updateCalls |> should equal 1
+            let processPendingWork () = processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
+
+            processPendingWork ()
 
             let afterStatusUpdate = Watch.pendingWatchWorkSnapshotForTests ()
 
             afterStatusUpdate.StatusUpdateTriggers
-            |> should equal Array.empty<string>
+            |> should
+                equal
+                [|
+                    "failed-status-application-delete.txt"
+                |]
 
-            Services.setLastScanForDifferencesSuccessfulForWatchTests true)
+            processPendingWork ()
+
+            updateCalls |> should equal 2
+
+            let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRetry.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
 
     /// Verifies that status only triggers added during status update remain pending for next pass.
     [<Test>]
@@ -1408,9 +1423,9 @@ module WatchTests =
             pending.FilesToProcess
             |> should equal Array.empty<string>)
 
-    /// Verifies that status only delete rescan clears stale working tree scan cache.
+    /// Verifies that status only delete derives from GraceStatus and final path state without scanning.
     [<Test>]
-    let ``status-only delete rescan clears stale working tree scan cache`` () =
+    let ``status-only delete derives tracked file delete without scan`` () =
         withTempRepo (fun root ->
             let relativePath = "stale-delete.txt"
             let filePath = Path.Combine(root, relativePath)
@@ -1418,26 +1433,42 @@ module WatchTests =
 
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
 
-            (Services.scanForDifferences status)
-                .GetAwaiter()
-                .GetResult()
-            |> ignore
-
             File.Delete(filePath)
             Watch.OnDeleted(deletedEvent filePath)
 
             /// Tracks observed Differences changes so this scenario can assert the resulting side effect explicitly.
             let mutable observedDifferences = List<FileSystemDifference>()
 
-            /// Builds update grace status test data used to exercise CLI watch behavior.
-            let updateGraceStatus status _ =
-                task {
-                    let! differences = Services.scanForDifferences status
-                    observedDifferences <- differences
-                    return Some status
-                }
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
 
-            processPendingWatchWorkWithStatusClients (fun () -> Task.FromResult(status)) updateGraceStatus
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
 
             observedDifferences
             |> Seq.exists (fun difference ->
@@ -1602,8 +1633,6 @@ module WatchTests =
             let addedPath = Path.Combine(root, "added.txt")
             let changedPath = Path.Combine(root, "changed.txt")
             let deletedPath = Path.Combine(root, "deleted.txt")
-            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
-            let mutable scanCalls = 0
             /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable scanOrientedUpdateCalls = 0
             /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
@@ -1631,11 +1660,6 @@ module WatchTests =
                 scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
                 Task.FromResult(Some status)
 
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>())
-
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
                 applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
@@ -1652,14 +1676,13 @@ module WatchTests =
                 readStatus
                 upload
                 updateGraceStatus
-                scanForDifferences
+                scannerHostileDifferenceDiscovery
                 updateGraceStatusFromDifferences
                 applyIncremental
                 updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
-            scanCalls |> should equal 0
             scanOrientedUpdateCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 1
 
@@ -2718,14 +2741,12 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.File, relativePath
                 |])
 
-    /// Verifies that a pending uploaded file addition is rescanned and cleared when a later delete removes the file.
+    /// Verifies that a pending uploaded file addition is cleared when a later delete removes the file.
     [<Test>]
-    let ``delete after failed uploaded add rescans and clears stale pending file difference`` () =
+    let ``delete after failed uploaded add clears stale pending file difference without scan`` () =
         withTempRepo (fun root ->
             let relativePath = "deleted-before-retry.txt"
             let filePath = Path.Combine(root, relativePath)
-            /// Tracks scan Calls changes so this scenario can assert stale pending work is rescanned.
-            let mutable scanCalls = 0
             /// Tracks apply-from-differences Calls changes so only the failed add attempt reached status apply.
             let mutable applyFromDifferencesCalls = 0
 
@@ -2740,13 +2761,8 @@ module WatchTests =
                 recordUploadedFileVersion $"{pendingFilePath}"
                 Task.FromResult(())
 
-            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ = Task.FromResult(Some status)
-
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>())
 
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status _ _ =
@@ -2764,7 +2780,7 @@ module WatchTests =
                     readStatus
                     upload
                     updateGraceStatus
-                    scanForDifferences
+                    scannerHostileDifferenceDiscovery
                     updateGraceStatusFromDifferences
                     applyIncremental
                     updateIpc)
@@ -2780,7 +2796,6 @@ module WatchTests =
 
             processPendingWork ()
 
-            scanCalls |> should equal 1
             applyFromDifferencesCalls |> should equal 1
 
             let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
@@ -2798,8 +2813,6 @@ module WatchTests =
             let relativePath = "new-parent/deleted-before-retry.txt"
             let parentPath = Path.Combine(root, "new-parent")
             let filePath = Path.Combine(root, relativePath)
-            /// Tracks scan Calls changes so this scenario proves stale parent cleanup uses the retry rescan.
-            let mutable scanCalls = 0
             /// Tracks apply-from-differences Calls changes so the stale parent add is not applied on retry.
             let mutable applyFromDifferencesCalls = 0
             /// Tracks the Differences passed to the apply seam so the first failed parent-plus-file add is proven.
@@ -2818,13 +2831,8 @@ module WatchTests =
                 recordUploadedFileVersion $"{pendingFilePath}"
                 Task.FromResult(())
 
-            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ = Task.FromResult(Some status)
-
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>())
 
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
@@ -2843,7 +2851,7 @@ module WatchTests =
                     readStatus
                     upload
                     updateGraceStatus
-                    scanForDifferences
+                    scannerHostileDifferenceDiscovery
                     updateGraceStatusFromDifferences
                     applyIncremental
                     updateIpc)
@@ -2870,7 +2878,6 @@ module WatchTests =
 
             processPendingWork ()
 
-            scanCalls |> should equal 1
             applyFromDifferencesCalls |> should equal 1
 
             let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
@@ -2883,12 +2890,10 @@ module WatchTests =
 
     /// Verifies that a clean retry drops a stale uploaded file change after the file returns to tracked content.
     [<Test>]
-    let ``clean rescan after reverted upload clears stale pending change`` () =
+    let ``clean upload retry after reverted content clears stale pending change without scan`` () =
         withTempRepo (fun root ->
             let relativePath = "reverted-before-retry.txt"
             let filePath = Path.Combine(root, relativePath)
-            /// Tracks scan Calls changes so this scenario can assert the clean retry path was used.
-            let mutable scanCalls = 0
             /// Tracks apply-from-differences Calls changes so stale changes are not re-applied.
             let mutable applyFromDifferencesCalls = 0
             /// Tracks the Differences passed to the apply seam so the first failed change is proven.
@@ -2913,13 +2918,8 @@ module WatchTests =
                 recordUploadedFileVersion $"{pendingFilePath}"
                 Task.FromResult(())
 
-            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ = Task.FromResult(Some status)
-
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>())
 
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
@@ -2938,7 +2938,7 @@ module WatchTests =
                     readStatus
                     upload
                     updateGraceStatus
-                    scanForDifferences
+                    scannerHostileDifferenceDiscovery
                     updateGraceStatusFromDifferences
                     applyIncremental
                     updateIpc)
@@ -2964,7 +2964,6 @@ module WatchTests =
             processPendingWork ()
             processPendingWork ()
 
-            scanCalls |> should equal 1
             applyFromDifferencesCalls |> should equal 1
 
             let afterRetry = Watch.pendingWatchWorkSnapshotForTests ()
@@ -3150,16 +3149,14 @@ module WatchTests =
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
-    /// Verifies that startup rescan changes do not apply a stale delete for the same recreated path.
+    /// Verifies that live file observations do not apply a stale startup delete for the same recreated path.
     [<Test>]
-    let ``startup rescan change suppresses stale delete for same path`` () =
+    let ``startup live change suppresses stale delete for same path without scan`` () =
         withTempRepo (fun root ->
             let relativePath = "recreated-with-change.txt"
             let fullPath = Path.Combine(root, relativePath)
             let staleDelete = FileSystemDifference.Create Delete FileSystemEntryType.File relativePath
             let liveChange = FileSystemDifference.Create Change FileSystemEntryType.File relativePath
-            /// Tracks scan Calls changes so this scenario can assert the startup fallback still runs when required.
-            let mutable scanCalls = 0
             /// Tracks apply-from-differences Calls changes so this scenario can assert the applied action set.
             let mutable applyFromDifferencesCalls = 0
             /// Tracks the Differences passed to the apply seam so the test fails on Delete plus Change.
@@ -3177,13 +3174,8 @@ module WatchTests =
                 recordUploadedFileVersion $"{filePath}"
                 Task.FromResult(())
 
-            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ = Task.FromResult(Some status)
-
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>([ liveChange ]))
 
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
@@ -3201,14 +3193,13 @@ module WatchTests =
                 readStatus
                 upload
                 updateGraceStatus
-                scanForDifferences
+                scannerHostileDifferenceDiscovery
                 updateGraceStatusFromDifferences
                 applyIncremental
                 updateIpc)
                 .GetAwaiter()
                 .GetResult()
 
-            scanCalls |> should equal 1
             applyFromDifferencesCalls |> should equal 1
 
             observedDifferences
@@ -3971,15 +3962,13 @@ module WatchTests =
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
-    /// Verifies that live uploads drained before startup apply are included by a fresh status scan.
+    /// Verifies that live uploads drained before startup apply are included without scanning.
     [<Test>]
-    let ``startup apply rescans after live upload drains before applying differences`` () =
+    let ``startup apply merges live upload differences without scan`` () =
         withTempRepo (fun root ->
             let startupDifference = FileSystemDifference.Create Delete FileSystemEntryType.File "offline-delete.txt"
             let liveFilePath = Path.Combine(root, "live-upload.txt")
             let liveUploadDifference = FileSystemDifference.Create Add FileSystemEntryType.File "live-upload.txt"
-            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
-            let mutable scanCalls = 0
             /// Tracks scan-oriented update Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable scanOrientedUpdateCalls = 0
             /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
@@ -4010,11 +3999,6 @@ module WatchTests =
                 scanOrientedUpdateCalls <- scanOrientedUpdateCalls + 1
                 Task.FromResult(Some status)
 
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Task.FromResult(List<FileSystemDifference>([ liveUploadDifference ]))
-
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
                 applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
@@ -4031,7 +4015,7 @@ module WatchTests =
                 readStatus
                 upload
                 updateGraceStatus
-                scanForDifferences
+                scannerHostileDifferenceDiscovery
                 updateGraceStatusFromDifferences
                 applyIncremental
                 updateIpc)
@@ -4039,7 +4023,6 @@ module WatchTests =
                 .GetResult()
 
             uploadCalls |> should equal 1
-            scanCalls |> should equal 1
             scanOrientedUpdateCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 1
 
@@ -4060,20 +4043,18 @@ module WatchTests =
             afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
-    /// Verifies that failed startup rescan retries before applying pending startup differences.
+    /// Verifies that failed startup status application retries pending startup differences.
     [<Test>]
-    let ``startup apply retries failed rescan before applying pending differences`` () =
+    let ``startup apply retries failed status application without scan`` () =
         withTempRepo (fun root ->
-            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "retry-after-failed-rescan.txt"
-            let liveFilePath = Path.Combine(root, "live-upload-after-failed-rescan.txt")
-            let liveUploadDifference = FileSystemDifference.Create Add FileSystemEntryType.File "live-upload-after-failed-rescan.txt"
-            /// Tracks scan Calls changes so this scenario can assert the resulting side effect explicitly.
-            let mutable scanCalls = 0
+            let startupDifference = FileSystemDifference.Create Add FileSystemEntryType.File "retry-after-failed-status.txt"
+            let liveFilePath = Path.Combine(root, "live-upload-after-failed-status.txt")
+            let liveUploadDifference = FileSystemDifference.Create Add FileSystemEntryType.File "live-upload-after-failed-status.txt"
             /// Tracks apply-from-differences Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable applyFromDifferencesCalls = 0
             /// Tracks upload Calls changes so this scenario can assert the resulting side effect explicitly.
             let mutable uploadCalls = 0
-            /// Tracks the Differences passed to the apply seam so the test fails if retry skips the failed rescan result.
+            /// Tracks the Differences passed to the apply seam so the retry proves failed work was not drained.
             let mutable observedDifferences = List<FileSystemDifference>()
 
             Watch.queueStartupDifferenceForWatch startupDifference
@@ -4092,21 +4073,18 @@ module WatchTests =
 
                 Task.FromResult(())
 
-            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
             let updateGraceStatus status _ = Task.FromResult(Some status)
-
-            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
-            let scanForDifferences _ =
-                scanCalls <- scanCalls + 1
-                Services.setLastScanForDifferencesSuccessfulForWatchTests (scanCalls > 1)
-
-                Task.FromResult(List<FileSystemDifference>([ liveUploadDifference ]))
 
             /// Builds apply-from-differences test data used to exercise CLI watch behavior.
             let updateGraceStatusFromDifferences status differences _ =
                 applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
                 observedDifferences <- differences
-                Task.FromResult(Some status)
+
+                if applyFromDifferencesCalls = 1 then
+                    Task.FromResult(None)
+                else
+                    Task.FromResult(Some status)
 
             /// Builds apply incremental test data used to exercise CLI watch behavior.
             let applyIncremental _ _ _ = Task.FromResult(())
@@ -4119,7 +4097,7 @@ module WatchTests =
                     readStatus
                     upload
                     updateGraceStatus
-                    scanForDifferences
+                    scannerHostileDifferenceDiscovery
                     updateGraceStatusFromDifferences
                     applyIncremental
                     updateIpc)
@@ -4128,14 +4106,12 @@ module WatchTests =
 
             processPendingWork ()
 
-            scanCalls |> should equal 1
-            applyFromDifferencesCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
 
             processPendingWork ()
 
             uploadCalls |> should equal 2
-            scanCalls |> should equal 2
-            applyFromDifferencesCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 2
 
             observedDifferences
             |> Seq.toArray

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -2741,6 +2741,88 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.File, relativePath
                 |])
 
+    /// Verifies that a stale delete cannot discard an already-uploaded untracked add before status application.
+    [<Test>]
+    let ``stale delete after processed untracked add preserves uploaded status work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "processed-add-stale-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so the test proves the original upload is reused.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the processed add reaches status.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the final add is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+            /// Tracks whether the stale delete has already been injected after upload processing.
+            let mutable staleDeleteQueued = false
+
+            File.WriteAllText(filePath, "uploaded add content")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to inject a stale delete after the upload has been processed.
+            let applyIncremental _ _ _ =
+                if not staleDeleteQueued then
+                    staleDeleteQueued <- true
+                    Watch.OnDeleted(deletedEvent filePath)
+
+                Task.FromResult(())
+
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.File, relativePath
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal Array.empty<string>)
+
     /// Verifies that a pending uploaded file addition is cleared when a later delete removes the file.
     [<Test>]
     let ``delete after failed uploaded add clears stale pending file difference without scan`` () =
@@ -3747,6 +3829,105 @@ module WatchTests =
 
             uploadCalls |> should equal 1
             scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Change, FileSystemEntryType.File, childRelativePath
+                |])
+
+    /// Verifies that stale parent triggers do not suppress retry for unmatched uploaded child content.
+    [<Test>]
+    let ``stale parent delete requeues unmatched processed child upload without scan`` () =
+        withTempRepo (fun root ->
+            let directoryRelativePath = "unmatched-parent"
+            let childRelativePath = "unmatched-parent/child.txt"
+            let directoryPath = Path.Combine(root, directoryRelativePath)
+            let childPath = Path.Combine(directoryPath, "child.txt")
+            let requeuedChildPath = Path.Combine(root, childRelativePath)
+
+            let status =
+                graceStatusTracking [| childRelativePath |] [|
+                    directoryRelativePath
+                |]
+
+            /// Tracks upload Calls changes so the unmatched child upload retry is proven.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so status waits for the retried upload.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the final child change is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+            /// Tracks whether the stale parent delete has already been injected after upload processing.
+            let mutable parentDeleteQueued = false
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+            File.WriteAllText(childPath, "uploaded child content")
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnChanged(changedEvent childPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds legacy status update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to make the uploaded child identity stale before status apply.
+            let applyIncremental _ _ _ =
+                if not parentDeleteQueued then
+                    parentDeleteQueued <- true
+                    File.WriteAllText(childPath, "final child content after stale parent delete")
+                    Watch.OnDeleted(deletedEvent directoryPath)
+
+                Task.FromResult(())
+
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            let afterRequeue = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterRequeue.FilesToProcess
+            |> should equal [| requeuedChildPath |]
+
+            afterRequeue.StatusUpdateTriggers
+            |> should equal [| directoryRelativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 2
             applyFromDifferencesCalls |> should equal 1
 
             observedDifferences

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -198,8 +198,6 @@ module Watch =
 
     let private pendingStatusDifferences = List<FileSystemDifference>()
 
-    let mutable private pendingStatusDifferencesRequireRescanRetry = false
-
     /// Defines structured data exchanged by CLI helpers.
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
 
@@ -778,14 +776,6 @@ module Watch =
                     String.Equals(normalizeRelativePath existing, normalizedRelativePath, watchPathComparison))
                 |> ignore)
 
-    /// Checks whether pending uploaded file work needs a final-state rescan before applying status differences.
-    let private staleUploadedFileDifferencesNeedRescan (differences: List<FileSystemDifference>) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
-        statusTriggerSnapshot.Length > 0
-        && differences
-           |> Seq.exists (fun difference ->
-               isStaleUploadedFileDifference difference
-               && hasMatchingStatusTrigger statusTriggerSnapshot difference)
-
     /// Removes stale differences when final path state proves newer same-path work superseded them.
     let private splitApplicableStatusDifferences (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (differences: List<FileSystemDifference>) =
         let applicable = List<FileSystemDifference>()
@@ -925,8 +915,8 @@ module Watch =
         else
             true
 
-    /// Requeues uploaded paths whose final content could not be matched to a completed upload identity.
-    let private reenqueueUnresolvedUploadedFinalFileVersions (relativePaths: seq<RelativePath>) =
+    /// Requeues uploaded paths whose final content could not be matched and is not superseded by delete-triggered work.
+    let private reenqueueUnresolvedUploadedFinalFileVersions (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (relativePaths: seq<RelativePath>) =
         let requeuedRelativePaths = List<RelativePath>()
 
         for relativePath in
@@ -934,10 +924,18 @@ module Watch =
             |> Seq.distinctBy normalizeRelativePath do
             let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
-            if
-                File.Exists(fullPath)
-                && enqueueFileUpload fullPath
-            then
+            let statusTriggerOwnsPath =
+                statusTriggerSnapshot
+                |> Array.exists (fun statusTrigger ->
+                    let statusTriggerRelativePath = RelativePath statusTrigger.RelativePath
+
+                    String.Equals(normalizeRelativePath statusTriggerRelativePath, normalizeRelativePath relativePath, watchPathComparison)
+                    || isPathUnderDirectoryTrigger statusTriggerRelativePath relativePath)
+
+            if not statusTriggerOwnsPath
+               && finalPathMatchesEntryType FileSystemEntryType.File relativePath
+               && File.Exists(fullPath)
+               && enqueueFileUpload fullPath then
                 requeuedRelativePaths.Add(relativePath)
 
         requeuedRelativePaths
@@ -1049,12 +1047,6 @@ module Watch =
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
 
-    /// Checks whether a failed startup rescan left pending differences that must rescan again before applying.
-    let private pendingStatusDifferencesRequireRescanRetrySnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferencesRequireRescanRetry)
-
-    /// Records that pending startup differences still need a successful rescan before they can be applied.
-    let private requirePendingStatusDifferencesRescanRetry () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferencesRequireRescanRetry <- true)
-
     /// Checks whether any pre-derived filesystem differences still need status application.
     let private hasPendingStatusDifferences () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Count > 0)
 
@@ -1065,16 +1057,12 @@ module Watch =
                 pendingStatusDifferences.Remove(difference)
                 |> ignore
 
-            if pendingStatusDifferences.Count = 0 then
-                pendingStatusDifferencesRequireRescanRetry <- false)
+            ())
 
     /// Clears pre-derived differences when tests reset watch module state.
-    let private clearPendingStatusDifferencesForTests () =
-        lock pendingStatusDifferencesLock (fun () ->
-            pendingStatusDifferences.Clear()
-            pendingStatusDifferencesRequireRescanRetry <- false)
+    let private clearPendingStatusDifferencesForTests () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Clear())
 
-    /// Combines pre-derived and freshly scanned status differences without applying the same filesystem observation twice.
+    /// Combines status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
         let merged = List<FileSystemDifference>()
 
@@ -1100,7 +1088,7 @@ module Watch =
         && left.FileSystemEntryType = right.FileSystemEntryType
         && String.Equals(normalizeRelativePath left.RelativePath, normalizeRelativePath right.RelativePath, watchPathComparison)
 
-    /// Checks whether a difference came from uploaded file work that a successful rescan can supersede.
+    /// Checks whether a difference came from uploaded file work that newer event-derived upload state can supersede.
     let private isUploadedFileAddOrChangeDifference (difference: FileSystemDifference) =
         difference.FileSystemEntryType = FileSystemEntryType.File
         && (difference.DifferenceType = DifferenceType.Add
@@ -1114,42 +1102,34 @@ module Watch =
         |> Seq.exists (fun uploadedFileVersion ->
             String.Equals(normalizeRelativePath uploadedFileVersion.RelativePath, normalizedRelativePath, watchPathComparison))
 
-    /// Revalidates pending uploaded file differences against a successful rescan before retrying status application.
-    let private mergeRescannedStartupDifferences
+    /// Combines retryable pending differences with the current event-derived result for the same watch pass.
+    let private mergeCurrentStatusDifferences
         (processedFilePaths: RelativePath seq)
-        (startupDifferences: List<FileSystemDifference>)
-        (rescannedDifferences: List<FileSystemDifference>)
+        (pendingDifferences: List<FileSystemDifference>)
+        (eventDerivedDifferences: List<FileSystemDifference>)
         =
-        let retainedStartupDifferences = List<FileSystemDifference>()
+        let retainedPendingDifferences = List<FileSystemDifference>()
 
         let processedUploadedPaths =
             processedFilePaths
             |> Seq.map normalizeRelativePath
             |> Seq.toArray
 
-        for startupDifference in startupDifferences do
-            let isSupersededUploadedFileDifference =
-                isUploadedFileAddOrChangeDifference startupDifference
-                && hasUploadedFileVersionForPath startupDifference.RelativePath
+        for pendingDifference in pendingDifferences do
+            let supersededUploadedDifference =
+                isUploadedFileAddOrChangeDifference pendingDifference
+                && hasUploadedFileVersionForPath pendingDifference.RelativePath
                 && processedUploadedPaths
-                   |> Array.exists (fun processedPath -> String.Equals(normalizeRelativePath startupDifference.RelativePath, processedPath, watchPathComparison))
+                   |> Array.exists (fun processedPath -> String.Equals(normalizeRelativePath pendingDifference.RelativePath, processedPath, watchPathComparison))
                 && not (
-                    rescannedDifferences
-                    |> Seq.exists (statusDifferenceMatches startupDifference)
+                    eventDerivedDifferences
+                    |> Seq.exists (statusDifferenceMatches pendingDifference)
                 )
 
-            let isSupersededParentDirectoryAdd =
-                isStaleParentDirectoryAddDifference startupDifference
-                && not (
-                    rescannedDifferences
-                    |> Seq.exists (statusDifferenceMatches startupDifference)
-                )
+            if not supersededUploadedDifference then
+                retainedPendingDifferences.Add(pendingDifference)
 
-            if not isSupersededUploadedFileDifference
-               && not isSupersededParentDirectoryAdd then
-                retainedStartupDifferences.Add(startupDifference)
-
-        mergeStatusDifferences retainedStartupDifferences rescannedDifferences
+        mergeStatusDifferences retainedPendingDifferences eventDerivedDifferences
 
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
@@ -1211,12 +1191,6 @@ module Watch =
             .ToArray()
             .Select(fun trigger -> { RelativePath = trigger.Key; Generation = trigger.Value })
             .ToArray()
-
-    /// Coordinates reset working tree scan cache for status only triggers behavior for this CLI command path.
-    let private resetWorkingTreeScanCacheForStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
-        if directorySnapshot.Length > 0
-           || statusTriggerSnapshot.Length > 0 then
-            clearWorkingDirectoryWriteTimesForWatchRescan ()
 
     /// Coordinates drain status only triggers behavior for this CLI command path.
     let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
@@ -1397,6 +1371,13 @@ module Watch =
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
 
             if enqueueStatusUpdateTrigger args.FullPath then
+                match repositoryRelativePath args.FullPath with
+                | Some relativePath ->
+                    let invalidatedRelativePath = RelativePath relativePath
+                    clearProcessedFileRelativePathsPendingStatus [ invalidatedRelativePath ]
+                    removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+                | None -> ()
+
                 if canceledFileUpload then
                     match repositoryRelativePath args.FullPath with
                     | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
@@ -1742,7 +1723,7 @@ module Watch =
         readGraceStatusFileClient
         copyFileToObjectDirectoryAndUploadToStorageClient
         _updateGraceStatusClient
-        scanForDifferencesClient
+        _scanForDifferencesClient
         updateGraceStatusFromDifferencesClient
         applyGraceStatusIncrementalClient
         updateGraceWatchInterprocessFileClient
@@ -1820,28 +1801,10 @@ module Watch =
                                 processedFileRelativePathsForStatus
                                 startupPendingDifferences
 
-                        resetWorkingTreeScanCacheForStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
-
-                        let pendingDifferencesNeedRescan =
-                            startupPendingDifferences.Count > 0
-                            && (processedAnyFile
-                                || pendingStatusDifferencesRequireRescanRetrySnapshot ()
-                                || staleUploadedFileDifferencesNeedRescan startupPendingDifferences statusTriggerSnapshot)
-
-                        let! startupDifferences =
-                            if pendingDifferencesNeedRescan then
-                                task {
-                                    let! rescannedDifferences = scanForDifferencesClient graceStatus
-
-                                    return mergeRescannedStartupDifferences processedFileRelativePathsForStatus startupPendingDifferences rescannedDifferences
-                                }
-                            else
-                                Task.FromResult(startupPendingDifferences)
-
                         let! uploadedFileDifferences, unresolvedUploadedFilePaths =
                             deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
 
-                        let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
+                        let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions statusTriggerSnapshot unresolvedUploadedFilePaths
 
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
                         let eventDerivedDifferences = mergeStatusDifferences deleteDifferences uploadedFileDifferences
@@ -1852,22 +1815,12 @@ module Watch =
                         let pendingDifferencesToClear = mergeStatusDifferences startupPendingDifferences eventDerivedDifferences
 
                         let statusDifferencesForApply =
-                            splitApplicableStatusDifferences statusTriggerSnapshot (mergeStatusDifferences startupDifferences eventDerivedDifferences)
+                            splitApplicableStatusDifferences
+                                statusTriggerSnapshot
+                                (mergeCurrentStatusDifferences processedFileRelativePathsForStatus startupPendingDifferences eventDerivedDifferences)
 
                         let! statusUpdateResult =
-                            if
-                                startupPendingDifferences.Count > 0
-                                && pendingDifferencesNeedRescan
-                                && not (wasLastScanForDifferencesSuccessful ())
-                            then
-                                requirePendingStatusDifferencesRescanRetry ()
-
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Grace Status pending startup differences need a successful rescan before status application; status-only triggers will retry."
-
-                                Task.FromResult(None)
-                            elif requeuedResolvedFileDeletePaths.Count > 0 then
+                            if requeuedResolvedFileDeletePaths.Count > 0 then
                                 logToAnsiConsole
                                     Colors.Important
                                     $"Grace Status stale delete differences requeued live final content; requeued uploads will finish before status application."
@@ -1889,8 +1842,6 @@ module Watch =
                             let statusUpdateCanCommit =
                                 filesToProcess.IsEmpty
                                 && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
-                                && (not pendingDifferencesNeedRescan
-                                    || wasLastScanForDifferencesSuccessful ())
 
                             if statusUpdateCanCommit then
                                 graceStatus <- newGraceStatus
@@ -1915,15 +1866,13 @@ module Watch =
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                 removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
                             else
-                                if wasLastScanForDifferencesSuccessful () then
-                                    clearPendingStatusDifferences pendingDifferencesToClear
-
+                                clearPendingStatusDifferences pendingDifferencesToClear
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                 removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
 
                                 logToAnsiConsole
                                     Colors.Important
-                                    $"Grace Status file update completed while file upload work or a failed scan was pending; status-only triggers will retry."
+                                    $"Grace Status file update completed while newer file upload work was pending; status-only triggers will retry."
                         | None ->
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -915,8 +915,8 @@ module Watch =
         else
             true
 
-    /// Requeues uploaded paths whose final content could not be matched and is not superseded by delete-triggered work.
-    let private reenqueueUnresolvedUploadedFinalFileVersions (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (relativePaths: seq<RelativePath>) =
+    /// Requeues uploaded paths whose final content could not be matched while the final file still exists.
+    let private reenqueueUnresolvedUploadedFinalFileVersions (relativePaths: seq<RelativePath>) =
         let requeuedRelativePaths = List<RelativePath>()
 
         for relativePath in
@@ -924,16 +924,7 @@ module Watch =
             |> Seq.distinctBy normalizeRelativePath do
             let fullPath = Path.Combine(Current().RootDirectory, $"{relativePath}")
 
-            let statusTriggerOwnsPath =
-                statusTriggerSnapshot
-                |> Array.exists (fun statusTrigger ->
-                    let statusTriggerRelativePath = RelativePath statusTrigger.RelativePath
-
-                    String.Equals(normalizeRelativePath statusTriggerRelativePath, normalizeRelativePath relativePath, watchPathComparison)
-                    || isPathUnderDirectoryTrigger statusTriggerRelativePath relativePath)
-
-            if not statusTriggerOwnsPath
-               && finalPathMatchesEntryType FileSystemEntryType.File relativePath
+            if finalPathMatchesEntryType FileSystemEntryType.File relativePath
                && File.Exists(fullPath)
                && enqueueFileUpload fullPath then
                 requeuedRelativePaths.Add(relativePath)
@@ -1374,8 +1365,13 @@ module Watch =
                 match repositoryRelativePath args.FullPath with
                 | Some relativePath ->
                     let invalidatedRelativePath = RelativePath relativePath
-                    clearProcessedFileRelativePathsPendingStatus [ invalidatedRelativePath ]
-                    removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+
+                    if
+                        canceledFileUpload
+                        || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
+                    then
+                        clearProcessedFileRelativePathsPendingStatus [ invalidatedRelativePath ]
+                        removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
                 | None -> ()
 
                 if canceledFileUpload then
@@ -1804,7 +1800,7 @@ module Watch =
                         let! uploadedFileDifferences, unresolvedUploadedFilePaths =
                             deriveUploadedFileDifferences graceStatus processedFileRelativePathsForStatus
 
-                        let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions statusTriggerSnapshot unresolvedUploadedFilePaths
+                        let requeuedUnresolvedUploadedFilePaths = reenqueueUnresolvedUploadedFinalFileVersions unresolvedUploadedFilePaths
 
                         let deleteDifferences = deriveDeleteDifferences graceStatus statusTriggerSnapshot
                         let eventDerivedDifferences = mergeStatusDifferences deleteDifferences uploadedFileDifferences


### PR DESCRIPTION
## Summary

- Remove the healthy running-mode status-application scan retry path from Watch queue processing.
- Preserve retryable pending status work when status application fails and preserve newer observations for the next pass.
- Add scanner-hostile and queue-drain proof coverage for the WS1.4 no-scan guard.

## Related Issue

References #484. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This finishes the WS1 invariant needed for `grace watch` to process healthy running-mode observations incrementally,
without falling back to whole-root scans as ordinary bookkeeping. That lowers local I/O cost and makes Watch behavior
more predictable for Grace users and coding agents working in active repositories.

## Validation

- Focused Watch tests passed after the review fix, 96/96 (`Grace.CLI.Tests`, `FullyQualifiedName~WatchTests`).
- `dotnet tool run fantomas -- src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed after the review fix.
- `git diff --check` passed after the review fix.

## Docs Impact

No docs update. This is internal Watch queue/status-application behavior and test coverage; no public command contract or
user-facing documentation changed.

## Review Status

- Current head: `52dead999adeb4ef29636358bb1ffc84ece2beca`.
- Worker bot-prevention self-review: complete after the review fix.
- Codex Code Review Bot: latest-head `+1` no-issues signal observed at 2026-07-03T19:50:29Z.
- Previous two P2 findings were fixed, replied to, and resolved.
- Prevention line: stale delete/upload retry regressions now have deterministic scanner-hostile Watch tests, and the
  latest Codex Code Review Bot pass found no further issues.
