### PR TITLE
WS5.2: Refuse branch switch without clean Watch preflight

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -163,6 +163,54 @@ module BranchCommandTests =
 
         result, inspected, markerCreated
 
+    /// Verifies that update marker names include repository and root identity before branch-name scoping.
+    [<Test>]
+    let ``branch switch update marker path is scoped by repository root and branch identity`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let current = Current()
+            let originalRepositoryName = current.RepositoryName
+            let originalBranchName = current.BranchName
+            let currentMarkerFile = Services.updateInProgressFileName ()
+            let legacyBranchOnlyMarkerFile = Path.Combine(Path.GetTempPath(), "Grace", originalBranchName, Constants.UpdateInProgressFileName)
+            let foreignRoot = Path.Combine(Path.GetTempPath(), $"grace-branch-switch-foreign-{Guid.NewGuid():N}")
+
+            let foreignMarkerFile =
+                Services.updateInProgressFileNameForIdentity (Guid.NewGuid()) originalRepositoryName foreignRoot (Guid.NewGuid()) originalBranchName
+
+            try
+                Directory.CreateDirectory(Path.GetDirectoryName(foreignMarkerFile))
+                |> ignore
+
+                File.WriteAllText(foreignMarkerFile, "foreign repository marker")
+
+                foreignMarkerFile
+                |> should not' (equal currentMarkerFile)
+
+                currentMarkerFile
+                |> should not' (equal legacyBranchOnlyMarkerFile)
+
+                File.Exists(foreignMarkerFile)
+                |> should equal true
+
+                File.Exists(currentMarkerFile)
+                |> should equal false
+
+                let result, inspected, markerCreated =
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ())
+                    |> runBranchSwitchPreflight (File.Exists(currentMarkerFile))
+
+                match result with
+                | Ok _ -> ()
+                | Error error -> Assert.Fail($"Expected unrelated repository marker to allow branch switch preflight, got: {error.Error}")
+
+                inspected |> should equal true
+                markerCreated |> should equal true
+
+            finally
+                if File.Exists(foreignMarkerFile) then File.Delete(foreignMarkerFile)
+
+                if Directory.Exists(foreignRoot) then Directory.Delete(foreignRoot, true))
+
     /// Verifies that branch switch accepts matching IDs even when display names in Watch status are stale.
     [<Test>]
     let ``branch switch Watch preflight allows healthy clean status with stale display names`` () =
@@ -184,13 +232,20 @@ module BranchCommandTests =
             inspected |> should equal true
             markerCreated |> should equal true)
 
-    /// Verifies that a pre-existing update marker refuses before Watch inspection or marker mutation.
+    /// Verifies that a pre-existing same-repository update marker refuses before Watch inspection or marker mutation.
     [<Test>]
-    let ``branch switch Watch preflight refuses existing update marker before inspection`` () =
+    let ``branch switch Watch preflight refuses existing same repository update marker before inspection`` () =
         withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "same repository marker")
+
             let result, inspected, markerCreated =
                 branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ())
-                |> runBranchSwitchPreflight true
+                |> runBranchSwitchPreflight (File.Exists(updateMarkerFile))
 
             match result with
             | Error error ->
@@ -203,6 +258,33 @@ module BranchCommandTests =
 
             inspected |> should equal false
             markerCreated |> should equal false)
+
+    /// Verifies that marker write failures remove the partial file created by this preflight.
+    [<Test>]
+    let ``branch switch update marker creation removes partial marker after write failure`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let partialText = markerText.Substring(0, 16)
+
+            let operation =
+                Func<Task> (fun () ->
+                    Branch.createBranchSwitchUpdateMarkerWithWriter
+                        (fun writer _ ->
+                            task {
+                                do! writer.WriteAsync(partialText)
+                                do! writer.FlushAsync()
+                                raise (IOException("simulated marker flush failure"))
+                            })
+                        updateMarkerFile
+                        markerText
+                    :> Task)
+
+            Assert.ThrowsAsync<IOException>(operation)
+            |> ignore
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
 
     /// Verifies that untrusted Watch states refuse before branch switch marker creation.
     [<Test>]

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -136,6 +136,13 @@ module BranchCommandTests =
     let private branchSwitchWatchInspection persistedMode status =
         { Exists = true; Status = Some status; PersistedMode = persistedMode; SafetyFlags = status.SafetyFlags; ReadError = None }
 
+    /// Writes a Watch IPC status snapshot for branch switch preflight tests.
+    let private writeBranchSwitchWatchStatus (fileName: string) status =
+        Directory.CreateDirectory(Path.GetDirectoryName(fileName))
+        |> ignore
+
+        File.WriteAllText(fileName, serialize status)
+
     /// Runs branch switch preflight with injected side effects and reports which effects occurred.
     let private runBranchSwitchPreflight markerExists inspection =
         let mutable inspected = false
@@ -232,6 +239,84 @@ module BranchCommandTests =
             inspected |> should equal true
             markerCreated |> should equal true)
 
