### PR TITLE
WS2.1: Prove empty directory structure contract

### DIFF
--- a/docs/adr/0007-empty-directories-are-versioned-structure.md
+++ b/docs/adr/0007-empty-directories-are-versioned-structure.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+date: 2026-07-03
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Treat empty directories as versioned structure
+
+Grace treats a non-ignored empty directory as meaningful repository structure. An empty directory is represented by a
+`LocalDirectoryVersion` or `DirectoryVersion` whose child directory list and file list are both empty. That directory
+version still has a relative path, version hashes, size, created timestamp, and last-write timestamp, and parent
+directory versions reference it by `DirectoryVersionId`.
+
+## Context
+
+WS2 of the Grace Watch incremental sync epic needs explicit empty-directory semantics before later leaves harden
+running watch application, durable journal replay, and platform watcher behavior. Without this contract, Grace could
+accidentally treat directories as file-derived implementation detail and drop a directory-only change when no uploaded
+file path forces status application.
+
+The current local model already has the right structural concepts:
+
+- `GraceStatus.Index` stores directory versions independently from files.
+- Local status persistence stores directory rows separately from directory-file rows.
+- The local object cache stores directory version rows and child relationships separately from cached file rows.
+- Materialization creates directories from directory-version DTOs before it processes file contents.
+
+Grace is not in production, so this decision states the current model. It does not create migration or compatibility
+behavior for older data.
+
+## Decision
+
+A non-ignored empty directory is versioned repository structure.
+
+The empty-directory contract is:
+
+- A directory version with no child directories and no files is valid.
+- Parent directory versions preserve empty child directories through their `Directories` list.
+- Local status persistence must write and read the empty directory version as a directory row.
+- The local object cache may store an empty directory version without child or file rows for that directory.
+- Current-state scans should report a non-ignored empty directory that exists in the final path state.
+- Current-state scans should not report ignored empty directories.
+- Materialization should create an empty directory from a directory-version DTO even when no file versions exist below
+  that directory.
+
+This ADR does not change public server, OpenAPI, SDK, or CLI output contracts. It records a local model and
+current-state proof point for WS2.1.
+
+## Deferred WS2 behavior
+
+WS2.1 deliberately does not implement the full running-mode watch apply behavior for empty-directory-only event streams.
+Later WS2 leaves own these cases:
+
+- A stale parent or subtree delete followed by empty-directory recreation before apply.
+- A non-ignored empty directory that exists in final path state after an earlier delete observation saw its parent
+  disappear.
+- Empty-directory-only replacement or rename preserving the final empty directory add when no uploaded file paths exist
+  to force file-derived status application.
+
+Those cases require watch event ordering and application rules beyond the WS2.1 proof slice. They should build on this
+contract instead of weakening it.
+
+## Consequences
+
+Tests and future implementation should assert empty directories as directory-version nodes, not as side effects of file
+uploads. A proof that only uploads file versions is insufficient for empty-directory semantics.
+
+Ignore processing remains authoritative. Ignored empty directories are untracked and should not become directory
+versions, status differences, object-cache rows, or watch apply work.
+
+Future WS2 watch work should use final path state to suppress stale deletes without losing a final non-ignored empty
+directory add. When a later change implements running-mode empty-directory application, it should preserve public CLI
+JSON, stdout, and stderr behavior unless that issue explicitly changes the CLI contract.

--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -10,6 +10,7 @@ open Grace.Types.Branch
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
 open Grace.Types.Reference
+open Microsoft.Data.Sqlite
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -189,7 +190,23 @@ module CurrentStateCaptureCliTests =
             | Some configuration -> updateConfiguration configuration
             | None -> resetConfiguration ()
 
-            if Directory.Exists(root) then Directory.Delete(root, true)
+            if Directory.Exists(root) then
+                SqliteConnection.ClearAllPools()
+                Directory.Delete(root, true)
+
+    /// Counts rows in the local state database so tests can assert persisted structure without model shortcuts.
+    let private countLocalStateRows dbPath commandText parameterName parameterValue =
+        use connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+
+        use command = connection.CreateCommand()
+        command.CommandText <- commandText
+
+        command.Parameters.Add(parameterName, SqliteType.Text)
+        |> ignore
+
+        command.Parameters[parameterName].Value <- parameterValue
+        Convert.ToInt32(command.ExecuteScalar())
 
     /// Verifies that directory delete removes subtree reference from nearest surviving parent.
     [<Test>]
