### PR TITLE
OPS2: Add UsageFact contracts and serialization tests

### DIFF
--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Webhooks.Types.Tests.fs" />
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Common.Types.Tests.fs" />
+    <Compile Include="Usage.Types.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/Usage.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Usage.Types.Tests.fs
@@ -1,5 +1,6 @@
 namespace Grace.Types.Tests
 
+open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Usage
@@ -258,3 +259,32 @@ type UsageFactContractTests() =
         let fact = { UsageFactTestData.validFact () with ObservedAt = UsageFactTestData.observedAtWithSeconds }
 
         assertInvalid "ObservedAt must be normalized to a UTC minute boundary." fact
+
+    /// Verifies that default observation timestamps fail validation instead of becoming accepted usage evidence.
+    [<Test>]
+    member _.DefaultObservedAtFailsValidationClearly() =
+        let fact = { UsageFactTestData.validFact () with ObservedAt = Constants.DefaultTimestamp }
+
+        assertInvalid "ObservedAt is required." fact
+
+    /// Verifies that null nested scope values become validation errors instead of a null dereference.
+    [<Test>]
+    member _.NullScopeFailsValidationClearly() =
+        let fact = { UsageFactTestData.validFact () with Scope = Unchecked.defaultof<UsageFactScope> }
+
+        Assert.DoesNotThrow(Action(fun () -> UsageFact.Validate fact |> ignore))
+
+        match UsageFact.Validate fact with
+        | Ok () -> Assert.Fail("Usage fact should fail validation when Scope is null.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("Scope is required."))
+
+    /// Verifies that null nested resource values become validation errors instead of a null dereference.
+    [<Test>]
+    member _.NullResourceFailsValidationClearly() =
+        let fact = { UsageFactTestData.validFact () with Resource = Unchecked.defaultof<UsageFactResource> }
+
+        Assert.DoesNotThrow(Action(fun () -> UsageFact.Validate fact |> ignore))
+
+        match UsageFact.Validate fact with
+        | Ok () -> Assert.Fail("Usage fact should fail validation when Resource is null.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("Resource is required."))

--- a/src/Grace.Types.Tests/Usage.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Usage.Types.Tests.fs
@@ -267,6 +267,17 @@ type UsageFactContractTests() =
 
         assertInvalid "ObservedAt is required." fact
 
+    /// Verifies that null root fact values become validation errors instead of a null dereference.
+    [<Test>]
+    member _.NullRootFactFailsValidationClearly() =
+        let fact = Unchecked.defaultof<UsageFact>
+
+        Assert.DoesNotThrow(Action(fun () -> UsageFact.Validate fact |> ignore))
+
+        match UsageFact.Validate fact with
+        | Ok () -> Assert.Fail("Usage fact should fail validation when the fact root is null.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains("UsageFact is required."))
+
     /// Verifies that null nested scope values become validation errors instead of a null dereference.
     [<Test>]
     member _.NullScopeFailsValidationClearly() =

--- a/src/Grace.Types.Tests/Usage.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Usage.Types.Tests.fs
@@ -1,0 +1,260 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.Usage
+open NodaTime
+open NUnit.Framework
+open System
+open System.Text.Json
+
+/// Contains usage fact test helpers.
+module UsageFactTestData =
+
+    /// Provides a deterministic usage fact identifier that differs from the correlation id.
+    let usageFactId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    /// Provides the deterministic correlation id carried beside the fact identifier.
+    let correlationId = CorrelationId "corr-usage-tracer-bullet"
+
+    /// Provides the deterministic owner id for repository-scoped usage facts.
+    let ownerId = OwnerId.Parse("11111111-1111-1111-1111-111111111111")
+
+    /// Provides the deterministic organization id for repository-scoped usage facts.
+    let organizationId = OrganizationId.Parse("22222222-2222-2222-2222-222222222222")
+
+    /// Provides the deterministic repository id for repository-scoped usage facts.
+    let repositoryId = RepositoryId.Parse("33333333-3333-3333-3333-333333333333")
+
+    /// Provides the deterministic storage pool id for repository storage facts.
+    let storagePoolId = StoragePoolId "storage-pool-main"
+
+    /// Provides an observation instant with seconds that should normalize into the minute bucket.
+    let observedAtWithSeconds = Instant.FromUtc(2026, 7, 4, 12, 34, 56)
+
+    /// Provides the expected minute bucket for the deterministic observation instant.
+    let observedAtMinute = Instant.FromUtc(2026, 7, 4, 12, 34)
+
+    /// Builds a valid repository storage fact for serialization and validation tests.
+    let validFact () =
+        UsageFact.RepositoryStorageBytesMinute(usageFactId, correlationId, ownerId, organizationId, repositoryId, storagePoolId, 4096L, observedAtWithSeconds)
+
+/// Contains tests covering usage fact contract behavior.
+[<Parallelizable(ParallelScope.All)>]
+type UsageFactContractTests() =
+
+    /// Reads a required JSON property from the serialized contract shape.
+    let property (document: JsonDocument) (name: string) = document.RootElement.GetProperty(name)
+
+    /// Reads a JSON property as a string for deterministic shape assertions.
+    let stringProperty (document: JsonDocument) (name: string) = (property document name).GetString()
+
+    /// Reads a JSON property as a guid for deterministic shape assertions.
+    let guidProperty (document: JsonDocument) (name: string) = (property document name).GetGuid()
+
+    /// Asserts that usage fact validation fails with a message containing the expected text.
+    let assertInvalid expected (fact: UsageFact) =
+        match UsageFact.Validate fact with
+        | Ok () -> Assert.Fail($"Usage fact should fail validation with '{expected}'.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains(expected))
+
+    /// Verifies that a valid repository storage fact serializes with the expected JSON field names and values.
+    [<Test>]
+    member _.RepositoryStorageUsageFactSerializesWithExpectedJsonShape() =
+        let fact = UsageFactTestData.validFact ()
+        let json = serialize fact
+
+        use document = JsonDocument.Parse(json)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(stringProperty document "Class", Is.EqualTo(nameof UsageFact))
+                Assert.That(guidProperty document "UsageFactId", Is.EqualTo(UsageFactTestData.usageFactId))
+                Assert.That(stringProperty document "CorrelationId", Is.EqualTo(UsageFactTestData.correlationId))
+                Assert.That(stringProperty document "FactKind", Is.EqualTo("repositoryStorageBytesMinute"))
+
+                Assert.That(
+                    (property document "Scope")
+                        .GetProperty("OwnerId")
+                        .GetGuid(),
+                    Is.EqualTo(UsageFactTestData.ownerId)
+                )
+
+                Assert.That(
+                    (property document "Scope")
+                        .GetProperty("OrganizationId")
+                        .GetGuid(),
+                    Is.EqualTo(UsageFactTestData.organizationId)
+                )
+
+                Assert.That(
+                    (property document "Scope")
+                        .GetProperty("RepositoryId")
+                        .GetGuid(),
+                    Is.EqualTo(UsageFactTestData.repositoryId)
+                )
+
+                Assert.That(
+                    (property document "Resource")
+                        .GetProperty("StoragePoolId")
+                        .GetString(),
+                    Is.EqualTo(UsageFactTestData.storagePoolId)
+                )
+
+                Assert.That((property document "Quantity").GetInt64(), Is.EqualTo(4096L))
+                Assert.That(stringProperty document "ObservedAt", Is.EqualTo("2026-07-04T12:34:00Z")))
+        )
+
+    /// Verifies that a valid repository storage fact round trips through Grace JSON serialization.
+    [<Test>]
+    member _.RepositoryStorageUsageFactRoundTripsThroughJson() =
+        let fact = UsageFactTestData.validFact ()
+        let roundTrip = deserialize<UsageFact> (serialize fact)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(roundTrip, Is.EqualTo(fact))
+
+                match UsageFact.Validate roundTrip with
+                | Ok () -> ()
+                | Error errors ->
+                    let errorText = String.Join("; ", errors)
+                    Assert.Fail($"Round-tripped usage fact should be valid, but failed with: {errorText}"))
+        )
+
+    /// Verifies that fact identity and request correlation remain separate serialized fields.
+    [<Test>]
+    member _.UsageFactIdAndCorrelationIdRemainSeparateSerializedFields() =
+        let fact = UsageFactTestData.validFact ()
+
+        use document = JsonDocument.Parse(serialize fact)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(stringProperty document "UsageFactId", Is.EqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+                Assert.That(stringProperty document "CorrelationId", Is.EqualTo("corr-usage-tracer-bullet"))
+                Assert.That(stringProperty document "UsageFactId", Is.Not.EqualTo(stringProperty document "CorrelationId")))
+        )
+
+    /// Verifies that default identity fields fail validation instead of becoming valid facts.
+    [<Test>]
+    member _.DefaultRequiredIdentityFieldsFailValidationClearly() =
+        let fact =
+            { UsageFactTestData.validFact () with
+                UsageFactId = UsageFactId.Empty
+                Scope = { OwnerId = OwnerId.Empty; OrganizationId = OrganizationId.Empty; RepositoryId = RepositoryId.Empty }
+            }
+
+        match UsageFact.Validate fact with
+        | Ok () -> Assert.Fail("Usage fact should fail validation when required identity fields are missing.")
+        | Error errors ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errors, Has.Some.Contains("UsageFactId is required."))
+                    Assert.That(errors, Has.Some.Contains("Scope.OwnerId is required."))
+                    Assert.That(errors, Has.Some.Contains("Scope.OrganizationId is required."))
+                    Assert.That(errors, Has.Some.Contains("Scope.RepositoryId is required.")))
+            )
+
+    /// Verifies that missing identity JSON fields fail before becoming a partial contract value.
+    [<Test>]
+    member _.MissingRequiredIdentityJsonFieldsFailDeserializationClearly() =
+        let missingIdentityJson =
+            """
+{
+  "Class": "UsageFact",
+  "CorrelationId": "corr-usage-tracer-bullet",
+  "FactKind": "repositoryStorageBytesMinute",
+  "Scope": {},
+  "Resource": {
+    "StoragePoolId": "storage-pool-main"
+  },
+  "Quantity": 4096,
+  "ObservedAt": "2026-07-04T12:34:00Z"
+}
+"""
+
+        let ex =
+            Assert.Throws<JsonException>(
+                Action (fun () ->
+                    deserialize<UsageFact> missingIdentityJson
+                    |> ignore)
+            )
+
+        Assert.That(
+            ex.Message,
+            Does
+                .Contain("Missing field")
+                .And.Contains("OwnerId")
+        )
+
+    /// Verifies that malformed identity JSON fails before becoming a contract value.
+    [<Test>]
+    member _.MalformedIdentityJsonFailsDeserializationClearly() =
+        let malformedJson =
+            """
+{
+  "Class": "UsageFact",
+  "UsageFactId": "not-a-guid",
+  "CorrelationId": "corr-usage-tracer-bullet",
+  "FactKind": "repositoryStorageBytesMinute",
+  "Scope": {
+    "OwnerId": "11111111-1111-1111-1111-111111111111",
+    "OrganizationId": "22222222-2222-2222-2222-222222222222",
+    "RepositoryId": "33333333-3333-3333-3333-333333333333"
+  },
+  "Resource": {
+    "StoragePoolId": "storage-pool-main"
+  },
+  "Quantity": 4096,
+  "ObservedAt": "2026-07-04T12:34:00Z"
+}
+"""
+
+        let ex = Assert.Throws<JsonException>(Action(fun () -> deserialize<UsageFact> malformedJson |> ignore))
+        Assert.That(ex.Message, Does.Contain("not-a-guid").Or.Contains("Guid"))
+
+    /// Verifies that unsupported future fact kind values are not accepted as known facts.
+    [<Test>]
+    member _.UnsupportedFutureFactKindValueFailsValidationClearly() =
+        let fact = { UsageFactTestData.validFact () with FactKind = enum<UsageFactKind> 999 }
+
+        assertInvalid "FactKind '999' is not supported." fact
+
+    /// Verifies that unknown future fact kind strings do not deserialize as known facts.
+    [<Test>]
+    member _.UnknownFutureFactKindStringFailsDeserializationClearly() =
+        let unknownKindJson =
+            (serialize (UsageFactTestData.validFact ()))
+                .Replace("repositoryStorageBytesMinute", "futureUsageFactKind")
+
+        let ex = Assert.Throws<JsonException>(Action(fun () -> deserialize<UsageFact> unknownKindJson |> ignore))
+
+        Assert.That(
+            ex.Message,
+            Does
+                .Contain("futureUsageFactKind")
+                .Or.Contains("UsageFactKind")
+        )
+
+    /// Verifies that zero and negative quantities are rejected by the contract validator.
+    [<TestCase(0L)>]
+    [<TestCase(-1L)>]
+    member _.ZeroAndNegativeQuantitiesFailValidationClearly(quantity: int64) =
+        let fact = { UsageFactTestData.validFact () with Quantity = quantity }
+
+        assertInvalid "Quantity must be greater than zero." fact
+
+    /// Verifies that observation timestamps normalize to minute buckets during construction.
+    [<Test>]
+    member _.RepositoryStorageFactCreationNormalizesObservedAtToMinuteBoundary() =
+        let fact = UsageFactTestData.validFact ()
+
+        Assert.That(fact.ObservedAt, Is.EqualTo(UsageFactTestData.observedAtMinute))
+
+    /// Verifies that non-normalized observation timestamps fail validation when bypassing the constructor.
+    [<Test>]
+    member _.NonMinuteBoundaryObservedAtFailsValidationClearly() =
+        let fact = { UsageFactTestData.validFact () with ObservedAt = UsageFactTestData.observedAtWithSeconds }
+
+        assertInvalid "ObservedAt must be normalized to a UTC minute boundary." fact

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -45,6 +45,7 @@
         <Compile Include="DirectoryVersion.Types.fs" />
         <Compile Include="UploadSession.Types.fs" />
         <Compile Include="RepositoryContentCounter.Types.fs" />
