### PR TITLE
WS5.1: Add watch status identity and clean flags

### DIFF
--- a/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs
@@ -788,6 +788,13 @@ module CurrentStateCaptureCliTests =
             {
                 UpdatedAt = Grace.Shared.Utilities.getCurrentInstant ()
                 IsStartupClaim = false
+                RepositoryId = RepositoryId.Empty
+                RepositoryName = RepositoryName String.Empty
+                BranchId = BranchId.Empty
+                BranchName = BranchName String.Empty
+                RootDirectory = Environment.CurrentDirectory
+                HasPendingWatchWork = false
+                IsWorkingTreeClean = true
                 RootDirectoryId = rootDirectoryId
                 RootDirectorySha256Hash = rootSha
                 RootDirectoryBlake3Hash = rootBlake3

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5967,6 +5967,47 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that Watch publication rechecks queued work before leaving a clean IPC snapshot on disk.
+    [<Test>]
+    let ``watch refresh rewrites clean ipc when pending work arrives during publish`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let filePath = Path.Combine(root, "queued-during-clean-publish.txt")
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            /// Simulates a stale clean writer losing a race to a FileSystemWatcher callback at the write boundary.
+            let mutable writerCalls = 0
+
+            let racingWriter status directoryIds =
+                writerCalls <- writerCalls + 1
+
+                if writerCalls = 1 then
+                    File.WriteAllText(filePath, "queued while clean status is publishing")
+                    Watch.OnChanged(changedEvent filePath)
+                    Services.setGraceWatchHasPendingWorkForStatus false
+
+                Services.updateGraceWatchInterprocessFile status directoryIds
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests status racingWriter)
+                .GetAwaiter()
+                .GetResult()
+
+            writerCalls |> should equal 2
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true)
+
     /// Verifies that non-Watch status refreshes preserve a live dirty Watch IPC state.
     [<Test>]
     let ``watch ipc non-watch update preserves live dirty work state`` () =
@@ -6005,6 +6046,133 @@ module WatchTests =
 
             Services.getGraceWatchStatus().Result
             |> should equal None)
+
+    /// Verifies that non-Watch status refreshes preserve same-repository non-incremental Watch state.
+    [<Test>]
+    let ``watch ipc non-watch update preserves current live recovery state`` () =
+        withTempRepo (fun root ->
+            let configuration = Current()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            configuration.RepositoryId <- repositoryId
+            configuration.RepositoryName <- "current-recovery-repo"
+            configuration.BranchId <- branchId
+            configuration.BranchName <- "current-recovery-branch"
+            configuration.RootDirectory <- root
+
+            let liveRootDirectoryId = Guid.NewGuid()
+
+            for mode, modeText in
+                [|
+                    Services.GraceWatchRuntimeMode.StartingUp, "startingUp"
+                    Services.GraceWatchRuntimeMode.Suspended, "suspended"
+                    Services.GraceWatchRuntimeMode.Resynchronizing, "resynchronizing"
+                |] do
+                let liveRecoveryStatus =
+                    { liveWatchStatus liveRootDirectoryId with
+                        RepositoryId = repositoryId
+                        RepositoryName = RepositoryName "current-recovery-repo"
+                        BranchId = branchId
+                        BranchName = BranchName "current-recovery-branch"
+                        RootDirectory = root
+                        HasPendingWatchWork = true
+                        IsWorkingTreeClean = false
+                    }
+
+                writeWatchStatusJsonWithPersistedMode mode liveRecoveryStatus
+                |> ignore
+
+                let cleanStatusFromNonWatch =
+                    { graceStatusTracking Array.empty<string> Array.empty<string> with
+                        RootDirectorySha256Hash = Sha256Hash $"current-non-watch-root-{modeText}"
+                    }
+
+                let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFilePreservingLiveWorkState cleanStatusFromNonWatch (Some cleanDirectoryIdsFromNonWatch))
+                    .GetAwaiter()
+                    .GetResult()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal true
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal false
+
+                readWatchStatusJsonStringProperty "Mode"
+                |> should equal modeText
+
+                readWatchStatusJsonStringProperty "RootDirectoryId"
+                |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
+
+    /// Verifies that non-Watch status refreshes do not preserve live Watch state from another repo or root.
+    [<Test>]
+    let ``watch ipc non-watch update skips foreign live recovery state`` () =
+        withTempRepo (fun root ->
+            let configuration = Current()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            configuration.RepositoryId <- repositoryId
+            configuration.RepositoryName <- "current-foreign-guard-repo"
+            configuration.BranchId <- branchId
+            configuration.BranchName <- "current-foreign-guard-branch"
+            configuration.RootDirectory <- root
+
+            let foreignRoot = Path.Combine(Path.GetTempPath(), $"grace-watch-foreign-{Guid.NewGuid():N}")
+
+            for mode in
+                [|
+                    Services.GraceWatchRuntimeMode.StartingUp
+                    Services.GraceWatchRuntimeMode.Suspended
+                    Services.GraceWatchRuntimeMode.Resynchronizing
+                |] do
+                let foreignRecoveryStatus =
+                    { liveWatchStatus (Guid.NewGuid()) with
+                        RepositoryId = Guid.NewGuid()
+                        RepositoryName = RepositoryName "foreign-repo"
+                        BranchId = Guid.NewGuid()
+                        BranchName = BranchName "current-foreign-guard-branch"
+                        RootDirectory = foreignRoot
+                        HasPendingWatchWork = true
+                        IsWorkingTreeClean = false
+                    }
+
+                writeWatchStatusJsonWithPersistedMode mode foreignRecoveryStatus
+                |> ignore
+
+                let cleanStatusFromNonWatch =
+                    { graceStatusTracking Array.empty<string> Array.empty<string> with RootDirectorySha256Hash = Sha256Hash $"foreign-guard-root-{mode}" }
+
+                let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFilePreservingLiveWorkState cleanStatusFromNonWatch (Some cleanDirectoryIdsFromNonWatch))
+                    .GetAwaiter()
+                    .GetResult()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal false
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal true
+
+                tryReadWatchStatusJsonStringProperty "Mode"
+                |> should equal None
+
+                readWatchStatusJsonStringProperty "RepositoryId"
+                |> should equal $"{repositoryId}"
+
+                readWatchStatusJsonStringProperty "BranchId"
+                |> should equal $"{branchId}"
+
+                readWatchStatusJsonStringProperty "RootDirectory"
+                |> should equal root
+
+                readWatchStatusJsonStringProperty "RootDirectoryId"
+                |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
 
     /// Verifies that a pending GraceStatus artifact refresh publishes dirty IPC before the timer reloads status.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -165,6 +165,20 @@ module WatchTests =
             DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
         }
 
+    /// Applies the current repository identity used by Watch IPC trust tests.
+    let private configureCurrentWatchIdentity rootDirectory repositoryName branchName =
+        let repositoryId = Guid.NewGuid()
+        let branchId = Guid.NewGuid()
+        let configuration = Current()
+
+        configuration.RepositoryId <- repositoryId
+        configuration.RepositoryName <- repositoryName
+        configuration.BranchId <- branchId
+        configuration.BranchName <- branchName
+        configuration.RootDirectory <- rootDirectory
+
+        repositoryId, branchId
+
     /// Removes the compact runtime surface so tests can simulate pre-WS3.1 IPC files.
     let private removeCompactWatchRuntimeSurface (json: string) =
         let statusNode = JsonNode.Parse(json).AsObject()
@@ -5598,6 +5612,109 @@ module WatchTests =
 
                 output
                 |> should not' (contain "Unable to acquire an access token for SignalR")))
+
+    /// Verifies that current-identity startup claims reject duplicate startup attempts.
+    [<Test>]
+    let ``watch startup claim blocks duplicate current identity claim`` () =
+        withTempRepo (fun root ->
+            let repositoryName = "current-startup-repo"
+            let branchName = $"current-startup-branch-{Guid.NewGuid():N}"
+            let repositoryId, branchId = configureCurrentWatchIdentity root repositoryName branchName
+            deleteWatchStatusFileIfExists ()
+
+            let firstClaimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            firstClaimed |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsStartupClaim"
+            |> should equal true
+
+            readWatchStatusJsonStringProperty "RepositoryId"
+            |> should equal $"{repositoryId}"
+
+            readWatchStatusJsonStringProperty "RepositoryName"
+            |> should equal repositoryName
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchId}"
+
+            readWatchStatusJsonStringProperty "BranchName"
+            |> should equal branchName
+
+            readWatchStatusJsonStringProperty "RootDirectory"
+            |> should equal root
+
+            let originalContents = File.ReadAllText(Services.IpcFileName())
+
+            let secondClaimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            secondClaimed |> should equal false
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal originalContents)
+
+    /// Verifies that a startup claim written by another same-branch worktree does not block this repository identity.
+    [<Test>]
+    let ``watch startup claim replaces foreign same branch startup claim`` () =
+        withTempRepo (fun root ->
+            let branchName = $"shared-startup-branch-{Guid.NewGuid():N}"
+            let foreignRoot = Path.Combine(root, "other-worktree")
+            Directory.CreateDirectory(foreignRoot) |> ignore
+
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-startup-repo" branchName
+            deleteWatchStatusFileIfExists ()
+
+            let foreignStartupClaim =
+                { Services.GraceWatchStatus.Default with
+                    UpdatedAt = getCurrentInstant ()
+                    IsStartupClaim = true
+                    RepositoryId = Guid.NewGuid()
+                    RepositoryName = RepositoryName "foreign-startup-repo"
+                    BranchId = Guid.NewGuid()
+                    BranchName = BranchName branchName
+                    RootDirectory = foreignRoot
+                }
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, serialize foreignStartupClaim)
+
+            Services
+                .inspectGraceWatchStatus()
+                .Result
+                .HasCurrentRepositoryIdentity
+            |> should equal false
+
+            let currentClaimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            currentClaimed |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsStartupClaim"
+            |> should equal true
+
+            readWatchStatusJsonStringProperty "RepositoryId"
+            |> should equal $"{currentRepositoryId}"
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{currentBranchId}"
+
+            readWatchStatusJsonStringProperty "BranchName"
+            |> should equal branchName
+
+            readWatchStatusJsonStringProperty "RootDirectory"
+            |> should equal root)
 
     /// Verifies that startup claim recognizes fresh legacy IPC instead of overwriting a live Watch file.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3471,6 +3471,45 @@ module WatchTests =
             uploadCalls |> should equal 2
             updateCalls |> should equal 1)
 
+    /// Verifies that a tracked renamed directory publishes dirty IPC even when the old path is ignored.
+    [<Test>]
+    let ``renamed directory add publishes dirty status when old path is ignored`` () =
+        withTempRepo (fun root ->
+            writeGraceIgnore root [| "ignored-old-assets/" |]
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Watch.setGraceStatusForWatchTests status
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let oldPath = Path.Combine(root, "ignored-old-assets")
+            let newPath = Path.Combine(root, "tracked-new-assets")
+            Directory.CreateDirectory(newPath) |> ignore
+
+            let childFile = Path.Combine(newPath, "asset.txt")
+            File.WriteAllText(childFile, "new tracked content")
+
+            Watch.OnRenamed(renamedEvent oldPath newPath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            pending.FilesToProcess
+            |> should equal [| childFile |])
+
     /// Verifies that renamed directory enumeration failure keeps old path trigger for retry.
     [<Test>]
     let ``renamed directory enumeration failure keeps old path trigger for retry`` () =
@@ -5743,6 +5782,74 @@ module WatchTests =
             File.ReadAllText(Services.IpcFileName())
             |> should equal dirtyJson)
 
+    /// Verifies that transient IPC write failures do not suppress the next dirty status publication attempt.
+    [<Test>]
+    let ``watch dirty status transition retries after ipc write failure`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            let filePath = Path.Combine(root, "dirty-retry.txt")
+
+            use lockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+
+            File.WriteAllText(filePath, "first content")
+            Watch.OnChanged(changedEvent filePath)
+            lockedIpc.Dispose()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            File.WriteAllText(filePath, "second content")
+            Watch.OnChanged(changedEvent filePath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
+
+    /// Verifies that startup catch-up publishes dirty IPC until the startup scan and apply path drains.
+    [<Test>]
+    let ``watch startup catch-up status is dirty before startup scan drains`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+            (Watch.publishStartupCatchUpPendingStatusForWatchTests status directoryIds Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
     /// Verifies that processing pending Watch work publishes the dirty-to-clean IPC transition.
     [<Test>]
     let ``watch clean status transition is published after pending work drains`` () =
@@ -5991,6 +6098,122 @@ module WatchTests =
             safetyFlags
             |> Set.contains "incrementalSafe"
             |> should equal false)
+
+    /// Verifies that stale dirty status requires explicit resync because no live Watch can drain the queued work.
+    [<Test>]
+    let ``watch status safety flags require resync when stale snapshot is dirty`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let staleStatus =
+                { liveWatchStatus rootDirectoryId with
+                    UpdatedAt =
+                        getCurrentInstant()
+                            .Minus(Duration.FromMinutes(6.0))
+                    HasPendingWatchWork = true
+                    IsWorkingTreeClean = false
+                }
+
+            writeWatchStatusJsonWithRuntimeSurface staleStatus
+            |> ignore
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let persistedSafetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            persistedSafetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            persistedSafetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            persistedSafetyFlags
+            |> Set.contains "pendingStatusApply"
+            |> should equal false)
+
+    /// Verifies that untrusted no-work Watch snapshots do not advertise a clean working tree.
+    [<Test>]
+    let ``watch status safety flags do not mark untrusted snapshots clean`` () =
+        withTempRepo (fun _ ->
+            let startupClaim = { Services.GraceWatchStatus.Default with UpdatedAt = getCurrentInstant (); IsStartupClaim = true }
+
+            let startupFlags = safetyFlagSet startupClaim
+
+            startupFlags
+            |> Set.contains "startupClaim"
+            |> should equal true
+
+            startupFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            startupFlags
+            |> Set.contains "noQueuedWatchWork"
+            |> should equal true
+
+            startupFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            let missingRoot =
+                { Services.GraceWatchStatus.Default with UpdatedAt = getCurrentInstant (); DirectoryIds = HashSet<DirectoryVersionId>([| Guid.NewGuid() |]) }
+
+            let missingRootFlags = safetyFlagSet missingRoot
+
+            missingRootFlags
+            |> Set.contains "missingRoot"
+            |> should equal true
+
+            missingRootFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            missingRootFlags
+            |> Set.contains "noQueuedWatchWork"
+            |> should equal true
+
+            missingRootFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
+
+    /// Verifies that persisted suspended snapshots do not carry a trusted clean flag.
+    [<Test>]
+    let ``suspended watch status serialization does not mark clean snapshots trusted`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { GraceStatus.Default with
+                    RootDirectoryId = rootDirectoryId
+                    RootDirectorySha256Hash = Sha256Hash "suspended-clean-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "suspended-clean-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+
+            (Services.updateGraceWatchInterprocessFileForSuspendedMode status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            safetyFlags
+            |> Set.contains "noQueuedWatchWork"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
 
     /// Verifies that legacy watch status json without compact runtime fields remains readable.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -172,6 +172,13 @@ module WatchTests =
         statusNode.Remove("SafetyFlags") |> ignore
         statusNode.ToJsonString(Constants.JsonSerializerOptions)
 
+    /// Removes the explicit clean/dirty fields so tests can simulate Watch IPC files written before issue #492.
+    let private removeExplicitWatchCleanFields (json: string) =
+        let statusNode = JsonNode.Parse(json).AsObject()
+        statusNode.Remove("HasPendingWatchWork") |> ignore
+        statusNode.Remove("IsWorkingTreeClean") |> ignore
+        statusNode.ToJsonString(Constants.JsonSerializerOptions)
+
     /// Reads safety flags into a deterministic set for assertions.
     let private safetyFlagSet (status: Services.GraceWatchStatus) = status.SafetyFlags |> Set.ofArray
 
@@ -5818,6 +5825,31 @@ module WatchTests =
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal false)
 
+    /// Verifies that Watch IPC writes recheck pending work at the serialized write boundary.
+    [<Test>]
+    let ``watch clean ipc write becomes dirty when pending work arrives at write boundary`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFileAfterPendingWorkProbeForWatchTests
+                (fun () -> Services.setGraceWatchHasPendingWorkForStatus true)
+                status
+                (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
     /// Verifies that startup catch-up publishes dirty IPC until the startup scan and apply path drains.
     [<Test>]
     let ``watch startup catch-up status is dirty before startup scan drains`` () =
@@ -6215,9 +6247,9 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
-    /// Verifies that legacy watch status json without compact runtime fields remains readable.
+    /// Verifies that legacy watch status json without compact runtime or clean fields remains readable.
     [<Test>]
-    let ``watch status reads legacy json without runtime mode fields`` () =
+    let ``watch status reads legacy json without runtime mode or clean fields`` () =
         withTempRepo (fun _ ->
             let rootDirectoryId = Guid.NewGuid()
 
@@ -6226,10 +6258,17 @@ module WatchTests =
                 |> liveWatchStatus
                 |> serialize
                 |> removeCompactWatchRuntimeSurface
+                |> removeExplicitWatchCleanFields
 
             legacyJson |> should not' (contain "Mode")
 
             legacyJson |> should not' (contain "SafetyFlags")
+
+            legacyJson
+            |> should not' (contain "HasPendingWatchWork")
+
+            legacyJson
+            |> should not' (contain "IsWorkingTreeClean")
 
             let ipcFileName = Services.IpcFileName()
 
@@ -6249,6 +6288,10 @@ module WatchTests =
                 safetyFlagSet status
                 |> Set.contains "incrementalSafe"
                 |> should equal true
+
+                status.IsWorkingTreeClean |> should equal true
+
+                status.HasPendingWatchWork |> should equal false
             | None -> Assert.Fail("Expected legacy watch status JSON to remain usable."))
 
     /// Verifies that incomplete watch status requests explicit resync instead of advertising incremental safety.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -172,15 +172,26 @@ module WatchTests =
         statusNode.Remove("SafetyFlags") |> ignore
         statusNode.ToJsonString(Constants.JsonSerializerOptions)
 
-    /// Removes the explicit clean/dirty fields so tests can simulate Watch IPC files written before issue #492.
-    let private removeExplicitWatchCleanFields (json: string) =
+    /// Removes issue #492 fields so tests can simulate Watch IPC files written by the previous CLI.
+    let private removeWatchStatusFieldsAddedForIssue492 (json: string) =
         let statusNode = JsonNode.Parse(json).AsObject()
+        statusNode.Remove("RepositoryId") |> ignore
+        statusNode.Remove("RepositoryName") |> ignore
+        statusNode.Remove("BranchId") |> ignore
+        statusNode.Remove("BranchName") |> ignore
+        statusNode.Remove("RootDirectory") |> ignore
         statusNode.Remove("HasPendingWatchWork") |> ignore
         statusNode.Remove("IsWorkingTreeClean") |> ignore
         statusNode.ToJsonString(Constants.JsonSerializerOptions)
 
     /// Reads safety flags into a deterministic set for assertions.
     let private safetyFlagSet (status: Services.GraceWatchStatus) = status.SafetyFlags |> Set.ofArray
+
+    /// Reports whether a persisted JSON snapshot contains the supplied top-level property.
+    let private jsonHasProperty (propertyName: string) (json: string) =
+        use document = JsonDocument.Parse(json)
+        let mutable property = Unchecked.defaultof<JsonElement>
+        document.RootElement.TryGetProperty(propertyName, &property)
 
     /// Reads a scalar property from the persisted Watch IPC JSON contract.
     let private readWatchStatusJsonStringProperty (propertyName: string) =
@@ -5727,7 +5738,7 @@ module WatchTests =
 
             safetyFlags
             |> Set.contains "cleanWorkingTree"
-            |> should equal true
+            |> should equal false
 
             match Services.getGraceWatchStatus().Result with
             | Some watchStatus ->
@@ -5781,6 +5792,10 @@ module WatchTests =
             |> Set.contains "pendingWatchWork"
             |> should equal true
 
+            safetyFlags
+            |> Set.contains "pendingStatusApply"
+            |> should equal false
+
             let dirtyJson = File.ReadAllText(Services.IpcFileName())
 
             File.WriteAllText(filePath, "second content")
@@ -5824,6 +5839,50 @@ module WatchTests =
 
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal false)
+
+    /// Verifies that resync-required publication retries after a swallowed IPC write failure.
+    [<Test>]
+    let ``watch resync-required status transition retries after ipc write failure`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true
+
+            use lockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            Watch.requestGraceWatchExplicitResyncForWatchTests "locked resync-required publication"
+            lockedIpc.Dispose()
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true
+
+            let filePath = Path.Combine(root, "resync-retry.txt")
+            File.WriteAllText(filePath, "retry resync publication")
+            Watch.OnChanged(changedEvent filePath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
 
     /// Verifies that Watch IPC writes recheck pending work at the serialized write boundary.
     [<Test>]
@@ -5941,7 +6000,7 @@ module WatchTests =
 
             safetyFlags
             |> Set.contains "cleanWorkingTree"
-            |> should equal true
+            |> should equal false
 
             safetyFlags
             |> Set.contains "pendingWatchWork"
@@ -6258,17 +6317,34 @@ module WatchTests =
                 |> liveWatchStatus
                 |> serialize
                 |> removeCompactWatchRuntimeSurface
-                |> removeExplicitWatchCleanFields
+                |> removeWatchStatusFieldsAddedForIssue492
 
-            legacyJson |> should not' (contain "Mode")
+            jsonHasProperty "Mode" legacyJson
+            |> should equal false
 
-            legacyJson |> should not' (contain "SafetyFlags")
+            jsonHasProperty "SafetyFlags" legacyJson
+            |> should equal false
 
-            legacyJson
-            |> should not' (contain "HasPendingWatchWork")
+            jsonHasProperty "HasPendingWatchWork" legacyJson
+            |> should equal false
 
-            legacyJson
-            |> should not' (contain "IsWorkingTreeClean")
+            jsonHasProperty "IsWorkingTreeClean" legacyJson
+            |> should equal false
+
+            jsonHasProperty "RepositoryId" legacyJson
+            |> should equal false
+
+            jsonHasProperty "RepositoryName" legacyJson
+            |> should equal false
+
+            jsonHasProperty "BranchId" legacyJson
+            |> should equal false
+
+            jsonHasProperty "BranchName" legacyJson
+            |> should equal false
+
+            jsonHasProperty "RootDirectory" legacyJson
+            |> should equal false
 
             let ipcFileName = Services.IpcFileName()
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5967,6 +5967,45 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that non-Watch status refreshes preserve a live dirty Watch IPC state.
+    [<Test>]
+    let ``watch ipc non-watch update preserves live dirty work state`` () =
+        withTempRepo (fun _ ->
+            let dirtyStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dirtyDirectoryIds = HashSet<DirectoryVersionId>(dirtyStatus.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus true
+
+            (Services.updateGraceWatchInterprocessFile dirtyStatus (Some dirtyDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let cleanStatusFromNonWatch =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with RootDirectorySha256Hash = Sha256Hash "non-watch-updated-root" }
+
+            let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFilePreservingLiveWorkState cleanStatusFromNonWatch (Some cleanDirectoryIdsFromNonWatch))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            readWatchStatusJsonStringProperty "RootDirectoryId"
+            |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}"
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
     /// Verifies that a pending GraceStatus artifact refresh publishes dirty IPC before the timer reloads status.
     [<Test>]
     let ``watch grace status artifact change publishes dirty ipc`` () =
@@ -6083,6 +6122,78 @@ module WatchTests =
             |> should equal true
 
             Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true)
+
+    /// Verifies that a stale clean IPC file is not accepted when the attempted clean publication never reached disk.
+    [<Test>]
+    let ``watch clean publication verification rejects stale clean snapshot`` () =
+        withTempRepo (fun root ->
+            let staleCleanStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let staleDirectoryIds = HashSet<DirectoryVersionId>(staleCleanStatus.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile staleCleanStatus (Some staleDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let staleCleanJson = File.ReadAllText(Services.IpcFileName())
+            let filePath = Path.Combine(root, "blocked-clean-verification.txt")
+
+            use lockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            File.WriteAllText(filePath, "pending content")
+            Watch.OnChanged(changedEvent filePath)
+            lockedIpc.Dispose()
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal staleCleanJson
+
+            let freshCleanStatus = graceStatusTracking [| "blocked-clean-verification.txt" |] Array.empty<string>
+
+            /// Reads status needed by the stale clean verification scenario.
+            let readStatus () = Task.FromResult(freshCleanStatus)
+
+            /// Builds upload test data used to drain the queued file work.
+            let upload _ pendingFilePath =
+                recordUploadedFileVersion $"{pendingFilePath}"
+                Task.FromResult(())
+
+            /// Keeps status unchanged after pending upload work drains in the test scenario.
+            let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+            /// Keeps status unchanged after event-derived differences apply in the test scenario.
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+
+            /// Keeps incremental local-state side effects out of this IPC verification test.
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            /// Simulates the production writer swallowing a transient clean IPC write failure.
+            let blockedWriter _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                blockedWriter)
+                .GetAwaiter()
+                .GetResult()
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal staleCleanJson
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should not' (equal staleCleanJson)
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
             |> should equal false

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -214,6 +214,31 @@ module WatchTests =
         | false, _ -> None
         | true, _ -> None
 
+    /// Returns the same path text with one ASCII letter cased differently for root identity regressions.
+    let private requireDifferentlyCasedPath path =
+        let chars = $"{path}".ToCharArray()
+        let mutable changed = false
+        let mutable index = 0
+
+        while not changed && index < chars.Length do
+            if Char.IsAsciiLetter(chars[index]) then
+                let replacement =
+                    if Char.IsUpper(chars[index]) then
+                        Char.ToLowerInvariant(chars[index])
+                    else
+                        Char.ToUpperInvariant(chars[index])
+
+                if replacement <> chars[index] then
+                    chars[index] <- replacement
+                    changed <- true
+
+            index <- index + 1
+
+        if not changed then
+            Assert.Fail($"Expected path '{path}' to contain an ASCII letter whose casing can be changed.")
+
+        String(chars)
+
     /// Reads a boolean property from the persisted Watch IPC JSON contract.
     let private readWatchStatusJsonBooleanProperty (propertyName: string) =
         let json = File.ReadAllText(Services.IpcFileName())
@@ -7634,6 +7659,75 @@ module WatchTests =
 
                 Services.getGraceWatchStatus().Result
                 |> should equal None)
+
+    /// Verifies that root identity comparisons reject case-only path differences under case-sensitive semantics.
+    [<Test>]
+    let ``watch root identity comparison respects case-sensitive path semantics`` () =
+        let currentRoot = Path.Combine(Path.GetTempPath(), "grace-watch-root")
+        let persistedRoot = requireDifferentlyCasedPath currentRoot
+
+        Services.watchRootDirectoriesMatchWithComparison StringComparison.Ordinal persistedRoot currentRoot
+        |> should equal false
+
+        Services.watchRootDirectoriesMatchWithComparison StringComparison.OrdinalIgnoreCase persistedRoot currentRoot
+        |> should equal true
+
+    /// Verifies that Watch IPC root reuse rejects case-only root differences on case-sensitive repositories.
+    [<Test>]
+    let ``watch status root identity rejects case-only mismatch on case-sensitive repository`` () =
+        Services.setWatchRootPathCaseInsensitiveLookupForTests (fun _ -> false)
+
+        try
+            withTempRepo (fun tempDir ->
+                let rootDirectoryId = Guid.NewGuid()
+                let persistedRoot = requireDifferentlyCasedPath tempDir
+                let status = { liveWatchStatus rootDirectoryId with RootDirectory = persistedRoot }
+
+                writeWatchStatusJsonWithRuntimeSurface status
+                |> ignore
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsLiveProcess |> should equal true
+
+                inspection.IsUsable |> should equal false
+
+                Services.getGraceWatchStatus().Result
+                |> should equal None)
+        finally
+            Services.resetWatchRootPathCaseInsensitiveLookupForTests ()
+
+    /// Verifies that Watch IPC root reuse preserves case-insensitive repository behavior.
+    [<Test>]
+    let ``watch status root identity accepts case-only mismatch on case-insensitive repository`` () =
+        Services.setWatchRootPathCaseInsensitiveLookupForTests (fun _ -> true)
+
+        try
+            withTempRepo (fun tempDir ->
+                let rootDirectoryId = Guid.NewGuid()
+                let persistedRoot = requireDifferentlyCasedPath tempDir
+                let status = { liveWatchStatus rootDirectoryId with RootDirectory = persistedRoot }
+
+                writeWatchStatusJsonWithRuntimeSurface status
+                |> ignore
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsLiveProcess |> should equal true
+                inspection.IsUsable |> should equal true
+
+                Services.getGraceWatchStatus().Result
+                |> should not' (equal None))
+        finally
+            Services.resetWatchRootPathCaseInsensitiveLookupForTests ()
 
     /// Verifies that watch check exits zero when live watcher status exists.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5986,9 +5986,7 @@ module WatchTests =
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal true
 
-            Watch.setGraceStatusHasChangedForWatchTests true
-
-            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
             |> should equal true
@@ -5998,6 +5996,31 @@ module WatchTests =
 
             Services.getGraceWatchStatus().Result
             |> should equal None)
+
+    /// Verifies that a consumed GraceStatus refresh can publish clean IPC during the same timer tick.
+    [<Test>]
+    let ``watch grace status refresh clears pending flag before clean ipc publish`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests status Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal false)
 
     /// Verifies that startup catch-up publishes dirty IPC until the startup scan and apply path drains.
     [<Test>]
@@ -7644,6 +7667,12 @@ module WatchTests =
                 |]
 
             for mismatchedStatus in mismatchCases do