+    /// Verifies that successful branch switch cleanup removes the old branch marker created by preflight.
+    [<Test>]
+    let ``branch switch working tree update preserves preflight marker lease for outer cleanup`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let preflightMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, preflightMarkerText)
+
+            (Branch.runBranchSwitchWorkingTreeUpdateWithMarker updateMarkerFile "`grace switch` is in progress." (fun () ->
+                task {
+                    let configuration = Current()
+                    configuration.BranchId <- Guid.NewGuid()
+                    configuration.BranchName <- "branch-switch-target"
+                }))
+                .GetAwaiter()
+                .GetResult()
+
+            File.Exists(updateMarkerFile) |> should equal true
+
+            File.ReadAllText(updateMarkerFile)
+            |> should equal preflightMarkerText
+
+            Branch.deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFile preflightMarkerText
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that same-branch Watch IPC from another checkout does not override the current repository snapshot.
+    [<Test>]
+    let ``branch switch Watch preflight reads repository scoped IPC for current checkout`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let current = Current()
+            let currentIpcFile = Services.IpcFileName()
+            let foreignRoot = Path.Combine(Path.GetTempPath(), $"grace-branch-switch-foreign-ipc-{Guid.NewGuid():N}")
+
+            let foreignIpcFile = Services.IpcFileNameForIdentity (Guid.NewGuid()) current.RepositoryName foreignRoot (Guid.NewGuid()) current.BranchName
+
+            try
+                let foreignStatus =
+                    { branchSwitchWatchStatus () with
+                        RepositoryId = Guid.NewGuid()
+                        BranchId = Guid.NewGuid()
+                        RootDirectory = foreignRoot
+                        HasPendingWatchWork = true
+                        IsWorkingTreeClean = false
+                    }
+
+                writeBranchSwitchWatchStatus foreignIpcFile foreignStatus
+                writeBranchSwitchWatchStatus currentIpcFile (branchSwitchWatchStatus ())
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.HasCurrentRepositoryIdentity
+                |> should equal true
+
+                inspection.IsUsable |> should equal true
+
+                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+
+                match result with
+                | Ok _ -> ()
+                | Error error -> Assert.Fail($"Expected current repository Watch IPC to allow branch switch, got: {error.Error}")
+
+                inspected |> should equal true
+                markerCreated |> should equal true
+            finally
+                if File.Exists(currentIpcFile) then File.Delete(currentIpcFile)
+
+                if File.Exists(foreignIpcFile) then File.Delete(foreignIpcFile))
+
     /// Verifies that a pre-existing same-repository update marker refuses before Watch inspection or marker mutation.
     [<Test>]
     let ``branch switch Watch preflight refuses existing same repository update marker before inspection`` () =
@@ -285,6 +370,38 @@ module BranchCommandTests =
 
             File.Exists(updateMarkerFile)
             |> should equal false)