@@ -446,6 +463,177 @@ module CurrentStateCaptureCliTests =
 
             newDirectoryVersions[0].RelativePath
             |> should equal Constants.RootDirectoryPath)
+
+    /// Verifies that empty directory additions create directory-version status without uploaded files.
+    [<Test>]
+    let ``empty directory add creates GraceStatus directory version without uploaded files`` () =
+        withTempRepo (fun root configuration ->
+            let emptyPath = Path.Combine(root, "empty")
+
+            Directory.CreateDirectory(emptyPath) |> ignore
+
+            let rootId = Guid.NewGuid()
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath Seq.empty Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath "empty")
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            let emptyDirectory =
+                updatedStatus.Index.Values
+                |> Seq.find (fun directoryVersion -> directoryVersion.RelativePath = RelativePath "empty")
+
+            emptyDirectory.Directories.Count |> should equal 0
+            emptyDirectory.Files.Count |> should equal 0
+            emptyDirectory.Size |> should equal 0L
+
+            let updatedRoot = updatedStatus.Index[updatedStatus.RootDirectoryId]
+
+            updatedRoot.Directories
+            |> Seq.exists (fun directoryVersionId -> directoryVersionId = emptyDirectory.DirectoryVersionId)
+            |> should equal true
+
+            getChangedFileVersionsReferencedByUpdatedDirectories differences newDirectoryVersions
+            |> Seq.isEmpty
+            |> should equal true)
+
+    /// Verifies that empty LocalDirectoryVersion rows survive local status and object-cache persistence.
+    [<Test>]
+    let ``empty directory version persists to status and object cache without child rows`` () =
+        withTempRepo (fun _ configuration ->
+            let rootId = Guid.NewGuid()
+            let emptyId = Guid.NewGuid()
+            let empty = directoryVersion configuration emptyId (RelativePath "empty") Seq.empty Seq.empty
+            let root = directoryVersion configuration rootId Constants.RootDirectoryPath [| emptyId |] Seq.empty
+            let status = graceStatusFromDirectories root [| root; empty |]
+
+            (writeGraceStatusFile status)
+                .GetAwaiter()
+                .GetResult()
+
+            (upsertObjectCache status.Index.Values)
+                .GetAwaiter()
+                .GetResult()
+
+            let readBack = (readGraceStatusFile ()).GetAwaiter().GetResult()
+
+            readBack.Index.ContainsKey(emptyId)
+            |> should equal true
+
+            let readBackEmpty = readBack.Index[emptyId]
+
+            readBackEmpty.RelativePath
+            |> should equal (RelativePath "empty")
+
+            readBackEmpty.Directories.Count |> should equal 0
+            readBackEmpty.Files.Count |> should equal 0
+            readBackEmpty.Size |> should equal 0L
+
+            readBack.Index[rootId].Directories
+            |> Seq.exists (fun directoryVersionId -> directoryVersionId = emptyId)
+            |> should equal true
+
+            countLocalStateRows
+                configuration.GraceStatusFile
+                "SELECT COUNT(*) FROM object_cache_directories WHERE directory_version_id = $directory_version_id;"
+                "$directory_version_id"
+                $"{emptyId}"
+            |> should equal 1
+
+            countLocalStateRows
+                configuration.GraceStatusFile
+                "SELECT COUNT(*) FROM object_cache_directory_children WHERE parent_directory_version_id = $parent_directory_version_id;"
+                "$parent_directory_version_id"
+                $"{emptyId}"
+            |> should equal 0
+
+            countLocalStateRows
+                configuration.GraceStatusFile
+                "SELECT COUNT(*) FROM object_cache_directory_files WHERE directory_version_id = $directory_version_id;"
+                "$directory_version_id"
+                $"{emptyId}"
+            |> should equal 0)
+
+    /// Verifies that read-only current-state scans track non-ignored empty directories and skip ignored ones.
+    [<Test>]
+    let ``read-only current-state scan tracks non-ignored empty directory and skips ignored empty directory`` () =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-current-state-scan-{Guid.NewGuid():N}")
+        let graceDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
+
+        try
+            Directory.CreateDirectory(Path.Combine(root, "empty"))
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, "ignored"))
+            |> ignore
+
+            Directory.CreateDirectory(graceDirectory)
+            |> ignore
+
+            let previousRoot = rootDirectoryVersion rootDirectoryId rootSha
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+
+            let scanInput =
+                {
+                    RootDirectory = root
+                    GraceDirectory = graceDirectory
+                    GraceStatusFile = Path.Combine(graceDirectory, Constants.GraceLocalStateDbFileName)
+                    DirectoryIgnoreEntries = [| "ignored" |]
+                    FileIgnoreEntries = Array.empty
+                }
+
+            match (scanWorkingTreeForDifferencesReadOnly scanInput previousStatus)
+                .Result
+                with
+            | Error error -> Assert.Fail($"Expected scan success, got: {error}")
+            | Ok differences ->
+                differences
+                |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, difference.RelativePath)
+                |> should
+                    equal
+                    [|
+                        DifferenceType.Add, FileSystemEntryType.Directory, RelativePath "empty"
+                    |]
+        finally
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    /// Verifies that materialization creates empty directories carried by directory-version DTOs.
+    [<Test>]
+    let ``updateWorkingDirectory materializes empty directory version`` () =
+        withTempRepo (fun root configuration ->
+            let previousRootId = Guid.NewGuid()
+            let updatedRootId = Guid.NewGuid()
+            let emptyId = Guid.NewGuid()
+            let previousRoot = directoryVersion configuration previousRootId Constants.RootDirectoryPath Seq.empty Seq.empty
+            let empty = directoryVersion configuration emptyId (RelativePath "empty") Seq.empty Seq.empty
+            let updatedRoot = directoryVersion configuration updatedRootId Constants.RootDirectoryPath [| emptyId |] Seq.empty
+            let previousStatus = graceStatusFromDirectories previousRoot [| previousRoot |]
+            let updatedStatus = graceStatusFromDirectories updatedRoot [| updatedRoot; empty |]
+
+            let directoryVersionDtos =
+                [|
+                    { DirectoryVersionDto.Default with DirectoryVersion = updatedRoot.ToDirectoryVersion }
+                    { DirectoryVersionDto.Default with DirectoryVersion = empty.ToDirectoryVersion }
+                |]
+
+            updateWorkingDirectory previousStatus updatedStatus directoryVersionDtos correlationId
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            let emptyPath = Path.Combine(root, "empty")
+
+            Directory.Exists(emptyPath) |> should equal true
+
+            Directory.EnumerateFileSystemEntries(emptyPath)
+            |> Seq.isEmpty
+            |> should equal true)
 
     /// Builds default operations test data used to exercise CLI current State Capture behavior.
     let private defaultOperations branchDto =


