### PR TITLE
WS3.3: Handle watch confidence loss and explicit resync

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5916,6 +5916,35 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that resync scans build fresh working-tree maps so stale cache entries cannot hide deletes.
+    [<Test>]
+    let ``scan for differences forgets deleted paths from previous scan`` () =
+        withTempRepo (fun root ->
+            let relativePath = "stale-cache-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            File.WriteAllText(filePath, "tracked content before delete")
+
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+
+            (Services.scanForDifferences status)
+                .GetAwaiter()
+                .GetResult()
+            |> ignore
+
+            File.Delete(filePath)
+
+            let differencesAfterDelete =
+                (Services.scanForDifferences status)
+                    .GetAwaiter()
+                    .GetResult()
+
+            differencesAfterDelete
+            |> Seq.exists (fun difference ->
+                difference.DifferenceType = DifferenceType.Delete
+                && difference.FileSystemEntryType = FileSystemEntryType.File
+                && string difference.RelativePath = relativePath)
+            |> should equal true)
+
     /// Verifies that observations captured during resync wait behind the scan-derived status boundary.
     [<Test>]
     let ``resync defers captured observations until scan status applies`` () =
@@ -6208,6 +6237,50 @@ module WatchTests =
             Watch.currentGraceWatchRuntimeModeForWatchTests ()
             |> should equal Services.GraceWatchRuntimeMode.Suspended)
 
+    /// Verifies that startup tail logic preserves a failed resync recovery instead of resuming healthy mode.
+    [<Test>]
+    let ``startup completion preserves suspended recovery state`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+            Watch.requestGraceWatchExplicitResyncForWatchTests "startup resync failure"
+
+            /// Reads status needed by the failed startup recovery scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Fails the startup resync scan before the durable status boundary.
+            let scanForDifferences _ = Task.FromException<List<FileSystemDifference>>(InvalidOperationException("startup scan failed"))
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ = Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.promoteStartupModeIfRecoverySucceededForWatchTests ()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Suspended)
+
     /// Verifies that liveness refresh cannot republish healthy IPC while Watch is suspended.
     [<Test>]
     let ``suspended liveness refresh publishes non-incremental ipc`` () =
@@ -6250,6 +6323,38 @@ module WatchTests =
                 (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
                 (fun _ _ _ -> Task.FromResult(()))
                 Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that Grace Status DB refreshes cannot publish healthy IPC while resync is pending.
+    [<Test>]
+    let ``resync status refresh publishes non-incremental ipc`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "resync-refresh-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "resync-refresh-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true
+
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test resync refresh"
+
+            (Watch.publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests status directoryIds Services.updateGraceWatchInterprocessFile)
                 .GetAwaiter()
                 .GetResult()
 
@@ -6311,6 +6416,131 @@ module WatchTests =
 
             Services.getGraceWatchStatus().Result
             |> should equal None)
+
+    /// Verifies that overflow during status application blocks later side effects in the same update.
+    [<Test>]
+    let ``overflow during status application cancels side effects`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let filePath = Path.Combine(root, "overflow-during-status.txt")
+            Watch.OnDeleted(deletedEvent filePath)
+
+            /// Tracks apply-from-differences Calls changes so the in-flight race is explicit.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks side effects that should be skipped after overflow changes the trust predicate.
+            let mutable trustedSideEffects = 0
+
+            /// Reads status needed by the overflow race scenario.
+            let readStatus () = Task.FromResult(graceStatusTracking [| "overflow-during-status.txt" |] Array.empty<string>)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise overflow during status application.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Watch.OnError(ErrorEventArgs(InternalBufferOverflowException("watch buffer overflow")))
+
+                if Watch.statusSideEffectsStillTrustedForWatchTests () then
+                    trustedSideEffects <- trustedSideEffects + 1
+
+                Task.FromResult(Some status)
+
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc status directoryIds = Services.updateGraceWatchInterprocessFile status directoryIds
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                (fun _ _ _ -> Task.FromResult(()))
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 1
+            trustedSideEffects |> should equal 0
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that startup upload completions are recorded before healthy mode so they are not uploaded again.
+    [<Test>]
+    let ``startup upload completion records processed path before healthy mode`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+            let relativePath = "startup-upload.txt"
+            let filePath = Path.Combine(root, relativePath)
+            File.WriteAllText(filePath, "startup upload content")
+
+            Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create Add FileSystemEntryType.File relativePath)
+
+            /// Tracks upload Calls changes so startup duplicate prevention is explicit.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so the retry remains pending without another upload.
+            let mutable applyFromDifferencesCalls = 0
+
+            /// Reads status needed by the startup upload scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Records uploaded content while Watch is still in startup mode.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Keeps startup status application retryable so processed upload state remains observable.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(None)
+
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            let processPendingWork () =
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    (fun _ _ _ -> Task.FromResult(()))
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal [| relativePath |]
+
+            processPendingWork ()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 2)
 
     /// Verifies that normal event-derived observations apply only in healthy incremental mode.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5869,6 +5869,206 @@ module WatchTests =
         Services.isGraceWatchScanLegal Services.GraceWatchRuntimeMode.Stopping
         |> should equal false
 
+    /// Verifies that watcher overflow requests resync and quarantines previously queued observations.
+    [<Test>]
+    let ``watcher error leaves healthy mode and quarantines pending observations`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "watch-error-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "watch-error-root-blake3"
+                }
+
+            (Services.updateGraceWatchInterprocessFile status (Some(HashSet<DirectoryVersionId>([| rootDirectoryId |]))))
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true
+
+            let filePath = Path.Combine(root, "queued-before-overflow.txt")
+            File.WriteAllText(filePath, "queued before overflow")
+            Watch.OnChanged(changedEvent filePath)
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal [| filePath |]
+
+            Watch.OnError(ErrorEventArgs(InternalBufferOverflowException("watch buffer overflow")))
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>
+
+            Watch.quarantinedWatchObservationCountForWatchTests ()
+            |> should equal 1
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that observations captured during resync wait behind the scan-derived status boundary.
+    [<Test>]
+    let ``resync defers captured observations until scan status applies`` () =
+        withTempRepo (fun root ->
+            let scanDifference = FileSystemDifference.Create Delete FileSystemEntryType.File "scan-delete.txt"
+            let liveFilePath = Path.Combine(root, "captured-during-resync.txt")
+            /// Tracks scan Calls changes so deferred observations cannot pass by skipping resync.
+            let mutable scanCalls = 0
+            /// Tracks upload Calls changes so the resync pass proves captured observations are deferred.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so scan and deferred event applications are ordered.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the first apply batch so the test fails if resync replays the deferred event immediately.
+            let mutable firstObservedDifferences = List<FileSystemDifference>()
+
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test resync"
+
+            /// Reads status needed by the resync scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to prove the resync pass does not process deferred observations.
+            let upload _ filePath =
+                uploadCalls <- uploadCalls + 1
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Captures a reliable observation while the resync scan is in progress.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                File.WriteAllText(liveFilePath, "captured while resyncing")
+                Watch.OnChanged(changedEvent liveFilePath)
+
+                let differences = List<FileSystemDifference>()
+                differences.Add(scanDifference)
+                Task.FromResult(differences)
+
+            /// Builds apply-from-differences test data used to prove scan-derived status applies first.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                if applyFromDifferencesCalls = 1 then firstObservedDifferences <- differences
+
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 1
+            uploadCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            firstObservedDifferences
+            |> Seq.toArray
+            |> should equal [| scanDifference |]
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal [| liveFilePath |]
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 2
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>)
+
+    /// Verifies that failed resync recovery suspends Watch instead of silently continuing.
+    [<Test>]
+    let ``failed resync recovery suspends observation capture`` () =
+        withTempRepo (fun root ->
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test resync failure"
+
+            /// Reads status needed by the failed resync scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Fails the scan-derived recovery before the durable status boundary.
+            let scanForDifferences _ = Task.FromException<List<FileSystemDifference>>(InvalidOperationException("scan failed"))
+
+            /// Builds apply-from-differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences status _ _ = Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Suspended
+
+            let ignoredPath = Path.Combine(root, "ignored-after-failed-resync.txt")
+            File.WriteAllText(ignoredPath, "ignored after failed resync")
+            Watch.OnChanged(changedEvent ignoredPath)
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that normal event-derived observations apply only in healthy incremental mode.
     [<Test>]
     let ``healthy runtime mode applies event-derived observations`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -6069,6 +6069,249 @@ module WatchTests =
                 .FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies that scan-derived file uploads keep resync retryable instead of suspending Watch.