+        <Compile Include="Usage.Types.fs" />
         <Compile Include="ManifestContributionWorkflow.Types.fs" />
         <Compile Include="Reminder.Types.fs" />
         <Compile Include="Events.Types.fs" />

--- a/src/Grace.Types/Usage.Types.fs
+++ b/src/Grace.Types/Usage.Types.fs
@@ -101,41 +101,44 @@ module Usage =
         static member Validate(fact: UsageFact) =
             let errors = ResizeArray<string>()
 
-            if fact.Class <> nameof UsageFact then errors.Add("Class must be UsageFact.")
-
-            if fact.UsageFactId = UsageFactId.Empty then
-                errors.Add("UsageFactId is required.")
-
-            if String.IsNullOrWhiteSpace fact.CorrelationId then
-                errors.Add("CorrelationId is required.")
-
-            if not (Enum.IsDefined(typeof<UsageFactKind>, fact.FactKind)) then
-                errors.Add($"FactKind '{int fact.FactKind}' is not supported.")
-
-            if isNull (box fact.Scope) then
-                errors.Add("Scope is required.")
+            if isNull (box fact) then
+                errors.Add("UsageFact is required.")
             else
-                if fact.Scope.OwnerId = OwnerId.Empty then
-                    errors.Add("Scope.OwnerId is required.")
+                if fact.Class <> nameof UsageFact then errors.Add("Class must be UsageFact.")
 