### PR DESCRIPTION
## Summary

- Prove that non-ignored empty directories can be represented as versioned local structure.
- Add current-state proof coverage for empty directory status, object-cache persistence, materialization, and ignored
  empty directories.
- Add ADR 0007 documenting the empty-directory contract and the WS2 behavior deferred to later leaves.

## Related Issue

References #485. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This establishes the WS2 contract that an empty directory can be meaningful Grace repository structure even when it has
no files or child directories. Grace users need that contract before Watch can safely add, delete, rename, materialize,
and sync empty structure without pretending that file-only changes are the whole repository shape.

## Validation

- Focused current-state capture tests passed, 31 tests (`CurrentStateCaptureCliTests`).
- Targeted Fantomas passed for `src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs`.
- MarkdownLint passed for `docs/adr/0007-empty-directories-are-versioned-structure.md`.
- `pwsh ./scripts/validate.ps1 -Fast` passed.
  - Authorization tests: 53/53.
  - Types tests: 133/133.
  - Server.Unit tests: 723/723.
  - CLI tests: 737/737.
- `git diff --check` passed.

## Docs Impact

Added ADR 0007 because WS2.1 establishes a durable local model contract: a non-ignored empty directory is versioned
structure even when it has no files or child directories.

No glossary update was made because the worker found no glossary surface under `docs`.

## Explicit Deferrals

This slice proves model, current-state, and materialization representation. It intentionally does not implement full
running-mode Watch application for stale parent/subtree deletes followed by empty-directory recreation,
empty-directory-only replacement, or empty-directory-only rename. Those remain in later WS2 leaves #486 and #487.

## Review Status

- Current head: `999767ce1cfe17a33844487b5f091934802235a3`.
- Worker bot-prevention self-review: complete.
- Codex Code Review Bot: latest-head `+1` no-issues signal observed at 2026-07-03T20:10:38Z.
