### PR TITLE
WS3.1: Add watch runtime mode status surface

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -168,6 +168,45 @@ module WatchTests =
     /// Reads safety flags into a deterministic set for assertions.
     let private safetyFlagSet (status: Services.GraceWatchStatus) = status.SafetyFlags |> Set.ofArray
 
+    /// Reads a scalar property from the persisted Watch IPC JSON contract.
+    let private readWatchStatusJsonStringProperty (propertyName: string) =
+        let json = File.ReadAllText(Services.IpcFileName())
+        use document = JsonDocument.Parse(json)
+
+        match document.RootElement.TryGetProperty(propertyName) with
+        | true, property -> property.GetString()
+        | false, _ ->
+            Assert.Fail($"Expected Watch IPC JSON property '{propertyName}'. JSON:{Environment.NewLine}{json}")
+            String.Empty
+
+    /// Reads the persisted Watch IPC safety flags into a deterministic set for assertions.
+    let private readWatchStatusJsonSafetyFlags () =
+        let json = File.ReadAllText(Services.IpcFileName())
+        use document = JsonDocument.Parse(json)
+
+        match document.RootElement.TryGetProperty("SafetyFlags") with
+        | true, property ->
+            property.EnumerateArray()
+            |> Seq.map (fun flag -> flag.GetString())
+            |> Set.ofSeq
+        | false, _ ->
+            Assert.Fail($"Expected Watch IPC JSON property 'SafetyFlags'. JSON:{Environment.NewLine}{json}")
+            Set.empty
+
+    /// Writes a Watch IPC JSON snapshot with compact runtime fields for deterministic stale-status tests.
+    let private writeWatchStatusJsonWithRuntimeSurface (status: Services.GraceWatchStatus) =
+        let statusNode = JsonNode.Parse(serialize status).AsObject()
+        statusNode["Mode"] <- JsonSerializer.SerializeToNode(status.Mode, Constants.JsonSerializerOptions)
+        statusNode["SafetyFlags"] <- JsonSerializer.SerializeToNode(status.SafetyFlags, Constants.JsonSerializerOptions)
+
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, statusNode.ToJsonString(Constants.JsonSerializerOptions))
+        ipcFileName
+
     /// Writes live watch status file needed by the test scenario.
     let private writeLiveWatchStatusFile () =
         let rootDirectoryId = Guid.NewGuid()
@@ -5397,6 +5436,9 @@ module WatchTests =
 
                 let claimStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
 
+                readWatchStatusJsonStringProperty "Mode"
+                |> should equal "startingUp"
+
                 claimStatus.Mode
                 |> should equal Services.GraceWatchRuntimeMode.StartingUp
 
@@ -5440,7 +5482,60 @@ module WatchTests =
             claimed |> should equal true
 
             let status = Services.getGraceWatchStatus().Result
-            status |> should equal None)
+            status |> should equal None
+
+            readWatchStatusJsonStringProperty "Mode"
+            |> should equal "startingUp"
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "startupClaim"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
+
+    /// Verifies that watch startup claim reclaims stale ipc files through the compact runtime contract.
+    [<Test>]
+    let ``watch startup claim replaces stale ipc file through runtime contract`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let staleStatus =
+                { liveWatchStatus rootDirectoryId with
+                    UpdatedAt =
+                        getCurrentInstant()
+                            .Minus(Duration.FromMinutes(6.0))
+                }
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, serialize staleStatus)
+
+            let claimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            claimed |> should equal true
+
+            readWatchStatusJsonStringProperty "Mode"
+            |> should equal "startingUp"
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "startupClaim"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
 
     /// Verifies that watch status serializes compact runtime mode and safety flags.
     [<Test>]
@@ -5494,6 +5589,39 @@ module WatchTests =
             safetyFlagSet roundTripped
             |> Set.contains "incrementalSafe"
             |> should equal true)
+
+    /// Verifies that stale watch status json does not advertise incremental safety.
+    [<Test>]
+    let ``watch status safety flags require resync when snapshot is stale`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let staleStatus =
+                { liveWatchStatus rootDirectoryId with
+                    UpdatedAt =
+                        getCurrentInstant()
+                            .Minus(Duration.FromMinutes(6.0))
+                }
+
+            writeWatchStatusJsonWithRuntimeSurface staleStatus
+            |> ignore
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "staleStatus"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal false)
 
     /// Verifies that legacy watch status json without compact runtime fields remains readable.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -179,6 +179,15 @@ module WatchTests =
             Assert.Fail($"Expected Watch IPC JSON property '{propertyName}'. JSON:{Environment.NewLine}{json}")
             String.Empty
 
