### PR TITLE
WS5.3: Narrow branch switch update marker window

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -285,6 +285,136 @@ module BranchCommandTests =
             File.Exists(updateMarkerFile)
             |> should equal false)
 
+    /// Verifies that the switch workflow lease serializes precomputation without creating the Watch suppression marker.
+    [<Test>]
+    let ``branch switch workflow lease serializes before precompute without update marker`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let switchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName updateMarkerFile
+            let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
+            let mutable inspected = false
+            let mutable workflowRan = false
+            let mutable leaseSeenByWorkflow = false
+            let mutable markerSeenByWorkflow = false
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+
+                            File.Exists(updateMarkerFile)
+                            |> should equal false
+
+                            File.Exists(switchLeaseFile) |> should equal true
+
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkflowWithLease operations correlationId switchLeaseFile switchLeaseText (fun () ->
+                    task {
+                        workflowRan <- true
+                        leaseSeenByWorkflow <- File.Exists(switchLeaseFile)
+                        markerSeenByWorkflow <- File.Exists(updateMarkerFile)
+                        return "computed"
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Ok value -> value |> should equal "computed"
+            | Error error -> Assert.Fail($"Expected branch switch lease to allow workflow, got: {error.Error}")
+
+            inspected |> should equal true
+            workflowRan |> should equal true
+            leaseSeenByWorkflow |> should equal true
+            markerSeenByWorkflow |> should equal false
+
+            File.Exists(switchLeaseFile) |> should equal false
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that an existing switch workflow lease refuses before Watch inspection and state precomputation.
+    [<Test>]
+    let ``branch switch workflow lease refuses competing switch before precompute`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let switchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName updateMarkerFile
+            let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
+            let mutable inspected = false
+            let mutable workflowRan = false
+
+            Directory.CreateDirectory(Path.GetDirectoryName(switchLeaseFile))
+            |> ignore
+
+            File.WriteAllText(switchLeaseFile, "competing switch workflow")
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkflowWithLease operations correlationId switchLeaseFile switchLeaseText (fun () ->
+                    task {
+                        workflowRan <- true
+                        return ()
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before state precomputation"
+            | Ok _ -> Assert.Fail("Expected competing switch workflow lease to refuse before precompute.")
+
+            inspected |> should equal false
+            workflowRan |> should equal false
+
+            File.ReadAllText(switchLeaseFile)
+            |> should equal "competing switch workflow"
+
+            File.Delete(switchLeaseFile))
+
+    /// Verifies that branch identity is moved before object-cache refresh can fail.
+    [<Test>]
+    let ``branch switch local state updates config before cache refresh failure`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let targetBranchId = Guid.NewGuid()
+            let targetBranchName = "branch-switch-target"
+
+            let operation =
+                Func<Task> (fun () ->
+                    Branch.applyBranchSwitchLocalState
+                        (fun () -> Task.CompletedTask)
+                        (fun () ->
+                            let configuration = Current()
+                            configuration.BranchId <- targetBranchId
+                            configuration.BranchName <- targetBranchName
+                            updateConfiguration configuration)
+                        (fun () -> task { raise (IOException("simulated object cache refresh failure")) })
+                    :> Task)
+
+            Assert.ThrowsAsync<IOException>(operation)
+            |> ignore
+
+            resetConfiguration ()
+            let configuration = Current()
+
+            configuration.BranchId
+            |> should equal targetBranchId
+
+            configuration.BranchName
+            |> should equal targetBranchName)
+
     /// Verifies that a second Watch-clean preflight failure prevents marker creation and working tree mutation.
     [<Test>]
     let ``branch switch working tree update refuses dirty mutation boundary before marker or rewrite`` () =

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -493,6 +493,9 @@ module BranchCommandTests =
             |> ignore
 
             File.Exists(updateMarkerFile)
+            |> should equal false
+
+            File.Exists(updateMarkerFile + ".completed")
             |> should equal false)
 
     /// Verifies that a raced marker creation failure does not run mutation work.

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -384,6 +384,69 @@ module BranchCommandTests =
 
             File.Delete(switchLeaseFile))
 
+    /// Verifies that switch workflow leases serialize the same worktree even after branch identity changes.
+    [<Test>]
+    let ``branch switch workflow lease is independent of mutable branch identity`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let current = Current()
+            let sourceUpdateMarkerFile = Services.updateInProgressFileName ()
+            let targetBranchId = Guid.NewGuid()
+            let targetBranchName = "branch-switch-target"
+
+            let targetUpdateMarkerFile =
+                Services.updateInProgressFileNameForIdentity current.RepositoryId current.RepositoryName current.RootDirectory targetBranchId targetBranchName
+
+            let sourceSwitchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName sourceUpdateMarkerFile
+            let targetSwitchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName targetUpdateMarkerFile
+
+            targetSwitchLeaseFile
+            |> should equal sourceSwitchLeaseFile
+
+            let sourceSwitchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
+            let targetSwitchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
+            let mutable inspected = false
+            let mutable workflowRan = false
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceSwitchLeaseFile))
+            |> ignore
+
+            File.WriteAllText(sourceSwitchLeaseFile, sourceSwitchLeaseText)
+
+            current.BranchId <- targetBranchId
+            current.BranchName <- targetBranchName
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(targetUpdateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkflowWithLease operations correlationId targetSwitchLeaseFile targetSwitchLeaseText (fun () ->
+                    task {
+                        workflowRan <- true
+                        return ()
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before state precomputation"
+            | Ok _ -> Assert.Fail("Expected same-worktree switch workflow lease to refuse after branch identity changes.")
+
+            inspected |> should equal false
+            workflowRan |> should equal false
+
+            File.ReadAllText(sourceSwitchLeaseFile)
+            |> should equal sourceSwitchLeaseText
+
+            File.Delete(sourceSwitchLeaseFile))
+
     /// Verifies that branch identity is moved before object-cache refresh can fail.
     [<Test>]
     let ``branch switch local state updates config before cache refresh failure`` () =

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -146,7 +146,6 @@ module BranchCommandTests =
     /// Runs branch switch preflight with injected side effects and reports which effects occurred.
     let private runBranchSwitchPreflight markerExists inspection =
         let mutable inspected = false
-        let mutable markerCreated = false
 
         let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
             {
@@ -155,12 +154,6 @@ module BranchCommandTests =
                     fun () ->
                         inspected <- true
                         Task.FromResult inspection
-                CreateUpdateMarker =
-                    fun () ->
-                        task {
-                            markerCreated <- true
-                            return ()
-                        }
             }
 
         let result =
@@ -168,7 +161,7 @@ module BranchCommandTests =
                 .GetAwaiter()
                 .GetResult()
 
-        result, inspected, markerCreated
+        result, inspected
 
     /// Verifies that update marker names include repository and root identity before branch-name scoping.
     [<Test>]
@@ -202,7 +195,7 @@ module BranchCommandTests =
                 File.Exists(currentMarkerFile)
                 |> should equal false
 
-                let result, inspected, markerCreated =
+                let result, inspected =
                     branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ())
                     |> runBranchSwitchPreflight (File.Exists(currentMarkerFile))
 
@@ -211,7 +204,9 @@ module BranchCommandTests =
                 | Error error -> Assert.Fail($"Expected unrelated repository marker to allow branch switch preflight, got: {error.Error}")
 
                 inspected |> should equal true
-                markerCreated |> should equal true
+
+                File.Exists(currentMarkerFile)
+                |> should equal false
 
             finally
                 if File.Exists(foreignMarkerFile) then File.Delete(foreignMarkerFile)
@@ -228,7 +223,9 @@ module BranchCommandTests =
                     BranchName = BranchName "stale-branch-display-name"
                 }
 
-            let result, inspected, markerCreated =
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            let result, inspected =
                 branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) status
                 |> runBranchSwitchPreflight false
 
@@ -237,38 +234,179 @@ module BranchCommandTests =
             | Error error -> Assert.Fail($"Expected healthy Watch status to allow branch switch, got: {error.Error}")
 
             inspected |> should equal true
-            markerCreated |> should equal true)
 
-    /// Verifies that successful branch switch cleanup removes the old branch marker created by preflight.
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that successful branch switch mutation creates the marker only after the second Watch-clean preflight.
     [<Test>]
-    let ``branch switch working tree update preserves preflight marker lease for outer cleanup`` () =
+    let ``branch switch working tree update creates marker after mutation boundary preflight`` () =
         withTempBranchSwitchRepo (fun () ->
             let updateMarkerFile = Services.updateInProgressFileName ()
-            let preflightMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let mutable inspected = false
+            let mutable operationRan = false
+            let mutable markerSeenByOperation = false
+            let mutationFile = Path.Combine(Current().RootDirectory, "grace-owned-mutation.txt")
 
-            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+
+                            File.Exists(updateMarkerFile)
+                            |> should equal false
+
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () ->
+                    task {
+                        operationRan <- true
+                        markerSeenByOperation <- File.Exists(updateMarkerFile)
+                        File.WriteAllText(mutationFile, "Grace-owned branch switch write")
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Ok _ -> ()
+            | Error error -> Assert.Fail($"Expected mutation-boundary preflight to allow branch switch, got: {error.Error}")
+
+            inspected |> should equal true
+            operationRan |> should equal true
+            markerSeenByOperation |> should equal true
+
+            File.Exists(mutationFile) |> should equal true
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that a second Watch-clean preflight failure prevents marker creation and working tree mutation.
+    [<Test>]
+    let ``branch switch working tree update refuses dirty mutation boundary before marker or rewrite`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let dirtyStatus = { branchSwitchWatchStatus () with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+            let mutationFile = Path.Combine(Current().RootDirectory, "must-not-be-written.txt")
+            let mutable inspected = false
+            let mutable operationRan = false
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+
+                            File.Exists(updateMarkerFile)
+                            |> should equal false
+
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) dirtyStatus)
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () ->
+                    task {
+                        operationRan <- true
+                        File.WriteAllText(mutationFile, "must not be written")
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error |> should contain "dirty working tree"
+            | Ok _ -> Assert.Fail("Expected dirty mutation-boundary Watch status to refuse branch switch.")
+
+            inspected |> should equal true
+            operationRan |> should equal false
+
+            File.Exists(mutationFile) |> should equal false
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that partial mutation failure removes the working-tree marker created by this invocation.
+    [<Test>]
+    let ``branch switch working tree update removes owned marker when operation fails`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let operation =
+                Func<Task> (fun () ->
+                    task {
+                        let! _ =
+                            Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () ->
+                                task { raise (InvalidOperationException("simulated partial mutation failure")) })
+
+                        return ()
+                    }
+                    :> Task)
+
+            Assert.ThrowsAsync<InvalidOperationException>(operation)
             |> ignore
 
-            File.WriteAllText(updateMarkerFile, preflightMarkerText)
+            File.Exists(updateMarkerFile)
+            |> should equal false)
 