-                if fact.Scope.OrganizationId = OrganizationId.Empty then
-                    errors.Add("Scope.OrganizationId is required.")
+                if fact.UsageFactId = UsageFactId.Empty then
+                    errors.Add("UsageFactId is required.")
 
-                if fact.Scope.RepositoryId = RepositoryId.Empty then
-                    errors.Add("Scope.RepositoryId is required.")
+                if String.IsNullOrWhiteSpace fact.CorrelationId then
+                    errors.Add("CorrelationId is required.")
 
-            if isNull (box fact.Resource) then
-                errors.Add("Resource is required.")
-            else if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
-                errors.Add("Resource.StoragePoolId is required.")
+                if not (Enum.IsDefined(typeof<UsageFactKind>, fact.FactKind)) then
+                    errors.Add($"FactKind '{int fact.FactKind}' is not supported.")
 
-            if fact.Quantity <= 0L then errors.Add("Quantity must be greater than zero.")
+                if isNull (box fact.Scope) then
+                    errors.Add("Scope is required.")
+                else
+                    if fact.Scope.OwnerId = OwnerId.Empty then
+                        errors.Add("Scope.OwnerId is required.")
 
-            if fact.ObservedAt
-               <> UsageFact.NormalizeObservedAtToMinute fact.ObservedAt then
-                errors.Add("ObservedAt must be normalized to a UTC minute boundary.")
+                    if fact.Scope.OrganizationId = OrganizationId.Empty then
+                        errors.Add("Scope.OrganizationId is required.")
 
