### PR TITLE
OPS3: Add operational fact Service Bus topic and publisher seam

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,10 @@ In general, values may come from:
 - `grace__azure_service_bus__operational_facts_topic`
   - Topic name for operational usage facts. This must differ from the Grace events topic.
 
+- `grace__azure_service_bus__operational_facts_processor_subscription`
+  - DebugAzure acknowledgement that the existing operational facts topic has the durable
+    `operational-facts-processor` subscription.
+
 - `grace__azure_service_bus__subscription`
   - Subscription name for Grace events.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,9 @@ In general, values may come from:
 - `grace__azure_service_bus__topic`
   - Topic name for Grace events.
 
+- `grace__azure_service_bus__operational_facts_topic`
+  - Topic name for operational usage facts. This must differ from the Grace events topic.
+
 - `grace__azure_service_bus__subscription`
   - Subscription name for Grace events.
 

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -26,6 +26,7 @@
         <Compile Include="PersonalAccessToken.Actor.fs" />
         <Compile Include="Timing.Actor.fs" />
         <Compile Include="ActorProxy.Extensions.Actor.fs" />
+        <Compile Include="OperationalFactsPublisher.Actor.fs" />
         <Compile Include="Services.Actor.fs" />
         <Compile Include="GrainRepository.Actor.fs" />
         <Compile Include="GlobalLock.Actor.fs" />

--- a/src/Grace.Actors/OperationalFactsPublisher.Actor.fs
+++ b/src/Grace.Actors/OperationalFactsPublisher.Actor.fs
@@ -1,0 +1,148 @@
+namespace Grace.Actors
+
+open Azure.Messaging.ServiceBus
+open Grace.Actors.Context
+open Grace.Shared
+open Grace.Shared.AzureEnvironment
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Extensions.Logging
+open System
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Publishes immutable operational usage facts without coupling them to GraceEvent.
+module OperationalFactsPublisher =
+    /// The JSON media type used for operational usage fact Service Bus messages.
+    [<Literal>]
+    let JsonContentType = "application/json"
+
+    /// The Service Bus subject used to distinguish operational usage fact messages.
+    [<Literal>]
+    let UsageFactSubject = "GraceOperationalUsageFact"
+
+    /// The application property that identifies the operational fact contract carried by the message.
+    [<Literal>]
+    let UsageFactMessageTypeProperty = "graceMessageType"
+
+    /// The application property value for operational usage fact messages.
+    [<Literal>]
+    let UsageFactMessageType = "UsageFact"
+
+    /// The application property that records the specific usage fact kind without parsing the payload.
+    [<Literal>]
+    let UsageFactKindProperty = "usageFactKind"
+
+    /// Carries the Service Bus topic and message envelope produced for one usage fact.
+    type UsageFactPublication = { TopicName: string; Message: ServiceBusMessage }
+
+    let private defaultAzureCredential = lazy (Azure.Identity.DefaultAzureCredential())
+
+    let private serviceBusClient =
+        lazy
+            let settings =
+                pubSubSettings.AzureServiceBus
+                |> Option.defaultWith (fun () -> invalidOp "Azure Service Bus settings are required before publishing operational usage facts.")
+
+            if settings.UseManagedIdentity then
+                let fullyQualifiedNamespace =
+                    if not (String.IsNullOrWhiteSpace settings.FullyQualifiedNamespace) then
+                        settings.FullyQualifiedNamespace
+                    else
+                        AzureEnvironment.tryGetServiceBusFullyQualifiedNamespace ()
+                        |> Option.defaultWith (fun () -> invalidOp "Azure Service Bus namespace is required for managed identity.")
+
+                logToConsole $"Creating operational facts ServiceBusClient with Managed Identity for namespace: {fullyQualifiedNamespace}."
+                ServiceBusClient(fullyQualifiedNamespace, defaultAzureCredential.Value)
+            else
+                logToConsole "Creating operational facts ServiceBusClient with connection string."
+                ServiceBusClient(settings.ConnectionString)
+
+    /// Resolves the required Service Bus topic for operational usage facts.
+    let internal resolveOperationalFactsTopicName () =
+        let environmentVariableName = EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+        let topicName = Environment.GetEnvironmentVariable environmentVariableName
+
+        if String.IsNullOrWhiteSpace topicName then
+            invalidOp (sprintf "Environment variable '%s' must be set when publishing operational usage facts to Azure Service Bus." environmentVariableName)
+
+        topicName
+
+    let private operationalFactsSender = lazy (serviceBusClient.Value.CreateSender(resolveOperationalFactsTopicName ()))
+
+    /// Builds the Service Bus message envelope for a serialized UsageFact payload.
+    let internal createMessage (usageFact: UsageFact) =
+        match UsageFact.Validate usageFact with
+        | Ok _ ->
+            let payload = JsonSerializer.SerializeToUtf8Bytes(usageFact, Constants.JsonSerializerOptions)
+            let message = ServiceBusMessage(payload)
+            message.ContentType <- JsonContentType
+            message.Subject <- UsageFactSubject
+            message.MessageId <- usageFact.UsageFactId.ToString("D")
+            message.CorrelationId <- usageFact.CorrelationId
+            message.ApplicationProperties[ UsageFactMessageTypeProperty ] <- UsageFactMessageType
+            message.ApplicationProperties[ UsageFactKindProperty ] <- usageFact.FactKind.ToString()
+            message
+        | Error errors ->
+            let validationErrors = String.Join("; ", errors)
+            invalidArg (nameof usageFact) $"UsageFact failed validation: {validationErrors}"
+
+    /// Builds the topic and Service Bus message envelope for one operational usage fact.
+    let internal createPublication (topicName: string) (usageFact: UsageFact) =
+        if String.IsNullOrWhiteSpace topicName then
+            invalidArg (nameof topicName) "Operational usage facts topic name is required."
+
+        { TopicName = topicName; Message = createMessage usageFact }
+
+    let private tryGetLogger () =
+        if isNull loggerFactory then
+            None
+        else
+            Some(loggerFactory.CreateLogger("OperationalFactsPublisher.Actor"))
+
+    /// Publishes an immutable UsageFact to the dedicated operational facts Service Bus topic.
+    let publishUsageFact (usageFact: UsageFact) (cancellationToken: CancellationToken) =
+        task {
+            match pubSubSettings.System with
+            | GracePubSubSystem.AzureServiceBus ->
+                let topicName = resolveOperationalFactsTopicName ()
+                let publication = createPublication topicName usageFact
+
+                do! operationalFactsSender.Value.SendMessageAsync(publication.Message, cancellationToken)
+
+                match tryGetLogger () with
+                | Some log ->
+                    log.LogInformation(
+                        "{CurrentInstant}: Published operational UsageFact via Azure Service Bus. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; FactKind: {FactKind}; Topic: {Topic}.",
+                        getCurrentInstantExtended (),
+                        usageFact.UsageFactId,
+                        usageFact.CorrelationId,
+                        usageFact.FactKind,
+                        topicName
+                    )
+                | None -> ()
+            | GracePubSubSystem.UnknownPubSubProvider ->
+                match tryGetLogger () with
+                | Some log ->
+                    log.LogDebug(
+                        "Pub-sub system disabled; dropping operational UsageFact {UsageFactId} with CorrelationId: {CorrelationId}.",
+                        usageFact.UsageFactId,
+                        usageFact.CorrelationId
+                    )
+                | None -> ()
+            | otherSystem ->
+                match tryGetLogger () with
+                | Some log ->
+                    log.LogWarning(
+                        "Grace pub-sub system {System} not yet implemented for operational UsageFact {UsageFactId} with CorrelationId: {CorrelationId}.",
+                        getDiscriminatedUnionCaseName otherSystem,
+                        usageFact.UsageFactId,
+                        usageFact.CorrelationId
+                    )
+                | None -> ()
+        }
+        :> Task

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -311,6 +311,7 @@ public partial class Program
                             )
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, Constants.GraceOperationalFactsTopic)
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, "grace-server");
                     }
                     else