-            (Branch.runBranchSwitchWorkingTreeUpdateWithMarker updateMarkerFile "`grace switch` is in progress." (fun () ->
-                task {
-                    let configuration = Current()
-                    configuration.BranchId <- Guid.NewGuid()
-                    configuration.BranchName <- "branch-switch-target"
-                }))
-                .GetAwaiter()
-                .GetResult()
+    /// Verifies that a raced marker creation failure does not run mutation work.
+    [<Test>]
+    let ``branch switch working tree update refuses raced marker before rewrite`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let mutable operationRan = false
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists =
+                        fun () ->
+                            if not (File.Exists(updateMarkerFile)) then
+                                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                                |> ignore
+
+                                File.WriteAllText(updateMarkerFile, "competing marker")
+
+                            false
+                    InspectWatchStatus =
+                        fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
+            let updateTask =
+                Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () -> task { operationRan <- true })
+
+            let result = updateTask.GetAwaiter().GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "update marker appeared while preflight was running"
+            | Ok _ -> Assert.Fail("Expected raced marker creation to refuse branch switch.")
+
+            operationRan |> should equal false
 
             File.Exists(updateMarkerFile) |> should equal true
 
             File.ReadAllText(updateMarkerFile)
-            |> should equal preflightMarkerText
+            |> should equal "competing marker"
 
-            Branch.deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFile preflightMarkerText
-
-            File.Exists(updateMarkerFile)
-            |> should equal false)
+            File.Delete(updateMarkerFile))
 
     /// Verifies that cancellation removes the working-tree marker when this invocation created it.
     [<Test>]
@@ -277,10 +415,22 @@ module BranchCommandTests =
             let updateMarkerFile = Services.updateInProgressFileName ()
             let markerText = "`grace switch` is in progress."
 
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                }
+
             let operation =
                 Func<Task> (fun () ->
-                    Branch.runBranchSwitchWorkingTreeUpdateWithMarker updateMarkerFile markerText (fun () ->
-                        task { raise (OperationCanceledException("simulated cancellation")) })
+                    task {
+                        let! _ =
+                            Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () ->
+                                task { raise (OperationCanceledException("simulated cancellation")) })
+
+                        return ()
+                    }
                     :> Task)
 
             Assert.ThrowsAsync<OperationCanceledException>(operation)
@@ -323,14 +473,16 @@ module BranchCommandTests =
 
                 inspection.IsUsable |> should equal true
 
-                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+                let result, inspected = runBranchSwitchPreflight false inspection
 
                 match result with
                 | Ok _ -> ()
                 | Error error -> Assert.Fail($"Expected current repository Watch IPC to allow branch switch, got: {error.Error}")
 
                 inspected |> should equal true
-                markerCreated |> should equal true
+
+                File.Exists(Services.updateInProgressFileName ())
+                |> should equal false
             finally
                 if File.Exists(currentIpcFile) then File.Delete(currentIpcFile)
 
@@ -347,7 +499,7 @@ module BranchCommandTests =
 
             File.WriteAllText(updateMarkerFile, "same repository marker")
 
-            let result, inspected, markerCreated =
+            let result, inspected =
                 branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ())
                 |> runBranchSwitchPreflight (File.Exists(updateMarkerFile))
 
@@ -360,8 +512,7 @@ module BranchCommandTests =
                 |> should contain "update marker already exists"
             | Ok _ -> Assert.Fail("Expected existing update marker to refuse branch switch.")
 
-            inspected |> should equal false
-            markerCreated |> should equal false)
+            inspected |> should equal false)
 
     /// Verifies that marker write failures remove the partial file created by this preflight.
     [<Test>]
@@ -407,7 +558,7 @@ module BranchCommandTests =
                         .GetAwaiter()
                         .GetResult()
 
-                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+                let result, inspected = runBranchSwitchPreflight false inspection
 
                 match result with
                 | Error error ->
@@ -418,7 +569,6 @@ module BranchCommandTests =
                 | Ok _ -> Assert.Fail("Expected dirty current-repository Watch IPC to refuse branch switch.")
 
                 inspected |> should equal true
-                markerCreated |> should equal false
             finally
                 if File.Exists(currentIpcFile) then File.Delete(currentIpcFile))
 
@@ -516,7 +666,7 @@ module BranchCommandTests =
                 |]
 
             for name, inspection, expectedReason in cases do
-                let result, inspected, markerCreated = runBranchSwitchPreflight false inspection
+                let result, inspected = runBranchSwitchPreflight false inspection
 
                 match result with
                 | Error error ->
@@ -526,8 +676,7 @@ module BranchCommandTests =
                     error.Error |> should contain expectedReason
                 | Ok _ -> Assert.Fail($"Expected {name} to refuse branch switch.")
 
-                inspected |> should equal true
-                markerCreated |> should equal false)
+                inspected |> should equal true)
 
     let private sampleAnnotation =
         let lastChangedReferenceId = Guid.NewGuid()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -397,6 +397,34 @@ module WatchTests =
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
 
+    /// Verifies that Grace-owned writes under the update marker do not enqueue Save-producing Watch work.
+    [<Test>]
+    let ``update marker suppresses changed file observation without local save work`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "grace-owned-write.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            try
+                File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+                File.WriteAllText(changedFilePath, "Grace-owned branch switch payload")
+                Watch.OnChanged(changedEvent changedFilePath)
+
+                let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pending.FilesToProcess
+                |> should equal Array.empty<string>
+
+                pending.DirectoriesToProcess
+                |> should equal Array.empty<string>
+
+                pending.StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                if File.Exists(updateMarkerFile) then File.Delete(updateMarkerFile))
+
     /// Produces an empty difference list for watch tests that do not exercise a scan path.
     let private scanForNoDifferences _ = Task.FromResult(List<FileSystemDifference>())
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -425,6 +425,59 @@ module WatchTests =
             finally
                 if File.Exists(updateMarkerFile) then File.Delete(updateMarkerFile))
 
+    /// Verifies that delayed callbacks for writes completed under the update marker do not enqueue after deletion.
+    [<Test>]
+    let ``update marker deletion keeps delayed Grace-owned changed observation suppressed`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "delayed-grace-owned-write.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.WriteAllText(changedFilePath, "Grace-owned branch switch payload")
+            File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(-1.0))
+            File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
+            File.Delete(updateMarkerFile)
+
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that user writes after marker deletion still enqueue as local Watch work.
+    [<Test>]
+    let ``update marker deletion does not suppress later user changed observation`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "later-user-write.txt")
+            let markerDeletedUtc = DateTime.UtcNow.AddSeconds(-5.0)
+
+            File.WriteAllText(changedFilePath, "user edit after branch switch")
+            File.SetLastWriteTimeUtc(changedFilePath, markerDeletedUtc.AddSeconds(1.0))
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests markerDeletedUtc
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| changedFilePath |]
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
     /// Produces an empty difference list for watch tests that do not exercise a scan path.
     let private scanForNoDifferences _ = Task.FromResult(List<FileSystemDifference>())
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -393,6 +393,16 @@ module WatchTests =
     /// Builds changed event test data used to exercise CLI watch behavior.
     let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
+    /// Records a completed update marker deletion through the same callback path used by FileSystemWatcher.
+    let private recordCompletedUpdateMarkerDeletion (updateMarkerFile: string) (markerCompletedUtc: DateTime) =
+        Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+        |> ignore
+
+        File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+        File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
+        File.Delete(updateMarkerFile)
+        Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
     /// Builds renamed event test data used to exercise CLI watch behavior.
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
@@ -688,6 +698,164 @@ module WatchTests =
             RootDirectorySha256Hash = root.Sha256Hash
             RootDirectoryBlake3Hash = root.Blake3Hash
         }
