### PR TITLE
WS3.4: Document watch states and status readability

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -24,6 +24,8 @@ grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
+grace --output Json watch --check
+grace watch --check --select Mode
 ```
 
 bash / zsh:
@@ -34,6 +36,8 @@ grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
+grace --output Json watch --check
+grace watch --check --select Mode
 ```
 
 ## Output Envelopes
@@ -131,13 +135,16 @@ The final registry-backed inventory covers every CLI leaf command with exactly o
 
 - Total leaf commands: `206`
 - JSON-ready routed commands: `185`
-- Intentionally human-only commands: `1`
+- Conditionally JSON-ready routed commands: `1`
+- Intentionally human-only commands: `0`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`
 - Deleted commands: `0`
 
-The intentionally human-only command is `watch`. In JSON mode, it short-circuits to a `GraceError` document instead of
-starting the continuous foreground workflow.
+The conditional command is `watch`. `grace watch --check --output Json` returns a `WatchStatusDto` in the normal
+`GraceReturnValue<T>` envelope so scripts and agents can read `IsRunning`, `CanUseIncrementalStatus`, `Mode`,
+`Reason`, and `SafetyFlags`. Foreground `grace watch --output Json` still short-circuits to a `GraceError` document
+instead of starting the continuous workflow.
 
 The source-only/unrouted commands are defined in source but are not attached to `GraceCommand.rootCommand` in V1:
 
@@ -167,9 +174,9 @@ metadata and V2 scope because their success paths still need migration before Gr
 - `diff.tag`
 - `history.run`
 
-The `watch` command is not counted in those V2 routed-success migrations. It is intentionally human-only for success
-behavior because it is a continuous foreground workflow; JSON mode returns an explicit error envelope instead of
-starting the watcher.
+The foreground `watch` workflow is not counted in those V2 routed-success migrations. Its supported machine-readable
+surface is the `--check` status probe; starting the continuous watcher in JSON mode still returns an explicit error
+envelope.
 
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
@@ -211,6 +218,7 @@ When using `--select`, request only the `ReturnValue` field path the automation 
 ```powershell
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
+grace watch --check --select Mode
 ```
 
 ## V2 Deferrals

--- a/docs/What grace watch does.md
+++ b/docs/What grace watch does.md
@@ -60,9 +60,20 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
     Save with an empty message because the changed root directory version is the durable record of the directory change.
 - In V1, renames are captured as the old path being deleted plus the new path being added or changed. Grace does not
   assign rename identity, tombstones, or a durable "same file moved" relationship for V1 rename capture.
+- `grace watch` gates incremental reconciliation through an explicit runtime mode. Healthy mode can apply filesystem
+  observations to local status and branch history. Startup and resync mode may scan, rebuild trusted state, and queue
+  observations, but they do not apply normal event-derived saves until the trusted status boundary is restored.
+- If the filesystem watcher reports confidence loss, `grace watch` quarantines queued observations, switches to
+  resynchronizing mode, and performs an explicit scan-derived reconciliation before incremental observations resume.
+  If that recovery cannot reach the durable local-status boundary, Watch suspends incremental capture instead of
+  guessing from stale events.
 - When a promotion event from your parent branch is sent to `grace watch` by the server, `grace watch` will run auto-rebase.
 - Every 4.8 minutes, `grace watch` will recompute and rewrite the Grace interprocess-communication (IPC) file, which requires reading and deserializing the local Grace Status file. The size of the IPC file is under 1K for small repos, and scales with the number of directories in the repo. A repo with 275 directories would fit in a 10K IPC file, and a repo with 2,750 directories would fit in a 100K IPC file. They're usually very small.
   > Long story about why we rewrite the file: Imagine that you're at the command line, and you run `grace checkpoint -m ...`. That instance of Grace uses the existence of the IPC file as proof that `grace watch` is running in a separate process. `grace watch` writes the IPC file as soon as it starts, and, deletes it in a `try...finally` clause when it exits. In other words: in any normal exit, including exits caused by unhandled exceptions, the IPC file will be deleted when `grace watch` exits. However: it's possible that `grace watch` could be killed before it has a chance to execute that `finally` clause. For instance, in Windows, if I open Task Manager, right-click on the `grace watch` process, and hit `End Task`, the process dies immediately, and does not execute the `finally` clause. To ensure that there's not a stale IPC file laying around, Grace checks the value of the UpdatedAt field; if it's more than 5 minutes old, Grace will ignore the IPC file and assume that `grace watch` isn't running. So: *that's* why the IPC file gets refreshed every 4.8 minutes: it resets the UpdatedAt field so the file stays under 5 minutes old.
+- `grace watch --check` reports whether the IPC file is usable for incremental shortcuts. Human output explains
+  starting, stale, resynchronizing, suspended, and stopping states without showing local IPC paths or exception stacks.
+  `grace watch --check --output Json` emits the same status as machine-readable fields, including `Mode`, `Reason`,
+  `CanUseIncrementalStatus`, and `SafetyFlags`.
 - Once a minute, `grace watch` does the fullest of garbage collection:
 
   `GC.Collect(2, GCCollectionMode.Forced, blocking = true, compacting = true)`

--- a/docs/adr/0008-grace-watch-state-gated-reconciliation.md
+++ b/docs/adr/0008-grace-watch-state-gated-reconciliation.md
@@ -1,0 +1,80 @@
+---
+status: accepted
+date: 2026-07-03
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Gate Grace Watch reconciliation by runtime state
+
+Grace Watch will use explicit runtime state to decide when filesystem observations may update local status and branch
+history. Healthy incremental mode can apply event-derived observations. Startup and resync modes may capture and queue
+observations, but normal event-derived status application waits until Watch has restored a trusted status boundary.
+Suspended and stopping modes do not capture new incremental observations.
+
+## Context
+
+`grace watch` is becoming an incremental, durable, recoverable workflow for clean current-branch sync. File system
+events are useful because they avoid full scans after every local edit, but they are not a durable source of truth by
+themselves. Watch can lose confidence when the `FileSystemWatcher` reports an overflow, when a scan fails before the
+durable status boundary, or when pending work was captured under an older branch, root, path, or observation identity.
+
+Before this decision, a happy-path implementation could accidentally continue applying queued observations after
+confidence loss. That would make Watch look fast while allowing stale local events to create saves, update
+`GraceStatus`, or advertise an IPC snapshot that other commands and agents should not trust.
+
+Grace is pre-production, so this decision does not preserve compatibility with old local data. The important
+compatibility surface is the current command and IPC behavior: older readers can ignore compact status fields, while
+newer status readers can inspect runtime mode and safety flags before trusting incremental shortcuts.
+
+## Decision
+
+Grace Watch reconciliation is state-gated:
+
+- `StartingUp` may perform startup scans and capture observations, but it does not advertise incremental safety until
+  the initial trusted status snapshot is published.
+- `HealthyIncremental` may capture and apply filesystem observations through the incremental status path.
+- `Resynchronizing` may run scan-derived recovery and capture observations for later processing, but it defers normal
+  event-derived status application until scan-derived reconciliation reaches the durable local-status boundary.
+- `Suspended` does not capture or apply new incremental observations. It is used after recovery cannot safely restore
+  confidence.
+- `Stopping` is not a live incremental source and must not be treated as usable status.
+
+When Watch loses confidence, it quarantines already queued observations, requests an explicit resync, and publishes a
+non-incremental IPC status until recovery succeeds. Other commands and agents should treat
+`CanUseIncrementalStatus = false` or `requiresExplicitResync` as a stop sign for incremental shortcuts.
+
+`grace watch --check` is the human and machine-readable surface for this state. Human output explains starting, stale,
+resynchronizing, suspended, and stopping states without local IPC paths or exception stacks. JSON output uses the
+normal Grace result envelope and returns a `WatchStatusDto` with `IsRunning`, `CanUseIncrementalStatus`, `Mode`,
+`Reason`, `Message`, `SafetyFlags`, freshness, and root snapshot facts.
+
+## Consequences
+
+This favors correctness over opportunistic event replay. Some recoverable failures may defer or suspend incremental
+work even when individual queued events later turn out to be harmless. That cost is acceptable because a later explicit
+resync can rebuild trusted state, while an unsafe save would pollute local status and branch history.
+
+The runtime state model also gives agents a stable way to decide whether Watch can be used as an incremental source.
+They can parse `watch --check --output Json`, use the process exit code for the coarse check result, and inspect
+`Mode`, `Reason`, and `SafetyFlags` for the recovery state.
+
+## Rejected alternatives
+
+### Continue applying queued events after confidence loss
+
+This keeps Watch responsive in the happy path, but it allows stale observations to cross the durable boundary. Grace
+needs the local status file and saved references to reflect trusted state, not merely recently observed events.
+
+### Treat the IPC file as a live state authority
+
+The IPC file is a liveness and shortcut signal, not a durable authority. It can be stale after a killed process and can
+be incomplete while Watch starts or recovers. Commands must derive trust from freshness, root snapshot facts, directory
+index facts, runtime mode, and safety flags.
+
+### Hide recovery states from users and agents
+
+Returning only "running" or "not running" makes automation brittle and leaves users guessing why incremental shortcuts
+are unavailable. Exposing compact mode and reason fields lets humans and agents make the same conservative decision.

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -748,10 +748,37 @@ module CommandOutputContractRegistryTests =
                 schema.Status |> should equal "schema-ready"
 
                 schema.Envelope
-                |> should contain "supported status-check success"
+                |> should contain "status envelope for status checks"
+
+                schema.Envelope
+                |> should contain "unavailable modes with nonzero exit codes"
+
+                schema.Envelope
+                |> should not' (contain "GraceError on unsupported or failed modes")
 
                 schema.ReturnValueContract
                 |> should equal "WatchStatusDto"
+
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                let watchStatusSchema =
+                    successSchema
+                        .RootElement
+                        .GetProperty("properties")
+                        .GetProperty("ReturnValue")
+
+                let requiredFields =
+                    watchStatusSchema
+                        .GetProperty("required")
+                        .EnumerateArray()
+                    |> Seq.map (fun field -> field.GetString())
+                    |> Set.ofSeq
+
+                requiredFields
+                |> should not' (contain "UpdatedAt")
+
+                requiredFields
+                |> should not' (contain "RootDirectoryId")
             | None -> Assert.Fail("watch schema introspection should include the conditional status schema document.")
         | None -> Assert.Fail("watch should have a registry entry.")
 

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -249,7 +249,10 @@ module CommandOutputContractRegistryTests =
         countBy CommonRenderOutputEnvelope
         |> should equal 185
 
-        countBy ImmediateJsonErrorOnly |> should equal 1
+        countBy ImmediateJsonErrorOnly |> should equal 0
+
+        countBy ConditionalCheckStatusEnvelope
+        |> should equal 1
 
         countBy HumanProgressOnlySuccess
         |> should equal 10
@@ -275,6 +278,12 @@ module CommandOutputContractRegistryTests =
                 | Routed, JsonModeErrorOnly _ -> true
                 | _ -> false)
 
+        let conditionalStatus =
+            countEntries (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ConditionalGraceResultEnvelope _ -> true
+                | _ -> false)
+
         let deferredV2 =
             countEntries (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
@@ -290,13 +299,15 @@ module CommandOutputContractRegistryTests =
         let deleted = 0
 
         jsonReady |> should equal 185
-        intentionallyHumanOnly |> should equal 1
+        intentionallyHumanOnly |> should equal 0
+        conditionalStatus |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
         deleted |> should equal 0
 
         jsonReady
         + intentionallyHumanOnly
+        + conditionalStatus
         + deferredV2
         + sourceOnly
         + deleted
@@ -387,6 +398,9 @@ module CommandOutputContractRegistryTests =
         |> should equal true
 
         behaviors.Contains ImmediateJsonErrorOnly
+        |> should equal false
+
+        behaviors.Contains ConditionalCheckStatusEnvelope
         |> should equal true
 
         behaviors.Contains ManualJsonUnenveloped
@@ -704,40 +718,41 @@ module CommandOutputContractRegistryTests =
         file.GetProperty("Blake3Hash").GetString()
         |> should equal "file-blake3"
 
-    /// Verifies that watch json mode is registered as immediate error only.
+    /// Verifies that watch json mode is registered as conditional check status output.
     [<Test>]
-    let ``watch json mode is registered as immediate error only`` () =
+    let ``watch json mode is registered as conditional check status output`` () =
         let identity = CommandOutputContract.commandIdentity [] "watch"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
             entry.CurrentJsonBehavior
-            |> should equal ImmediateJsonErrorOnly
+            |> should equal ConditionalCheckStatusEnvelope
 
             match entry.EnvelopeContract with
-            | JsonModeErrorOnly reason ->
-                reason
-                |> should contain "short-circuited before command execution"
-            | other -> Assert.Fail($"Expected watch to be registered as JsonModeErrorOnly, got {other}.")
+            | ConditionalGraceResultEnvelope (RequiresCliDto, condition) -> condition |> should contain "watch --check"
+            | other -> Assert.Fail($"Expected watch to be registered as ConditionalGraceResultEnvelope, got {other}.")
 
             entry.Features.JsonMode
             |> should equal ExistingBehavior
 
             entry.Features.Select
-            |> should equal RequiresMigration
+            |> should equal ExistingBehavior
 
             entry.ReturnValueContract.Status
-            |> should equal ContractUnsupported
+            |> should equal SchemaReady
 
             let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
 
             match schemaDocument.Schema with
             | Some schema ->
-                schema.Status |> should equal "unsupported"
+                schema.Status |> should equal "schema-ready"
 
                 schema.Envelope
-                |> should contain "GraceError only in JSON mode"
-            | None -> Assert.Fail("watch schema introspection should include the explicit unsupported schema document.")
+                |> should contain "supported status-check success"
+
+                schema.ReturnValueContract
+                |> should equal "WatchStatusDto"
+            | None -> Assert.Fail("watch schema introspection should include the conditional status schema document.")
         | None -> Assert.Fail("watch should have a registry entry.")
 
     /// Verifies that schema ready registry entries describe success and error envelopes.
@@ -1062,6 +1077,12 @@ module CommandOutputContractRegistryTests =
                 | Routed, JsonModeErrorOnly _ -> true
                 | _ -> false)
 
+        let conditionalStatus =
+            countDocsTracked (fun entry ->
+                match entry.RouteDisposition, entry.EnvelopeContract with
+                | Routed, ConditionalGraceResultEnvelope _ -> true
+                | _ -> false)
+
         let deferredV2 =
             commandIdsForDocsTracked (fun entry ->
                 match entry.RouteDisposition, entry.EnvelopeContract with
@@ -1079,6 +1100,7 @@ module CommandOutputContractRegistryTests =
         [
             $"Total leaf commands: `{docsTrackedEntries.Length}`"
             $"JSON-ready routed commands: `{jsonReady}`"
+            $"Conditionally JSON-ready routed commands: `{conditionalStatus}`"
             $"Intentionally human-only commands: `{intentionallyHumanOnly}`"
             $"Deferred routed commands with explicit V2 scope: `{deferredV2.Length}`"
             $"Source-only/unrouted commands: `{sourceOnly.Length}`"

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -217,6 +217,20 @@ module WatchTests =
         File.WriteAllText(ipcFileName, statusNode.ToJsonString(Constants.JsonSerializerOptions))
         ipcFileName
 
+    /// Writes a Watch IPC JSON snapshot with an explicit persisted runtime mode for status-readability tests.
+    let private writeWatchStatusJsonWithPersistedMode mode (status: Services.GraceWatchStatus) =
+        let statusNode = JsonNode.Parse(serialize status).AsObject()
+        statusNode["Mode"] <- JsonSerializer.SerializeToNode(mode, Constants.JsonSerializerOptions)
+        statusNode["SafetyFlags"] <- JsonSerializer.SerializeToNode(status.SafetyFlags, Constants.JsonSerializerOptions)
+
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, statusNode.ToJsonString(Constants.JsonSerializerOptions))
+        ipcFileName
+
     /// Rewrites only the Watch IPC heartbeat timestamp so tests can model a healthy writer that later dies.
     let private updatePersistedWatchStatusUpdatedAt updatedAt =
         let ipcFileName = Services.IpcFileName()
@@ -7009,9 +7023,9 @@ module WatchTests =
             readFileIfExists ipcFileName
             |> should equal originalContents)
 
-    /// Verifies that watch check json mode emits error envelope and preserves live watcher status.
+    /// Verifies that watch check json mode emits a status envelope and preserves live watcher status.
     [<Test>]
-    let ``watch check json mode emits error envelope and preserves live watcher status`` () =
+    let ``watch check json mode emits status envelope and preserves live watcher status`` () =
         withTempRepo (fun _ ->
             let ipcFileName = writeLiveWatchStatusFile ()
             let originalContents = readFileIfExists ipcFileName
@@ -7023,30 +7037,51 @@ module WatchTests =
                                                   "watch"
                                                   "--check" |]
 
-            exitCode |> should equal -1
+            exitCode |> should equal 0
             standardError |> should equal String.Empty
-
-            standardOut
-            |> should not' (contain "GraceWatch is running")
 
             use document = parseJsonOutput standardOut
             let root = document.RootElement
 
-            root.GetProperty("Error").GetString()
-            |> should contain "watch is a continuous foreground workflow"
+            root
+                .GetProperty("ReturnValue")
+                .GetProperty("IsRunning")
+                .GetBoolean()
+            |> should equal true
 
-            /// Tracks return Value changes so this scenario can assert the resulting side effect explicitly.
-            let mutable returnValue = Unchecked.defaultof<JsonElement>
+            root
+                .GetProperty("ReturnValue")
+                .GetProperty("CanUseIncrementalStatus")
+                .GetBoolean()
+            |> should equal true
 
-            root.TryGetProperty("ReturnValue", &returnValue)
+            root
+                .GetProperty("ReturnValue")
+                .GetProperty("Mode")
+                .GetString()
+            |> should equal "HealthyIncremental"
+
+            root
+                .GetProperty("ReturnValue")
+                .GetProperty("SafetyFlags")
+                .EnumerateArray()
+            |> Seq.map (fun flag -> flag.GetString())
+            |> Set.ofSeq
+            |> Set.contains "incrementalSafe"
+            |> should equal true
+
+            /// Tracks error changes so this scenario can assert the resulting side effect explicitly.
+            let mutable error = Unchecked.defaultof<JsonElement>
+
+            root.TryGetProperty("Error", &error)
             |> should equal false
 
             readFileIfExists ipcFileName
             |> should equal originalContents)
 
-    /// Verifies that watch check select mode emits error envelope and preserves live watcher status.
+    /// Verifies that watch check select mode projects status fields and preserves live watcher status.
     [<Test>]
-    let ``watch check select mode emits error envelope and preserves live watcher status`` () =
+    let ``watch check select mode projects status field and preserves live watcher status`` () =
         withTempRepo (fun _ ->
             let ipcFileName = writeLiveWatchStatusFile ()
             let originalContents = readFileIfExists ipcFileName
@@ -7056,28 +7091,136 @@ module WatchTests =
                 runWithCapturedStdoutAndStderr [| "watch"
                                                   "--check"
                                                   "--select"
-                                                  "RootDirectoryId" |]
+                                                  "Mode" |]
 
-            exitCode |> should equal -1
+            exitCode |> should equal 0
             standardError |> should equal String.Empty
 
             standardOut
             |> should not' (contain "GraceWatch is running")
 
-            use document = parseJsonOutput standardOut
-            let root = document.RootElement
-
-            root.GetProperty("Error").GetString()
-            |> should contain "does not support --select in this release"
-
-            /// Tracks return Value changes so this scenario can assert the resulting side effect explicitly.
-            let mutable returnValue = Unchecked.defaultof<JsonElement>
-
-            root.TryGetProperty("ReturnValue", &returnValue)
-            |> should equal false
+            standardOut.Trim()
+            |> should equal "\"HealthyIncremental\""
 
             readFileIfExists ipcFileName
             |> should equal originalContents)
+
+    /// Verifies that watch check json mode reports missing status without human text.
+    [<Test>]
+    let ``watch check json mode reports missing status`` () =
+        withTempRepo (fun _ ->
+            clearWatchAuthEnv (fun () ->
+                /// Verifies that the CLI watch scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "watch"
+                                                      "--check" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+                let root = document.RootElement.GetProperty("ReturnValue")
+
+                root.GetProperty("IsRunning").GetBoolean()
+                |> should equal false
+
+                root
+                    .GetProperty("CanUseIncrementalStatus")
+                    .GetBoolean()
+                |> should equal false
+
+                root.GetProperty("Mode").GetString()
+                |> should equal "Unavailable"
+
+                root.GetProperty("Reason").GetString()
+                |> should equal "notRunning"))
+
+    /// Verifies that watch check explains resynchronizing state without exposing local status internals.
+    [<Test>]
+    let ``watch check explains resynchronizing state without raw paths or stacks`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status = { liveWatchStatus rootDirectoryId with DirectoryIds = HashSet<DirectoryVersionId>() }
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, serialize status)
+
+            /// Verifies that the CLI watch scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "watch"
+                                         "--check" |]
+
+            exitCode |> should equal -1
+
+            output
+            |> should contain "resynchronizing trusted state"
+
+            output
+            |> should contain "incremental status shortcuts are suspended until resync completes"
+
+            output |> should not' (contain ipcFileName)
+            output |> should not' (contain "StackTrace")
+            output |> should not' (contain "System."))
+
+    /// Verifies that watch check explains suspended state without exposing local status internals.
+    [<Test>]
+    let ``watch check explains suspended state without raw paths or stacks`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            rootDirectoryId
+            |> liveWatchStatus
+            |> writeWatchStatusJsonWithPersistedMode Services.GraceWatchRuntimeMode.Suspended
+            |> ignore
+
+            /// Verifies that the CLI watch scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "watch"
+                                         "--check" |]
+
+            exitCode |> should equal -1
+
+            output
+            |> should contain "suspended after confidence loss"
+
+            output
+            |> should not' (contain (Services.IpcFileName()))
+
+            output |> should not' (contain "StackTrace")
+            output |> should not' (contain "System."))
+
+    /// Verifies that watch check handles malformed status without exposing parser exception details.
+    [<Test>]
+    let ``watch check handles malformed status without raw paths or stacks`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, "not-json")
+
+            /// Verifies that the CLI watch scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "watch"
+                                         "--check" |]
+
+            exitCode |> should equal -1
+
+            output
+            |> should contain "status exists but could not be read"
+
+            output |> should not' (contain ipcFileName)
+            output |> should not' (contain "Json")
+            output |> should not' (contain "StackTrace")
+            output |> should not' (contain "System."))
 
     /// Verifies that watch check exits nonzero when live watcher status is missing.
     [<Test>]