@@ -357,6 +358,9 @@ public partial class Program
                     var cosmosContainerName = GetRequiredSetting(configuration, EnvironmentVariables.AzureCosmosDBContainerName);
                     var serviceBusNamespace = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusNamespace);
                     var serviceBusTopic = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusTopic);
+                    var operationalFactsTopic =
+                        ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
+                        ?? Constants.GraceOperationalFactsTopic;
                     var serviceBusSubscription = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription);
 
                     graceServer
@@ -367,6 +371,7 @@ public partial class Program
                         .WithEnvironment(EnvironmentVariables.AzureCosmosDBContainerName, cosmosContainerName)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, serviceBusNamespace)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopic)
+                        .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopic)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscription)
                         .WithEnvironment(EnvironmentVariables.GraceLogDirectory, logDirectory)
                         .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Azure");
@@ -397,6 +402,14 @@ public partial class Program
                 var serviceBus = builder.AddAzureServiceBus("servicebus");
                 _ = serviceBus.AddServiceBusTopic(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
                     .AddServiceBusSubscription(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server");
+                _ = serviceBus.AddServiceBusTopic(
+                        "operational-facts",
+                        configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)] ?? Constants.GraceOperationalFactsTopic)
+                    .WithProperties(topic =>
+                    {
+                        topic.RequiresDuplicateDetection = true;
+                        topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(5);
+                    });
 
                 var otlpEndpoint = configuration["grace:otlp_endpoint"] ?? "http://localhost:18889";
                 var publishLogDirectory = configuration["grace:log_directory"] ?? "/tmp/grace-logs";
@@ -424,6 +437,7 @@ public partial class Program
                     .WithEnvironment(EnvironmentVariables.OrleansServiceId, configuration[getConfigKey(EnvironmentVariables.OrleansServiceId)] ?? "grace-prod")
                         .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
+                    .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)] ?? Constants.GraceOperationalFactsTopic)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server")
                     .WithEnvironment(EnvironmentVariables.GraceLogDirectory, publishLogDirectory)
                     .WithEnvironment(EnvironmentVariables.GraceAuthOidcAuthority, configuration[EnvironmentVariables.GraceAuthOidcAuthority])
@@ -598,6 +612,9 @@ public partial class Program
     private static void CreateServiceBusConfiguration(string configFilePath, IConfiguration configuration)
     {
         var topicName = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic) ?? "graceeventstream";
+        var operationalFactsTopicName =
+            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic) ?? Constants.GraceOperationalFactsTopic;
+        var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
         var subscriptionName = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription) ?? "grace-server";
         var testSubscriptionName = $"{subscriptionName}-tests";
 
@@ -611,7 +628,7 @@ public partial class Program
                     {
                         Name = "sbemulatorns",
                         Queues = Array.Empty<object>(),
-                        Topics = new[]
+                        Topics = new object[]
                         {
                             new
                             {
@@ -642,6 +659,34 @@ public partial class Program
                                     new
                                     {
                                         Name = testSubscriptionName,
+                                        Properties = new
+                                        {
+                                            DeadLetteringOnMessageExpiration = false,
+                                            DefaultMessageTimeToLive = "PT1H",
+                                            LockDuration = "PT1M",
+                                            MaxDeliveryCount = 10,
+                                            ForwardDeadLetteredMessagesTo = "",
+                                            ForwardTo = "",
+                                            RequiresSession = false
+                                        },
+                                        Rules = Array.Empty<object>()
+                                    }
+                                }
+                            },
+                            new
+                            {
+                                Name = operationalFactsTopicName,
+                                Properties = new
+                                {
+                                    DefaultMessageTimeToLive = "PT1H",
+                                    DuplicateDetectionHistoryTimeWindow = "PT5M",
+                                    RequiresDuplicateDetection = true
+                                },
+                                Subscriptions = new[]
+                                {
+                                    new
+                                    {
+                                        Name = operationalFactsSubscriptionName,
                                         Properties = new
                                         {
                                             DeadLetteringOnMessageExpiration = false,

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -328,6 +328,7 @@ public partial class Program
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopicName)
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
+                            .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscriptionName);
                     }
                     else
@@ -390,6 +391,7 @@ public partial class Program
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, serviceBusNamespace)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopic)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopic)
+                        .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscription)
                         .WithEnvironment(EnvironmentVariables.GraceLogDirectory, logDirectory)
                         .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Azure");
@@ -467,9 +469,10 @@ public partial class Program
                     .WithEnvironment(EnvironmentVariables.RedisPort, "6379")
                     .WithEnvironment(EnvironmentVariables.OrleansClusterId, configuration[getConfigKey(EnvironmentVariables.OrleansClusterId)] ?? "production")
                     .WithEnvironment(EnvironmentVariables.OrleansServiceId, configuration[getConfigKey(EnvironmentVariables.OrleansServiceId)] ?? "grace-prod")
-                        .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
+                    .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopicName)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
+                    .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server")
                     .WithEnvironment(EnvironmentVariables.GraceLogDirectory, publishLogDirectory)
                     .WithEnvironment(EnvironmentVariables.GraceAuthOidcAuthority, configuration[EnvironmentVariables.GraceAuthOidcAuthority])

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -23,7 +23,12 @@ public partial class Program
     private const string AspireResourceModeEnvVar = "ASPIRE_RESOURCE_MODE";
     private const string AspireResourceModeLocal = "Local";
     private const string AspireResourceModeAzure = "Azure";
+    private const string GraceEventTopicResourceName = "grace-event-topic";
+    private const string GraceEventSubscriptionResourceName = "grace-event-subscription";
+    private const string OperationalFactsTopicResourceName = "grace-operational-facts-topic";
     private const string OperationalFactsProcessorSubscriptionName = "operational-facts-processor";
+    private const string OperationalFactsProcessorSubscriptionResourceName = "grace-operational-facts-processor-subscription";
+    private const string OperationalFactsProcessorSubscriptionSettingName = "grace__azure_service_bus__operational_facts_processor_subscription";
 
     private static void Main(string[] args)
     {
@@ -371,6 +376,9 @@ public partial class Program
                     var serviceBusTopic = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusTopic);
                     var operationalFactsTopic = GetRequiredSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic);
                     EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic);
+                    var operationalFactsProcessorSubscription =
+                        GetRequiredSetting(configuration, OperationalFactsProcessorSubscriptionSettingName);
+                    EnsureOperationalFactsProcessorSubscription(operationalFactsProcessorSubscription);
                     var serviceBusSubscription = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription);
 
                     graceServer
@@ -390,6 +398,7 @@ public partial class Program
                     Console.WriteLine("  - Azure Storage: using DefaultAzureCredential.");
                     Console.WriteLine("  - Azure Cosmos: using DefaultAzureCredential.");
                     Console.WriteLine("  - Azure Service Bus: using DefaultAzureCredential.");
+                    Console.WriteLine($"  - Operational facts processor subscription: {operationalFactsProcessorSubscription}.");
                     Console.WriteLine("  - Aspire dashboard at http://localhost:18888");
                     Console.WriteLine($"  - OTLP endpoint {otlpEndpoint}");
                 }
@@ -417,17 +426,22 @@ public partial class Program
                     configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)]
                     ?? Constants.GraceOperationalFactsTopic;
                 EnsureDistinctServiceBusTopics(serviceBusTopicName, operationalFactsTopicName);
-                _ = serviceBus.AddServiceBusTopic(serviceBusTopicName)
-                    .AddServiceBusSubscription(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server");
+                var graceEventSubscriptionName =
+                    configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)]
+                    ?? "grace-server";
+                _ = serviceBus.AddServiceBusTopic(GraceEventTopicResourceName, serviceBusTopicName)
+                    .AddServiceBusSubscription(GraceEventSubscriptionResourceName, graceEventSubscriptionName);
                 _ = serviceBus.AddServiceBusTopic(
-                        "operational-facts",
+                        OperationalFactsTopicResourceName,
                         operationalFactsTopicName)
                     .WithProperties(topic =>
                     {
                         topic.RequiresDuplicateDetection = true;
                         topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(5);
                     })
