### PR TITLE
OPS4: Add Azure SQL operational fact storage and minute aggregate projection

### DIFF
--- a/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageReference Update="FSharp.Core" Version="10.1.301" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grace.Operations\Grace.Operations.fsproj" />
+    <ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations.Data/OperationsData.fs
@@ -2,8 +2,10 @@ namespace Grace.Operations.Data
 
 open Grace.Types.Common
 open Grace.Types.Usage
+open Microsoft.Data.SqlClient
 open NodaTime
 open System
+open System.Data
 open System.Threading
 open System.Threading.Tasks
 
@@ -68,6 +70,10 @@ module OperationsUsageSql =
     [<Literal>]
     let UsageAggregateMinuteTable = "ops.UsageAggregateMinute"
 
+    /// Keeps storage-pool identities case-sensitive even when the database default collation is case-insensitive.
+    [<Literal>]
+    let CaseSensitiveStoragePoolIdCollation = "Latin1_General_100_BIN2"
+
     /// Creates the operations schema when it is absent.
     [<Literal>]
     let CreateSchema = "IF SCHEMA_ID(N'ops') IS NULL EXEC(N'CREATE SCHEMA ops');"
@@ -86,7 +92,7 @@ BEGIN
         OwnerId uniqueidentifier NOT NULL,
         OrganizationId uniqueidentifier NOT NULL,
         RepositoryId uniqueidentifier NOT NULL,
-        StoragePoolId nvarchar(256) NOT NULL,
+        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
         Quantity bigint NOT NULL,
         ObservedAtUtc datetime2(7) NOT NULL,
         CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_RawUsageFact_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
@@ -107,7 +113,7 @@ BEGIN
         OwnerId uniqueidentifier NOT NULL,
         OrganizationId uniqueidentifier NOT NULL,
         RepositoryId uniqueidentifier NOT NULL,
-        StoragePoolId nvarchar(256) NOT NULL,
+        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
         BucketStartUtc datetime2(7) NOT NULL,
         Quantity bigint NOT NULL,
         UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_UsageAggregateMinute_UpdatedAtUtc DEFAULT SYSUTCDATETIME(),
@@ -170,7 +176,7 @@ USING
         @OwnerId AS OwnerId,
         @OrganizationId AS OrganizationId,
         @RepositoryId AS RepositoryId,
-        @StoragePoolId AS StoragePoolId,
+        CAST(@StoragePoolId AS nvarchar(256)) COLLATE Latin1_General_100_BIN2 AS StoragePoolId,
         @BucketStartUtc AS BucketStartUtc,
         @Quantity AS Quantity
 ) AS source
@@ -265,6 +271,109 @@ type IOperationsUsageTransactionScope =
 
     /// Executes the supplied operation and commits only when it completes successfully.
     abstract ExecuteAsync<'T> : operation: (IOperationsUsageTransaction -> CancellationToken -> Task<'T>) * cancellationToken: CancellationToken -> Task<'T>