+                let statusLevelFlags = safetyFlagSet mismatchedStatus
+
+                statusLevelFlags
+                |> Set.contains "cleanWorkingTree"
+                |> should equal true
+
                 writeWatchStatusJsonWithRuntimeSurface mismatchedStatus
                 |> ignore
 
@@ -7656,6 +7685,20 @@ module WatchTests =
                 inspection.IsLiveProcess |> should equal true
 
                 inspection.IsUsable |> should equal false
+
+                let inspectionSafetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+                inspectionSafetyFlags
+                |> Set.contains "cleanWorkingTree"
+                |> should equal false
+
+                inspectionSafetyFlags
+                |> Set.contains "incrementalSafe"
+                |> should equal false
+
+                inspectionSafetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
 
                 Services.getGraceWatchStatus().Result
                 |> should equal None)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5574,6 +5574,39 @@ module WatchTests =
                 output
                 |> should not' (contain "Unable to acquire an access token for SignalR")))
 
+    /// Verifies that startup claim recognizes fresh legacy IPC instead of overwriting a live Watch file.
+    [<Test>]
+    let ``watch startup claim preserves fresh legacy status`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let legacyJson =
+                rootDirectoryId
+                |> liveWatchStatus
+                |> serialize
+                |> removeWatchStatusFieldsAddedForIssue492
+
+            let ipcFileName = Services.IpcFileName()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+            |> ignore
+
+            File.WriteAllText(ipcFileName, legacyJson)
+
+            let claimed =
+                Services
+                    .tryClaimGraceWatchInterprocessFile()
+                    .Result
+
+            claimed |> should equal false
+
+            File.ReadAllText(ipcFileName)
+            |> should equal legacyJson
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true)
+
     /// Verifies that watch startup claim replaces malformed stale ipc file.
     [<Test>]
     let ``watch startup claim replaces malformed stale ipc file`` () =
@@ -5899,6 +5932,38 @@ module WatchTests =
                 (Some directoryIds))
                 .GetAwaiter()
                 .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that a pending GraceStatus artifact refresh publishes dirty IPC before the timer reloads status.
+    [<Test>]
+    let ``watch grace status artifact change publishes dirty ipc`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
             |> should equal true
@@ -7538,6 +7603,37 @@ module WatchTests =
                 status.RootDirectoryBlake3Hash
                 |> should equal rootBlake3Hash
             | None -> Assert.Fail("Expected usable watch status with fallback root BLAKE3."))
+
+    /// Verifies that fresh clean Watch IPC must belong to the current repository, branch, and root before reuse.
+    [<Test>]
+    let ``watch status rejects clean non-legacy identity mismatches`` () =
+        withTempRepo (fun tempDir ->
+            let rootDirectoryId = Guid.NewGuid()
+            let baseStatus = liveWatchStatus rootDirectoryId
+
+            let mismatchCases =
+                [|
+                    { baseStatus with RepositoryId = Guid.NewGuid() }
+                    { baseStatus with BranchId = Guid.NewGuid() }
+                    { baseStatus with RootDirectory = Path.Combine(tempDir, "other-worktree") }
+                |]
+
+            for mismatchedStatus in mismatchCases do
+                writeWatchStatusJsonWithRuntimeSurface mismatchedStatus
+                |> ignore
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsLiveProcess |> should equal true
+
+                inspection.IsUsable |> should equal false
+
+                Services.getGraceWatchStatus().Result
+                |> should equal None)
 
     /// Verifies that watch check exits zero when live watcher status exists.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5997,6 +5997,38 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that a blocked dirty IPC write can retry while the GraceStatus refresh flag is already pending.
+    [<Test>]
+    let ``watch grace status artifact change retries dirty ipc while refresh is pending`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            use blockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            blockedIpc.Dispose()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
+
     /// Verifies that a consumed GraceStatus refresh can publish clean IPC during the same timer tick.
     [<Test>]
     let ``watch grace status refresh clears pending flag before clean ipc publish`` () =
@@ -6021,6 +6053,42 @@ module WatchTests =
             safetyFlags
             |> Set.contains "pendingWatchWork"
             |> should equal false)
+
+    /// Verifies that a blocked clean IPC refresh does not suppress the next clean transition retry.
+    [<Test>]
+    let ``watch grace status refresh retries clean ipc after blocked write`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus true
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            /// Simulates the production writer swallowing a transient IPC write failure without changing the file.
+            let blockedWriter _ _ = Task.FromResult(())
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests status blockedWriter)
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true)
 
     /// Verifies that startup catch-up publishes dirty IPC until the startup scan and apply path drains.
     [<Test>]
@@ -7745,7 +7813,7 @@ module WatchTests =
 
             inspectionSafetyFlags
             |> Set.contains "requiresExplicitResync"
-            |> should equal true)
+            |> should equal false)
 
     /// Verifies that root identity comparisons reject case-only path differences under case-sensitive semantics.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5632,6 +5632,37 @@ module WatchTests =
             |> Option.isSome
             |> should equal true)
 
+    /// Verifies that fresh Watch IPC from another repository identity does not block startup for the current worktree.
+    [<Test>]
+    let ``watch startup claim replaces fresh foreign identity status`` () =
+        withTempRepo (fun tempDir ->
+            let rootDirectoryId = Guid.NewGuid()
+            let baseStatus = liveWatchStatus rootDirectoryId
+
+            let foreignStatuses =
+                [|
+                    { baseStatus with RepositoryId = Guid.NewGuid() }
+                    { baseStatus with BranchId = Guid.NewGuid() }
+                    { baseStatus with RootDirectory = Path.Combine(tempDir, "other-worktree") }
+                |]
+
+            for foreignStatus in foreignStatuses do
+                writeWatchStatusJsonWithRuntimeSurface foreignStatus
+                |> ignore
+
+                let claimed =
+                    Services
+                        .tryClaimGraceWatchInterprocessFile()
+                        .Result
+
+                claimed |> should equal true
+
+                readWatchStatusJsonBooleanProperty "IsStartupClaim"
+                |> should equal true
+
+                Services.getGraceWatchStatus().Result
+                |> should equal None)
+
     /// Verifies that watch startup claim replaces malformed stale ipc file.
     [<Test>]
     let ``watch startup claim replaces malformed stale ipc file`` () =
@@ -6368,6 +6399,78 @@ module WatchTests =
 
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal true)
+
+    /// Verifies that a clean transition retries after a transient Grace Status read failure.
+    [<Test>]
+    let ``watch clean transition retries after status read failure`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus true
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                Task.FromException<GraceStatus>(InvalidOperationException("transient status read failure")))
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            match Services.getGraceWatchStatus().Result with
+            | Some publishedStatus ->
+                publishedStatus.RootDirectoryId
+                |> should equal status.RootDirectoryId
+            | None -> Assert.Fail("Expected trusted clean Watch IPC after the status read recovers."))
+
+    /// Verifies that dirty transitions still publish non-incremental IPC when Grace Status cannot be read.
+    [<Test>]
+    let ``watch dirty transition publishes non-incremental status after status read failure`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                Task.FromException<GraceStatus>(InvalidOperationException("transient status read failure")))
+
+            let filePath = Path.Combine(root, "dirty-read-failure.txt")
+            File.WriteAllText(filePath, "dirty transition content")
+            Watch.OnChanged(changedEvent filePath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
 
     /// Verifies that startup catch-up publishes dirty IPC until the startup scan and apply path drains.
     [<Test>]
@@ -8315,6 +8418,63 @@ module WatchTests =
             safetyFlags
             |> Set.contains "pendingStatusApply"
             |> should equal false)