@@ -7123,8 +7266,7 @@ module WatchTests =
 
                 exitCode |> should equal -1
 
-                output
-                |> should contain "GraceWatch is not running"
+                output |> should contain "GraceWatch is starting"
 
                 output
                 |> should not' (contain "Unable to acquire an access token for SignalR")

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -6543,7 +6543,15 @@ module WatchTests =
                 .GetResult()
 
             Services.getGraceWatchStatus().Result
-            |> should equal None)
+            |> should equal None
+
+            readWatchStatusJsonStringProperty "Mode"
+            |> should equal "suspended"
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.PersistedMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Suspended))
 
     /// Verifies that Grace Status DB refreshes cannot publish healthy IPC while resync is pending.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -6103,6 +6103,16 @@ module WatchTests =
             Watch.currentGraceWatchRuntimeModeForWatchTests ()
             |> should equal Services.GraceWatchRuntimeMode.Suspended
 
+            readWatchStatusJsonStringProperty "Mode"
+            |> should equal "suspended"
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Suspended)
+
+            inspection.IsUsable |> should equal false
+
             let ignoredPath = Path.Combine(root, "ignored-after-failed-resync.txt")
             File.WriteAllText(ignoredPath, "ignored after failed resync")
             Watch.OnChanged(changedEvent ignoredPath)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -261,7 +261,7 @@ module Services =
         | _ -> false
 
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
-    let private toGraceWatchStatusContract (status: GraceWatchStatus) =
+    let private toGraceWatchStatusContractWithPersistedMode persistedModeOverride (status: GraceWatchStatus) =
         {
             UpdatedAt = status.UpdatedAt
             IsStartupClaim = status.IsStartupClaim
@@ -271,12 +271,21 @@ module Services =
             LastFileUploadInstant = status.LastFileUploadInstant
             LastDirectoryVersionInstant = status.LastDirectoryVersionInstant
             DirectoryIds = status.DirectoryIds
-            Mode = modeForGraceWatchStatusContract status
+            Mode =
+                persistedModeOverride
+                |> Option.orElseWith (fun () -> modeForGraceWatchStatusContract status)
             SafetyFlags = safetyFlagsForGraceWatchStatusContract status
         }
 