+    /// Reads an optional scalar property from the persisted Watch IPC JSON contract.
+    let private tryReadWatchStatusJsonStringProperty (propertyName: string) =
+        let json = File.ReadAllText(Services.IpcFileName())
+        use document = JsonDocument.Parse(json)
+
+        match document.RootElement.TryGetProperty(propertyName) with
+        | true, property -> Some(property.GetString())
+        | false, _ -> None
+
     /// Reads the persisted Watch IPC safety flags into a deterministic set for assertions.
     let private readWatchStatusJsonSafetyFlags () =
         let json = File.ReadAllText(Services.IpcFileName())
@@ -5549,9 +5558,9 @@ module WatchTests =
             |> Set.contains "requiresExplicitResync"
             |> should equal true)
 
-    /// Verifies that watch status serializes compact runtime mode and safety flags.
+    /// Verifies that watch status serializes compact safety flags without durable liveness-sensitive mode.
     [<Test>]
-    let ``watch status serializes compact runtime mode and safety flags`` () =
+    let ``watch status serializes compact safety flags without healthy runtime mode`` () =
         withTempRepo (fun _ ->
             let rootDirectoryId = Guid.NewGuid()
 
@@ -5573,8 +5582,11 @@ module WatchTests =
             use document = JsonDocument.Parse(json)
             let root = document.RootElement
 
-            root.GetProperty("Mode").GetString()
-            |> should equal "healthyIncremental"
+            match root.TryGetProperty("Mode") with
+            | true, mode ->
+                mode.GetString()
+                |> should not' (equal "healthyIncremental")
+            | false, _ -> ()
 
             let safetyFlags =
                 root.GetProperty("SafetyFlags").EnumerateArray()
@@ -5625,6 +5637,9 @@ module WatchTests =
             |> Set.contains "incrementalSafe"
             |> should equal false
 
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should not' (equal (Some "healthyIncremental"))
+
             getCurrentInstant()
                 .Minus(Duration.FromMinutes(6.0))
             |> updatePersistedWatchStatusUpdatedAt
@@ -5635,6 +5650,9 @@ module WatchTests =
             readWatchStatusJsonSafetyFlags ()
             |> Set.contains "incrementalSafe"
             |> should equal false
+
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should not' (equal (Some "healthyIncremental"))
 
             let agedStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
             let derivedSafetyFlags = safetyFlagSet agedStatus

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -16,6 +16,7 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.IO
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Threading.Tasks
 
 /// Groups watch coverage for the CLI test project.
@@ -144,21 +145,34 @@ module WatchTests =
 
         JsonDocument.Parse(output)
 
+    /// Builds a healthy live Watch status snapshot for IPC compatibility tests.
+    let private liveWatchStatus rootDirectoryId : Services.GraceWatchStatus =
+        {
+            UpdatedAt = getCurrentInstant ()
+            IsStartupClaim = false
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = Sha256Hash "live-watch-root"
+            RootDirectoryBlake3Hash = Blake3Hash "live-watch-root-blake3"
+            LastFileUploadInstant = Instant.MinValue
+            LastDirectoryVersionInstant = Instant.MinValue
+            DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+        }
+
+    /// Removes the compact runtime surface so tests can simulate pre-WS3.1 IPC files.
+    let private removeCompactWatchRuntimeSurface (json: string) =
+        let statusNode = JsonNode.Parse(json).AsObject()
+        statusNode.Remove("Mode") |> ignore
+        statusNode.Remove("SafetyFlags") |> ignore
+        statusNode.ToJsonString(Constants.JsonSerializerOptions)
+
+    /// Reads safety flags into a deterministic set for assertions.
+    let private safetyFlagSet (status: Services.GraceWatchStatus) = status.SafetyFlags |> Set.ofArray
+
     /// Writes live watch status file needed by the test scenario.
     let private writeLiveWatchStatusFile () =
         let rootDirectoryId = Guid.NewGuid()
 
-        let status: Services.GraceWatchStatus =
-            {
-                UpdatedAt = getCurrentInstant ()
-                IsStartupClaim = false
-                RootDirectoryId = rootDirectoryId
-                RootDirectorySha256Hash = Sha256Hash "live-watch-root"
-                RootDirectoryBlake3Hash = Blake3Hash "live-watch-root-blake3"
-                LastFileUploadInstant = Instant.MinValue
-                LastDirectoryVersionInstant = Instant.MinValue
-                DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
-            }
+        let status = liveWatchStatus rootDirectoryId
 
         let ipcFileName = Services.IpcFileName()
 
@@ -5381,6 +5395,21 @@ module WatchTests =
                 let status = Services.getGraceWatchStatus().Result
                 status |> should equal None
 
+                let claimStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
+
+                claimStatus.Mode
+                |> should equal Services.GraceWatchRuntimeMode.StartingUp
+
+                let safetyFlags = safetyFlagSet claimStatus
+
+                safetyFlags
+                |> Set.contains "startupClaim"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
+
                 /// Verifies that the CLI watch scenario exits with the expected process status.
                 let exitCode, output = runWithCapturedOutput [| "watch" |]
 
@@ -5412,6 +5441,128 @@ module WatchTests =
 
             let status = Services.getGraceWatchStatus().Result
             status |> should equal None)