+
+    /// Verifies that current-repository untrusted Watch IPC still refuses before marker creation.
+    [<Test>]
+    let ``branch switch Watch preflight refuses dirty current repository IPC before marker creation`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let currentIpcFile = Services.IpcFileName()
+
+            try
+                let dirtyStatus = { branchSwitchWatchStatus () with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+                writeBranchSwitchWatchStatus currentIpcFile dirtyStatus
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+
+                match result with
+                | Error error ->
+                    error.Error
+                    |> should contain "Branch switch refused before mutation"
+
+                    error.Error |> should contain "dirty working tree"
+                | Ok _ -> Assert.Fail("Expected dirty current-repository Watch IPC to refuse branch switch.")
+
+                inspected |> should equal true
+                markerCreated |> should equal false
+            finally
+                if File.Exists(currentIpcFile) then File.Delete(currentIpcFile))
 
     /// Verifies that untrusted Watch states refuse before branch switch marker creation.
     [<Test>]

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -5,11 +5,13 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.CLI.Services
 open Grace.Shared
+open Grace.Shared.Client.Configuration
 open Grace.Shared.Parameters.Branch
 open Grace.Shared.Utilities
 open Grace.Types.Annotation
 open Grace.Types.Common
 open Grace.Types.Reference
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
@@ -77,6 +79,237 @@ module BranchCommandTests =
             Source = ExplicitReference
             CreatedSaveMessage = None
         }
+
+    /// Runs the supplied action with a temporary current repository identity for branch switch preflight tests.
+    let private withTempBranchSwitchRepo (action: unit -> unit) =
+        let tempDir = Path.Combine(Path.GetTempPath(), $"grace-branch-switch-tests-{Guid.NewGuid():N}")
+        let graceDir = Path.Combine(tempDir, Constants.GraceConfigDirectory)
+        let originalDir = Environment.CurrentDirectory
+        let originalParseResult = Services.parseResult
+
+        try
+            Directory.CreateDirectory(graceDir) |> ignore
+            File.WriteAllText(Path.Combine(graceDir, Constants.GraceConfigFileName), "{}")
+            Environment.CurrentDirectory <- tempDir
+            Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
+            resetConfiguration ()
+
+            let configuration = Current()
+            configuration.RepositoryId <- repositoryId
+            configuration.RepositoryName <- "branch-switch-repository"
+            configuration.BranchId <- branchId
+            configuration.BranchName <- "branch-switch-current"
+            configuration.RootDirectory <- tempDir
+
+            action ()
+        finally
+            resetConfiguration ()
+            Services.parseResult <- originalParseResult
+            Environment.CurrentDirectory <- originalDir
+
+            if Directory.Exists(tempDir) then Directory.Delete(tempDir, true)
+
+    /// Builds a trusted Watch IPC inspection snapshot for branch switch preflight tests.
+    let private branchSwitchWatchStatus () : GraceWatchStatus =
+        let current = Current()
+        let rootDirectoryId = Guid.NewGuid()
+
+        {
+            UpdatedAt = getCurrentInstant ()
+            IsStartupClaim = false
+            RepositoryId = current.RepositoryId
+            RepositoryName = RepositoryName current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = BranchName current.BranchName
+            RootDirectory = current.RootDirectory
+            HasPendingWatchWork = false
+            IsWorkingTreeClean = true
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = Sha256Hash "branch-switch-watch-root"
+            RootDirectoryBlake3Hash = Blake3Hash "branch-switch-watch-root-blake3"
+            LastFileUploadInstant = Instant.MinValue
+            LastDirectoryVersionInstant = Instant.MinValue
+            DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
+        }
+
+    /// Wraps a status snapshot in the inspection shape consumed by branch switch preflight.
+    let private branchSwitchWatchInspection persistedMode status =
+        { Exists = true; Status = Some status; PersistedMode = persistedMode; SafetyFlags = status.SafetyFlags; ReadError = None }
+
+    /// Runs branch switch preflight with injected side effects and reports which effects occurred.
+    let private runBranchSwitchPreflight markerExists inspection =
+        let mutable inspected = false
+        let mutable markerCreated = false
+
+        let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+            {
+                UpdateMarkerExists = fun () -> markerExists
+                InspectWatchStatus =
+                    fun () ->
+                        inspected <- true
+                        Task.FromResult inspection
+                CreateUpdateMarker =
+                    fun () ->
+                        task {
+                            markerCreated <- true
+                            return ()
+                        }
+            }
+
+        let result =
+            (Branch.runBranchSwitchWatchCleanPreflight operations correlationId)
+                .GetAwaiter()
+                .GetResult()
+
+        result, inspected, markerCreated
+
+    /// Verifies that branch switch accepts matching IDs even when display names in Watch status are stale.
+    [<Test>]
+    let ``branch switch Watch preflight allows healthy clean status with stale display names`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let status =
+                { branchSwitchWatchStatus () with
+                    RepositoryName = RepositoryName "stale-repository-display-name"
+                    BranchName = BranchName "stale-branch-display-name"
+                }
+
+            let result, inspected, markerCreated =
+                branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) status
+                |> runBranchSwitchPreflight false
+
+            match result with
+            | Ok _ -> ()
+            | Error error -> Assert.Fail($"Expected healthy Watch status to allow branch switch, got: {error.Error}")
+
+            inspected |> should equal true
+            markerCreated |> should equal true)
+
+    /// Verifies that a pre-existing update marker refuses before Watch inspection or marker mutation.
+    [<Test>]
+    let ``branch switch Watch preflight refuses existing update marker before inspection`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let result, inspected, markerCreated =
+                branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ())
+                |> runBranchSwitchPreflight true
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error
+                |> should contain "update marker already exists"
+            | Ok _ -> Assert.Fail("Expected existing update marker to refuse branch switch.")
+
+            inspected |> should equal false
+            markerCreated |> should equal false)
+
+    /// Verifies that untrusted Watch states refuse before branch switch marker creation.
+    [<Test>]
+    let ``branch switch Watch preflight refuses untrusted Watch states before marker creation`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let current = Current()
+            let healthyStatus = branchSwitchWatchStatus ()
+
+            let missingStatus: GraceWatchStatusInspection =
+                {
+                    Exists = false
+                    Status = None
+                    PersistedMode = None
+                    SafetyFlags =
+                        [|
+                            "missingStatus"
+                            "requiresExplicitResync"
+                        |]
+                    ReadError = None
+                }
+
+            let unreadableStatus: GraceWatchStatusInspection =
+                {
+                    Exists = true
+                    Status = None
+                    PersistedMode = None
+                    SafetyFlags =
+                        [|
+                            "unreadableStatus"
+                            "requiresExplicitResync"
+                        |]
+                    ReadError = Some "The Grace Watch status file exists but could not be read."
+                }
+
+            let staleStatus =
+                { healthyStatus with
+                    UpdatedAt =
+                        getCurrentInstant()
+                            .Minus(Duration.FromMinutes(10.0))
+                }
+
+            let crossRootStatus = { healthyStatus with RootDirectory = Path.Combine(Path.GetTempPath(), $"other-root-{Guid.NewGuid():N}") }
+
+            let crossRepositoryStatus = { healthyStatus with RepositoryId = Guid.NewGuid(); RepositoryName = RepositoryName current.RepositoryName }
+
+            let crossBranchStatus = { healthyStatus with BranchId = Guid.NewGuid(); BranchName = BranchName current.BranchName }
+
+            let legacyNonAuthoritativeStatus =
+                { healthyStatus with
+                    RepositoryId = RepositoryId.Empty
+                    RepositoryName = RepositoryName String.Empty
+                    BranchId = BranchId.Empty
+                    BranchName = BranchName String.Empty
+                    RootDirectory = String.Empty
+                }
+
+            let resynchronizingStatus = { healthyStatus with DirectoryIds = HashSet<DirectoryVersionId>() }
+
+            let pendingStatus = { healthyStatus with HasPendingWatchWork = true }
+
+            let dirtyStatus = { healthyStatus with IsWorkingTreeClean = false }
+
+            let startupStatus = { healthyStatus with IsStartupClaim = true }
+
+            let cases =
+                [|
+                    "missing Watch status", missingStatus, "status file is missing"
+                    "unreadable Watch status", unreadableStatus, "could not be read"
+                    "stale Watch heartbeat", branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) staleStatus, "heartbeat is stale"
+                    "cross-root Watch status",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) crossRootStatus,
+                    "does not match the current repository root"
+                    "cross-repository Watch status",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) crossRepositoryStatus,
+                    "persisted IDs are authoritative"
+                    "cross-branch Watch status",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) crossBranchStatus,
+                    "persisted IDs are authoritative"
+                    "legacy non-authoritative Watch status",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) legacyNonAuthoritativeStatus,
+                    "legacy non-authoritative identity"
+                    "suspended Watch mode",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.Suspended) healthyStatus,
+                    "requires healthy/current incremental mode"
+                    "resynchronizing Watch status",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) resynchronizingStatus,
+                    "resynchronizing"
+                    "pending local observations",
+                    branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) pendingStatus,
+                    "pending local observations"
+                    "dirty Watch status", branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) dirtyStatus, "dirty working tree"
+                    "startup Watch claim", branchSwitchWatchInspection (Some GraceWatchRuntimeMode.StartingUp) startupStatus, "still starting"
+                |]
+
+            for name, inspection, expectedReason in cases do
+                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+
+                match result with
+                | Error error ->
+                    error.Error
+                    |> should contain "Branch switch refused before mutation"
+
+                    error.Error |> should contain expectedReason
+                | Ok _ -> Assert.Fail($"Expected {name} to refuse branch switch.")
+
+                inspected |> should equal true
+                markerCreated |> should equal false)
 
     let private sampleAnnotation =
         let lastChangedReferenceId = Guid.NewGuid()

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -270,6 +270,25 @@ module BranchCommandTests =
             File.Exists(updateMarkerFile)
             |> should equal false)
 