+
+/// Executes operations usage SQL commands through an already-open SQL connection and transaction.
+type private SqlOperationsUsageTransaction(connection: SqlConnection, transaction: SqlTransaction) =
+
+    /// Adds a SQL parameter and assigns either the supplied value or database null.
+    let addParameter (command: SqlCommand) name sqlDbType value =
+        let parameter = command.Parameters.Add(name, sqlDbType)
+        parameter.Value <- value
+
+    /// Adds a SQL parameter for a Grace string alias value.
+    let addStringParameter (command: SqlCommand) name length (value: string) =
+        let parameter = command.Parameters.Add(name, SqlDbType.NVarChar, length)
+        parameter.Value <- value
+
+    /// Creates a command that participates in the current operations usage transaction.
+    let createCommand commandText =
+        let command = connection.CreateCommand()
+        command.Transaction <- transaction
+        command.CommandType <- CommandType.Text
+        command.CommandText <- commandText
+        command
+
+    /// Converts a NodaTime instant to the UTC SQL timestamp shape used by operations usage tables.
+    let toUtcDateTime (instant: Instant) = instant.ToDateTimeUtc()
+
+    /// Adds the raw usage fact parameters expected by `OperationsUsageSql.TryInsertRawUsageFact`.
+    let addRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
+        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+        addStringParameter command "@CorrelationId" 200 rawFact.CorrelationId
+        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
+        addStringParameter command "@StoragePoolId" 256 rawFact.StoragePoolId
+        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
+        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
+
+    /// Adds the aggregate parameters expected by `OperationsUsageSql.AddToUsageAggregateMinute`.
+    let addUsageAggregateMinuteParameters (command: SqlCommand) (aggregate: UsageAggregateMinute) =
+        addParameter command "@FactKind" SqlDbType.Int (int aggregate.Key.FactKind)
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier aggregate.Key.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier aggregate.Key.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier aggregate.Key.RepositoryId
+        addStringParameter command "@StoragePoolId" 256 aggregate.Key.StoragePoolId
+        addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
+        addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
+
+    interface IOperationsUsageTransaction with
+
+        member _.TryInsertRawUsageFactAsync(rawFact, cancellationToken) =
+            task {
+                use command = createCommand OperationsUsageSql.TryInsertRawUsageFact
+                addRawUsageFactParameters command rawFact
+                let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
+                return rowsAffected = 1
+            }
+
+        member _.AddToUsageAggregateMinuteAsync(aggregate, cancellationToken) =
+            task {
+                use command = createCommand OperationsUsageSql.AddToUsageAggregateMinute
+                addUsageAggregateMinuteParameters command aggregate
+                let! _ = command.ExecuteNonQueryAsync cancellationToken
+                return ()
+            }
+
+/// Runs operations usage mutations inside a concrete Azure SQL transaction boundary.
+type SqlOperationsUsageTransactionScope(connectionString: string) =
+
+    /// Opens a SQL connection for one operations usage transaction.
+    let openConnectionAsync cancellationToken =
+        task {
+            let connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Rolls back a failed transaction while preserving the original failure when rollback also fails.
+    let rollbackIgnoringFailuresAsync (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    interface IOperationsUsageTransactionScope with
+
+        member _.ExecuteAsync(operation, cancellationToken) =
+            task {
+                use! connection = openConnectionAsync cancellationToken
+                let! dbTransaction = connection.BeginTransactionAsync cancellationToken
+                use transaction = dbTransaction :?> SqlTransaction
+                let operationsTransaction = SqlOperationsUsageTransaction(connection, transaction)
+
+                try
+                    let! result = operation operationsTransaction cancellationToken
+                    do! transaction.CommitAsync cancellationToken
+                    return result
+                with
+                | ex ->
+                    do! rollbackIgnoringFailuresAsync transaction
+                    return raise ex
+            }
 
 /// Persists usage facts through a transaction-scoped raw insert and aggregate projection.
 type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =

--- a/src/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations.Data/OperationsData.fs
@@ -1,7 +1,292 @@
 namespace Grace.Operations.Data
 
+open Grace.Types.Common
+open Grace.Types.Usage
+open NodaTime
+open System
+open System.Threading
+open System.Threading.Tasks
+
 /// Identifies the Grace operations data assembly while persistence contracts remain owned by later slices.
 [<AbstractClass; Sealed>]
 type internal OperationsDataAssembly =
     class
     end
+
+/// Describes a raw immutable usage fact row in `ops.RawUsageFact`.
+type RawUsageFact =
+    {
+        UsageFactId: UsageFactId
+        CorrelationId: CorrelationId
+        FactKind: UsageFactKind
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        StoragePoolId: StoragePoolId
+        Quantity: int64
+        ObservedAt: Instant
+    }
+
+/// Identifies one UTC minute aggregate row in `ops.UsageAggregateMinute`.
+type UsageAggregateMinuteKey =
+    {
+        FactKind: UsageFactKind
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        StoragePoolId: StoragePoolId
+        BucketStart: Instant
+    }
+
+/// Describes the aggregate quantity projected for one Grace repository resource and UTC minute.
+type UsageAggregateMinute = { Key: UsageAggregateMinuteKey; Quantity: int64 }
+
+/// Carries the raw insert and aggregate update that must commit or roll back together.
+type UsageFactPersistencePlan = { RawFact: RawUsageFact; Aggregate: UsageAggregateMinute }
+
+/// Reports whether a usage fact changed storage state or was already present.
+type UsageFactPersistenceStatus =
+    | Accepted = 1
+    | AlreadyProcessed = 2
+
+/// Reports the outcome of transactionally storing a usage fact.
+type UsageFactPersistenceResult = { Status: UsageFactPersistenceStatus; UsageFactId: UsageFactId; Aggregate: UsageAggregateMinute option }
+
+/// Provides SQL Server schema and command text for the operations usage fact tables.
+[<RequireQualifiedAccess>]
+module OperationsUsageSql =
+
+    /// Names the SQL schema used by Grace operations data.
+    [<Literal>]
+    let SchemaName = "ops"
+
+    /// Names the raw immutable fact table.
+    [<Literal>]
+    let RawUsageFactTable = "ops.RawUsageFact"
+
+    /// Names the minute aggregate table derived from accepted raw facts.
+    [<Literal>]
+    let UsageAggregateMinuteTable = "ops.UsageAggregateMinute"
+
+    /// Creates the operations schema when it is absent.
+    [<Literal>]
+    let CreateSchema = "IF SCHEMA_ID(N'ops') IS NULL EXEC(N'CREATE SCHEMA ops');"
+
+    /// Creates `ops.RawUsageFact` with `UsageFactId` as the durable dedupe key.
+    [<Literal>]
+    let CreateRawUsageFactTable =
+        """
+IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL
+BEGIN
+    CREATE TABLE ops.RawUsageFact
+    (
+        UsageFactId uniqueidentifier NOT NULL,
+        CorrelationId nvarchar(200) NOT NULL,
+        FactKind int NOT NULL,
+        OwnerId uniqueidentifier NOT NULL,
+        OrganizationId uniqueidentifier NOT NULL,
+        RepositoryId uniqueidentifier NOT NULL,
+        StoragePoolId nvarchar(256) NOT NULL,
+        Quantity bigint NOT NULL,
+        ObservedAtUtc datetime2(7) NOT NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_RawUsageFact_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)
+    );
+END;
+"""
+
+    /// Creates `ops.UsageAggregateMinute` with one row per repository resource and UTC minute.
+    [<Literal>]
+    let CreateUsageAggregateMinuteTable =
+        """
+IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL
+BEGIN
+    CREATE TABLE ops.UsageAggregateMinute
+    (
+        FactKind int NOT NULL,
+        OwnerId uniqueidentifier NOT NULL,
+        OrganizationId uniqueidentifier NOT NULL,
+        RepositoryId uniqueidentifier NOT NULL,
+        StoragePoolId nvarchar(256) NOT NULL,
+        BucketStartUtc datetime2(7) NOT NULL,
+        Quantity bigint NOT NULL,
+        UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_UsageAggregateMinute_UpdatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED
+        (
+            FactKind,
+            OwnerId,
+            OrganizationId,
+            RepositoryId,
+            StoragePoolId,
+            BucketStartUtc
+        )
+    );
+END;
+"""
+
+    /// Inserts one raw usage fact only when its durable identity has not already been accepted.
+    [<Literal>]
+    let TryInsertRawUsageFact =
+        """
+INSERT INTO ops.RawUsageFact
+(
+    UsageFactId,
+    CorrelationId,
+    FactKind,
+    OwnerId,
+    OrganizationId,
+    RepositoryId,
+    StoragePoolId,
+    Quantity,
+    ObservedAtUtc
+)
+SELECT
+    @UsageFactId,
+    @CorrelationId,
+    @FactKind,
+    @OwnerId,
+    @OrganizationId,
+    @RepositoryId,
+    @StoragePoolId,
+    @Quantity,
+    @ObservedAtUtc
+WHERE NOT EXISTS
+(
+    SELECT 1
+    FROM ops.RawUsageFact WITH (UPDLOCK, HOLDLOCK)
+    WHERE UsageFactId = @UsageFactId
+);
+"""
+
+    /// Adds a quantity to the minute aggregate row associated with a newly accepted raw fact.
+    [<Literal>]
+    let AddToUsageAggregateMinute =
+        """
+MERGE ops.UsageAggregateMinute WITH (HOLDLOCK) AS target
+USING
+(
+    SELECT
+        @FactKind AS FactKind,
+        @OwnerId AS OwnerId,
+        @OrganizationId AS OrganizationId,
+        @RepositoryId AS RepositoryId,
+        @StoragePoolId AS StoragePoolId,
+        @BucketStartUtc AS BucketStartUtc,
+        @Quantity AS Quantity
+) AS source
+ON
+    target.FactKind = source.FactKind
+    AND target.OwnerId = source.OwnerId
+    AND target.OrganizationId = source.OrganizationId
+    AND target.RepositoryId = source.RepositoryId
+    AND target.StoragePoolId = source.StoragePoolId
+    AND target.BucketStartUtc = source.BucketStartUtc
+WHEN MATCHED THEN
+    UPDATE SET
+        Quantity = target.Quantity + source.Quantity,
+        UpdatedAtUtc = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+    INSERT
+    (
+        FactKind,
+        OwnerId,
+        OrganizationId,
+        RepositoryId,
+        StoragePoolId,
+        BucketStartUtc,
+        Quantity
+    )
+    VALUES
+    (
+        source.FactKind,
+        source.OwnerId,
+        source.OrganizationId,
+        source.RepositoryId,
+        source.StoragePoolId,
+        source.BucketStartUtc,
+        source.Quantity
+    );
+"""
+
+/// Builds deterministic raw fact and aggregate projection plans from the shared usage contract.
+[<RequireQualifiedAccess>]
+module UsageFactPersistencePlan =
+
+    /// Rounds a fact timestamp to the UTC minute bucket used for operations aggregates.
+    let bucketObservedAt (observedAt: Instant) = UsageFact.NormalizeObservedAtToMinute observedAt
+
+    /// Validates a usage fact and converts it into the transaction plan required by operations storage.
+    let tryCreate (fact: UsageFact) =
+        match UsageFact.Validate fact with
+        | Error errors -> Error errors
+        | Ok () ->
+            let bucketStart = bucketObservedAt fact.ObservedAt
+
+            let rawFact =
+                {
+                    UsageFactId = fact.UsageFactId
+                    CorrelationId = fact.CorrelationId
+                    FactKind = fact.FactKind
+                    OwnerId = fact.Scope.OwnerId
+                    OrganizationId = fact.Scope.OrganizationId
+                    RepositoryId = fact.Scope.RepositoryId
+                    StoragePoolId = fact.Resource.StoragePoolId
+                    Quantity = fact.Quantity
+                    ObservedAt = bucketStart
+                }
+
+            let aggregate =
+                {
+                    Key =
+                        {
+                            FactKind = fact.FactKind
+                            OwnerId = fact.Scope.OwnerId
+                            OrganizationId = fact.Scope.OrganizationId
+                            RepositoryId = fact.Scope.RepositoryId
+                            StoragePoolId = fact.Resource.StoragePoolId
+                            BucketStart = bucketStart
+                        }
+                    Quantity = fact.Quantity
+                }
+
+            Ok { RawFact = rawFact; Aggregate = aggregate }
+
+/// Represents the commands available inside one durable operations usage transaction.
+type IOperationsUsageTransaction =
+
+    /// Attempts to insert the raw fact, returning `false` when `UsageFactId` already exists.
+    abstract TryInsertRawUsageFactAsync: rawFact: RawUsageFact * cancellationToken: CancellationToken -> Task<bool>
+
+    /// Adds the accepted raw fact quantity to the derived minute aggregate.
+    abstract AddToUsageAggregateMinuteAsync: aggregate: UsageAggregateMinute * cancellationToken: CancellationToken -> Task
+
+/// Runs operations usage mutations inside one storage transaction boundary.
+type IOperationsUsageTransactionScope =
+
+    /// Executes the supplied operation and commits only when it completes successfully.
+    abstract ExecuteAsync<'T> : operation: (IOperationsUsageTransaction -> CancellationToken -> Task<'T>) * cancellationToken: CancellationToken -> Task<'T>
+
+/// Persists usage facts through a transaction-scoped raw insert and aggregate projection.
+type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
+
+    /// Stores a usage fact exactly once by durable `UsageFactId` and projects aggregates only for newly accepted facts.
+    member _.StoreUsageFactAsync(fact: UsageFact, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreate fact with
+            | Error errors -> return Error errors
+            | Ok plan ->
+                let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
+                    task {
+                        let! accepted = transaction.TryInsertRawUsageFactAsync(plan.RawFact, operationCancellationToken)
+
+                        if accepted then
+                            do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+
+                            return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
+                        else
+                            return { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = plan.RawFact.UsageFactId; Aggregate = None }
+                    }
+
+                let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
+                return Ok result
+        }

--- a/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Compile Include="OperationsSkeleton.Tests.fs" />
+    <Compile Include="OperationsUsageStorage.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -1,0 +1,252 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Types.Common
+open Grace.Types.Usage
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
+
+/// Provides deterministic usage facts for operations storage tests.
+module OperationsUsageStorageTestData =
+
+    /// Provides the owner used by all test usage facts.
+    let ownerId = OwnerId.Parse("11111111-1111-1111-1111-111111111111")
+
+    /// Provides the organization used by all test usage facts.
+    let organizationId = OrganizationId.Parse("22222222-2222-2222-2222-222222222222")
+
+    /// Provides the repository used by all test usage facts.
+    let repositoryId = RepositoryId.Parse("33333333-3333-3333-3333-333333333333")
+
+    /// Provides the storage pool used by all test usage facts.
+    let storagePoolId = StoragePoolId "storage-pool-main"
+
+    /// Creates a valid repository storage usage fact with deterministic scope and resource values.
+    let fact usageFactId quantity observedAt =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"corr-{usageFactId}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            storagePoolId,
+            quantity,
+            observedAt
+        )
+
+/// Stores transaction state for the operations usage test double.
+type private InMemoryOperationsUsageState = { RawFacts: Dictionary<UsageFactId, RawUsageFact>; Aggregates: Dictionary<UsageAggregateMinuteKey, int64> }
+
+/// Provides a rollback-capable transaction scope for proving data-layer ordering without SQL Server.
+type private InMemoryOperationsUsageTransactionScope() =
+    let state = { RawFacts = Dictionary<UsageFactId, RawUsageFact>(); Aggregates = Dictionary<UsageAggregateMinuteKey, int64>() }
+
+    let mutable failNextAggregateUpdate = false
+
+    /// Replaces dictionary contents after a transaction commits.
+    let replaceDictionary (target: Dictionary<'TKey, 'TValue>) (source: Dictionary<'TKey, 'TValue>) =
+        target.Clear()
+
+        source
+        |> Seq.iter (fun pair -> target[pair.Key] <- pair.Value)
+
+    /// Returns the number of committed raw facts.
+    member _.RawFactCount = state.RawFacts.Count
+
+    /// Returns the committed quantity for an aggregate row.
+    member _.AggregateQuantity(key: UsageAggregateMinuteKey) =
+        match state.Aggregates.TryGetValue key with
+        | true, quantity -> quantity
+        | false, _ -> 0L
+
+    /// Forces the next aggregate update to fail after the raw insert has been staged.
+    member _.FailNextAggregateUpdate() = failNextAggregateUpdate <- true
+
+    interface IOperationsUsageTransactionScope with
+
+        member _.ExecuteAsync(operation, cancellationToken) =
+            task {
+                cancellationToken.ThrowIfCancellationRequested()
+
+                let rawFacts = Dictionary<UsageFactId, RawUsageFact>(state.RawFacts)
+                let aggregates = Dictionary<UsageAggregateMinuteKey, int64>(state.Aggregates)
+
+                let transaction =
+                    { new IOperationsUsageTransaction with
+                        member _.TryInsertRawUsageFactAsync(rawFact, insertCancellationToken) =
+                            insertCancellationToken.ThrowIfCancellationRequested()
+
+                            if rawFacts.ContainsKey rawFact.UsageFactId then
+                                Task.FromResult false
+                            else
+                                rawFacts.Add(rawFact.UsageFactId, rawFact)
+                                Task.FromResult true
+
+                        member _.AddToUsageAggregateMinuteAsync(aggregate, updateCancellationToken) =
+                            updateCancellationToken.ThrowIfCancellationRequested()
+
+                            if failNextAggregateUpdate then
+                                failNextAggregateUpdate <- false
+                                Task.FromException(InvalidOperationException("forced aggregate failure"))
+                            else
+                                let current =
+                                    match aggregates.TryGetValue aggregate.Key with
+                                    | true, quantity -> quantity
+                                    | false, _ -> 0L
+
+                                aggregates[aggregate.Key] <- current + aggregate.Quantity
+                                Task.CompletedTask
+                    }
+
+                let! result = operation transaction cancellationToken
+
+                replaceDictionary state.RawFacts rawFacts
+                replaceDictionary state.Aggregates aggregates
+
+                return result
+            }
+
+/// Covers operations usage storage idempotency and aggregate projection behavior.
+[<TestFixture>]
+type OperationsUsageStorageTests() =
+
+    /// Builds a store backed by the rollback-capable test transaction scope.
+    let createStore () =
+        let transactionScope = InMemoryOperationsUsageTransactionScope()
+        OperationsUsageStore transactionScope, transactionScope
+
+    /// Extracts a successful storage result from the data-layer result shape.
+    let requireStored (result: Result<UsageFactPersistenceResult, string list>) =
+        match result with
+        | Ok stored -> stored
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            failwith $"Storage failed validation: {errorText}"
+
+    /// Extracts a successful persistence plan from validation.
+    let requirePlan (result: Result<UsageFactPersistencePlan, string list>) =
+        match result with
+        | Ok plan -> plan
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            failwith $"Persistence plan failed validation: {errorText}"
+
+    /// Verifies the SQL DDL keeps raw fact identity as the durable dedupe boundary.
+    [<Test>]
+    member _.SqlSchemaUsesUsageFactIdAsRawFactPrimaryKey() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(OperationsUsageSql.CreateSchema, Does.Contain("CREATE SCHEMA ops"))
+                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("ops.RawUsageFact"))
+                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("PRIMARY KEY CLUSTERED (UsageFactId)"))
+                Assert.That(OperationsUsageSql.TryInsertRawUsageFact, Does.Contain("WITH (UPDLOCK, HOLDLOCK)"))
+                Assert.That(OperationsUsageSql.CreateUsageAggregateMinuteTable, Does.Contain("ops.UsageAggregateMinute"))
+                Assert.That(OperationsUsageSql.AddToUsageAggregateMinute, Does.Contain("MERGE ops.UsageAggregateMinute WITH (HOLDLOCK)")))
+        )
+
+    /// Verifies a first usage fact inserts a raw row and increments the expected aggregate minute.
+    [<Test>]
+    member _.FirstFactStoresRawFactAndIncrementsMinuteAggregate() =
+        task {
+            let store, transactionScope = createStore ()
+            let usageFactId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            let fact = OperationsUsageStorageTestData.fact usageFactId 4096L (Instant.FromUtc(2026, 7, 4, 12, 34, 56))
+
+            let! result = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let stored = requireStored result
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(stored.Status, Is.EqualTo(UsageFactPersistenceStatus.Accepted))
+                    Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(stored.Aggregate.IsSome, Is.True)
+                    Assert.That(transactionScope.AggregateQuantity(stored.Aggregate.Value.Key), Is.EqualTo(4096L)))
+            )
+        }
+
+    /// Verifies duplicate `UsageFactId` delivery is acknowledged without changing aggregate totals.
+    [<Test>]
+    member _.DuplicateUsageFactIdDoesNotDoubleCountAggregate() =
+        task {
+            let store, transactionScope = createStore ()
+            let usageFactId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+            let fact = OperationsUsageStorageTestData.fact usageFactId 2048L (Instant.FromUtc(2026, 7, 4, 12, 34, 0))
+
+            let! firstResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let firstStored = requireStored firstResult
+
+            let! duplicateResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let duplicateStored = requireStored duplicateResult
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(firstStored.Status, Is.EqualTo(UsageFactPersistenceStatus.Accepted))
+                    Assert.That(duplicateStored.Status, Is.EqualTo(UsageFactPersistenceStatus.AlreadyProcessed))
+                    Assert.That(duplicateStored.Aggregate, Is.EqualTo(None))
+                    Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(transactionScope.AggregateQuantity(firstStored.Aggregate.Value.Key), Is.EqualTo(2048L)))
+            )
+        }
+
+    /// Verifies raw insertion and aggregate projection roll back together when projection fails.
+    [<Test>]
+    member _.RawInsertAndAggregateProjectionRollbackTogetherOnFailure() =
+        task {
+            let store, transactionScope = createStore ()
+            let usageFactId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+            let fact = OperationsUsageStorageTestData.fact usageFactId 1024L (Instant.FromUtc(2026, 7, 4, 12, 35, 0))
+            transactionScope.FailNextAggregateUpdate()
+
+            let mutable thrownMessage = None
+
+            try
+                let! _ = store.StoreUsageFactAsync(fact, CancellationToken.None)
+                Assert.Fail("Aggregate failure should propagate instead of reporting successful storage.")
+            with
+            | :? InvalidOperationException as ex -> thrownMessage <- Some ex.Message
+
+            Assert.That(thrownMessage, Is.EqualTo(Some "forced aggregate failure"))
+            Assert.That(transactionScope.RawFactCount, Is.EqualTo(0))
+
+            let! retryResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let retryStored = requireStored retryResult
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(retryStored.Status, Is.EqualTo(UsageFactPersistenceStatus.Accepted))
+                    Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(transactionScope.AggregateQuantity(retryStored.Aggregate.Value.Key), Is.EqualTo(1024L)))
+            )
+        }
+
+    /// Verifies aggregate minute bucketing is deterministic and UTC based.
+    [<Test>]
+    member _.ObservedAtBucketsAreDeterministicUtcMinuteBoundaries() =
+        let first = OperationsUsageStorageTestData.fact (Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd")) 1L (Instant.FromUtc(2026, 7, 4, 12, 34, 59))
+
+        let second = OperationsUsageStorageTestData.fact (Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")) 1L (Instant.FromUtc(2026, 7, 4, 12, 34, 0))
+
+        let third = OperationsUsageStorageTestData.fact (Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")) 1L (Instant.FromUtc(2026, 7, 4, 12, 35, 0))
+
+        let firstPlan =
+            UsageFactPersistencePlan.tryCreate first
+            |> requirePlan
+
+        let secondPlan =
+            UsageFactPersistencePlan.tryCreate second
+            |> requirePlan
+
+        let thirdPlan =
+            UsageFactPersistencePlan.tryCreate third
+            |> requirePlan
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(firstPlan.Aggregate.Key.BucketStart, Is.EqualTo(Instant.FromUtc(2026, 7, 4, 12, 34)))
+                Assert.That(secondPlan.Aggregate.Key.BucketStart, Is.EqualTo(firstPlan.Aggregate.Key.BucketStart))
+                Assert.That(thirdPlan.Aggregate.Key.BucketStart, Is.EqualTo(Instant.FromUtc(2026, 7, 4, 12, 35))))
+        )

--- a/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -25,8 +25,24 @@ module OperationsUsageStorageTestData =
     /// Provides the storage pool used by all test usage facts.
     let storagePoolId = StoragePoolId "storage-pool-main"
 
+    /// Provides a second storage pool whose value differs only by case.
+    let storagePoolIdWithDifferentCase = StoragePoolId "Storage-Pool-Main"
+
     /// Creates a valid repository storage usage fact with deterministic scope and resource values.
     let fact usageFactId quantity observedAt =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"corr-{usageFactId}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            storagePoolId,
+            quantity,
+            observedAt
+        )
+
+    /// Creates a valid repository storage usage fact with an explicit storage-pool identity.
+    let factForStoragePool usageFactId storagePoolId quantity observedAt =
         UsageFact.RepositoryStorageBytesMinute(
             usageFactId,
             CorrelationId $"corr-{usageFactId}",
@@ -147,6 +163,62 @@ type OperationsUsageStorageTests() =
                 Assert.That(OperationsUsageSql.CreateUsageAggregateMinuteTable, Does.Contain("ops.UsageAggregateMinute"))
                 Assert.That(OperationsUsageSql.AddToUsageAggregateMinute, Does.Contain("MERGE ops.UsageAggregateMinute WITH (HOLDLOCK)")))
         )