+
+    /// Verifies that watch status serializes compact runtime mode and safety flags.
+    [<Test>]
+    let ``watch status serializes compact runtime mode and safety flags`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "live-watch-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "live-watch-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let json = File.ReadAllText(Services.IpcFileName())
+
+            use document = JsonDocument.Parse(json)
+            let root = document.RootElement
+
+            root.GetProperty("Mode").GetString()
+            |> should equal "healthyIncremental"
+
+            let safetyFlags =
+                root.GetProperty("SafetyFlags").EnumerateArray()
+                |> Seq.map (fun flag -> flag.GetString())
+                |> Set.ofSeq
+
+            safetyFlags
+            |> Set.contains "usableRoot"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "directoryIndex"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal true
+
+            let roundTripped: Services.GraceWatchStatus = deserialize json
+
+            roundTripped.Mode
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            safetyFlagSet roundTripped
+            |> Set.contains "incrementalSafe"
+            |> should equal true)
+
+    /// Verifies that legacy watch status json without compact runtime fields remains readable.
+    [<Test>]
+    let ``watch status reads legacy json without runtime mode fields`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let legacyJson =
+                rootDirectoryId
+                |> liveWatchStatus
+                |> serialize
+                |> removeCompactWatchRuntimeSurface
+
+            legacyJson |> should not' (contain "Mode")
+
+            legacyJson |> should not' (contain "SafetyFlags")
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, legacyJson)
+
+            match Services.getGraceWatchStatus().Result with
+            | Some status ->
+                status.RootDirectoryId
+                |> should equal rootDirectoryId
+
+                status.Mode
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                safetyFlagSet status
+                |> Set.contains "incrementalSafe"
+                |> should equal true
+            | None -> Assert.Fail("Expected legacy watch status JSON to remain usable."))
+
+    /// Verifies that incomplete watch status requests explicit resync instead of advertising incremental safety.
+    [<Test>]
+    let ``watch status without directory index requires explicit resync`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status = { liveWatchStatus rootDirectoryId with DirectoryIds = HashSet<DirectoryVersionId>() }
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, serialize status)
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let persistedStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(ipcFileName))
+
+            persistedStatus.Mode
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let safetyFlags = safetyFlagSet persistedStatus
+
+            safetyFlags
+            |> Set.contains "missingDirectoryIndex"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
 
     /// Verifies that watch status preserves root blake3 from grace status index.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -185,8 +185,9 @@ module WatchTests =
         use document = JsonDocument.Parse(json)
 
         match document.RootElement.TryGetProperty(propertyName) with
-        | true, property -> Some(property.GetString())
+        | true, property when property.ValueKind <> JsonValueKind.Null -> Some(property.GetString())
         | false, _ -> None
+        | true, _ -> None
 
     /// Reads the persisted Watch IPC safety flags into a deterministic set for assertions.
     let private readWatchStatusJsonSafetyFlags () =
@@ -5457,8 +5458,8 @@ module WatchTests =
 
                 let claimStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
 
-                readWatchStatusJsonStringProperty "Mode"
-                |> should equal "startingUp"
+                tryReadWatchStatusJsonStringProperty "Mode"
+                |> should equal None
 
                 claimStatus.Mode
                 |> should equal Services.GraceWatchRuntimeMode.StartingUp
@@ -5505,8 +5506,8 @@ module WatchTests =
             let status = Services.getGraceWatchStatus().Result
             status |> should equal None
 
-            readWatchStatusJsonStringProperty "Mode"
-            |> should equal "startingUp"
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
 
             let safetyFlags = readWatchStatusJsonSafetyFlags ()
 
@@ -5545,8 +5546,8 @@ module WatchTests =
 
             claimed |> should equal true
 
-            readWatchStatusJsonStringProperty "Mode"
-            |> should equal "startingUp"
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
 
             let safetyFlags = readWatchStatusJsonSafetyFlags ()
 
@@ -5555,6 +5556,49 @@ module WatchTests =
             |> should equal true
 
             safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
+
+    /// Verifies that a dead startup claim cannot keep advertising a live startup mode in raw compact IPC JSON.
+    [<Test>]
+    let ``watch compact startup claim does not expose starting mode after heartbeat ages`` () =
+        withTempRepo (fun _ ->
+            let claimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            claimed |> should equal true
+
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
+
+            getCurrentInstant()
+                .Minus(Duration.FromMinutes(6.0))
+            |> updatePersistedWatchStatusUpdatedAt
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
+
+            let agedStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
+
+            agedStatus.Mode
+            |> should equal Services.GraceWatchRuntimeMode.StartingUp
+
+            let derivedSafetyFlags = safetyFlagSet agedStatus
+
+            derivedSafetyFlags
+            |> Set.contains "startupClaim"
+            |> should equal true
+
+            derivedSafetyFlags
+            |> Set.contains "staleStatus"
+            |> should equal true
+
+            derivedSafetyFlags
             |> Set.contains "requiresExplicitResync"
             |> should equal true)
 
@@ -5577,16 +5621,13 @@ module WatchTests =
                 .GetAwaiter()
                 .GetResult()
 
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
+
             let json = File.ReadAllText(Services.IpcFileName())
 
             use document = JsonDocument.Parse(json)
             let root = document.RootElement
-
-            match root.TryGetProperty("Mode") with
-            | true, mode ->
-                mode.GetString()
-                |> should not' (equal "healthyIncremental")
-            | false, _ -> ()
 
             let safetyFlags =
                 root.GetProperty("SafetyFlags").EnumerateArray()
@@ -5614,6 +5655,45 @@ module WatchTests =
             |> Set.contains "incrementalSafe"
             |> should equal true)
 
+    /// Verifies that incomplete Watch IPC snapshots derive resync state instead of persisting it as a live raw mode.
+    [<Test>]
+    let ``watch status serializes compact safety flags without resync runtime mode`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "resync-watch-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "resync-watch-root-blake3"
+                }
+
+            (Services.updateGraceWatchInterprocessFile status (Some(HashSet<DirectoryVersionId>())))
+                .GetAwaiter()
+                .GetResult()
+
+            tryReadWatchStatusJsonStringProperty "Mode"
+            |> should equal None
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "missingDirectoryIndex"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal false
+
+            let roundTripped: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
+
+            roundTripped.Mode
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing)
+
     /// Verifies that raw compact IPC readers cannot inherit incremental safety after a healthy writer dies.
     [<Test>]
     let ``watch compact status does not expose incremental safety after healthy snapshot ages`` () =