-                    .AddServiceBusSubscription(OperationalFactsProcessorSubscriptionName);
+                    .AddServiceBusSubscription(
+                        OperationalFactsProcessorSubscriptionResourceName,
+                        OperationalFactsProcessorSubscriptionName);
 
                 var otlpEndpoint = configuration["grace:otlp_endpoint"] ?? "http://localhost:18889";
                 var publishLogDirectory = configuration["grace:log_directory"] ?? "/tmp/grace-logs";
@@ -555,6 +569,15 @@ public partial class Program
         {
             throw new InvalidOperationException(
                 $"Service Bus topic '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must differ from '{EnvironmentVariables.AzureServiceBusTopic}' so usage facts cannot enter the GraceEvent topic/subscriber path.");
+        }
+    }
+
+    private static void EnsureOperationalFactsProcessorSubscription(string? subscriptionName)
+    {
+        if (!OperationalFactsProcessorSubscriptionName.Equals(subscriptionName?.Trim(), StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"DebugAzure requires existing Azure Service Bus topic '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' to contain durable subscription '{OperationalFactsProcessorSubscriptionName}'. Set '{OperationalFactsProcessorSubscriptionSettingName}' to '{OperationalFactsProcessorSubscriptionName}' after creating that subscription.");
         }
     }
 

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -409,16 +409,21 @@ public partial class Program
                 var zipStorage = storage.AddBlobContainer("zipfiles");
 
                 var serviceBus = builder.AddAzureServiceBus("servicebus");
+                var operationalFactsTopicName =
+                    configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)]
+                    ?? Constants.GraceOperationalFactsTopic;
+                var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
                 _ = serviceBus.AddServiceBusTopic(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
                     .AddServiceBusSubscription(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server");
                 _ = serviceBus.AddServiceBusTopic(
                         "operational-facts",
-                        configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)] ?? Constants.GraceOperationalFactsTopic)
+                        operationalFactsTopicName)
                     .WithProperties(topic =>
                     {
                         topic.RequiresDuplicateDetection = true;
                         topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(5);
-                    });
+                    })
+                    .AddServiceBusSubscription(operationalFactsSubscriptionName);
 
                 var otlpEndpoint = configuration["grace:otlp_endpoint"] ?? "http://localhost:18889";
                 var publishLogDirectory = configuration["grace:log_directory"] ?? "/tmp/grace-logs";
@@ -446,7 +451,7 @@ public partial class Program
                     .WithEnvironment(EnvironmentVariables.OrleansServiceId, configuration[getConfigKey(EnvironmentVariables.OrleansServiceId)] ?? "grace-prod")
                         .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
-                    .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)] ?? Constants.GraceOperationalFactsTopic)
+                    .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server")
                     .WithEnvironment(EnvironmentVariables.GraceLogDirectory, publishLogDirectory)
                     .WithEnvironment(EnvironmentVariables.GraceAuthOidcAuthority, configuration[EnvironmentVariables.GraceAuthOidcAuthority])

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -164,6 +164,16 @@ public partial class Program
                 Directory.CreateDirectory(cosmosCertPath);
                 Directory.CreateDirectory(serviceBusConfigPath);
 
+                var serviceBusTopicName =
+                    ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusTopic)
+                    ?? Constants.GraceEventStreamTopic;
+                var operationalFactsTopicName =
+                    ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
+                    ?? Constants.GraceOperationalFactsTopic;
+                var serviceBusSubscriptionName =
+                    ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription)
+                    ?? "grace-server";
+
                 // Create Service Bus emulator config (when enabled for tests)
                 string? serviceBusConfigFile = null;
                 if (!skipServiceBus)
@@ -310,9 +320,9 @@ public partial class Program
                                 )
                             )
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
-                            .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
-                            .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, Constants.GraceOperationalFactsTopic)
-                            .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, "grace-server");
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopicName)
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscriptionName);
                     }
                     else
                     {
@@ -611,11 +621,16 @@ public partial class Program
     /// </summary>
     private static void CreateServiceBusConfiguration(string configFilePath, IConfiguration configuration)
     {
-        var topicName = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic) ?? "graceeventstream";
+        var topicName =
+            ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusTopic)
+            ?? Constants.GraceEventStreamTopic;
         var operationalFactsTopicName =
-            Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic) ?? Constants.GraceOperationalFactsTopic;
+            ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
+            ?? Constants.GraceOperationalFactsTopic;
         var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
-        var subscriptionName = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription) ?? "grace-server";
+        var subscriptionName =
+            ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusSubscription)
+            ?? "grace-server";
         var testSubscriptionName = $"{subscriptionName}-tests";
 
         var config = new

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -23,6 +23,7 @@ public partial class Program
     private const string AspireResourceModeEnvVar = "ASPIRE_RESOURCE_MODE";
     private const string AspireResourceModeLocal = "Local";
     private const string AspireResourceModeAzure = "Azure";
+    private const string OperationalFactsProcessorSubscriptionName = "operational-facts-processor";
 
     private static void Main(string[] args)
     {
@@ -409,11 +410,14 @@ public partial class Program
                 var zipStorage = storage.AddBlobContainer("zipfiles");
 
                 var serviceBus = builder.AddAzureServiceBus("servicebus");
+                var serviceBusTopicName =
+                    configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)]
+                    ?? Constants.GraceEventStreamTopic;
                 var operationalFactsTopicName =
                     configuration[getConfigKey(EnvironmentVariables.AzureServiceBusOperationalFactsTopic)]
                     ?? Constants.GraceOperationalFactsTopic;
-                var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
-                _ = serviceBus.AddServiceBusTopic(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
+                EnsureDistinctServiceBusTopics(serviceBusTopicName, operationalFactsTopicName);
+                _ = serviceBus.AddServiceBusTopic(serviceBusTopicName)
                     .AddServiceBusSubscription(configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server");
                 _ = serviceBus.AddServiceBusTopic(
                         "operational-facts",
@@ -423,7 +427,7 @@ public partial class Program
                         topic.RequiresDuplicateDetection = true;
                         topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(5);
                     })
-                    .AddServiceBusSubscription(operationalFactsSubscriptionName);
+                    .AddServiceBusSubscription(OperationalFactsProcessorSubscriptionName);
 
                 var otlpEndpoint = configuration["grace:otlp_endpoint"] ?? "http://localhost:18889";
                 var publishLogDirectory = configuration["grace:log_directory"] ?? "/tmp/grace-logs";
@@ -450,7 +454,7 @@ public partial class Program
                     .WithEnvironment(EnvironmentVariables.OrleansClusterId, configuration[getConfigKey(EnvironmentVariables.OrleansClusterId)] ?? "production")
                     .WithEnvironment(EnvironmentVariables.OrleansServiceId, configuration[getConfigKey(EnvironmentVariables.OrleansServiceId)] ?? "grace-prod")
                         .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
-                    .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusTopic)] ?? "graceeventstream")
+                    .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopicName)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
                     .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, configuration[getConfigKey(EnvironmentVariables.AzureServiceBusSubscription)] ?? "grace-server")
                     .WithEnvironment(EnvironmentVariables.GraceLogDirectory, publishLogDirectory)
@@ -646,7 +650,6 @@ public partial class Program
             ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
             ?? Constants.GraceOperationalFactsTopic;
         EnsureDistinctServiceBusTopics(topicName, operationalFactsTopicName);
-        var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
         var subscriptionName =
             ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusSubscription)
             ?? "grace-server";
@@ -720,7 +723,7 @@ public partial class Program
                                 {
                                     new
                                     {
-                                        Name = operationalFactsSubscriptionName,
+                                        Name = OperationalFactsProcessorSubscriptionName,
                                         Properties = new
                                         {
                                             DeadLetteringOnMessageExpiration = false,

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -368,9 +368,8 @@ public partial class Program
                     var cosmosContainerName = GetRequiredSetting(configuration, EnvironmentVariables.AzureCosmosDBContainerName);
                     var serviceBusNamespace = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusNamespace);
                     var serviceBusTopic = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusTopic);
-                    var operationalFactsTopic =
-                        ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
-                        ?? Constants.GraceOperationalFactsTopic;
+                    var operationalFactsTopic = GetRequiredSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic);
+                    EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic);
                     var serviceBusSubscription = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription);
 
                     graceServer
