### PR TITLE
WS3.2: Gate watch scans and observations by runtime state

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5851,6 +5851,182 @@ module WatchTests =
             |> Set.contains "requiresExplicitResync"
             |> should equal true)
 
+    /// Verifies that scan legality follows the compact Watch runtime state contract.
+    [<Test>]
+    let ``watch runtime mode gates scan legality`` () =
+        Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.StartingUp
+        |> should equal true
+
+        Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.Resynchronizing
+        |> should equal true
+
+        Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.HealthyIncremental
+        |> should equal false
+
+        Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.Suspended
+        |> should equal false
+
+        Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.Stopping
+        |> should equal false
+
+    /// Verifies that normal event-derived observations apply only in healthy incremental mode.
+    [<Test>]
+    let ``healthy runtime mode applies event-derived observations`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let filePath = Path.Combine(root, "healthy-observation.txt")
+            File.WriteAllText(filePath, "healthy observation")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Tracks apply-from-differences Calls changes so healthy mode proves observation application.
+            let mutable applyFromDifferencesCalls = 0
+
+            /// Reads status needed by the state-gate scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise healthy observation processing.
+            let upload _ filePath =
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise healthy observation processing.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 1)
+
+    /// Verifies that suspended mode does not queue or apply filesystem observations.
+    [<Test>]
+    let ``suspended runtime mode does not apply observations`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.Suspended
+
+            let filePath = Path.Combine(root, "suspended-observation.txt")
+            File.WriteAllText(filePath, "suspended observation")
+            Watch.OnChanged(changedEvent filePath)
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>
+
+            /// Tracks apply-from-differences Calls changes so suspended mode proves no status application.
+            let mutable applyFromDifferencesCalls = 0
+
+            /// Reads status needed by the state-gate scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise suspended observation processing.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise suspended observation processing.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 0)
+
+    /// Verifies that stopping mode leaves queued observation work untouched and cannot create a new Save.
+    [<Test>]
+    let ``stopping runtime mode does not create saves from queued observations`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let filePath = Path.Combine(root, "stopping-observation.txt")
+            File.WriteAllText(filePath, "stopping observation")
+            Watch.OnChanged(changedEvent filePath)
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.Stopping
+
+            /// Tracks apply-from-differences Calls changes so stopping mode proves no Save-producing application.
+            let mutable applyFromDifferencesCalls = 0
+
+            /// Reads status needed by the state-gate scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise stopping observation processing.
+            let upload _ filePath =
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise stopping observation processing.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 0
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal [| "stopping-observation.txt" |])
+
     /// Verifies that watch status preserves root blake3 from grace status index.
     [<Test>]
     let ``watch status preserves root Blake3 from GraceStatus index`` () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -188,6 +188,36 @@ module Services =
         | GraceWatchRuntimeMode.Stopping -> None
         | mode -> Some mode
 
+    /// Reports whether Grace Watch may perform a full working-tree scan in the supplied runtime mode.
+    let isGraceWatchScanLegal mode =
+        match mode with
+        | GraceWatchRuntimeMode.StartingUp
+        | GraceWatchRuntimeMode.Resynchronizing -> true
+        | GraceWatchRuntimeMode.HealthyIncremental
+        | GraceWatchRuntimeMode.Suspended
+        | GraceWatchRuntimeMode.Stopping
+        | _ -> false
+
+    /// Reports whether Grace Watch may record filesystem observations for later incremental application.
+    let isGraceWatchObservationCaptureLegal mode =
+        match mode with
+        | GraceWatchRuntimeMode.StartingUp
+        | GraceWatchRuntimeMode.HealthyIncremental -> true
+        | GraceWatchRuntimeMode.Resynchronizing
+        | GraceWatchRuntimeMode.Suspended
+        | GraceWatchRuntimeMode.Stopping
+        | _ -> false
+
+    /// Reports whether Grace Watch may apply normal event-derived observations to Grace Status and branch history.
+    let isGraceWatchObservationApplicationLegal mode =
+        match mode with
+        | GraceWatchRuntimeMode.HealthyIncremental -> true
+        | GraceWatchRuntimeMode.StartingUp
+        | GraceWatchRuntimeMode.Resynchronizing
+        | GraceWatchRuntimeMode.Suspended
+        | GraceWatchRuntimeMode.Stopping
+        | _ -> false
+
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
     let private toGraceWatchStatusContract (status: GraceWatchStatus) =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -45,6 +45,26 @@ open Grace.Types.Automation
 module Watch =
     exception private WatchCommandExit of int
 
+    let mutable private graceWatchRuntimeModeValue = int GraceWatchRuntimeMode.HealthyIncremental
+
+    /// Reads the process-local Grace Watch runtime mode used to gate scans and filesystem observations.
+    let private currentGraceWatchRuntimeMode () = enum<GraceWatchRuntimeMode> (Volatile.Read(&graceWatchRuntimeModeValue))
+
+    /// Updates the process-local Grace Watch runtime mode used by event handlers and status application.
+    let private setGraceWatchRuntimeMode mode =
+        Interlocked.Exchange(&graceWatchRuntimeModeValue, int mode)
+        |> ignore
+
+    /// Sets Grace Watch runtime mode for tests that exercise state-gated observation behavior.
+    let internal setGraceWatchRuntimeModeForWatchTests mode = setGraceWatchRuntimeMode mode
+
+    /// Checks whether the current runtime mode can record filesystem observations.
+    let private canCaptureFilesystemObservation () = isGraceWatchObservationCaptureLegal (currentGraceWatchRuntimeMode ())
+
+    /// Reports that a filesystem observation was ignored because the current runtime mode cannot capture it.
+    let private logObservationSuppressed fullPath =
+        logToAnsiConsole Colors.Verbose $"Grace Watch ignored filesystem observation for {fullPath} while runtime mode is {currentGraceWatchRuntimeMode ()}."
+
     let private uploadedFileVersions = ConcurrentDictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
 
     /// Reads uploaded file version identity data needed by the command workflow without changing remote state.
@@ -1311,6 +1331,7 @@ module Watch =
         fileExistsForWatchFinalPath <- File.Exists
         directoryExistsForWatchFinalPath <- Directory.Exists
         createLocalFileVersionForWatchStatus <- createLocalFileVersion
+        setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
         setLastScanForDifferencesSuccessfulForWatchTests true
 
     /// Coordinates pending watch work snapshot for tests behavior for this CLI command path.
@@ -1474,7 +1495,9 @@ module Watch =
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
-        if
+        if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif
             updateNotInProgress ()
             && Directory.Exists(args.FullPath)
         then
@@ -1496,8 +1519,10 @@ module Watch =
 
     /// Coordinates on changed behavior for this CLI command path.
     let OnChanged (args: FileSystemEventArgs) =
-        if updateNotInProgress ()
-           && isNotDirectory args.FullPath then
+        if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif updateNotInProgress ()
+             && isNotDirectory args.FullPath then
             let shouldIgnore = shouldIgnoreFile args.FullPath
             //logToAnsiConsole Colors.Verbose $"Should ignore {args.FullPath}: {shouldIgnore}."
 
@@ -1530,7 +1555,9 @@ module Watch =
 
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
-        if updateNotInProgress () then
+        if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif updateNotInProgress () then
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
 
             if enqueueStatusUpdateTrigger args.FullPath then
@@ -1559,7 +1586,9 @@ module Watch =
 
     /// Coordinates on renamed behavior for this CLI command path.
     let OnRenamed (args: RenamedEventArgs) =
-        if updateNotInProgress () then
+        if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif updateNotInProgress () then
             let newPathIsDirectory = Directory.Exists(args.FullPath)
 
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
@@ -1786,9 +1815,15 @@ module Watch =
     /// Updates the Grace Status file's Index with updates detected from the file system.
     let updateGraceStatus graceStatus correlationId =
         task {
-            // Get the list of differences between what's in the working directory, and what Grace Index knows about.
-            let! differences = scanForDifferences graceStatus
-            return! updateGraceStatusFromDifferences graceStatus differences correlationId
+            let runtimeMode = currentGraceWatchRuntimeMode ()
+
+            if not (isGraceWatchScanLegal runtimeMode) then
+                logToAnsiConsole Colors.Verbose $"Grace Watch skipped working-tree scan while runtime mode is {runtimeMode}."
+                return Some graceStatus
+            else
+                // Get the list of differences between what's in the working directory, and what Grace Index knows about.
+                let! differences = scanForDifferences graceStatus
+                return! updateGraceStatusFromDifferences graceStatus differences correlationId
         }
 
     /// Reads cached file version for upload skip from ParseResult, local configuration, or Grace ids.
@@ -1911,6 +1946,7 @@ module Watch =
             // First, check if there's anything to process.
             if hasPendingWatchWork () then
                 try
+                    let runtimeMode = currentGraceWatchRuntimeMode ()
                     let correlationId = generateCorrelationId ()
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     graceStatus <- graceStatusFromDisk
@@ -1997,6 +2033,11 @@ module Watch =
                                 statusTriggerSnapshot
                                 (mergeCurrentStatusDifferences processedFileRelativePathsForStatus startupPendingDifferences eventDerivedDifferences)
 
+                        let statusApplicationLegal =
+                            if runtimeMode = GraceWatchRuntimeMode.Stopping then false
+                            elif startupPendingDifferences.Count > 0 then true
+                            else isGraceWatchObservationApplicationLegal runtimeMode
+
                         let! statusUpdateResult =
                             if requeuedResolvedFileDeletePaths.Count > 0 then
                                 logToAnsiConsole
@@ -2009,6 +2050,9 @@ module Watch =
                                     Colors.Important
                                     $"Grace Status uploaded file differences include unresolved final content; requeued uploads will finish before status application."
 
+                                Task.FromResult(None)
+                            elif not statusApplicationLegal then
+                                logToAnsiConsole Colors.Verbose $"Grace Watch deferred status application while runtime mode is {runtimeMode}."
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then
                                 updateGraceStatusFromDifferencesClient graceStatus statusDifferencesForApply.Applicable correlationId
@@ -2130,6 +2174,7 @@ module Watch =
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
 
+                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.StartingUp
                     configureWatchPathComparisonForCurrentRepository ()
 
                     // Create the FileSystemWatcher, but don't enable it yet.
@@ -2353,7 +2398,14 @@ module Watch =
 
                     // Check for changes that occurred while not running.
                     logToAnsiConsole Colors.Verbose $"Scanning for differences."
-                    let! differences = scanForDifferences graceStatus // <--- This always finds the directories with updated write times, but we never update GraceStatus below..
+
+                    let! differences =
+                        if isGraceWatchScanLegal (currentGraceWatchRuntimeMode ()) then
+                            scanForDifferences graceStatus // <--- This always finds the directories with updated write times, but we never update GraceStatus below..
+                        else
+                            logToAnsiConsole Colors.Verbose $"Grace Watch skipped startup scan while runtime mode is {currentGraceWatchRuntimeMode ()}."
+
+                            Task.FromResult(List<FileSystemDifference>())
 
                     if differences |> Seq.isEmpty then
                         logToAnsiConsole Colors.Verbose $"Already up-to-date."
@@ -2366,6 +2418,7 @@ module Watch =
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
+                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
 
                     // Create a timer to process the file changes detected by the FileSystemWatcher.
                     // This timer is the reason that there's a delay in stopping `grace watch`.
@@ -2409,6 +2462,8 @@ module Watch =
                             GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
                             //logToAnsiConsole Colors.Verbose $"Memory before GC: {memoryBeforeGC:N0}; after: {Process.GetCurrentProcess().WorkingSet64:N0}."
                             previousGC <- getCurrentInstant ()
+
+                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.Stopping
 
                     if parseResult |> json then
                         return renderJsonResult parseResult true true "Watch completed because cancellation was requested or the timer stopped."


### PR DESCRIPTION
## Summary

- Add explicit Watch runtime legality predicates for scan, observation capture, and observation application.
- Track process-local Watch runtime mode transitions through startup, healthy incremental operation, and normal stop.
- Gate event capture and Save-producing observation application so suspended/stopping modes do not create new work.

## Related Issue

References #489. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This advances WS3 by making Watch runtime state an actual behavior gate instead of only a status vocabulary. Grace needs
that gate before later leaves add confidence-loss handling and explicit resync, because scan and observation work must be
legal only in states where the watcher still has a trustworthy current-branch view.

## Validation

- Targeted Fantomas passed for `src/Grace.CLI/Command/Services.CLI.fs`, `src/Grace.CLI/Command/Watch.CLI.fs`, and
  `src/Grace.CLI.Tests/Watch.Tests.fs`.
- Focused Watch tests passed: 119/119.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed with a clean Release build and fast test profile green.
- GitHub `full` check passed on `f18099293c0967a473afb07b1538791a75bbdc90`.

## Docs Impact

No docs change. This slice changes internal Watch runtime gating behavior, not public command options, output contracts,
IPC JSON shape, or user-facing docs. Follow-on WS3 documentation remains tracked by #491.

## Explicit Deferrals

- #490: confidence loss, explicit resync workflow, suspension recovery behavior, and deferred observation recovery were
  not implemented.
- #491: broader Watch docs, ADR updates, and status command/readability polish were not implemented.

## Review Status

- Current head: `f18099293c0967a473afb07b1538791a75bbdc90`.
- Worker bot-prevention self-review: complete.
- Codex Code Review Bot: `+1` on the current head.
- Review threads: no unresolved bot findings.
- Prevention line: focused tests cover legal startup/resync scans, healthy-only observation application, suspended
  observation suppression, and stopping-mode no-save behavior.