+
+    /// Verifies that non-healthy current-repository recovery snapshots do not advertise apply-style pending drains.
+    [<Test>]
+    let ``watch check json strips pending apply for non-healthy dirty current status`` () =
+        withTempRepo (fun _ ->
+            for mode in
+                [|
+                    Services.GraceWatchRuntimeMode.Suspended
+                    Services.GraceWatchRuntimeMode.Resynchronizing
+                |] do
+                let rootDirectoryId = Guid.NewGuid()
+
+                let dirtyStatus = { liveWatchStatus rootDirectoryId with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+                safetyFlagSet dirtyStatus
+                |> Set.contains "pendingStatusApply"
+                |> should equal true
+
+                writeWatchStatusJsonWithPersistedMode mode dirtyStatus
+                |> ignore
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "watch"
+                                                      "--check" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+                let root = document.RootElement.GetProperty("ReturnValue")
+
+                root.GetProperty("Mode").GetString()
+                |> should equal $"{mode}"
+
+                root
+                    .GetProperty("CanUseIncrementalStatus")
+                    .GetBoolean()
+                |> should equal false
+
+                let safetyFlags =
+                    root.GetProperty("SafetyFlags").EnumerateArray()
+                    |> Seq.map (fun flag -> flag.GetString())
+                    |> Set.ofSeq
+
+                safetyFlags
+                |> Set.contains "pendingWatchWork"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "pendingStatusApply"
+                |> should equal false)
 
     /// Verifies that watch check select mode projects status fields and preserves live watcher status.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -150,6 +150,13 @@ module WatchTests =
         {
             UpdatedAt = getCurrentInstant ()
             IsStartupClaim = false
+            RepositoryId = RepositoryId.Empty
+            RepositoryName = RepositoryName String.Empty
+            BranchId = BranchId.Empty
+            BranchName = BranchName String.Empty
+            RootDirectory = Environment.CurrentDirectory
+            HasPendingWatchWork = false
+            IsWorkingTreeClean = true
             RootDirectoryId = rootDirectoryId
             RootDirectorySha256Hash = Sha256Hash "live-watch-root"
             RootDirectoryBlake3Hash = Blake3Hash "live-watch-root-blake3"
@@ -188,6 +195,17 @@ module WatchTests =
         | true, property when property.ValueKind <> JsonValueKind.Null -> Some(property.GetString())
         | false, _ -> None
         | true, _ -> None
+
+    /// Reads a boolean property from the persisted Watch IPC JSON contract.
+    let private readWatchStatusJsonBooleanProperty (propertyName: string) =
+        let json = File.ReadAllText(Services.IpcFileName())
+        use document = JsonDocument.Parse(json)
+
+        match document.RootElement.TryGetProperty(propertyName) with
+        | true, property -> property.GetBoolean()
+        | false, _ ->
+            Assert.Fail($"Expected Watch IPC JSON property '{propertyName}'. JSON:{Environment.NewLine}{json}")
+            false
 
     /// Reads the persisted Watch IPC safety flags into a deterministic set for assertions.
     let private readWatchStatusJsonSafetyFlags () =
@@ -5615,6 +5633,184 @@ module WatchTests =
             derivedSafetyFlags
             |> Set.contains "requiresExplicitResync"
             |> should equal true)
+
+    /// Verifies that watch status serializes the factual identity and clean fields branch-switch safety needs.
+    [<Test>]
+    let ``watch status serializes branch repository root identity and clean flags`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let configuration = Current()
+            configuration.RepositoryId <- repositoryId
+            configuration.RepositoryName <- "status-repo"
+            configuration.BranchId <- branchId
+            configuration.BranchName <- "status-branch"
+            configuration.RootDirectory <- root
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonStringProperty "RepositoryId"
+            |> should equal $"{repositoryId}"
+
+            readWatchStatusJsonStringProperty "RepositoryName"
+            |> should equal "status-repo"
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchId}"
+
+            readWatchStatusJsonStringProperty "BranchName"
+            |> should equal "status-branch"
+
+            readWatchStatusJsonStringProperty "RootDirectory"
+            |> should equal root
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal true
+
+            match Services.getGraceWatchStatus().Result with
+            | Some watchStatus ->
+                watchStatus.RepositoryId
+                |> should equal repositoryId
+
+                watchStatus.RepositoryName
+                |> should equal "status-repo"
+
+                watchStatus.BranchId |> should equal branchId
+
+                watchStatus.BranchName
+                |> should equal "status-branch"
+
+                watchStatus.RootDirectory |> should equal root
+
+                watchStatus.IsWorkingTreeClean
+                |> should equal true
+
+                watchStatus.HasPendingWatchWork
+                |> should equal false
+            | None -> Assert.Fail("Expected clean status to remain usable."))
+
+    /// Verifies that repeated raw events while already dirty do not rewrite Watch IPC status.
+    [<Test>]
+    let ``watch dirty status transition is not rewritten for repeated raw events`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let filePath = Path.Combine(root, "dirty-once.txt")
+            File.WriteAllText(filePath, "first content")
+
+            Watch.OnChanged(changedEvent filePath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            let dirtyJson = File.ReadAllText(Services.IpcFileName())
+
+            File.WriteAllText(filePath, "second content")
+            Watch.OnChanged(changedEvent filePath)
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal dirtyJson)
+
+    /// Verifies that processing pending Watch work publishes the dirty-to-clean IPC transition.
+    [<Test>]
+    let ``watch clean status transition is published after pending work drains`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let filePath = Path.Combine(root, "clean-after-process.txt")
+            File.WriteAllText(filePath, "pending content")
+            Watch.OnChanged(changedEvent filePath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+
+            /// Builds upload test data used to exercise CLI watch behavior.
+            let upload _ filePath =
+                recordUploadedFileVersion $"{filePath}"
+                Task.FromResult(())
+
+            /// Builds update grace status test data used to exercise CLI watch behavior.
+            let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+            /// Builds update grace status from differences test data used to exercise CLI watch behavior.
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal false
+
+            (Watch.pendingWatchWorkSnapshotForTests ())
+                .FilesToProcess
+            |> should equal Array.empty<string>)
 
     /// Verifies that watch status serializes compact safety flags without durable liveness-sensitive mode.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -7703,6 +7703,50 @@ module WatchTests =
                 Services.getGraceWatchStatus().Result
                 |> should equal None)
 
+    /// Verifies that unusable dirty Watch IPC keeps current-repo pending diagnostics after identity validation.
+    [<Test>]
+    let ``watch status preserves current repo pending apply when dirty snapshot is unusable`` () =
+        withTempRepo (fun _ ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let dirtyStatus = { liveWatchStatus rootDirectoryId with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let statusLevelFlags = safetyFlagSet dirtyStatus
+
+            statusLevelFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            statusLevelFlags
+            |> Set.contains "pendingStatusApply"
+            |> should equal true
+
+            writeWatchStatusJsonWithRuntimeSurface dirtyStatus
+            |> ignore
+
+            let inspection =
+                Services
+                    .inspectGraceWatchStatus()
+                    .GetAwaiter()
+                    .GetResult()
+
+            inspection.IsLiveProcess |> should equal true
+            inspection.IsUsable |> should equal false
+
+            let inspectionSafetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+            inspectionSafetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            inspectionSafetyFlags
+            |> Set.contains "pendingStatusApply"
+            |> should equal true
+
+            inspectionSafetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true)
+
     /// Verifies that root identity comparisons reject case-only path differences under case-sensitive semantics.
     [<Test>]
     let ``watch root identity comparison respects case-sensitive path semantics`` () =
@@ -7867,6 +7911,63 @@ module WatchTests =
 
             readFileIfExists ipcFileName
             |> should equal originalContents)
+
+    /// Verifies that watch check does not advertise pending apply from a dirty snapshot for another root.
+    [<Test>]
+    let ``watch check json strips pending apply for dirty root mismatch`` () =
+        withTempRepo (fun tempDir ->
+            let rootDirectoryId = Guid.NewGuid()
+
+            let dirtyMismatchedStatus =
+                { liveWatchStatus rootDirectoryId with
+                    RootDirectory = Path.Combine(tempDir, "other-worktree")
+                    HasPendingWatchWork = true
+                    IsWorkingTreeClean = false
+                }
+
+            safetyFlagSet dirtyMismatchedStatus
+            |> Set.contains "pendingStatusApply"
+            |> should equal true
+
+            writeWatchStatusJsonWithRuntimeSurface dirtyMismatchedStatus
+            |> ignore
+
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "watch"
+                                                  "--check" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement.GetProperty("ReturnValue")
+
+            root.GetProperty("IsRunning").GetBoolean()
+            |> should equal true
+
+            root
+                .GetProperty("CanUseIncrementalStatus")
+                .GetBoolean()
+            |> should equal false
+
+            let safetyFlags =
+                root.GetProperty("SafetyFlags").EnumerateArray()
+                |> Seq.map (fun flag -> flag.GetString())
+                |> Set.ofSeq
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "pendingStatusApply"
+            |> should equal false)
 
     /// Verifies that watch check select mode projects status fields and preserves live watcher status.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -6195,6 +6195,46 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that non-Watch status refreshes re-read live IPC before preserving clean state.
+    [<Test>]
+    let ``watch ipc non-watch update rechecks clean live state before write`` () =
+        withTempRepo (fun _ ->
+            let liveRootDirectoryId = Guid.NewGuid()
+            let initialCleanStatus = liveWatchStatus liveRootDirectoryId
+
+            writeWatchStatusJsonWithRuntimeSurface initialCleanStatus
+            |> ignore
+
+            let cleanStatusFromNonWatch = graceStatusTracking Array.empty<string> Array.empty<string>
+            let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
+
+            let publishDirtyLiveStatus () =
+                let dirtyLiveStatus = { initialCleanStatus with UpdatedAt = getCurrentInstant (); HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+                writeWatchStatusJsonWithRuntimeSurface dirtyLiveStatus
+                |> ignore
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFilePreservingLiveWorkStateAfterInspectionForWatchTests
+                publishDirtyLiveStatus
+                cleanStatusFromNonWatch
+                (Some cleanDirectoryIdsFromNonWatch))
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            readWatchStatusJsonStringProperty "RootDirectoryId"
+            |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}"
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
     /// Verifies that non-Watch status refreshes preserve same-repository non-incremental Watch state.
     [<Test>]
     let ``watch ipc non-watch update preserves current live recovery state`` () =
@@ -6234,6 +6274,50 @@ module WatchTests =
                     { graceStatusTracking Array.empty<string> Array.empty<string> with
                         RootDirectorySha256Hash = Sha256Hash $"current-non-watch-root-{modeText}"
                     }
+
+                let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFilePreservingLiveWorkState cleanStatusFromNonWatch (Some cleanDirectoryIdsFromNonWatch))
+                    .GetAwaiter()
+                    .GetResult()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal true
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal false
+
+                readWatchStatusJsonStringProperty "Mode"
+                |> should equal modeText
+
+                readWatchStatusJsonStringProperty "RootDirectoryId"
+                |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
+
+    /// Verifies that non-Watch status refreshes preserve same-branch legacy recovery snapshots.
+    [<Test>]
+    let ``watch ipc non-watch update preserves legacy recovery state with blank root identity`` () =
+        withTempRepo (fun _ ->
+            let liveRootDirectoryId = Guid.NewGuid()
+
+            for mode, modeText in
+                [|
+                    Services.GraceWatchRuntimeMode.Suspended, "suspended"
+                    Services.GraceWatchRuntimeMode.Resynchronizing, "resynchronizing"
+                |] do
+                let liveRecoveryStatus = { liveWatchStatus liveRootDirectoryId with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+                let ipcFileName = writeWatchStatusJsonWithPersistedMode mode liveRecoveryStatus
+
+                let legacyJson =
+                    File.ReadAllText(ipcFileName)
+                    |> removeWatchStatusFieldsAddedForIssue492
+
+                File.WriteAllText(ipcFileName, legacyJson)
+
+                let cleanStatusFromNonWatch =
+                    { graceStatusTracking Array.empty<string> Array.empty<string> with RootDirectorySha256Hash = Sha256Hash $"legacy-recovery-root-{modeText}" }
 
                 let cleanDirectoryIdsFromNonWatch = HashSet<DirectoryVersionId>(cleanStatusFromNonWatch.Index.Keys)
 
@@ -8269,6 +8353,58 @@ module WatchTests =
 
                 Services.getGraceWatchStatus().Result
                 |> should equal None)
+
+    /// Verifies that persisted HealthyIncremental mode cannot override missing derived root and directory data.
+    [<Test>]
+    let ``watch status rejects persisted healthy mode without derived root data`` () =
+        withTempRepo (fun _ ->
+            let emptyRootStatus =
+                { liveWatchStatus Guid.Empty with
+                    RootDirectoryId = Guid.Empty
+                    RootDirectorySha256Hash = Sha256Hash String.Empty
+                    RootDirectoryBlake3Hash = Blake3Hash String.Empty
+                    DirectoryIds = HashSet<DirectoryVersionId>()
+                    HasPendingWatchWork = false
+                    IsWorkingTreeClean = true
+                }
+
+            writeWatchStatusJsonWithPersistedMode Services.GraceWatchRuntimeMode.HealthyIncremental emptyRootStatus
+            |> ignore
+
+            let inspection =
+                Services
+                    .inspectGraceWatchStatus()
+                    .GetAwaiter()
+                    .GetResult()
+
+            inspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.HealthyIncremental)
+
+            match inspection.Status with
+            | Some status ->
+                status.Mode
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+            | None -> Assert.Fail("Expected readable Watch IPC status.")
+
+            inspection.IsLiveProcess |> should equal true
+            inspection.IsUsable |> should equal false
+
+            let inspectionSafetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+            inspectionSafetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal false
+
+            inspectionSafetyFlags
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            inspectionSafetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
 
     /// Verifies that unusable dirty Watch IPC keeps current-repo pending diagnostics after identity validation.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -147,14 +147,16 @@ module WatchTests =
 
     /// Builds a healthy live Watch status snapshot for IPC compatibility tests.
     let private liveWatchStatus rootDirectoryId : Services.GraceWatchStatus =
+        let current = Current()
+
         {
             UpdatedAt = getCurrentInstant ()
             IsStartupClaim = false
-            RepositoryId = RepositoryId.Empty
-            RepositoryName = RepositoryName String.Empty
-            BranchId = BranchId.Empty
-            BranchName = BranchName String.Empty
-            RootDirectory = Environment.CurrentDirectory
+            RepositoryId = current.RepositoryId
+            RepositoryName = RepositoryName current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = BranchName current.BranchName
+            RootDirectory = current.RootDirectory
             HasPendingWatchWork = false
             IsWorkingTreeClean = true
             RootDirectoryId = rootDirectoryId
@@ -356,6 +358,12 @@ module WatchTests =
             Environment.CurrentDirectory <- tempDir
             Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
             resetConfiguration ()
+            let configuration = Current()
+            configuration.RepositoryId <- Guid.NewGuid()
+            configuration.RepositoryName <- "watch-test-repository"
+            configuration.BranchId <- Guid.NewGuid()
+            configuration.BranchName <- "watch-test-branch"
+            configuration.RootDirectory <- tempDir
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
             deleteWatchStatusFileIfExists ()
@@ -5716,9 +5724,9 @@ module WatchTests =
             readWatchStatusJsonStringProperty "RootDirectory"
             |> should equal root)
 
-    /// Verifies that startup claim recognizes fresh legacy IPC instead of overwriting a live Watch file.
+    /// Verifies that startup claim can replace legacy IPC that lacks current identity authority.
     [<Test>]
-    let ``watch startup claim preserves fresh legacy status`` () =
+    let ``watch startup claim replaces fresh legacy status without current identity`` () =
         withTempRepo (fun _ ->
             let rootDirectoryId = Guid.NewGuid()
 
@@ -5740,14 +5748,13 @@ module WatchTests =
                     .tryClaimGraceWatchInterprocessFile()
                     .Result
 
-            claimed |> should equal false
+            claimed |> should equal true
 
             File.ReadAllText(ipcFileName)
-            |> should equal legacyJson
+            |> should not' (equal legacyJson)
 
             Services.getGraceWatchStatus().Result
-            |> Option.isSome
-            |> should equal true)
+            |> should equal None)
 
     /// Verifies that fresh Watch IPC from another repository identity does not block startup for the current worktree.
     [<Test>]
@@ -6521,7 +6528,9 @@ module WatchTests =
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
             |> should equal true
 
-            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests status Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
             |> should equal false
@@ -7070,9 +7079,9 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
-    /// Verifies that legacy watch status json without compact runtime or clean fields remains readable.
+    /// Verifies that legacy watch status json without identity remains readable but cannot grant clean authority.
     [<Test>]
-    let ``watch status reads legacy json without runtime mode or clean fields`` () =
+    let ``watch status reads legacy json without identity as non-authoritative`` () =
         withTempRepo (fun _ ->
             let rootDirectoryId = Guid.NewGuid()
 
@@ -7117,22 +7126,21 @@ module WatchTests =
 
             File.WriteAllText(ipcFileName, legacyJson)
 
-            match Services.getGraceWatchStatus().Result with
-            | Some status ->
-                status.RootDirectoryId
-                |> should equal rootDirectoryId
+            let inspection = Services.inspectGraceWatchStatus().Result
 
-                status.Mode
-                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+            inspection.Status
+            |> Option.isSome
+            |> should equal true
 
-                safetyFlagSet status
-                |> Set.contains "incrementalSafe"
-                |> should equal true
+            inspection.IsUsable |> should equal false
 
-                status.IsWorkingTreeClean |> should equal true
+            inspection.SafetyFlags
+            |> Set.ofArray
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
 
-                status.HasPendingWatchWork |> should equal false
-            | None -> Assert.Fail("Expected legacy watch status JSON to remain usable."))
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
 
     /// Verifies that incomplete watch status requests explicit resync instead of advertising incremental safety.
     [<Test>]
@@ -7887,6 +7895,106 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that a newer Grace Status refresh observed during publication survives for the next timer pass.
+    [<Test>]
+    let ``newer status refresh observed during clean publication remains pending`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            let status =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "refresh-race-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "refresh-race-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            /// Tracks IPC writes so the concurrent refresh can force a dirty retry publication.
+            let mutable updateCalls = 0
+
+            /// Publishes IPC and observes a newer Grace Status DB refresh during the first clean attempt.
+            let updateIpc publishedStatus publishedDirectoryIds =
+                updateCalls <- updateCalls + 1
+
+                if updateCalls = 1 then Watch.setGraceStatusHasChangedForWatchTests true
+
+                Services.updateGraceWatchInterprocessFile publishedStatus publishedDirectoryIds
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests status updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            updateCalls |> should equal 2
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal true
+
+            let persistedStatus = Services.inspectGraceWatchStatus().Result.Status
+
+            match persistedStatus with
+            | Some watchStatus ->
+                watchStatus.HasPendingWatchWork
+                |> should equal true
+
+                watchStatus.IsWorkingTreeClean
+                |> should equal false
+
+                watchStatus.DirectoryIds.SetEquals(directoryIds)
+                |> should equal true
+            | None -> Assert.Fail("Expected dirty retry Watch IPC after concurrent refresh."))
+
+    /// Verifies that clean and dirty transition publication reads do not replace the timer pass's in-flight state.
+    [<Test>]
+    let ``pending work transition publication does not mutate in-flight status`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let inFlightStatus =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "in-flight-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "in-flight-root-blake3"
+                }
+
+            let transitionStatus =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "transition-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "transition-root-blake3"
+                }
+
+            let inFlightRootDirectoryId = inFlightStatus.RootDirectoryId
+            let transitionRootDirectoryId = transitionStatus.RootDirectoryId
+            let inFlightDirectoryIds = HashSet<DirectoryVersionId>(inFlightStatus.Index.Keys)
+
+            Watch.setGraceStatusForWatchTests inFlightStatus
+            Watch.updateGraceStatusDirectoryIds inFlightStatus
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(transitionStatus))
+
+            (Services.updateGraceWatchInterprocessFile inFlightStatus (Some inFlightDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setGraceStatusHasChangedForWatchTests true
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            Watch.graceStatusForWatchTests().RootDirectoryId
+            |> should equal inFlightRootDirectoryId
+
+            Watch
+                .graceStatusDirectoryIdsForWatchTests()
+                .SetEquals(inFlightDirectoryIds)
+            |> should equal true
+
+            let persistedStatus = Services.inspectGraceWatchStatus().Result.Status
+
+            match persistedStatus with
+            | Some watchStatus ->
+                watchStatus.RootDirectoryId
+                |> should equal transitionRootDirectoryId
+
+                watchStatus.HasPendingWatchWork
+                |> should equal true
+            | None -> Assert.Fail("Expected transition IPC to publish from the local transition read."))
+
     /// Verifies that overflow during an in-flight upload cancels normal status application.
     [<Test>]
     let ``overflow during upload prevents stale observation commit`` () =
@@ -8353,6 +8461,72 @@ module WatchTests =
 
                 Services.getGraceWatchStatus().Result
                 |> should equal None)
+
+    /// Verifies that persisted repository and branch ids are the authoritative Watch IPC identity.
+    [<Test>]
+    let ``watch status accepts current ids with stale display names`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { liveWatchStatus rootDirectoryId with
+                    RepositoryId = currentRepositoryId
+                    RepositoryName = RepositoryName "stale-repo-name"
+                    BranchId = currentBranchId
+                    BranchName = BranchName "stale-branch-name"
+                    RootDirectory = root
+                }
+
+            writeWatchStatusJsonWithRuntimeSurface status
+            |> ignore
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.HasCurrentRepositoryIdentity
+            |> should equal true
+
+            inspection.IsUsable |> should equal true
+
+            Services.getGraceWatchStatus().Result
+            |> Option.isSome
+            |> should equal true)
+
+    /// Verifies that stale non-empty ids cannot be rescued by matching display names.
+    [<Test>]
+    let ``watch status rejects mismatched ids even when display names match`` () =
+        withTempRepo (fun root ->
+            configureCurrentWatchIdentity root "current-repo" "current-branch"
+            |> ignore
+
+            let rootDirectoryId = Guid.NewGuid()
+
+            let status =
+                { liveWatchStatus rootDirectoryId with
+                    RepositoryId = Guid.NewGuid()
+                    RepositoryName = RepositoryName "current-repo"
+                    BranchId = Guid.NewGuid()
+                    BranchName = BranchName "current-branch"
+                    RootDirectory = root
+                }
+
+            writeWatchStatusJsonWithRuntimeSurface status
+            |> ignore
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.HasCurrentRepositoryIdentity
+            |> should equal false
+
+            inspection.IsUsable |> should equal false
+
+            inspection.SafetyFlags
+            |> Set.ofArray
+            |> Set.contains "cleanWorkingTree"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
 
     /// Verifies that persisted HealthyIncremental mode cannot override missing derived root and directory data.
     [<Test>]

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -4029,7 +4029,7 @@ module Branch =
 
                                             let! result = uploadNewDirectoryVersions branchDto newDirectoryVersions
                                             do! writeGraceStatusFile updatedGraceStatus
-                                            do! updateGraceWatchInterprocessFile updatedGraceStatus None
+                                            do! updateGraceWatchInterprocessFilePreservingLiveWorkState updatedGraceStatus None
                                             newGraceStatus <- updatedGraceStatus
 
                                         | Error error -> logToAnsiConsole Colors.Error (Markup.Escape($"{error}"))

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -306,7 +306,7 @@ module Services =
 
                 let rootDirectoryMatchesCurrent =
                     if String.IsNullOrWhiteSpace(status.RootDirectory) then
-                        true
+                        false
                     else
                         try
                             watchRootDirectoriesMatchWithComparison
@@ -316,14 +316,22 @@ module Services =
                         with
                         | _ -> false
 
-                (status.RepositoryId = RepositoryId.Empty
-                 || status.RepositoryId = current.RepositoryId)
-                && (String.IsNullOrWhiteSpace(string status.RepositoryName)
-                    || String.Equals(string status.RepositoryName, current.RepositoryName, StringComparison.OrdinalIgnoreCase))
-                && (status.BranchId = BranchId.Empty
-                    || status.BranchId = current.BranchId)
-                && (String.IsNullOrWhiteSpace(string status.BranchName)
-                    || String.Equals(string status.BranchName, current.BranchName, StringComparison.OrdinalIgnoreCase))
+                let repositoryIdentityMatches =
+                    if status.RepositoryId <> RepositoryId.Empty then
+                        status.RepositoryId = current.RepositoryId
+                    else
+                        not (String.IsNullOrWhiteSpace(string status.RepositoryName))
+                        && String.Equals(string status.RepositoryName, current.RepositoryName, StringComparison.OrdinalIgnoreCase)
+
+                let branchIdentityMatches =
+                    if status.BranchId <> BranchId.Empty then
+                        status.BranchId = current.BranchId
+                    else
+                        not (String.IsNullOrWhiteSpace(string status.BranchName))
+                        && String.Equals(string status.BranchName, current.BranchName, StringComparison.OrdinalIgnoreCase)
+
+                repositoryIdentityMatches
+                && branchIdentityMatches
                 && rootDirectoryMatchesCurrent
             | _ -> false
 
@@ -341,10 +349,11 @@ module Services =
         /// Reports whether live Watch state has enough persisted identity to be preserved by another command.
         member this.HasCurrentLiveWatchStateIdentity =
             match this.Status, this.EffectiveMode with
-            | Some status, Some _ ->
+            | Some _, Some effectiveMode ->
                 this.HasCurrentRepositoryIdentity
-                && (not (String.IsNullOrWhiteSpace(status.RootDirectory))
-                    || this.HasLegacyLiveWatchStateIdentity)
+                || (effectiveMode
+                    <> GraceWatchRuntimeMode.HealthyIncremental
+                    && this.HasLegacyLiveWatchStateIdentity)
             | _ -> false
 
         /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -298,8 +298,8 @@ module Services =
                     .Minus(Duration.FromMinutes(5.0))
             | None -> false
 
-        /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.
-        member this.IsUsable =
+        /// Reports whether the IPC snapshot belongs to the current repository identity before trust checks.
+        member this.HasCurrentRepositoryIdentity =
             match this.Status, this.EffectiveMode with
             | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
                 let current = Current()
@@ -316,16 +316,23 @@ module Services =
                         with
                         | _ -> false
 
-                this.IsFresh
-                && not status.IsStartupClaim
-                && status.IsWorkingTreeClean
-                && not status.HasPendingWatchWork
-                && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
+                status.Mode = GraceWatchRuntimeMode.HealthyIncremental
                 && (status.RepositoryId = RepositoryId.Empty
                     || status.RepositoryId = current.RepositoryId)
                 && (status.BranchId = BranchId.Empty
                     || status.BranchId = current.BranchId)
                 && rootDirectoryMatchesCurrent
+            | _ -> false
+
+        /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.
+        member this.IsUsable =
+            match this.Status, this.EffectiveMode with
+            | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                this.IsFresh
+                && not status.IsStartupClaim
+                && status.IsWorkingTreeClean
+                && not status.HasPendingWatchWork
+                && this.HasCurrentRepositoryIdentity
             | _ -> false
 
         /// Reports whether a fresh Watch process appears to own the IPC file even when shortcuts are unavailable.
@@ -346,6 +353,11 @@ module Services =
     let private isCleanShortcutSafetyFlag safetyFlag =
         String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)
         || String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal)
+
+    /// Reports whether a compact Watch safety flag depends on current-repository identity validation.
+    let private isIdentitySensitiveSafetyFlag safetyFlag =
+        isCleanShortcutSafetyFlag safetyFlag
+        || String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)
 
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
     let private safetyFlagsForGraceWatchStatusContract persistedModeOverride (status: GraceWatchStatus) =