@@ -536,6 +535,20 @@ public partial class Program
             $"Missing required setting '{name}' (or '{key}') for DebugAzure.");
     }
 
+    private static void EnsureDistinctServiceBusTopics(string? graceEventTopic, string? operationalFactsTopic)
+    {
+        if (string.IsNullOrWhiteSpace(graceEventTopic) || string.IsNullOrWhiteSpace(operationalFactsTopic))
+        {
+            return;
+        }
+
+        if (graceEventTopic.Trim().Equals(operationalFactsTopic.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Service Bus topic '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must differ from '{EnvironmentVariables.AzureServiceBusTopic}' so usage facts cannot enter the GraceEvent topic/subscriber path.");
+        }
+    }
+
     private static void AddOptionalEnvironment(
         IResourceBuilder<ProjectResource> resource,
         IConfiguration configuration,
@@ -627,6 +640,7 @@ public partial class Program
         var operationalFactsTopicName =
             ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
             ?? Constants.GraceOperationalFactsTopic;
+        EnsureDistinctServiceBusTopics(topicName, operationalFactsTopicName);
         var operationalFactsSubscriptionName = $"{operationalFactsTopicName}-processor";
         var subscriptionName =
             ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusSubscription)

--- a/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
@@ -98,6 +98,7 @@ type AspireTestHostDiagnosticsTests() =
             [|
                 Constants.EnvironmentVariables.AzureCosmosDBContainerName
                 Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
                 Constants.EnvironmentVariables.AzureServiceBusSubscription
             |]
 

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -579,6 +579,7 @@ module AspireTestHost =
                 if not skipServiceBus then
                     Constants.EnvironmentVariables.AzureServiceBusConnectionString
                     Constants.EnvironmentVariables.AzureServiceBusTopic
+                    Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
                     Constants.EnvironmentVariables.AzureServiceBusSubscription
             ]
 

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="AspireTestHost.fs" />
     <Compile Include="AspireTestHost.Diagnostics.Tests.fs" />
+    <Compile Include="OperationalFactsPublisher.AppHost.Tests.fs" />
     <Compile Include="General.Server.Tests.fs" />
     <Compile Include="Smoke.Server.Tests.fs" />
     <Compile Include="Slop.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -9,10 +9,13 @@ open System.IO
 [<TestFixture>]
 type OperationalFactsPublisherAppHostTests() =
 
+    /// Reads the AppHost source so focused wiring assertions stay on the Aspire-facing test surface.
+    let appHostSource () = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
+
     /// Verifies that AppHost provisions and forwards the same operational facts topic name.
     [<Test>]
     member _.AppHostConfiguresOperationalFactsTopicConsistently() =
-        let appHostSource = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
+        let appHostSource = appHostSource ()
 
         Assert.Multiple(
             Action (fun () ->
@@ -37,5 +40,60 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
                 Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\""))
 
-                Assert.That(appHostSource, Does.Contain(".AddServiceBusSubscription(OperationalFactsProcessorSubscriptionName)")))
+                Assert.That(appHostSource, Does.Contain("OperationalFactsProcessorSubscriptionName,"))
+                Assert.That(appHostSource, Does.Contain("Name = OperationalFactsProcessorSubscriptionName")))
+        )
+
+    /// Verifies publish mode keeps Aspire resource identities independent from configurable Azure entity names.
+    [<Test>]
+    member _.PublishModeUsesStableResourceNamesForOperationalFactEntities() =
+        let appHostSource = appHostSource ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(appHostSource, Does.Contain("GraceEventTopicResourceName = \"grace-event-topic\""))
+                Assert.That(appHostSource, Does.Contain("GraceEventSubscriptionResourceName = \"grace-event-subscription\""))
+                Assert.That(appHostSource, Does.Contain("OperationalFactsTopicResourceName = \"grace-operational-facts-topic\""))
+
+                Assert.That(
+                    appHostSource,
+                    Does.Contain("OperationalFactsProcessorSubscriptionResourceName = \"grace-operational-facts-processor-subscription\"")
+                )
+
+                Assert.That(appHostSource, Does.Contain("serviceBus.AddServiceBusTopic(GraceEventTopicResourceName, serviceBusTopicName)"))
+
+                Assert.That(appHostSource, Does.Contain(".AddServiceBusSubscription(GraceEventSubscriptionResourceName, graceEventSubscriptionName)"))
+
+                Assert.That(appHostSource, Does.Contain("OperationalFactsTopicResourceName,"))
+                Assert.That(appHostSource, Does.Contain("operationalFactsTopicName)"))
+
+                Assert.That(appHostSource, Does.Contain("OperationalFactsProcessorSubscriptionResourceName,"))
+
+                Assert.That(appHostSource, Does.Not.Contain("serviceBus.AddServiceBusTopic(serviceBusTopicName)"))
+                Assert.That(appHostSource, Does.Not.Contain("\"operational-facts\",\r\n                        operationalFactsTopicName"))
+                Assert.That(appHostSource, Does.Not.Contain(".AddServiceBusSubscription(OperationalFactsProcessorSubscriptionName)")))
+        )
+
+    /// Verifies DebugAzure requires the durable operational facts processor subscription to exist.
+    [<Test>]
+    member _.DebugAzureRequiresOperationalFactsProcessorSubscription() =
+        let appHostSource = appHostSource ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(
+                    appHostSource,
+                    Does.Contain("OperationalFactsProcessorSubscriptionSettingName = \"grace__azure_service_bus__operational_facts_processor_subscription\"")
+                )
+
+                Assert.That(appHostSource, Does.Contain("var operationalFactsProcessorSubscription ="))
+
+                Assert.That(appHostSource, Does.Contain("GetRequiredSetting(configuration, OperationalFactsProcessorSubscriptionSettingName);"))
+
+                Assert.That(appHostSource, Does.Contain("EnsureOperationalFactsProcessorSubscription(operationalFactsProcessorSubscription);"))
+
+                Assert.That(
+                    appHostSource,
+                    Does.Contain("Set '{OperationalFactsProcessorSubscriptionSettingName}' to '{OperationalFactsProcessorSubscriptionName}'")
+                ))
         )

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -31,6 +31,9 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic)"))
                 Assert.That(appHostSource, Does.Contain("ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)"))
                 Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(topicName, operationalFactsTopicName)"))
+                Assert.That(appHostSource, Does.Contain("var operationalFactsSubscriptionName = $\"{operationalFactsTopicName}-processor\";"))
                 Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
-                Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\"")))
+                Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\""))
+
+                Assert.That(appHostSource, Does.Contain(".AddServiceBusSubscription(operationalFactsSubscriptionName)")))
         )

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -1,0 +1,29 @@
+namespace Grace.Server.Tests
+
+open Grace.Shared
+open NUnit.Framework
+open System
+open System.IO
+
+/// Covers Aspire AppHost wiring for the operational usage facts Service Bus topic.
+[<TestFixture>]
+type OperationalFactsPublisherAppHostTests() =
+
+    /// Verifies that AppHost provisions and forwards the same operational facts topic name.
+    [<Test>]
+    member _.AppHostConfiguresOperationalFactsTopicConsistently() =
+        let appHostSource = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(appHostSource, Does.Contain("ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic)"))
+
+                Assert.That(
+                    appHostSource,
+                    Does.Contain(".WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)")
+                )
+
+                Assert.That(appHostSource, Does.Contain("ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)"))
+                Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
+                Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\"")))
+        )

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -28,12 +28,14 @@ type OperationalFactsPublisherAppHostTests() =
                     Does.Contain("var operationalFactsTopic = GetRequiredSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic);")
                 )
 
+                Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(serviceBusTopicName, operationalFactsTopicName);"))
                 Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic)"))
                 Assert.That(appHostSource, Does.Contain("ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)"))
                 Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(topicName, operationalFactsTopicName)"))
