### PR TITLE
WS2.2: Handle running-mode empty directory events

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -215,6 +215,9 @@ module WatchTests =
     /// Builds deleted event test data used to exercise CLI watch behavior.
     let private deletedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
+    /// Builds created event test data used to exercise CLI watch behavior.
+    let private createdEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Created, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
+
     /// Builds changed event test data used to exercise CLI watch behavior.
     let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
@@ -3564,6 +3567,260 @@ module WatchTests =
             scanCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 0)
 
+    /// Verifies that a non-ignored empty directory create reaches status application without a whole-root scan.
+    [<Test>]
+    let ``created non-ignored empty directory derives directory add without scan`` () =
+        withTempRepo (fun root ->
+            let relativePath = "new-empty"
+            let directoryPath = Path.Combine(root, relativePath)
+            /// Tracks upload Calls changes so the test proves the empty directory is not file-derived.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so healthy running mode stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the directory add creates status work.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the empty directory add is explicit.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.OnCreated(createdEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, relativePath
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that a refreshed status snapshot suppresses a queued directory add that is already tracked.
+    [<Test>]
+    let ``already tracked empty directory add derives no save after status refresh`` () =
+        withTempRepo (fun root ->
+            let relativePath = "already-tracked-empty"
+            let directoryPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking Array.empty<string> [| relativePath |]
+            /// Tracks scan Calls changes so refreshed-status suppression stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so already-tracked directories cannot create Saves.
+            let mutable applyFromDifferencesCalls = 0
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.OnCreated(createdEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that ignored empty directory create and delete observations do not create status work.
+    [<Test>]
+    let ``ignored empty directory create and delete derive no save without scan`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "ignored/" |]
+
+            let directoryPath = Path.Combine(root, "ignored")
+            /// Tracks scan Calls changes so ignored directory noise stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so ignored directories cannot create Saves.
+            let mutable applyFromDifferencesCalls = 0
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.OnCreated(createdEvent directoryPath)
+            Directory.Delete(directoryPath)
+            Watch.OnDeleted(deletedEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that directory mtime-only change observations do not create status work.
+    [<Test>]
+    let ``directory mtime-only change derives no save without scan`` () =
+        withTempRepo (fun root ->
+            let directoryPath = Path.Combine(root, "mtime-only")
+            /// Tracks scan Calls changes so mtime-only directory noise stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so directory metadata noise cannot create Saves.
+            let mutable applyFromDifferencesCalls = 0
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+            Directory.SetLastWriteTimeUtc(directoryPath, DateTime.UtcNow.AddMinutes(1.0))
+            Watch.OnChanged(changedEvent directoryPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 0)
+
     /// Verifies that a recreated directory invalidates a stale directory delete before status apply.
     [<Test>]
     let ``recreated directory suppresses stale directory delete without scan`` () =
@@ -3619,6 +3876,168 @@ module WatchTests =
 
             scanCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that a stale parent delete does not drop a final non-ignored empty child directory add.
+    [<Test>]
+    let ``stale parent delete preserves recreated empty child directory add without scan`` () =
+        withTempRepo (fun root ->
+            let parentRelativePath = "parent-assets"
+            let childRelativePath = "parent-assets/empty-child"
+            let parentPath = Path.Combine(root, parentRelativePath)
+            let childPath = Path.Combine(root, childRelativePath)
+            let status = graceStatusTracking Array.empty<string> [| parentRelativePath |]
+            /// Tracks upload Calls changes so the final empty directory add is not file-derived.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so stale parent resolution stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the child add reaches status application.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the stale parent delete is suppressed.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent parentPath)
+
+            Directory.CreateDirectory(childPath) |> ignore
+            Watch.OnCreated(createdEvent childPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, childRelativePath
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that replacing a tracked file with an empty directory preserves the final directory add.
+    [<Test>]
+    let ``empty directory only replacement preserves final directory add without uploaded files`` () =
+        withTempRepo (fun root ->
+            let relativePath = "replace-me"
+            let replacementPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            /// Tracks upload Calls changes so no uploaded file path can force status application.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so replacement stays event-derived.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the replacement creates status work.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so the final directory add is explicit.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnDeleted(deletedEvent replacementPath)
+
+            Directory.CreateDirectory(replacementPath)
+            |> ignore
+
+            Watch.OnCreated(createdEvent replacementPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.sortBy (fun (_, entryType, _) -> if entryType = FileSystemEntryType.File then 0 else 1)
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, relativePath
+                |])
 
     /// Verifies that a directory replaced by a file emits the directory delete before the file add.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3645,6 +3645,114 @@ module WatchTests =
             afterProcessing.FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that a leaf-only nested empty directory event queues every missing parent before the child add.
+    [<Test>]
+    let ``nested empty directory leaf event derives missing parent adds without scan`` () =
+        withTempRepo (fun root ->
+            let parentRelativePath = "new-parent"
+            let childRelativePath = "new-parent/empty-child"
+            let childPath = Path.Combine(root, childRelativePath)
+            /// Tracks upload Calls changes so the empty directory tree is not file-derived.
+            let mutable uploadCalls = 0
+            /// Tracks scan Calls changes so healthy running mode stays event-derived for leaf-only directory events.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so the nested directory adds create status work.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so missing parents are explicit.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(childPath) |> ignore
+            Watch.OnCreated(createdEvent childPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds scan-for-differences test data used to exercise CLI watch behavior.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            scanCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equal
+                [|
+                    DifferenceType.Add, FileSystemEntryType.Directory, parentRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, childRelativePath
+                |]
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that directory-create classification reuses one refreshed GraceStatus snapshot across a burst.
+    [<Test>]
+    let ``directory create classification caches refreshed status for burst`` () =
+        withTempRepo (fun root ->
+            let firstDirectoryPath = Path.Combine(root, "bulk-empty-one")
+            let secondDirectoryPath = Path.Combine(root, "bulk-empty-two")
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            /// Tracks status reload Calls so burst directory-create callbacks do not reopen the local status DB per event.
+            let mutable readStatusCalls = 0
+
+            Watch.setGraceStatusForWatchTests GraceStatus.Default
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                readStatusCalls <- readStatusCalls + 1
+                Task.FromResult(status))
+
+            Directory.CreateDirectory(firstDirectoryPath)
+            |> ignore
+
+            Watch.OnCreated(createdEvent firstDirectoryPath)
+
+            Directory.CreateDirectory(secondDirectoryPath)
+            |> ignore
+
+            Watch.OnCreated(createdEvent secondDirectoryPath)
+
+            readStatusCalls |> should equal 1)
+
     /// Verifies that a refreshed status snapshot suppresses a queued directory add that is already tracked.
     [<Test>]
     let ``already tracked empty directory add derives no save after status refresh`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -596,14 +596,14 @@ module Watch =
     /// Installs the local file-version reader used by watch status derivation tests.
     let internal setCreateLocalFileVersionForWatchTests createLocalFileVersionClient = createLocalFileVersionForWatchStatus <- createLocalFileVersionClient
 
-    /// Lists missing parent directories that must be added before a new uploaded file can link into GraceStatus.
-    let private deriveParentDirectoryAddDifferences (status: GraceStatus) (relativePath: RelativePath) =
+    /// Lists untracked directory add differences through the selected repository-relative path segment.
+    let private deriveDirectoryAddDifferencesThroughSegment (status: GraceStatus) (relativePath: RelativePath) lastSegmentIndex =
         let differences = List<FileSystemDifference>()
         let normalizedRelativePath = normalizeRelativePath relativePath
         let segments = normalizedRelativePath.Split('/', StringSplitOptions.RemoveEmptyEntries)
 
-        if segments.Length > 1 then
-            for index in 0 .. segments.Length - 2 do
+        if segments.Length > 0 && lastSegmentIndex >= 0 then
+            for index in 0 .. min lastSegmentIndex (segments.Length - 1) do
                 let parentRelativePath = RelativePath(String.Join("/", segments[0..index]))
                 let parentDifferenceRelativePath = canonicalizeTrackedAncestorCasing status parentRelativePath
 
@@ -620,6 +620,17 @@ module Watch =
                     differences.Add(FileSystemDifference.Create Add FileSystemEntryType.Directory parentDifferenceRelativePath)
 
         differences
+
+    /// Lists missing parent directories that must be added before a new uploaded file can link into GraceStatus.
+    let private deriveParentDirectoryAddDifferences (status: GraceStatus) (relativePath: RelativePath) =
+        let segmentCount =
+            (normalizeRelativePath relativePath).Split(
+                '/',
+                StringSplitOptions.RemoveEmptyEntries
+            )
+                .Length
+
+        deriveDirectoryAddDifferencesThroughSegment status relativePath (segmentCount - 2)
 
     /// Derives add and change differences from uploads already completed by the watch loop.
     let private deriveUploadedFileDifferences (status: GraceStatus) (processedFilePaths: seq<RelativePath>) =
@@ -1054,9 +1065,13 @@ module Watch =
             graceStatus
         else
             try
-                (readGraceStatusFileForDeletedPathClassification ())
-                    .GetAwaiter()
-                    .GetResult()
+                let refreshedStatus =
+                    (readGraceStatusFileForDeletedPathClassification ())
+                        .GetAwaiter()
+                        .GetResult()
+
+                graceStatus <- refreshedStatus
+                refreshedStatus
             with
             | _ -> GraceStatus.Default
 
@@ -1074,7 +1089,20 @@ module Watch =
                 let canonicalRelativePath = canonicalizeTrackedAncestorCasing status relativePath
 
                 if not (isTrackedDirectory status canonicalRelativePath) then
-                    addPendingStatusDifference (FileSystemDifference.Create Add FileSystemEntryType.Directory canonicalRelativePath)
+                    let directoryAddDifferences =
+                        let segmentCount =
+                            (normalizeRelativePath canonicalRelativePath)
+                                .Split(
+                                '/',
+                                StringSplitOptions.RemoveEmptyEntries
+                            )
+                                .Length
+
+                        deriveDirectoryAddDifferencesThroughSegment status canonicalRelativePath (segmentCount - 1)
+
+                    for difference in directoryAddDifferences do
+                        addPendingStatusDifference difference
+
                     true
                 else
                     false

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -703,6 +703,12 @@ module Watch =
         && difference.DifferenceType = Add
         && not (directoryExistsUsingWatchPathComparison difference.RelativePath)
 
+    /// Checks whether a queued directory add was already incorporated by a fresher GraceStatus snapshot.
+    let private isAlreadyTrackedDirectoryAddDifference (status: GraceStatus) (difference: FileSystemDifference) =
+        difference.FileSystemEntryType = FileSystemEntryType.Directory
+        && difference.DifferenceType = Add
+        && isTrackedDirectory status difference.RelativePath
+
     /// Checks whether a status-only trigger covers the same path as a pending file difference.
     let private hasMatchingStatusTrigger (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (difference: FileSystemDifference) =
         statusTriggerSnapshot
@@ -777,7 +783,11 @@ module Watch =
                 |> ignore)
 
     /// Removes stale differences when final path state proves newer same-path work superseded them.
-    let private splitApplicableStatusDifferences (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) (differences: List<FileSystemDifference>) =
+    let private splitApplicableStatusDifferences
+        (status: GraceStatus)
+        (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array)
+        (differences: List<FileSystemDifference>)
+        =
         let applicable = List<FileSystemDifference>()
         let resolved = List<FileSystemDifference>()
 
@@ -790,6 +800,8 @@ module Watch =
                      || hasContainingStatusTrigger statusTriggerSnapshot difference) then
                 resolved.Add(difference)
             elif isStaleParentDirectoryAddDifference difference then
+                resolved.Add(difference)
+            elif isAlreadyTrackedDirectoryAddDifference status difference then
                 resolved.Add(difference)
             else
                 applicable.Add(difference)
@@ -1034,6 +1046,41 @@ module Watch =
                    && existing.DifferenceType = difference.DifferenceType
                    && existing.FileSystemEntryType = difference.FileSystemEntryType) then
                 pendingStatusDifferences.Add(difference))