@@ -379,7 +391,12 @@ module Services =
         else
             let safetyFlags =
                 inspection.SafetyFlags
-                |> Array.filter (isCleanShortcutSafetyFlag >> not)
+                |> Array.filter (
+                    if inspection.HasCurrentRepositoryIdentity then
+                        isCleanShortcutSafetyFlag >> not
+                    else
+                        isIdentitySensitiveSafetyFlag >> not
+                )
 
             if safetyFlags
                |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "requiresExplicitResync", StringComparison.Ordinal)) then

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -327,12 +327,24 @@ module Services =
                 && rootDirectoryMatchesCurrent
             | _ -> false
 
+        /// Reports whether a recovery snapshot came from a same-branch legacy Watch writer without root identity fields.
+        member private this.HasLegacyLiveWatchStateIdentity =
+            match this.Status with
+            | Some status ->
+                String.IsNullOrWhiteSpace(status.RootDirectory)
+                && status.RepositoryId = RepositoryId.Empty
+                && String.IsNullOrWhiteSpace(string status.RepositoryName)
+                && status.BranchId = BranchId.Empty
+                && String.IsNullOrWhiteSpace(string status.BranchName)
+            | None -> false
+
         /// Reports whether live Watch state has enough persisted identity to be preserved by another command.
         member this.HasCurrentLiveWatchStateIdentity =
             match this.Status, this.EffectiveMode with
             | Some status, Some _ ->
-                not (String.IsNullOrWhiteSpace(status.RootDirectory))
-                && this.HasCurrentRepositoryIdentity
+                this.HasCurrentRepositoryIdentity
+                && (not (String.IsNullOrWhiteSpace(status.RootDirectory))
+                    || this.HasLegacyLiveWatchStateIdentity)
             | _ -> false
 
         /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.
@@ -341,6 +353,7 @@ module Services =
             | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
                 this.IsFresh
                 && not status.IsStartupClaim
+                && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
                 && status.IsWorkingTreeClean
                 && not status.HasPendingWatchWork
                 && this.HasCurrentRepositoryIdentity
@@ -416,6 +429,7 @@ module Services =
                 | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
                     inspection.IsFresh
                     && not status.IsStartupClaim
+                    && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
                     && inspection.HasCurrentRepositoryIdentity
                     && (status.HasPendingWatchWork
                         || not status.IsWorkingTreeClean)
@@ -2612,22 +2626,26 @@ module Services =
     let private writeGraceWatchStatus fileMode graceWatchStatus = writeGraceWatchStatusWithPersistedMode None fileMode graceWatchStatus
 
     /// Writes Grace Watch IPC content after converting the current Grace status snapshot.
-    let private updateGraceWatchInterprocessFileCore
+    let private writeGraceWatchInterprocessFileSnapshotUnderGate
         persistedModeOverride
         pendingWorkOverride
         (graceStatus: GraceStatus)
         (directoryIdsOverride: HashSet<DirectoryVersionId> option)
         =
+        let newGraceWatchStatus = createGraceWatchStatusWithPendingWork pendingWorkOverride graceStatus directoryIdsOverride
+        //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
+        //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
+
+        writeGraceWatchStatusWithPersistedModeCore persistedModeOverride FileMode.Create newGraceWatchStatus
+
+    /// Writes Grace Watch IPC content after converting the current Grace status snapshot.
+    let private updateGraceWatchInterprocessFileCore persistedModeOverride pendingWorkOverride graceStatus directoryIdsOverride =
         task {
             try
                 do! graceWatchStatusWriteGate.WaitAsync()
 
                 try
-                    let newGraceWatchStatus = createGraceWatchStatusWithPendingWork pendingWorkOverride graceStatus directoryIdsOverride
-                    //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
-                    //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
-
-                    do! writeGraceWatchStatusWithPersistedModeCore persistedModeOverride FileMode.Create newGraceWatchStatus
+                    do! writeGraceWatchInterprocessFileSnapshotUnderGate persistedModeOverride pendingWorkOverride graceStatus directoryIdsOverride
                 finally
                     graceWatchStatusWriteGate.Release() |> ignore
 
@@ -2643,48 +2661,85 @@ module Services =
     let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
         updateGraceWatchInterprocessFileCore None None graceStatus directoryIdsOverride
 
+    /// Selects the live Watch pending and mode facts that a non-Watch writer must not erase.
+    let private liveWorkPreservationFromInspection (inspection: GraceWatchStatusInspection) =
+        let shouldPreserveLiveWork =
+            inspection.IsLiveProcess
+            && match inspection.EffectiveMode with
+               | Some GraceWatchRuntimeMode.HealthyIncremental ->
+                   match inspection.Status with
+                   | Some status when status.Mode = GraceWatchRuntimeMode.HealthyIncremental -> inspection.HasCurrentRepositoryIdentity
+                   | _ -> false
+               | Some GraceWatchRuntimeMode.StartingUp
+               | Some GraceWatchRuntimeMode.Suspended
+               | Some GraceWatchRuntimeMode.Resynchronizing
+               | Some GraceWatchRuntimeMode.Stopping -> inspection.HasCurrentLiveWatchStateIdentity
+               | Some _ -> inspection.HasCurrentLiveWatchStateIdentity
+               | None -> false
+
+        let pendingWorkOverride =
+            if shouldPreserveLiveWork then
+                match inspection.Status, inspection.EffectiveMode with
+                | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                    Some(
+                        status.HasPendingWatchWork
+                        || not status.IsWorkingTreeClean
+                    )
+                | Some _, Some _ -> Some true
+                | _ -> None
+            else
+                None
+
+        let persistedModeOverride =
+            if shouldPreserveLiveWork then
+                match inspection.EffectiveMode with
+                | Some GraceWatchRuntimeMode.StartingUp
+                | Some GraceWatchRuntimeMode.Suspended
+                | Some GraceWatchRuntimeMode.Resynchronizing
+                | Some GraceWatchRuntimeMode.Stopping -> inspection.EffectiveMode
+                | _ -> None
+            else
+                None
+
+        persistedModeOverride, pendingWorkOverride
+
+    /// Updates Watch IPC identity fields without turning live Watch pending or recovery state into a clean shortcut.
+    let private updateGraceWatchInterprocessFilePreservingLiveWorkStateCore beforeWriteBoundary graceStatus directoryIdsOverride =
+        task {
+            let! _ = inspectGraceWatchStatus ()
+
+            try
+                do! graceWatchStatusWriteGate.WaitAsync()
+
+                try
+                    beforeWriteBoundary ()
+
+                    let! boundaryInspection = inspectGraceWatchStatus ()
+                    let persistedModeOverride, pendingWorkOverride = liveWorkPreservationFromInspection boundaryInspection
+
+                    do! writeGraceWatchInterprocessFileSnapshotUnderGate persistedModeOverride pendingWorkOverride graceStatus directoryIdsOverride
+                finally
+                    graceWatchStatusWriteGate.Release() |> ignore
+
+                logToAnsiConsole Colors.Important $"Wrote inter-process communication file."
+            with
+            | ex ->
+                logToAnsiConsole Colors.Error $"Exception in updateGraceWatchInterprocessFile."
+                logToAnsiConsole Colors.Error $"ex.GetType: {ex.GetType().FullName}{Environment.NewLine}{Environment.NewLine}"
+                logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
+        }
+
     /// Updates Watch IPC identity fields without turning live Watch pending or recovery state into a clean shortcut.
     let updateGraceWatchInterprocessFilePreservingLiveWorkState (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
-        task {
-            let! inspection = inspectGraceWatchStatus ()
+        updateGraceWatchInterprocessFilePreservingLiveWorkStateCore ignore graceStatus directoryIdsOverride
 
-            let shouldPreserveLiveWork =
-                inspection.IsLiveProcess
-                && match inspection.EffectiveMode with
-                   | Some GraceWatchRuntimeMode.HealthyIncremental -> inspection.HasCurrentRepositoryIdentity
-                   | Some GraceWatchRuntimeMode.StartingUp
-                   | Some GraceWatchRuntimeMode.Suspended
-                   | Some GraceWatchRuntimeMode.Resynchronizing
-                   | Some GraceWatchRuntimeMode.Stopping -> inspection.HasCurrentLiveWatchStateIdentity
-                   | Some _ -> inspection.HasCurrentLiveWatchStateIdentity
-                   | None -> false
-
-            let pendingWorkOverride =
-                if shouldPreserveLiveWork then
-                    match inspection.Status, inspection.EffectiveMode with
-                    | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
-                        Some(
-                            status.HasPendingWatchWork
-                            || not status.IsWorkingTreeClean
-                        )
-                    | Some _, Some _ -> Some true
-                    | _ -> None
-                else
-                    None
-
-            let persistedModeOverride =
-                if shouldPreserveLiveWork then
-                    match inspection.EffectiveMode with
-                    | Some GraceWatchRuntimeMode.StartingUp
-                    | Some GraceWatchRuntimeMode.Suspended
-                    | Some GraceWatchRuntimeMode.Resynchronizing
-                    | Some GraceWatchRuntimeMode.Stopping -> inspection.EffectiveMode
-                    | _ -> None
-                else
-                    None
-
-            do! updateGraceWatchInterprocessFileCore persistedModeOverride pendingWorkOverride graceStatus directoryIdsOverride
-        }
+    /// Exercises the non-Watch IPC write boundary after a test-controlled live Watch status change.
+    let internal updateGraceWatchInterprocessFilePreservingLiveWorkStateAfterInspectionForWatchTests
+        beforeWriteBoundary
+        (graceStatus: GraceStatus)
+        (directoryIdsOverride: HashSet<DirectoryVersionId> option)
+        =
+        updateGraceWatchInterprocessFilePreservingLiveWorkStateCore beforeWriteBoundary graceStatus directoryIdsOverride
 
     /// Exercises the gated Watch IPC write boundary after a test-controlled pending-work state change.
     let internal updateGraceWatchInterprocessFileAfterPendingWorkProbeForWatchTests

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -370,6 +370,17 @@ module Services =
         isCleanShortcutSafetyFlag safetyFlag
         || String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)
 
+    /// Reports whether a compact Watch safety flag should be kept after inspection trust checks.
+    let private isAllowedInspectedSafetyFlag isCurrentRepositoryLiveDirtySnapshot hasCurrentRepositoryIdentity safetyFlag =
+        if isCleanShortcutSafetyFlag safetyFlag then
+            false
+        elif String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal) then
+            isCurrentRepositoryLiveDirtySnapshot
+        elif hasCurrentRepositoryIdentity then
+            true
+        else
+            not (isIdentitySensitiveSafetyFlag safetyFlag)
+
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
     let private safetyFlagsForGraceWatchStatusContract persistedModeOverride (status: GraceWatchStatus) =
         let safetyFlags =
@@ -412,12 +423,7 @@ module Services =
 
             let safetyFlags =
                 inspection.SafetyFlags
-                |> Array.filter (
-                    if inspection.HasCurrentRepositoryIdentity then
-                        isCleanShortcutSafetyFlag >> not
-                    else
-                        isIdentitySensitiveSafetyFlag >> not
-                )
+                |> Array.filter (isAllowedInspectedSafetyFlag isCurrentRepositoryLiveDirtySnapshot inspection.HasCurrentRepositoryIdentity)
 
             if safetyFlags
                |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "requiresExplicitResync", StringComparison.Ordinal)) then
@@ -2738,7 +2744,17 @@ module Services =
 
                         let existingGraceWatchStatus = deserializeNormalizedGraceWatchStatus json
 
-                        if isGraceWatchStatusFresh existingGraceWatchStatus then
+                        let existingGraceWatchInspection =
+                            {
+                                Exists = true
+                                Status = Some existingGraceWatchStatus
+                                PersistedMode = tryReadGraceWatchPersistedMode json
+                                SafetyFlags = existingGraceWatchStatus.SafetyFlags
+                                ReadError = None
+                            }
+
+                        if isGraceWatchStatusFresh existingGraceWatchStatus
+                           && existingGraceWatchInspection.HasCurrentRepositoryIdentity then
                             return false
                         else
                             do! writeClaimToExistingFile fileStream

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -342,6 +342,11 @@ module Services =
         || String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal)
         || String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)
 
+    /// Reports whether a compact Watch safety flag would let a command skip local status verification.
+    let private isCleanShortcutSafetyFlag safetyFlag =
+        String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)
+        || String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal)
+
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
     let private safetyFlagsForGraceWatchStatusContract persistedModeOverride (status: GraceWatchStatus) =
         let safetyFlags =
@@ -366,6 +371,25 @@ module Services =
             |> Array.append nonIncrementalFlags
             |> Array.distinct
         | _ -> safetyFlags
+
+    /// Removes clean shortcut claims from inspected IPC when current repository identity makes the snapshot unusable.
+    let private safetyFlagsForGraceWatchStatusInspection (inspection: GraceWatchStatusInspection) =
+        if inspection.IsUsable then
+            inspection.SafetyFlags
+        else
+            let safetyFlags =
+                inspection.SafetyFlags
+                |> Array.filter (isCleanShortcutSafetyFlag >> not)
+
+            if safetyFlags
+               |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "requiresExplicitResync", StringComparison.Ordinal)) then
+                safetyFlags
+            else
+                [|
+                    yield! safetyFlags
+                    "requiresExplicitResync"
+                |]
+                |> Array.distinct
 
     /// Selects only durable compact modes for persisted IPC JSON so liveness must be derived from the raw status data.
     let private modeForGraceWatchStatusContract (status: GraceWatchStatus) =
@@ -2400,7 +2424,7 @@ module Services =
 
                     let status = deserializeNormalizedGraceWatchStatus json
 
-                    return
+                    let inspection =
                         {
                             Exists = true
                             Status = Some status
@@ -2408,6 +2432,8 @@ module Services =
                             SafetyFlags = status.SafetyFlags
                             ReadError = None
                         }
+
+                    return { inspection with SafetyFlags = safetyFlagsForGraceWatchStatusInspection inspection }
                 with
                 | _ ->
                     return

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -81,6 +81,61 @@ module Services =
         /// Grace Watch is shutting down and should not be treated as a live incremental source.
         | Stopping = 4
 
+    /// Checks whether the repository root resolves differently-cased names to the same file.
+    let private detectWatchRootPathCaseInsensitiveLookup (rootDirectory: string) =
+        let mutable probePath = String.Empty
+        let mutable alternateProbePath = String.Empty
+
+        try
+            try
+                let probeDirectory = Path.Combine(rootDirectory, Constants.GraceConfigDirectory)
+
+                Directory.CreateDirectory(probeDirectory)
+                |> ignore
+
+                let probeName = $"grace-watch-root-case-probe-{Guid.NewGuid():N}"
+                probePath <- Path.Combine(probeDirectory, probeName.ToLowerInvariant())
+                alternateProbePath <- Path.Combine(probeDirectory, probeName.ToUpperInvariant())
+
+                File.WriteAllText(probePath, String.Empty)
+                File.Exists(alternateProbePath)
+            with
+            | _ -> OperatingSystem.IsWindows()
+        finally
+            for path in [| probePath; alternateProbePath |] do
+                try
+                    if
+                        not (String.IsNullOrWhiteSpace(path))
+                        && File.Exists(path)
+                    then
+                        File.Delete(path)
+                with
+                | _ -> ()
+
+    let mutable private watchRootPathCaseInsensitiveLookup = detectWatchRootPathCaseInsensitiveLookup
+
+    /// Chooses the root path identity comparison used when trusting Watch IPC snapshots.
+    let private watchRootPathComparisonForRepository rootDirectory =
+        if watchRootPathCaseInsensitiveLookup rootDirectory then
+            StringComparison.OrdinalIgnoreCase
+        else
+            StringComparison.Ordinal
+
+    /// Compares normalized repository root paths using the supplied repository path identity semantics.
+    let internal watchRootDirectoriesMatchWithComparison comparison persistedRootDirectory currentRootDirectory =
+        let normalizeRootDirectory (rootDirectory: string) =
+            Path
+                .GetFullPath(rootDirectory)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+        String.Equals(normalizeRootDirectory persistedRootDirectory, normalizeRootDirectory currentRootDirectory, comparison)
+
+    /// Installs root path case lookup behavior used by Watch IPC identity tests.
+    let internal setWatchRootPathCaseInsensitiveLookupForTests detector = watchRootPathCaseInsensitiveLookup <- detector
+
+    /// Restores the production root path case lookup behavior after Watch IPC identity tests.
+    let internal resetWatchRootPathCaseInsensitiveLookupForTests () = watchRootPathCaseInsensitiveLookup <- detectWatchRootPathCaseInsensitiveLookup
+
     /// GraceWatchStatus defines the schema for the inter-process communication (IPC) file that lets Grace know if `grace watch` is already running.
     ///
     /// It's written by `grace watch`. It holds everything required to allow other instances of Grace to skip checking current status.
@@ -254,16 +309,10 @@ module Services =
                         true
                     else
                         try
-                            let normalizeRootDirectory (rootDirectory: string) =
-                                Path
-                                    .GetFullPath(rootDirectory)
-                                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-
-                            String.Equals(
-                                normalizeRootDirectory status.RootDirectory,
-                                normalizeRootDirectory current.RootDirectory,
-                                StringComparison.OrdinalIgnoreCase
-                            )
+                            watchRootDirectoriesMatchWithComparison
+                                (watchRootPathComparisonForRepository current.RootDirectory)
+                                status.RootDirectory
+                                current.RootDirectory
                         with
                         | _ -> false
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2493,9 +2493,16 @@ module Services =
         }
 
     /// Builds the persisted Grace Watch status snapshot used by check and startup coordination.
-    let private createGraceWatchStatus (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+    let private createGraceWatchStatusWithPendingWork
+        (pendingWorkOverride: bool option)
+        (graceStatus: GraceStatus)
+        (directoryIdsOverride: HashSet<DirectoryVersionId> option)
+        =
         let current = Current()
-        let hasPendingWatchWork = hasGraceWatchPendingWorkForStatus ()
+
+        let hasPendingWatchWork =
+            pendingWorkOverride
+            |> Option.defaultWith hasGraceWatchPendingWorkForStatus
 
         let directoryIds =
             match directoryIdsOverride with
@@ -2529,6 +2536,9 @@ module Services =
             LastDirectoryVersionInstant = graceStatus.LastSuccessfulDirectoryVersionUpload
             DirectoryIds = directoryIds
         }
+
+    /// Builds a Watch IPC snapshot using the current process pending-work flag.
+    let private createGraceWatchStatus graceStatus directoryIdsOverride = createGraceWatchStatusWithPendingWork None graceStatus directoryIdsOverride
 
     /// Builds the startup-claim record that prevents duplicate Grace Watch instances.
     let private createGraceWatchStartupClaim () = { GraceWatchStatus.Default with UpdatedAt = getCurrentInstant (); IsStartupClaim = true }
@@ -2576,6 +2586,7 @@ module Services =
     /// Writes Grace Watch IPC content after converting the current Grace status snapshot.
     let private updateGraceWatchInterprocessFileCore
         persistedModeOverride
+        pendingWorkOverride
         (graceStatus: GraceStatus)
         (directoryIdsOverride: HashSet<DirectoryVersionId> option)
         =
@@ -2584,7 +2595,7 @@ module Services =
                 do! graceWatchStatusWriteGate.WaitAsync()
 
                 try
-                    let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
+                    let newGraceWatchStatus = createGraceWatchStatusWithPendingWork pendingWorkOverride graceStatus directoryIdsOverride
                     //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
                     //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
 
@@ -2602,7 +2613,46 @@ module Services =
 
     /// Updates the contents of the `grace watch` status inter-process communication file.
     let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