@@ -5638,7 +5718,7 @@ module WatchTests =
             |> should equal false
 
             tryReadWatchStatusJsonStringProperty "Mode"
-            |> should not' (equal (Some "healthyIncremental"))
+            |> should equal None
 
             getCurrentInstant()
                 .Minus(Duration.FromMinutes(6.0))
@@ -5652,7 +5732,7 @@ module WatchTests =
             |> should equal false
 
             tryReadWatchStatusJsonStringProperty "Mode"
-            |> should not' (equal (Some "healthyIncremental"))
+            |> should equal None
 
             let agedStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
             let derivedSafetyFlags = safetyFlagSet agedStatus

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -207,6 +207,18 @@ module WatchTests =
         File.WriteAllText(ipcFileName, statusNode.ToJsonString(Constants.JsonSerializerOptions))
         ipcFileName
 
+    /// Rewrites only the Watch IPC heartbeat timestamp so tests can model a healthy writer that later dies.
+    let private updatePersistedWatchStatusUpdatedAt updatedAt =
+        let ipcFileName = Services.IpcFileName()
+
+        let statusNode =
+            JsonNode
+                .Parse(File.ReadAllText(ipcFileName))
+                .AsObject()
+
+        statusNode["UpdatedAt"] <- JsonSerializer.SerializeToNode(updatedAt, Constants.JsonSerializerOptions)
+        File.WriteAllText(ipcFileName, statusNode.ToJsonString(Constants.JsonSerializerOptions))
+
     /// Writes live watch status file needed by the test scenario.
     let private writeLiveWatchStatusFile () =
         let rootDirectoryId = Guid.NewGuid()