-                Assert.That(appHostSource, Does.Contain("var operationalFactsSubscriptionName = $\"{operationalFactsTopicName}-processor\";"))
+                Assert.That(appHostSource, Does.Contain("OperationalFactsProcessorSubscriptionName = \"operational-facts-processor\""))
+                Assert.That(appHostSource, Does.Not.Contain("var operationalFactsSubscriptionName = $\"{operationalFactsTopicName}-processor\";"))
                 Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
                 Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\""))
 
-                Assert.That(appHostSource, Does.Contain(".AddServiceBusSubscription(operationalFactsSubscriptionName)")))
+                Assert.That(appHostSource, Does.Contain(".AddServiceBusSubscription(OperationalFactsProcessorSubscriptionName)")))
         )

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -23,7 +23,14 @@ type OperationalFactsPublisherAppHostTests() =
                     Does.Contain(".WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)")
                 )
 
+                Assert.That(
+                    appHostSource,
+                    Does.Contain("var operationalFactsTopic = GetRequiredSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic);")
+                )
+
+                Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic)"))
                 Assert.That(appHostSource, Does.Contain("ResolveSetting(configuration, Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)"))
+                Assert.That(appHostSource, Does.Contain("EnsureDistinctServiceBusTopics(topicName, operationalFactsTopicName)"))
                 Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
                 Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\"")))
         )

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="StoragePoolRouting.Server.Tests.fs" />
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />
+    <Compile Include="OperationalFactsPublisher.Actor.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
@@ -137,6 +137,51 @@ type OperationalFactsPublisherActorTests() =
             previous
             |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))
 
+    /// Verifies that usage facts cannot be configured onto the GraceEvent topic/subscriber path.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.StartupValidationRejectsOperationalFactsTopicAlias() =
+        let keys =
+            [|
+                Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusNamespace
+                Constants.EnvironmentVariables.AzureServiceBusTopic
+                Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                Constants.EnvironmentVariables.AzureServiceBusSubscription
+            |]
+
+        let previous =
+            keys
+            |> Array.map (fun key -> key, Environment.GetEnvironmentVariable key)
+
+        try
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+
+            Environment.SetEnvironmentVariable(
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE"
+            )
+
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, "GraceEventStream")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
+
+            let ex =
+                Assert.Throws<InvalidOperationException>(
+                    Action (fun () ->
+                        ApplicationContext.configurePubSubSettings ()
+                        |> ignore)
+                )
+
+            Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic))
+            Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusTopic))
+            Assert.That(ex.Message, Does.Contain("must differ"))
+        finally
+            previous
+            |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))
+
     /// Verifies that the existing GraceEvent publisher keeps the event stream topic and event metadata shape.
     [<Test>]
     member _.GraceEventPublisherStillUsesEventTopicAndMetadata() =

--- a/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
@@ -1,0 +1,112 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Types.Common
+open Grace.Types.Usage
+open NodaTime
+open NUnit.Framework
+open System
+open System.IO
+open System.Text.Json
+
+/// Covers operational usage fact publisher behavior without booting Aspire or Service Bus.
+[<Parallelizable(ParallelScope.All)>]
+type OperationalFactsPublisherActorTests() =
+
+    /// Builds a valid repository storage usage fact for publisher envelope assertions.
+    let usageFact usageFactId correlationId =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            correlationId,
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            StoragePoolId "default",
+            4096L,
+            Instant.FromUtc(2026, 7, 4, 12, 34)
+        )
+
+    /// Verifies that usage facts map to the operational topic and required Service Bus envelope fields.
+    [<Test>]
+    member _.UsageFactMessageUsesOperationalTopicAndUsageEnvelope() =
+        let usageFactId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        let correlationId = "corr-operational-fact"
+        let fact = usageFact usageFactId correlationId
+
+        let publication = OperationalFactsPublisher.createPublication Constants.GraceOperationalFactsTopic fact
+
+        Assert.That(publication.TopicName, Is.EqualTo(Constants.GraceOperationalFactsTopic))
+        Assert.That(publication.Message.ContentType, Is.EqualTo(OperationalFactsPublisher.JsonContentType))
+        Assert.That(publication.Message.Subject, Is.EqualTo(OperationalFactsPublisher.UsageFactSubject))
+        Assert.That(publication.Message.MessageId, Is.EqualTo(usageFactId.ToString("D")))
+        Assert.That(publication.Message.CorrelationId, Is.EqualTo(correlationId))
+
+        Assert.That(
+            publication.Message.ApplicationProperties[OperationalFactsPublisher.UsageFactMessageTypeProperty],
+            Is.EqualTo(OperationalFactsPublisher.UsageFactMessageType)
+        )
+
+        Assert.That(
+            publication.Message.ApplicationProperties[OperationalFactsPublisher.UsageFactKindProperty],
+            Is.EqualTo(nameof UsageFactKind.RepositoryStorageBytesMinute)
+        )
+
+        use payload = JsonDocument.Parse(publication.Message.Body.ToString())
+
+        Assert.That(
+            payload
+                .RootElement
+                .GetProperty("UsageFactId")
+                .GetGuid(),
+            Is.EqualTo(usageFactId)
+        )
+
+        Assert.That(
+            payload
+                .RootElement
+                .GetProperty("CorrelationId")
+                .GetString(),
+            Is.EqualTo(correlationId)
+        )
+
+    /// Verifies that missing operational topic configuration fails before any event topic fallback can happen.
+    [<Test>]
+    member _.MissingOperationalFactsTopicFailsClearly() =
+        let previous = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
+
+        try
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, null)
+
+            let ex =
+                Assert.Throws<InvalidOperationException>(
+                    Action (fun () ->
+                        OperationalFactsPublisher.resolveOperationalFactsTopicName ()
+                        |> ignore)
+                )
+
+            Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic))
+            Assert.That(ex.Message, Does.Not.Contain(Constants.EnvironmentVariables.AzureServiceBusTopic))
+        finally
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, previous)
+
+    /// Verifies that the existing GraceEvent publisher keeps the event stream topic and event metadata shape.
+    [<Test>]
+    member _.GraceEventPublisherStillUsesEventTopicAndMetadata() =
+        let servicesSource = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Actors", "Services.Actor.fs")))
+
+        Assert.That(servicesSource, Does.Contain("CreateSender(pubSubSettings.AzureServiceBus.Value.TopicName)"))
+        Assert.That(servicesSource, Does.Contain("message.Subject <- \"GraceEvent\""))
+        Assert.That(servicesSource, Does.Contain("message.ApplicationProperties[ \"graceEventType\" ] <- getDiscriminatedUnionFullName graceEvent"))
+        Assert.That(servicesSource, Does.Not.Contain("GraceOperationalUsageFact"))
+
+    /// Verifies that AppHost provisions the operational facts topic with duplicate detection enabled.
+    [<Test>]
+    member _.AppHostConfiguresOperationalFactsTopicWithDuplicateDetection() =
+        let appHostSource = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
+
+        Assert.That(appHostSource, Does.Contain("AzureServiceBusOperationalFactsTopic"))
+        Assert.That(appHostSource, Does.Contain("GraceOperationalFactsTopic"))
+        Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
+        Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\""))

--- a/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Grace.Actors
+open Grace.Server
 open Grace.Shared
 open Grace.Shared.Constants
 open Grace.Types.Common
@@ -73,6 +74,7 @@ type OperationalFactsPublisherActorTests() =
 
     /// Verifies that missing operational topic configuration fails before any event topic fallback can happen.
     [<Test>]
+    [<NonParallelizable>]
     member _.MissingOperationalFactsTopicFailsClearly() =
         let previous = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic)
 
@@ -91,6 +93,50 @@ type OperationalFactsPublisherActorTests() =
         finally
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, previous)
 