+    [<Test>]
+    let ``resync retries after queued file uploads complete`` () =
+        withTempRepo (fun root ->
+            let relativePath = "resync-upload-retry.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let scanDifference = FileSystemDifference.Create Add FileSystemEntryType.File relativePath
+            /// Tracks upload Calls changes so the test proves queued resync uploads run before retry.
+            let mutable uploadCalls = 0
+            /// Tracks scan-derived apply Calls changes so the first retryable none does not suspend Watch.
+            let mutable applyFromDifferencesCalls = 0
+
+            File.WriteAllText(filePath, "resync upload retry")
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test resync retry"
+
+            /// Reads status needed by the retryable resync scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Records uploaded content for the scan-derived retry path.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Produces a file add discovered by the resync scan.
+            let scanForDifferences _ =
+                let differences = List<FileSystemDifference>()
+                differences.Add(scanDifference)
+                Task.FromResult(differences)
+
+            /// Queues missing file content on the first status attempt and succeeds after upload.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                if applyFromDifferencesCalls = 1 then
+                    Watch.OnChanged(changedEvent filePath)
+                    Task.FromResult(None)
+                else
+                    Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal [| filePath |]
+
+            uploadCalls |> should equal 0
+            applyFromDifferencesCalls |> should equal 1
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 2)
+
+    /// Verifies that a swallowed scan failure cannot complete resync as a clean empty scan.
+    [<Test>]
+    let ``resync suspends when scan reports failure with empty differences`` () =
+        withTempRepo (fun _ ->
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test scan failure"
+
+            /// Reads status needed by the failed scan scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Models the production scanner's fail-closed flag with an empty result.
+            let scanForDifferences _ =
+                Services.setLastScanForDifferencesSuccessfulForWatchTests false
+                Task.FromResult(List<FileSystemDifference>())
+
+            /// Fails if a failed empty scan reaches status application.
+            let updateGraceStatusFromDifferences _ _ _ =
+                Assert.Fail("Failed resync scan must not apply status.")
+                Task.FromResult(None)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Suspended)
+
+    /// Verifies that liveness refresh cannot republish healthy IPC while Watch is suspended.
+    [<Test>]
+    let ``suspended liveness refresh publishes non-incremental ipc`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "suspended-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "suspended-root-blake3"
+                }
+
+            (Services.updateGraceWatchInterprocessFile status (Some(HashSet<DirectoryVersionId>([| rootDirectoryId |]))))
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true
+
+            Services.graceWatchStatusUpdateTime <- Instant.MinValue
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.Suspended
+
+            /// Reads status needed by the liveness scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForNoDifferences
+                (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                (fun _ _ _ -> Task.FromResult(()))
+                Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that overflow during an in-flight upload cancels normal status application.
+    [<Test>]
+    let ``overflow during upload prevents stale observation commit`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let filePath = Path.Combine(root, "overflow-during-upload.txt")
+            File.WriteAllText(filePath, "overflow during upload")
+            Watch.OnChanged(changedEvent filePath)
+
+            /// Tracks apply-from-differences Calls changes so overflow cannot commit stale observations.
+            let mutable applyFromDifferencesCalls = 0
+
+            /// Reads status needed by the overflow race scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Raises overflow after upload starts to model confidence loss during awaited work.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Watch.OnError(ErrorEventArgs(InternalBufferOverflowException("watch buffer overflow")))
+                Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Builds apply-from-differences test data used to exercise overflow race behavior.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc status directoryIds = Services.updateGraceWatchInterprocessFile status directoryIds
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                (fun _ _ _ -> Task.FromResult(()))
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch.processedFileRelativePathsPendingStatusForWatchTests ()
+            |> should equal Array.empty<string>
+
+            applyFromDifferencesCalls |> should equal 0
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
     /// Verifies that normal event-derived observations apply only in healthy incremental mode.
     [<Test>]
     let ``healthy runtime mode applies event-derived observations`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -6192,6 +6192,198 @@ module WatchTests =
             uploadCalls |> should equal 1
             applyFromDifferencesCalls |> should equal 2)
 
+    /// Verifies that a newer overflow during a resync scan cannot be cleared by the older scan result.
+    [<Test>]
+    let ``overflow during resync scan requires a later scan before healthy mode`` () =
+        withTempRepo (fun _ ->
+            let scanDifference = FileSystemDifference.Create Delete FileSystemEntryType.File "stale-resync-delete.txt"
+            /// Tracks scan Calls changes so the newer overflow must produce a fresh scan.
+            let mutable scanCalls = 0
+            /// Tracks apply-from-differences Calls changes so stale scan output cannot commit.
+            let mutable applyFromDifferencesCalls = 0
+
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test stale resync"
+
+            /// Reads status needed by the stale resync scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Raises a second overflow during the first scan so that attempt cannot clear pending resync.
+            let scanForDifferences _ =
+                scanCalls <- scanCalls + 1
+                let differences = List<FileSystemDifference>()
+
+                if scanCalls = 1 then
+                    Watch.OnError(ErrorEventArgs(InternalBufferOverflowException("second resync overflow")))
+                    differences.Add(scanDifference)
+
+                Task.FromResult(differences)
+
+            /// Builds apply-from-differences test data used to prove stale scan output is ignored.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 0
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            scanCalls |> should equal 2
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental)
+
+    /// Verifies that transient upload failures during resync leave scan-derived work queued for retry.
+    [<Test>]
+    let ``resync upload retry failure keeps queued work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "resync-upload-transient.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let scanDifference = FileSystemDifference.Create Add FileSystemEntryType.File relativePath
+            /// Tracks upload Calls changes so the failed upload is retried on the next tick.
+            let mutable uploadCalls = 0
+            /// Tracks apply-from-differences Calls changes so failed upload does not suspend recovery.
+            let mutable applyFromDifferencesCalls = 0
+
+            File.WriteAllText(filePath, "resync upload transient")
+            Watch.requestGraceWatchExplicitResyncForWatchTests "test transient resync upload"
+
+            /// Reads status needed by the transient upload scenario.
+            let readStatus () = Task.FromResult(GraceStatus.Default)
+
+            /// Fails the first queued resync upload and succeeds when the next timer tick retries it.
+            let upload _ pendingFilePath =
+                uploadCalls <- uploadCalls + 1
+
+                if uploadCalls = 1 then
+                    Task.FromException<unit>(InvalidOperationException("transient upload failure"))
+                else
+                    recordUploadedFileVersion $"{pendingFilePath}"
+                    Task.FromResult(())
+
+            /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+            let updateGraceStatus status _ = Task.FromResult(Some status)
+
+            /// Produces a file add discovered by the resync scan.
+            let scanForDifferences _ =
+                let differences = List<FileSystemDifference>()
+                differences.Add(scanDifference)
+                Task.FromResult(differences)
+
+            /// Queues missing file content on the first status attempt and succeeds after upload.
+            let updateGraceStatusFromDifferences status _ _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+
+                if applyFromDifferencesCalls = 1 then
+                    Watch.OnChanged(changedEvent filePath)
+                    Task.FromResult(None)
+                else
+                    Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal [| filePath |]
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 1
+            applyFromDifferencesCalls |> should equal 1
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal [| filePath |]
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 2
+            applyFromDifferencesCalls |> should equal 2
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            Watch
+                .pendingWatchWorkSnapshotForTests()
+                .FilesToProcess
+            |> should equal Array.empty<string>)
+
     /// Verifies that a swallowed scan failure cannot complete resync as a clean empty scan.
     [<Test>]
     let ``resync suspends when scan reports failure with empty differences`` () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -202,8 +202,8 @@ module Services =
     let isGraceWatchObservationCaptureLegal mode =
         match mode with
         | GraceWatchRuntimeMode.StartingUp
-        | GraceWatchRuntimeMode.HealthyIncremental -> true
-        | GraceWatchRuntimeMode.Resynchronizing
+        | GraceWatchRuntimeMode.HealthyIncremental
+        | GraceWatchRuntimeMode.Resynchronizing -> true
         | GraceWatchRuntimeMode.Suspended
         | GraceWatchRuntimeMode.Stopping
         | _ -> false

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -696,8 +696,6 @@ module Services =
                 RootDirectoryBlake3Hash = rootDirectoryVersion.Blake3Hash
             }
 
-    let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
-
     let mutable private lastScanForDifferencesSucceeded = true
 
     /// Coordinates was last scan for differences successful behavior for this CLI command path.
@@ -706,41 +704,45 @@ module Services =
     /// Coordinates set last scan for differences successful for watch tests behavior for this CLI command path.
     let internal setLastScanForDifferencesSuccessfulForWatchTests succeeded = lastScanForDifferencesSucceeded <- succeeded
 
-    /// Clears inherited working directory write times for watch rescan values so explicitly scoped access commands do not target child resources accidentally.
-    let internal clearWorkingDirectoryWriteTimesForWatchRescan () = localWriteTimes.Clear()
+    /// Preserves the old test reset hook after working-tree scans moved to fresh per-scan write-time maps.
+    let internal clearWorkingDirectoryWriteTimesForWatchRescan () = ()
 
     /// Gets a dictionary of local paths and their last write times.
-    let rec getWorkingDirectoryWriteTimes (directoryInfo: DirectoryInfo) =
-        if shouldNotIgnoreDirectory directoryInfo.FullName then
-            // Add the current directory to the lookup dictionary
-            let directoryFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(Current().RootDirectory, directoryInfo.FullName)))
+    let getWorkingDirectoryWriteTimes (directoryInfo: DirectoryInfo) =
+        let localWriteTimes = ConcurrentDictionary<FileSystemEntryType * RelativePath, DateTime>()
 
-            localWriteTimes.AddOrUpdate(
-                (FileSystemEntryType.Directory, directoryFullPath),
-                (fun _ -> directoryInfo.LastWriteTimeUtc),
-                (fun _ _ -> directoryInfo.LastWriteTimeUtc)
-            )
-            |> ignore
+        /// Adds non-ignored working-tree entries to the current scan's write-time map.
+        let rec addWorkingDirectoryWriteTimes (directoryInfo: DirectoryInfo) =
+            if shouldNotIgnoreDirectory directoryInfo.FullName then
+                // Add the current directory to the lookup dictionary
+                let directoryFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(Current().RootDirectory, directoryInfo.FullName)))
 
-            // Add each file to the lookup dictionary
-            for f in
-                directoryInfo
-                    .GetFiles()
-                    .Where(fun f -> not <| shouldIgnoreFile f.FullName) do
-                let fileFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(Current().RootDirectory, f.FullName)))
-
-                localWriteTimes.AddOrUpdate((FileSystemEntryType.File, fileFullPath), (fun _ -> f.LastWriteTimeUtc), (fun _ _ -> f.LastWriteTimeUtc))
+                localWriteTimes.AddOrUpdate(
+                    (FileSystemEntryType.Directory, directoryFullPath),
+                    (fun _ -> directoryInfo.LastWriteTimeUtc),
+                    (fun _ _ -> directoryInfo.LastWriteTimeUtc)
+                )
                 |> ignore
 
-            // Call recursively for each subdirectory
-            let parallelLoopResult =
-                Parallel.ForEach(directoryInfo.GetDirectories(), Constants.ParallelOptions, (fun d -> getWorkingDirectoryWriteTimes d |> ignore))
+                // Add each file to the lookup dictionary
+                for f in
+                    directoryInfo
+                        .GetFiles()
+                        .Where(fun f -> not <| shouldIgnoreFile f.FullName) do
+                    let fileFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(Current().RootDirectory, f.FullName)))
 
-            if parallelLoopResult.IsCompleted then
-                ()
-            else
-                printfn $"Failed while gathering local write times."
+                    localWriteTimes.AddOrUpdate((FileSystemEntryType.File, fileFullPath), (fun _ -> f.LastWriteTimeUtc), (fun _ _ -> f.LastWriteTimeUtc))
+                    |> ignore
 
+                // Call recursively for each subdirectory
+                let parallelLoopResult = Parallel.ForEach(directoryInfo.GetDirectories(), Constants.ParallelOptions, (fun d -> addWorkingDirectoryWriteTimes d))
+
+                if parallelLoopResult.IsCompleted then
+                    ()
+                else
+                    printfn $"Failed while gathering local write times."
+
+        addWorkingDirectoryWriteTimes directoryInfo
         localWriteTimes
 
     /// Reads local state db path from ParseResult, local configuration, or Grace ids.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -223,7 +223,7 @@ module Watch =
 
     let mutable private quarantinedWatchObservationCount = 0
 
-    let mutable private graceWatchResyncPending = 0
+    let mutable private graceWatchResyncGeneration = 0L
 
     /// Defines structured data exchanged by CLI helpers.
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
@@ -1287,8 +1287,21 @@ module Watch =
         if quarantinedCount > 0 then
             logToAnsiConsole Colors.Important $"Grace Watch quarantined {quarantinedCount} pending observations after confidence loss: {reason}."
 
+    /// Reads the active explicit-resync attempt token used to reject stale recovery side effects.
+    let private currentGraceWatchResyncAttempt () = Volatile.Read(&graceWatchResyncGeneration)
+
     /// Reports whether an explicit resync scan must run before incremental observation application resumes.
-    let private isGraceWatchResyncPending () = Volatile.Read(&graceWatchResyncPending) <> 0
+    let private isGraceWatchResyncPending () = currentGraceWatchResyncAttempt () <> 0L
+
+    /// Reports whether an in-flight resync attempt still owns the recovery boundary.
+    let private isGraceWatchResyncAttemptCurrent attempt =
+        attempt <> 0L
+        && currentGraceWatchResyncAttempt () = attempt
+
+    /// Reports whether an in-flight resync attempt may still apply recovery side effects.
+    let private isGraceWatchResyncAttemptActive attempt =
+        isGraceWatchResyncAttemptCurrent attempt
+        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.Resynchronizing
 
     let mutable private statusSideEffectTrustPredicate = fun () -> true
 
@@ -1320,7 +1333,10 @@ module Watch =
         allowed
 
     /// Clears the pending resync request once scan-derived status has reached the durable boundary.
-    let private clearGraceWatchResyncPending () = Volatile.Write(&graceWatchResyncPending, 0)
+    let private clearGraceWatchResyncPending () = Volatile.Write(&graceWatchResyncGeneration, 0L)
+
+    /// Clears a specific resync attempt without losing a newer confidence-loss request.
+    let private tryClearGraceWatchResyncAttempt attempt = Interlocked.CompareExchange(&graceWatchResyncGeneration, 0L, attempt) = attempt
 
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
@@ -1342,18 +1358,29 @@ module Watch =
         with
         | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
 
-    /// Suspends incremental Watch processing after recovery fails so Grace does not silently continue.
-    let private suspendGraceWatchAfterFailedRecovery reason =
-        quarantinePendingWatchWork reason
-        clearGraceWatchResyncPending ()
-        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
-        publishGraceWatchResyncRequired ()
-        logToAnsiConsole Colors.Error $"Grace Watch suspended incremental processing: {reason}."
+    /// Suspends only the resync attempt that observed the failure, preserving newer overflow requests.
+    let private suspendGraceWatchAttemptAfterFailedRecovery attempt reason =
+        if isGraceWatchResyncAttemptActive attempt then
+            quarantinePendingWatchWork reason
+            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
+
+            if tryClearGraceWatchResyncAttempt attempt then
+                publishGraceWatchResyncRequired ()
+                logToAnsiConsole Colors.Error $"Grace Watch suspended incremental processing: {reason}."
+            else
+                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                logToAnsiConsole Colors.Important $"Grace Watch kept newer resync attempt pending after stale attempt {attempt} failed."
+        else
+            logToAnsiConsole Colors.Important $"Grace Watch ignored stale resync failure for attempt {attempt} because a newer resync attempt is pending."
 
     /// Requests a scan-derived resync and quarantines observations captured under the previous root confidence.
     let private requestGraceWatchExplicitResync reason =
         quarantinePendingWatchWork reason
-        Volatile.Write(&graceWatchResyncPending, 1)
+
+        Interlocked.Increment(&graceWatchResyncGeneration)
+        |> ignore
+
         setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
         publishGraceWatchResyncRequired ()
         logToAnsiConsole Colors.Important $"Grace Watch requires an explicit resync before incremental observations can resume: {reason}."
@@ -2116,6 +2143,7 @@ module Watch =
         applyGraceStatusIncrementalClient
         correlationId
         recordProcessedPaths
+        resyncAttempt
         =
         task {
             let! graceStatusFromDisk = readGraceStatusMetaClient ()
@@ -2149,14 +2177,14 @@ module Watch =
                     let currentMode = currentGraceWatchRuntimeMode ()
 
                     let uploadResultStillTrusted =
-                        if recordProcessedPaths then
-                            not (isGraceWatchResyncPending ())
+                        match resyncAttempt with
+                        | Some attempt -> isGraceWatchResyncAttemptActive attempt
+                        | None ->
+                            recordProcessedPaths
+                            && not (isGraceWatchResyncPending ())
                             && (isGraceWatchObservationApplicationLegal currentMode
                                 || currentMode = GraceWatchRuntimeMode.StartingUp
                                 || currentMode = GraceWatchRuntimeMode.Stopping)
-                        else
-                            isGraceWatchResyncPending ()
-                            && currentMode = GraceWatchRuntimeMode.Resynchronizing
 
                     if
                         uploadResultStillTrusted
@@ -2213,74 +2241,110 @@ module Watch =
 
             // First, check if there's anything to process.
             if isGraceWatchResyncPending () then
+                let resyncAttempt = currentGraceWatchResyncAttempt ()
+
                 try
                     let correlationId = generateCorrelationId ()
 
-                    let! uploadedRetryContent =
+                    let! uploadedRetryContent, uploadRetryFailed =
                         if filesToProcess.IsEmpty then
-                            Task.FromResult(false)
+                            Task.FromResult(false, false)
                         else
-                            uploadPendingWatchFilesForStatusRetry
-                                readGraceStatusMetaClient
-                                copyFileToObjectDirectoryAndUploadToStorageClient
-                                applyGraceStatusIncrementalClient
-                                correlationId
-                                false
+                            task {
+                                try
+                                    let! uploadedRetryContent =
+                                        uploadPendingWatchFilesForStatusRetry
+                                            readGraceStatusMetaClient
+                                            copyFileToObjectDirectoryAndUploadToStorageClient
+                                            applyGraceStatusIncrementalClient
+                                            correlationId
+                                            false
+                                            (Some resyncAttempt)
 
-                    if uploadedRetryContent then
-                        logToAnsiConsole
-                            Colors.Important
-                            "Grace Watch uploaded file content queued by resync recovery; retrying the scan-derived status boundary."
+                                    return uploadedRetryContent, false
+                                with
+                                | ex ->
+                                    if isGraceWatchResyncAttemptActive resyncAttempt then
+                                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
 
-                    let! graceStatusSnapshot = readGraceStatusFileClient ()
-                    graceStatus <- graceStatusSnapshot
+                                    logToAnsiConsole
+                                        Colors.Error
+                                        $"Grace Watch resync upload retry failed and will remain queued for another tick: {ex.Message}"
 
-                    let! scanDerivedDifferences = _scanForDifferencesClient graceStatus
+                                    return false, true
+                            }
 
-                    if not (wasLastScanForDifferencesSuccessful ()) then
-                        failwith "scan-derived resync did not complete successfully"
+                    let resyncStatusUpdateStillTrusted () = isGraceWatchResyncAttemptActive resyncAttempt
 
-                    let resyncStatusUpdateStillTrusted () =
-                        isGraceWatchResyncPending ()
-                        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.Resynchronizing
-
-                    let! statusUpdateResult =
-                        if scanDerivedDifferences.Count > 0 then
-                            updateGraceStatusFromDifferencesWhenTrusted
-                                resyncStatusUpdateStillTrusted
-                                updateGraceStatusFromDifferencesClient
-                                graceStatus
-                                scanDerivedDifferences
-                                correlationId
-                        else
-                            Task.FromResult(Some graceStatus)
-
-                    match statusUpdateResult with
-                    | Some newGraceStatus ->
-                        graceStatus <- newGraceStatus
-                        updateGraceStatusDirectoryIds graceStatus
-                        clearGraceWatchResyncPending ()
-                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
-                        do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
-
-                        logToAnsiConsole
-                            Colors.Important
-                            $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
-                    | None ->
-                        if filesToProcess.IsEmpty then
-                            suspendGraceWatchAfterFailedRecovery "scan-derived status update returned no durable status"
-                        else
-                            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
-
+                    if uploadRetryFailed then
+                        ()
+                    elif not (resyncStatusUpdateStillTrusted ()) then
+                        logToAnsiConsole Colors.Important $"Grace Watch skipped stale resync attempt {resyncAttempt} because a newer resync attempt is pending."
+                    else
+                        if uploadedRetryContent then
                             logToAnsiConsole
                                 Colors.Important
-                                $"Grace Watch resync queued file uploads before applying scan-derived status; retry will continue after uploads complete."
+                                "Grace Watch uploaded file content queued by resync recovery; retrying the scan-derived status boundary."
+
+                        let! graceStatusSnapshot = readGraceStatusFileClient ()
+                        graceStatus <- graceStatusSnapshot
+
+                        let! scanDerivedDifferences = _scanForDifferencesClient graceStatus
+
+                        if not (wasLastScanForDifferencesSuccessful ()) then
+                            failwith "scan-derived resync did not complete successfully"
+
+                        let! statusUpdateResult =
+                            if scanDerivedDifferences.Count > 0 then
+                                updateGraceStatusFromDifferencesWhenTrusted
+                                    resyncStatusUpdateStillTrusted
+                                    updateGraceStatusFromDifferencesClient
+                                    graceStatus
+                                    scanDerivedDifferences
+                                    correlationId
+                            else
+                                Task.FromResult(Some graceStatus)
+
+                        match statusUpdateResult with
+                        | Some newGraceStatus when resyncStatusUpdateStillTrusted () ->
+                            graceStatus <- newGraceStatus
+                            updateGraceStatusDirectoryIds graceStatus
+
+                            setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
+
+                            let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
+
+                            if clearedResyncAttempt then
+                                do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                            else
+                                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed."
+                        | Some _ ->
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Grace Watch skipped stale resync commit for attempt {resyncAttempt} because confidence changed before commit."
+                        | None ->
+                            if filesToProcess.IsEmpty then
+                                suspendGraceWatchAttemptAfterFailedRecovery resyncAttempt "scan-derived status update returned no durable status"
+                            else
+                                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Watch resync queued file uploads before applying scan-derived status; retry will continue after uploads complete."
 
                     graceStatus <- GraceStatus.Default
                     GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
                 with
                 | ex ->
-                    suspendGraceWatchAfterFailedRecovery $"resync failed before the durable status boundary: {ex.Message}"
+                    suspendGraceWatchAttemptAfterFailedRecovery resyncAttempt $"resync failed before the durable status boundary: {ex.Message}"
 
                     logToAnsiConsole
                         Colors.Error
@@ -2296,6 +2360,7 @@ module Watch =
                             applyGraceStatusIncrementalClient
                             correlationId
                             true
+                            None
 
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1290,8 +1290,48 @@ module Watch =
     /// Reports whether an explicit resync scan must run before incremental observation application resumes.
     let private isGraceWatchResyncPending () = Volatile.Read(&graceWatchResyncPending) <> 0
 
+    let mutable private statusSideEffectTrustPredicate = fun () -> true
+
+    /// Reports whether Watch still trusts the current status update enough to write remote or local side effects.
+    let private statusSideEffectsStillTrusted () = statusSideEffectTrustPredicate ()
+
+    /// Reports the active status side-effect trust state for Watch confidence-boundary tests.
+    let internal statusSideEffectsStillTrustedForWatchTests () = statusSideEffectsStillTrusted ()
+
+    /// Runs status application with a confidence predicate that can be rechecked between side effects.
+    let private runWithStatusSideEffectTrustPredicate predicate operation =
+        task {
+            let previousPredicate = statusSideEffectTrustPredicate
+            statusSideEffectTrustPredicate <- predicate
+
+            try
+                return! operation ()
+            finally
+                statusSideEffectTrustPredicate <- previousPredicate
+        }
+
+    /// Stops status application before a side effect when Watch lost the confidence boundary for this update.
+    let private statusSideEffectStillAllowed sideEffectName =
+        let allowed = statusSideEffectsStillTrusted ()
+
+        if not allowed then
+            logToAnsiConsole Colors.Important $"Grace Watch skipped {sideEffectName} because confidence was lost before status side effects completed."
+
+        allowed
+
     /// Clears the pending resync request once scan-derived status has reached the durable boundary.
     let private clearGraceWatchResyncPending () = Volatile.Write(&graceWatchResyncPending, 0)
+
+    /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
+    let private promoteStartupModeIfRecoverySucceeded () =
+        if
+            currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
+            && not (isGraceWatchResyncPending ())
+        then
+            setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
+
+    /// Completes startup for tests that verify failed recovery does not resume incremental mode.
+    let internal promoteStartupModeIfRecoverySucceededForWatchTests () = promoteStartupModeIfRecoverySucceeded ()
 
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
@@ -1820,14 +1860,15 @@ module Watch =
                     .ToList()
 
             if unuploadedFileDifferences.Count > 0 then
-                for fileDifference in unuploadedFileDifferences do
-                    let fullPath = Path.Combine(Current().RootDirectory, string fileDifference.RelativePath)
+                if statusSideEffectStillAllowed "missing-upload retry queueing" then
+                    for fileDifference in unuploadedFileDifferences do
+                        let fullPath = Path.Combine(Current().RootDirectory, string fileDifference.RelativePath)
 
-                    enqueueFileUpload fullPath |> ignore
+                        enqueueFileUpload fullPath |> ignore
 
-                logToAnsiConsole
-                    Colors.Important
-                    $"Grace Status update found {unuploadedFileDifferences.Count} file add/change differences without uploaded file content; file uploads will run before retrying the status update."
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Grace Status update found {unuploadedFileDifferences.Count} file add/change differences without uploaded file content; file uploads will run before retrying the status update."
 
                 return None
             else
@@ -1845,68 +1886,85 @@ module Watch =
                             savedDirectoryVersions
                             newDirectoryVersions
 
-                    let! result = saveDirectoryVersions directoryVersionsToSave correlationId
+                    let! result =
+                        if statusSideEffectStillAllowed "directory-version upload" then
+                            saveDirectoryVersions directoryVersionsToSave correlationId
+                        else
+                            Task.FromResult(Error(GraceError.Create "Watch confidence lost before directory-version upload." correlationId))
 
                     match result with
                     | Ok returnValue ->
                         let newGraceStatus = syncGraceStatusRootDirectoryHash newGraceStatus
 
-                        do! updateObjectCacheFile newDirectoryVersions
-
-                        let fileDifferences =
-                            differences
-                                .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
-                                .ToList()
-
-                        let message =
-                            if fileDifferences |> Seq.isEmpty then
-                                String.Empty
-                            else
-                                let sb = stringBuilderPool.Get()
-
-                                try
-                                    for fileDifference in fileDifferences do
-                                        //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
-                                        match fileDifference.DifferenceType with
-                                        | Change ->
-                                            sb.AppendLine($"{fileDifference.RelativePath}")
-                                            |> ignore
-                                        | Add ->
-                                            sb.AppendLine($"Add {fileDifference.RelativePath}")
-                                            |> ignore
-                                        | Delete ->
-                                            sb.AppendLine($"Delete {fileDifference.RelativePath}")
-                                            |> ignore
-
-                                    let saveMessage = sb.ToString()
-                                    saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
-                                finally
-                                    stringBuilderPool.Return(sb)
-
-                        // If there are changes either to files or just to directories, create a save reference.
-                        if (differences.Count > 0) then
-                            match! createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId with
-                            | Ok returnValue ->
-                                let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
-                                // Apply incremental changes to the Grace Status DB.
-                                do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
-
-                                for fileVersion in directoryUploadedFileVersions do
-                                    let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
-
-                                    uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
-                                    |> ignore
-
-                                //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
-                                graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
-                                return Some newGraceStatusWithUpdatedTime
-                            | Error error ->
-                                logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
-                                return None
+                        if not (statusSideEffectStillAllowed "object-cache update") then
+                            return None
                         else
-                            // There were no changes to process, so just return the existing GraceStatus.
-                            //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
-                            return Some graceStatus
+                            do! updateObjectCacheFile newDirectoryVersions
+
+                            let fileDifferences =
+                                differences
+                                    .Where(fun diff -> diff.FileSystemEntryType = FileSystemEntryType.File)
+                                    .ToList()
+
+                            let message =
+                                if fileDifferences |> Seq.isEmpty then
+                                    String.Empty
+                                else
+                                    let sb = stringBuilderPool.Get()
+
+                                    try
+                                        for fileDifference in fileDifferences do
+                                            //sb.AppendLine($"{(getDiscriminatedUnionCaseNameToString fileDifference.DifferenceType)}: {fileDifference.RelativePath}") |> ignore
+                                            match fileDifference.DifferenceType with
+                                            | Change ->
+                                                sb.AppendLine($"{fileDifference.RelativePath}")
+                                                |> ignore
+                                            | Add ->
+                                                sb.AppendLine($"Add {fileDifference.RelativePath}")
+                                                |> ignore
+                                            | Delete ->
+                                                sb.AppendLine($"Delete {fileDifference.RelativePath}")
+                                                |> ignore
+
+                                        let saveMessage = sb.ToString()
+                                        saveMessage.Remove(saveMessage.LastIndexOf(Environment.NewLine), Environment.NewLine.Length)
+                                    finally
+                                        stringBuilderPool.Return(sb)
+
+                            // If there are changes either to files or just to directories, create a save reference.
+                            if (differences.Count > 0) then
+                                let! saveReferenceResult =
+                                    if statusSideEffectStillAllowed "save reference creation" then
+                                        createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId
+                                    else
+                                        Task.FromResult(Error(GraceError.Create "Watch confidence lost before save reference creation." correlationId))
+
+                                match saveReferenceResult with
+                                | Ok returnValue ->
+                                    let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
+
+                                    if statusSideEffectStillAllowed "local status application" then
+                                        // Apply incremental changes to the Grace Status DB.
+                                        do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+
+                                        for fileVersion in directoryUploadedFileVersions do
+                                            let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+
+                                            uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
+                                            |> ignore
+
+                                        //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
+                                        graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
+                                        return Some newGraceStatusWithUpdatedTime
+                                    else
+                                        return None
+                                | Error error ->
+                                    logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
+                                    return None
+                            else
+                                // There were no changes to process, so just return the existing GraceStatus.
+                                //logToAnsiConsole Colors.Verbose "No fileDifferences or newDirectoryVersions to process; not updating GraceStatus."
+                                return Some graceStatus
                     | Error error ->
                         logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
                         return None
@@ -2029,6 +2087,28 @@ module Watch =
     /// Coordinates update grace status directory ids behavior for this CLI command path.
     let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
+    /// Publishes a trusted Watch IPC snapshot only when incremental mode is currently safe for other processes.
+    let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
+        task {
+            let runtimeMode = currentGraceWatchRuntimeMode ()
+
+            if
+                runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
+                && not (isGraceWatchResyncPending ())
+            then
+                do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
+            else
+                do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+
+                logToAnsiConsole
+                    Colors.Important
+                    $"Grace Watch published non-incremental IPC for {context} while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
+        }
+
+    /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
+    let internal publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
+        publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient "test refresh"
+
     /// Uploads pending file content while preserving the confidence boundary for the current Watch mode.
     let private uploadPendingWatchFilesForStatusRetry
         readGraceStatusMetaClient
@@ -2072,6 +2152,7 @@ module Watch =
                         if recordProcessedPaths then
                             not (isGraceWatchResyncPending ())
                             && (isGraceWatchObservationApplicationLegal currentMode
+                                || currentMode = GraceWatchRuntimeMode.StartingUp
                                 || currentMode = GraceWatchRuntimeMode.Stopping)
                         else
                             isGraceWatchResyncPending ()
@@ -2103,6 +2184,17 @@ module Watch =
                 do! applyGraceStatusIncrementalClient graceStatus Seq.empty Seq.empty
 
             return processedAnyFile
+        }
+
+    /// Invokes status application only while the caller's confidence boundary still holds.
+    let private updateGraceStatusFromDifferencesWhenTrusted trustPredicate updateGraceStatusFromDifferencesClient graceStatus differences correlationId =
+        task {
+            if trustPredicate () then
+                return!
+                    runWithStatusSideEffectTrustPredicate trustPredicate (fun () -> updateGraceStatusFromDifferencesClient graceStatus differences correlationId)
+            else
+                logToAnsiConsole Colors.Important "Grace Watch skipped status application because confidence was lost before status side effects started."
+                return None
         }
 
     /// Processes any changed files since the last timer tick.
@@ -2148,9 +2240,18 @@ module Watch =
                     if not (wasLastScanForDifferencesSuccessful ()) then
                         failwith "scan-derived resync did not complete successfully"
 
+                    let resyncStatusUpdateStillTrusted () =
+                        isGraceWatchResyncPending ()
+                        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.Resynchronizing
+
                     let! statusUpdateResult =
                         if scanDerivedDifferences.Count > 0 then
-                            updateGraceStatusFromDifferencesClient graceStatus scanDerivedDifferences correlationId
+                            updateGraceStatusFromDifferencesWhenTrusted
+                                resyncStatusUpdateStillTrusted
+                                updateGraceStatusFromDifferencesClient
+                                graceStatus
+                                scanDerivedDifferences
+                                correlationId
                         else
                             Task.FromResult(Some graceStatus)
 
@@ -2235,15 +2336,24 @@ module Watch =
                                 statusTriggerSnapshot
                                 (mergeCurrentStatusDifferences processedFileRelativePathsForStatus startupPendingDifferences eventDerivedDifferences)
 
-                        let statusApplicationLegal =
+                        let statusApplicationModeStillTrusted () =
                             let runtimeModeBeforeStatusApplication = currentGraceWatchRuntimeMode ()
 
                             if runtimeModeBeforeStatusApplication = GraceWatchRuntimeMode.Stopping then
                                 false
                             elif startupPendingDifferences.Count > 0 then
-                                true
+                                runtimeModeBeforeStatusApplication = GraceWatchRuntimeMode.StartingUp
+                                || runtimeModeBeforeStatusApplication = GraceWatchRuntimeMode.HealthyIncremental
                             else
                                 isGraceWatchObservationApplicationLegal runtimeModeBeforeStatusApplication
+
+                        let statusApplicationLegal = statusApplicationModeStillTrusted ()
+
+                        let statusUpdateStillTrusted () =
+                            filesToProcess.IsEmpty
+                            && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
+                            && not (isGraceWatchResyncPending ())
+                            && statusApplicationModeStillTrusted ()
 
                         let! statusUpdateResult =
                             if requeuedResolvedFileDeletePaths.Count > 0 then
@@ -2265,7 +2375,12 @@ module Watch =
 
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then
-                                updateGraceStatusFromDifferencesClient graceStatus statusDifferencesForApply.Applicable correlationId
+                                updateGraceStatusFromDifferencesWhenTrusted
+                                    statusUpdateStillTrusted
+                                    updateGraceStatusFromDifferencesClient
+                                    graceStatus
+                                    statusDifferencesForApply.Applicable
+                                    correlationId
                             else
                                 Task.FromResult(Some graceStatus)
 
@@ -2274,9 +2389,7 @@ module Watch =
                             let commitRuntimeMode = currentGraceWatchRuntimeMode ()
 
                             let statusUpdateCanCommit =
-                                filesToProcess.IsEmpty
-                                && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
-                                && not (isGraceWatchResyncPending ())
+                                statusUpdateStillTrusted ()
                                 && (startupPendingDifferences.Count > 0
                                     || isGraceWatchObservationApplicationLegal commitRuntimeMode)
 
@@ -2658,7 +2771,7 @@ module Watch =
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
-                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
+                    promoteStartupModeIfRecoverySucceeded ()
 
                     // Create a timer to process the file changes detected by the FileSystemWatcher.
                     // This timer is the reason that there's a delay in stopping `grace watch`.
@@ -2675,7 +2788,14 @@ module Watch =
                             let! updatedGraceStatus = readGraceStatusFile ()
                             graceStatus <- updatedGraceStatus
                             updateGraceStatusDirectoryIds graceStatus
-                            do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
+
+                            do!
+                                publishGraceWatchInterprocessFileForCurrentConfidence
+                                    graceStatus
+                                    graceStatusDirectoryIds
+                                    updateGraceWatchInterprocessFile
+                                    "Grace Status refresh"
+
                             //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in OnWatch(). Current value: {graceStatusHasChanged}."
                             graceStatusHasChanged <- false
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1293,13 +1293,6 @@ module Watch =
     /// Clears the pending resync request once scan-derived status has reached the durable boundary.
     let private clearGraceWatchResyncPending () = Volatile.Write(&graceWatchResyncPending, 0)
 
-    /// Suspends incremental Watch processing after recovery fails so Grace does not silently continue.
-    let private suspendGraceWatchAfterFailedRecovery reason =
-        quarantinePendingWatchWork reason
-        clearGraceWatchResyncPending ()
-        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
-        logToAnsiConsole Colors.Error $"Grace Watch suspended incremental processing: {reason}."
-
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
         try
@@ -1308,6 +1301,14 @@ module Watch =
                 .GetResult()
         with
         | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
+
+    /// Suspends incremental Watch processing after recovery fails so Grace does not silently continue.
+    let private suspendGraceWatchAfterFailedRecovery reason =
+        quarantinePendingWatchWork reason
+        clearGraceWatchResyncPending ()
+        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
+        publishGraceWatchResyncRequired ()
+        logToAnsiConsole Colors.Error $"Grace Watch suspended incremental processing: {reason}."
 
     /// Requests a scan-derived resync and quarantines observations captured under the previous root confidence.
     let private requestGraceWatchExplicitResync reason =
@@ -2028,6 +2029,82 @@ module Watch =
     /// Coordinates update grace status directory ids behavior for this CLI command path.
     let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
+    /// Uploads pending file content while preserving the confidence boundary for the current Watch mode.
+    let private uploadPendingWatchFilesForStatusRetry
+        readGraceStatusMetaClient
+        copyFileToObjectDirectoryAndUploadToStorageClient
+        applyGraceStatusIncrementalClient
+        correlationId
+        recordProcessedPaths
+        =
+        task {
+            let! graceStatusFromDisk = readGraceStatusMetaClient ()
+            graceStatus <- graceStatusFromDisk
+
+            let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
+            let mutable processedAnyFile = false
+
+            retryPendingDirectoryUploads ()
+
+            let getUploadMetadataForFilesParameters =
+                GetUploadMetadataForFilesParameters(
+                    OwnerId = $"{Current().OwnerId}",
+                    OrganizationId = $"{Current().OrganizationId}",
+                    RepositoryId = $"{Current().RepositoryId}",
+                    CorrelationId = correlationId
+                )
+
+            for pendingFile in
+                filesToProcess
+                    .ToArray()
+                    .Take(50)
+                    .Select(fun entry -> { FullPath = entry.Key; Generation = entry.Value }) do
+                let pendingPair = KeyValuePair(pendingFile.FullPath, pendingFile.Generation)
+
+                if (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
+                    .Contains(pendingPair) then
+                    logToAnsiConsole Colors.Verbose $"Processing {pendingFile.FullPath}. filesToProcess.Count: {filesToProcess.Count}."
+                    do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath pendingFile.FullPath)
+
+                    let currentMode = currentGraceWatchRuntimeMode ()
+
+                    let uploadResultStillTrusted =
+                        if recordProcessedPaths then
+                            not (isGraceWatchResyncPending ())
+                            && (isGraceWatchObservationApplicationLegal currentMode
+                                || currentMode = GraceWatchRuntimeMode.Stopping)
+                        else
+                            isGraceWatchResyncPending ()
+                            && currentMode = GraceWatchRuntimeMode.Resynchronizing
+
+                    if
+                        uploadResultStillTrusted
+                        && (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
+                            .Contains(pendingPair)
+                    then
+                        (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
+                            .Remove(pendingPair)
+                        |> ignore
+
+                        if recordProcessedPaths then
+                            match repositoryRelativePath pendingFile.FullPath with
+                            | Some relativePath -> addProcessedFileRelativePathPendingStatus (RelativePath relativePath)
+                            | None -> ()
+
+                        processedAnyFile <- true
+                        lastFileUploadInstant <- getCurrentInstant ()
+                    else
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Grace Watch discarded upload completion for {pendingFile.FullPath} because runtime mode is {currentMode} and resync pending is {isGraceWatchResyncPending ()}."
+
+            if processedAnyFile then
+                graceStatus <- { graceStatus with LastSuccessfulFileUpload = lastFileUploadInstant }
+                do! applyGraceStatusIncrementalClient graceStatus Seq.empty Seq.empty
+
+            return processedAnyFile
+        }
+
     /// Processes any changed files since the last timer tick.
     let internal processChangedFilesWithClients
         readGraceStatusMetaClient
@@ -2046,10 +2123,30 @@ module Watch =
             if isGraceWatchResyncPending () then
                 try
                     let correlationId = generateCorrelationId ()
+
+                    let! uploadedRetryContent =
+                        if filesToProcess.IsEmpty then
+                            Task.FromResult(false)
+                        else
+                            uploadPendingWatchFilesForStatusRetry
+                                readGraceStatusMetaClient
+                                copyFileToObjectDirectoryAndUploadToStorageClient
+                                applyGraceStatusIncrementalClient
+                                correlationId
+                                false
+
+                    if uploadedRetryContent then
+                        logToAnsiConsole
+                            Colors.Important
+                            "Grace Watch uploaded file content queued by resync recovery; retrying the scan-derived status boundary."
+
                     let! graceStatusSnapshot = readGraceStatusFileClient ()
                     graceStatus <- graceStatusSnapshot
 
                     let! scanDerivedDifferences = _scanForDifferencesClient graceStatus
+
+                    if not (wasLastScanForDifferencesSuccessful ()) then
+                        failwith "scan-derived resync did not complete successfully"
 
                     let! statusUpdateResult =
                         if scanDerivedDifferences.Count > 0 then
@@ -2068,7 +2165,15 @@ module Watch =
                         logToAnsiConsole
                             Colors.Important
                             $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
-                    | None -> suspendGraceWatchAfterFailedRecovery "scan-derived status update returned no durable status"
+                    | None ->
+                        if filesToProcess.IsEmpty then
+                            suspendGraceWatchAfterFailedRecovery "scan-derived status update returned no durable status"
+                        else
+                            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Grace Watch resync queued file uploads before applying scan-derived status; retry will continue after uploads complete."
 
                     graceStatus <- GraceStatus.Default
                     GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
@@ -2081,53 +2186,15 @@ module Watch =
                         $"Error in processChangedFiles resync: Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
             elif hasPendingWatchWork () then
                 try
-                    let runtimeMode = currentGraceWatchRuntimeMode ()
                     let correlationId = generateCorrelationId ()
-                    let! graceStatusFromDisk = readGraceStatusMetaClient ()
-                    graceStatus <- graceStatusFromDisk
 
-                    let mutable lastFileUploadInstant = graceStatus.LastSuccessfulFileUpload
-                    let mutable processedAnyFile = false
-
-                    retryPendingDirectoryUploads ()
-
-                    // Loop through no more than 50 files. Copy them to the objects directory, and upload them to storage.
-                    //   In the incredibly rare event that more than 50 files have changed, we'll get 50-per-timer-tick,
-                    //   and clear the queue quickly without overwhelming the system.
-                    let getUploadMetadataForFilesParameters =
-                        GetUploadMetadataForFilesParameters(
-                            OwnerId = $"{Current().OwnerId}",
-                            OrganizationId = $"{Current().OrganizationId}",
-                            RepositoryId = $"{Current().RepositoryId}",
-                            CorrelationId = correlationId
-                        )
-
-                    for pendingFile in
-                        filesToProcess
-                            .ToArray()
-                            .Take(50)
-                            .Select(fun entry -> { FullPath = entry.Key; Generation = entry.Value }) do
-                        let pendingPair = KeyValuePair(pendingFile.FullPath, pendingFile.Generation)
-
-                        if (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
-                            .Contains(pendingPair) then
-                            logToAnsiConsole Colors.Verbose $"Processing {pendingFile.FullPath}. filesToProcess.Count: {filesToProcess.Count}."
-                            do! copyFileToObjectDirectoryAndUploadToStorageClient getUploadMetadataForFilesParameters (FilePath pendingFile.FullPath)
-
-                            (filesToProcess :> ICollection<KeyValuePair<string, int64>>)
-                                .Remove(pendingPair)
-                            |> ignore
-
-                            match repositoryRelativePath pendingFile.FullPath with
-                            | Some relativePath -> addProcessedFileRelativePathPendingStatus (RelativePath relativePath)
-                            | None -> ()
-
-                            processedAnyFile <- true
-                            lastFileUploadInstant <- getCurrentInstant ()
-
-                    if processedAnyFile then
-                        graceStatus <- { graceStatus with LastSuccessfulFileUpload = lastFileUploadInstant }
-                        do! applyGraceStatusIncrementalClient graceStatus Seq.empty Seq.empty
+                    let! _ =
+                        uploadPendingWatchFilesForStatusRetry
+                            readGraceStatusMetaClient
+                            copyFileToObjectDirectoryAndUploadToStorageClient
+                            applyGraceStatusIncrementalClient
+                            correlationId
+                            true
 
                     // If we've drained all of the files that changed (and we'll almost always have done so), update all the things:
                     //   GraceStatus, directory versions, etc.
@@ -2169,9 +2236,14 @@ module Watch =
                                 (mergeCurrentStatusDifferences processedFileRelativePathsForStatus startupPendingDifferences eventDerivedDifferences)
 
                         let statusApplicationLegal =
-                            if runtimeMode = GraceWatchRuntimeMode.Stopping then false
-                            elif startupPendingDifferences.Count > 0 then true
-                            else isGraceWatchObservationApplicationLegal runtimeMode
+                            let runtimeModeBeforeStatusApplication = currentGraceWatchRuntimeMode ()
+
+                            if runtimeModeBeforeStatusApplication = GraceWatchRuntimeMode.Stopping then
+                                false
+                            elif startupPendingDifferences.Count > 0 then
+                                true
+                            else
+                                isGraceWatchObservationApplicationLegal runtimeModeBeforeStatusApplication
 
                         let! statusUpdateResult =
                             if requeuedResolvedFileDeletePaths.Count > 0 then
@@ -2187,7 +2259,10 @@ module Watch =
 
                                 Task.FromResult(None)
                             elif not statusApplicationLegal then
-                                logToAnsiConsole Colors.Verbose $"Grace Watch deferred status application while runtime mode is {runtimeMode}."
+                                logToAnsiConsole
+                                    Colors.Verbose
+                                    $"Grace Watch deferred status application while runtime mode is {currentGraceWatchRuntimeMode ()}."
+
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then
                                 updateGraceStatusFromDifferencesClient graceStatus statusDifferencesForApply.Applicable correlationId
@@ -2196,9 +2271,14 @@ module Watch =
 
                         match statusUpdateResult with
                         | Some newGraceStatus ->
+                            let commitRuntimeMode = currentGraceWatchRuntimeMode ()
+
                             let statusUpdateCanCommit =
                                 filesToProcess.IsEmpty
                                 && Volatile.Read(&fileUploadWorkGeneration) = fileWorkGenerationBeforeStatusUpdate
+                                && not (isGraceWatchResyncPending ())
+                                && (startupPendingDifferences.Count > 0
+                                    || isGraceWatchObservationApplicationLegal commitRuntimeMode)
 
                             if statusUpdateCanCommit then
                                 graceStatus <- newGraceStatus
@@ -2234,8 +2314,20 @@ module Watch =
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.
 
-                    updateGraceStatusDirectoryIds graceStatus
-                    do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+                    let runtimeModeAfterProcessing = currentGraceWatchRuntimeMode ()
+
+                    if
+                        runtimeModeAfterProcessing = GraceWatchRuntimeMode.HealthyIncremental
+                        && not (isGraceWatchResyncPending ())
+                    then
+                        updateGraceStatusDirectoryIds graceStatus
+                        do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+                    else
+                        do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Grace Watch published non-incremental IPC after processing ended in runtime mode {runtimeModeAfterProcessing} with resync pending {isGraceWatchResyncPending ()}."
 
                     // Reset the in-memory Grace Status to empty to minimize memory usage.
                     graceStatus <- GraceStatus.Default
@@ -2250,8 +2342,21 @@ module Watch =
                 graceWatchStatusUpdateTime
                 < getCurrentInstant().Minus(Duration.FromMinutes(4.8))
             then
-                let! graceStatusFromDisk = readGraceStatusMeta ()
-                do! updateGraceWatchInterprocessFile graceStatusFromDisk (Some graceStatusDirectoryIds)
+                let runtimeMode = currentGraceWatchRuntimeMode ()
+
+                if
+                    runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
+                    && not (isGraceWatchResyncPending ())
+                then
+                    let! graceStatusFromDisk = readGraceStatusMetaClient ()
+                    do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
+                else
+                    do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Grace Watch refreshed non-incremental IPC while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
+
                 GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
         }
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -58,6 +58,9 @@ module Watch =
     /// Sets Grace Watch runtime mode for tests that exercise state-gated observation behavior.
     let internal setGraceWatchRuntimeModeForWatchTests mode = setGraceWatchRuntimeMode mode
 
+    /// Reads Grace Watch runtime mode for tests that exercise confidence-loss transitions.
+    let internal currentGraceWatchRuntimeModeForWatchTests () = currentGraceWatchRuntimeMode ()
+
     /// Checks whether the current runtime mode can record filesystem observations.
     let private canCaptureFilesystemObservation () = isGraceWatchObservationCaptureLegal (currentGraceWatchRuntimeMode ())
 
@@ -217,6 +220,10 @@ module Watch =
     let private pendingStatusDifferencesLock = obj ()
 
     let private pendingStatusDifferences = List<FileSystemDifference>()
+
+    let mutable private quarantinedWatchObservationCount = 0
+
+    let mutable private graceWatchResyncPending = 0
 
     /// Defines structured data exchanged by CLI helpers.
     type internal PendingWatchWorkSnapshot = { FilesToProcess: string array; DirectoriesToProcess: string array; StatusUpdateTriggers: string array }
@@ -1234,6 +1241,88 @@ module Watch =
     /// Clears pre-derived differences when tests reset watch module state.
     let private clearPendingStatusDifferencesForTests () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.Clear())
 
+    /// Records one pending observation as quarantined so confidence recovery never replays it implicitly.
+    let private quarantineWatchObservation reason observationKind path =
+        Interlocked.Increment(&quarantinedWatchObservationCount)
+        |> ignore
+
+        logToAnsiConsole Colors.Verbose $"Grace Watch quarantined {observationKind} observation for {path}: {reason}."
+
+    /// Moves currently queued watch observations out of the trusted incremental path after confidence is lost.
+    let private quarantinePendingWatchWork reason =
+        let mutable quarantinedCount = 0
+        let mutable fileGeneration = 0L
+        let mutable triggerGeneration = 0L
+        let mutable unitValue = ()
+
+        for pendingFile in filesToProcess.ToArray() do
+            if filesToProcess.TryRemove(pendingFile.Key, &fileGeneration) then
+                quarantineWatchObservation reason "file" pendingFile.Key
+                quarantinedCount <- quarantinedCount + 1
+
+        for pendingDirectory in directoriesToProcess.ToArray() do
+            if directoriesToProcess.TryRemove(pendingDirectory.Key, &unitValue) then
+                quarantineWatchObservation reason "directory" pendingDirectory.Key
+                quarantinedCount <- quarantinedCount + 1
+
+        for pendingTrigger in statusUpdateTriggers.ToArray() do
+            if statusUpdateTriggers.TryRemove(pendingTrigger.Key, &triggerGeneration) then
+                quarantineWatchObservation reason "status-trigger" pendingTrigger.Key
+                quarantinedCount <- quarantinedCount + 1
+
+        let pendingDifferences =
+            lock pendingStatusDifferencesLock (fun () ->
+                let snapshot = pendingStatusDifferences.ToArray()
+                pendingStatusDifferences.Clear()
+                snapshot)
+
+        for pendingDifference in pendingDifferences do
+            quarantineWatchObservation reason "status-difference" $"{pendingDifference.RelativePath}"
+            quarantinedCount <- quarantinedCount + 1
+
+        uploadedFileVersions.Clear()
+        lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
+        lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.Clear())
+
+        if quarantinedCount > 0 then
+            logToAnsiConsole Colors.Important $"Grace Watch quarantined {quarantinedCount} pending observations after confidence loss: {reason}."
+
+    /// Reports whether an explicit resync scan must run before incremental observation application resumes.
+    let private isGraceWatchResyncPending () = Volatile.Read(&graceWatchResyncPending) <> 0
+
+    /// Clears the pending resync request once scan-derived status has reached the durable boundary.
+    let private clearGraceWatchResyncPending () = Volatile.Write(&graceWatchResyncPending, 0)
+
+    /// Suspends incremental Watch processing after recovery fails so Grace does not silently continue.
+    let private suspendGraceWatchAfterFailedRecovery reason =
+        quarantinePendingWatchWork reason
+        clearGraceWatchResyncPending ()
+        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
+        logToAnsiConsole Colors.Error $"Grace Watch suspended incremental processing: {reason}."
+
+    /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
+    let private publishGraceWatchResyncRequired () =
+        try
+            (updateGraceWatchInterprocessFile GraceStatus.Default (Some(HashSet<DirectoryVersionId>())))
+                .GetAwaiter()
+                .GetResult()
+        with
+        | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
+
+    /// Requests a scan-derived resync and quarantines observations captured under the previous root confidence.
+    let private requestGraceWatchExplicitResync reason =
+        quarantinePendingWatchWork reason
+        Volatile.Write(&graceWatchResyncPending, 1)
+        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+        publishGraceWatchResyncRequired ()
+        logToAnsiConsole Colors.Important $"Grace Watch requires an explicit resync before incremental observations can resume: {reason}."
+
+    /// Requests explicit resync for tests that exercise confidence-loss and deferred-observation behavior.
+    let internal requestGraceWatchExplicitResyncForWatchTests reason = requestGraceWatchExplicitResync reason
+
+    /// Counts quarantined observations for tests that verify confidence loss does not replay stale work.
+    let internal quarantinedWatchObservationCountForWatchTests () = Volatile.Read(&quarantinedWatchObservationCount)
+
     /// Combines status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
         let merged = List<FileSystemDifference>()
@@ -1312,6 +1401,10 @@ module Watch =
         lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
         lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.Clear())
         clearPendingStatusDifferencesForTests ()
+        clearGraceWatchResyncPending ()
+
+        Interlocked.Exchange(&quarantinedWatchObservationCount, 0)
+        |> ignore
 
         Interlocked.Exchange(&statusUpdateTriggerGeneration, 0L)
         |> ignore
@@ -1351,7 +1444,8 @@ module Watch =
 
     /// Evaluates has pending watch work against parsed options and command state.
     let private hasPendingWatchWork () =
-        not (
+        isGraceWatchResyncPending ()
+        || not (
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty
             && statusUpdateTriggers.IsEmpty
@@ -1621,8 +1715,13 @@ module Watch =
     /// Coordinates on error behavior for this CLI command path.
     let OnError (args: ErrorEventArgs) =
         let correlationId = generateCorrelationId ()
+        let message = args.GetException().Message
 
-        logToAnsiConsole Colors.Error $"I saw that the FileSystemWatcher threw an exception: {args.GetException().Message}. grace watch should be restarted."
+        requestGraceWatchExplicitResync $"FileSystemWatcher error {correlationId}: {message}"
+
+        logToAnsiConsole
+            Colors.Error
+            $"I saw that the FileSystemWatcher threw an exception: {message}. grace watch is resynchronizing before incremental work resumes."
 
     /// Coordinates on grace update in progress created behavior for this CLI command path.
     let OnGraceUpdateInProgressCreated (args: FileSystemEventArgs) =
@@ -1935,8 +2034,8 @@ module Watch =
         readGraceStatusFileClient
         copyFileToObjectDirectoryAndUploadToStorageClient
         _updateGraceStatusClient
-        _scanForDifferencesClient
-        updateGraceStatusFromDifferencesClient
+        (_scanForDifferencesClient: GraceStatus -> Task<List<FileSystemDifference>>)
+        (updateGraceStatusFromDifferencesClient: GraceStatus -> List<FileSystemDifference> -> CorrelationId -> Task<GraceStatus option>)
         applyGraceStatusIncrementalClient
         updateGraceWatchInterprocessFileClient
         =
@@ -1944,7 +2043,43 @@ module Watch =
             configureWatchPathComparisonForCurrentRepository ()
 
             // First, check if there's anything to process.
-            if hasPendingWatchWork () then
+            if isGraceWatchResyncPending () then
+                try
+                    let correlationId = generateCorrelationId ()
+                    let! graceStatusSnapshot = readGraceStatusFileClient ()
+                    graceStatus <- graceStatusSnapshot
+
+                    let! scanDerivedDifferences = _scanForDifferencesClient graceStatus
+
+                    let! statusUpdateResult =
+                        if scanDerivedDifferences.Count > 0 then
+                            updateGraceStatusFromDifferencesClient graceStatus scanDerivedDifferences correlationId
+                        else
+                            Task.FromResult(Some graceStatus)
+
+                    match statusUpdateResult with
+                    | Some newGraceStatus ->
+                        graceStatus <- newGraceStatus
+                        updateGraceStatusDirectoryIds graceStatus
+                        clearGraceWatchResyncPending ()
+                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
+                        do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                    | None -> suspendGraceWatchAfterFailedRecovery "scan-derived status update returned no durable status"
+
+                    graceStatus <- GraceStatus.Default
+                    GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)
+                with
+                | ex ->
+                    suspendGraceWatchAfterFailedRecovery $"resync failed before the durable status boundary: {ex.Message}"
+
+                    logToAnsiConsole
+                        Colors.Error
+                        $"Error in processChangedFiles resync: Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
+            elif hasPendingWatchWork () then
                 try
                     let runtimeMode = currentGraceWatchRuntimeMode ()
                     let correlationId = generateCorrelationId ()


### PR DESCRIPTION
## Summary

- Route `FileSystemWatcher.Error` and confidence loss into explicit resync instead of only logging and continuing.
- Quarantine pre-resync observations, invalidate Watch IPC to a non-incremental snapshot, and suspend capture after
  failed recovery.
- Defer observations captured during startup/resync until scan-derived status has been applied and the watcher returns
  to healthy incremental mode.

## Related Issue

References #490. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This completes the behavioral part of WS3 by making confidence loss explicit. Grace should not keep applying filesystem
observations after the watcher no longer trusts its current-branch view; resync must clear that unsafe state before
incremental observation application resumes.

## Validation

- Targeted Fantomas passed for `src/Grace.CLI/Command/Watch.CLI.fs`, `src/Grace.CLI/Command/Services.CLI.fs`, and
  `src/Grace.CLI.Tests/Watch.Tests.fs` before review fixes.
- Review-fix targeted Fantomas passed for touched F# files after each completed review-fix pass.
- Focused Watch tests passed before review fixes: 123/123.
- First review-fix focused Watch tests passed: 127 tests.
- Second review-fix focused Watch tests passed: 132 tests.
- Latest review-fix focused Watch tests passed: 133 tests.
- `git diff --check` passed before review fixes and after each completed review-fix pass.
- `pwsh ./scripts/validate.ps1 -Fast` passed before review fixes and after each completed review-fix pass.
- GitHub `full` check passed on latest head `665b784f21b5d4bd0408ce1b798696f6d3f370cf`.

## Docs Impact

No docs change. This does not add a public CLI option or change a documented command shape. The behavior is covered in
Watch runtime tests, and IPC compatibility is preserved by writing an already-supported non-usable status snapshot during
resync. Follow-on WS3 docs and readability polish remain tracked by #491.

## Explicit Deferrals

- #491: broader Watch docs, ADR updates, and status command/readability polish were not implemented.

## Review Status

- Current head: `665b784f21b5d4bd0408ce1b798696f6d3f370cf`.
- Worker bot-prevention self-review: complete after latest review fix.
- Codex Code Review Bot: passed with `+1` on latest head at `2026-07-04T01:28:43Z`.
- Review threads: all Codex Code Review Bot findings were replied to with fix commits and validation evidence, then
  resolved before merge.
- Prevention line: focused regressions now cover second-overflow resync generation invalidation and retryable transient
  upload failures during resync recovery.