+
+    /// Reads the best available GraceStatus snapshot for classifying directory-create observations.
+    let private readGraceStatusForDirectoryAddClassification () =
+        if (not graceStatusHasChanged)
+           && graceStatus.Index.Count > 0 then
+            graceStatus
+        else
+            try
+                (readGraceStatusFileForDeletedPathClassification ())
+                    .GetAwaiter()
+                    .GetResult()
+            with
+            | _ -> GraceStatus.Default
+
+    /// Queues a directory-only structural add when final path state contains a new non-ignored directory.
+    let private enqueueDirectoryStatusAdd fullPath =
+        if
+            Directory.Exists(fullPath)
+            && shouldNotIgnoreDirectory fullPath
+        then
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                let relativePath = RelativePath relativePath
+                let status = readGraceStatusForDirectoryAddClassification ()
+
+                let canonicalRelativePath = canonicalizeTrackedAncestorCasing status relativePath
+
+                if not (isTrackedDirectory status canonicalRelativePath) then
+                    addPendingStatusDifference (FileSystemDifference.Create Add FileSystemEntryType.Directory canonicalRelativePath)
+                    true
+                else
+                    false
+            | None -> false
+        else
+            false
 
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
@@ -1312,15 +1359,16 @@ module Watch =
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
-        // Ignore directory creation; need to think about this more... should we capture new empty directories?
-        if updateNotInProgress ()
-           && isNotDirectory args.FullPath then
-            let shouldIgnore = shouldIgnoreFile args.FullPath
-            //logToAnsiConsole Colors.Verbose $"Should ignore {args.FullPath}: {shouldIgnore}."
-
-            if not <| shouldIgnore then
+        if
+            updateNotInProgress ()
+            && Directory.Exists(args.FullPath)
+        then
+            if enqueueDirectoryStatusAdd args.FullPath then
+                logToAnsiConsole Colors.Added $"I saw that directory {args.FullPath} was created."
+        elif updateNotInProgress ()
+             && isNotDirectory args.FullPath then
+            if enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Added $"I saw that {args.FullPath} was created."
-                enqueueFileUpload args.FullPath |> ignore
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -1812,6 +1860,7 @@ module Watch =
 
                         let statusDifferencesForApply =
                             splitApplicableStatusDifferences
