### PR TITLE
WS2.3: Preserve empty directories in renamed subtrees

### DIFF
--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -505,6 +505,105 @@ module CurrentStateCaptureCliTests =
             |> Seq.isEmpty
             |> should equal true)
 
+    /// Verifies that a directory rename modeled as delete plus add preserves empty children in the added subtree.
+    [<Test>]
+    let ``directory rename delete plus add preserves empty child directories in added subtree`` () =
+        withTempRepo (fun root configuration ->
+            let oldRootRelativePath = RelativePath "old-assets"
+            let oldContentRelativePath = RelativePath "old-assets/content"
+            let oldEmptyChildRelativePath = RelativePath "old-assets/empty-child"
+            let oldFileRelativePath = RelativePath "old-assets/content/asset.txt"
+            let newRootRelativePath = RelativePath "new-assets"
+            let newContentRelativePath = RelativePath "new-assets/content"
+            let newEmptyChildRelativePath = RelativePath "new-assets/empty-child"
+
+            Directory.CreateDirectory(Path.Combine(root, string newContentRelativePath))
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, string newEmptyChildRelativePath))
+            |> ignore
+
+            let rootId = Guid.NewGuid()
+            let oldRootId = Guid.NewGuid()
+            let oldContentId = Guid.NewGuid()
+            let oldEmptyChildId = Guid.NewGuid()
+            let oldFile = fileVersion oldFileRelativePath "old subtree content"
+            let oldContent = directoryVersion configuration oldContentId oldContentRelativePath Seq.empty [| oldFile |]
+            let oldEmptyChild = directoryVersion configuration oldEmptyChildId oldEmptyChildRelativePath Seq.empty Seq.empty
+            let oldRoot = directoryVersion configuration oldRootId oldRootRelativePath [| oldContentId; oldEmptyChildId |] Seq.empty
+            let previousRoot = directoryVersion configuration rootId Constants.RootDirectoryPath [| oldRootId |] Seq.empty
+
+            let previousStatus =
+                graceStatusFromDirectories
+                    previousRoot
+                    [|
+                        previousRoot
+                        oldRoot
+                        oldContent
+                        oldEmptyChild
+                    |]
+
+            let differences =
+                List<FileSystemDifference>(
+                    [|
+                        FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory oldRootRelativePath
+                        FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory newRootRelativePath
+                        FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory newContentRelativePath
+                        FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory newEmptyChildRelativePath
+                    |]
+                )
+
+            let updatedStatus, newDirectoryVersions =
+                (getNewGraceStatusAndDirectoryVersions previousStatus differences)
+                    .Result
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = oldRootRelativePath)
+            |> should equal false
+
+            updatedStatus.Index.Values
+            |> Seq.exists (fun directoryVersion -> directoryVersion.RelativePath = oldEmptyChildRelativePath)
+            |> should equal false
+
+            let newRoot =
+                updatedStatus.Index.Values
+                |> Seq.find (fun directoryVersion -> directoryVersion.RelativePath = newRootRelativePath)
+
+            let newEmptyChild =
+                updatedStatus.Index.Values
+                |> Seq.find (fun directoryVersion -> directoryVersion.RelativePath = newEmptyChildRelativePath)
+
+            newEmptyChild.Directories.Count |> should equal 0
+            newEmptyChild.Files.Count |> should equal 0
+            newEmptyChild.Size |> should equal 0L
+
+            newRoot.Directories
+            |> Seq.map (fun directoryId -> updatedStatus.Index[directoryId].RelativePath)
+            |> should
+                equivalent
+                [|
+                    newContentRelativePath
+                    newEmptyChildRelativePath
+                |]
+
+            let newContent =
+                updatedStatus.Index.Values
+                |> Seq.find (fun directoryVersion -> directoryVersion.RelativePath = newContentRelativePath)
+
+            newContent.Directories.Count |> should equal 0
+            newContent.Files.Count |> should equal 0
+
+            newDirectoryVersions
+            |> Seq.map (fun directoryVersion -> directoryVersion.RelativePath)
+            |> should
+                equivalent
+                [|
+                    newRootRelativePath
+                    newContentRelativePath
+                    newEmptyChildRelativePath
+                    Constants.RootDirectoryPath
+                |])
+
     /// Verifies that empty LocalDirectoryVersion rows survive local status and object-cache persistence.
     [<Test>]
     let ``empty directory version persists to status and object cache without child rows`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -4141,6 +4141,87 @@ module WatchTests =
             |> Seq.exists (fun difference -> $"{difference.RelativePath}" = unrelatedRelativePath)
             |> should equal false)
 
+    /// Verifies that ignored directories under a renamed subtree are pruned before directory adds are derived.
+    [<Test>]
+    let ``renamed subtree prunes ignored directory descendants before status adds`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "ignored/" |]
+
+            let oldRelativePath = "old-assets"
+            let newRelativePath = "new-assets"
+            let ignoredRelativePath = $"{newRelativePath}/ignored"
+            let ignoredChildRelativePath = $"{ignoredRelativePath}/empty"
+            let oldPath = Path.Combine(root, oldRelativePath)
+            let newPath = Path.Combine(root, newRelativePath)
+            let status = graceStatusTracking Array.empty<string> [| oldRelativePath |]
+            /// Tracks upload Calls changes so ignored empty directory descendants cannot be file-derived.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so status work stays event-derived.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so ignored ancestors cannot be reintroduced.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(Path.Combine(root, ignoredChildRelativePath))
+            |> ignore
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equivalent
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, oldRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, newRelativePath
+                |]
+
+            observedDifferences
+            |> Seq.exists (fun difference ->
+                let relativePath = $"{difference.RelativePath}"
+
+                relativePath = ignoredRelativePath
+                || relativePath = ignoredChildRelativePath)
+            |> should equal false)
+
     /// Verifies that a stale parent delete does not drop a final non-ignored empty child directory add.
     [<Test>]
     let ``stale parent delete preserves recreated empty child directory add without scan`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3985,6 +3985,162 @@ module WatchTests =
             scanCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 0)
 
+    /// Verifies that an empty directory rename is represented as a delete plus add without file upload or scanning.
+    [<Test>]
+    let ``renamed empty directory derives delete plus add without scan`` () =
+        withTempRepo (fun root ->
+            let oldRelativePath = "old-empty"
+            let newRelativePath = "new-empty"
+            let oldPath = Path.Combine(root, oldRelativePath)
+            let newPath = Path.Combine(root, newRelativePath)
+            let status = graceStatusTracking Array.empty<string> [| oldRelativePath |]
+            /// Tracks upload Calls changes so empty directory rename cannot depend on uploaded file identity.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the rename reaches the event-derived status seam.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so delete-plus-add semantics are explicit.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(newPath) |> ignore
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equivalent
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, oldRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, newRelativePath
+                |])
+
+    /// Verifies that a renamed directory enumerates only its subtree and keeps empty child directories.
+    [<Test>]
+    let ``renamed subtree preserves empty child directory adds without root scan`` () =
+        withTempRepo (fun root ->
+            let oldRelativePath = "old-assets"
+            let newRelativePath = "new-assets"
+            let oldPath = Path.Combine(root, oldRelativePath)
+            let newPath = Path.Combine(root, newRelativePath)
+            let fileParentRelativePath = $"{newRelativePath}/content"
+            let emptyChildRelativePath = $"{newRelativePath}/empty-child"
+            let fileRelativePath = $"{fileParentRelativePath}/asset.txt"
+            let unrelatedRelativePath = "unrelated-empty"
+            let filePath = Path.Combine(root, fileRelativePath)
+            let status = graceStatusTracking Array.empty<string> [| oldRelativePath |]
+            /// Tracks upload Calls changes so the file-bearing part of the subtree is still processed.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so status work stays event-derived.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the Differences passed to the apply seam so bounded subtree enumeration is proven.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(Path.Combine(root, fileParentRelativePath))
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, emptyChildRelativePath))
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, unrelatedRelativePath))
+            |> ignore
+
+            File.WriteAllText(filePath, "renamed subtree content")
+            Watch.setGraceStatusForWatchTests status
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equivalent
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.Directory, oldRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, newRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, fileParentRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, emptyChildRelativePath
+                    DifferenceType.Add, FileSystemEntryType.File, fileRelativePath
+                |]
+
+            observedDifferences
+            |> Seq.exists (fun difference -> $"{difference.RelativePath}" = unrelatedRelativePath)
+            |> should equal false)
+
     /// Verifies that a stale parent delete does not drop a final non-ignored empty child directory add.
     [<Test>]
     let ``stale parent delete preserves recreated empty child directory add without scan`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -382,6 +382,9 @@ module Watch =
 
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
+    let mutable private enumerateDirectoriesForDirectoryStatusAdd =
+        fun directoryPath -> Directory.EnumerateDirectories(directoryPath, "*", SearchOption.AllDirectories)
+
     /// Records an uploaded watch path until the status update pass drains every file upload batch.
     let private addProcessedFileRelativePathPendingStatus (relativePath: RelativePath) =
         lock processedFileRelativePathsPendingStatusLock (fun () ->
@@ -631,6 +634,65 @@ module Watch =
                 .Length
 
         deriveDirectoryAddDifferencesThroughSegment status relativePath (segmentCount - 2)
+
+    /// Lists new non-ignored directories under the observed directory without scanning outside that subtree.
+    let private tryDeriveDirectorySubtreeAddDifferences (status: GraceStatus) (directoryPath: string) =
+        let differences = List<FileSystemDifference>()
+
+        /// Adds one directory add difference when GraceStatus does not already track the final path.
+        let addDirectoryDifference fullPath =
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                let canonicalRelativePath =
+                    RelativePath relativePath
+                    |> canonicalizeTrackedAncestorCasing status
+
+                let segmentCount =
+                    (normalizeRelativePath canonicalRelativePath)
+                        .Split(
+                        '/',
+                        StringSplitOptions.RemoveEmptyEntries
+                    )
+                        .Length
+
+                let directoryAddDifferences = deriveDirectoryAddDifferencesThroughSegment status canonicalRelativePath (segmentCount - 1)
+
+                for directoryAddDifference in directoryAddDifferences do
+                    let alreadyAdded =
+                        differences
+                        |> Seq.exists (fun difference ->
+                            difference.FileSystemEntryType = FileSystemEntryType.Directory
+                            && difference.DifferenceType = Add
+                            && String.Equals(
+                                normalizeRelativePath difference.RelativePath,
+                                normalizeRelativePath directoryAddDifference.RelativePath,
+                                watchPathComparison
+                            ))
+
+                    if not alreadyAdded then differences.Add(directoryAddDifference)
+            | None -> ()
+
+        if
+            Directory.Exists(directoryPath)
+            && shouldNotIgnoreDirectory directoryPath
+        then
+            try
+                addDirectoryDifference directoryPath
+
+                for childDirectoryPath in enumerateDirectoriesForDirectoryStatusAdd directoryPath do
+                    if shouldNotIgnoreDirectory childDirectoryPath then
+                        addDirectoryDifference childDirectoryPath
+
+                differences, true
+            with
+            | ex ->
+                logToAnsiConsole
+                    Colors.Error
+                    $"Unable to enumerate directory subtree {directoryPath}; status update will retry after directory adds can be queued. {Markup.Escape(ex.Message)}"
+
+                differences, false
+        else
+            differences, true
 
     /// Derives add and change differences from uploads already completed by the watch loop.
     let private deriveUploadedFileDifferences (status: GraceStatus) (processedFilePaths: seq<RelativePath>) =
@@ -1075,40 +1137,15 @@ module Watch =
             with
             | _ -> GraceStatus.Default
 
-    /// Queues a directory-only structural add when final path state contains a new non-ignored directory.
-    let private enqueueDirectoryStatusAdd fullPath =
-        if
-            Directory.Exists(fullPath)
-            && shouldNotIgnoreDirectory fullPath
-        then
-            match repositoryRelativePath fullPath with
-            | Some relativePath ->
-                let relativePath = RelativePath relativePath
-                let status = readGraceStatusForDirectoryAddClassification ()
+    /// Queues directory add differences and reports whether the affected subtree was fully enumerated.
+    let private tryEnqueueDirectoryStatusAdds fullPath =
+        let status = readGraceStatusForDirectoryAddClassification ()
+        let directoryAddDifferences, completedEnumeration = tryDeriveDirectorySubtreeAddDifferences status fullPath
 
-                let canonicalRelativePath = canonicalizeTrackedAncestorCasing status relativePath
+        for difference in directoryAddDifferences do
+            addPendingStatusDifference difference
 
-                if not (isTrackedDirectory status canonicalRelativePath) then
-                    let directoryAddDifferences =
-                        let segmentCount =
-                            (normalizeRelativePath canonicalRelativePath)
-                                .Split(
-                                '/',
-                                StringSplitOptions.RemoveEmptyEntries
-                            )
-                                .Length
-
-                        deriveDirectoryAddDifferencesThroughSegment status canonicalRelativePath (segmentCount - 1)
-
-                    for difference in directoryAddDifferences do
-                        addPendingStatusDifference difference
-
-                    true
-                else
-                    false
-            | None -> false
-        else
-            false
+        directoryAddDifferences.Count > 0, completedEnumeration
 
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
@@ -1217,6 +1254,7 @@ module Watch =
         graceStatusHasChanged <- false
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
+        enumerateDirectoriesForDirectoryStatusAdd <- fun directoryPath -> Directory.EnumerateDirectories(directoryPath, "*", SearchOption.AllDirectories)
         watchPathComparison <- defaultWatchPathComparison ()
         watchPathComparisonOverride <- None
         watchPathComparisonConfiguredRoot <- None
@@ -1391,8 +1429,13 @@ module Watch =
             updateNotInProgress ()
             && Directory.Exists(args.FullPath)
         then
-            if enqueueDirectoryStatusAdd args.FullPath then
+            let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
+
+            if directoryStatusAddQueued then
                 logToAnsiConsole Colors.Added $"I saw that directory {args.FullPath} was created."
+
+            if not directoryStatusEnumerationComplete then
+                enqueueDirectoryUploadRetry args.FullPath
         elif updateNotInProgress ()
              && isNotDirectory args.FullPath then
             if enqueueFileUpload args.FullPath then
@@ -1428,7 +1471,11 @@ module Watch =
         let mutable unitValue = ()
 
         for directoryPath in directoriesToProcess.Keys.ToArray() do
-            if enqueueDirectoryContentsForUpload directoryPath then
+            let _, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds directoryPath
+            let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload directoryPath
+
+            if directoryStatusEnumerationComplete
+               && fileUploadEnumerationComplete then
                 directoriesToProcess.TryRemove(directoryPath, &unitValue)
                 |> ignore
 
@@ -1479,7 +1526,16 @@ module Watch =
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
             if newPathIsDirectory then
+                let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
+
+                if directoryStatusAddQueued
+                   && not oldPathStatusQueued then
+                    logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
+
                 if not (enqueueDirectoryContentsForUpload args.FullPath) then
+                    enqueueDirectoryUploadRetry args.FullPath
+
+                if not directoryStatusEnumerationComplete then
                     enqueueDirectoryUploadRetry args.FullPath
             elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -382,8 +382,53 @@ module Watch =
 
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
-    let mutable private enumerateDirectoriesForDirectoryStatusAdd =
-        fun directoryPath -> Directory.EnumerateDirectories(directoryPath, "*", SearchOption.AllDirectories)
+    /// Checks whether a directory and each repository-relative ancestor remains eligible for watch indexing.
+    let private directoryAndAncestorsShouldNotBeIgnored (directoryPath: string) =
+        let rootDirectory =
+            Current().RootDirectory
+            |> Path.GetFullPath
+            |> Path.TrimEndingDirectorySeparator
+
+        let rootDirectoryWithSeparator = rootDirectory + string Path.DirectorySeparatorChar
+
+        let normalizedDirectoryPath =
+            directoryPath
+            |> Path.GetFullPath
+            |> Path.TrimEndingDirectorySeparator
+
+        let isInsideRepository =
+            normalizedDirectoryPath.Equals(rootDirectory, watchPathComparison)
+            || normalizedDirectoryPath.StartsWith(rootDirectoryWithSeparator, watchPathComparison)
+
+        let mutable eligible = isInsideRepository
+        let mutable currentDirectory = DirectoryInfo(normalizedDirectoryPath)
+
+        while eligible
+              && not (isNull currentDirectory)
+              && not (currentDirectory.FullName.Equals(rootDirectory, watchPathComparison)) do
+            if shouldNotIgnoreDirectory currentDirectory.FullName then
+                currentDirectory <- currentDirectory.Parent
+            else
+                eligible <- false
+
+        eligible
+
+    /// Enumerates directory-add candidates under an affected subtree while pruning ignored directory branches.
+    let private enumerateDirectoriesForDirectoryStatusAddWithPruning directoryPath =
+        seq {
+            let pendingDirectories = Stack<string>()
+            pendingDirectories.Push(directoryPath)
+
+            while pendingDirectories.Count > 0 do
+                let parentDirectory = pendingDirectories.Pop()
+
+                for childDirectory in Directory.EnumerateDirectories(parentDirectory) do
+                    if directoryAndAncestorsShouldNotBeIgnored childDirectory then
+                        yield childDirectory
+                        pendingDirectories.Push(childDirectory)
+        }
+
+    let mutable private enumerateDirectoriesForDirectoryStatusAdd = enumerateDirectoriesForDirectoryStatusAddWithPruning
 
     /// Records an uploaded watch path until the status update pass drains every file upload batch.
     let private addProcessedFileRelativePathPendingStatus (relativePath: RelativePath) =
@@ -658,6 +703,8 @@ module Watch =
                 let directoryAddDifferences = deriveDirectoryAddDifferencesThroughSegment status canonicalRelativePath (segmentCount - 1)
 
                 for directoryAddDifference in directoryAddDifferences do
+                    let directoryDifferenceFullPath = Path.Combine(Current().RootDirectory, normalizeRelativePath directoryAddDifference.RelativePath)
+
                     let alreadyAdded =
                         differences
                         |> Seq.exists (fun difference ->
@@ -669,12 +716,14 @@ module Watch =
                                 watchPathComparison
                             ))
 