+    /// Verifies that cancellation removes the working-tree marker when this invocation created it.
+    [<Test>]
+    let ``branch switch working tree update removes owned marker when operation cancels`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = "`grace switch` is in progress."
+
+            let operation =
+                Func<Task> (fun () ->
+                    Branch.runBranchSwitchWorkingTreeUpdateWithMarker updateMarkerFile markerText (fun () ->
+                        task { raise (OperationCanceledException("simulated cancellation")) })
+                    :> Task)
+
+            Assert.ThrowsAsync<OperationCanceledException>(operation)
+            |> ignore
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
     /// Verifies that same-branch Watch IPC from another checkout does not override the current repository snapshot.
     [<Test>]
     let ``branch switch Watch preflight reads repository scoped IPC for current checkout`` () =

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2876,6 +2876,123 @@ module Branch =
         /// Stores a parsed command value for handler execution.
         member val ReferenceId: string = String.Empty with get, set
 
+    /// Defines the injected side-effect boundary for branch-switch Watch-clean preflight tests.
+    type internal BranchSwitchWatchCleanPreflightOperations =
+        {
+            UpdateMarkerExists: unit -> bool
+            InspectWatchStatus: unit -> Task<GraceWatchStatusInspection>
+            CreateUpdateMarker: unit -> Task<unit>
+        }
+
+    /// Builds the branch-switch refusal reason for an untrusted Watch IPC snapshot.
+    let private branchSwitchWatchCleanPreflightRefusalReason updateMarkerExists (inspection: GraceWatchStatusInspection) =
+        let modeText =
+            inspection.EffectiveMode
+            |> Option.map string
+            |> Option.defaultValue "unknown"
+
+        match updateMarkerExists, inspection.Status with
+        | true, _ -> Some "the Grace update marker already exists for the current branch; another Grace-owned working-tree update may be in progress."
+        | false, _ when not inspection.Exists -> Some "the Grace Watch status file is missing."
+        | false, _ when inspection.ReadError.IsSome -> Some "the Grace Watch status file exists but could not be read."
+        | false, None -> Some "the Grace Watch status file is unreadable."
+        | false, Some status when not inspection.IsFresh -> Some "the Grace Watch status heartbeat is stale."
+        | false, Some status when status.IsStartupClaim -> Some "Grace Watch is still starting and has not published a usable clean snapshot."
+        | false, Some status when not inspection.HasCurrentRepositoryIdentity ->
+            let hasLegacyNonAuthoritativeIdentity =
+                String.IsNullOrWhiteSpace(status.RootDirectory)
+                || (status.RepositoryId = RepositoryId.Empty
+                    && String.IsNullOrWhiteSpace(string status.RepositoryName))
+                || (status.BranchId = BranchId.Empty
+                    && String.IsNullOrWhiteSpace(string status.BranchName))
+
+            if hasLegacyNonAuthoritativeIdentity then
+                Some "the Grace Watch status uses legacy non-authoritative identity and cannot prove the current repository root, repository ID, and branch ID."
+            else
+                Some
+                    "the Grace Watch status does not match the current repository root, repository ID, or branch ID; persisted IDs are authoritative, and names are only a legacy fallback when IDs are empty."
+        | false, Some _ when
+            inspection.EffectiveMode
+            <> Some GraceWatchRuntimeMode.HealthyIncremental
+            ->
+            Some $"Grace Watch mode is {modeText}; branch switch requires healthy/current incremental mode with no scan or apply confidence loss."
+        | false, Some status when
+            status.Mode
+            <> GraceWatchRuntimeMode.HealthyIncremental
+            ->
+            Some "the Grace Watch status is resynchronizing because it lacks trusted root or directory index data."
+        | false, Some status when not status.IsWorkingTreeClean -> Some "Grace Watch reports a dirty working tree."
+        | false, Some status when status.HasPendingWatchWork -> Some "Grace Watch reports pending local observations or pending status apply work."
+        | false, Some _ when not inspection.IsUsable ->
+            let flags =
+                if isNull inspection.SafetyFlags
+                   || inspection.SafetyFlags.Length = 0 then
+                    "none"
+                else
+                    String.Join(", ", inspection.SafetyFlags)
+
+            Some $"Grace Watch status did not prove a clean current branch. Safety flags: {flags}."
+        | false, Some _ -> None
+
+    /// Validates the branch-switch Watch-clean preflight contract without creating the update marker.
+    let internal validateBranchSwitchWatchCleanPreflight updateMarkerExists inspection =
+        match branchSwitchWatchCleanPreflightRefusalReason updateMarkerExists inspection with
+        | Some reason -> Error reason
+        | None -> Ok()
+
+    /// Runs the branch-switch Watch-clean preflight and creates the update marker only after trust is proven.
+    let internal runBranchSwitchWatchCleanPreflight (operations: BranchSwitchWatchCleanPreflightOperations) correlationId =
+        task {
+            if operations.UpdateMarkerExists() then
+                return
+                    Error(
+                        GraceError.Create
+                            "Branch switch refused before mutation: the Grace update marker already exists for the current branch; another Grace-owned working-tree update may be in progress."
+                            correlationId
+                    )
+            else
+                let! inspection = operations.InspectWatchStatus()
+
+                match validateBranchSwitchWatchCleanPreflight false inspection with
+                | Error reason -> return Error(GraceError.Create $"Branch switch refused before mutation: {reason}" correlationId)
+                | Ok () ->
+                    try
+                        do! operations.CreateUpdateMarker()
+                        return Ok()
+                    with
+                    | :? IOException ->
+                        return
+                            Error(
+                                GraceError.Create
+                                    "Branch switch refused before mutation: the Grace update marker appeared while preflight was running; another Grace-owned working-tree update may be in progress."
+                                    correlationId
+                            )
+        }
+
+    /// Creates the Grace update marker used to keep Watch from observing branch-switch working-tree writes.
+    let private createBranchSwitchUpdateMarker (updateMarkerFileName: string) (markerText: string) =
+        task {
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFileName))
+            |> ignore
+
+            use fileStream = new FileStream(updateMarkerFileName, FileMode.CreateNew, FileAccess.Write, FileShare.None)
+            use writer = new StreamWriter(fileStream, Encoding.UTF8)
+            do! writer.WriteAsync(markerText)
+            do! writer.FlushAsync()
+        }
+
+    /// Removes only the branch-switch marker content written by this command invocation.
+    let private deleteBranchSwitchUpdateMarkerIfOwned (updateMarkerFileName: string) (markerText: string) =
+        try
+            if
+                File.Exists(updateMarkerFileName)
+                && String.Equals(File.ReadAllText(updateMarkerFileName), markerText, StringComparison.Ordinal)
+            then
+                File.Delete(updateMarkerFileName)
+        with
+        | :? IOException -> ()
+        | :? UnauthorizedAccessException -> ()
+
     /// Executes the switch command by binding ParseResult values to the SDK request and CLI output contract.
     type Switch() =
         inherit AsynchronousCommandLineAction()
@@ -3656,40 +3773,61 @@ module Branch =
         /// Runs the asynchronous switch action when System.CommandLine dispatches the parsed command.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
-                Directory.CreateDirectory(Path.GetDirectoryName(updateInProgressFileName ()))
-                |> ignore
+                let updateMarkerFileName = updateInProgressFileName ()
+                let updateMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+                let mutable updateMarkerCreated = false
 
                 try
                     if parseResult |> verbose then printParseResult parseResult
 
-                    do! File.WriteAllTextAsync(updateInProgressFileName (), "`grace switch` is in progress.")
+                    let preflightOperations =
+                        {
+                            UpdateMarkerExists = fun () -> File.Exists(updateMarkerFileName)
+                            InspectWatchStatus = inspectGraceWatchStatus
+                            CreateUpdateMarker =
+                                fun () ->
+                                    task {
+                                        do! createBranchSwitchUpdateMarker updateMarkerFileName updateMarkerText
+                                        updateMarkerCreated <- true
+                                    }
+                        }
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
+                    match! runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult) with
+                    | Error error ->
+                        if parseResult |> verbose then
+                            AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
+                        else
+                            AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
 
-                    let switchParameters = SwitchParameters()
+                        return -1
+                    | Ok () ->
+                        let switchParameters = SwitchParameters()
 
-                    let toBranchId = parseResult.GetValue(Options.toBranchId)
-                    if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
+                        let toBranchId = parseResult.GetValue(Options.toBranchId)
+                        if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
 
-                    let toBranchName = parseResult.GetValue(Options.toBranchName)
-                    switchParameters.ToBranchName <- toBranchName
+                        let toBranchName = parseResult.GetValue(Options.toBranchName)
+                        switchParameters.ToBranchName <- toBranchName
 
-                    let referenceId = parseResult.GetValue(Options.referenceId)
+                        let referenceId = parseResult.GetValue(Options.referenceId)
 
-                    if referenceId <> Guid.Empty then
-                        switchParameters.ReferenceId <- $"{referenceId}"
+                        if referenceId <> Guid.Empty then
+                            switchParameters.ReferenceId <- $"{referenceId}"
 
-                    let sha256Hash = getSha256HashPrefix parseResult
-                    switchParameters.Sha256Hash <- sha256Hash
+                        let sha256Hash = getSha256HashPrefix parseResult
+                        switchParameters.Sha256Hash <- sha256Hash
 
-                    let blake3Hash = getBlake3HashPrefix parseResult
-                    switchParameters.Blake3Hash <- blake3Hash
+                        let blake3Hash = getBlake3HashPrefix parseResult
+                        switchParameters.Blake3Hash <- blake3Hash
 
-                    let! result = switchHandler parseResult switchParameters
-                    return result
+                        let! result = switchHandler parseResult switchParameters
+                        return result
                 finally
-                    if File.Exists(updateInProgressFileName ()) then
-                        File.Delete(updateInProgressFileName ())
+                    if
+                        updateMarkerCreated
+                        && File.Exists(updateMarkerFileName)
+                    then
+                        deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName updateMarkerText
             }
 
     /// Routes the rebase command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3010,7 +3010,7 @@ module Branch =
             markerText
 
     /// Removes only the branch-switch marker content written by this command invocation.
-    let private deleteBranchSwitchUpdateMarkerIfOwned (updateMarkerFileName: string) (markerText: string) =
+    let internal deleteBranchSwitchUpdateMarkerIfOwned (updateMarkerFileName: string) (markerText: string) =
         try
             if
                 File.Exists(updateMarkerFileName)
@@ -3020,6 +3020,23 @@ module Branch =
         with
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
+
+    /// Runs branch-switch working-tree mutation without replacing a preflight marker lease owned by the outer command.
+    let internal runBranchSwitchWorkingTreeUpdateWithMarker (updateMarkerFileName: string) (markerText: string) (operation: unit -> Task<'T>) =
+        task {
+            let mutable markerCreatedByThisInvocation = false
+
+            try
+                if not (File.Exists(updateMarkerFileName)) then
+                    do! createBranchSwitchUpdateMarker updateMarkerFileName markerText
+                    markerCreatedByThisInvocation <- true
+
+                let! result = operation ()
+                return result
+            finally
+                if markerCreatedByThisInvocation then
+                    deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText
+        }
 
     /// Executes the switch command by binding ParseResult values to the SDK request and CLI output contract.
     type Switch() =
@@ -3634,35 +3651,32 @@ module Branch =
                                         isError <- true
 
                                 if not <| isError then
-                                    try
-                                        //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
+                                    let workingTreeUpdateMarkerFileName = updateInProgressFileName ()
 
-                                        // Write the UpdatesInProgress file to let grace watch know to ignore these changes.
-                                        // This file is deleted in the finally clause.
-                                        do! File.WriteAllTextAsync(updateInProgressFileName (), "`grace switch` is in progress.")
+                                    do!
+                                        runBranchSwitchWorkingTreeUpdateWithMarker workingTreeUpdateMarkerFileName "`grace switch` is in progress." (fun () ->
+                                            task {
+                                                //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
 
-                                        // Update working directory based on new GraceStatus.Index
-                                        do!
-                                            updateWorkingDirectory
-                                                newGraceStatus
-                                                graceStatusWithNewDirectoryVersionsFromServer
-                                                newDirectoryVersionDtos
-                                                (getCorrelationId parseResult)
-                                        //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
+                                                // Update working directory based on new GraceStatus.Index
+                                                do!
+                                                    updateWorkingDirectory
+                                                        newGraceStatus
+                                                        graceStatusWithNewDirectoryVersionsFromServer
+                                                        newDirectoryVersionDtos
+                                                        (getCorrelationId parseResult)
+                                                //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
 
-                                        // Save the new Grace Status.
-                                        do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
+                                                // Save the new Grace Status.
+                                                do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
 
-                                        // Update graceconfig.json.
-                                        let configuration = Current()
-                                        configuration.BranchId <- newBranch.BranchId
-                                        configuration.BranchName <- newBranch.BranchName
-                                        updateConfiguration configuration
-                                        t |> setProgressTaskValue showOutput 100.0
-                                    finally
-                                        // Delete the UpdatesInProgress file.
-                                        if File.Exists(updateInProgressFileName ()) then
-                                            File.Delete(updateInProgressFileName ())
+                                                // Update graceconfig.json.
+                                                let configuration = Current()
+                                                configuration.BranchId <- newBranch.BranchId
+                                                configuration.BranchName <- newBranch.BranchName
+                                                updateConfiguration configuration
+                                                t |> setProgressTaskValue showOutput 100.0
+                                            })
 
                                     newGraceStatus <- graceStatusWithNewDirectoryVersionsFromServer
                                     rootDirectoryId <- newGraceStatus.RootDirectoryId

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2969,17 +2969,45 @@ module Branch =
                             )
         }
 
-    /// Creates the Grace update marker used to keep Watch from observing branch-switch working-tree writes.
-    let private createBranchSwitchUpdateMarker (updateMarkerFileName: string) (markerText: string) =
+    /// Writes branch-switch marker content through an injectable writer so failure cleanup can be tested deterministically.
+    let internal createBranchSwitchUpdateMarkerWithWriter
+        (writeMarkerText: StreamWriter -> string -> Task)
+        (updateMarkerFileName: string)
+        (markerText: string)
+        =
         task {
             Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFileName))
             |> ignore
 
-            use fileStream = new FileStream(updateMarkerFileName, FileMode.CreateNew, FileAccess.Write, FileShare.None)
-            use writer = new StreamWriter(fileStream, Encoding.UTF8)
-            do! writer.WriteAsync(markerText)
-            do! writer.FlushAsync()
+            let mutable markerCreatedByThisInvocation = false
+
+            try
+                use fileStream = new FileStream(updateMarkerFileName, FileMode.CreateNew, FileAccess.Write, FileShare.None)
+                markerCreatedByThisInvocation <- true
+                use writer = new StreamWriter(fileStream, Encoding.UTF8)
+                do! writeMarkerText writer markerText
+            with
+            | ex ->
+                if markerCreatedByThisInvocation then
+                    try
+                        if File.Exists(updateMarkerFileName) then File.Delete(updateMarkerFileName)
+                    with
+                    | :? IOException -> ()
+                    | :? UnauthorizedAccessException -> ()
+
+                return raise ex
         }
+
+    /// Creates the Grace update marker used to keep Watch from observing branch-switch working-tree writes.
+    let private createBranchSwitchUpdateMarker (updateMarkerFileName: string) (markerText: string) =
+        createBranchSwitchUpdateMarkerWithWriter
+            (fun writer markerText ->
+                task {
+                    do! writer.WriteAsync(markerText)
+                    do! writer.FlushAsync()
+                })
+            updateMarkerFileName
+            markerText
 
     /// Removes only the branch-switch marker content written by this command invocation.
     let private deleteBranchSwitchUpdateMarkerIfOwned (updateMarkerFileName: string) (markerText: string) =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2481,8 +2481,64 @@ module Services =
                 | Error error -> return Error error
         }
 
+    /// Computes a stable path segment from repository identity text without leaking local paths into temp directory names.
+    let private localRepositoryScopeSegment (value: string) =
+        let normalizedValue = if String.IsNullOrWhiteSpace(value) then "empty" else value.Trim()
+
+        Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedValue)))
+            .ToLowerInvariant()
+
+    /// Gets the normalized repository root text used to keep local coordination files scoped to one checkout.
+    let private localRepositoryRootScope (rootDirectory: string) =
+        if String.IsNullOrWhiteSpace(rootDirectory) then
+            "empty-root"
+        else
+            let normalizedRoot =
+                Path
+                    .GetFullPath(rootDirectory)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+            if runningOnWindows then normalizedRoot.ToUpperInvariant() else normalizedRoot
+
+    /// Gets the temp directory shared by local coordination files for one repository root and branch identity.
+    let internal localRepositoryBranchTempDirectoryForIdentity
+        (repositoryId: Guid)
+        (repositoryName: string)
+        (rootDirectory: string)
+        (branchId: Guid)
+        (branchName: string)
+        =
+        let repositoryScope =
+            if repositoryId <> Guid.Empty then
+                repositoryId.ToString("N")
+            else
+                localRepositoryScopeSegment repositoryName
+
+        let rootScope =
+            rootDirectory
+            |> localRepositoryRootScope
+            |> localRepositoryScopeSegment
+
+        let branchScope =
+            if branchId <> Guid.Empty then
+                branchId.ToString("N")
+            else
+                localRepositoryScopeSegment branchName
+
+        Path.Combine(Path.GetTempPath(), "Grace", "repositories", repositoryScope, rootScope, "branches", branchScope)
+
+    /// Gets the repository-scoped Watch IPC path for a specific local repository identity.
+    let internal IpcFileNameForIdentity (repositoryId: Guid) (repositoryName: string) (rootDirectory: string) (branchId: Guid) (branchName: string) =
+        getNativeFilePath (
+            Path.Combine(localRepositoryBranchTempDirectoryForIdentity repositoryId repositoryName rootDirectory branchId branchName, Constants.IpcFileName)
+        )
+
     /// The full path of the inter-process communication file that grace watch uses to communicate with other invocations of Grace.
-    let IpcFileName () = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.IpcFileName)
+    let IpcFileName () =
+        let current = Current()
+
+        IpcFileNameForIdentity current.RepositoryId current.RepositoryName current.RootDirectory current.BranchId current.BranchName
 
     /// Reads Watch IPC status for diagnostics without logging file paths, stack traces, or raw JSON.
     let inspectGraceWatchStatus () =
@@ -2944,26 +3000,6 @@ module Services =
 
         newGraceStatus
 
-    /// Computes a stable path segment from repository identity text without leaking local paths into temp directory names.
-    let private updateInProgressScopeSegment (value: string) =
-        let normalizedValue = if String.IsNullOrWhiteSpace(value) then "empty" else value.Trim()
-
-        Convert
-            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedValue)))
-            .ToLowerInvariant()
-
-    /// Gets the normalized repository root text used to keep update markers scoped to one local checkout.
-    let private updateInProgressRootScope (rootDirectory: string) =
-        if String.IsNullOrWhiteSpace(rootDirectory) then
-            "empty-root"
-        else
-            let normalizedRoot =
-                Path
-                    .GetFullPath(rootDirectory)
-                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-
-            if runningOnWindows then normalizedRoot.ToUpperInvariant() else normalizedRoot
-
     /// Gets the repository-scoped update marker path for a specific local repository identity.
     let internal updateInProgressFileNameForIdentity
         (repositoryId: Guid)
@@ -2972,24 +3008,7 @@ module Services =
         (branchId: Guid)
         (branchName: string)
         =
-        let repositoryScope =
-            if repositoryId <> Guid.Empty then
-                repositoryId.ToString("N")
-            else
-                updateInProgressScopeSegment repositoryName
-
-        let rootScope =
-            rootDirectory
-            |> updateInProgressRootScope
-            |> updateInProgressScopeSegment
-
-        let branchScope =
-            if branchId <> Guid.Empty then
-                branchId.ToString("N")
-            else
-                updateInProgressScopeSegment branchName
-
-        let directory = Path.Combine(Path.GetTempPath(), "Grace", "repositories", repositoryScope, rootScope, "branches", branchScope)
+        let directory = localRepositoryBranchTempDirectoryForIdentity repositoryId repositoryName rootDirectory branchId branchName
 
         Directory.CreateDirectory(directory) |> ignore
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2944,12 +2944,62 @@ module Services =
 
         newGraceStatus
 
-    /// Gets the file name used to indicate to `grace watch` that updates are in progress from another Grace command, and that it should ignore them.
-    let updateInProgressFileName () =
-        let directory = Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName)
+    /// Computes a stable path segment from repository identity text without leaking local paths into temp directory names.
+    let private updateInProgressScopeSegment (value: string) =
+        let normalizedValue = if String.IsNullOrWhiteSpace(value) then "empty" else value.Trim()
+
+        Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedValue)))
+            .ToLowerInvariant()
+
+    /// Gets the normalized repository root text used to keep update markers scoped to one local checkout.
+    let private updateInProgressRootScope (rootDirectory: string) =
+        if String.IsNullOrWhiteSpace(rootDirectory) then
+            "empty-root"
+        else
+            let normalizedRoot =
+                Path
+                    .GetFullPath(rootDirectory)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+            if runningOnWindows then normalizedRoot.ToUpperInvariant() else normalizedRoot
+
+    /// Gets the repository-scoped update marker path for a specific local repository identity.
+    let internal updateInProgressFileNameForIdentity
+        (repositoryId: Guid)
+        (repositoryName: string)
+        (rootDirectory: string)
+        (branchId: Guid)
+        (branchName: string)
+        =
+        let repositoryScope =
+            if repositoryId <> Guid.Empty then
+                repositoryId.ToString("N")
+            else
+                updateInProgressScopeSegment repositoryName
+
+        let rootScope =
+            rootDirectory
+            |> updateInProgressRootScope
+            |> updateInProgressScopeSegment
+
+        let branchScope =
+            if branchId <> Guid.Empty then
+                branchId.ToString("N")
+            else
+                updateInProgressScopeSegment branchName
+
+        let directory = Path.Combine(Path.GetTempPath(), "Grace", "repositories", repositoryScope, rootScope, "branches", branchScope)
+
         Directory.CreateDirectory(directory) |> ignore
 
-        getNativeFilePath (Path.Combine(Path.GetTempPath(), "Grace", Current().BranchName, Constants.UpdateInProgressFileName))
+        getNativeFilePath (Path.Combine(directory, Constants.UpdateInProgressFileName))
+
+    /// Gets the file name used to indicate to `grace watch` that updates are in progress from another Grace command, and that it should ignore them.
+    let updateInProgressFileName () =
+        let current = Current()
+
+        updateInProgressFileNameForIdentity current.RepositoryId current.RepositoryName current.RootDirectory current.BranchId current.BranchName
 
     /// Updates the working directory to match the contents of new DirectoryVersions.
     ///


### PR DESCRIPTION
## Summary

- Add a branch-switch Watch-clean preflight before update-marker creation and before the existing branch-switch handler
  can mutate state.
- Refuse branch switch when Watch cannot prove the current repository, branch, root, health, clean state, pending-work
  flags, and marker ownership are coherent.
- Consume #492's Watch IPC trust contract so repository and branch IDs remain authoritative and names are only legacy
  fallback values when persisted IDs are empty.
- Add false-positive-resistant branch CLI tests for clean current Watch status, stale display names with matching IDs,
  mismatched IDs with matching names, pre-existing marker refusal, and untrusted Watch states.

## Related Issue

References #493. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This advances WS5 by making `grace branch switch` refuse before mutation when Watch cannot prove the working tree is
clean and current. That keeps later branch-switch transition work from relying on unsafe status guesses, while keeping
update-marker narrowing, transition completion, and SignalR refresh in their separate leaf issues.

## Validation

- Targeted Fantomas passed for:
  - `src/Grace.CLI/Command/Branch.CLI.fs`
  - `src/Grace.CLI.Tests/Branch.CLI.Tests.fs`
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` passed.
- `dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj` passed: 822 tests.
- `git diff --check` passed.
- Final gate `pwsh ./scripts/validate.ps1 -Fast` passed in `00:00:25.0511730`.