+
+    /// Verifies SQL storage-pool keys stay case-sensitive under Azure SQL default collations.
+    [<Test>]
+    member _.SqlSchemaUsesBinaryCollationForStoragePoolAggregateKeys() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation, Is.EqualTo("Latin1_General_100_BIN2"))
+
+                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL"))
+
+                Assert.That(
+                    OperationsUsageSql.CreateUsageAggregateMinuteTable,
+                    Does.Contain("StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL")
+                )
+
+                Assert.That(
+                    OperationsUsageSql.AddToUsageAggregateMinute,
+                    Does.Contain("CAST(@StoragePoolId AS nvarchar(256)) COLLATE Latin1_General_100_BIN2 AS StoragePoolId")
+                ))
+        )
+
+    /// Verifies storage-pool identities that differ only by case produce separate aggregate keys before SQL persistence.
+    [<Test>]
+    member _.StoragePoolIdsDifferingOnlyByCaseProduceDistinctAggregateKeys() =
+        let observedAt = Instant.FromUtc(2026, 7, 4, 12, 36, 0)
+
+        let lowerPoolPlan =
+            OperationsUsageStorageTestData.factForStoragePool
+                (Guid.Parse("12121212-1212-1212-1212-121212121212"))
+                OperationsUsageStorageTestData.storagePoolId
+                1L
+                observedAt
+            |> UsageFactPersistencePlan.tryCreate
+            |> requirePlan
+
+        let mixedPoolPlan =
+            OperationsUsageStorageTestData.factForStoragePool
+                (Guid.Parse("34343434-3434-3434-3434-343434343434"))
+                OperationsUsageStorageTestData.storagePoolIdWithDifferentCase
+                1L
+                observedAt
+            |> UsageFactPersistencePlan.tryCreate
+            |> requirePlan
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(lowerPoolPlan.Aggregate.Key.StoragePoolId, Is.Not.EqualTo(mixedPoolPlan.Aggregate.Key.StoragePoolId))
+                Assert.That(lowerPoolPlan.Aggregate.Key, Is.Not.EqualTo(mixedPoolPlan.Aggregate.Key)))
+        )
+
+    /// Verifies the production SQL transaction scope satisfies the store dependency.
+    [<Test>]
+    member _.SqlTransactionScopeImplementsOperationsUsageTransactionScope() =
+        let transactionScope = SqlOperationsUsageTransactionScope "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsTests;Integrated Security=true;"
+
+        Assert.That(transactionScope, Is.InstanceOf<IOperationsUsageTransactionScope>())
 
     /// Verifies a first usage fact inserts a raw row and increments the expected aggregate minute.
     [<Test>]