-                    if not alreadyAdded then differences.Add(directoryAddDifference)
+                    if not alreadyAdded
+                       && directoryAndAncestorsShouldNotBeIgnored directoryDifferenceFullPath then
+                        differences.Add(directoryAddDifference)
             | None -> ()
 
         if
             Directory.Exists(directoryPath)
-            && shouldNotIgnoreDirectory directoryPath
+            && directoryAndAncestorsShouldNotBeIgnored directoryPath
         then
             try
                 addDirectoryDifference directoryPath
@@ -1254,7 +1303,7 @@ module Watch =
         graceStatusHasChanged <- false
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
-        enumerateDirectoriesForDirectoryStatusAdd <- fun directoryPath -> Directory.EnumerateDirectories(directoryPath, "*", SearchOption.AllDirectories)
+        enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         watchPathComparison <- defaultWatchPathComparison ()
         watchPathComparisonOverride <- None
         watchPathComparisonConfiguredRoot <- None


### PR DESCRIPTION
## Summary

- Treat directory rename-new handling as bounded delete-plus-add status work, not rename identity.
- Preserve empty child directories inside renamed subtrees by enumerating only the affected new subtree.
- Keep directory status-add work queued when bounded enumeration fails so retry can happen before the work drains.

## Related Issue

References #487. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This completes the WS2 empty-directory behavior slice by making renamed directory structure visible to Watch without a
whole-root scan. Grace users can preserve empty directories inside renamed subtrees while the implementation remains
incremental and avoids introducing persistent rename identity.