- Review fix targeted Fantomas passed for `Services.CLI.fs`, `Branch.CLI.fs`, and `Branch.CLI.Tests.fs`.
- Review fix focused Branch CLI tests passed: 24 tests.
- Review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Review fix `git diff --check` passed.

- Stabilization targeted Fantomas passed for `Branch.CLI.fs`, `Services.CLI.fs`, and `Branch.CLI.Tests.fs`.
- Stabilization focused BranchCommandTests passed: 28 tests.
- Stabilization focused Watch status/IPC tests passed: 90 tests.
- Stabilization `pwsh ./scripts/validate.ps1 -Fast` passed.
- Stabilization `git diff --check` passed.

## Docs Impact

No docs changed. This leaf adds a safety refusal to the existing `branch switch` behavior without changing command
syntax, options, examples, or documented workflows.

## Explicit Deferrals

- #494: update-marker narrowing remains out of scope.
- #495: Watch transition-completion after clean branch switch remains out of scope.
- #496: SignalR subscription refresh and WS5 ADR remain out of scope.
- Remote materialization, durable journal authority, `--force`, `--wait`, and `grace watch flush` remain out of scope.

## Review Status

- Current head: `57510c2397b99959292df2057b772fe995cfc2d9`.
- Stabilization fix commits:
  - `80b7cb9a9fc2edc0e23a9c6c4661d03db7b06a96` (`Stabilize branch switch watch preflight`).
  - `57510c2397b99959292df2057b772fe995cfc2d9` (`Prove branch switch marker cancellation cleanup`).