-        updateGraceWatchInterprocessFileCore None graceStatus directoryIdsOverride
+        updateGraceWatchInterprocessFileCore None None graceStatus directoryIdsOverride
+
+    /// Updates Watch IPC identity fields without turning live Watch pending or recovery state into a clean shortcut.
+    let updateGraceWatchInterprocessFilePreservingLiveWorkState (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+        task {
+            let! inspection = inspectGraceWatchStatus ()
+
+            let shouldPreserveLiveWork =
+                inspection.IsLiveProcess
+                && match inspection.EffectiveMode with
+                   | Some GraceWatchRuntimeMode.HealthyIncremental -> inspection.HasCurrentRepositoryIdentity
+                   | Some _ -> true
+                   | None -> false
+
+            let pendingWorkOverride =
+                if shouldPreserveLiveWork then
+                    match inspection.Status, inspection.EffectiveMode with
+                    | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                        Some(
+                            status.HasPendingWatchWork
+                            || not status.IsWorkingTreeClean
+                        )
+                    | Some _, Some _ -> Some true
+                    | _ -> None
+                else
+                    None
+
+            let persistedModeOverride =
+                if shouldPreserveLiveWork then
+                    match inspection.EffectiveMode with
+                    | Some GraceWatchRuntimeMode.StartingUp
+                    | Some GraceWatchRuntimeMode.Suspended
+                    | Some GraceWatchRuntimeMode.Resynchronizing
+                    | Some GraceWatchRuntimeMode.Stopping -> inspection.EffectiveMode
+                    | _ -> None
+                else
+                    None
+
+            do! updateGraceWatchInterprocessFileCore persistedModeOverride pendingWorkOverride graceStatus directoryIdsOverride
+        }
 
     /// Exercises the gated Watch IPC write boundary after a test-controlled pending-work state change.
     let internal updateGraceWatchInterprocessFileAfterPendingWorkProbeForWatchTests
@@ -2629,7 +2679,7 @@ module Services =
 
     /// Updates Watch IPC while preserving the suspended mode that cannot be derived from the compact status payload.
     let internal updateGraceWatchInterprocessFileForSuspendedMode (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
-        updateGraceWatchInterprocessFileCore (Some GraceWatchRuntimeMode.Suspended) graceStatus directoryIdsOverride
+        updateGraceWatchInterprocessFileCore (Some GraceWatchRuntimeMode.Suspended) None graceStatus directoryIdsOverride
 
     /// Reads the `grace watch` status inter-process communication file.
     let getGraceWatchStatus () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -88,6 +88,13 @@ module Services =
         {
             UpdatedAt: Instant
             IsStartupClaim: bool
+            RepositoryId: RepositoryId
+            RepositoryName: RepositoryName
+            BranchId: BranchId
+            BranchName: BranchName
+            RootDirectory: string
+            HasPendingWatchWork: bool
+            IsWorkingTreeClean: bool
             RootDirectoryId: DirectoryVersionId
             RootDirectorySha256Hash: Sha256Hash
             RootDirectoryBlake3Hash: Blake3Hash
@@ -130,18 +137,27 @@ module Services =
             let isFreshSnapshot = this.IsFreshSnapshot
             let mode = this.Mode
 
+            let hasPendingWatchWork =
+                this.HasPendingWatchWork
+                || not this.IsWorkingTreeClean
+
             [|
                 if isStartupClaim then "startupClaim"
 
                 if not isFreshSnapshot then "staleStatus"
+
+                if hasPendingWatchWork then "pendingWatchWork" else "cleanWorkingTree"
 
                 if hasUsableRootSnapshot then "usableRoot" else "missingRoot"
 
                 if hasDirectoryIndexSnapshot then "directoryIndex" else "missingDirectoryIndex"
 
                 if mode = GraceWatchRuntimeMode.HealthyIncremental
-                   && isFreshSnapshot then
+                   && isFreshSnapshot
+                   && not hasPendingWatchWork then
                     "incrementalSafe"
+                elif hasPendingWatchWork then
+                    "pendingStatusApply"
                 else
                     "requiresExplicitResync"
             |]
@@ -151,6 +167,13 @@ module Services =
             {
                 UpdatedAt = Instant.MinValue
                 IsStartupClaim = false
+                RepositoryId = RepositoryId.Empty
+                RepositoryName = RepositoryName String.Empty
+                BranchId = BranchId.Empty
+                BranchName = BranchName String.Empty
+                RootDirectory = String.Empty
+                HasPendingWatchWork = false
+                IsWorkingTreeClean = true
                 RootDirectoryId = Guid.Empty
                 RootDirectorySha256Hash = Sha256Hash String.Empty
                 RootDirectoryBlake3Hash = Blake3Hash String.Empty
@@ -164,6 +187,13 @@ module Services =
         {
             UpdatedAt: Instant
             IsStartupClaim: bool
+            RepositoryId: RepositoryId
+            RepositoryName: RepositoryName
+            BranchId: BranchId
+            BranchName: BranchName
+            RootDirectory: string
+            HasPendingWatchWork: bool
+            IsWorkingTreeClean: bool
             RootDirectoryId: DirectoryVersionId
             RootDirectorySha256Hash: Sha256Hash
             RootDirectoryBlake3Hash: Blake3Hash
@@ -205,6 +235,8 @@ module Services =
             | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
                 this.IsFresh
                 && not status.IsStartupClaim
+                && status.IsWorkingTreeClean
+                && not status.HasPendingWatchWork
                 && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
             | _ -> false
 
@@ -265,6 +297,13 @@ module Services =
         {
             UpdatedAt = status.UpdatedAt
             IsStartupClaim = status.IsStartupClaim
+            RepositoryId = status.RepositoryId
+            RepositoryName = status.RepositoryName
+            BranchId = status.BranchId
+            BranchName = status.BranchName
+            RootDirectory = status.RootDirectory
+            HasPendingWatchWork = status.HasPendingWatchWork
+            IsWorkingTreeClean = status.IsWorkingTreeClean
             RootDirectoryId = status.RootDirectoryId
             RootDirectorySha256Hash = status.RootDirectorySha256Hash
             RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
@@ -314,8 +353,19 @@ module Services =
         | _ -> None
 
     let mutable graceWatchStatusUpdateTime = Instant.MinValue
+    let mutable private graceWatchHasPendingWorkForStatus = 0
     let mutable parseResult: ParseResult = null
     let mutable private invocationCorrelationId: CorrelationId option = None
+
+    /// Records whether the next Grace Watch IPC write should advertise unapplied local observations.
+    let internal setGraceWatchHasPendingWorkForStatus hasPendingWork =
+        Interlocked.Exchange(&graceWatchHasPendingWorkForStatus, (if hasPendingWork then 1 else 0))
+        |> ignore
+
+    /// Reads the pending-work fact that is copied into Grace Watch IPC status snapshots.
+    let private hasGraceWatchPendingWorkForStatus () =
+        Volatile.Read(&graceWatchHasPendingWorkForStatus)
+        <> 0
 
     /// Coordinates directory version preimage entries behavior for this CLI command path.
     let private directoryVersionPreimageEntries (directories: seq<LocalDirectoryVersion>) (files: seq<LocalFileVersion>) =
@@ -2243,6 +2293,9 @@ module Services =
 
     /// Builds the persisted Grace Watch status snapshot used by check and startup coordination.
     let private createGraceWatchStatus (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
+        let current = Current()
+        let hasPendingWatchWork = hasGraceWatchPendingWorkForStatus ()
+
         let directoryIds =
             match directoryIdsOverride with
             | Some ids -> HashSet<DirectoryVersionId>(ids)
@@ -2261,6 +2314,13 @@ module Services =
         {
             UpdatedAt = getCurrentInstant ()
             IsStartupClaim = false
+            RepositoryId = current.RepositoryId
+            RepositoryName = current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = current.BranchName
+            RootDirectory = current.RootDirectory
+            HasPendingWatchWork = hasPendingWatchWork
+            IsWorkingTreeClean = not hasPendingWatchWork
             RootDirectoryId = graceStatus.RootDirectoryId
             RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
             RootDirectoryBlake3Hash = rootDirectoryBlake3Hash

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -301,7 +301,7 @@ module Services =
         /// Reports whether the IPC snapshot belongs to the current repository identity before trust checks.
         member this.HasCurrentRepositoryIdentity =
             match this.Status, this.EffectiveMode with
-            | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+            | Some status, Some _ ->
                 let current = Current()
 
                 let rootDirectoryMatchesCurrent =
@@ -316,12 +316,23 @@ module Services =
                         with
                         | _ -> false
 
-                status.Mode = GraceWatchRuntimeMode.HealthyIncremental
-                && (status.RepositoryId = RepositoryId.Empty
-                    || status.RepositoryId = current.RepositoryId)
+                (status.RepositoryId = RepositoryId.Empty
+                 || status.RepositoryId = current.RepositoryId)
+                && (String.IsNullOrWhiteSpace(string status.RepositoryName)
+                    || String.Equals(string status.RepositoryName, current.RepositoryName, StringComparison.OrdinalIgnoreCase))
                 && (status.BranchId = BranchId.Empty
                     || status.BranchId = current.BranchId)
+                && (String.IsNullOrWhiteSpace(string status.BranchName)
+                    || String.Equals(string status.BranchName, current.BranchName, StringComparison.OrdinalIgnoreCase))
                 && rootDirectoryMatchesCurrent
+            | _ -> false
+
+        /// Reports whether live Watch state has enough persisted identity to be preserved by another command.
+        member this.HasCurrentLiveWatchStateIdentity =
+            match this.Status, this.EffectiveMode with
+            | Some status, Some _ ->
+                not (String.IsNullOrWhiteSpace(status.RootDirectory))
+                && this.HasCurrentRepositoryIdentity
             | _ -> false
 
         /// Reports whether the IPC snapshot can serve trusted incremental shortcuts.
@@ -2624,7 +2635,11 @@ module Services =
                 inspection.IsLiveProcess
                 && match inspection.EffectiveMode with
                    | Some GraceWatchRuntimeMode.HealthyIncremental -> inspection.HasCurrentRepositoryIdentity
-                   | Some _ -> true
+                   | Some GraceWatchRuntimeMode.StartingUp
+                   | Some GraceWatchRuntimeMode.Suspended
+                   | Some GraceWatchRuntimeMode.Resynchronizing
+                   | Some GraceWatchRuntimeMode.Stopping -> inspection.HasCurrentLiveWatchStateIdentity
+                   | Some _ -> inspection.HasCurrentLiveWatchStateIdentity
                    | None -> false
 
             let pendingWorkOverride =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2557,8 +2557,19 @@ module Services =
     /// Builds a Watch IPC snapshot using the current process pending-work flag.
     let private createGraceWatchStatus graceStatus directoryIdsOverride = createGraceWatchStatusWithPendingWork None graceStatus directoryIdsOverride
 
-    /// Builds the startup-claim record that prevents duplicate Grace Watch instances.
-    let private createGraceWatchStartupClaim () = { GraceWatchStatus.Default with UpdatedAt = getCurrentInstant (); IsStartupClaim = true }
+    /// Builds the startup-claim record that prevents duplicate Grace Watch instances for the current repository identity.
+    let private createGraceWatchStartupClaim () =
+        let current = Current()
+
+        { GraceWatchStatus.Default with
+            UpdatedAt = getCurrentInstant ()
+            IsStartupClaim = true
+            RepositoryId = current.RepositoryId
+            RepositoryName = current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = current.BranchName
+            RootDirectory = current.RootDirectory
+        }
 
     /// Checks if the Grace Watch status is within the past 5m.
     let private isGraceWatchStatusFresh (graceWatchStatus: GraceWatchStatus) =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -31,6 +31,7 @@ open System.Reflection
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Threading.Tasks
 open System.Reactive.Linq
 open System.Threading
@@ -390,6 +391,7 @@ module Services =
 
     let mutable graceWatchStatusUpdateTime = Instant.MinValue
     let mutable private graceWatchHasPendingWorkForStatus = 0
+    let private graceWatchStatusWriteGate = new SemaphoreSlim(1, 1)
     let mutable parseResult: ParseResult = null
     let mutable private invocationCorrelationId: CorrelationId option = None
 
@@ -402,6 +404,27 @@ module Services =
     let private hasGraceWatchPendingWorkForStatus () =
         Volatile.Read(&graceWatchHasPendingWorkForStatus)
         <> 0
+
+    /// Restores the clean/no-pending JSON fields omitted by Watch IPC snapshots before explicit clean fields existed.
+    let private normalizeLegacyGraceWatchCleanFields (json: string) =
+        try
+            use document = JsonDocument.Parse(json)
+            let mutable pendingElement = Unchecked.defaultof<JsonElement>
+            let mutable cleanElement = Unchecked.defaultof<JsonElement>
+
+            let hasPendingField = document.RootElement.TryGetProperty("HasPendingWatchWork", &pendingElement)
+
+            let hasCleanField = document.RootElement.TryGetProperty("IsWorkingTreeClean", &cleanElement)
+
+            if not hasPendingField && not hasCleanField then
+                let statusNode = JsonNode.Parse(json).AsObject()
+                statusNode["HasPendingWatchWork"] <- JsonValue.Create(false)
+                statusNode["IsWorkingTreeClean"] <- JsonValue.Create(true)
+                statusNode.ToJsonString(Constants.JsonSerializerOptions)
+            else
+                json
+        with
+        | _ -> json
 
     /// Coordinates directory version preimage entries behavior for this CLI command path.
     let private directoryVersionPreimageEntries (directories: seq<LocalDirectoryVersion>) (files: seq<LocalFileVersion>) =
@@ -2288,7 +2311,9 @@ module Services =
             if System.IO.File.Exists(IpcFileName()) then
                 try
                     let json = System.IO.File.ReadAllText(IpcFileName())
-                    let status = deserialize<GraceWatchStatus> json
+
+                    let normalizedJson = normalizeLegacyGraceWatchCleanFields json
+                    let status = deserialize<GraceWatchStatus> normalizedJson
 
                     return
                         {
@@ -2379,8 +2404,8 @@ module Services =
         && not graceWatchStatus.IsStartupClaim
         && graceWatchStatus.Mode = GraceWatchRuntimeMode.HealthyIncremental
 
-    /// Writes grace watch status data through the CLI output contract with an optional runtime-mode override.
-    let private writeGraceWatchStatusWithPersistedMode persistedModeOverride fileMode graceWatchStatus =
+    /// Writes Grace Watch IPC JSON to disk after the caller has acquired the status write gate.
+    let private writeGraceWatchStatusWithPersistedModeCore persistedModeOverride fileMode graceWatchStatus =
         task {
             Directory.CreateDirectory(Path.GetDirectoryName(IpcFileName()))
             |> ignore
@@ -2394,6 +2419,17 @@ module Services =
             graceWatchStatusUpdateTime <- graceWatchStatus.UpdatedAt
         }
 
+    /// Writes grace watch status data through the CLI output contract with an optional runtime-mode override.
+    let private writeGraceWatchStatusWithPersistedMode persistedModeOverride fileMode graceWatchStatus =
+        task {
+            do! graceWatchStatusWriteGate.WaitAsync()
+
+            try
+                do! writeGraceWatchStatusWithPersistedModeCore persistedModeOverride fileMode graceWatchStatus
+            finally
+                graceWatchStatusWriteGate.Release() |> ignore
+        }
+
     /// Writes Grace Watch IPC status without forcing a compact runtime mode override.
     let private writeGraceWatchStatus fileMode graceWatchStatus = writeGraceWatchStatusWithPersistedMode None fileMode graceWatchStatus
 
@@ -2405,11 +2441,17 @@ module Services =
         =
         task {
             try
-                let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
-                //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
-                //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
+                do! graceWatchStatusWriteGate.WaitAsync()
 
-                do! writeGraceWatchStatusWithPersistedMode persistedModeOverride FileMode.Create newGraceWatchStatus
+                try
+                    let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
+                    //logToAnsiConsole Colors.Important $"In updateGraceWatchStatus. newGraceWatchStatus.UpdatedAt: {newGraceWatchStatus.UpdatedAt.ToString(InstantPattern.ExtendedIso.PatternText, CultureInfo.InvariantCulture)}."
+                    //logToAnsiConsole Colors.Highlighted $"{Markup.Escape(EnhancedStackTrace.Current().ToString())}"
+
+                    do! writeGraceWatchStatusWithPersistedModeCore persistedModeOverride FileMode.Create newGraceWatchStatus
+                finally
+                    graceWatchStatusWriteGate.Release() |> ignore
+
                 logToAnsiConsole Colors.Important $"Wrote inter-process communication file."
             with
             | ex ->
@@ -2421,6 +2463,29 @@ module Services =
     /// Updates the contents of the `grace watch` status inter-process communication file.
     let updateGraceWatchInterprocessFile (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =
         updateGraceWatchInterprocessFileCore None graceStatus directoryIdsOverride
+
+    /// Exercises the gated Watch IPC write boundary after a test-controlled pending-work state change.
+    let internal updateGraceWatchInterprocessFileAfterPendingWorkProbeForWatchTests
+        beforeStatusCreation
+        (graceStatus: GraceStatus)
+        (directoryIdsOverride: HashSet<DirectoryVersionId> option)
+        =
+        task {
+            try
+                do! graceWatchStatusWriteGate.WaitAsync()
+
+                try
+                    beforeStatusCreation ()
+                    let newGraceWatchStatus = createGraceWatchStatus graceStatus directoryIdsOverride
+                    do! writeGraceWatchStatusWithPersistedModeCore None FileMode.Create newGraceWatchStatus
+                finally
+                    graceWatchStatusWriteGate.Release() |> ignore
+            with
+            | ex ->
+                logToAnsiConsole Colors.Error $"Exception in updateGraceWatchInterprocessFile."
+                logToAnsiConsole Colors.Error $"ex.GetType: {ex.GetType().FullName}{Environment.NewLine}{Environment.NewLine}"
+                logToAnsiConsole Colors.Error $"ex.Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
+        }
 
     /// Updates Watch IPC while preserving the suspended mode that cannot be derived from the compact status payload.
     let internal updateGraceWatchInterprocessFileForSuspendedMode (graceStatus: GraceStatus) (directoryIdsOverride: HashSet<DirectoryVersionId> option) =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -141,25 +141,38 @@ module Services =
                 this.HasPendingWatchWork
                 || not this.IsWorkingTreeClean
 
+            let isTrustedCleanSnapshot =
+                mode = GraceWatchRuntimeMode.HealthyIncremental
+                && isFreshSnapshot
+                && not isStartupClaim
+                && hasUsableRootSnapshot
+                && hasDirectoryIndexSnapshot
+                && not hasPendingWatchWork
+
+            let isLiveDirtySnapshot =
+                mode = GraceWatchRuntimeMode.HealthyIncremental
+                && isFreshSnapshot
+                && not isStartupClaim
+                && hasUsableRootSnapshot
+                && hasDirectoryIndexSnapshot
+                && hasPendingWatchWork
+
             [|
                 if isStartupClaim then "startupClaim"
 
                 if not isFreshSnapshot then "staleStatus"
 
-                if hasPendingWatchWork then "pendingWatchWork" else "cleanWorkingTree"
+                if hasPendingWatchWork then "pendingWatchWork"
+                elif isTrustedCleanSnapshot then "cleanWorkingTree"
+                else "noQueuedWatchWork"
 
                 if hasUsableRootSnapshot then "usableRoot" else "missingRoot"
 
                 if hasDirectoryIndexSnapshot then "directoryIndex" else "missingDirectoryIndex"
 
-                if mode = GraceWatchRuntimeMode.HealthyIncremental
-                   && isFreshSnapshot
-                   && not hasPendingWatchWork then
-                    "incrementalSafe"
-                elif hasPendingWatchWork then
-                    "pendingStatusApply"
-                else
-                    "requiresExplicitResync"
+                if isTrustedCleanSnapshot then "incrementalSafe"
+                elif isLiveDirtySnapshot then "pendingStatusApply"
+                else "requiresExplicitResync"
             |]
 
         /// Defines the empty Grace Watch status used before a live status snapshot is available.
@@ -249,9 +262,32 @@ module Services =
                <> Some GraceWatchRuntimeMode.Stopping
 
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
-    let private safetyFlagsForGraceWatchStatusContract (status: GraceWatchStatus) =
-        status.SafetyFlags
-        |> Array.filter (fun safetyFlag -> not (String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)))
+    let private safetyFlagsForGraceWatchStatusContract persistedModeOverride (status: GraceWatchStatus) =
+        let safetyFlags =
+            status.SafetyFlags
+            |> Array.filter (fun safetyFlag -> not (String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)))
+
+        match persistedModeOverride with
+        | Some GraceWatchRuntimeMode.Suspended
+        | Some GraceWatchRuntimeMode.Resynchronizing
+        | Some GraceWatchRuntimeMode.Stopping ->
+            let nonIncrementalFlags =
+                if safetyFlags
+                   |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "pendingWatchWork", StringComparison.Ordinal)) then
+                    [| "requiresExplicitResync" |]
+                else
+                    [|
+                        "noQueuedWatchWork"
+                        "requiresExplicitResync"
+                    |]
+
+            safetyFlags
+            |> Array.filter (fun safetyFlag ->
+                not (String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal))
+                && not (String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)))
+            |> Array.append nonIncrementalFlags
+            |> Array.distinct
+        | _ -> safetyFlags
 
     /// Selects only durable compact modes for persisted IPC JSON so liveness must be derived from the raw status data.
     let private modeForGraceWatchStatusContract (status: GraceWatchStatus) =
@@ -313,7 +349,7 @@ module Services =
             Mode =
                 persistedModeOverride
                 |> Option.orElseWith (fun () -> modeForGraceWatchStatusContract status)
-            SafetyFlags = safetyFlagsForGraceWatchStatusContract status
+            SafetyFlags = safetyFlagsForGraceWatchStatusContract persistedModeOverride status
         }
 
     /// Converts the in-memory Watch status model without forcing a runtime mode into IPC JSON.

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -247,11 +247,36 @@ module Services =
         member this.IsUsable =
             match this.Status, this.EffectiveMode with
             | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                let current = Current()
+
+                let rootDirectoryMatchesCurrent =
+                    if String.IsNullOrWhiteSpace(status.RootDirectory) then
+                        true
+                    else
+                        try
+                            let normalizeRootDirectory (rootDirectory: string) =
+                                Path
+                                    .GetFullPath(rootDirectory)
+                                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+                            String.Equals(
+                                normalizeRootDirectory status.RootDirectory,
+                                normalizeRootDirectory current.RootDirectory,
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                        with
+                        | _ -> false
+
                 this.IsFresh
                 && not status.IsStartupClaim
                 && status.IsWorkingTreeClean
                 && not status.HasPendingWatchWork
                 && status.Mode = GraceWatchRuntimeMode.HealthyIncremental
+                && (status.RepositoryId = RepositoryId.Empty
+                    || status.RepositoryId = current.RepositoryId)
+                && (status.BranchId = BranchId.Empty
+                    || status.BranchId = current.BranchId)
+                && rootDirectoryMatchesCurrent
             | _ -> false
 
         /// Reports whether a fresh Watch process appears to own the IPC file even when shortcuts are unavailable.
@@ -431,6 +456,12 @@ module Services =
                 json
         with
         | _ -> json
+
+    /// Reads Watch IPC JSON while backfilling fields omitted by legacy Watch writers.
+    let private deserializeNormalizedGraceWatchStatus (json: string) =
+        json
+        |> normalizeLegacyGraceWatchStatusFields
+        |> deserialize<GraceWatchStatus>
 
     /// Coordinates directory version preimage entries behavior for this CLI command path.
     let private directoryVersionPreimageEntries (directories: seq<LocalDirectoryVersion>) (files: seq<LocalFileVersion>) =
@@ -2318,8 +2349,7 @@ module Services =
                 try
                     let json = System.IO.File.ReadAllText(IpcFileName())
 
-                    let normalizedJson = normalizeLegacyGraceWatchStatusFields json
-                    let status = deserialize<GraceWatchStatus> normalizedJson
+                    let status = deserializeNormalizedGraceWatchStatus json
 
                     return
                         {
@@ -2533,7 +2563,11 @@ module Services =
                     use fileStream = new FileStream(IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
 
                     try
-                        let! existingGraceWatchStatus = deserializeAsync<GraceWatchStatus> fileStream
+                        use reader = new StreamReader(fileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks = true, bufferSize = 4096, leaveOpen = true)
+                        let! json = reader.ReadToEndAsync()
+                        fileStream.Position <- 0L
+
+                        let existingGraceWatchStatus = deserializeNormalizedGraceWatchStatus json
 
                         if isGraceWatchStatusFresh existingGraceWatchStatus then
                             return false

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -262,11 +262,17 @@ module Services =
             && this.EffectiveMode
                <> Some GraceWatchRuntimeMode.Stopping
 
+    /// Reports whether a compact Watch safety flag must be recomputed from a fresh heartbeat before consumers trust it.
+    let private isRawGraceWatchSafetyFlagLivenessSensitive safetyFlag =
+        String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)
+        || String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal)
+        || String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)
+
     /// Removes liveness-sensitive safety claims from persisted IPC JSON so raw readers never trust a dead Watch process.
     let private safetyFlagsForGraceWatchStatusContract persistedModeOverride (status: GraceWatchStatus) =
         let safetyFlags =
             status.SafetyFlags
-            |> Array.filter (fun safetyFlag -> not (String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal)))
+            |> Array.filter (isRawGraceWatchSafetyFlagLivenessSensitive >> not)
 
         match persistedModeOverride with
         | Some GraceWatchRuntimeMode.Suspended
@@ -283,9 +289,6 @@ module Services =
                     |]
 
             safetyFlags
-            |> Array.filter (fun safetyFlag ->
-                not (String.Equals(safetyFlag, "cleanWorkingTree", StringComparison.Ordinal))
-                && not (String.Equals(safetyFlag, "pendingStatusApply", StringComparison.Ordinal)))
             |> Array.append nonIncrementalFlags
             |> Array.distinct
         | _ -> safetyFlags
@@ -405,21 +408,24 @@ module Services =
         Volatile.Read(&graceWatchHasPendingWorkForStatus)
         <> 0
 
-    /// Restores the clean/no-pending JSON fields omitted by Watch IPC snapshots before explicit clean fields existed.
-    let private normalizeLegacyGraceWatchCleanFields (json: string) =
+    /// Restores fields omitted by Watch IPC snapshots written before the current status identity and clean contract.
+    let private normalizeLegacyGraceWatchStatusFields (json: string) =
         try
-            use document = JsonDocument.Parse(json)
-            let mutable pendingElement = Unchecked.defaultof<JsonElement>
-            let mutable cleanElement = Unchecked.defaultof<JsonElement>
+            let statusNode = JsonNode.Parse(json).AsObject()
 
-            let hasPendingField = document.RootElement.TryGetProperty("HasPendingWatchWork", &pendingElement)
+            let defaultStatusNode =
+                JsonNode
+                    .Parse(serialize GraceWatchStatus.Default)
+                    .AsObject()
 
-            let hasCleanField = document.RootElement.TryGetProperty("IsWorkingTreeClean", &cleanElement)
+            let mutable addedLegacyField = false
 
-            if not hasPendingField && not hasCleanField then
-                let statusNode = JsonNode.Parse(json).AsObject()
-                statusNode["HasPendingWatchWork"] <- JsonValue.Create(false)
-                statusNode["IsWorkingTreeClean"] <- JsonValue.Create(true)
+            for defaultProperty in defaultStatusNode do
+                if not (statusNode.ContainsKey(defaultProperty.Key)) then
+                    statusNode[defaultProperty.Key] <- defaultProperty.Value.DeepClone()
+                    addedLegacyField <- true
+
+            if addedLegacyField then
                 statusNode.ToJsonString(Constants.JsonSerializerOptions)
             else
                 json
@@ -2312,7 +2318,7 @@ module Services =
                 try
                     let json = System.IO.File.ReadAllText(IpcFileName())
 
-                    let normalizedJson = normalizeLegacyGraceWatchCleanFields json
+                    let normalizedJson = normalizeLegacyGraceWatchStatusFields json
                     let status = deserialize<GraceWatchStatus> normalizedJson
 
                     return

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -389,6 +389,16 @@ module Services =
         if inspection.IsUsable then
             inspection.SafetyFlags
         else
+            let isCurrentRepositoryLiveDirtySnapshot =
+                match inspection.Status, inspection.EffectiveMode with
+                | Some status, Some GraceWatchRuntimeMode.HealthyIncremental ->
+                    inspection.IsFresh
+                    && not status.IsStartupClaim
+                    && inspection.HasCurrentRepositoryIdentity
+                    && (status.HasPendingWatchWork
+                        || not status.IsWorkingTreeClean)
+                | _ -> false
+
             let safetyFlags =
                 inspection.SafetyFlags
                 |> Array.filter (
@@ -400,6 +410,8 @@ module Services =
 
             if safetyFlags
                |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "requiresExplicitResync", StringComparison.Ordinal)) then
+                safetyFlags
+            elif isCurrentRepositoryLiveDirtySnapshot then
                 safetyFlags
             else
                 [|

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1352,10 +1352,27 @@ module Watch =
         )
 
     /// Records the pending-work flag that the next Watch IPC snapshot should publish.
-    let private setGraceWatchPendingWorkStatusFlag hasPendingWork =
-        lock watchStatusPublishLock (fun () ->
-            setGraceWatchHasPendingWorkForStatus hasPendingWork
-            lastPublishedHasPendingWatchWork <- Some hasPendingWork)
+    let private setGraceWatchPendingWorkStatusFlag hasPendingWork = lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
+
+    /// Advances the pending-work publication cache only after the IPC file proves the requested state reached disk.
+    let private cachePendingWatchWorkPublicationIfVerified hasPendingWork =
+        let transitionWasPublished =
+            try
+                let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+                inspection.Status
+                |> Option.exists (fun status ->
+                    status.HasPendingWatchWork = hasPendingWork
+                    && status.IsWorkingTreeClean = not hasPendingWork)
+            with
+            | _ -> false
+
+        lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- if transitionWasPublished then Some hasPendingWork else None)
+
+        if not transitionWasPublished then
+            logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
+
+        transitionWasPublished |> ignore
 
     /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
     let private publishPendingWatchWorkTransitionIfNeeded () =