## Validation

- Focused Watch plus current-state capture tests passed before review, 138 tests.
- Review-fix focused Watch tests passed, 107/107.
- Targeted Fantomas passed for touched F# files before review and after the review fix.
- `pwsh ./scripts/validate.ps1 -Fast` passed after the review fix.
- `git diff --check` passed after the review fix.

## Docs Impact

No docs change. ADR 0007 already defines the empty-directory structure contract, and this PR preserves CLI public
JSON/stdout/stderr behavior without adding or renaming commands, options, SDK/OpenAPI contracts, or user-facing
documented behavior.

## Explicit Deferrals

- Persistent rename identity remains out of scope; rename is modeled as delete-plus-add.
- Durable journal behavior and broader platform watcher hardening remain later workstreams.
- No server APIs, OpenAPI, SDK contracts, or public CLI output contracts were changed.

## Review Status

- Current head: `9238bb2246c964f95a69aad5e52ac2df3cfcab01`.
- Worker bot-prevention self-review: complete after the review fix.
- Codex Code Review Bot: latest-head `+1` no-issues signal observed at 2026-07-03T21:40:53Z.
- Previous P2 finding was fixed, replied to, and resolved.
- Prevention line: ignored-directory pruning during bounded subtree enumeration now has focused regression proof, and the
  latest Codex Code Review Bot pass found no further issues.