@@ -5579,7 +5591,7 @@ module WatchTests =
 
             safetyFlags
             |> Set.contains "incrementalSafe"
-            |> should equal true
+            |> should equal false
 
             let roundTripped: Services.GraceWatchStatus = deserialize json
 
@@ -5589,6 +5601,55 @@ module WatchTests =
             safetyFlagSet roundTripped
             |> Set.contains "incrementalSafe"
             |> should equal true)
+
+    /// Verifies that raw compact IPC readers cannot inherit incremental safety after a healthy writer dies.
+    [<Test>]
+    let ``watch compact status does not expose incremental safety after healthy snapshot ages`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "aging-watch-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "aging-watch-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonSafetyFlags ()
+            |> Set.contains "incrementalSafe"
+            |> should equal false
+
+            getCurrentInstant()
+                .Minus(Duration.FromMinutes(6.0))
+            |> updatePersistedWatchStatusUpdatedAt
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            readWatchStatusJsonSafetyFlags ()
+            |> Set.contains "incrementalSafe"
+            |> should equal false
+
+            let agedStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
+            let derivedSafetyFlags = safetyFlagSet agedStatus
+
+            derivedSafetyFlags
+            |> Set.contains "staleStatus"
+            |> should equal true
+
+            derivedSafetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            derivedSafetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal false)
 
     /// Verifies that stale watch status json does not advertise incremental safety.
     [<Test>]

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -182,7 +182,10 @@ module Services =
     /// Selects only durable compact modes for persisted IPC JSON so liveness must be derived from the raw status data.
     let private modeForGraceWatchStatusContract (status: GraceWatchStatus) =
         match status.Mode with
-        | GraceWatchRuntimeMode.HealthyIncremental -> None
+        | GraceWatchRuntimeMode.StartingUp
+        | GraceWatchRuntimeMode.HealthyIncremental
+        | GraceWatchRuntimeMode.Resynchronizing
+        | GraceWatchRuntimeMode.Stopping -> None
         | mode -> Some mode
 
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -179,6 +179,12 @@ module Services =
         status.SafetyFlags
         |> Array.filter (fun safetyFlag -> not (String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)))
 
+    /// Selects only durable compact modes for persisted IPC JSON so liveness must be derived from the raw status data.
+    let private modeForGraceWatchStatusContract (status: GraceWatchStatus) =
+        match status.Mode with
+        | GraceWatchRuntimeMode.HealthyIncremental -> None
+        | mode -> Some mode
+
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
     let private toGraceWatchStatusContract (status: GraceWatchStatus) =
         {
@@ -190,7 +196,7 @@ module Services =
             LastFileUploadInstant = status.LastFileUploadInstant
             LastDirectoryVersionInstant = status.LastDirectoryVersionInstant
             DirectoryIds = status.DirectoryIds
-            Mode = Some status.Mode
+            Mode = modeForGraceWatchStatusContract status
             SafetyFlags = safetyFlagsForGraceWatchStatusContract status
         }
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -174,6 +174,11 @@ module Services =
             SafetyFlags: string array
         }
 
+    /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
+    let private safetyFlagsForGraceWatchStatusContract (status: GraceWatchStatus) =
+        status.SafetyFlags
+        |> Array.filter (fun safetyFlag -> not (String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)))
+
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
     let private toGraceWatchStatusContract (status: GraceWatchStatus) =
         {
@@ -186,7 +191,7 @@ module Services =
             LastDirectoryVersionInstant = status.LastDirectoryVersionInstant
             DirectoryIds = status.DirectoryIds
             Mode = Some status.Mode
-            SafetyFlags = status.SafetyFlags
+            SafetyFlags = safetyFlagsForGraceWatchStatusContract status
         }
 
     /// Writes the compact Watch IPC JSON contract to the already-open status stream.

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -107,6 +107,11 @@ module Services =
             not (isNull this.DirectoryIds)
             && this.DirectoryIds.Count > 0
 
+        /// Reports whether this status is recent enough to represent a live Watch process.
+        member private this.IsFreshSnapshot =
+            this.UpdatedAt > getCurrentInstant()
+                .Minus(Duration.FromMinutes(5.0))
+
         /// Identifies the current Grace Watch runtime mode without introducing a larger state hierarchy.
         member this.Mode =
             if this.IsStartupClaim then
@@ -122,16 +127,20 @@ module Services =
             let isStartupClaim = this.IsStartupClaim
             let hasUsableRootSnapshot = this.HasUsableRootSnapshot
             let hasDirectoryIndexSnapshot = this.HasDirectoryIndexSnapshot
+            let isFreshSnapshot = this.IsFreshSnapshot
             let mode = this.Mode
 
             [|
                 if isStartupClaim then "startupClaim"
 
+                if not isFreshSnapshot then "staleStatus"
+
                 if hasUsableRootSnapshot then "usableRoot" else "missingRoot"
 
                 if hasDirectoryIndexSnapshot then "directoryIndex" else "missingDirectoryIndex"
 
-                if mode = GraceWatchRuntimeMode.HealthyIncremental then
+                if mode = GraceWatchRuntimeMode.HealthyIncremental
+                   && isFreshSnapshot then
                     "incrementalSafe"
                 else
                     "requiresExplicitResync"
@@ -161,7 +170,7 @@ module Services =
             LastFileUploadInstant: Instant
             LastDirectoryVersionInstant: Instant
             DirectoryIds: HashSet<DirectoryVersionId>
-            Mode: GraceWatchRuntimeMode
+            Mode: GraceWatchRuntimeMode option
             SafetyFlags: string array
         }
 
@@ -176,9 +185,12 @@ module Services =
             LastFileUploadInstant = status.LastFileUploadInstant
             LastDirectoryVersionInstant = status.LastDirectoryVersionInstant
             DirectoryIds = status.DirectoryIds
-            Mode = status.Mode
+            Mode = Some status.Mode
             SafetyFlags = status.SafetyFlags
         }
+
+    /// Writes the compact Watch IPC JSON contract to the already-open status stream.
+    let private writeGraceWatchStatusContractToStream fileStream graceWatchStatus = serializeAsync fileStream (toGraceWatchStatusContract graceWatchStatus)
 
     let mutable graceWatchStatusUpdateTime = Instant.MinValue
     let mutable parseResult: ParseResult = null
@@ -2111,7 +2123,7 @@ module Services =
 
             use fileStream = new FileStream(IpcFileName(), fileMode, FileAccess.Write, FileShare.None)
 
-            do! serializeAsync fileStream (toGraceWatchStatusContract graceWatchStatus)
+            do! writeGraceWatchStatusContractToStream fileStream graceWatchStatus
             graceWatchStatusUpdateTime <- graceWatchStatus.UpdatedAt
         }
 
@@ -2174,7 +2186,7 @@ module Services =
                 task {
                     fileStream.SetLength(0L)
                     fileStream.Position <- 0L
-                    do! serializeAsync fileStream claimStatus
+                    do! writeGraceWatchStatusContractToStream fileStream claimStatus
                     graceWatchStatusUpdateTime <- claimStatus.UpdatedAt
                 }
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -67,6 +67,19 @@ module Services =
         else
             false
 
+    /// Names the compact runtime state advertised by the Grace Watch IPC status file.
+    type GraceWatchRuntimeMode =
+        /// Grace Watch has claimed startup ownership but has not published a usable status snapshot yet.
+        | StartingUp = 0
+        /// Grace Watch has a usable root snapshot and can serve incremental status shortcuts.
+        | HealthyIncremental = 1
+        /// Grace Watch is rebuilding trusted state before incremental shortcuts can be used.
+        | Resynchronizing = 2
+        /// Grace Watch has stopped accepting incremental shortcuts until an explicit resume or resync occurs.
+        | Suspended = 3
+        /// Grace Watch is shutting down and should not be treated as a live incremental source.
+        | Stopping = 4
+
     /// GraceWatchStatus defines the schema for the inter-process communication (IPC) file that lets Grace know if `grace watch` is already running.
     ///
     /// It's written by `grace watch`. It holds everything required to allow other instances of Grace to skip checking current status.
@@ -83,6 +96,47 @@ module Services =
             DirectoryIds: HashSet<DirectoryVersionId>
         }
 
+        /// Reports whether this status has the root identity fields required for trusted incremental consumers.
+        member private this.HasUsableRootSnapshot =
+            this.RootDirectoryId <> Guid.Empty
+            && not (String.IsNullOrWhiteSpace($"{this.RootDirectorySha256Hash}"))
+            && not (String.IsNullOrWhiteSpace($"{this.RootDirectoryBlake3Hash}"))
+
+        /// Reports whether this status has at least one directory identity for current-state comparisons.
+        member private this.HasDirectoryIndexSnapshot =
+            not (isNull this.DirectoryIds)
+            && this.DirectoryIds.Count > 0
+
+        /// Identifies the current Grace Watch runtime mode without introducing a larger state hierarchy.
+        member this.Mode =
+            if this.IsStartupClaim then
+                GraceWatchRuntimeMode.StartingUp
+            elif this.HasUsableRootSnapshot
+                 && this.HasDirectoryIndexSnapshot then
+                GraceWatchRuntimeMode.HealthyIncremental
+            else
+                GraceWatchRuntimeMode.Resynchronizing
+
+        /// Lists compact safety facts that command and agent consumers can inspect before trusting the status snapshot.
+        member this.SafetyFlags =
+            let isStartupClaim = this.IsStartupClaim
+            let hasUsableRootSnapshot = this.HasUsableRootSnapshot
+            let hasDirectoryIndexSnapshot = this.HasDirectoryIndexSnapshot
+            let mode = this.Mode
+
+            [|
+                if isStartupClaim then "startupClaim"
+
+                if hasUsableRootSnapshot then "usableRoot" else "missingRoot"
+
+                if hasDirectoryIndexSnapshot then "directoryIndex" else "missingDirectoryIndex"
+
+                if mode = GraceWatchRuntimeMode.HealthyIncremental then
+                    "incrementalSafe"
+                else
+                    "requiresExplicitResync"
+            |]
+
         /// Defines the empty Grace Watch status used before a live status snapshot is available.
         static member Default =
             {
@@ -95,6 +149,36 @@ module Services =
                 LastDirectoryVersionInstant = Instant.MinValue
                 DirectoryIds = HashSet<DirectoryVersionId>()
             }
+
+    /// Mirrors GraceWatchStatus for IPC writes while adding compact runtime fields that older readers can ignore.
+    type private GraceWatchStatusContract =
+        {
+            UpdatedAt: Instant
+            IsStartupClaim: bool
+            RootDirectoryId: DirectoryVersionId
+            RootDirectorySha256Hash: Sha256Hash
+            RootDirectoryBlake3Hash: Blake3Hash
+            LastFileUploadInstant: Instant
+            LastDirectoryVersionInstant: Instant
+            DirectoryIds: HashSet<DirectoryVersionId>
+            Mode: GraceWatchRuntimeMode
+            SafetyFlags: string array
+        }
+
+    /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
+    let private toGraceWatchStatusContract (status: GraceWatchStatus) =
+        {
+            UpdatedAt = status.UpdatedAt
+            IsStartupClaim = status.IsStartupClaim
+            RootDirectoryId = status.RootDirectoryId
+            RootDirectorySha256Hash = status.RootDirectorySha256Hash
+            RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+            LastFileUploadInstant = status.LastFileUploadInstant
+            LastDirectoryVersionInstant = status.LastDirectoryVersionInstant
+            DirectoryIds = status.DirectoryIds
+            Mode = status.Mode
+            SafetyFlags = status.SafetyFlags
+        }
 
     let mutable graceWatchStatusUpdateTime = Instant.MinValue
     let mutable parseResult: ParseResult = null
@@ -2017,11 +2101,7 @@ module Services =
     let private isGraceWatchStatusUsable (graceWatchStatus: GraceWatchStatus) =
         isGraceWatchStatusFresh graceWatchStatus
         && not graceWatchStatus.IsStartupClaim
-        && graceWatchStatus.RootDirectoryId <> Guid.Empty
-        && not (String.IsNullOrWhiteSpace($"{graceWatchStatus.RootDirectorySha256Hash}"))
-        && not (String.IsNullOrWhiteSpace($"{graceWatchStatus.RootDirectoryBlake3Hash}"))
-        && not (isNull graceWatchStatus.DirectoryIds)
-        && graceWatchStatus.DirectoryIds.Count > 0
+        && graceWatchStatus.Mode = GraceWatchRuntimeMode.HealthyIncremental
 
     /// Writes grace watch status data through the CLI output contract.
     let private writeGraceWatchStatus fileMode graceWatchStatus =
@@ -2031,7 +2111,7 @@ module Services =
 
             use fileStream = new FileStream(IpcFileName(), fileMode, FileAccess.Write, FileShare.None)
 
-            do! serializeAsync fileStream graceWatchStatus
+            do! serializeAsync fileStream (toGraceWatchStatusContract graceWatchStatus)
             graceWatchStatusUpdateTime <- graceWatchStatus.UpdatedAt
         }
 


### PR DESCRIPTION
## Summary

- Add the compact `GraceWatchRuntimeMode` vocabulary for WS3.1 Watch runtime status.
- Expose `Mode` and `SafetyFlags` on the Watch IPC JSON status surface while keeping existing readers compatible.
- Reuse `HealthyIncremental` as the compact usable-status check without changing the existing freshness/root/hash/index
  invariants.

## Related Issue

References #488. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This starts WS3 by giving Grace commands and agents a compact runtime status vocabulary before later leaves add actual
state-gated reconciliation and confidence-loss behavior. That makes Watch coordination more explicit without widening the
runtime model beyond the modes the epic needs.

## Validation

- Focused Watch tests passed, 110 tests before review fixes.
- First review-fix focused Watch tests passed, 112 tests after adding IPC regression coverage.
- Safety-flag review-fix focused Watch tests passed, 114 tests after adding safety-flag freshness coverage.
- Healthy-mode review-fix focused Watch tests passed, 113 tests after adding compact mode freshness coverage.
- Startup/liveness-mode review-fix focused Watch tests passed, 115 tests after adding startup and resync mode coverage.
- Targeted Fantomas passed for `src/Grace.CLI/Command/Services.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs` after
  each completed review-fix pass.
- `pwsh ./scripts/validate.ps1 -Fast` passed before review fixes and after each completed review-fix pass.
- `git diff --check` passed after each completed review-fix pass.
- GitHub `full` check passed on `6edc9b65591bf1fe7f3e181561e6d3681cf92a9b`.

## Docs Impact

No docs change. This slice changes the Watch IPC status contract for commands and agents, but does not change visible
CLI stdout/stderr behavior, user-facing command syntax, or published docs. No ADR was accepted in this leaf.

## Explicit Deferrals

- #489: state-gated reconciliation behavior was not implemented.
- #490: confidence loss, explicit resync workflow, suspension behavior, and recovery transitions were not implemented.
- #491: broader Watch docs polish and user-facing operational documentation were not implemented.
- `Suspended` and `Stopping` are modeled for the compact vocabulary but are not produced by runtime transitions in this
  leaf.

## Review Status

- Current head: `6edc9b65591bf1fe7f3e181561e6d3681cf92a9b`.
- Worker bot-prevention self-review: complete after latest review fix.
- Codex Code Review Bot: `+1` on the current head.
- Review threads: all current-head and prior bot findings have fix replies and are resolved.
- Prevention line: compact IPC JSON regression coverage now suppresses liveness-sensitive modes that can age stale,
  including startup claims, healthy incremental snapshots, resync snapshots, and stopping state.