+    /// Converts the in-memory Watch status model without forcing a runtime mode into IPC JSON.
+    let private toGraceWatchStatusContract status = toGraceWatchStatusContractWithPersistedMode None status
+
     /// Writes the compact Watch IPC JSON contract to the already-open status stream.
     let private writeGraceWatchStatusContractToStream fileStream graceWatchStatus = serializeAsync fileStream (toGraceWatchStatusContract graceWatchStatus)
+
+    /// Writes the compact Watch IPC JSON contract while preserving a known non-incremental runtime mode.
+    let private writeGraceWatchStatusContractWithPersistedModeToStream fileStream mode graceWatchStatus =
+        serializeAsync fileStream (toGraceWatchStatusContractWithPersistedMode (Some mode) graceWatchStatus)
 
     /// Reads the compact persisted Watch runtime mode from IPC JSON written by newer Watch processes.
     let private tryReadGraceWatchPersistedMode (json: string) =
@@ -2274,27 +2283,37 @@ module Services =
         && not graceWatchStatus.IsStartupClaim
         && graceWatchStatus.Mode = GraceWatchRuntimeMode.HealthyIncremental
 
-    /// Writes grace watch status data through the CLI output contract.
-    let private writeGraceWatchStatus fileMode graceWatchStatus =
+    /// Writes grace watch status data through the CLI output contract with an optional runtime-mode override.
+    let private writeGraceWatchStatusWithPersistedMode persistedModeOverride fileMode graceWatchStatus =
         task {
             Directory.CreateDirectory(Path.GetDirectoryName(IpcFileName()))
             |> ignore
 
             use fileStream = new FileStream(IpcFileName(), fileMode, FileAccess.Write, FileShare.None)
 
-            do! writeGraceWatchStatusContractToStream fileStream graceWatchStatus
+            match persistedModeOverride with
+            | Some mode -> do! writeGraceWatchStatusContractWithPersistedModeToStream fileStream mode graceWatchStatus
+            | None -> do! writeGraceWatchStatusContractToStream fileStream graceWatchStatus
+
             graceWatchStatusUpdateTime <- graceWatchStatus.UpdatedAt
         }
 