+    /// Verifies that server startup validates the operational facts topic with the Service Bus settings.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.StartupValidationRejectsMissingOperationalFactsTopic() =
+        let keys =
+            [|
+                Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusNamespace
+                Constants.EnvironmentVariables.AzureServiceBusTopic
+                Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                Constants.EnvironmentVariables.AzureServiceBusSubscription
+            |]
+
+        let previous =
+            keys
+            |> Array.map (fun key -> key, Environment.GetEnvironmentVariable key)
+
+        try
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+
+            Environment.SetEnvironmentVariable(
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE"
+            )
+
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, null)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
+
+            let ex =
+                Assert.Throws<InvalidOperationException>(
+                    Action (fun () ->
+                        ApplicationContext.configurePubSubSettings ()
+                        |> ignore)
+                )
+
+            Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic))
+            Assert.That(ex.Message, Does.Not.Contain(Constants.EnvironmentVariables.AzureServiceBusTopic))
+        finally
+            previous
+            |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))
+
     /// Verifies that the existing GraceEvent publisher keeps the event stream topic and event metadata shape.
     [<Test>]
     member _.GraceEventPublisherStillUsesEventTopicAndMetadata() =
@@ -100,13 +146,3 @@ type OperationalFactsPublisherActorTests() =
         Assert.That(servicesSource, Does.Contain("message.Subject <- \"GraceEvent\""))
         Assert.That(servicesSource, Does.Contain("message.ApplicationProperties[ \"graceEventType\" ] <- getDiscriminatedUnionFullName graceEvent"))
         Assert.That(servicesSource, Does.Not.Contain("GraceOperationalUsageFact"))
-
-    /// Verifies that AppHost provisions the operational facts topic with duplicate detection enabled.
-    [<Test>]
-    member _.AppHostConfiguresOperationalFactsTopicWithDuplicateDetection() =
-        let appHostSource = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
-
-        Assert.That(appHostSource, Does.Contain("AzureServiceBusOperationalFactsTopic"))
-        Assert.That(appHostSource, Does.Contain("GraceOperationalFactsTopic"))
-        Assert.That(appHostSource, Does.Contain("RequiresDuplicateDetection = true"))
-        Assert.That(appHostSource, Does.Contain("DuplicateDetectionHistoryTimeWindow = \"PT5M\""))

--- a/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
@@ -16,6 +16,14 @@ open System.Text.Json
 [<Parallelizable(ParallelScope.All)>]
 type OperationalFactsPublisherActorTests() =
 
+    /// Server startup acknowledgement that the durable operational facts processor subscription exists.
+    [<Literal>]
+    let OperationalFactsProcessorSubscriptionSettingName = "grace__azure_service_bus__operational_facts_processor_subscription"
+
+    /// Durable Service Bus subscription required before publishing operational usage facts.
+    [<Literal>]
+    let OperationalFactsProcessorSubscriptionName = "operational-facts-processor"
+
     /// Builds a valid repository storage usage fact for publisher envelope assertions.
     let usageFact usageFactId correlationId =
         UsageFact.RepositoryStorageBytesMinute(
@@ -100,10 +108,13 @@ type OperationalFactsPublisherActorTests() =
         let keys =
             [|
                 Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.DebugEnvironment
+                Constants.EnvironmentVariables.AzureStorageKey
                 Constants.EnvironmentVariables.AzureServiceBusConnectionString
                 Constants.EnvironmentVariables.AzureServiceBusNamespace
                 Constants.EnvironmentVariables.AzureServiceBusTopic
                 Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                OperationalFactsProcessorSubscriptionSettingName
                 Constants.EnvironmentVariables.AzureServiceBusSubscription
             |]
 
@@ -113,6 +124,8 @@ type OperationalFactsPublisherActorTests() =
 
         try
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.DebugEnvironment, "Local")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureStorageKey, "Zm9v")
 
             Environment.SetEnvironmentVariable(
                 Constants.EnvironmentVariables.AzureServiceBusConnectionString,
@@ -122,6 +135,7 @@ type OperationalFactsPublisherActorTests() =
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, null)
+            Environment.SetEnvironmentVariable(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
 
             let ex =
@@ -144,10 +158,13 @@ type OperationalFactsPublisherActorTests() =
         let keys =
             [|
                 Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.DebugEnvironment
+                Constants.EnvironmentVariables.AzureStorageKey
                 Constants.EnvironmentVariables.AzureServiceBusConnectionString
                 Constants.EnvironmentVariables.AzureServiceBusNamespace
                 Constants.EnvironmentVariables.AzureServiceBusTopic
                 Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                OperationalFactsProcessorSubscriptionSettingName
                 Constants.EnvironmentVariables.AzureServiceBusSubscription
             |]
 
@@ -157,6 +174,8 @@ type OperationalFactsPublisherActorTests() =
 
         try
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.DebugEnvironment, "Local")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureStorageKey, "Zm9v")
 
             Environment.SetEnvironmentVariable(
                 Constants.EnvironmentVariables.AzureServiceBusConnectionString,
@@ -166,6 +185,7 @@ type OperationalFactsPublisherActorTests() =
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, "GraceEventStream")
+            Environment.SetEnvironmentVariable(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
 
             let ex =
@@ -178,6 +198,108 @@ type OperationalFactsPublisherActorTests() =
             Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic))
             Assert.That(ex.Message, Does.Contain(Constants.EnvironmentVariables.AzureServiceBusTopic))
             Assert.That(ex.Message, Does.Contain("must differ"))
+        finally
+            previous
+            |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))
+
+    /// Verifies that server startup requires acknowledgement of the durable operational facts processor subscription.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.StartupValidationRejectsMissingOperationalFactsProcessorSubscription() =
+        let keys =
+            [|
+                Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.DebugEnvironment
+                Constants.EnvironmentVariables.AzureStorageKey
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusNamespace
+                Constants.EnvironmentVariables.AzureServiceBusTopic
+                Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                OperationalFactsProcessorSubscriptionSettingName
+                Constants.EnvironmentVariables.AzureServiceBusSubscription
+            |]
+
+        let previous =
+            keys
+            |> Array.map (fun key -> key, Environment.GetEnvironmentVariable key)
+
+        try
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.DebugEnvironment, "Local")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureStorageKey, "Zm9v")
+
+            Environment.SetEnvironmentVariable(
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE"
+            )
+
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, "grace-operational-facts")
+            Environment.SetEnvironmentVariable(OperationalFactsProcessorSubscriptionSettingName, null)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
+
+            let ex =
+                Assert.Throws<InvalidOperationException>(
+                    Action (fun () ->
+                        ApplicationContext.configurePubSubSettings ()
+                        |> ignore)
+                )
+
+            Assert.That(ex.Message, Does.Contain(OperationalFactsProcessorSubscriptionSettingName))
+            Assert.That(ex.Message, Does.Contain(OperationalFactsProcessorSubscriptionName))
+            Assert.That(ex.Message, Does.Contain("durable subscription"))
+        finally
+            previous
+            |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))
+
+    /// Verifies that server startup rejects processor subscription acknowledgements for the wrong durable subscription.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.StartupValidationRejectsInvalidOperationalFactsProcessorSubscription() =
+        let keys =
+            [|
+                Constants.EnvironmentVariables.GracePubSubSystem
+                Constants.EnvironmentVariables.DebugEnvironment
+                Constants.EnvironmentVariables.AzureStorageKey
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString
+                Constants.EnvironmentVariables.AzureServiceBusNamespace
+                Constants.EnvironmentVariables.AzureServiceBusTopic
+                Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+                OperationalFactsProcessorSubscriptionSettingName
+                Constants.EnvironmentVariables.AzureServiceBusSubscription
+            |]
+
+        let previous =
+            keys
+            |> Array.map (fun key -> key, Environment.GetEnvironmentVariable key)
+
+        try
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GracePubSubSystem, nameof GracePubSubSystem.AzureServiceBus)
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.DebugEnvironment, "Local")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureStorageKey, "Zm9v")
+
+            Environment.SetEnvironmentVariable(
+                Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE"
+            )
+
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusTopic, "graceeventstream")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic, "grace-operational-facts")
+            Environment.SetEnvironmentVariable(OperationalFactsProcessorSubscriptionSettingName, "operational-facts-dev")
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.AzureServiceBusSubscription, "grace-server")
+
+            let ex =
+                Assert.Throws<InvalidOperationException>(
+                    Action (fun () ->
+                        ApplicationContext.configurePubSubSettings ()
+                        |> ignore)
+                )
+
+            Assert.That(ex.Message, Does.Contain(OperationalFactsProcessorSubscriptionSettingName))
+            Assert.That(ex.Message, Does.Contain(OperationalFactsProcessorSubscriptionName))
+            Assert.That(ex.Message, Does.Contain("durable subscription"))
         finally
             previous
             |> Array.iter (fun (key, value) -> Environment.SetEnvironmentVariable(key, value))