- Worker bot-prevention self-review: complete after the stabilization pass and cancellation-proof follow-up.
- Final Codex Code Review Bot state: 👍 no-issues reaction on current head at 2026-07-04T11:10:03Z.
- Latest completed Codex Code Review Bot review with findings: review `4629347983` on prior head
  `7387c0fd3f739c82abca6c753a0930d8fc3db383`, submitted 2026-07-04T10:44:30Z.
- Prior #493-scope findings resolved after the stabilization fix:
  - `r3523008873`: Delete the old branch marker after switch.
  - `r3523008874`: Scope Watch IPC before preflight.
- Deferred finding:
  - `r3523008875`: Delay marker creation until working-tree mutation belongs to #494. #494 has been updated with the
    exact finding and proof obligation, and the thread was resolved as future-leaf scope.
- Current unresolved review conversations: none.
- GitHub checks: `full` completed successfully for `57510c2397b99959292df2057b772fe995cfc2d9`.
- Stabilization validation: targeted Fantomas passed; BranchCommandTests passed 28/28; Watch status/IPC tests passed
  90/90; final-state `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed.
- Review cycle count: high-risk cycle 2 for #532; stabilization ledger implemented and current-head review passed.
- Prevention line: marker lifecycle authority, marker identity scope, and Watch IPC locality were proven together;
  #494 owns marker-window narrowing.

### Stabilization Status Map

- Marker lifecycle authority: implemented and proven.
  Code seam: `Branch.CLI.fs` cleanup helpers. Proof: Branch tests and `validate -Fast`. Residual risk: none.
- Marker identity scope: implemented and proven.
  Code seam: `Services.CLI.fs` scoped temp paths. Proof: same-repo and unrelated marker tests. Residual risk: none.
- Watch IPC locality: implemented and proven.
  Code seam: `Services.CLI.fs` scoped IPC path. Proof: current and unrelated IPC tests. Residual risk: none.
- Leaf boundary: implemented and proven.
  Code seam: #493 preflight kept and #494 deferred. Proof: diff self-review and #494 update. Residual risk: #494
  remains deferred.

## Residual Risks

- This PR is intentionally limited to the preflight/refusal leaf. It does not implement #494 update-marker narrowing,
  #495 transition completion, #496 SignalR/ADR work, remote materialization, durable journal authority, `--force`,
  `--wait`, or `grace watch flush`.
- The existing inner working-directory update path still writes/deletes the legacy update marker during mutation. This
  leaf only hardens the new outer preflight marker ownership so the scope stays reviewable.