+                                graceStatus
                                 statusTriggerSnapshot
                                 (mergeCurrentStatusDifferences processedFileRelativePathsForStatus startupPendingDifferences eventDerivedDifferences)
 


### PR DESCRIPTION
## Summary

- Add running-mode Watch handling for non-ignored empty directory create events without healthy-mode scans.
- Preserve empty directory final state across stale delete/recreate and empty-directory replacement cases.
- Add no-save coverage for ignored empty directory create/delete events and directory mtime-only noise.

## Related Issue

References #486. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This implements the WS2 running-mode behavior needed after ADR 0007: Grace users can rely on non-ignored empty
directories as meaningful repository structure, while ignored directories and directory metadata noise do not create
unnecessary Saves. It keeps Watch incremental by proving these cases do not fall back to whole-root scans.

## Validation

- Focused Watch tests passed before review, 102/102 (`Grace.CLI.Tests`, `FullyQualifiedName~WatchTests`).
- Review-fix focused regression tests passed, 3/3.
- Targeted Fantomas passed for `src/Grace.CLI/Command/Watch.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs`.
- `pwsh ./scripts/validate.ps1 -Fast` passed after the review fix.
  - CLI tests: 745/745.
- `git diff --check` passed after the review fix.

## Docs Impact

No docs change. ADR 0007 already defines non-ignored empty directories as versioned structure, and this PR follows that
contract without changing public CLI JSON/stdout/stderr contracts or server/OpenAPI/SDK contracts.

## Explicit Deferrals

- Directory rename identity remains deferred to #487.
- WS2.3 affected-subtree enumeration was not implemented.
- Durable journal and platform watcher hardening remain separate workstreams.
- No server APIs, OpenAPI, SDK contracts, or public CLI output contracts were changed.

## Review Status

- Current head: `89cdaf828d07d36617e954463bd06923f7db8de4`.
- Worker bot-prevention self-review: complete after the review fix.
- Codex Code Review Bot: latest-head `+1` no-issues signal observed at 2026-07-03T20:57:20Z.
- Previous two P2 findings were fixed, replied to, and resolved.
- Prevention line: nested empty directory parent derivation and directory-create status-cache reuse now have focused
  regression tests, and the latest Codex Code Review Bot pass found no further issues.