### PR DESCRIPTION
# OPS4: Add Azure SQL operational fact storage and minute aggregate projection

## Related issue

Related to #529. Part of #525.

## Why this matters

Grace needs the raw usage fact and aggregate correctness boundary before the worker can consume operational facts or
future reporting and billing work can trust derived usage. This slice makes duplicate delivery safe in the data-layer
contract instead of relying on Service Bus duplicate detection or an in-memory cache.

## Summary

- Added SQL-oriented models and schema command text for `ops.RawUsageFact` and `ops.UsageAggregateMinute`.
- Added an `OperationsUsageStore` transaction abstraction around raw fact insert and aggregate update.
- Added a concrete SQL transaction scope for runtime/worker use.
- Preserved case-sensitive `StoragePoolId` aggregate identity in the SQL schema.
- Ensured duplicate `UsageFactId` processing returns `AlreadyProcessed` without incrementing aggregates again.
- Added deterministic UTC minute bucketing for aggregate keys.
- Added rollback-capable focused tests for idempotency, transaction ordering, duplicate handling, and minute buckets.

## Touched paths

- `src/Grace.Operations.Data/Grace.Operations.Data.fsproj`
- `src/Grace.Operations.Data/OperationsData.fs`
- `src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`
- `src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs`

## Validation

- `dotnet tool run fantomas <operations data/test files>`: passed.
- `dotnet test --configuration Release src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`: passed, 11/11 tests.
- pwsh ./scripts/validate.ps1 -Fast: passed.
- GitHub Actions ull: passed on current head df82c221eac3acf35064f8284e7f8996d54f8d2d.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commits.