-    /// Updates the contents of the `grace watch` status inter-process communication file.
-    let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+    /// Writes Grace Watch IPC status without forcing a compact runtime mode override.
+    let private writeGraceWatchStatus fileMode graceWatchStatus = writeGraceWatchStatusWithPersistedMode None fileMode graceWatchStatus
+
+    /// Writes Grace Watch IPC content after converting the current Grace status snapshot.
+    let private updateGraceWatchInterprocessFileCore
+        persistedModeOverride
+        (graceStatus: GraceStatus)
+        (directoryIdsOverride: HashSet<DirectoryVersionId> option)
+        =
         task {
             try
                 let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
                 //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
                 //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
 
-                do! writeGraceWatchStatus FileMode.Create newGraceWatchStatus
+                do! writeGraceWatchStatusWithPersistedMode persistedModeOverride FileMode.Create newGraceWatchStatus
                 logToAnsiConsole Colors.Important $"Wrote inter-process communication file."
             with
             | ex ->
@@ -2302,6 +2321,14 @@ module Services =
                 logToAnsiConsole Colors.Error $"ex.GetType: {ex.GetType().FullName}{Environment.NewLine}{Environment.NewLine}"
                 logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
         }
+
+    /// Updates the contents of the `grace watch` status inter-process communication file.
+    let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+        updateGraceWatchInterprocessFileCore None graceStatus directoryIdsOverride
+
+    /// Updates Watch IPC while preserving the suspended mode that cannot be derived from the compact status payload.
+    let internal updateGraceWatchInterprocessFileForSuspendedMode (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+        updateGraceWatchInterprocessFileCore (Some GraceWatchRuntimeMode.Suspended) graceStatus directoryIdsOverride
 
     /// Reads the `grace watch` status inter-process communication file.
     let getGraceWatchStatus () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -174,6 +174,48 @@ module Services =
             SafetyFlags: string array
         }
 