--- a/src/Grace.Server/ApplicationContext.Server.fs
+++ b/src/Grace.Server/ApplicationContext.Server.fs
@@ -43,6 +43,14 @@ open Microsoft.AspNetCore.SignalR
 /// Contains Grace Server application context behavior and supporting helpers.
 module ApplicationContext =
 
+    /// Environment variable that acknowledges the durable operational facts processor subscription exists.
+    [<Literal>]
+    let private AzureServiceBusOperationalFactsProcessorSubscription = "grace__azure_service_bus__operational_facts_processor_subscription"
+
+    /// Fixed Service Bus subscription that consumes immutable operational usage facts.
+    [<Literal>]
+    let private OperationalFactsProcessorSubscriptionName = "operational-facts-processor"
+
     let mutable private configuration: IConfiguration = null
     let Configuration () : IConfiguration = configuration
     let mutable private log: ILogger = null
@@ -227,6 +235,15 @@ module ApplicationContext =
                 if String.Equals(topic.Trim(), operationalFactsTopic.Trim(), StringComparison.OrdinalIgnoreCase) then
                     invalidOp
                         $"Environment variable '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must differ from '{EnvironmentVariables.AzureServiceBusTopic}' so usage facts cannot enter the GraceEvent topic/subscriber path."
+
+                let operationalFactsProcessorSubscription =
+                    match Environment.GetEnvironmentVariable AzureServiceBusOperationalFactsProcessorSubscription with
+                    | null -> String.Empty
+                    | value -> value.Trim()
+
+                if not (String.Equals(operationalFactsProcessorSubscription, OperationalFactsProcessorSubscriptionName, StringComparison.Ordinal)) then
+                    invalidOp
+                        $"Environment variable '{AzureServiceBusOperationalFactsProcessorSubscription}' must be set to '{OperationalFactsProcessorSubscriptionName}' when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}, after confirming topic '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' has that durable subscription."
 
                 let subscription = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusSubscription
 

--- a/src/Grace.Server/ApplicationContext.Server.fs
+++ b/src/Grace.Server/ApplicationContext.Server.fs
@@ -224,6 +224,10 @@ module ApplicationContext =
                     invalidOp
                         $"Environment variable '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}."
 
+                if String.Equals(topic.Trim(), operationalFactsTopic.Trim(), StringComparison.OrdinalIgnoreCase) then
+                    invalidOp
+                        $"Environment variable '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must differ from '{EnvironmentVariables.AzureServiceBusTopic}' so usage facts cannot enter the GraceEvent topic/subscriber path."
+
                 let subscription = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusSubscription
 
                 if String.IsNullOrWhiteSpace(subscription) then

--- a/src/Grace.Server/ApplicationContext.Server.fs
+++ b/src/Grace.Server/ApplicationContext.Server.fs
@@ -206,13 +206,6 @@ module ApplicationContext =
         let azureServiceBusSettings =
             if system = GracePubSubSystem.AzureServiceBus then
                 let serviceBusConnectionString = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusConnectionString
-
-                if not
-                   <| AzureEnvironment.useManagedIdentityForServiceBus then
-                    if String.IsNullOrWhiteSpace(serviceBusConnectionString) then
-                        invalidOp
-                            $"Environment variable '{EnvironmentVariables.AzureServiceBusConnectionString}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus} and you're not using a managed identity."
-
                 let sb_namespace = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusNamespace
 
                 if String.IsNullOrWhiteSpace(sb_namespace) then
@@ -225,19 +218,32 @@ module ApplicationContext =
                     invalidOp
                         $"Environment variable '{EnvironmentVariables.AzureServiceBusTopic}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}."
 
+                let operationalFactsTopic = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusOperationalFactsTopic
+
+                if String.IsNullOrWhiteSpace(operationalFactsTopic) then
+                    invalidOp
+                        $"Environment variable '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}."
+
                 let subscription = Environment.GetEnvironmentVariable EnvironmentVariables.AzureServiceBusSubscription
 
                 if String.IsNullOrWhiteSpace(subscription) then
                     invalidOp
                         $"Environment variable '{EnvironmentVariables.AzureServiceBusSubscription}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}."
 
+                let useManagedIdentity = AzureEnvironment.useManagedIdentityForServiceBus
+
+                if
+                    not useManagedIdentity
+                    && String.IsNullOrWhiteSpace(serviceBusConnectionString)
+                then
+                    invalidOp
+                        $"Environment variable '{EnvironmentVariables.AzureServiceBusConnectionString}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus} and you're not using a managed identity."
+
                 let fullyQualifiedNamespace =
                     AzureEnvironment.tryGetServiceBusFullyQualifiedNamespace ()
                     |> Option.defaultWith (fun () ->
                         invalidOp
                             $"Environment variable '{EnvironmentVariables.AzureServiceBusNamespace}' must be set when {EnvironmentVariables.GracePubSubSystem} is {GracePubSubSystem.AzureServiceBus}.")