+
+    /// Verifies that marker deletion records the switch completion instant instead of late Watch handling time.
+    [<Test>]
+    let ``update marker deletion uses completed timestamp for delayed changed classification`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "user-write-after-switch.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow.AddSeconds(-5.0)
+
+            File.WriteAllText(changedFilePath, "user edit after branch switch completed")
+            File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(1.0))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| changedFilePath |]
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that delayed create callbacks from completed Grace-owned switch writes are suppressed.
+    [<Test>]
+    let ``update marker deletion suppresses delayed Grace-owned created observation`` () =
+        withTempRepo (fun root ->
+            let createdFilePath = Path.Combine(root, "delayed-grace-owned-create.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            File.WriteAllText(createdFilePath, "Grace-owned branch switch create")
+            File.SetLastWriteTimeUtc(createdFilePath, markerCompletedUtc.AddSeconds(-1.0))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnCreated(createdEvent createdFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that delayed delete callbacks for paths absent from post-switch GraceStatus are suppressed.
+    [<Test>]
+    let ``update marker deletion suppresses delayed Grace-owned deleted observation`` () =
+        withTempRepo (fun root ->
+            let deletedFilePath = Path.Combine(root, "removed-by-switch.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking Array.empty<string> Array.empty<string>))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnDeleted(deletedEvent deletedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that delayed delete suppression does not hide paths still tracked by completed GraceStatus.
+    [<Test>]
+    let ``update marker deletion preserves tracked deleted observation`` () =
+        withTempRepo (fun root ->
+            let deletedFilePath = Path.Combine(root, "tracked-user-delete.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking [| "tracked-user-delete.txt" |] Array.empty<string>))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnDeleted(deletedEvent deletedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "tracked-user-delete.txt" |])
+
+    /// Verifies that delayed directory callbacks from completed Grace-owned switch writes are suppressed.
+    [<Test>]
+    let ``update marker deletion suppresses delayed Grace-owned directory observation`` () =
+        withTempRepo (fun root ->
+            let directoryPath = Path.Combine(root, "delayed-grace-owned-directory")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            Directory.SetLastWriteTimeUtc(directoryPath, markerCompletedUtc.AddSeconds(-1.0))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnCreated(createdEvent directoryPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that delayed GraceStatus artifact observations still publish refresh work after switch completion.
+    [<Test>]
+    let ``update marker deletion preserves delayed GraceStatus artifact refresh observation`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+            let graceStatusFile = Current().GraceStatusFile
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(graceStatusFile))
+            |> ignore
+
+            File.WriteAllText(graceStatusFile, "Grace-owned local state refresh")
+            File.SetLastWriteTimeUtc(graceStatusFile, markerCompletedUtc.AddSeconds(-1.0))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.OnChanged(changedEvent graceStatusFile)
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
 
     /// Builds GraceStatus around explicit file versions so tests can model content-equivalent uploads.
     let private graceStatusTrackingFileVersions (trackedFiles: LocalFileVersion array) =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -393,6 +393,72 @@ module WatchTests =
     /// Builds changed event test data used to exercise CLI watch behavior.
     let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
+    /// Builds local file version test data used to exercise CLI watch behavior.
+    let private localFileVersion relativePath =
+        LocalFileVersion.CreateWithHashes
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            false
+            1L
+            (getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    /// Builds local directory version test data used to exercise CLI watch behavior.
+    let private localDirectoryVersion relativePath directories files =
+        LocalDirectoryVersion.CreateWithHashes
+            (Guid.NewGuid())
+            OwnerId.Empty
+            OrganizationId.Empty
+            RepositoryId.Empty
+            relativePath
+            (Sha256Hash $"sha-{relativePath}")
+            (Blake3Hash $"blake3-{relativePath}")
+            directories
+            files
+            1L
+            DateTime.UtcNow
+
+    /// Builds grace status tracking test data used to exercise CLI watch behavior.
+    let private graceStatusTracking trackedFiles trackedDirectories =
+        let rootDirectoryId = Guid.NewGuid()
+        let index = GraceIndex()
+
+        let childDirectories =
+            trackedDirectories
+            |> Array.map (fun relativePath -> localDirectoryVersion relativePath (List<DirectoryVersionId>()) (List<LocalFileVersion>()))
+
+        let root =
+            LocalDirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                OwnerId.Empty
+                OrganizationId.Empty
+                RepositoryId.Empty
+                Constants.RootDirectoryPath
+                (Sha256Hash "root-sha")
+                (Blake3Hash "root-blake3")
+                (List<DirectoryVersionId>(
+                    childDirectories
+                    |> Array.map (fun directory -> directory.DirectoryVersionId)
+                ))
+                (List<LocalFileVersion>(trackedFiles |> Array.map localFileVersion))
+                1L
+                DateTime.UtcNow
+
+        index.TryAdd(rootDirectoryId, root) |> ignore
+
+        for directory in childDirectories do
+            index.TryAdd(directory.DirectoryVersionId, directory)
+            |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = rootDirectoryId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
     /// Records a completed update marker deletion through the same callback path used by FileSystemWatcher.
     let private recordCompletedUpdateMarkerDeletion (updateMarkerFile: string) (markerCompletedUtc: DateTime) =
         Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
@@ -460,6 +526,7 @@ module WatchTests =
             File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(-1.0))
             File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
             File.Delete(updateMarkerFile)
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking [| "delayed-grace-owned-write.txt" |] Array.empty<string>))
 
             Watch.OnChanged(changedEvent changedFilePath)
 
@@ -473,6 +540,72 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that a late marker-created callback does not remove the successful switch completion sidecar.
+    [<Test>]
+    let ``late update marker created event keeps completed sidecar authoritative until deletion`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "late-created-grace-owned-write.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let completedSidecar = updateMarkerFile + ".completed"
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.SetLastWriteTimeUtc(updateMarkerFile, markerCompletedUtc.AddSeconds(-1.0))
+            File.WriteAllText(changedFilePath, "Grace-owned branch switch payload")
+            File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(-1.0))
+            File.WriteAllText(completedSidecar, markerCompletedUtc.ToString("O"))
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                Task.FromResult(
+                    graceStatusTracking
+                        [|
+                            "late-created-grace-owned-write.txt"
+                        |]
+                        Array.empty<string>
+                ))
+
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+
+            File.Exists(completedSidecar) |> should equal true
+
+            File.Delete(updateMarkerFile)
+            Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that marker-created cleanup still removes stale completion sidecars from earlier switches.
+    [<Test>]
+    let ``new update marker created event clears stale completed sidecar`` () =
+        withTempRepo (fun _ ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let completedSidecar = updateMarkerFile + ".completed"
+            let previousMarkerCompletedUtc = DateTime.UtcNow.AddSeconds(-10.0)
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(completedSidecar, previousMarkerCompletedUtc.ToString("O"))
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.SetLastWriteTimeUtc(updateMarkerFile, previousMarkerCompletedUtc.AddSeconds(5.0))
+
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+
+            File.Exists(completedSidecar)
+            |> should equal false)
 
     /// Verifies that marker deletion without a completion sidecar cannot authorize delayed suppression.
     [<Test>]
@@ -666,72 +799,6 @@ module WatchTests =
         File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), String.Join(Environment.NewLine, entries))
         resetConfiguration ()
 
-    /// Builds local file version test data used to exercise CLI watch behavior.
-    let private localFileVersion relativePath =
-        LocalFileVersion.CreateWithHashes
-            relativePath
-            (Sha256Hash $"sha-{relativePath}")
-            (Blake3Hash $"blake3-{relativePath}")
-            false
-            1L
-            (getCurrentInstant ())
-            true
-            DateTime.UtcNow
-
-    /// Builds local directory version test data used to exercise CLI watch behavior.
-    let private localDirectoryVersion relativePath directories files =
-        LocalDirectoryVersion.CreateWithHashes
-            (Guid.NewGuid())
-            OwnerId.Empty
-            OrganizationId.Empty
-            RepositoryId.Empty
-            relativePath
-            (Sha256Hash $"sha-{relativePath}")
-            (Blake3Hash $"blake3-{relativePath}")
-            directories
-            files
-            1L
-            DateTime.UtcNow
-
-    /// Builds grace status tracking test data used to exercise CLI watch behavior.
-    let private graceStatusTracking trackedFiles trackedDirectories =
-        let rootDirectoryId = Guid.NewGuid()
-        let index = GraceIndex()
-
-        let childDirectories =
-            trackedDirectories
-            |> Array.map (fun relativePath -> localDirectoryVersion relativePath (List<DirectoryVersionId>()) (List<LocalFileVersion>()))
-
-        let root =
-            LocalDirectoryVersion.CreateWithHashes
-                rootDirectoryId
-                OwnerId.Empty
-                OrganizationId.Empty
-                RepositoryId.Empty
-                Constants.RootDirectoryPath
-                (Sha256Hash "root-sha")
-                (Blake3Hash "root-blake3")
-                (List<DirectoryVersionId>(
-                    childDirectories
-                    |> Array.map (fun directory -> directory.DirectoryVersionId)
-                ))
-                (List<LocalFileVersion>(trackedFiles |> Array.map localFileVersion))
-                1L
-                DateTime.UtcNow
-
-        index.TryAdd(rootDirectoryId, root) |> ignore
-
-        for directory in childDirectories do
-            index.TryAdd(directory.DirectoryVersionId, directory)
-            |> ignore
-
-        { GraceStatus.Default with
-            Index = index
-            RootDirectoryId = rootDirectoryId
-            RootDirectorySha256Hash = root.Sha256Hash
-            RootDirectoryBlake3Hash = root.Blake3Hash
-        }
-
     /// Verifies that marker deletion records the switch completion instant instead of late Watch handling time.
     [<Test>]
     let ``update marker deletion uses completed timestamp for delayed changed classification`` () =
@@ -767,6 +834,7 @@ module WatchTests =
 
             File.WriteAllText(createdFilePath, "Grace-owned branch switch create")
             File.SetLastWriteTimeUtc(createdFilePath, markerCompletedUtc.AddSeconds(-1.0))
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking [| "delayed-grace-owned-create.txt" |] Array.empty<string>))
             recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
 
             Watch.OnCreated(createdEvent createdFilePath)
@@ -775,6 +843,58 @@ module WatchTests =
 
             pending.FilesToProcess
             |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that preserved older mtimes alone cannot suppress a new user-created file after switch completion.
+    [<Test>]
+    let ``update marker deletion does not suppress untracked created file with preserved old mtime`` () =
+        withTempRepo (fun root ->
+            let createdFilePath = Path.Combine(root, "user-created-preserved-mtime.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking Array.empty<string> Array.empty<string>))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            File.WriteAllText(createdFilePath, "user-created payload with preserved timestamp")
+            File.SetLastWriteTimeUtc(createdFilePath, markerCompletedUtc.AddSeconds(-10.0))
+            Watch.OnCreated(createdEvent createdFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| createdFilePath |]
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that preserved older mtimes alone cannot suppress a changed user file absent from completed status.
+    [<Test>]
+    let ``update marker deletion does not suppress untracked changed file with preserved old mtime`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "user-changed-preserved-mtime.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking Array.empty<string> Array.empty<string>))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            File.WriteAllText(changedFilePath, "user-changed payload with preserved timestamp")
+            File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(-10.0))
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| changedFilePath |]
 
             pending.DirectoriesToProcess
             |> should equal Array.empty<string>