+    /// Describes the Watch IPC snapshot without requiring it to be trusted for incremental status shortcuts.
+    type GraceWatchStatusInspection =
+        {
+            Exists: bool
+            Status: GraceWatchStatus option
+            PersistedMode: GraceWatchRuntimeMode option
+            SafetyFlags: string array
+            ReadError: string option
+        }
+
+        /// Reports the best runtime mode available from persisted IPC metadata or derived status facts.
+        member this.EffectiveMode =
+            match this.PersistedMode, this.Status with
+            | Some mode, _ -> Some mode
+            | None, Some status -> Some status.Mode
+            | None, None -> None
+
+        /// Reports whether the IPC heartbeat is recent enough to represent a live Watch process.
+        member this.IsFresh =
+            match this.Status with
+            | Some status ->
+                status.UpdatedAt > getCurrentInstant()
+                    .Minus(Duration.FromMinutes(5.0))
+            | None -> false
+
+        /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.
+        member this.IsUsable =
+            match this.Status, this.EffectiveMode with
+            | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                this.IsFresh
+                && not status.IsStartupClaim
+                && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
+            | _ -> false
+
+        /// Reports whether a fresh Watch process appears to own the IPC file even when shortcuts are unavailable.
+        member this.IsLiveProcess =
+            this.Exists
+            && this.IsFresh
+            && this.Status.IsSome
+            && this.EffectiveMode
+               <> Some GraceWatchRuntimeMode.Stopping
+
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
     let private safetyFlagsForGraceWatchStatusContract (status: GraceWatchStatus) =
         status.SafetyFlags
@@ -235,6 +277,32 @@ module Services =
 
     /// Writes the compact Watch IPC JSON contract to the already-open status stream.
     let private writeGraceWatchStatusContractToStream fileStream graceWatchStatus = serializeAsync fileStream (toGraceWatchStatusContract graceWatchStatus)
+
+    /// Reads the compact persisted Watch runtime mode from IPC JSON written by newer Watch processes.
+    let private tryReadGraceWatchPersistedMode (json: string) =
+        try
+            use document = JsonDocument.Parse(json)
+            let mutable modeElement = Unchecked.defaultof<JsonElement>
+
+            if document.RootElement.TryGetProperty("Mode", &modeElement)
+               && modeElement.ValueKind <> JsonValueKind.Null
+               && modeElement.ValueKind <> JsonValueKind.Undefined then
+                let modeText =
+                    if modeElement.ValueKind = System.Text.Json.JsonValueKind.String then
+                        modeElement.GetString()
+                    else
+                        modeElement.GetRawText()
+
+                let mutable parsedMode = Unchecked.defaultof<GraceWatchRuntimeMode>
+
+                if Enum.TryParse<GraceWatchRuntimeMode>(modeText, true, &parsedMode) then
+                    Some parsedMode
+                else
+                    None
+            else
+                None
+        with
+        | _ -> None
 
     let mutable graceWatchStatusUpdateTime = Instant.MinValue
     let mutable parseResult: ParseResult = null
@@ -2119,6 +2187,51 @@ module Services =
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
     let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
 
+    /// Reads Watch IPC status for diagnostics without logging file paths, stack traces, or raw JSON.
+    let inspectGraceWatchStatus () =
+        task {
+            if System.IO.File.Exists(IpcFileName()) then
+                try
+                    let json = System.IO.File.ReadAllText(IpcFileName())
+                    let status = deserialize<GraceWatchStatus> json
+
+                    return
+                        {
+                            Exists = true
+                            Status = Some status
+                            PersistedMode = tryReadGraceWatchPersistedMode json
+                            SafetyFlags = status.SafetyFlags
+                            ReadError = None
+                        }
+                with
+                | _ ->
+                    return
+                        {
+                            Exists = true
+                            Status = None
+                            PersistedMode = None
+                            SafetyFlags =
+                                [|
+                                    "unreadableStatus"
+                                    "requiresExplicitResync"
+                                |]
+                            ReadError = Some "The Grace Watch status file exists but could not be read."
+                        }
+            else
+                return
+                    {
+                        Exists = false
+                        Status = None
+                        PersistedMode = None
+                        SafetyFlags =
+                            [|
+                                "missingStatus"
+                                "requiresExplicitResync"
+                            |]
+                        ReadError = None
+                    }
+        }
+
     /// Builds the persisted Grace Watch status snapshot used by check and startup coordination.
     let private createGraceWatchStatus (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
         let directoryIds =
@@ -2193,33 +2306,14 @@ module Services =
     /// Reads the `grace watch` status inter-process communication file.
     let getGraceWatchStatus () =
         task {
-            try
-                // If the file exists, `grace watch` is running.
-                if File.Exists(IpcFileName()) then
-                    //logToAnsiConsole Colors.Verbose $"File {IpcFileName} exists."
-                    use fileStream = new FileStream(IpcFileName(), FileMode.Open, FileAccess.Read, FileShare.Read)
+            let! inspection = inspectGraceWatchStatus ()
 
-                    let! graceWatchStatus = deserializeAsync<GraceWatchStatus> fileStream
-
-                    // `grace watch` updates the file at least every five minutes to indicate that it's still alive.
-                    // When `grace watch` exits, the status file is deleted in a try...finally (Program.CLI.fs), so the only
-                    //   circumstance where it would be on-disk without `grace watch` running is if the process were killed.
-                    // Just to be safe, only return fresh status that contains real root data. A startup claim is only a
-                    // duplicate-start guard and must not be consumed as a usable repository snapshot.
-                    if isGraceWatchStatusUsable graceWatchStatus then
-                        return Some graceWatchStatus
-                    else
-                        return None // The file is stale, a startup claim, or does not contain usable root data.
-                else
-                    //logToAnsiConsole Colors.Verbose $"File {IpcFileName} does not exist."
-                    return None // `grace watch` isn't running.
-            with
-            | ex ->
-                logToAnsiConsole Colors.Error $"Exception when reading inter-process communication file."
-                logToAnsiConsole Colors.Error $"ex.GetType: {ex.GetType().FullName}."
-                logToAnsiConsole Colors.Error $"ex.Message: {StringExtensions.EscapeMarkup(ex.Message)}."
-                logToAnsiConsole Colors.Error $"{Environment.NewLine}{StringExtensions.EscapeMarkup(ex.StackTrace)}."
-                return None
+            // `grace watch` updates the file at least every five minutes to indicate that it's still alive.
+            // When `grace watch` exits, the status file is deleted in a try...finally (Program.CLI.fs), so the only
+            // circumstance where it would be on-disk without `grace watch` running is if the process were killed.
+            // Just to be safe, only return fresh status that contains real root data. A startup claim is only a
+            // duplicate-start guard and must not be consumed as a usable repository snapshot.
+            if inspection.IsUsable then return inspection.Status else return None // The file is stale, a startup claim, unreadable, or does not contain usable root data.
         }
 
     /// Atomically claims the `grace watch` status IPC file before foreground watch startup.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1352,9 +1352,12 @@ module Watch =
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
         try
-            (updateGraceWatchInterprocessFile GraceStatus.Default (Some(HashSet<DirectoryVersionId>())))
-                .GetAwaiter()
-                .GetResult()
+            let writeTask =
+                match currentGraceWatchRuntimeMode () with
+                | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+
+            writeTask.GetAwaiter().GetResult()
         with
         | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1602,6 +1602,130 @@ module Watch =
             return resolveSignalRAccessTokenResult tokenResult
         }
 