-
-                let useManagedIdentity = AzureEnvironment.useManagedIdentityForServiceBus
 
                 Some
                     {

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -398,6 +398,10 @@ module Constants =
         [<Literal>]
         let AzureServiceBusTopic = "grace__azure_service_bus__topic"
 
+        /// Azure Service Bus topic name for operational usage facts.
+        [<Literal>]
+        let AzureServiceBusOperationalFactsTopic = "grace__azure_service_bus__operational_facts_topic"
+
         /// Azure Service Bus subscription name for Grace events.
         [<Literal>]
         let AzureServiceBusSubscription = "grace__azure_service_bus__subscription"
@@ -569,6 +573,10 @@ module Constants =
 
     /// A special Grace Event Actor Id used for publishing events in Grace.Server. Value: 63097EF4-9D67-4CFB-8010-938484668E4A.
     let GraceEventActorId = Guid("63097EF4-9D67-4CFB-8010-938484668E4A") // There's nothing special about this Guid. I just generated it one day.
+
+    /// The Service Bus topic that carries immutable operational usage facts.
+    [<Literal>]
+    let GraceOperationalFactsTopic = "grace-operational-facts"
 
     /// The name of the inter-process communication file used by grace watch to share status with other invocations of Grace.
     [<Literal>]

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -190,6 +190,8 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 - `grace__azure_service_bus__topic`: Service Bus topic name.
 - `grace__azure_service_bus__operational_facts_topic`: Service Bus topic for operational usage facts. Defaults to
   `grace-operational-facts` in Aspire-managed local and publish configurations.
+- `grace__azure_service_bus__operational_facts_processor_subscription`: DebugAzure preflight acknowledgement that the
+  existing operational facts topic already has the durable `operational-facts-processor` subscription.
 - `grace__azure_service_bus__subscription`: Service Bus subscription name.
 
 ### Redis

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -190,8 +190,8 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 - `grace__azure_service_bus__topic`: Service Bus topic name.
 - `grace__azure_service_bus__operational_facts_topic`: Service Bus topic for operational usage facts. Defaults to
   `grace-operational-facts` in Aspire-managed local and publish configurations.
-- `grace__azure_service_bus__operational_facts_processor_subscription`: DebugAzure preflight acknowledgement that the
-  existing operational facts topic already has the durable `operational-facts-processor` subscription.
+- `grace__azure_service_bus__operational_facts_processor_subscription`: Required Azure Service Bus startup
+  acknowledgement that the operational facts topic already has the durable `operational-facts-processor` subscription.
 - `grace__azure_service_bus__subscription`: Service Bus subscription name.
 
 ### Redis

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -188,6 +188,8 @@ These capture failure classification, retryability, cleanup notes, and runtime m
 - `grace__azure_service_bus__connectionstring`: Service Bus connection string.
 - `grace__azure_service_bus__namespace`: Service Bus namespace.
 - `grace__azure_service_bus__topic`: Service Bus topic name.
+- `grace__azure_service_bus__operational_facts_topic`: Service Bus topic for operational usage facts. Defaults to
+  `grace-operational-facts` in Aspire-managed local and publish configurations.
 - `grace__azure_service_bus__subscription`: Service Bus subscription name.
 
 ### Redis


### PR DESCRIPTION
# OPS3: Add operational fact Service Bus topic and publisher seam

## Related issue

Related to #528. Part of #525.

## Why this matters

Operations accounting needs a transport boundary that is separate from the Grace event stream. This slice publishes
`UsageFact` messages to a dedicated operational facts topic so later worker, SQL, and reporting slices do not couple
operational usage to `GraceEvent`.

## Summary

- Added a dedicated operational facts publisher seam that serializes `UsageFact` messages.
- Mapped `UsageFactId` to Service Bus `MessageId` and kept `CorrelationId` as message correlation.
- Kept operational facts out of `GraceEvent` and out of the Grace event topic.
- Added AppHost Service Bus emulator configuration for the operational facts topic with duplicate detection enabled.
- Added an emulator-only subscription because the Service Bus emulator requires at least one subscription per topic.
- Added publish-mode/AppHost Azure provisioning for a durable operational facts processor subscription.
- Separated Aspire resource names from configurable Azure Service Bus topic and subscription names.
- Validated the operational facts topic in startup/config diagnostics.
- Rejected same-topic GraceEvent and UsageFact Service Bus configurations in runtime/debug/publish paths.
- Used a fixed short operational facts processor subscription name.
- Threaded the configured operational facts topic through DebugLocal instead of hard-coding the default topic.
- Required the operational facts topic explicitly in DebugAzure for existing Azure Service Bus resources.
- Required DebugAzure existing-resource mode to acknowledge the durable operational facts processor subscription.
- Required standalone server Azure Service Bus startup to acknowledge the durable operational facts processor
  subscription.
- Moved AppHost-specific coverage to the Aspire-facing server test surface.
- Documented the operational facts topic in environment guidance and `CONTRIBUTING.md`.

## Touched paths

- `CONTRIBUTING.md`
- `src/Grace.Shared/Constants.Shared.fs`
- `src/Grace.Actors/Grace.Actors.fsproj`
- `src/Grace.Actors/OperationalFactsPublisher.Actor.fs`
- `src/Grace.Server/ApplicationContext.Server.fs`
- `src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
- `src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs`
- `src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs`
- `src/Grace.Server.Tests/AspireTestHost.fs`
- `src/Grace.Server.Tests/Grace.Server.Tests.fsproj`
- `src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs`
- `src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs`
- `src/docs/ENVIRONMENT.md`

## Validation

- `dotnet tool run fantomas <touched F# files>`: passed.
- Focused `Grace.Server.Unit.Tests` publisher tests: passed, 5/5.
- Focused `OperationalFactsPublisherActorTests`: passed, latest set 7/7.
- Focused `Grace.Server.Tests` AppHost diagnostics/AppHost tests: passed, latest AppHost set 3/3.
- `dotnet build --configuration Release src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj`: passed.
- `npx --yes markdownlint-cli2 "src/docs/ENVIRONMENT.md"`: passed.
- `npx --yes markdownlint-cli2 "CONTRIBUTING.md"`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commits.
- GitHub Actions `full`: passed on `325c6936`.

## Review Status

- Current head: `325c6936a61d3ac3e15ca87cf4623a36f7446568`.
- Workers: Turing implemented the publisher; Chandrasekhar fixed the first topic/config/AppHost coverage review
  findings; Nietzsche fixed the second topic-boundary and DebugAzure findings; Cicero fixed the publish-mode durable
  subscription stabilization invariant; Heisenberg fixed the publish-mode topic separation, subscription naming, and
  CONTRIBUTING review findings; James fixed the AppHost resource-identity and DebugAzure processor-subscription
  findings; Hilbert fixed the standalone server processor-subscription guard.
- Worker self-review: complete for implementation and fixes; checked topic/message mapping, `UsageFactId`/correlation
  separation, GraceEvent coupling, AppHost duplicate detection, config failure behavior, DebugLocal topic forwarding,
  startup Service Bus validation ordering, same-topic rejection, DebugAzure required configuration, publish-mode durable
  subscription provisioning, fixed subscription naming, AppHost test boundary placement, secret/payload logging, tests,
  and docs.
- Codex Code Review Bot: first review found three configuration/test-boundary issues on `c76c911c`; fixed in
  `0d8b57f3`. Second review found two separate-topic/DebugAzure configuration issues on `0d8b57f3`; fixed in
  `6dfccbd6`. Third review found one P1 publish-mode durable-subscription issue on `6dfccbd6`; fixed in `e246b987`.
  Fourth review found publish-mode topic separation, subscription naming, and CONTRIBUTING gaps on `e246b987`; fixed in
  `faf42ed0`. Fifth review found AppHost resource-name collision and DebugAzure durable-subscription gaps on
  `faf42ed0`; fixed in `da80b2f9`. Sixth review found a standalone server durable-subscription guard gap on
  `da80b2f9`; fixed in `325c6936`.
- Review/fix evidence: replied on
  [discussion_r3523184154](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523184154),
  [discussion_r3523184165](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523184165), and
  [discussion_r3523184178](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523184178); all conversations
  are resolved.
- Second review/fix evidence: replied on
  [discussion_r3523205447](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523205447) and
  [discussion_r3523205466](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523205466); both conversations
  are resolved.
- Stabilization: accepted invariant is implemented and proven in `e246b987`: every AppHost-created operational facts
  topic has a durable processor subscription. Replied on
  [discussion_r3523226264](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523226264), and the conversation
  is resolved.
- Latest review/fix evidence: fixed in `faf42ed0`; replied on
  [discussion_r3523275314](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523275314),
  [discussion_r3523275336](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523275336), and
  [discussion_r3523275369](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523275369); all conversations
  are resolved.
- Latest fresh findings: `discussion_r3523285374`, `discussion_r3523285376`, and `discussion_r3523285379` are accepted
  as #528 AppHost transport-boundary prerequisites. Stabilization addendum posted to
  [#528](https://github.com/ScottArbeit/Grace/issues/528#issuecomment-4882240595) and
  [PR #537](https://github.com/ScottArbeit/Grace/pull/537#issuecomment-4882240596).
- Latest review/fix evidence: fixed in `da80b2f9`; replied on
  [discussion_r3523306028](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523306028),
  [discussion_r3523306058](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523306058), and
  [discussion_r3523306082](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523306082); all conversations
  are resolved.
- Latest fresh finding: `discussion_r3523311573` is accepted as a #528 server-level transport-boundary prerequisite.
  Stabilization addendum posted to
  [#528](https://github.com/ScottArbeit/Grace/issues/528#issuecomment-4882338296) and
  [PR #537](https://github.com/ScottArbeit/Grace/pull/537#issuecomment-4882338301).
- Latest review/fix evidence: fixed in `325c6936`; replied on
  [discussion_r3523336942](https://github.com/ScottArbeit/Grace/pull/537#discussion_r3523336942), and the conversation
  is resolved.
- Manual trigger: one missed-ack trigger was used after a timestamp parsing defect in
  `scripts/guard-codex-review-trigger.ps1` incorrectly reported the current head as being in the future. Codex
  acknowledged with a current-head review.

## Docs impact

Updated `src/docs/ENVIRONMENT.md` and `CONTRIBUTING.md` for the operational facts topic.

## Residual risk

Low residual risk for the stabilization and latest review fixes. Direct Service Bus publishing remains intentionally
non-outbox for issue #528; durable outbox work is deferred outside this tracer bullet.