-            if fact.ObservedAt = Constants.DefaultTimestamp then
-                errors.Add("ObservedAt is required.")
+                    if fact.Scope.RepositoryId = RepositoryId.Empty then
+                        errors.Add("Scope.RepositoryId is required.")
+
+                if isNull (box fact.Resource) then
+                    errors.Add("Resource is required.")
+                else if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
+                    errors.Add("Resource.StoragePoolId is required.")
+
+                if fact.Quantity <= 0L then errors.Add("Quantity must be greater than zero.")
+
+                if fact.ObservedAt
+                   <> UsageFact.NormalizeObservedAtToMinute fact.ObservedAt then
+                    errors.Add("ObservedAt must be normalized to a UTC minute boundary.")
+
+                if fact.ObservedAt = Constants.DefaultTimestamp then
+                    errors.Add("ObservedAt is required.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)

--- a/src/Grace.Types/Usage.Types.fs
+++ b/src/Grace.Types/Usage.Types.fs
@@ -1,0 +1,133 @@
+namespace Grace.Types
+
+open Grace.Shared
+open Grace.Types.Common
+open NodaTime
+open Orleans
+open System
+
+/// Contains immutable usage fact contracts for Grace operations telemetry.
+module Usage =
+
+    /// The durable identity of an immutable usage fact.
+    type UsageFactId = Guid
+
+    /// Identifies the known operational usage measurement carried by a usage fact.
+    type UsageFactKind =
+        | RepositoryStorageBytesMinute = 1
+
+    /// Identifies the Grace repository scope that owns a usage fact.
+    [<GenerateSerializer>]
+    type UsageFactScope =
+        {
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+        }
+
+        /// Represents the deterministic empty scope used before caller input contributes identifiers.
+        static member Empty = { OwnerId = OwnerId.Empty; OrganizationId = OrganizationId.Empty; RepositoryId = RepositoryId.Empty }
+
+    /// Identifies the Grace resource that produced a usage fact.
+    [<GenerateSerializer>]
+    type UsageFactResource =
+        {
+            StoragePoolId: StoragePoolId
+        }
+
+        /// Represents the deterministic empty resource used before caller input contributes identifiers.
+        static member Empty = { StoragePoolId = StoragePoolId String.Empty }
+
+    /// Captures one immutable raw operational usage measurement before downstream ledger projection.
+    [<GenerateSerializer>]
+    type UsageFact =
+        {
+            Class: string
+            UsageFactId: UsageFactId
+            CorrelationId: CorrelationId
+            FactKind: UsageFactKind
+            Scope: UsageFactScope
+            Resource: UsageFactResource
+            Quantity: int64
+            ObservedAt: Instant
+        }
+
+        /// Represents the deterministic empty fact used before caller input contributes usage evidence.
+        static member Empty =
+            {
+                Class = nameof UsageFact
+                UsageFactId = UsageFactId.Empty
+                CorrelationId = String.Empty
+                FactKind = UsageFactKind.RepositoryStorageBytesMinute
+                Scope = UsageFactScope.Empty
+                Resource = UsageFactResource.Empty
+                Quantity = 0L
+                ObservedAt = Constants.DefaultTimestamp
+            }
+
+        /// Normalizes an observation timestamp to the minute bucket used by repository storage facts.
+        static member NormalizeObservedAtToMinute(observedAt: Instant) =
+            let minuteTicks = Duration.FromMinutes(1.0).BclCompatibleTicks
+
+            Instant.FromUnixTimeTicks(
+                (observedAt.ToUnixTimeTicks() / minuteTicks)
+                * minuteTicks
+            )
+
+        /// Builds a repository storage fact with the timestamp normalized to the minute bucket Grace bills and replays.
+        static member RepositoryStorageBytesMinute
+            (
+                usageFactId: UsageFactId,
+                correlationId: CorrelationId,
+                ownerId: OwnerId,
+                organizationId: OrganizationId,
+                repositoryId: RepositoryId,
+                storagePoolId: StoragePoolId,
+                quantity: int64,
+                observedAt: Instant
+            ) =
+            {
+                Class = nameof UsageFact
+                UsageFactId = usageFactId
+                CorrelationId = correlationId
+                FactKind = UsageFactKind.RepositoryStorageBytesMinute
+                Scope = { OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId }
+                Resource = { StoragePoolId = storagePoolId }
+                Quantity = quantity
+                ObservedAt = UsageFact.NormalizeObservedAtToMinute observedAt
+            }
+
+        /// Validates the contract invariants required before a raw fact can enter a durable usage stream.
+        static member Validate(fact: UsageFact) =
+            let errors = ResizeArray<string>()
+
+            if fact.Class <> nameof UsageFact then errors.Add("Class must be UsageFact.")
+
+            if fact.UsageFactId = UsageFactId.Empty then
+                errors.Add("UsageFactId is required.")
+
+            if String.IsNullOrWhiteSpace fact.CorrelationId then
+                errors.Add("CorrelationId is required.")
+
+            if not (Enum.IsDefined(typeof<UsageFactKind>, fact.FactKind)) then
+                errors.Add($"FactKind '{int fact.FactKind}' is not supported.")
+
+            if fact.Scope.OwnerId = OwnerId.Empty then
+                errors.Add("Scope.OwnerId is required.")
+
+            if fact.Scope.OrganizationId = OrganizationId.Empty then
+                errors.Add("Scope.OrganizationId is required.")
+
+            if fact.Scope.RepositoryId = RepositoryId.Empty then
+                errors.Add("Scope.RepositoryId is required.")
+
+            if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
+                errors.Add("Resource.StoragePoolId is required.")
+
+            if fact.Quantity <= 0L then errors.Add("Quantity must be greater than zero.")
+
+            if fact.ObservedAt
+               <> UsageFact.NormalizeObservedAtToMinute fact.ObservedAt then
+                errors.Add("ObservedAt must be normalized to a UTC minute boundary.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)

--- a/src/Grace.Types/Usage.Types.fs
+++ b/src/Grace.Types/Usage.Types.fs
@@ -112,16 +112,21 @@ module Usage =
             if not (Enum.IsDefined(typeof<UsageFactKind>, fact.FactKind)) then
                 errors.Add($"FactKind '{int fact.FactKind}' is not supported.")
 
-            if fact.Scope.OwnerId = OwnerId.Empty then
-                errors.Add("Scope.OwnerId is required.")
+            if isNull (box fact.Scope) then
+                errors.Add("Scope is required.")
+            else
+                if fact.Scope.OwnerId = OwnerId.Empty then
+                    errors.Add("Scope.OwnerId is required.")
 
-            if fact.Scope.OrganizationId = OrganizationId.Empty then
-                errors.Add("Scope.OrganizationId is required.")
+                if fact.Scope.OrganizationId = OrganizationId.Empty then
+                    errors.Add("Scope.OrganizationId is required.")
 
-            if fact.Scope.RepositoryId = RepositoryId.Empty then
-                errors.Add("Scope.RepositoryId is required.")
+                if fact.Scope.RepositoryId = RepositoryId.Empty then
+                    errors.Add("Scope.RepositoryId is required.")
 
-            if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
+            if isNull (box fact.Resource) then
+                errors.Add("Resource is required.")
+            else if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
                 errors.Add("Resource.StoragePoolId is required.")
 
             if fact.Quantity <= 0L then errors.Add("Quantity must be greater than zero.")
@@ -129,5 +134,8 @@ module Usage =
             if fact.ObservedAt
                <> UsageFact.NormalizeObservedAtToMinute fact.ObservedAt then
                 errors.Add("ObservedAt must be normalized to a UTC minute boundary.")
+
+            if fact.ObservedAt = Constants.DefaultTimestamp then
+                errors.Add("ObservedAt is required.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)


### PR DESCRIPTION
# OPS2: Add UsageFact contracts and serialization tests

## Related issue

Related to #527. Part of #525.

## Why this matters

The usage fact contract is the accounting spine for later operations, pricing, ledger, and reporting work. This slice
keeps the first Grace-owned operational usage record explicit, testable, and separate from both `GraceEvent` and future
billing/reporting concepts.

## Summary

- Added the minimal `UsageFact` contract surface to `Grace.Types`.
- Added deterministic JSON and validation tests in `Grace.Types.Tests`.
- Proved `UsageFactId` and `CorrelationId` remain distinct serialized fields.
- Proved unsupported/future fact kinds and invalid identity/quantity/timestamp cases fail clearly.
- Fixed review-found validation gaps for default observation timestamps, null nested contract records, and root null
  contract values.
- Kept runtime publishing, SQL projection, pricing, billing, generated clients, and reporting out of scope.

## Touched paths

- `src/Grace.Types/Usage.Types.fs`
- `src/Grace.Types/Grace.Types.fsproj`
- `src/Grace.Types.Tests/Usage.Types.Tests.fs`
- `src/Grace.Types.Tests/Grace.Types.Tests.fsproj`

## Validation

- `dotnet tool run fantomas src/Grace.Types/Usage.Types.fs src/Grace.Types.Tests/Usage.Types.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj`: passed, 0 warnings,
  0 errors.
- `dotnet test --no-build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj`: passed, 149 tests.
- pwsh ./scripts/validate.ps1 -Fast: passed; selected suites green with the existing 1 skipped CLI test.
- GitHub Actions ull: passed on current head 2ff93217a3b2ecd100110eb9e94b76bb23b4650c.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commits.

## Review Status

- Current head: `2ff93217a3b2ecd100110eb9e94b76bb23b4650c`.
- Workers: Euclid implemented the contract; Descartes fixed default timestamp and nested null guards; Ampere fixed the
  root null guard.
- Worker self-review: complete for implementation and fixes; checked serialization shape, identity/correlation
  separation, unknown/future fact kind handling, validation coverage, compile order, XML docs, timestamp normalization,
  default timestamp rejection, null nested record handling, root null handling, owned-path scope, and accidental
  pricing/billing scope creep.
- Codex Code Review Bot: reviews on `046198b2` and `0e449215` found contract validation gaps; fixed in `0e449215` and
  `2ff93217`.
- Review/fix evidence: replied on [discussion_r3523037282](https://github.com/ScottArbeit/Grace/pull/534#discussion_r3523037282),
  [discussion_r3523037344](https://github.com/ScottArbeit/Grace/pull/534#discussion_r3523037344), and
  [discussion_r3523057233](https://github.com/ScottArbeit/Grace/pull/534#discussion_r3523057233); all conversations are
  resolved.
- Codex Code Review Bot: 👍🏻 no-issues state observed on current head `2ff93217a3b2ecd100110eb9e94b76bb23b4650c`.
- Manual trigger lock: not attempted. The orchestrator will use the PR reaction state and
  `scripts/guard-codex-review-trigger.ps1` before any missed-ack path.

## Docs impact

No runtime or user-facing docs changed. This slice adds shared contracts and contract tests only.

## Residual risk

No known residual risk for the #527 contract slice. Runtime publication, Service Bus envelope mapping, SQL projection,
pricing, billing, generated clients, and reporting remain intentionally scoped to later child issues.