+    /// Defines the machine-readable payload emitted by `grace watch --check`.
+    type private WatchCheckStatusDto =
+        {
+            IsRunning: bool
+            CanUseIncrementalStatus: bool
+            Mode: string
+            Reason: string
+            Message: string
+            SafetyFlags: string array
+            IsFresh: bool
+            HasUsableRootSnapshot: bool
+            HasDirectoryIndexSnapshot: bool
+            IsStartupClaim: bool
+            UpdatedAt: string option
+            RootDirectoryId: DirectoryVersionId option
+        }
+
+    /// Reports whether a Watch IPC snapshot has the root identity needed by incremental status shortcuts.
+    let private hasUsableRootSnapshotForCheck (status: GraceWatchStatus) =
+        status.RootDirectoryId <> Guid.Empty
+        && not (String.IsNullOrWhiteSpace($"{status.RootDirectorySha256Hash}"))
+        && not (String.IsNullOrWhiteSpace($"{status.RootDirectoryBlake3Hash}"))
+
+    /// Reports whether a Watch IPC snapshot includes directory identities for current-state comparisons.
+    let private hasDirectoryIndexSnapshotForCheck (status: GraceWatchStatus) =
+        not (isNull status.DirectoryIds)
+        && status.DirectoryIds.Count > 0
+
+    /// Builds safety flags for `watch --check` after combining persisted and derived mode facts.
+    let private safetyFlagsForWatchCheck (inspection: GraceWatchStatusInspection) =
+        let flags = HashSet<string>(inspection.SafetyFlags, StringComparer.Ordinal)
+
+        if not inspection.IsUsable then
+            flags.Remove("incrementalSafe") |> ignore
+            flags.Add("requiresExplicitResync") |> ignore
+
+        flags |> Seq.sort |> Seq.toArray
+
+    /// Maps a Watch IPC inspection result to the stable status reason emitted to humans and agents.
+    let private watchCheckReason (inspection: GraceWatchStatusInspection) =
+        match inspection.ReadError, inspection.Exists, inspection.Status, inspection.EffectiveMode with
+        | Some _, _, _, _ -> "unreadableStatus"
+        | None, false, _, _ -> "notRunning"
+        | None, true, None, _ -> "unreadableStatus"
+        | None, true, Some _, _ when not inspection.IsFresh -> "staleStatus"
+        | None, true, Some status, _ when status.IsStartupClaim -> "startingUp"
+        | None, true, Some _, Some GraceWatchRuntimeMode.HealthyIncremental when inspection.IsUsable -> "running"
+        | None, true, Some _, Some GraceWatchRuntimeMode.Resynchronizing -> "resynchronizing"
+        | None, true, Some _, Some GraceWatchRuntimeMode.Suspended -> "suspended"
+        | None, true, Some _, Some GraceWatchRuntimeMode.Stopping -> "stopping"
+        | None, true, Some _, Some GraceWatchRuntimeMode.StartingUp -> "startingUp"
+        | _ -> "notReady"
+
+    /// Explains Watch check status without exposing local IPC paths, raw repository paths, or exception stacks.
+    let private watchCheckMessage reason =
+        match reason with
+        | "running" -> "GraceWatch is running in HealthyIncremental mode. Incremental status shortcuts are available."
+        | "startingUp" -> "GraceWatch is starting and has not published a usable status snapshot yet."
+        | "resynchronizing" -> "GraceWatch is resynchronizing trusted state; incremental status shortcuts are suspended until resync completes."
+        | "suspended" -> "GraceWatch is suspended after confidence loss; restart watch or run an explicit resync before relying on incremental status."
+        | "stopping" -> "GraceWatch is stopping and should not be treated as a live incremental source."
+        | "staleStatus" -> "GraceWatch status is stale. The previous watcher may have exited before removing its status file."
+        | "unreadableStatus" -> "GraceWatch status exists but could not be read. Restart watch or clear the stale status file by starting watch again."
+        | "notRunning" -> "GraceWatch is not running."
+        | _ -> "GraceWatch status is not ready for incremental shortcuts."
+
+    /// Converts Watch IPC inspection into the public `watch --check` status payload.
+    let private toWatchCheckStatusDto (inspection: GraceWatchStatusInspection) =
+        let status = inspection.Status
+        let reason = watchCheckReason inspection
+
+        let mode =
+            inspection.EffectiveMode
+            |> Option.map (fun mode -> $"{mode}")
+            |> Option.defaultValue "Unavailable"
+
+        {
+            IsRunning = inspection.IsLiveProcess
+            CanUseIncrementalStatus = inspection.IsUsable
+            Mode = mode
+            Reason = reason
+            Message = watchCheckMessage reason
+            SafetyFlags = safetyFlagsForWatchCheck inspection
+            IsFresh = inspection.IsFresh
+            HasUsableRootSnapshot =
+                status
+                |> Option.map hasUsableRootSnapshotForCheck
+                |> Option.defaultValue false
+            HasDirectoryIndexSnapshot =
+                status
+                |> Option.map hasDirectoryIndexSnapshotForCheck
+                |> Option.defaultValue false
+            IsStartupClaim =
+                status
+                |> Option.map (fun status -> status.IsStartupClaim)
+                |> Option.defaultValue false
+            UpdatedAt =
+                status
+                |> Option.map (fun status -> status.UpdatedAt.ToString())
+            RootDirectoryId =
+                status
+                |> Option.map (fun status -> status.RootDirectoryId)
+        }
+
+    /// Renders `watch --check` in either human or machine-readable mode while preserving check exit semantics.
+    let private renderWatchCheckStatus parseResult (status: WatchCheckStatusDto) =
+        if parseResult |> json then
+            let renderExit =
+                Ok(GraceReturnValue.Create status (getCorrelationId parseResult))
+                |> renderOutput parseResult
+
+            if renderExit <> 0 then renderExit
+            elif status.CanUseIncrementalStatus then 0
+            else -1
+        else
+            let color =
+                if status.CanUseIncrementalStatus then Colors.Important
+                elif status.IsRunning then Colors.Important
+                else Colors.Error
+
+            logToAnsiConsole color status.Message
+
+            if status.CanUseIncrementalStatus then 0 else -1
+
     /// Renders json result results only when the selected output mode includes human-readable console text.
     let private renderJsonResult parseResult started completed message =
         let configuration = Current()
@@ -2576,15 +2700,9 @@ module Watch =
             task {
                 try
                     if isCheckRequested parseResult then
-                        let! existingGraceWatchStatus = getGraceWatchStatus ()
-
-                        match existingGraceWatchStatus with
-                        | Some _ ->
-                            logToAnsiConsole Colors.Important "GraceWatch is running."
-                            raise (WatchCommandExit 0)
-                        | None ->
-                            logToAnsiConsole Colors.Error "GraceWatch is not running."
-                            raise (WatchCommandExit -1)
+                        let! watchStatusInspection = inspectGraceWatchStatus ()
+                        let watchCheckStatus = toWatchCheckStatusDto watchStatusInspection
+                        raise (WatchCommandExit(renderWatchCheckStatus parseResult watchCheckStatus))
 
                     let! claimedGraceWatchStatus = tryClaimGraceWatchInterprocessFile ()
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2655,6 +2655,8 @@ module Watch =
                 then
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
+                elif runtimeMode = GraceWatchRuntimeMode.Suspended then
+                    do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
                 else
                     do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
 

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -452,8 +452,6 @@ module CommandOutputContract =
                 "HasUsableRootSnapshot"
                 "HasDirectoryIndexSnapshot"
                 "IsStartupClaim"
-                "UpdatedAt"
-                "RootDirectoryId"
             |]
 
     let private watchStatusExample =