## Review Status

- Current head: `df82c221eac3acf35064f8284e7f8996d54f8d2d`.
- Workers: Noether implemented the data layer; Kuhn fixed the SQL collation and transaction-scope review findings.
- Worker self-review: complete for implementation and fix; checked duplicate double-counting, raw/aggregate transaction
  ordering, rollback semantics, UTC minute bucketing, SQL collation semantics, transaction boundary, cancellation
  propagation, validation false positives, sensitive fields, owned-path scope, and SQL environment residual risk.
- Codex Code Review Bot: first current-head review found two SQL persistence boundary issues on `06bf5fd5`; fixed in
  `df82c221`.
- Review/fix evidence: replied on [discussion_r3523164541](https://github.com/ScottArbeit/Grace/pull/536#discussion_r3523164541)
  and [discussion_r3523164562](https://github.com/ScottArbeit/Grace/pull/536#discussion_r3523164562), then resolved both
  conversations.
- Codex Code Review Bot: 👍🏻 no-issues state observed on current head `df82c221eac3acf35064f8284e7f8996d54f8d2d`.
- Manual trigger lock: not attempted. The orchestrator will use the PR reaction state and
  `scripts/guard-codex-review-trigger.ps1` before any missed-ack path.

## Docs impact

No runtime docs changed because this slice adds SQL-oriented data-layer contracts and command text without adding a SQL
Server container, Aspire resource, runtime configuration, worker connection string, or operator run command.

## Residual risk

No live Azure SQL execution was performed in this slice. The focused tests prove the data-layer algorithm and modeled
rollback semantics; the concrete SQL transaction scope is compile-ready and covered by deterministic schema/interface
tests. Azure SQL engine execution, isolation behavior, and runtime connection configuration remain for the worker/runtime
wiring slices.