@@ -1419,9 +1436,9 @@ module Watch =
 
     /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
     let private markGraceStatusChangedAndPublishPendingWorkTransition () =
-        if not graceStatusHasChanged then
-            graceStatusHasChanged <- true
-            publishPendingWatchWorkTransitionIfNeeded ()
+        if not graceStatusHasChanged then graceStatusHasChanged <- true
+
+        publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
@@ -1917,8 +1934,7 @@ module Watch =
                 logToAnsiConsole Colors.Added $"I saw that {args.FullPath} was created."
                 publishPendingWatchWorkTransitionIfNeeded ()
 
-            if (isGraceStatusArtifact args.FullPath)
-               && (not <| graceStatusHasChanged) then
+            if isGraceStatusArtifact args.FullPath then
                 markGraceStatusChangedAndPublishPendingWorkTransition ()
 
     /// Coordinates on changed behavior for this CLI command path.
@@ -1936,8 +1952,7 @@ module Watch =
                 publishPendingWatchWorkTransitionIfNeeded ()
 
             // Special handling for the Grace status file; if that is the changed file, we'll set this flag so we reload it in OnWatch() in the main loop
-            if (isGraceStatusArtifact args.FullPath)
-               && (not <| graceStatusHasChanged) then
+            if isGraceStatusArtifact args.FullPath then
                 //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to true in OnChanged(). Current value: {graceStatusHasChanged}."
                 markGraceStatusChangedAndPublishPendingWorkTransition ()
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
@@ -1986,8 +2001,7 @@ module Watch =
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
                 publishPendingWatchWorkTransitionIfNeeded ()
 
-            if (isGraceStatusArtifact args.FullPath)
-               && (not <| graceStatusHasChanged) then
+            if isGraceStatusArtifact args.FullPath then
                 markGraceStatusChangedAndPublishPendingWorkTransition ()
 
     /// Coordinates on renamed behavior for this CLI command path.
@@ -2375,7 +2389,8 @@ module Watch =
     let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
         task {
             let runtimeMode = currentGraceWatchRuntimeMode ()
-            setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+            let hasPendingWork = hasPendingWatchWork ()
+            setGraceWatchPendingWorkStatusFlag hasPendingWork
 
             if
                 runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
@@ -2388,6 +2403,8 @@ module Watch =
                 logToAnsiConsole
                     Colors.Important
                     $"Grace Watch published non-incremental IPC for {context} while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
+
+            cachePendingWatchWorkPublicationIfVerified hasPendingWork
         }
 
     /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
@@ -2421,6 +2438,7 @@ module Watch =
         task {
             setGraceWatchPendingWorkStatusFlag true
             do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
+            cachePendingWatchWorkPublicationIfVerified true
         }
 
     /// Publishes startup catch-up IPC for tests that verify startup scans do not expose trusted clean state early.
@@ -2606,8 +2624,10 @@ module Watch =
                             let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 
                             if clearedResyncAttempt then
-                                setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                                let hasPendingWork = hasPendingWatchWork ()
+                                setGraceWatchPendingWorkStatusFlag hasPendingWork
                                 do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+                                cachePendingWatchWorkPublicationIfVerified hasPendingWork
 
                                 logToAnsiConsole
                                     Colors.Important
@@ -2790,12 +2810,16 @@ module Watch =
                         runtimeModeAfterProcessing = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
                     then
-                        setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                        let hasPendingWork = hasPendingWatchWork ()
+                        setGraceWatchPendingWorkStatusFlag hasPendingWork
                         updateGraceStatusDirectoryIds graceStatus
                         do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
+                        cachePendingWatchWorkPublicationIfVerified hasPendingWork
                     else
-                        setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                        let hasPendingWork = hasPendingWatchWork ()
+                        setGraceWatchPendingWorkStatusFlag hasPendingWork
                         do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                        cachePendingWatchWorkPublicationIfVerified hasPendingWork
 
                         logToAnsiConsole
                             Colors.Important
@@ -2820,15 +2844,21 @@ module Watch =
                     runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                     && not (isGraceWatchResyncPending ())
                 then
-                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                    let hasPendingWork = hasPendingWatchWork ()
+                    setGraceWatchPendingWorkStatusFlag hasPendingWork
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
+                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
                 elif runtimeMode = GraceWatchRuntimeMode.Suspended then
-                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                    let hasPendingWork = hasPendingWatchWork ()
+                    setGraceWatchPendingWorkStatusFlag hasPendingWork
                     do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
                 else
-                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+                    let hasPendingWork = hasPendingWatchWork ()
+                    setGraceWatchPendingWorkStatusFlag hasPendingWork
                     do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
 
                     logToAnsiConsole
                         Colors.Important

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -409,6 +409,8 @@ module Watch =
 
     let mutable private readGraceStatusFileForDeletedPathClassification = readGraceStatusFile
 
+    let mutable private readGraceStatusFileForPendingWorkTransition = readGraceStatusFile
+
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
     /// Checks whether a directory and each repository-relative ancestor remains eligible for watch indexing.
@@ -511,6 +513,8 @@ module Watch =
     let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
     /// Coordinates set read grace status file for watch tests behavior for this CLI command path.
     let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
+    /// Sets the Grace Status reader used by pending-work transition tests.
+    let internal setReadGraceStatusFileForPendingWorkTransitionForWatchTests readStatusFile = readGraceStatusFileForPendingWorkTransition <- readStatusFile
     /// Reads set enumerate files for directory upload for watch tests data needed by the command workflow without changing remote state.
     let internal setEnumerateFilesForDirectoryUploadForWatchTests enumerateFiles = enumerateFilesForDirectoryUpload <- enumerateFiles
 
@@ -1436,54 +1440,73 @@ module Watch =
 
                 let runtimeMode = currentGraceWatchRuntimeMode ()
 
-                let statusForPublish, directoryIdsForPublish =
+                let shouldPublish, statusForPublish, directoryIdsForPublish =
                     if
                         runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
                     then
                         try
-                            let status = readGraceStatusFile().GetAwaiter().GetResult()
+                            let status =
+                                readGraceStatusFileForPendingWorkTransition()
+                                    .GetAwaiter()
+                                    .GetResult()
+
                             graceStatus <- status
                             graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
-                            status, Some graceStatusDirectoryIds
+                            true, status, Some graceStatusDirectoryIds
                         with
-                        | _ -> GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                        | ex ->
+                            if hasPendingWork then
+                                logToAnsiConsole
+                                    Colors.Error
+                                    $"Grace Watch could not read Grace Status for pending-work dirty status transition; publishing non-incremental status and retrying later: {ex.Message}"
+
+                                true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                            else
+                                lastPublishedHasPendingWatchWork <- None
+
+                                logToAnsiConsole
+                                    Colors.Error
+                                    $"Grace Watch could not read Grace Status for pending-work clean status transition; retrying later: {ex.Message}"
+
+                                false, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
                     else
-                        GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                        true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
 
-                let publicationStartedAt = getCurrentInstant ()
+                if shouldPublish then
+                    let publicationStartedAt = getCurrentInstant ()
 
-                try
-                    let writeTask =
-                        if runtimeMode = GraceWatchRuntimeMode.Suspended then
-                            updateGraceWatchInterprocessFileForSuspendedMode statusForPublish directoryIdsForPublish
-                        else
-                            updateGraceWatchInterprocessFile statusForPublish directoryIdsForPublish
-
-                    writeTask.GetAwaiter().GetResult()
-                with
-                | ex ->
-                    lastPublishedHasPendingWatchWork <- None
-                    logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
-
-                let transitionWasPublished =
                     try
-                        let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+                        let writeTask =
+                            if runtimeMode = GraceWatchRuntimeMode.Suspended then
+                                updateGraceWatchInterprocessFileForSuspendedMode statusForPublish directoryIdsForPublish
+                            else
+                                updateGraceWatchInterprocessFile statusForPublish directoryIdsForPublish
 
-                        let expectedDirectoryIds =
-                            directoryIdsForPublish
-                            |> Option.defaultWith (fun () -> statusForPublish.Index.Keys.ToHashSet())
-
-                        inspection.Status
-                        |> Option.exists (statusMatchesVerifiedPublication statusForPublish expectedDirectoryIds hasPendingWork publicationStartedAt)
+                        writeTask.GetAwaiter().GetResult()
                     with
-                    | _ -> false
+                    | ex ->
+                        lastPublishedHasPendingWatchWork <- None
+                        logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
-                if transitionWasPublished then
-                    lastPublishedHasPendingWatchWork <- Some hasPendingWork
-                else
-                    lastPublishedHasPendingWatchWork <- None
-                    logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check.")
+                    let transitionWasPublished =
+                        try
+                            let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+                            let expectedDirectoryIds =
+                                directoryIdsForPublish
+                                |> Option.defaultWith (fun () -> statusForPublish.Index.Keys.ToHashSet())
+
+                            inspection.Status
+                            |> Option.exists (statusMatchesVerifiedPublication statusForPublish expectedDirectoryIds hasPendingWork publicationStartedAt)
+                        with
+                        | _ -> false
+
+                    if transitionWasPublished then
+                        lastPublishedHasPendingWatchWork <- Some hasPendingWork
+                    else
+                        lastPublishedHasPendingWatchWork <- None
+                        logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check.")
 
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
@@ -1675,6 +1698,7 @@ module Watch =
             setGraceWatchHasPendingWorkForStatus false)
 
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
+        readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         watchPathComparison <- defaultWatchPathComparison ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1417,6 +1417,12 @@ module Watch =
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
 
+    /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
+    let private markGraceStatusChangedAndPublishPendingWorkTransition () =
+        if not graceStatusHasChanged then
+            graceStatusHasChanged <- true
+            publishPendingWatchWorkTransitionIfNeeded ()
+
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
         if
@@ -1913,7 +1919,7 @@ module Watch =
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
-                graceStatusHasChanged <- true
+                markGraceStatusChangedAndPublishPendingWorkTransition ()
 
     /// Coordinates on changed behavior for this CLI command path.
     let OnChanged (args: FileSystemEventArgs) =
@@ -1933,7 +1939,7 @@ module Watch =
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
                 //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to true in OnChanged(). Current value: {graceStatusHasChanged}."
-                graceStatusHasChanged <- true
+                markGraceStatusChangedAndPublishPendingWorkTransition ()
                 logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
@@ -1982,7 +1988,7 @@ module Watch =
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
-                graceStatusHasChanged <- true
+                markGraceStatusChangedAndPublishPendingWorkTransition ()
 
     /// Coordinates on renamed behavior for this CLI command path.
     let OnRenamed (args: RenamedEventArgs) =
@@ -2387,6 +2393,28 @@ module Watch =
     /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
     let internal publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
         publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient "test refresh"
+
+    /// Publishes a reloaded Grace Status snapshot after clearing the refresh flag consumed by this timer tick.
+    let private publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFileClient =
+        task {
+            graceStatus <- updatedGraceStatus
+            updateGraceStatusDirectoryIds graceStatus
+
+            // The reloaded snapshot is the durable status change represented by this flag. Clear it before publishing
+            // so the clean IPC heartbeat reflects the already-applied refresh instead of waiting for a later timer tick.
+            graceStatusHasChanged <- false
+
+            do!
+                publishGraceWatchInterprocessFileForCurrentConfidence
+                    graceStatus
+                    graceStatusDirectoryIds
+                    updateGraceWatchInterprocessFileClient
+                    "Grace Status refresh"
+        }
+
+    /// Publishes a Grace Status refresh snapshot for tests that verify clean IPC after refresh consumption.
+    let internal publishGraceStatusRefreshSnapshotForWatchTests updatedGraceStatus updateGraceWatchInterprocessFileClient =
+        publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFileClient
 
     /// Publishes the startup catch-up boundary as dirty so commands cannot trust pre-scan incremental status.
     let private publishStartupCatchUpPendingStatus trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
@@ -3127,18 +3155,7 @@ module Watch =
                         // Grace Status may have changed from branch switch, or other commands.
                         if graceStatusHasChanged then
                             let! updatedGraceStatus = readGraceStatusFile ()
-                            graceStatus <- updatedGraceStatus
-                            updateGraceStatusDirectoryIds graceStatus
-
-                            do!
-                                publishGraceWatchInterprocessFileForCurrentConfidence
-                                    graceStatus
-                                    graceStatusDirectoryIds
-                                    updateGraceWatchInterprocessFile
-                                    "Grace Status refresh"
-
-                            //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in OnWatch(). Current value: {graceStatusHasChanged}."
-                            graceStatusHasChanged <- false
+                            do! publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFile
 
                         do! processChangedFiles ()
                         let! tick = periodicTimer.WaitForNextTickAsync()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -240,6 +240,7 @@ module Watch =
     let mutable private graceStatusDirectoryIds = HashSet<DirectoryVersionId>()
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
+    let mutable private graceStatusRefreshGeneration = 0L
     let private watchStatusPublishLock = obj ()
     let mutable private lastPublishedHasPendingWatchWork: bool option = None
 
@@ -509,8 +510,26 @@ module Watch =
 
     /// Coordinates set grace status for watch tests behavior for this CLI command path.
     let internal setGraceStatusForWatchTests status = graceStatus <- status
+    /// Reads the in-memory Grace Status snapshot so transition-publication tests can prove state isolation.
+    let internal graceStatusForWatchTests () = graceStatus
+    /// Reads the in-memory Grace Status directory identities so transition-publication tests can prove state isolation.
+    let internal graceStatusDirectoryIdsForWatchTests () = graceStatusDirectoryIds
+    /// Reports whether the Watch timer still owes a Grace Status refresh pass.
+    let internal graceStatusHasChangedForWatchTests () = graceStatusHasChanged
+
     /// Checks whether set grace status has changed for watch tests is true for the parsed command input.
-    let internal setGraceStatusHasChangedForWatchTests hasChanged = graceStatusHasChanged <- hasChanged
+    let internal setGraceStatusHasChangedForWatchTests hasChanged =
+        if hasChanged then
+            Interlocked.Increment(&graceStatusRefreshGeneration)
+            |> ignore
+
+            graceStatusHasChanged <- true
+        else
+            Interlocked.Exchange(&graceStatusRefreshGeneration, 0L)
+            |> ignore
+
+            graceStatusHasChanged <- false
+
     /// Coordinates set read grace status file for watch tests behavior for this CLI command path.
     let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
     /// Sets the Grace Status reader used by pending-work transition tests.
@@ -1355,6 +1374,25 @@ module Watch =
             && not (hasPendingStatusDifferences ())
         )
 
+    /// Reads the generation for Grace Status DB refresh events observed from the filesystem.
+    let private currentGraceStatusRefreshGeneration () = Volatile.Read(&graceStatusRefreshGeneration)
+
+    /// Records that a Grace Status DB, WAL, SHM, or journal observation must be applied by a timer pass.
+    let private recordGraceStatusRefreshObservation () =
+        Interlocked.Increment(&graceStatusRefreshGeneration)
+        |> ignore
+
+        graceStatusHasChanged <- true
+
+    /// Clears exactly the Grace Status refresh generation consumed by a successful publication.
+    let private tryClearGraceStatusRefreshGeneration observedGeneration =
+        if Interlocked.CompareExchange(&graceStatusRefreshGeneration, 0L, observedGeneration) = observedGeneration then
+            graceStatusHasChanged <- false
+            true
+        else
+            graceStatusHasChanged <- true
+            false
+
     /// Records the pending-work flag that the next Watch IPC snapshot should publish.
     let private setGraceWatchPendingWorkStatusFlag hasPendingWork = lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
 