@@ -834,7 +832,7 @@ module CommandOutputContract =
                 match entry.EnvelopeContract with
                 | JsonModeErrorOnly reason -> $"GraceError only in JSON mode for this release; no success ReturnValue envelope is emitted. {reason}"
                 | ConditionalGraceResultEnvelope (_, condition) ->
-                    $"GraceReturnValue<T> on supported status-check success; GraceError on unsupported or failed modes. {condition}"
+                    $"GraceReturnValue<T> status envelope for status checks, including unavailable modes with nonzero exit codes. GraceError remains for parser and command execution errors outside that status-check path. {condition}"
                 | _ -> "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
             ReturnValueContract = entry.ReturnValueContract.Name

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -30,6 +30,7 @@ module CommandOutputContract =
     type CurrentJsonBehavior =
         | CommonRenderOutputEnvelope
         | ImmediateJsonErrorOnly
+        | ConditionalCheckStatusEnvelope
         | HumanProgressOnlySuccess
         | PartialManualSuccess
         | ManualJsonUnenveloped
@@ -65,6 +66,7 @@ module CommandOutputContract =
     /// Models envelope contract values passed between the parser and command output contract handlers.
     type EnvelopeContract =
         | ExistingGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
+        | ConditionalGraceResultEnvelope of dtoDisposition: OutputDtoDisposition * condition: string
         | MigrationRequiredToGraceResultEnvelope of dtoDisposition: OutputDtoDisposition
         | JsonModeErrorOnly of reason: string
         | SourceOnlyUnsupported of disposition: string
@@ -422,6 +424,60 @@ module CommandOutputContract =
                     |]
             |}
 
+    let private watchStatusSchema =
+        schemaObject
+            "WatchStatusDto"
+            [
+                "IsRunning", scalarSchema "boolean"
+                "CanUseIncrementalStatus", scalarSchema "boolean"
+                "Mode", scalarSchema "string"
+                "Reason", scalarSchema "string"
+                "Message", scalarSchema "string"
+                "SafetyFlags", arraySchema (scalarSchema "string") "Compact status facts for agents deciding whether to trust Watch."
+                "IsFresh", scalarSchema "boolean"
+                "HasUsableRootSnapshot", scalarSchema "boolean"
+                "HasDirectoryIndexSnapshot", scalarSchema "boolean"
+                "IsStartupClaim", scalarSchema "boolean"
+                "UpdatedAt", nullableStringSchema "Watch IPC heartbeat timestamp when a status snapshot is readable."
+                "RootDirectoryId", nullableStringSchema "Root directory version id when a status snapshot is readable."
+            ]
+            [|
+                "IsRunning"
+                "CanUseIncrementalStatus"
+                "Mode"
+                "Reason"
+                "Message"
+                "SafetyFlags"
+                "IsFresh"
+                "HasUsableRootSnapshot"
+                "HasDirectoryIndexSnapshot"
+                "IsStartupClaim"
+                "UpdatedAt"
+                "RootDirectoryId"
+            |]
+
+    let private watchStatusExample =
+        box
+            {|
+                IsRunning = true
+                CanUseIncrementalStatus = true
+                Mode = "HealthyIncremental"
+                Reason = "running"
+                Message = "GraceWatch is running in HealthyIncremental mode. Incremental status shortcuts are available."
+                SafetyFlags =
+                    [|
+                        "directoryIndex"
+                        "incrementalSafe"
+                        "usableRoot"
+                    |]
+                IsFresh = true
+                HasUsableRootSnapshot = true
+                HasDirectoryIndexSnapshot = true
+                IsStartupClaim = false
+                UpdatedAt = "2026-06-05T00:00:00Z"
+                RootDirectoryId = "11111111-1111-1111-1111-111111111111"
+            |}
+
     let private doctorCheckSchema =
         schemaObject
             "DoctorCheckDto"
@@ -589,6 +645,7 @@ module CommandOutputContract =
     let private envelopeContractText (contract: EnvelopeContract) =
         match contract with
         | ExistingGraceResultEnvelope disposition -> $"ExistingGraceResultEnvelope: {outputDtoDispositionText disposition}"
+        | ConditionalGraceResultEnvelope (disposition, condition) -> $"ConditionalGraceResultEnvelope: {outputDtoDispositionText disposition}; {condition}"
         | MigrationRequiredToGraceResultEnvelope disposition -> $"MigrationRequiredToGraceResultEnvelope: {outputDtoDispositionText disposition}"
         | JsonModeErrorOnly reason -> $"JsonModeErrorOnly: {reason}"
         | SourceOnlyUnsupported reason -> $"SourceOnlyUnsupported: {reason}"
@@ -597,6 +654,7 @@ module CommandOutputContract =
     let private returnValueDispositionText (contract: EnvelopeContract) =
         match contract with
         | ExistingGraceResultEnvelope disposition
+        | ConditionalGraceResultEnvelope (disposition, _)
         | MigrationRequiredToGraceResultEnvelope disposition -> outputDtoDispositionText disposition
         | JsonModeErrorOnly reason -> $"Unsupported: {reason}"
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
@@ -682,13 +740,26 @@ module CommandOutputContract =
                 [
                     "Representative scalar ReturnValue schema for a common Grace result envelope command."
                 ]
-        | "watch", JsonModeErrorOnly reason -> unsupportedReturnValueContract "WatchResultDto" reason
+        | "watch", ConditionalGraceResultEnvelope (RequiresCliDto, _) ->
+            supportedReturnValueContract
+                "WatchStatusDto"
+                "Grace.CLI.Command.Watch"
+                watchStatusSchema
+                watchStatusExample
+                [
+                    "`grace watch --check` emits this status DTO in JSON mode. Foreground `grace watch --output Json` remains unsupported because the watcher is a continuous workflow."
+                ]
+        | "watch", JsonModeErrorOnly reason -> unsupportedReturnValueContract "WatchStatusDto" reason
         | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
         | _, JsonModeErrorOnly reason -> unsupportedReturnValueContract "unsupported" reason
         | _, MigrationRequiredToGraceResultEnvelope disposition ->
             incompleteReturnValueContract
                 (outputDtoDispositionText disposition)
                 "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
+        | _, ConditionalGraceResultEnvelope (disposition, condition) ->
+            incompleteReturnValueContract
+                (outputDtoDispositionText disposition)
+                $"This command has a conditional JSON success path, but command-specific ReturnValue schema/example metadata has not been declared yet. {condition}"
         | _, ExistingGraceResultEnvelope disposition ->
             incompleteReturnValueContract
                 (outputDtoDispositionText disposition)
@@ -762,6 +833,8 @@ module CommandOutputContract =
             Envelope =
                 match entry.EnvelopeContract with
                 | JsonModeErrorOnly reason -> $"GraceError only in JSON mode for this release; no success ReturnValue envelope is emitted. {reason}"