@@ -883,6 +1003,7 @@ module WatchTests =
             Directory.CreateDirectory(directoryPath) |> ignore
 
             Directory.SetLastWriteTimeUtc(directoryPath, markerCompletedUtc.AddSeconds(-1.0))
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking Array.empty<string> [| "delayed-grace-owned-directory" |]))
             recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
 
             Watch.OnCreated(createdEvent directoryPath)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -403,6 +403,15 @@ module WatchTests =
         File.Delete(updateMarkerFile)
         Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
 
+    /// Records a marker deletion without the completed sidecar produced by a successful branch switch mutation.
+    let private recordIncompleteUpdateMarkerDeletion (updateMarkerFile: string) =
+        Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+        |> ignore
+
+        File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+        File.Delete(updateMarkerFile)
+        Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
     /// Builds renamed event test data used to exercise CLI watch behavior.
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
@@ -458,6 +467,30 @@ module WatchTests =
 
             pending.FilesToProcess
             |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that marker deletion without a completion sidecar cannot authorize delayed suppression.
+    [<Test>]
+    let ``update marker deletion without completion sidecar does not suppress delayed changed observation`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "partial-switch-write.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            File.WriteAllText(changedFilePath, "partial branch switch payload")
+            File.SetLastWriteTimeUtc(changedFilePath, DateTime.UtcNow.AddSeconds(-1.0))
+            recordIncompleteUpdateMarkerDeletion updateMarkerFile
+
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| changedFilePath |]
 
             pending.DirectoriesToProcess
             |> should equal Array.empty<string>
@@ -771,6 +804,48 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that post-switch user-created files are drained when deleted inside the completed-marker window.
+    [<Test>]
+    let ``update marker deletion drains post-switch user-created file deleted inside suppression window`` () =
+        withTempRepo (fun root ->
+            let createdFilePath = Path.Combine(root, "post-switch-user-created.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow.AddSeconds(-5.0)
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking Array.empty<string> Array.empty<string>))
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            File.WriteAllText(createdFilePath, "user-created payload")
+            File.SetLastWriteTimeUtc(createdFilePath, markerCompletedUtc.AddSeconds(1.0))
+            Watch.OnCreated(createdEvent createdFilePath)
+
+            File.Delete(createdFilePath)
+            Watch.OnDeleted(deletedEvent createdFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal [| "post-switch-user-created.txt" |]
+
+            let updateCalls, uploadCalls = processPendingWatchWorkForTestWithStatus (graceStatusTracking Array.empty<string> Array.empty<string>)
+
+            updateCalls |> should equal 0
+            uploadCalls |> should equal 0
+
+            let afterProcessing = Watch.pendingWatchWorkSnapshotForTests ()
+
+            afterProcessing.FilesToProcess
+            |> should equal Array.empty<string>
+
+            afterProcessing.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
     /// Verifies that delayed delete suppression does not hide paths still tracked by completed GraceStatus.

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3027,9 +3027,12 @@ module Branch =
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
 
-    /// Gets the branch-switch workflow lease path that serializes state precomputation without suppressing Watch.
+    /// Gets the repository/worktree-scoped branch-switch workflow lease path without using mutable branch identity.
     let internal branchSwitchWorkflowLeaseFileName (updateMarkerFileName: string) =
-        Path.Combine(Path.GetDirectoryName(updateMarkerFileName), "branch-switch-workflow.lease")
+        let branchDirectory = DirectoryInfo(Path.GetDirectoryName(updateMarkerFileName))
+        let repositoryRootScopeDirectory = branchDirectory.Parent.Parent
+
+        Path.Combine(repositoryRootScopeDirectory.FullName, "branch-switch-workflow.lease")
 
     /// Creates the branch-switch workflow lease through an injectable writer for deterministic race tests.
     let internal createBranchSwitchWorkflowLeaseWithWriter (writeLeaseText: StreamWriter -> string -> Task) (switchLeaseFileName: string) (leaseText: string) =

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3133,10 +3133,10 @@ module Branch =
                 | Ok () ->
                     try
                         let! result = operation ()
+                        writeBranchSwitchUpdateMarkerCompleted updateMarkerFileName
                         return Ok result
                     finally
                         if markerCreatedByThisInvocation then
-                            writeBranchSwitchUpdateMarkerCompleted updateMarkerFileName
                             deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText
         }
 

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2877,12 +2877,7 @@ module Branch =
         member val ReferenceId: string = String.Empty with get, set
 
     /// Defines the injected side-effect boundary for branch-switch Watch-clean preflight tests.
-    type internal BranchSwitchWatchCleanPreflightOperations =
-        {
-            UpdateMarkerExists: unit -> bool
-            InspectWatchStatus: unit -> Task<GraceWatchStatusInspection>
-            CreateUpdateMarker: unit -> Task<unit>
-        }
+    type internal BranchSwitchWatchCleanPreflightOperations = { UpdateMarkerExists: unit -> bool; InspectWatchStatus: unit -> Task<GraceWatchStatusInspection> }
 
     /// Builds the branch-switch refusal reason for an untrusted Watch IPC snapshot.
     let private branchSwitchWatchCleanPreflightRefusalReason updateMarkerExists (inspection: GraceWatchStatusInspection) =
@@ -2940,7 +2935,7 @@ module Branch =
         | Some reason -> Error reason
         | None -> Ok()
 
-    /// Runs the branch-switch Watch-clean preflight and creates the update marker only after trust is proven.
+    /// Runs the branch-switch Watch-clean preflight without suppressing later filesystem observations.
     let internal runBranchSwitchWatchCleanPreflight (operations: BranchSwitchWatchCleanPreflightOperations) correlationId =
         task {
             if operations.UpdateMarkerExists() then
@@ -2955,18 +2950,7 @@ module Branch =
 
                 match validateBranchSwitchWatchCleanPreflight false inspection with
                 | Error reason -> return Error(GraceError.Create $"Branch switch refused before mutation: {reason}" correlationId)
-                | Ok () ->
-                    try
-                        do! operations.CreateUpdateMarker()
-                        return Ok()
-                    with
-                    | :? IOException ->
-                        return
-                            Error(
-                                GraceError.Create
-                                    "Branch switch refused before mutation: the Grace update marker appeared while preflight was running; another Grace-owned working-tree update may be in progress."
-                                    correlationId
-                            )
+                | Ok () -> return Ok()
         }
 
     /// Writes branch-switch marker content through an injectable writer so failure cleanup can be tested deterministically.
@@ -3021,21 +3005,45 @@ module Branch =
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
 
-    /// Runs branch-switch working-tree mutation without replacing a preflight marker lease owned by the outer command.
-    let internal runBranchSwitchWorkingTreeUpdateWithMarker (updateMarkerFileName: string) (markerText: string) (operation: unit -> Task<'T>) =
+    /// Runs branch-switch working-tree mutation after a mutation-boundary Watch-clean preflight creates the marker.
+    let internal runBranchSwitchWorkingTreeUpdateWithMarker
+        (operations: BranchSwitchWatchCleanPreflightOperations)
+        correlationId
+        (updateMarkerFileName: string)
+        (markerText: string)
+        (operation: unit -> Task<'T>)
+        =
         task {
             let mutable markerCreatedByThisInvocation = false
 
-            try
-                if not (File.Exists(updateMarkerFileName)) then
-                    do! createBranchSwitchUpdateMarker updateMarkerFileName markerText
-                    markerCreatedByThisInvocation <- true
+            match! runBranchSwitchWatchCleanPreflight operations correlationId with
+            | Error error -> return Error error
+            | Ok () ->
+                let! markerResult =
+                    task {
+                        try
+                            do! createBranchSwitchUpdateMarker updateMarkerFileName markerText
+                            markerCreatedByThisInvocation <- true
+                            return Ok()
+                        with
+                        | :? IOException ->
+                            return
+                                Error(
+                                    GraceError.Create
+                                        "Branch switch refused before mutation: the Grace update marker appeared while preflight was running; another Grace-owned working-tree update may be in progress."
+                                        correlationId
+                                )
+                    }
 
-                let! result = operation ()
-                return result
-            finally
-                if markerCreatedByThisInvocation then
-                    deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText
+                match markerResult with
+                | Error error -> return Error error
+                | Ok () ->
+                    try
+                        let! result = operation ()
+                        return Ok result
+                    finally
+                        if markerCreatedByThisInvocation then
+                            deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText
         }
 
     /// Executes the switch command by binding ParseResult values to the SDK request and CLI output contract.
@@ -3652,41 +3660,59 @@ module Branch =
 
                                 if not <| isError then
                                     let workingTreeUpdateMarkerFileName = updateInProgressFileName ()
+                                    let workingTreeUpdateMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
 
-                                    do!
-                                        runBranchSwitchWorkingTreeUpdateWithMarker workingTreeUpdateMarkerFileName "`grace switch` is in progress." (fun () ->
-                                            task {
-                                                //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
+                                    let preflightOperations =
+                                        {
+                                            UpdateMarkerExists = fun () -> File.Exists(workingTreeUpdateMarkerFileName)
+                                            InspectWatchStatus = inspectGraceWatchStatus
+                                        }
 
-                                                // Update working directory based on new GraceStatus.Index
-                                                do!
-                                                    updateWorkingDirectory
-                                                        newGraceStatus
-                                                        graceStatusWithNewDirectoryVersionsFromServer
-                                                        newDirectoryVersionDtos
-                                                        (getCorrelationId parseResult)
-                                                //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
+                                    let! workingTreeUpdateResult =
+                                        runBranchSwitchWorkingTreeUpdateWithMarker
+                                            preflightOperations
+                                            (getCorrelationId parseResult)
+                                            workingTreeUpdateMarkerFileName
+                                            workingTreeUpdateMarkerText
+                                            (fun () ->
+                                                task {
+                                                    //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
 
-                                                // Save the new Grace Status.
-                                                do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
+                                                    // Update working directory based on new GraceStatus.Index
+                                                    do!
+                                                        updateWorkingDirectory
+                                                            newGraceStatus
+                                                            graceStatusWithNewDirectoryVersionsFromServer
+                                                            newDirectoryVersionDtos
+                                                            (getCorrelationId parseResult)
+                                                    //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
 
-                                                // Update graceconfig.json.
-                                                let configuration = Current()
-                                                configuration.BranchId <- newBranch.BranchId
-                                                configuration.BranchName <- newBranch.BranchName
-                                                updateConfiguration configuration
-                                                t |> setProgressTaskValue showOutput 100.0
-                                            })
+                                                    // Save the new Grace Status.
+                                                    do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
 
-                                    newGraceStatus <- graceStatusWithNewDirectoryVersionsFromServer
-                                    rootDirectoryId <- newGraceStatus.RootDirectoryId
-                                    rootDirectorySha256Hash <- newGraceStatus.RootDirectorySha256Hash
-                                    directoryIdsInNewGraceStatus <- newGraceStatus.Index.Keys.ToHashSet()
+                                                    // Update the local object cache that backs the new status while Watch still sees a Grace-owned mutation.
+                                                    do! upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values
 
-                                    if parseResult |> verbose then
-                                        logToAnsiConsole Colors.Verbose $"About to exit updateWorkingDirectory."
+                                                    // Update graceconfig.json.
+                                                    let configuration = Current()
+                                                    configuration.BranchId <- newBranch.BranchId
+                                                    configuration.BranchName <- newBranch.BranchName
+                                                    updateConfiguration configuration
+                                                    t |> setProgressTaskValue showOutput 100.0
+                                                })
 
-                                    return Ok(showOutput, parseResult, parameters, newBranch, $"Save created after branch switch.")
+                                    match workingTreeUpdateResult with
+                                    | Error error -> return Error error
+                                    | Ok () ->
+                                        newGraceStatus <- graceStatusWithNewDirectoryVersionsFromServer
+                                        rootDirectoryId <- newGraceStatus.RootDirectoryId
+                                        rootDirectorySha256Hash <- newGraceStatus.RootDirectorySha256Hash
+                                        directoryIdsInNewGraceStatus <- newGraceStatus.Index.Keys.ToHashSet()
+
+                                        if parseResult |> verbose then
+                                            logToAnsiConsole Colors.Verbose $"About to exit updateWorkingDirectory."
+
+                                        return Ok(showOutput, parseResult, parameters, newBranch, $"Save created after branch switch.")
                                 else
                                     return Error(GraceError.Create $"Failed downloading files from object storage." (parseResult |> getCorrelationId))
                             | Error error ->
@@ -3695,17 +3721,6 @@ module Branch =
 
                                 logToAnsiConsole Colors.Error $"{error}"
                                 return Error(GraceError.Create $"{error}" (parseResult |> getCorrelationId))
-                        }
-
-                    /// Writes new grace status data through the CLI output contract.
-                    let writeNewGraceStatus (t: ProgressTask) (showOutput, parseResult: ParseResult, parameters: SwitchParameters, currentBranch: BranchDto) =
-                        task {
-                            t |> startProgressTask showOutput
-                            do! writeGraceStatusFile newGraceStatus
-                            do! upsertObjectCache newGraceStatus.Index.Values
-
-                            t |> setProgressTaskValue showOutput 100.0
-                            return Ok(showOutput, parseResult, parameters, currentBranch)
                         }
 
                     /// Coordinates generate result behavior for this CLI command path.
@@ -3724,7 +3739,6 @@ module Branch =
                                 >>=! getVersionToSwitchTo progressTasks[7]
                                 >>=! updateWorkingDirectory progressTasks[8]
                                 >>=! createSaveReference progressTasks[9]
-                                >>=! writeNewGraceStatus progressTasks[10]
 
                             match result with
                             | Ok _ -> return 0
@@ -3774,9 +3788,6 @@ module Branch =
                                         let t9 =
                                             progressContext.AddTask($"[{Color.DodgerBlue1}]{UIString.getString CreatingSaveReference}[/]", autoStart = false)
 
-                                        let t10 =
-                                            progressContext.AddTask($"[{Color.DodgerBlue1}]{UIString.getString WritingGraceStatusFile}[/]", autoStart = false)
-
                                         return!
                                             generateResult [| t0
                                                               t1
@@ -3787,14 +3798,12 @@ module Branch =
                                                               t6
                                                               t7
                                                               t8
-                                                              t9
-                                                              t10 |]
+                                                              t9 |]
                                     })
                     else
                         // If we're not showing output, we don't need to create the progress tasks.
                         return!
                             generateResult [| emptyTask
-                                              emptyTask
                                               emptyTask
                                               emptyTask
                                               emptyTask
@@ -3816,60 +3825,41 @@ module Branch =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 let updateMarkerFileName = updateInProgressFileName ()
-                let updateMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
-                let mutable updateMarkerCreated = false
 
-                try
-                    if parseResult |> verbose then printParseResult parseResult
+                if parseResult |> verbose then printParseResult parseResult
 
-                    let preflightOperations =
-                        {
-                            UpdateMarkerExists = fun () -> File.Exists(updateMarkerFileName)
-                            InspectWatchStatus = inspectGraceWatchStatus
-                            CreateUpdateMarker =
-                                fun () ->
-                                    task {
-                                        do! createBranchSwitchUpdateMarker updateMarkerFileName updateMarkerText
-                                        updateMarkerCreated <- true
-                                    }
-                        }
+                let preflightOperations = { UpdateMarkerExists = (fun () -> File.Exists(updateMarkerFileName)); InspectWatchStatus = inspectGraceWatchStatus }
 
-                    match! runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult) with
-                    | Error error ->
-                        if parseResult |> verbose then
-                            AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
-                        else
-                            AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
+                match! runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult) with
+                | Error error ->
+                    if parseResult |> verbose then
+                        AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
+                    else
+                        AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
 
-                        return -1
-                    | Ok () ->
-                        let switchParameters = SwitchParameters()
+                    return -1
+                | Ok () ->
+                    let switchParameters = SwitchParameters()
 
-                        let toBranchId = parseResult.GetValue(Options.toBranchId)
-                        if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
+                    let toBranchId = parseResult.GetValue(Options.toBranchId)
+                    if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
 
-                        let toBranchName = parseResult.GetValue(Options.toBranchName)
-                        switchParameters.ToBranchName <- toBranchName
+                    let toBranchName = parseResult.GetValue(Options.toBranchName)
+                    switchParameters.ToBranchName <- toBranchName
 
-                        let referenceId = parseResult.GetValue(Options.referenceId)
+                    let referenceId = parseResult.GetValue(Options.referenceId)
 
-                        if referenceId <> Guid.Empty then
-                            switchParameters.ReferenceId <- $"{referenceId}"
+                    if referenceId <> Guid.Empty then
+                        switchParameters.ReferenceId <- $"{referenceId}"
 
-                        let sha256Hash = getSha256HashPrefix parseResult
-                        switchParameters.Sha256Hash <- sha256Hash
+                    let sha256Hash = getSha256HashPrefix parseResult
+                    switchParameters.Sha256Hash <- sha256Hash
 
-                        let blake3Hash = getBlake3HashPrefix parseResult
-                        switchParameters.Blake3Hash <- blake3Hash
+                    let blake3Hash = getBlake3HashPrefix parseResult
+                    switchParameters.Blake3Hash <- blake3Hash
 
-                        let! result = switchHandler parseResult switchParameters
-                        return result
-                finally
-                    if
-                        updateMarkerCreated
-                        && File.Exists(updateMarkerFileName)
-                    then
-                        deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName updateMarkerText
+                    let! result = switchHandler parseResult switchParameters
+                    return result
             }
 
     /// Routes the rebase command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2984,6 +2984,15 @@ module Branch =
 
     /// Creates the Grace update marker used to keep Watch from observing branch-switch working-tree writes.
     let private createBranchSwitchUpdateMarker (updateMarkerFileName: string) (markerText: string) =
+        let completedFileName = updateMarkerFileName + ".completed"
+
+        if File.Exists(completedFileName) then
+            try
+                File.Delete(completedFileName)
+            with
+            | :? IOException -> ()
+            | :? UnauthorizedAccessException -> ()
+
         createBranchSwitchUpdateMarkerWithWriter
             (fun writer markerText ->
                 task {
@@ -2992,6 +3001,19 @@ module Branch =
                 })
             updateMarkerFileName
             markerText
+
+    /// Records the update marker completion instant before marker removal so Watch can classify delayed callbacks.
+    let private writeBranchSwitchUpdateMarkerCompleted (updateMarkerFileName: string) =
+        try
+            let completedFileName = updateMarkerFileName + ".completed"
+
+            Directory.CreateDirectory(Path.GetDirectoryName(completedFileName))
+            |> ignore
+
+            File.WriteAllText(completedFileName, DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture))
+        with
+        | :? IOException -> ()
+        | :? UnauthorizedAccessException -> ()
 
     /// Removes only the branch-switch marker content written by this command invocation.
     let internal deleteBranchSwitchUpdateMarkerIfOwned (updateMarkerFileName: string) (markerText: string) =
@@ -3004,6 +3026,77 @@ module Branch =
         with
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
+
+    /// Gets the branch-switch workflow lease path that serializes state precomputation without suppressing Watch.
+    let internal branchSwitchWorkflowLeaseFileName (updateMarkerFileName: string) =
+        Path.Combine(Path.GetDirectoryName(updateMarkerFileName), "branch-switch-workflow.lease")
+
+    /// Creates the branch-switch workflow lease through an injectable writer for deterministic race tests.
+    let internal createBranchSwitchWorkflowLeaseWithWriter (writeLeaseText: StreamWriter -> string -> Task) (switchLeaseFileName: string) (leaseText: string) =
+        createBranchSwitchUpdateMarkerWithWriter writeLeaseText switchLeaseFileName leaseText
+
+    /// Removes only the branch-switch workflow lease content written by this command invocation.
+    let internal deleteBranchSwitchWorkflowLeaseIfOwned (switchLeaseFileName: string) (leaseText: string) =
+        deleteBranchSwitchUpdateMarkerIfOwned switchLeaseFileName leaseText
+
+    /// Runs a branch-switch workflow under a non-Watch-suppressing lease before state is computed.
+    let internal runBranchSwitchWorkflowWithLease
+        (operations: BranchSwitchWatchCleanPreflightOperations)
+        correlationId
+        (switchLeaseFileName: string)
+        (leaseText: string)
+        (workflow: unit -> Task<'T>)
+        =
+        task {
+            let mutable leaseCreatedByThisInvocation = false
+
+            let! leaseResult =
+                task {
+                    try
+                        do!
+                            createBranchSwitchWorkflowLeaseWithWriter
+                                (fun writer leaseText ->
+                                    task {
+                                        do! writer.WriteAsync(leaseText)
+                                        do! writer.FlushAsync()
+                                    })
+                                switchLeaseFileName
+                                leaseText
+
+                        leaseCreatedByThisInvocation <- true
+                        return Ok()
+                    with
+                    | :? IOException
+                    | :? UnauthorizedAccessException ->
+                        return
+                            Error(
+                                GraceError.Create
+                                    "Branch switch refused before state precomputation: another `grace switch` workflow is already in progress for the current branch."
+                                    correlationId
+                            )
+                }
+
+            match leaseResult with
+            | Error error -> return Error error
+            | Ok () ->
+                try
+                    match! runBranchSwitchWatchCleanPreflight operations correlationId with
+                    | Error error -> return Error error
+                    | Ok () ->
+                        let! result = workflow ()
+                        return Ok result
+                finally
+                    if leaseCreatedByThisInvocation then
+                        deleteBranchSwitchWorkflowLeaseIfOwned switchLeaseFileName leaseText
+        }
+
+    /// Applies branch switch local state in the order that keeps branch identity ahead of cache refresh failures.
+    let internal applyBranchSwitchLocalState (writeStatus: unit -> Task) (updateBranchIdentity: unit -> unit) (refreshObjectCache: unit -> Task) =
+        task {
+            do! writeStatus ()
+            updateBranchIdentity ()
+            do! refreshObjectCache ()
+        }
 
     /// Runs branch-switch working-tree mutation after a mutation-boundary Watch-clean preflight creates the marker.
     let internal runBranchSwitchWorkingTreeUpdateWithMarker
@@ -3043,6 +3136,7 @@ module Branch =
                         return Ok result
                     finally
                         if markerCreatedByThisInvocation then
+                            writeBranchSwitchUpdateMarkerCompleted updateMarkerFileName
                             deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText
         }
 
@@ -3688,16 +3782,16 @@ module Branch =
                                                     //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
 
                                                     // Save the new Grace Status.
-                                                    do! writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer
+                                                    do!
+                                                        applyBranchSwitchLocalState
+                                                            (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
+                                                            (fun () ->
+                                                                let configuration = Current()
+                                                                configuration.BranchId <- newBranch.BranchId
+                                                                configuration.BranchName <- newBranch.BranchName
+                                                                updateConfiguration configuration)
+                                                            (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
 
-                                                    // Update the local object cache that backs the new status while Watch still sees a Grace-owned mutation.
-                                                    do! upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values
-
-                                                    // Update graceconfig.json.
-                                                    let configuration = Current()
-                                                    configuration.BranchId <- newBranch.BranchId
-                                                    configuration.BranchName <- newBranch.BranchName
-                                                    updateConfiguration configuration
                                                     t |> setProgressTaskValue showOutput 100.0
                                                 })
 
@@ -3825,12 +3919,40 @@ module Branch =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 let updateMarkerFileName = updateInProgressFileName ()
+                let switchLeaseFileName = branchSwitchWorkflowLeaseFileName updateMarkerFileName
+                let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
 
                 if parseResult |> verbose then printParseResult parseResult
 
                 let preflightOperations = { UpdateMarkerExists = (fun () -> File.Exists(updateMarkerFileName)); InspectWatchStatus = inspectGraceWatchStatus }
 
-                match! runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult) with
+                let! switchResult =
+                    runBranchSwitchWorkflowWithLease preflightOperations (getCorrelationId parseResult) switchLeaseFileName switchLeaseText (fun () ->
+                        task {
+                            let switchParameters = SwitchParameters()
+
+                            let toBranchId = parseResult.GetValue(Options.toBranchId)
+                            if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
+
+                            let toBranchName = parseResult.GetValue(Options.toBranchName)
+                            switchParameters.ToBranchName <- toBranchName
+
+                            let referenceId = parseResult.GetValue(Options.referenceId)
+
+                            if referenceId <> Guid.Empty then
+                                switchParameters.ReferenceId <- $"{referenceId}"
+
+                            let sha256Hash = getSha256HashPrefix parseResult
+                            switchParameters.Sha256Hash <- sha256Hash
+
+                            let blake3Hash = getBlake3HashPrefix parseResult
+                            switchParameters.Blake3Hash <- blake3Hash
+
+                            let! result = switchHandler parseResult switchParameters
+                            return result
+                        })
+
+                match switchResult with
                 | Error error ->
                     if parseResult |> verbose then
                         AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
@@ -3838,28 +3960,7 @@ module Branch =
                         AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
 
                     return -1
-                | Ok () ->
-                    let switchParameters = SwitchParameters()
-
-                    let toBranchId = parseResult.GetValue(Options.toBranchId)
-                    if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
-
-                    let toBranchName = parseResult.GetValue(Options.toBranchName)
-                    switchParameters.ToBranchName <- toBranchName
-
-                    let referenceId = parseResult.GetValue(Options.referenceId)
-
-                    if referenceId <> Guid.Empty then
-                        switchParameters.ReferenceId <- $"{referenceId}"
-
-                    let sha256Hash = getSha256HashPrefix parseResult
-                    switchParameters.Sha256Hash <- sha256Hash
-
-                    let blake3Hash = getBlake3HashPrefix parseResult
-                    switchParameters.Blake3Hash <- blake3Hash
-
-                    let! result = switchHandler parseResult switchParameters
-                    return result
+                | Ok result -> return result
             }
 
     /// Routes the rebase command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2211,12 +2211,13 @@ module Watch =
         elif updateNotInProgress ()
              && isGraceStatusArtifact args.FullPath then
             markGraceStatusChangedAndPublishPendingWorkTransition ()
-        elif isDelayedGraceOwnedFileObservation args.FullPath then
-            logObservationSuppressed args.FullPath
         elif updateNotInProgress () then
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
 
-            if enqueueStatusUpdateTrigger args.FullPath then
+            if isDelayedGraceOwnedFileObservation args.FullPath
+               && not canceledFileUpload then
+                logObservationSuppressed args.FullPath
+            elif enqueueStatusUpdateTrigger args.FullPath then
                 match repositoryRelativePath args.FullPath with
                 | Some relativePath ->
                     let invalidatedRelativePath = RelativePath relativePath
@@ -2311,12 +2312,13 @@ module Watch =
     let OnGraceUpdateInProgressDeleted (args: FileSystemEventArgs) =
         if args.FullPath = updateInProgressFileName () then
             if updateNotInProgress () then
-                let completedUtc =
-                    tryReadGraceUpdateMarkerCompletedUtc ()
-                    |> Option.defaultValue DateTime.UtcNow
-
-                recordGraceUpdateMarkerCompletedUtc completedUtc
-                logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
+                match tryReadGraceUpdateMarkerCompletedUtc () with
+                | Some completedUtc ->
+                    recordGraceUpdateMarkerCompletedUtc completedUtc
+                    logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
+                | None ->
+                    clearGraceUpdateMarkerDeletedUtc ()
+                    logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -260,12 +260,13 @@ module Watch =
     /// Gets the completion sidecar written before the Grace update marker is removed.
     let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
 
-    /// Records when the Grace-owned update marker disappeared so stale changed/created callbacks can be classified.
-    let private recordGraceUpdateMarkerDeletedUtc deletedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc <- deletedUtc)
+    /// Records the completed Grace-owned update instant so delayed callbacks can be classified by switch authority.
+    let private recordGraceUpdateMarkerCompletedUtc completedUtc =
+        lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc <- completedUtc)
 
     /// Clears the recent marker-deletion fact when a new Grace-owned update starts or tests reset Watch state.
     let private clearGraceUpdateMarkerDeletedUtc () =
-        recordGraceUpdateMarkerDeletedUtc DateTime.MinValue
+        recordGraceUpdateMarkerCompletedUtc DateTime.MinValue
 
         try
             let completedFileName = updateMarkerCompletedFileName ()
@@ -276,7 +277,7 @@ module Watch =
         | :? UnauthorizedAccessException -> ()
 
     /// Sets the recent Grace update marker deletion instant for deterministic Watch callback tests.
-    let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc = recordGraceUpdateMarkerDeletedUtc deletedUtc
+    let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc = recordGraceUpdateMarkerCompletedUtc deletedUtc
 
     /// Reads the marker completion sidecar when a file callback arrives before Watch observes marker deletion.
     let private tryReadGraceUpdateMarkerCompletedUtc () =
@@ -292,37 +293,6 @@ module Watch =
         with
         | :? IOException -> None
         | :? UnauthorizedAccessException -> None
-
-    /// Identifies delayed file callbacks for writes that completed while a Grace update marker was still present.
-    let private isDelayedGraceOwnedFileObservation fullPath =
-        let markerDeletedUtc =
-            let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
-
-            if recordedUtc <> DateTime.MinValue then
-                Some recordedUtc
-            else
-                tryReadGraceUpdateMarkerCompletedUtc ()
-
-        match markerDeletedUtc with
-        | None -> false
-        | Some markerDeletedUtc when DateTime.UtcNow - markerDeletedUtc > graceUpdateMarkerDeletedObservationWindow -> false
-        | Some _ when
-            not (File.Exists fullPath)
-            && not (Directory.Exists fullPath)
-            ->
-            false
-        | Some markerDeletedUtc ->
-            try
-                let lastWriteTimeUtc =
-                    if File.Exists fullPath then
-                        File.GetLastWriteTimeUtc(fullPath)
-                    else
-                        Directory.GetLastWriteTimeUtc(fullPath)
-
-                lastWriteTimeUtc <= markerDeletedUtc
-            with
-            | :? IOException -> false
-            | :? UnauthorizedAccessException -> false
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.
     type private DeletedPathKind =
@@ -577,6 +547,65 @@ module Watch =
             trackedDeletedPathKind status relativePath
         with
         | _ -> DeletedPathStatusUnavailable
+
+    /// Reads the switch-owned completion instant that should govern delayed Watch callback suppression.
+    let private tryRecentGraceUpdateMarkerCompletedUtc () =
+        let markerCompletedUtc =
+            match tryReadGraceUpdateMarkerCompletedUtc () with
+            | Some completedUtc -> Some completedUtc
+            | None ->
+                let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
+
+                if recordedUtc <> DateTime.MinValue then Some recordedUtc else None
+
+        match markerCompletedUtc with
+        | Some completedUtc when
+            DateTime.UtcNow - completedUtc
+            <= graceUpdateMarkerDeletedObservationWindow
+            ->
+            Some completedUtc
+        | _ -> None
+
+    /// Reports whether a missing path is already absent from the post-switch GraceStatus snapshot.
+    let private completedSwitchRemovedPathFromGraceStatus fullPath =
+        match repositoryRelativePath fullPath with
+        | None -> false
+        | Some relativePath ->
+            try
+                let completedStatus =
+                    readGraceStatusFileForDeletedPathClassification()
+                        .GetAwaiter()
+                        .GetResult()
+
+                match trackedDeletedPathKind completedStatus relativePath with
+                | DeletedPathKindUnknown -> true
+                | DeletedFile
+                | DeletedDirectory
+                | DeletedPathStatusUnavailable -> false
+            with
+            | _ -> false
+
+    /// Identifies delayed callbacks for writes that completed while a Grace update marker was still present.
+    let private isDelayedGraceOwnedFileObservation fullPath =
+        match tryRecentGraceUpdateMarkerCompletedUtc () with
+        | None -> false
+        | Some markerCompletedUtc when
+            not (File.Exists fullPath)
+            && not (Directory.Exists fullPath)
+            ->
+            completedSwitchRemovedPathFromGraceStatus fullPath
+        | Some markerCompletedUtc ->
+            try
+                let lastWriteTimeUtc =
+                    if File.Exists fullPath then
+                        File.GetLastWriteTimeUtc(fullPath)
+                    else
+                        Directory.GetLastWriteTimeUtc(fullPath)
+
+                lastWriteTimeUtc <= markerCompletedUtc
+            with
+            | :? IOException -> false
+            | :? UnauthorizedAccessException -> false
 
     /// Coordinates set grace status for watch tests behavior for this CLI command path.
     let internal setGraceStatusForWatchTests status = graceStatus <- status
@@ -2110,6 +2139,9 @@ module Watch =
     let OnCreated (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
+        elif updateNotInProgress ()
+             && isGraceStatusArtifact args.FullPath then
+            markGraceStatusChangedAndPublishPendingWorkTransition ()
         elif isDelayedGraceOwnedFileObservation args.FullPath then
             logObservationSuppressed args.FullPath
         elif
@@ -2140,6 +2172,10 @@ module Watch =
     let OnChanged (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
+        elif updateNotInProgress ()
+             && isGraceStatusArtifact args.FullPath then
+            markGraceStatusChangedAndPublishPendingWorkTransition ()
+            logToAnsiConsole Colors.Important $"Grace Status file has been updated."
         elif isDelayedGraceOwnedFileObservation args.FullPath then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress ()
@@ -2151,12 +2187,6 @@ module Watch =
                 logToAnsiConsole Colors.Changed $"I saw that {args.FullPath} changed."
                 enqueueFileUpload args.FullPath |> ignore
                 publishPendingWatchWorkTransitionIfNeeded ()
-
-            // Special handling for the Grace status file; if that is the changed file, we'll set this flag so we reload it in OnWatch() in the main loop
-            if isGraceStatusArtifact args.FullPath then
-                //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to true in OnChanged(). Current value: {graceStatusHasChanged}."
-                markGraceStatusChangedAndPublishPendingWorkTransition ()
-                logToAnsiConsole Colors.Important $"Grace Status file has been updated."
 
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
     let private enqueueDirectoryContentsForUpload directoryPath = tryEnqueueDirectoryContentsForUpload directoryPath
@@ -2177,6 +2207,11 @@ module Watch =
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif updateNotInProgress ()
+             && isGraceStatusArtifact args.FullPath then
+            markGraceStatusChangedAndPublishPendingWorkTransition ()
+        elif isDelayedGraceOwnedFileObservation args.FullPath then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress () then
             let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
@@ -2276,7 +2311,11 @@ module Watch =
     let OnGraceUpdateInProgressDeleted (args: FileSystemEventArgs) =
         if args.FullPath = updateInProgressFileName () then
             if updateNotInProgress () then
-                recordGraceUpdateMarkerDeletedUtc DateTime.UtcNow
+                let completedUtc =
+                    tryReadGraceUpdateMarkerCompletedUtc ()
+                    |> Option.defaultValue DateTime.UtcNow
+
+                recordGraceUpdateMarkerCompletedUtc completedUtc
                 logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -253,6 +253,76 @@ module Watch =
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     /// Coordinates update not in progress behavior for this CLI command path.
     let updateNotInProgress () = not <| updateInProgress ()
+    let private graceUpdateMarkerDeletionLock = obj ()
+    let private graceUpdateMarkerDeletedObservationWindow = TimeSpan.FromSeconds(30.0)
+    let mutable private lastGraceUpdateMarkerDeletedUtc = DateTime.MinValue
+
+    /// Gets the completion sidecar written before the Grace update marker is removed.
+    let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
+
+    /// Records when the Grace-owned update marker disappeared so stale changed/created callbacks can be classified.
+    let private recordGraceUpdateMarkerDeletedUtc deletedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc <- deletedUtc)
+
+    /// Clears the recent marker-deletion fact when a new Grace-owned update starts or tests reset Watch state.
+    let private clearGraceUpdateMarkerDeletedUtc () =
+        recordGraceUpdateMarkerDeletedUtc DateTime.MinValue
+
+        try
+            let completedFileName = updateMarkerCompletedFileName ()
+
+            if File.Exists(completedFileName) then File.Delete(completedFileName)
+        with
+        | :? IOException -> ()
+        | :? UnauthorizedAccessException -> ()
+
+    /// Sets the recent Grace update marker deletion instant for deterministic Watch callback tests.
+    let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc = recordGraceUpdateMarkerDeletedUtc deletedUtc
+
+    /// Reads the marker completion sidecar when a file callback arrives before Watch observes marker deletion.
+    let private tryReadGraceUpdateMarkerCompletedUtc () =
+        try
+            let completedFileName = updateMarkerCompletedFileName ()
+
+            if File.Exists(completedFileName) then
+                match DateTime.TryParse(File.ReadAllText(completedFileName), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind) with
+                | true, completedUtc -> Some completedUtc
+                | false, _ -> None
+            else
+                None
+        with
+        | :? IOException -> None
+        | :? UnauthorizedAccessException -> None
+
+    /// Identifies delayed file callbacks for writes that completed while a Grace update marker was still present.
+    let private isDelayedGraceOwnedFileObservation fullPath =
+        let markerDeletedUtc =
+            let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
+
+            if recordedUtc <> DateTime.MinValue then
+                Some recordedUtc
+            else
+                tryReadGraceUpdateMarkerCompletedUtc ()
+
+        match markerDeletedUtc with
+        | None -> false
+        | Some markerDeletedUtc when DateTime.UtcNow - markerDeletedUtc > graceUpdateMarkerDeletedObservationWindow -> false
+        | Some _ when
+            not (File.Exists fullPath)
+            && not (Directory.Exists fullPath)
+            ->
+            false
+        | Some markerDeletedUtc ->
+            try
+                let lastWriteTimeUtc =
+                    if File.Exists fullPath then
+                        File.GetLastWriteTimeUtc(fullPath)
+                    else
+                        Directory.GetLastWriteTimeUtc(fullPath)
+
+                lastWriteTimeUtc <= markerDeletedUtc
+            with
+            | :? IOException -> false
+            | :? UnauthorizedAccessException -> false
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.
     type private DeletedPathKind =
@@ -1749,6 +1819,7 @@ module Watch =
         readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
+        clearGraceUpdateMarkerDeletedUtc ()
         watchPathComparison <- defaultWatchPathComparison ()
         watchPathComparisonOverride <- None
         watchPathComparisonConfiguredRoot <- None
@@ -2039,6 +2110,8 @@ module Watch =
     let OnCreated (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
+        elif isDelayedGraceOwnedFileObservation args.FullPath then
+            logObservationSuppressed args.FullPath
         elif
             updateNotInProgress ()
             && Directory.Exists(args.FullPath)
@@ -2066,6 +2139,8 @@ module Watch =
     /// Coordinates on changed behavior for this CLI command path.
     let OnChanged (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
+            logObservationSuppressed args.FullPath
+        elif isDelayedGraceOwnedFileObservation args.FullPath then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress ()
              && isNotDirectory args.FullPath then
@@ -2192,6 +2267,7 @@ module Watch =
     let OnGraceUpdateInProgressCreated (args: FileSystemEventArgs) =
         if args.FullPath = updateInProgressFileName () then
             if updateInProgress () then
+                clearGraceUpdateMarkerDeletedUtc ()
                 logToAnsiConsole Colors.Important $"Update is in progress from another Grace instance."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should already exist, but it doesn't."
@@ -2200,6 +2276,7 @@ module Watch =
     let OnGraceUpdateInProgressDeleted (args: FileSystemEventArgs) =
         if args.FullPath = updateInProgressFileName () then
             if updateNotInProgress () then
+                recordGraceUpdateMarkerDeletedUtc DateTime.UtcNow
                 logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -294,6 +294,15 @@ module Watch =
         | :? IOException -> None
         | :? UnauthorizedAccessException -> None
 
+    /// Reports whether the completed sidecar was written for the marker that is currently still present.
+    let private currentUpdateMarkerMatchesCompletedSidecar completedUtc =
+        try
+            File.GetLastWriteTimeUtc(updateInProgressFileName ())
+            <= completedUtc
+        with
+        | :? IOException -> false
+        | :? UnauthorizedAccessException -> false
+
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.
     type private DeletedPathKind =
         | DeletedFile
@@ -585,6 +594,25 @@ module Watch =
             with
             | _ -> false
 
+    /// Reports whether an existing path belongs to the post-switch GraceStatus snapshot.
+    let private completedSwitchTracksExistingPathFromGraceStatus fullPath =
+        match repositoryRelativePath fullPath with
+        | None -> false
+        | Some relativePath ->
+            try
+                let completedStatus =
+                    readGraceStatusFileForDeletedPathClassification()
+                        .GetAwaiter()
+                        .GetResult()
+
+                match trackedDeletedPathKind completedStatus relativePath with
+                | DeletedFile -> File.Exists fullPath
+                | DeletedDirectory -> Directory.Exists fullPath
+                | DeletedPathKindUnknown
+                | DeletedPathStatusUnavailable -> false
+            with
+            | _ -> false
+
     /// Identifies delayed callbacks for writes that completed while a Grace update marker was still present.
     let private isDelayedGraceOwnedFileObservation fullPath =
         match tryRecentGraceUpdateMarkerCompletedUtc () with
@@ -595,17 +623,18 @@ module Watch =
             ->
             completedSwitchRemovedPathFromGraceStatus fullPath
         | Some markerCompletedUtc ->
-            try
-                let lastWriteTimeUtc =
-                    if File.Exists fullPath then
-                        File.GetLastWriteTimeUtc(fullPath)
-                    else
-                        Directory.GetLastWriteTimeUtc(fullPath)
+            completedSwitchTracksExistingPathFromGraceStatus fullPath
+            && (try
+                    let lastWriteTimeUtc =
+                        if File.Exists fullPath then
+                            File.GetLastWriteTimeUtc(fullPath)
+                        else
+                            Directory.GetLastWriteTimeUtc(fullPath)
 
-                lastWriteTimeUtc <= markerCompletedUtc
-            with
-            | :? IOException -> false
-            | :? UnauthorizedAccessException -> false
+                    lastWriteTimeUtc <= markerCompletedUtc
+                with
+                | :? IOException -> false
+                | :? UnauthorizedAccessException -> false)
 
     /// Coordinates set grace status for watch tests behavior for this CLI command path.
     let internal setGraceStatusForWatchTests status = graceStatus <- status
@@ -2303,7 +2332,13 @@ module Watch =
     let OnGraceUpdateInProgressCreated (args: FileSystemEventArgs) =
         if args.FullPath = updateInProgressFileName () then
             if updateInProgress () then
-                clearGraceUpdateMarkerDeletedUtc ()
+                let hasCurrentCompletedSidecar =
+                    match tryReadGraceUpdateMarkerCompletedUtc () with
+                    | Some completedUtc -> currentUpdateMarkerMatchesCompletedSidecar completedUtc
+                    | None -> false
+
+                if not hasCurrentCompletedSidecar then clearGraceUpdateMarkerDeletedUtc ()
+
                 logToAnsiConsole Colors.Important $"Update is in progress from another Grace instance."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should already exist, but it doesn't."


### PR DESCRIPTION
## Summary

- Narrow the branch-switch update marker so the initial Watch-clean preflight and pre-mutation work run without the
  marker suppressing Watch observations.
- Add a mutation-boundary Watch-clean preflight immediately before the working-tree rewrite; if it fails, the marker is
  not created and the rewrite does not run.
- Keep the working-tree update, `GraceStatus` write, object-cache local-state update, and config update inside the
  marker window.
- Cover the carried #532 finding with tests for marker-free preflight, second-preflight refusal, raced marker creation,
  success/failure/cancellation cleanup, marker ownership, and Watch suppression during marker-covered writes.

## Related Issue

References #494. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This advances WS5 by keeping user edits observable during branch-switch setup work while still suppressing Grace-owned
working-tree writes during the actual mutation window. It preserves #493's Watch-clean refusal contract and marker
ownership while moving marker timing to the leaf that owns it.

## Validation

- Targeted Fantomas passed for:
  - `src/Grace.CLI/Command/Branch.CLI.fs`
  - `src/Grace.CLI.Tests/Branch.CLI.Tests.fs`
  - `src/Grace.CLI.Tests/Watch.Tests.fs`
- Focused Grace.CLI.Tests Branch/Watch filter passed: 209 tests.
- `git diff --check` passed.
- Final gate `pwsh ./scripts/validate.ps1 -Fast` passed with a 0-warning build and selected fast tests green.

- Review fix targeted Fantomas passed for `Branch.CLI.fs`, `Watch.CLI.fs`, `Branch.CLI.Tests.fs`, and
  `Watch.Tests.fs`.
- Review fix focused Branch/Watch CLI tests passed: 214 tests.
- Review fix `pwsh ./scripts/validate.ps1 -Fast` passed.
- Review fix `git diff --check` passed.

- Stabilization targeted Fantomas passed for `Watch.CLI.fs`, `Branch.CLI.fs`, `Watch.Tests.fs`, and
  `Branch.CLI.Tests.fs`.
- Stabilization focused Branch/Watch CLI tests passed: 220 tests.
- Stabilization `pwsh ./scripts/validate.ps1 -Fast` passed.
- Stabilization `git diff --check` passed.

## Docs Impact

No docs changed. This leaf changes internal marker timing and Watch/local-state discrimination behavior without changing
command syntax, options, examples, ADR decisions, or public docs contracts.

## Explicit Deferrals

- #495: Watch transition-completion after clean branch switch remains out of scope.
- #496: SignalR subscription refresh and WS5 ADR remain out of scope.
- Remote materialization, durable journal authority, `--force`, `--wait`, and `grace watch flush` remain out of scope.

## Review Status

- Final head reviewed: `7a1a4aa1b4c45f22b31214dc269fef125dd03807`.
- Merge commit: `6470c501f5c6380a532432109418c42df183a5ed` into `epic/473-grace-watch-incremental-sync`.
- Codex Code Review Bot final state: 👍 no-issues reaction on PR body at 2026-07-04T13:43:53Z.
- GitHub checks: `full:COMPLETED:SUCCESS`.
- Review threads: all Codex review conversations resolved before merge.
- Current-head stabilization validation: targeted Fantomas passed; focused Watch CLI tests passed 198/198;
  `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed.