@@ -1402,12 +1440,13 @@ module Watch =
         if not transitionWasPublished then
             logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
 
-        transitionWasPublished |> ignore
+        transitionWasPublished
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
-    let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
+    let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
         lock watchStatusPublishLock (fun () ->
             let mutable attempts = 0
+            let mutable transitionWasPublished = false
             let mutable pendingWorkChangedDuringWrite = true
 
             while pendingWorkChangedDuringWrite && attempts < 2 do
@@ -1418,13 +1457,20 @@ module Watch =
 
                 try
                     writeSnapshot().GetAwaiter().GetResult()
-                    cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt
+                    transitionWasPublished <- cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt
                 with
                 | ex ->
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
-                pendingWorkChangedDuringWrite <- hasPendingWatchWork () <> hasPendingWork)
+                pendingWorkChangedDuringWrite <- hasPendingWatchWork () <> hasPendingWork
+
+            transitionWasPublished)
+
+    /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
+    let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot =
+        tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot
+        |> ignore
 
     /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
     let private publishPendingWatchWorkTransitionIfNeeded () =
@@ -1451,9 +1497,8 @@ module Watch =
                                     .GetAwaiter()
                                     .GetResult()
 
-                            graceStatus <- status
-                            graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
-                            true, status, Some graceStatusDirectoryIds
+                            let statusDirectoryIds = status.Index.Keys.ToHashSet()
+                            true, status, Some statusDirectoryIds
                         with
                         | ex ->
                             if hasPendingWork then
@@ -1513,7 +1558,7 @@ module Watch =
 
     /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
     let private markGraceStatusChangedAndPublishPendingWorkTransition () =
-        if not graceStatusHasChanged then graceStatusHasChanged <- true
+        recordGraceStatusRefreshObservation ()
 
         publishPendingWatchWorkTransitionIfNeeded ()
 
@@ -1688,6 +1733,9 @@ module Watch =
         |> ignore
 
         Interlocked.Exchange(&fileUploadWorkGeneration, 0L)
+        |> ignore
+
+        Interlocked.Exchange(&graceStatusRefreshGeneration, 0L)
         |> ignore
 
         graceStatus <- GraceStatus.Default
@@ -2330,7 +2378,7 @@ module Watch =
                                             |> ignore
 
                                         //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
-                                        graceStatusHasChanged <- false // We *just* changed it ourselves, so we don't have to re-process it in the timer loop.
+                                        graceStatusHasChanged <- currentGraceStatusRefreshGeneration () <> 0L // We *just* changed it ourselves, but a newer observed refresh must still be processed.
                                         return Some newGraceStatusWithUpdatedTime
                                     else
                                         return None
@@ -2464,25 +2512,39 @@ module Watch =
     let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
     /// Publishes a trusted Watch IPC snapshot only when incremental mode is currently safe for other processes.
-    let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
+    let private tryPublishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
         task {
             let runtimeMode = currentGraceWatchRuntimeMode ()
 
-            if
-                runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
-                && not (isGraceWatchResyncPending ())
-            then
-                publishWatchIpcWithFreshPendingWorkProbe trustedStatus directoryIds (fun () ->
-                    updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds))
-            else
-                let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+            let publicationVerified =
+                if
+                    runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
+                    && not (isGraceWatchResyncPending ())
+                then
+                    tryPublishWatchIpcWithFreshPendingWorkProbe trustedStatus directoryIds (fun () ->
+                        updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds))
+                else
+                    let emptyDirectoryIds = HashSet<DirectoryVersionId>()
 
-                publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                    updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+                    let verified =
+                        tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
 
-                logToAnsiConsole
-                    Colors.Important
-                    $"Grace Watch published non-incremental IPC for {context} while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Grace Watch published non-incremental IPC for {context} while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
+
+                    verified
+
+            return publicationVerified
+        }
+
+    /// Publishes a trusted Watch IPC snapshot only when incremental mode is currently safe for other processes.
+    let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
+        task {
+            let! _ = tryPublishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context
+
+            ()
         }
 
     /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
@@ -2490,26 +2552,32 @@ module Watch =
         publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient "test refresh"
 
     /// Publishes a reloaded Grace Status snapshot after clearing the refresh flag consumed by this timer tick.
-    let private publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFileClient =
+    let private publishGraceStatusRefreshSnapshot observedRefreshGeneration updatedGraceStatus updateGraceWatchInterprocessFileClient =
         task {
             graceStatus <- updatedGraceStatus
             updateGraceStatusDirectoryIds graceStatus
 
-            // The reloaded snapshot is the durable status change represented by this flag. Clear it before publishing
-            // so the clean IPC heartbeat reflects the already-applied refresh instead of waiting for a later timer tick.
-            graceStatusHasChanged <- false
+            graceStatusHasChanged <-
+                currentGraceStatusRefreshGeneration ()
+                <> observedRefreshGeneration
 
-            do!
-                publishGraceWatchInterprocessFileForCurrentConfidence
+            let! publicationVerified =
+                tryPublishGraceWatchInterprocessFileForCurrentConfidence
                     graceStatus
                     graceStatusDirectoryIds
                     updateGraceWatchInterprocessFileClient
                     "Grace Status refresh"
+
+            if publicationVerified then
+                tryClearGraceStatusRefreshGeneration observedRefreshGeneration
+                |> ignore
+            else
+                graceStatusHasChanged <- true
         }
 
     /// Publishes a Grace Status refresh snapshot for tests that verify clean IPC after refresh consumption.
     let internal publishGraceStatusRefreshSnapshotForWatchTests updatedGraceStatus updateGraceWatchInterprocessFileClient =
-        publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFileClient
+        publishGraceStatusRefreshSnapshot (currentGraceStatusRefreshGeneration ()) updatedGraceStatus updateGraceWatchInterprocessFileClient
 
     /// Publishes the startup catch-up boundary as dirty so commands cannot trust pre-scan incremental status.
     let private publishStartupCatchUpPendingStatus trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
@@ -2517,7 +2585,9 @@ module Watch =
             setGraceWatchPendingWorkStatusFlag true
             let publicationStartedAt = getCurrentInstant ()
             do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
+
             cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds true publicationStartedAt
+            |> ignore
         }
 
     /// Publishes startup catch-up IPC for tests that verify startup scans do not expose trusted clean state early.
@@ -3259,8 +3329,9 @@ module Watch =
                           && not (cancellationToken.IsCancellationRequested) do
                         // Grace Status may have changed from branch switch, or other commands.
                         if graceStatusHasChanged then
+                            let refreshGeneration = currentGraceStatusRefreshGeneration ()
                             let! updatedGraceStatus = readGraceStatusFile ()
-                            do! publishGraceStatusRefreshSnapshot updatedGraceStatus updateGraceWatchInterprocessFile
+                            do! publishGraceStatusRefreshSnapshot refreshGeneration updatedGraceStatus updateGraceWatchInterprocessFile
 
                         do! processChangedFiles ()
                         let! tick = periodicTimer.WaitForNextTickAsync()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1354,16 +1354,42 @@ module Watch =
     /// Records the pending-work flag that the next Watch IPC snapshot should publish.
     let private setGraceWatchPendingWorkStatusFlag hasPendingWork = lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
 
-    /// Advances the pending-work publication cache only after the IPC file proves the requested state reached disk.
-    let private cachePendingWatchWorkPublicationIfVerified hasPendingWork =
+    /// Returns the root BLAKE3 hash that Watch expects to see in the IPC snapshot it just published.
+    let private expectedRootDirectoryBlake3Hash (status: GraceStatus) =
+        let mutable rootDirectoryVersion = LocalDirectoryVersion.Default
+
+        if status.Index.TryGetValue(status.RootDirectoryId, &rootDirectoryVersion) then
+            rootDirectoryVersion.Blake3Hash
+        elif not (String.IsNullOrWhiteSpace(string status.RootDirectoryBlake3Hash)) then
+            status.RootDirectoryBlake3Hash
+        else
+            Blake3Hash String.Empty
+
+    /// Verifies the on-disk Watch IPC snapshot is the snapshot this publication attempt wrote.
+    let private statusMatchesVerifiedPublication
+        (expectedStatus: GraceStatus)
+        (expectedDirectoryIds: HashSet<DirectoryVersionId>)
+        hasPendingWork
+        publicationStartedAt
+        (status: GraceWatchStatus)
+        =
+        status.UpdatedAt >= publicationStartedAt
+        && status.HasPendingWatchWork = hasPendingWork
+        && status.IsWorkingTreeClean = not hasPendingWork
+        && status.RootDirectoryId = expectedStatus.RootDirectoryId
+        && status.RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
+        && status.RootDirectoryBlake3Hash = expectedRootDirectoryBlake3Hash expectedStatus
+        && not (isNull status.DirectoryIds)
+        && status.DirectoryIds.SetEquals(expectedDirectoryIds)
+
+    /// Advances the pending-work publication cache only after the exact IPC snapshot proves it reached disk.
+    let private cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt =
         let transitionWasPublished =
             try
                 let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
 
                 inspection.Status
-                |> Option.exists (fun status ->
-                    status.HasPendingWatchWork = hasPendingWork
-                    && status.IsWorkingTreeClean = not hasPendingWork)
+                |> Option.exists (statusMatchesVerifiedPublication expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt)
             with
             | _ -> false
 
@@ -1403,6 +1429,8 @@ module Watch =
                     else
                         GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
 
+                let publicationStartedAt = getCurrentInstant ()
+
                 try
                     let writeTask =
                         if runtimeMode = GraceWatchRuntimeMode.Suspended then
@@ -1412,16 +1440,20 @@ module Watch =
 
                     writeTask.GetAwaiter().GetResult()
                 with
-                | ex -> logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
+                | ex ->
+                    lastPublishedHasPendingWatchWork <- None
+                    logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
                 let transitionWasPublished =
                     try
                         let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
 
+                        let expectedDirectoryIds =
+                            directoryIdsForPublish
+                            |> Option.defaultWith (fun () -> statusForPublish.Index.Keys.ToHashSet())
+
                         inspection.Status
-                        |> Option.exists (fun status ->
-                            status.HasPendingWatchWork = hasPendingWork
-                            && status.IsWorkingTreeClean = not hasPendingWork)
+                        |> Option.exists (statusMatchesVerifiedPublication statusForPublish expectedDirectoryIds hasPendingWork publicationStartedAt)
                     with
                     | _ -> false
 
@@ -2396,15 +2428,18 @@ module Watch =
                 runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                 && not (isGraceWatchResyncPending ())
             then
+                let publicationStartedAt = getCurrentInstant ()
                 do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
+                cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds hasPendingWork publicationStartedAt
             else
-                do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                let publicationStartedAt = getCurrentInstant ()
+                let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
+                cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
 
                 logToAnsiConsole
                     Colors.Important
                     $"Grace Watch published non-incremental IPC for {context} while runtime mode is {runtimeMode} and resync pending is {isGraceWatchResyncPending ()}."
-
-            cachePendingWatchWorkPublicationIfVerified hasPendingWork
         }
 
     /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
@@ -2437,8 +2472,9 @@ module Watch =
     let private publishStartupCatchUpPendingStatus trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
         task {
             setGraceWatchPendingWorkStatusFlag true
+            let publicationStartedAt = getCurrentInstant ()
             do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
-            cachePendingWatchWorkPublicationIfVerified true
+            cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds true publicationStartedAt
         }
 
     /// Publishes startup catch-up IPC for tests that verify startup scans do not expose trusted clean state early.
@@ -2626,8 +2662,9 @@ module Watch =
                             if clearedResyncAttempt then
                                 let hasPendingWork = hasPendingWatchWork ()
                                 setGraceWatchPendingWorkStatusFlag hasPendingWork
+                                let publicationStartedAt = getCurrentInstant ()
                                 do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
-                                cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                                cachePendingWatchWorkPublicationIfVerified graceStatus graceStatusDirectoryIds hasPendingWork publicationStartedAt
 
                                 logToAnsiConsole
                                     Colors.Important
@@ -2813,13 +2850,16 @@ module Watch =
                         let hasPendingWork = hasPendingWatchWork ()
                         setGraceWatchPendingWorkStatusFlag hasPendingWork
                         updateGraceStatusDirectoryIds graceStatus
+                        let publicationStartedAt = getCurrentInstant ()
                         do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
-                        cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                        cachePendingWatchWorkPublicationIfVerified graceStatus graceStatusDirectoryIds hasPendingWork publicationStartedAt
                     else
                         let hasPendingWork = hasPendingWatchWork ()
                         setGraceWatchPendingWorkStatusFlag hasPendingWork
-                        do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
-                        cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                        let publicationStartedAt = getCurrentInstant ()
+                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                        do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
+                        cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
 
                         logToAnsiConsole
                             Colors.Important
@@ -2847,18 +2887,23 @@ module Watch =
                     let hasPendingWork = hasPendingWatchWork ()
                     setGraceWatchPendingWorkStatusFlag hasPendingWork
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
+                    let publicationStartedAt = getCurrentInstant ()
                     do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
-                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                    cachePendingWatchWorkPublicationIfVerified graceStatusFromDisk graceStatusDirectoryIds hasPendingWork publicationStartedAt
                 elif runtimeMode = GraceWatchRuntimeMode.Suspended then
                     let hasPendingWork = hasPendingWatchWork ()
                     setGraceWatchPendingWorkStatusFlag hasPendingWork
-                    do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
-                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                    let publicationStartedAt = getCurrentInstant ()
+                    let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
+                    cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
                 else
                     let hasPendingWork = hasPendingWatchWork ()
                     setGraceWatchPendingWorkStatusFlag hasPendingWork
-                    do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
-                    cachePendingWatchWorkPublicationIfVerified hasPendingWork
+                    let publicationStartedAt = getCurrentInstant ()
+                    let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
+                    cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
 
                     logToAnsiConsole
                         Colors.Important

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1424,10 +1424,22 @@ module Watch =
     /// Completes startup for tests that verify failed recovery does not resume incremental mode.
     let internal promoteStartupModeIfRecoverySucceededForWatchTests () = promoteStartupModeIfRecoverySucceeded ()
 
+    /// Verifies that the persisted IPC snapshot forces readers away from incremental shortcuts during resync.
+    let private isGraceWatchResyncRequiredStatusPublished (inspection: GraceWatchStatusInspection) =
+        inspection.Status
+        |> Option.exists (fun status ->
+            status.HasPendingWatchWork
+            && not status.IsWorkingTreeClean
+            && not inspection.IsUsable
+            && inspection.EffectiveMode
+               <> Some GraceWatchRuntimeMode.HealthyIncremental)
+
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
+        let hasPendingWork = hasPendingWatchWork ()
+
         try
-            setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+            lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
 
             let writeTask =
                 match currentGraceWatchRuntimeMode () with
@@ -1435,8 +1447,22 @@ module Watch =
                 | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
 
             writeTask.GetAwaiter().GetResult()
+
+            let resyncRequiredWasPublished =
+                try
+                    inspectGraceWatchStatus().GetAwaiter().GetResult()
+                    |> isGraceWatchResyncRequiredStatusPublished
+                with
+                | _ -> false
+
+            lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- if resyncRequiredWasPublished then Some hasPendingWork else None)
+
+            if not resyncRequiredWasPublished then
+                logToAnsiConsole Colors.Important $"Grace Watch will retry resync-required status publication on the next transition check."
         with
-        | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
+        | ex ->
+            lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
+            logToAnsiConsole Colors.Error $"Grace Watch could not publish resync-required status: {Markup.Escape(ex.Message)}."
 
     /// Suspends only the resync attempt that observed the failure, preserving newer overflow requests.
     let private suspendGraceWatchAttemptAfterFailedRecovery attempt reason =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1367,7 +1367,6 @@ module Watch =
                    <> Some hasPendingWork
             then
                 setGraceWatchHasPendingWorkForStatus hasPendingWork
-                lastPublishedHasPendingWatchWork <- Some hasPendingWork
 
                 let runtimeMode = currentGraceWatchRuntimeMode ()
 
@@ -1395,7 +1394,24 @@ module Watch =
 
                     writeTask.GetAwaiter().GetResult()
                 with
-                | ex -> logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}")
+                | ex -> logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
+
+                let transitionWasPublished =
+                    try
+                        let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+                        inspection.Status
+                        |> Option.exists (fun status ->
+                            status.HasPendingWatchWork = hasPendingWork
+                            && status.IsWorkingTreeClean = not hasPendingWork)
+                    with
+                    | _ -> false
+
+                if transitionWasPublished then
+                    lastPublishedHasPendingWatchWork <- Some hasPendingWork
+                else
+                    lastPublishedHasPendingWatchWork <- None
+                    logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check.")
 
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
@@ -1961,13 +1977,19 @@ module Watch =
 
             if newPathIsDirectory then
                 let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
+                queuedPendingWork <- queuedPendingWork || directoryStatusAddQueued
 
                 if directoryStatusAddQueued
                    && not oldPathStatusQueued then
                     logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
-                if not (enqueueDirectoryContentsForUpload args.FullPath) then
+                let fileUploadWorkCountBefore = filesToProcess.Count
+                let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload args.FullPath
+
+                if not fileUploadEnumerationComplete then
                     enqueueDirectoryUploadRetry args.FullPath
+                    queuedPendingWork <- true
+                elif filesToProcess.Count > fileUploadWorkCountBefore then
                     queuedPendingWork <- true
 
                 if not directoryStatusEnumerationComplete then
@@ -2335,6 +2357,17 @@ module Watch =
     /// Publishes Watch IPC for tests that verify confidence-lost states cannot advertise incremental safety.
     let internal publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
         publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient "test refresh"
+
+    /// Publishes the startup catch-up boundary as dirty so commands cannot trust pre-scan incremental status.
+    let private publishStartupCatchUpPendingStatus trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
+        task {
+            setGraceWatchPendingWorkStatusFlag true
+            do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
+        }
+
+    /// Publishes startup catch-up IPC for tests that verify startup scans do not expose trusted clean state early.
+    let internal publishStartupCatchUpPendingStatusForWatchTests trustedStatus directoryIds updateGraceWatchInterprocessFileClient =
+        publishStartupCatchUpPendingStatus trustedStatus directoryIds updateGraceWatchInterprocessFileClient
 
     /// Uploads pending file content while preserving the confidence boundary for the current Watch mode.
     let private uploadPendingWatchFilesForStatusRetry
@@ -2853,8 +2886,7 @@ module Watch =
                     updateGraceStatusDirectoryIds graceStatus
 
                     // Create the inter-process communication file.
-                    setGraceWatchPendingWorkStatusFlag false
-                    do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
+                    do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
 
                     // Enable the FileSystemWatcher.
                     rootDirectoryFileSystemWatcher.EnableRaisingEvents <- true
@@ -3040,6 +3072,17 @@ module Watch =
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
                     promoteStartupModeIfRecoverySucceeded ()
+
+                    if not (hasPendingWatchWork ()) then
+                        let! startupCatchUpStatus = readGraceStatusFile ()
+                        updateGraceStatusDirectoryIds startupCatchUpStatus
+
+                        do!
+                            publishGraceWatchInterprocessFileForCurrentConfidence
+                                startupCatchUpStatus
+                                graceStatusDirectoryIds
+                                updateGraceWatchInterprocessFile
+                                "startup catch-up"
 
                     // Create a timer to process the file changes detected by the FileSystemWatcher.
                     // This timer is the reason that there's a delay in stopping `grace watch`.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1343,6 +1343,7 @@ module Watch =
     /// Evaluates has pending watch work against parsed options and command state.
     let private hasPendingWatchWork () =
         isGraceWatchResyncPending ()