+                | ConditionalGraceResultEnvelope (_, condition) ->
+                    $"GraceReturnValue<T> on supported status-check success; GraceError on unsupported or failed modes. {condition}"
                 | _ -> "GraceReturnValue<T> on success; GraceError on error. CLI success Properties are emitted as Key/Value entries."
             ReturnValueDisposition = returnValueDispositionText entry.EnvelopeContract
             ReturnValueContract = entry.ReturnValueContract.Name
@@ -866,6 +939,8 @@ module CommandOutputContract =
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
         | ImmediateJsonErrorOnly ->
             { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = RequiresMigration }
+        | ConditionalCheckStatusEnvelope ->
+            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | CommonRenderOutputEnvelope ->
             { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
@@ -875,6 +950,11 @@ module CommandOutputContract =
         match routed, behavior with
         | false, _ -> SourceOnlyUnsupported "Defined in source but not root-routed for V1."
         | true, CommonRenderOutputEnvelope -> ExistingGraceResultEnvelope dtoDisposition
+        | true, ConditionalCheckStatusEnvelope ->
+            ConditionalGraceResultEnvelope(
+                dtoDisposition,
+                "`grace watch --check` supports JSON and --select status output; foreground `grace watch` still returns a JSON error because it is a continuous workflow."
+            )
         | true, ImmediateJsonErrorOnly ->
             JsonModeErrorOnly
                 "The command is routed, but --output Json is intentionally short-circuited before command execution because watch is a continuous foreground workflow."
@@ -935,6 +1015,7 @@ module CommandOutputContract =
 
     let private common_renderOutput_envelope = CommonRenderOutputEnvelope
     let private immediate_json_error_only = ImmediateJsonErrorOnly
+    let private conditional_check_status_envelope = ConditionalCheckStatusEnvelope
     let private human_progress_only_success = HumanProgressOnlySuccess
     let private partial_manual_success = PartialManualSuccess
     let private manual_json_unenveloped = ManualJsonUnenveloped
@@ -1225,7 +1306,7 @@ module CommandOutputContract =
             row [ "review"; "report" ] "export" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review"; "report" ] "show" true false common_renderOutput_envelope read_list_search composite_local_server RequiresCliDto
             row [ "review" ] "resolve" true true common_renderOutput_envelope mutating_state_transition verify ReuseExistingApiOrSdkDto
-            row [] "watch" true true immediate_json_error_only progress_local_workflow local_client RequiresCliDto
+            row [] "watch" true true conditional_check_status_envelope progress_local_workflow local_client RequiresCliDto
             row [ "webhook" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "delete" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "deliveries" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1385,7 +1385,7 @@ module GraceCommand =
                             //parseResult <- caseInsensitiveMiddleware (rootCommand, parseResult, isCaseInsensitive)
 
                             if (parseResult |> json)
-                               && (parseResult |> isGraceWatch) then
+                               && (parseResult |> isGraceWatchForeground) then
                                 let error =
                                     GraceError.Create
                                         "watch is a continuous foreground workflow; JSON mode requires a cancellation-aware automation host in this release."
@@ -1394,7 +1394,10 @@ module GraceCommand =
                                 Common.writeJsonErrorStdout error
                                 returnValue <- -1
                             else
-                                if parseResult |> hasOutput then
+                                if
+                                    (parseResult |> hasOutput)
+                                    && not (parseResult |> json)
+                                then
                                     if parseResult |> verbose then
                                         AnsiConsole.Write(
                                             (new Rule($"[{Colors.Important}]Started: {formatInstantExtended startTime}.[/]"))
@@ -1425,7 +1428,10 @@ module GraceCommand =
                                     logToAnsiConsole Colors.Important (getLocalizedString StringResourceName.InterprocessFileDeleted)
 
                                 // If we're writing output, write the final Rule() to the console.
-                                if parseResult |> hasOutput then
+                                if
+                                    (parseResult |> hasOutput)
+                                    && not (parseResult |> json)
+                                then
                                     let finishTime = getCurrentInstant ()
 
                                     let elapsed =


### PR DESCRIPTION
## Summary

- Add readable `watch --check` state reporting for healthy, startup, resync, suspended, stale, missing, and unreadable
  Watch IPC states.
- Add conditional `watch --check --output Json` and `watch --check --select Mode` support while keeping foreground
  `grace watch --output Json` blocked as a continuous workflow.
- Document state-gated reconciliation in ADR-0008 and update Watch and machine-readable CLI docs.
- Persist real failed-recovery suspended mode through the IPC/status surface used by `watch --check`, including delayed
  heartbeat refreshes while suspended.
- Align the Watch status schema with actual unavailable-status JSON envelopes and optional absent snapshot fields.

## Related Issue

References #491. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This completes the WS3 readability and decision-record slice. Grace users and agents need to know whether Watch is
healthy, recovering, suspended, or unavailable without scraping logs or seeing internal IPC paths and exception details.
The machine-readable status also gives future automation a stable way to inspect Watch mode before trusting incremental
status.

## Validation

- `dotnet tool run fantomas <touched F# files>` passed.
- `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed: 779 tests.
- MarkdownLint passed with 0 errors for:
  - `docs/Machine-readable CLI output.md`
  - `docs/What grace watch does.md`
  - `docs/adr/0008-grace-watch-state-gated-reconciliation.md`
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed.
- First review fix Fantomas check passed for `Services.CLI.fs`, `Watch.CLI.fs`, and `Watch.Tests.fs`.
- First review fix focused Watch tests passed: 137 tests.
- First review fix `git diff --check` passed.
- First review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Second review fix Fantomas passed for touched CLI and CLI test files.
- Second review fix focused Watch and command-output registry tests passed: 159 tests.
- Second review fix `git diff --check` passed.
- Second review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- GitHub `full` check passed on latest head `3cb38e4c6691da9524f900a80c358a0b3878933c`.

## Docs Impact

- Added `docs/adr/0008-grace-watch-state-gated-reconciliation.md`.
- Updated `docs/What grace watch does.md` with Watch runtime modes and recovery semantics.
- Updated `docs/Machine-readable CLI output.md` for conditional Watch status JSON and select support.

## Review Status

- Current head: `3cb38e4c6691da9524f900a80c358a0b3878933c`.
- Worker bot-prevention self-review: complete after implementation and both review-fix passes.
- Codex Code Review Bot: passed with `+1` on latest head at `2026-07-04T02:53:53Z`.
- Review threads: all Codex Code Review Bot findings were replied to with fix commits and validation evidence, then
  resolved before merge.
- Prevention line: status checks now cover JSON/stdout behavior, nonzero unavailable status semantics, no raw IPC or
  stack details in human output, command-output registry/doc/test alignment, real failed-recovery suspended IPC mode,
  suspended heartbeat refresh preservation, status-envelope schema wording, and optional absent snapshot fields.

## Residual Risks

- `WatchStatusDto` is CLI-local registry metadata, not a shared SDK/OpenAPI DTO. Future public API work should avoid
  silently duplicating it.
- The suspended-mode fix is scoped to persisted IPC mode metadata for failed-recovery suspended watchers. Existing
  healthy and ordinary resync snapshot behavior remains derived from the compact status payload.