- Future-leaf deferral: `r3523257569` was carried to #495 with the exact transition-completion invariant and proof
  obligation before resolving the thread. #494 did not broaden into #495 transition completion.
- Prevention line: completed-sidecar event ordering, GraceStatus-owned delayed suppression authority, post-switch user
  lifecycle precedence, and worktree-wide switch serialization were proven before merge.

### Stabilization Status Map

- Valid completed sidecar survives late marker-created event: implemented and proven.
- Stale completed sidecar from an earlier switch is still cleared when a new marker starts: implemented and proven.
- Created/Changed existing-path suppression requires completed GraceStatus ownership, not mtime alone: implemented and
  proven.
- Grace-owned Created/Changed/Directory delayed callbacks remain suppressible when completed GraceStatus owns the path:
  implemented and proven.
- No completion sidecar means no completed-update suppression: implemented and proven.
- Post-switch user-created file deletes drain queued work: implemented and proven.
- GraceStatus refresh events remain visible for #495 transition completion: implemented and proven for #494; #495 owns
  config/status reload and in-memory identity transition.
- Branch-switch workflow lease is worktree-wide and failed/partial switch does not mark completion: implemented and
  proven.

## Residual Risks

- This PR intentionally stops at marker-window narrowing. #495 transition completion and #496 SignalR/ADR work remain
  separate WS5 leaves.