+        || graceStatusHasChanged
         || not (
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty
@@ -1412,6 +1413,9 @@ module Watch =
                 else
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check.")
+
+    /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
+    let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -240,6 +240,8 @@ module Watch =
     let mutable private graceStatusDirectoryIds = HashSet<DirectoryVersionId>()
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
+    let private watchStatusPublishLock = obj ()
+    let mutable private lastPublishedHasPendingWatchWork: bool option = None
 
     /// Coordinates file deleted behavior for this CLI command path.
     let fileDeleted filePath = logToConsole $"In Delete: filePath: {filePath}"
@@ -1338,6 +1340,63 @@ module Watch =
     /// Clears a specific resync attempt without losing a newer confidence-loss request.
     let private tryClearGraceWatchResyncAttempt attempt = Interlocked.CompareExchange(&graceWatchResyncGeneration, 0L, attempt) = attempt
 
+    /// Evaluates has pending watch work against parsed options and command state.
+    let private hasPendingWatchWork () =
+        isGraceWatchResyncPending ()
+        || not (
+            filesToProcess.IsEmpty
+            && directoriesToProcess.IsEmpty
+            && statusUpdateTriggers.IsEmpty
+            && not (hasPendingStatusDifferences ())
+        )
+
+    /// Records the pending-work flag that the next Watch IPC snapshot should publish.
+    let private setGraceWatchPendingWorkStatusFlag hasPendingWork =
+        lock watchStatusPublishLock (fun () ->
+            setGraceWatchHasPendingWorkForStatus hasPendingWork
+            lastPublishedHasPendingWatchWork <- Some hasPendingWork)
+
+    /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
+    let private publishPendingWatchWorkTransitionIfNeeded () =
+        lock watchStatusPublishLock (fun () ->
+            let hasPendingWork = hasPendingWatchWork ()
+
+            if
+                File.Exists(IpcFileName())
+                && lastPublishedHasPendingWatchWork
+                   <> Some hasPendingWork
+            then
+                setGraceWatchHasPendingWorkForStatus hasPendingWork
+                lastPublishedHasPendingWatchWork <- Some hasPendingWork
+
+                let runtimeMode = currentGraceWatchRuntimeMode ()
+
+                let statusForPublish, directoryIdsForPublish =
+                    if
+                        runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
+                        && not (isGraceWatchResyncPending ())
+                    then
+                        try
+                            let status = readGraceStatusFile().GetAwaiter().GetResult()
+                            graceStatus <- status
+                            graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
+                            status, Some graceStatusDirectoryIds
+                        with
+                        | _ -> GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                    else
+                        GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+
+                try
+                    let writeTask =
+                        if runtimeMode = GraceWatchRuntimeMode.Suspended then
+                            updateGraceWatchInterprocessFileForSuspendedMode statusForPublish directoryIdsForPublish
+                        else
+                            updateGraceWatchInterprocessFile statusForPublish directoryIdsForPublish
+
+                    writeTask.GetAwaiter().GetResult()
+                with
+                | ex -> logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}")
+
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
         if
@@ -1352,6 +1411,8 @@ module Watch =
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
         try
+            setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
+
             let writeTask =
                 match currentGraceWatchRuntimeMode () with
                 | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
@@ -1485,6 +1546,11 @@ module Watch =
 
         graceStatus <- GraceStatus.Default
         graceStatusHasChanged <- false
+
+        lock watchStatusPublishLock (fun () ->
+            lastPublishedHasPendingWatchWork <- None
+            setGraceWatchHasPendingWorkForStatus false)
+
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
@@ -1512,16 +1578,6 @@ module Watch =
         |> Seq.map string
         |> Seq.sort
         |> Seq.toArray
-
-    /// Evaluates has pending watch work against parsed options and command state.
-    let private hasPendingWatchWork () =
-        isGraceWatchResyncPending ()
-        || not (
-            filesToProcess.IsEmpty
-            && directoriesToProcess.IsEmpty
-            && statusUpdateTriggers.IsEmpty
-            && not (hasPendingStatusDifferences ())
-        )
 
     /// Coordinates status only trigger snapshot behavior for this CLI command path.
     let private statusOnlyTriggerSnapshot () =
@@ -1639,7 +1695,9 @@ module Watch =
 
         if not inspection.IsUsable then
             flags.Remove("incrementalSafe") |> ignore
-            flags.Add("requiresExplicitResync") |> ignore
+
+            if not (flags.Contains("pendingWatchWork")) then
+                flags.Add("requiresExplicitResync") |> ignore
 
         flags |> Seq.sort |> Seq.toArray
 
@@ -1797,10 +1855,15 @@ module Watch =
 
             if not directoryStatusEnumerationComplete then
                 enqueueDirectoryUploadRetry args.FullPath
+
+            if directoryStatusAddQueued
+               || not directoryStatusEnumerationComplete then
+                publishPendingWatchWorkTransitionIfNeeded ()
         elif updateNotInProgress ()
              && isNotDirectory args.FullPath then
             if enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Added $"I saw that {args.FullPath} was created."
+                publishPendingWatchWorkTransitionIfNeeded ()
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -1818,6 +1881,7 @@ module Watch =
             if not <| shouldIgnore then
                 logToAnsiConsole Colors.Changed $"I saw that {args.FullPath} changed."
                 enqueueFileUpload args.FullPath |> ignore
+                publishPendingWatchWorkTransitionIfNeeded ()
 
             // Special handling for the Grace status file; if that is the changed file, we'll set this flag so we reload it in OnWatch() in the main loop
             if (isGraceStatusArtifact args.FullPath)
@@ -1868,6 +1932,7 @@ module Watch =
                     | None -> ()
 
                 logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
+                publishPendingWatchWorkTransitionIfNeeded ()
 
             if (isGraceStatusArtifact args.FullPath)
                && (not <| graceStatusHasChanged) then
@@ -1878,11 +1943,13 @@ module Watch =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress () then
+            let mutable queuedPendingWork = false
             let newPathIsDirectory = Directory.Exists(args.FullPath)
 
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
 
             let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
+            queuedPendingWork <- queuedPendingWork || oldPathStatusQueued
 
             if oldPathStatusQueued then
                 if canceledFileUpload then
@@ -1901,11 +1968,16 @@ module Watch =
 
                 if not (enqueueDirectoryContentsForUpload args.FullPath) then
                     enqueueDirectoryUploadRetry args.FullPath
+                    queuedPendingWork <- true
 
                 if not directoryStatusEnumerationComplete then
                     enqueueDirectoryUploadRetry args.FullPath
+                    queuedPendingWork <- true
             elif enqueueFileUpload args.FullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
+                queuedPendingWork <- true
+
+            if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Coordinates on error behavior for this CLI command path.
     let OnError (args: ErrorEventArgs) =
@@ -2245,6 +2317,7 @@ module Watch =
     let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
         task {
             let runtimeMode = currentGraceWatchRuntimeMode ()
+            setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
 
             if
                 runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
@@ -2442,6 +2515,7 @@ module Watch =
                             let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 
                             if clearedResyncAttempt then
+                                setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                                 do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
 
                                 logToAnsiConsole
@@ -2625,9 +2699,11 @@ module Watch =
                         runtimeModeAfterProcessing = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
                     then
+                        setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                         updateGraceStatusDirectoryIds graceStatus
                         do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
                     else
+                        setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                         do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
 
                         logToAnsiConsole
@@ -2653,11 +2729,14 @@ module Watch =
                     runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                     && not (isGraceWatchResyncPending ())
                 then
+                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
                     do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
                 elif runtimeMode = GraceWatchRuntimeMode.Suspended then
+                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                     do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
                 else
+                    setGraceWatchPendingWorkStatusFlag (hasPendingWatchWork ())
                     do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
 
                     logToAnsiConsole
@@ -2774,6 +2853,7 @@ module Watch =
                     updateGraceStatusDirectoryIds graceStatus
 
                     // Create the inter-process communication file.
+                    setGraceWatchPendingWorkStatusFlag false
                     do! updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds)
 
                     // Enable the FileSystemWatcher.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1400,6 +1400,28 @@ module Watch =
 
         transitionWasPublished |> ignore
 
+    /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
+    let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
+        lock watchStatusPublishLock (fun () ->
+            let mutable attempts = 0
+            let mutable pendingWorkChangedDuringWrite = true
+
+            while pendingWorkChangedDuringWrite && attempts < 2 do
+                attempts <- attempts + 1
+                let hasPendingWork = hasPendingWatchWork ()
+                setGraceWatchHasPendingWorkForStatus hasPendingWork
+                let publicationStartedAt = getCurrentInstant ()
+
+                try
+                    writeSnapshot().GetAwaiter().GetResult()
+                    cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt
+                with
+                | ex ->
+                    lastPublishedHasPendingWatchWork <- None
+                    logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
+
+                pendingWorkChangedDuringWrite <- hasPendingWatchWork () <> hasPendingWork)
+
     /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
     let private publishPendingWatchWorkTransitionIfNeeded () =
         lock watchStatusPublishLock (fun () ->
@@ -2421,21 +2443,18 @@ module Watch =
     let private publishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =
         task {
             let runtimeMode = currentGraceWatchRuntimeMode ()
-            let hasPendingWork = hasPendingWatchWork ()
-            setGraceWatchPendingWorkStatusFlag hasPendingWork
 
             if
                 runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                 && not (isGraceWatchResyncPending ())
             then
-                let publicationStartedAt = getCurrentInstant ()
-                do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
-                cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds hasPendingWork publicationStartedAt
+                publishWatchIpcWithFreshPendingWorkProbe trustedStatus directoryIds (fun () ->
+                    updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds))
             else
-                let publicationStartedAt = getCurrentInstant ()
                 let emptyDirectoryIds = HashSet<DirectoryVersionId>()
-                do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
-                cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
+
+                publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                    updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
 
                 logToAnsiConsole
                     Colors.Important
@@ -2660,11 +2679,8 @@ module Watch =
                             let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 
                             if clearedResyncAttempt then
-                                let hasPendingWork = hasPendingWatchWork ()
-                                setGraceWatchPendingWorkStatusFlag hasPendingWork
-                                let publicationStartedAt = getCurrentInstant ()
-                                do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
-                                cachePendingWatchWorkPublicationIfVerified graceStatus graceStatusDirectoryIds hasPendingWork publicationStartedAt
+                                publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                                    updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
                                 logToAnsiConsole
                                     Colors.Important
@@ -2847,19 +2863,15 @@ module Watch =
                         runtimeModeAfterProcessing = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
                     then
-                        let hasPendingWork = hasPendingWatchWork ()
-                        setGraceWatchPendingWorkStatusFlag hasPendingWork
                         updateGraceStatusDirectoryIds graceStatus
-                        let publicationStartedAt = getCurrentInstant ()
-                        do! updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds)
-                        cachePendingWatchWorkPublicationIfVerified graceStatus graceStatusDirectoryIds hasPendingWork publicationStartedAt
+
+                        publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
                     else
-                        let hasPendingWork = hasPendingWatchWork ()
-                        setGraceWatchPendingWorkStatusFlag hasPendingWork
-                        let publicationStartedAt = getCurrentInstant ()
                         let emptyDirectoryIds = HashSet<DirectoryVersionId>()
-                        do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
-                        cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
+
+                        publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
 
                         logToAnsiConsole
                             Colors.Important
@@ -2884,26 +2896,20 @@ module Watch =
                     runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                     && not (isGraceWatchResyncPending ())
                 then
-                    let hasPendingWork = hasPendingWatchWork ()
-                    setGraceWatchPendingWorkStatusFlag hasPendingWork
                     let! graceStatusFromDisk = readGraceStatusMetaClient ()
-                    let publicationStartedAt = getCurrentInstant ()
-                    do! updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds)
-                    cachePendingWatchWorkPublicationIfVerified graceStatusFromDisk graceStatusDirectoryIds hasPendingWork publicationStartedAt
+
+                    publishWatchIpcWithFreshPendingWorkProbe graceStatusFromDisk graceStatusDirectoryIds (fun () ->
+                        updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds))
                 elif runtimeMode = GraceWatchRuntimeMode.Suspended then
-                    let hasPendingWork = hasPendingWatchWork ()
-                    setGraceWatchPendingWorkStatusFlag hasPendingWork
-                    let publicationStartedAt = getCurrentInstant ()
                     let emptyDirectoryIds = HashSet<DirectoryVersionId>()
-                    do! updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
-                    cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
+
+                    publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                        updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds))
                 else
-                    let hasPendingWork = hasPendingWatchWork ()
-                    setGraceWatchPendingWorkStatusFlag hasPendingWork
-                    let publicationStartedAt = getCurrentInstant ()
                     let emptyDirectoryIds = HashSet<DirectoryVersionId>()
-                    do! updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds)
-                    cachePendingWatchWorkPublicationIfVerified GraceStatus.Default emptyDirectoryIds hasPendingWork publicationStartedAt
+
+                    publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                        updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
 
                     logToAnsiConsole
                         Colors.Important


### PR DESCRIPTION
## Summary

- Extend the Watch IPC/status contract with factual repository, branch, root path, and clean/pending-work fields needed
  by later branch-switch safety checks.
- Publish clean-to-dirty and dirty-to-clean Watch status transitions while avoiding repeated status rewrites for repeated
  raw events while already dirty.
- Update Watch status tests and compile-only direct `GraceWatchStatus` construction after the contract extension.
- Harden dirty status publication for startup catch-up, directory rename queuing, transient IPC write failures, stale
  dirty snapshots, untrusted clean-safety flags, clean/dirty IPC write ordering, legacy IPC snapshots, resync-required
  publication, raw IPC safety flags, IPC identity validation, legacy startup claims, pending GraceStatus refresh,
  case-sensitive root identity, post-identity safety flags, and cross-identity pending-apply flags.

## Related Issue

References #492. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This starts WS5 by giving Grace a small, factual Watch status surface that later branch-switch refusal and transition
completion slices can trust. The change keeps the branch-switch policy out of this leaf while making pending local work
and current Watch identity visible enough for the next WS5 issues to make safe decisions.

## Validation

- Targeted Fantomas passed for initial implementation files:
  - `src/Grace.CLI/Command/Services.CLI.fs`
  - `src/Grace.CLI/Command/Watch.CLI.fs`
  - `src/Grace.CLI.Tests/Watch.Tests.fs`
  - `src/Grace.CLI.Tests/CurrentStateCapture.CLI.Tests.fs`
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` passed with 0 warnings and 0 errors.
- `dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` passed: 782 tests.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed.
- Review fix targeted Fantomas passed for `Services.CLI.fs`, `Watch.CLI.fs`, and `Watch.Tests.fs`.
- Review fix `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed.
- Review fix focused Watch tests passed: 146 tests.
- Review fix `git diff --check` passed.
- Review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Second review fix targeted Fantomas passed for `Services.CLI.fs` and `Watch.Tests.fs`.
- Second review fix focused Watch tests passed: 147 tests.
- Second review fix `git diff --check` passed.
- Second review fix `pwsh ./scripts/validate.ps1 -Fast` passed: `Grace.CLI.Tests` 789 passed.
- Third review fix targeted Fantomas passed for `Services.CLI.fs`, `Watch.CLI.fs`, and `Watch.Tests.fs`.
- Third review fix focused Watch tests passed: 148 tests.
- Third review fix `git diff --check` passed.
- Third review fix `pwsh ./scripts/validate.ps1 -Fast` passed: `Grace.CLI.Tests` 790 passed.
- Fourth review fix targeted Fantomas passed for `Services.CLI.fs`, `Watch.CLI.fs`, and `Watch.Tests.fs`.
- Fourth review fix focused Watch tests passed: 151 tests.
- Fourth review fix `git diff --check` passed.
- Fourth review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Fifth review fix targeted Fantomas check passed for `Services.CLI.fs` and `Watch.Tests.fs`.
- Fifth review fix focused Watch tests passed: 154 tests.
- Fifth review fix `git diff --check` passed.
- Fifth review fix `pwsh ./scripts/validate.ps1 -Fast` passed: `Grace.CLI.Tests` 796 passed.
- Sixth review fix targeted Fantomas passed for `Watch.CLI.fs`, `Services.CLI.fs`, and `Watch.Tests.fs`.
- Sixth review fix focused Watch tests passed: 155 tests.
- Sixth review fix `git diff --check` passed.
- Sixth review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Seventh review fix targeted Fantomas passed for `Services.CLI.fs` and `Watch.Tests.fs`.
- Seventh review fix focused Watch tests passed: 157 tests.
- Seventh review fix `git diff --check` passed.
- Seventh review fix `pwsh ./scripts/validate.ps1 -Fast` passed: `Grace.CLI.Tests` 799 passed.
- Structural stabilization targeted Fantomas passed for `Services.CLI.fs`, `Watch.CLI.fs`, and `Watch.Tests.fs`.
- Structural stabilization focused Release build passed for `src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`.
- Structural stabilization focused Watch tests passed: 177 tests.
- Structural stabilization `pwsh ./scripts/validate.ps1 -Fast` passed.
- Structural stabilization `git diff --check` passed.
- GitHub `full` check completed successfully on latest head `126e349838ff6a0967b3abf550e434943ee809f6`.

## Docs Impact

No Markdown or user-facing docs changed. This leaf only extends local Watch IPC/status facts and tests; it does not add
a user-facing command, option, ADR-worthy transition policy, remote sync behavior, or branch-switch refusal behavior.

## Explicit Deferrals

- #493: branch-switch refusal consumes these factual status fields.
- #494: update marker narrowing is intentionally not implemented here.
- #495: clean branch-switch transition completion is intentionally not implemented here.
- #496: SignalR subscription refresh and WS5 ADR are intentionally not implemented here.

## Review Stabilization Ledger

This PR has crossed the repeated-review hard-stop threshold. Treat the remaining work as a stabilization pass, not as
another one-off review fix. The issue underspecified the Watch IPC trust model; this ledger is now part of the
acceptance target for #492 and PR #524.

### Scope

Applies to Watch IPC/status identity, clean/dirty status authority, pending status refresh publication, clean/dirty
transition publication, and legacy Watch status trust boundaries in the #492 owned paths.

Out of scope: actual branch-switch refusal (#493), update marker narrowing (#494), clean branch-switch transition
completion (#495), SignalR subscription refresh and WS5 ADR work (#496), remote sync materialization, and durable
journal authority.

### Acceptance Invariants

1. **Authoritative identity.** Current Watch identity is `RepositoryId`, `BranchId`, and `RootDirectory` under the
   existing platform-aware root comparison. `RepositoryName` and `BranchName` are display or legacy fallback values
   only when the corresponding persisted ID is empty.
1. **Writer authority.** Only fresh, current-identity, healthy Watch state with usable root proof can advertise
   `cleanWorkingTree` or `pendingStatusApply`. Non-Watch writers may preserve or degrade state, but they must not create
   clean authority from their local process state.
1. **Publication transaction.** Pending-work, clean/dirty, resync, and refresh transition caches or flags advance only
   after the exact intended IPC snapshot is written and verified. Failed reads or writes preserve retry eligibility.
1. **GraceStatus refresh generation.** A `.grace/grace-local.db`, WAL, or SHM refresh observed after a timer pass loaded
   its snapshot must remain pending. Clearing refresh state must be scoped to the observed generation or snapshot, not a
   blind boolean erase.
1. **State isolation.** Dirty/clean transition publication reads must not mutate the main Watch processing loop's
   authoritative `graceStatus` or `graceStatusDirectoryIds` values unless both operations are synchronized under the same
   boundary.
1. **Legacy trust.** Legacy snapshots may be normalized for classification, but missing fields must not grant
   clean/current authority. Legacy `Suspended` and `Resynchronizing` snapshots remain recovery snapshots.

### Required Proof

Focused proof must cover:

- current repository and branch IDs with stale names are accepted; non-empty mismatched IDs are rejected even when names
  match;
- a newer GraceStatus DB/WAL/SHM refresh observed during clean refresh publication remains pending and causes retry or
  dirty publication;
- dirty/clean transition publication does not overwrite the timer pass's in-flight `graceStatus` or directory IDs;
- existing legacy, stale, non-Watch, clean/dirty, resync, pending-apply, and root identity tests still pass.

### Required Self-Review Before Another Review Request

Before requesting another review, post a status map for each invariant using one of: `implemented and proven`,
`implemented but proof incomplete`, `waived`, `out of scope`, or `not applicable`.

Do not request another review until the status map, focused tests, validation, and residual-risk notes are present.

## Review Status

- Current head: `126e349838ff6a0967b3abf550e434943ee809f6`.
- Stabilization fix: `126e349838ff6a0967b3abf550e434943ee809f6` (`Stabilize watch IPC authority`).
- Worker bot-prevention self-review: complete after the structural stabilization pass.
- Final Codex Code Review Bot state: 👍 no-issues reaction on current head at 2026-07-04T09:52:27Z.
- Latest finding review addressed: review `4629259090` on prior head
  `a53e132b60eec414ef3f20f0169328e6daf7a542`, submitted 2026-07-04.
- Stabilization findings resolved after the fix commit:
  - `r3522913329`: Avoid clearing newer GraceStatus refresh events.
  - `r3522913330`: Prefer repository IDs over stale names.
  - `r3522913331`: Keep dirty-transition reads out of Watch state.
- Current unresolved review conversations: none.
- Manual trigger decision: not attempted. The bot acknowledged and completed the current-head review path.
- GitHub checks: `full` completed successfully for `126e349838ff6a0967b3abf550e434943ee809f6`.
- Stabilization validation: targeted Fantomas passed; focused Release build passed; focused WatchTests passed 177/177;
  final `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed.
- Prevention line: contract-propagation, stale-identity, and async-runtime ordering gaps are now covered by the #492
  stabilization ledger; later WS5 sibling issues consume these facts but do not own making this leaf trustworthy.

### Stabilization Status Map

| Invariant | Status | Proof |
| --------- | ------ | ----- |
| Authoritative identity | implemented and proven | ID-first matching covers stale names and mismatched IDs. |
| Writer authority | implemented and proven | Clean and pending-apply flags require fresh current Watch authority. |
| Publication transaction | implemented and proven | Publication caches advance only after verified IPC writes. |
| GraceStatus refresh generation | implemented and proven | Newer status refreshes remain pending after older passes. |
| State isolation | implemented and proven | Transition reads use local snapshots instead of mutating timer state. |
| Legacy trust | implemented and proven | Legacy snapshots classify without granting clean/current authority. |

Residual risk: Watch IPC behavior is timing-sensitive across processes and filesystem notifications. The added tests
exercise deterministic race seams and publication boundaries, but they are not a true multi-process timing stress test.

## Residual Risks

- #493 still needs to consume these factual fields for actual branch-switch refusal.
- Dirty transition publication reads the current local Grace status once, synchronously, only on clean-to-dirty
  transition. Later work should keep branch-switch refusal based on inspection facts rather than assuming every dirty
  IPC snapshot has a fully usable root.
- Legacy IPC compatibility intentionally repairs missing fields from an otherwise parseable legacy snapshot; malformed
  JSON and corrupt payloads still fall back as unreadable.
- Resync-required publication now preserves retry eligibility after a swallowed IPC write failure, but retry still depends
  on a later Watch transition or publication attempt.
- Root case lookup uses a short-lived probe under `.grace` and falls back to case-insensitive behavior if probing fails,
  matching the existing Watch-side fallback behavior.
