### PR TITLE
WS5.4: Complete Watch transition after branch switch marker deletion

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -796,9 +796,9 @@ module WatchTests =
             finally
                 Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
 
-    /// Verifies that locked old branch IPC still yields target-branch resync IPC after transition completion.
+    /// Verifies that failed old branch IPC retirement still yields target-branch resync IPC after transition completion.
     [<Test>]
-    let ``update marker deletion publishes target branch resync ipc when old branch ipc is locked`` () =
+    let ``update marker deletion publishes target branch resync ipc when old branch ipc retirement fails`` () =
         withTempRepo (fun root ->
             let repositoryId = Guid.NewGuid()
             let branchAId = Guid.NewGuid()
@@ -829,26 +829,30 @@ module WatchTests =
             writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
             Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
 
-            use lockedBranchAIpc = new FileStream(branchAIpc, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            try
+                Watch.setRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests (fun _ ->
+                    raise (IOException("test-controlled old branch IPC retirement failure")))
 
-            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+                recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
 
-            branchAIpc |> File.Exists |> should equal true
-            branchBIpc |> File.Exists |> should equal true
+                branchAIpc |> File.Exists |> should equal true
+                branchBIpc |> File.Exists |> should equal true
 
-            Watch.currentGraceWatchRuntimeModeForWatchTests ()
-            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
 
-            readWatchStatusJsonStringProperty "BranchId"
-            |> should equal $"{branchBId}"
+                readWatchStatusJsonStringProperty "BranchId"
+                |> should equal $"{branchBId}"
 
-            Services.getGraceWatchStatus().Result
-            |> should equal None
+                Services.getGraceWatchStatus().Result
+                |> should equal None
 
-            let inspection = Services.inspectGraceWatchStatus().Result
+                let inspection = Services.inspectGraceWatchStatus().Result
 
-            inspection.EffectiveMode
-            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing))
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+            finally
+                Watch.resetRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests ())
 
     /// Verifies that transition reload clears process-wide ignore decisions after `.graceignore` changes.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -707,15 +707,83 @@ module WatchTests =
                 |> should equal true
             | None -> Assert.Fail("Expected branch B Watch IPC status after transition completion.")
 
-            let branchAJson = File.ReadAllText(branchAIpc)
+            branchAIpc |> File.Exists |> should equal false
 
-            use branchADocument = JsonDocument.Parse(branchAJson)
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
 
-            branchADocument
-                .RootElement
-                .GetProperty("BranchId")
-                .GetString()
-            |> should equal $"{branchAId}")
+            let branchAInspection = Services.inspectGraceWatchStatus().Result
+
+            branchAInspection.Exists |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that repeated same-process branch transitions rebind marker observation to each refreshed branch.
+    [<Test>]
+    let ``update marker deletion rebinds marker watcher for repeated branch transitions`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let repositoryName = "transition-rebind-repo"
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let branchCId = Guid.NewGuid()
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+            let branchCName = "branch-c"
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusC = graceStatusTracking Array.empty<string> Array.empty<string>
+            let reboundMarkerFiles = ResizeArray<string>()
+
+            try
+                Watch.setUpdateMarkerWatcherRebindForWatchTests (fun () -> reboundMarkerFiles.Add(Services.updateInProgressFileName ()))
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+                let branchAIpc = Services.IpcFileName()
+
+                (Services.updateGraceWatchInterprocessFile statusA (Some(HashSet<DirectoryVersionId>(statusA.Index.Keys))))
+                    .GetAwaiter()
+                    .GetResult()
+
+                branchAIpc |> File.Exists |> should equal true
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+                let branchAMarker = Services.updateInProgressFileName ()
+
+                recordCompletedUpdateMarkerDeletion branchAMarker DateTime.UtcNow
+
+                let branchBMarker = Services.updateInProgressFileName ()
+                let branchBIpc = Services.IpcFileName()
+
+                branchAIpc |> File.Exists |> should equal false
+                branchBIpc |> File.Exists |> should equal true
+
+                reboundMarkerFiles.ToArray()
+                |> should equal [| branchBMarker |]
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchCId branchCName
+                Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusC))
+
+                recordCompletedUpdateMarkerDeletion branchBMarker DateTime.UtcNow
+
+                let branchCMarker = Services.updateInProgressFileName ()
+                let branchCIpc = Services.IpcFileName()
+
+                branchBIpc |> File.Exists |> should equal false
+                branchCIpc |> File.Exists |> should equal true
+
+                reboundMarkerFiles.ToArray()
+                |> should equal [| branchBMarker; branchCMarker |]
+            finally
+                Watch.resetUpdateMarkerWatcherRebindForWatchTests ())
 
     /// Verifies that incoherent refreshed state cannot advertise healthy incremental status after marker deletion.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -17,6 +17,7 @@ open System.Diagnostics
 open System.IO
 open System.Text.Json
 open System.Text.Json.Nodes
+open System.Threading
 open System.Threading.Tasks
 
 /// Groups watch coverage for the CLI test project.
@@ -716,6 +717,175 @@ module WatchTests =
             let branchAInspection = Services.inspectGraceWatchStatus().Result
 
             branchAInspection.Exists |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None)
+
+    /// Verifies that old branch IPC cannot be recreated while transition completion is retiring and reloading identity.
+    [<Test>]
+    let ``update marker deletion serializes old branch ipc retirement against pending publication`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-serialized-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            let branchAIpc = Services.IpcFileName()
+
+            branchAIpc |> File.Exists |> should equal true
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            use publisherStarted = new ManualResetEventSlim(false)
+            use publisherCompleted = new ManualResetEventSlim(false)
+            let mutable publisherTask = Task.CompletedTask
+
+            try
+                Watch.setBranchTransitionCompletionAfterRetireProbeForWatchTests (fun () ->
+                    Services.setGraceWatchHasPendingWorkForStatus true
+
+                    publisherTask <-
+                        Task.Run(
+                            Action (fun () ->
+                                publisherStarted.Set()
+                                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+                                publisherCompleted.Set())
+                        )
+
+                    publisherStarted.Wait(TimeSpan.FromSeconds(5.0))
+                    |> should equal true
+
+                    publisherCompleted.Wait(TimeSpan.FromMilliseconds(100.0))
+                    |> should equal false
+
+                    branchAIpc |> File.Exists |> should equal false)
+
+                recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+                publisherTask.Wait(TimeSpan.FromSeconds(5.0))
+                |> should equal true
+
+                let branchBIpc = Services.IpcFileName()
+
+                branchAIpc |> File.Exists |> should equal false
+                branchBIpc |> File.Exists |> should equal true
+
+                readWatchStatusJsonStringProperty "BranchId"
+                |> should equal $"{branchBId}"
+            finally
+                Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
+
+    /// Verifies that current transition completion authority wins over stale sidecars in the target branch directory.
+    [<Test>]
+    let ``update marker deletion prefers current deletion over stale target branch sidecar`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-stale-sidecar-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+            let relativePath = "grace-owned-after-switch.txt"
+            let changedFilePath = Path.Combine(root, relativePath)
+            let staleTargetBranchCompletedUtc = DateTime.UtcNow.AddSeconds(-20.0)
+            let currentTransitionCompletedUtc = DateTime.UtcNow
+            let statusB = graceStatusTracking [| relativePath |] Array.empty<string>
+            let branchBMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchBMarker))
+            |> ignore
+
+            File.WriteAllText(branchBMarker + ".completed", staleTargetBranchCompletedUtc.ToString("O"))
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(statusB))
+
+            File.WriteAllText(changedFilePath, "Grace-owned payload from the current transition")
+            File.SetLastWriteTimeUtc(changedFilePath, currentTransitionCompletedUtc.AddSeconds(-1.0))
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) currentTransitionCompletedUtc
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that transition completion cannot claim healthy incremental mode after an unverified branch IPC publish.
+    [<Test>]
+    let ``update marker deletion requests resync when new branch ipc publication is not verified`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-unverified-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            let branchAIpc = Services.IpcFileName()
+            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchBIpc))
+            |> ignore
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            use lockedBranchBIpc = new FileStream(branchBIpc, FileMode.Create, FileAccess.ReadWrite, FileShare.None)
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            lockedBranchBIpc.Dispose()
+
+            branchAIpc |> File.Exists |> should equal false
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
 
             Services.getGraceWatchStatus().Result
             |> should equal None)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -181,6 +181,17 @@ module WatchTests =
 
         repositoryId, branchId
 
+    /// Writes a repository configuration file without relying on the process-local cached Current() value.
+    let private writeRepositoryConfiguration rootDirectory repositoryId repositoryName branchId branchName =
+        let configuration = GraceConfiguration()
+        configuration.RepositoryId <- repositoryId
+        configuration.RepositoryName <- repositoryName
+        configuration.BranchId <- branchId
+        configuration.BranchName <- branchName
+        configuration.RootDirectory <- rootDirectory
+
+        saveConfigFile (Path.Combine(rootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)) configuration
+
     /// Removes the compact runtime surface so tests can simulate pre-WS3.1 IPC files.
     let private removeCompactWatchRuntimeSurface (json: string) =
         let statusNode = JsonNode.Parse(json).AsObject()
@@ -364,6 +375,7 @@ module WatchTests =
             configuration.BranchId <- Guid.NewGuid()
             configuration.BranchName <- "watch-test-branch"
             configuration.RootDirectory <- tempDir
+            saveConfigFile configPath configuration
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
             deleteWatchStatusFileIfExists ()
@@ -630,6 +642,164 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that marker deletion completes a same-process branch transition by reloading config and publishing branch B IPC.
+    [<Test>]
+    let ``update marker deletion reloads branch config and publishes new branch ipc`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+            let directoryIdsB = HashSet<DirectoryVersionId>(statusB.Index.Keys)
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            let branchAIpc = Services.IpcFileName()
+
+            branchAIpc |> File.Exists |> should equal true
+
+            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            branchBIpc |> File.Exists |> should equal false
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            Services.IpcFileName() |> should equal branchBIpc
+
+            branchBIpc |> File.Exists |> should equal true
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchBId}"
+
+            readWatchStatusJsonStringProperty "BranchName"
+            |> should equal branchBName
+
+            readWatchStatusJsonStringProperty "RootDirectoryId"
+            |> should equal $"{statusB.RootDirectoryId}"
+
+            let branchBInspection = Services.inspectGraceWatchStatus().Result
+
+            branchBInspection.IsUsable |> should equal true
+
+            match branchBInspection.Status with
+            | Some watchStatus ->
+                watchStatus.BranchId |> should equal branchBId
+
+                watchStatus.DirectoryIds.SetEquals(directoryIdsB)
+                |> should equal true
+            | None -> Assert.Fail("Expected branch B Watch IPC status after transition completion.")
+
+            let branchAJson = File.ReadAllText(branchAIpc)
+
+            use branchADocument = JsonDocument.Parse(branchAJson)
+
+            branchADocument
+                .RootElement
+                .GetProperty("BranchId")
+                .GetString()
+            |> should equal $"{branchAId}")
+
+    /// Verifies that incoherent refreshed state cannot advertise healthy incremental status after marker deletion.
+    [<Test>]
+    let ``update marker deletion with incoherent status publishes non-incremental new branch ipc`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-incoherent-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(GraceStatus.Default))
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            Services.IpcFileName() |> should equal branchBIpc
+
+            branchBIpc |> File.Exists |> should equal true
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchBId}"
+
+            readWatchStatusJsonStringProperty "BranchName"
+            |> should equal branchBName
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing)
+
+    /// Verifies that startup marker completion cannot skip startup catch-up and publish healthy incremental status.
+    [<Test>]
+    let ``startup update marker deletion keeps startup from entering healthy incremental`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let repositoryName = "startup-transition-repo"
+            let branchName = "startup-branch"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchId branchName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(status))
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.StartingUp
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing))
 
     /// Verifies that user writes after marker deletion still enqueue as local Watch work.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -941,6 +941,83 @@ module WatchTests =
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
+    /// Verifies that later marker starts cannot erase delayed callback authority from the completed transition.
+    [<Test>]
+    let ``new update marker created event preserves delayed callback authority from completed transition`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "delayed-after-later-marker-start.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let firstTransitionCompletedUtc = DateTime.UtcNow
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(changedFilePath, "Grace-owned payload from the first transition")
+            File.SetLastWriteTimeUtc(changedFilePath, firstTransitionCompletedUtc.AddSeconds(-1.0))
+
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests firstTransitionCompletedUtc
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                Task.FromResult(
+                    graceStatusTracking
+                        [|
+                            "delayed-after-later-marker-start.txt"
+                        |]
+                        Array.empty<string>
+                ))
+
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress again.")
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+            File.Delete(updateMarkerFile)
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that an unrelated marker deletion without sidecar cannot erase delayed callback authority.
+    [<Test>]
+    let ``update marker deletion without sidecar preserves delayed callback authority from completed transition`` () =
+        withTempRepo (fun root ->
+            let changedFilePath = Path.Combine(root, "delayed-after-no-sidecar-marker.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let firstTransitionCompletedUtc = DateTime.UtcNow
+
+            File.WriteAllText(changedFilePath, "Grace-owned payload from the completed transition")
+            File.SetLastWriteTimeUtc(changedFilePath, firstTransitionCompletedUtc.AddSeconds(-1.0))
+
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests firstTransitionCompletedUtc
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                Task.FromResult(
+                    graceStatusTracking
+                        [|
+                            "delayed-after-no-sidecar-marker.txt"
+                        |]
+                        Array.empty<string>
+                ))
+
+            recordIncompleteUpdateMarkerDeletion updateMarkerFile
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
     /// Verifies that repeated transition deletion uses the just-deleted marker sidecar after configuration advances.
     [<Test>]
     let ``update marker deletion uses deleted marker sidecar after repeated transition advances config`` () =
@@ -1020,6 +1097,46 @@ module WatchTests =
 
             File.Exists(branchCCompletedSidecar)
             |> should equal true)
+
+    /// Verifies that a stale completed marker cannot finish transition work while the current marker is still live.
+    [<Test>]
+    let ``stale marker deletion with sidecar does not complete transition while current marker is live`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-stale-live-marker-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+            let branchAMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchAId branchAName
+            let branchBMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+            let staleTransitionCompletedUtc = DateTime.UtcNow
+            let mutable completionProbeCalls = 0
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchAMarker))
+            |> ignore
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchBMarker))
+            |> ignore
+
+            File.WriteAllText(branchAMarker, "`grace switch` from branch A is finishing late.")
+            File.WriteAllText(branchAMarker + ".completed", staleTransitionCompletedUtc.ToString("O"))
+            File.WriteAllText(branchBMarker, "`grace switch` to branch C is still in progress.")
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            resetConfiguration ()
+            Current() |> ignore
+
+            try
+                Watch.setBranchTransitionCompletionAfterRetireProbeForWatchTests (fun () -> completionProbeCalls <- completionProbeCalls + 1)
+
+                File.Delete(branchAMarker)
+                Watch.OnGraceUpdateInProgressDeleted(deletedEvent branchAMarker)
+
+                completionProbeCalls |> should equal 0
+                File.Exists(branchBMarker) |> should equal true
+            finally
+                Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
 
     /// Verifies that transition completion cannot claim healthy incremental mode after an unverified branch IPC publish.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -379,11 +379,13 @@ module WatchTests =
             saveConfigFile configPath configuration
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
+            Services.clearShouldIgnoreCache ()
             deleteWatchStatusFileIfExists ()
             Watch.clearPendingWatchWorkForTests ()
             action tempDir
         finally
             Watch.clearPendingWatchWorkForTests ()
+            Services.clearShouldIgnoreCache ()
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
             deleteWatchStatusFileIfExists ()
             Services.graceWatchStatusUpdateTime <- Instant.MinValue
@@ -794,6 +796,96 @@ module WatchTests =
             finally
                 Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
 
+    /// Verifies that locked old branch IPC still yields target-branch resync IPC after transition completion.
+    [<Test>]
+    let ``update marker deletion publishes target branch resync ipc when old branch ipc is locked`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-locked-old-ipc-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            let branchAIpc = Services.IpcFileName()
+
+            branchAIpc |> File.Exists |> should equal true
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            use lockedBranchAIpc = new FileStream(branchAIpc, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            branchAIpc |> File.Exists |> should equal true
+            branchBIpc |> File.Exists |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchBId}"
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing))
+
+    /// Verifies that transition reload clears process-wide ignore decisions after `.graceignore` changes.
+    [<Test>]
+    let ``update marker deletion clears stale graceignore decisions before resuming`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-ignore-cache-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+            let fileName = "ignore-cache-sensitive.tmp"
+            let filePath = Path.Combine(root, fileName)
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            File.WriteAllText(filePath, "cache me before branch switch")
+
+            Services.shouldIgnoreFile filePath
+            |> should equal false
+
+            File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), fileName)
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+            Services.shouldIgnoreFile filePath
+            |> should equal true)
+
     /// Verifies that current transition completion authority wins over stale sidecars in the target branch directory.
     [<Test>]
     let ``update marker deletion prefers current deletion over stale target branch sidecar`` () =
@@ -841,6 +933,86 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that repeated transition deletion uses the just-deleted marker sidecar after configuration advances.
+    [<Test>]
+    let ``update marker deletion uses deleted marker sidecar after repeated transition advances config`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let branchCId = Guid.NewGuid()
+            let repositoryName = "transition-current-sidecar-repo"
+            let branchBName = "branch-b"
+            let branchCName = "branch-c"
+            let relativePath = "current-sidecar-owned.txt"
+            let changedFilePath = Path.Combine(root, relativePath)
+            let staleRecordedCompletedUtc = DateTime.UtcNow.AddSeconds(-20.0)
+            let branchBCompletedUtc = DateTime.UtcNow
+            let statusC = graceStatusTracking [| relativePath |] Array.empty<string>
+            let branchBMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchBMarker))
+            |> ignore
+
+            File.WriteAllText(branchBMarker, "`grace switch` is in progress.")
+            File.WriteAllText(branchBMarker + ".completed", branchBCompletedUtc.ToString("O"))
+            File.WriteAllText(changedFilePath, "Grace-owned payload from the repeated transition")
+            File.SetLastWriteTimeUtc(changedFilePath, branchBCompletedUtc.AddSeconds(-1.0))
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchCId branchCName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests staleRecordedCompletedUtc
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(statusC))
+
+            File.Delete(branchBMarker)
+            Watch.OnGraceUpdateInProgressDeleted(deletedEvent branchBMarker)
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that an incomplete stale marker deletion does not remove the current branch completion sidecar.
+    [<Test>]
+    let ``update marker deletion without sidecar preserves current branch sidecar`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let branchCId = Guid.NewGuid()
+            let repositoryName = "transition-incomplete-stale-marker-repo"
+            let branchBName = "branch-b"
+            let branchCName = "branch-c"
+            let branchBMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+            let branchCMarker = Services.updateInProgressFileNameForIdentity repositoryId repositoryName root branchCId branchCName
+            let branchCCompletedSidecar = branchCMarker + ".completed"
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchBMarker))
+            |> ignore
+
+            Directory.CreateDirectory(Path.GetDirectoryName(branchCMarker))
+            |> ignore
+
+            File.WriteAllText(branchBMarker, "`grace switch` is in progress.")
+            File.WriteAllText(branchCCompletedSidecar, DateTime.UtcNow.ToString("O"))
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchCId branchCName
+            resetConfiguration ()
+            Current() |> ignore
+
+            File.Delete(branchBMarker)
+            Watch.OnGraceUpdateInProgressDeleted(deletedEvent branchBMarker)
+
+            File.Exists(branchCCompletedSidecar)
+            |> should equal true)
 
     /// Verifies that transition completion cannot claim healthy incremental mode after an unverified branch IPC publish.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -480,6 +480,8 @@ module WatchTests =
         |> ignore
 
         File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+        File.SetLastWriteTimeUtc(updateMarkerFile, markerCompletedUtc.AddSeconds(-1.0))
+        Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
         File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
         File.Delete(updateMarkerFile)
         Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
@@ -537,6 +539,8 @@ module WatchTests =
             |> ignore
 
             File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.SetLastWriteTimeUtc(updateMarkerFile, markerCompletedUtc.AddSeconds(-1.0))
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
             File.WriteAllText(changedFilePath, "Grace-owned branch switch payload")
             File.SetLastWriteTimeUtc(changedFilePath, markerCompletedUtc.AddSeconds(-1.0))
             File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
@@ -1038,7 +1042,10 @@ module WatchTests =
             Directory.CreateDirectory(Path.GetDirectoryName(branchBMarker))
             |> ignore
 
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests staleRecordedCompletedUtc
             File.WriteAllText(branchBMarker, "`grace switch` is in progress.")
+            File.SetLastWriteTimeUtc(branchBMarker, branchBCompletedUtc.AddSeconds(-1.0))
+            Watch.OnGraceUpdateInProgressCreated(createdEvent branchBMarker)
             File.WriteAllText(branchBMarker + ".completed", branchBCompletedUtc.ToString("O"))
             File.WriteAllText(changedFilePath, "Grace-owned payload from the repeated transition")
             File.SetLastWriteTimeUtc(changedFilePath, branchBCompletedUtc.AddSeconds(-1.0))
@@ -1047,11 +1054,47 @@ module WatchTests =
             resetConfiguration ()
             Current() |> ignore
 
-            Watch.recordGraceUpdateMarkerDeletedUtcForTests staleRecordedCompletedUtc
             Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(statusC))
 
             File.Delete(branchBMarker)
             Watch.OnGraceUpdateInProgressDeleted(deletedEvent branchBMarker)
+            Watch.OnChanged(changedEvent changedFilePath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
+
+    /// Verifies that delayed callbacks prefer the current sidecar before Watch observes marker deletion.
+    [<Test>]
+    let ``current marker sidecar suppresses repeated transition callback before deletion handler`` () =
+        withTempRepo (fun root ->
+            let relativePath = "current-sidecar-before-deletion.txt"
+            let changedFilePath = Path.Combine(root, relativePath)
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let staleRecordedCompletedUtc = DateTime.UtcNow.AddSeconds(-20.0)
+            let currentCompletedUtc = DateTime.UtcNow
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            Watch.recordGraceUpdateMarkerDeletedUtcForTests staleRecordedCompletedUtc
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.SetLastWriteTimeUtc(updateMarkerFile, currentCompletedUtc.AddSeconds(-1.0))
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+            File.WriteAllText(updateMarkerFile + ".completed", currentCompletedUtc.ToString("O"))
+            File.WriteAllText(changedFilePath, "Grace-owned payload before marker deletion callback")
+            File.SetLastWriteTimeUtc(changedFilePath, currentCompletedUtc.AddSeconds(-1.0))
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(graceStatusTracking [| relativePath |] Array.empty<string>))
+
+            File.Delete(updateMarkerFile)
             Watch.OnChanged(changedEvent changedFilePath)
 
             let pending = Watch.pendingWatchWorkSnapshotForTests ()
@@ -1135,6 +1178,35 @@ module WatchTests =
 
                 completionProbeCalls |> should equal 0
                 File.Exists(branchBMarker) |> should equal true
+            finally
+                Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
+
+    /// Verifies that stale sidecars cannot complete a later marker lifecycle when Watch never observed that marker.
+    [<Test>]
+    let ``stale same branch sidecar without fresh marker observation does not complete transition`` () =
+        withTempRepo (fun _ ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let staleCompletedUtc = DateTime.UtcNow.AddSeconds(-5.0)
+            let mutable completionProbeCalls = 0
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "`grace switch` ended before completing.")
+            Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+            File.Delete(updateMarkerFile)
+            Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
+            File.WriteAllText(updateMarkerFile + ".completed", staleCompletedUtc.ToString("O"))
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress without a new sidecar.")
+
+            try
+                Watch.setBranchTransitionCompletionAfterRetireProbeForWatchTests (fun () -> completionProbeCalls <- completionProbeCalls + 1)
+
+                File.Delete(updateMarkerFile)
+                Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
+                completionProbeCalls |> should equal 0
             finally
                 Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -841,6 +841,9 @@ module WatchTests =
                 Watch.currentGraceWatchRuntimeModeForWatchTests ()
                 |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
 
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal true
+
                 readWatchStatusJsonStringProperty "BranchId"
                 |> should equal $"{branchBId}"
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -486,6 +486,17 @@ module WatchTests =
         File.Delete(updateMarkerFile)
         Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
 
+    /// Records a completed marker deletion when Watch missed the marker-created callback.
+    let private recordUnobservedCompletedUpdateMarkerDeletion (updateMarkerFile: string) (markerCompletedUtc: DateTime) =
+        Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+        |> ignore
+
+        File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+        File.SetLastWriteTimeUtc(updateMarkerFile, markerCompletedUtc.AddSeconds(-1.0))
+        File.WriteAllText(updateMarkerFile + ".completed", markerCompletedUtc.ToString("O"))
+        File.Delete(updateMarkerFile)
+        Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
     /// Records a marker deletion without the completed sidecar produced by a successful branch switch mutation.
     let private recordIncompleteUpdateMarkerDeletion (updateMarkerFile: string) =
         Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
@@ -726,6 +737,65 @@ module WatchTests =
 
             Services.getGraceWatchStatus().Result
             |> should equal None)
+
+    /// Verifies that a missed marker-created callback cannot leave Watch serving the previous branch indefinitely.
+    [<Test>]
+    let ``unobserved current marker completed sidecar reloads target branch resync ipc`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let repositoryName = "transition-unobserved-sidecar-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+            let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+            let branchAMarker = Services.updateInProgressFileName ()
+            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+
+            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                .GetAwaiter()
+                .GetResult()
+
+            let branchAIpc = Services.IpcFileName()
+
+            branchAIpc |> File.Exists |> should equal true
+            branchBIpc |> File.Exists |> should equal false
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+            recordUnobservedCompletedUpdateMarkerDeletion branchAMarker DateTime.UtcNow
+
+            Services.IpcFileName() |> should equal branchBIpc
+
+            branchAIpc |> File.Exists |> should equal false
+            branchBIpc |> File.Exists |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            readWatchStatusJsonStringProperty "BranchId"
+            |> should equal $"{branchBId}"
+
+            Services.getGraceWatchStatus().Result
+            |> should equal None
+
+            let branchBInspection = Services.inspectGraceWatchStatus().Result
+
+            branchBInspection.EffectiveMode
+            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing))
 
     /// Verifies that old branch IPC cannot be recreated while transition completion is retiring and reloading identity.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -870,7 +870,7 @@ module WatchTests =
             finally
                 Watch.resetBranchTransitionCompletionAfterRetireProbeForWatchTests ())
 
-    /// Verifies that failed old branch IPC retirement still yields target-branch resync IPC after transition completion.
+    /// Verifies that failed old branch IPC retirement downgrades old IPC before publishing target-branch resync IPC.
     [<Test>]
     let ``update marker deletion publishes target branch resync ipc when old branch ipc retirement fails`` () =
         withTempRepo (fun root ->
@@ -903,9 +903,18 @@ module WatchTests =
             writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
             Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
 
+            let mutable oldIpcReader: FileStream option = Some(new FileStream(branchAIpc, FileMode.Open, FileAccess.Read, FileShare.Read))
+
             try
                 Watch.setRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests (fun _ ->
                     raise (IOException("test-controlled old branch IPC retirement failure")))
+
+                Watch.setPreviousBranchIpcDowngradeRetryProbeForWatchTests (fun () ->
+                    match oldIpcReader with
+                    | Some reader ->
+                        reader.Dispose()
+                        oldIpcReader <- None
+                    | None -> ())
 
                 recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
 
@@ -928,8 +937,27 @@ module WatchTests =
 
                 inspection.EffectiveMode
                 |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                let oldBranchInspection = Services.inspectGraceWatchStatus().Result
+
+                oldBranchInspection.Exists |> should equal true
+                oldBranchInspection.IsUsable |> should equal false
+
+                oldBranchInspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+                Services.getGraceWatchStatus().Result
+                |> should equal None
             finally
-                Watch.resetRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests ())
+                oldIpcReader
+                |> Option.iter (fun reader -> reader.Dispose())
+
+                Watch.resetRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests ()
+                Watch.resetPreviousBranchIpcDowngradeRetryProbeForWatchTests ())
 
     /// Verifies that transition reload clears process-wide ignore decisions after `.graceignore` changes.
     [<Test>]

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -55,6 +55,9 @@ module Services =
     /// A cache of paths that we've already decided to ignore or not.
     let private shouldIgnoreCache = ConcurrentDictionary<FilePath, bool>()
 
+    /// Clears process-local `.graceignore` decisions after repository configuration changes.
+    let clearShouldIgnoreCache () = shouldIgnoreCache.Clear()
+
     // This section is "borrowed" from Common.CLI.fs, because Services.CLI.fs comes before Common.CLI.fs in the build order.
 
     /// Checks if the output format from the command line is a specific format.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -462,6 +462,30 @@ module Watch =
     let mutable private readGraceStatusFileForPendingWorkTransition = readGraceStatusFile
     let mutable private readGraceStatusFileForTransitionCompletion = readGraceStatusFile
 
+    let private updateMarkerWatcherRebindLock = obj ()
+    let mutable private rebindUpdateMarkerWatcherForTransitionCompletion = ignore
+
+    /// Installs the active update-marker watcher retarget operation used after branch identity changes.
+    let private registerUpdateMarkerWatcherRebind rebind =
+        lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion <- rebind)
+
+        { new IDisposable with
+            member _.Dispose() = lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion <- ignore)
+        }
+
+    /// Runs the current update-marker watcher retarget operation after transition identity reloads.
+    let private rebindUpdateMarkerWatcherAfterTransitionCompletion () =
+        let rebind = lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion)
+        rebind ()
+
+    /// Installs the update-marker watcher retarget operation used by transition-completion tests.
+    let internal setUpdateMarkerWatcherRebindForWatchTests rebind =
+        lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion <- rebind)
+
+    /// Restores the default no-op update-marker watcher retarget operation after transition-completion tests.
+    let internal resetUpdateMarkerWatcherRebindForWatchTests () =
+        lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion <- ignore)
+
     /// Reloads repository configuration after another Grace process changes the current branch.
     let private reloadConfigurationForTransitionCompletion () =
         resetConfiguration ()
@@ -1831,11 +1855,20 @@ module Watch =
 
         logToAnsiConsole Colors.Important $"Grace Watch published non-incremental IPC for branch transition completion: {context}."
 
+    /// Removes the previous branch IPC snapshot so stale healthy status cannot survive a branch transition.
+    let private retirePreviousBranchWatchIpc previousIpcFileName =
+        if File.Exists(previousIpcFileName) then
+            File.Delete(previousIpcFileName)
+
+            logToAnsiConsole Colors.Important $"Grace Watch retired previous branch IPC before completing branch transition: {previousIpcFileName}."
+
     /// Completes a Grace-owned branch transition after the update marker is cleanly deleted.
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
-        let reloadedConfiguration =
+        let previousIpcFileName = IpcFileName()
+
+        let previousIpcRetired =
             try
-                reloadConfigurationForTransitionCompletion ()
+                retirePreviousBranchWatchIpc previousIpcFileName
                 true
             with
             | ex ->
@@ -1846,39 +1879,58 @@ module Watch =
 
                 logToAnsiConsole
                     Colors.Error
-                    $"Grace Watch could not reload configuration after transition marker deletion at {completedUtc:O}; old branch IPC will not be republished: {Markup.Escape(ex.Message)}."
+                    $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; incremental observations will not resume: {Markup.Escape(ex.Message)}."
 
                 false
 
-        if reloadedConfiguration then
-            try
-                let refreshedStatus =
-                    readGraceStatusFileForTransitionCompletion()
-                        .GetAwaiter()
-                        .GetResult()
+        if previousIpcRetired then
+            let reloadedConfiguration =
+                try
+                    reloadConfigurationForTransitionCompletion ()
+                    rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+                    true
+                with
+                | ex ->
+                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+                    graceStatusHasChanged <- true
 
-                graceStatus <- refreshedStatus
-                updateGraceStatusDirectoryIds graceStatus
+                    lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
 
-                if isTransitionCompletionConfigurationCoherent ()
-                   && isTransitionCompletionGraceStatusCoherent graceStatus then
-                    if
-                        currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
-                        && not (isGraceWatchResyncPending ())
-                    then
-                        publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
-                            updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
+                    logToAnsiConsole
+                        Colors.Error
+                        $"Grace Watch could not reload configuration or rebind marker watcher after transition marker deletion at {completedUtc:O}; old branch IPC will not be republished: {Markup.Escape(ex.Message)}."
 
-                        logToAnsiConsole
-                            Colors.Important
-                            $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                    false
+
+            if reloadedConfiguration then
+                try
+                    let refreshedStatus =
+                        readGraceStatusFileForTransitionCompletion()
+                            .GetAwaiter()
+                            .GetResult()
+
+                    graceStatus <- refreshedStatus
+                    updateGraceStatusDirectoryIds graceStatus
+
+                    if isTransitionCompletionConfigurationCoherent ()
+                       && isTransitionCompletionGraceStatusCoherent graceStatus then
+                        if
+                            currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                            && not (isGraceWatchResyncPending ())
+                        then
+                            publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                                updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
+
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                        else
+                            publishNonIncrementalTransitionCompletionStatus
+                                $"runtime mode is {currentGraceWatchRuntimeMode ()} and resync pending is {isGraceWatchResyncPending ()}"
                     else
-                        publishNonIncrementalTransitionCompletionStatus
-                            $"runtime mode is {currentGraceWatchRuntimeMode ()} and resync pending is {isGraceWatchResyncPending ()}"
-                else
-                    requestGraceWatchExplicitResync "branch transition completion reloaded incoherent configuration or GraceStatus"
-            with
-            | ex -> requestGraceWatchExplicitResync $"branch transition completion could not reload GraceStatus: {ex.Message}"
+                        requestGraceWatchExplicitResync "branch transition completion reloaded incoherent configuration or GraceStatus"
+                with
+                | ex -> requestGraceWatchExplicitResync $"branch transition completion could not reload GraceStatus: {ex.Message}"
 
     /// Combines status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
@@ -3358,6 +3410,35 @@ module Watch =
                     |> ignore
 
                     use updateInProgressFileSystemWatcher = createFileSystemWatcher (Path.GetDirectoryName(updateInProgressFileName ()))
+
+                    use updateMarkerWatcherRebindRegistration =
+                        registerUpdateMarkerWatcherRebind (fun () ->
+                            let markerDirectory = Path.GetDirectoryName(updateInProgressFileName ())
+
+                            Directory.CreateDirectory(markerDirectory)
+                            |> ignore
+
+                            let currentPath = Path.GetFullPath(updateInProgressFileSystemWatcher.Path)
+                            let targetPath = Path.GetFullPath(markerDirectory)
+
+                            if
+                                not
+                                <| String.Equals
+                                    (
+                                        currentPath,
+                                        targetPath,
+                                        if OperatingSystem.IsWindows() then
+                                            StringComparison.OrdinalIgnoreCase
+                                        else
+                                            StringComparison.Ordinal
+                                    )
+                            then
+                                let wasEnabled = updateInProgressFileSystemWatcher.EnableRaisingEvents
+                                updateInProgressFileSystemWatcher.EnableRaisingEvents <- false
+                                updateInProgressFileSystemWatcher.Path <- markerDirectory
+                                updateInProgressFileSystemWatcher.EnableRaisingEvents <- wasEnabled
+
+                                logToAnsiConsole Colors.Important $"Grace Watch rebound update marker watcher to {markerDirectory}.")
 
                     use updateInProgressChanged =
                         Observable

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -563,6 +563,8 @@ module Watch =
     let mutable private rebindUpdateMarkerWatcherForTransitionCompletion = ignore
     let private branchTransitionCompletionProbeLock = obj ()
     let mutable private branchTransitionCompletionAfterRetireProbe = ignore
+    let private previousBranchIpcDowngradeRetryProbeLock = obj ()
+    let mutable private previousBranchIpcDowngradeRetryProbe = ignore
 
     /// Installs the active update-marker watcher retarget operation used after branch identity changes.
     let private registerUpdateMarkerWatcherRebind rebind =
@@ -597,6 +599,19 @@ module Watch =
     /// Restores the transition-boundary probe to the production no-op behavior after Watch tests.
     let internal resetBranchTransitionCompletionAfterRetireProbeForWatchTests () =
         lock branchTransitionCompletionProbeLock (fun () -> branchTransitionCompletionAfterRetireProbe <- ignore)
+
+    /// Runs the current previous-branch IPC downgrade retry probe after a failed verification.
+    let private runPreviousBranchIpcDowngradeRetryProbe () =
+        let probe = lock previousBranchIpcDowngradeRetryProbeLock (fun () -> previousBranchIpcDowngradeRetryProbe)
+        probe ()
+
+    /// Installs a retry probe used to make previous-branch IPC downgrade verification deterministic in tests.
+    let internal setPreviousBranchIpcDowngradeRetryProbeForWatchTests probe =
+        lock previousBranchIpcDowngradeRetryProbeLock (fun () -> previousBranchIpcDowngradeRetryProbe <- probe)
+
+    /// Restores the previous-branch IPC downgrade retry probe to the production no-op behavior after Watch tests.
+    let internal resetPreviousBranchIpcDowngradeRetryProbeForWatchTests () =
+        lock previousBranchIpcDowngradeRetryProbeLock (fun () -> previousBranchIpcDowngradeRetryProbe <- ignore)
 
     /// Removes stale source-branch Watch IPC before transition completion publishes under the target identity.
     let mutable private retirePreviousBranchWatchIpcForTransitionCompletion = fun previousIpcFileName -> File.Delete(previousIpcFileName)
@@ -2008,23 +2023,73 @@ module Watch =
 
             logToAnsiConsole Colors.Important $"Grace Watch retired previous branch IPC before completing branch transition: {previousIpcFileName}."
 
+        not (File.Exists(previousIpcFileName))
+
+    /// Verifies that the previous branch IPC no longer exposes a healthy incremental shortcut.
+    let private previousBranchWatchIpcRetiredOrNonIncremental previousIpcFileName =
+        if not (File.Exists(previousIpcFileName)) then
+            true
+        else
+            try
+                let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+                String.Equals(IpcFileName(), previousIpcFileName, StringComparison.OrdinalIgnoreCase)
+                && isGraceWatchResyncRequiredStatusPublished inspection
+            with
+            | _ -> false
+
+    /// Retries deletion or downgrades the previous branch IPC before Watch abandons that branch identity.
+    let private retryOrDowngradePreviousBranchWatchIpc previousIpcFileName failure =
+        requestGraceWatchExplicitResync $"previous branch IPC retirement failed: {failure}"
+
+        let maxAttempts = 3
+        let mutable attempt = 1
+        let mutable verified = previousBranchWatchIpcRetiredOrNonIncremental previousIpcFileName
+
+        while not verified && attempt < maxAttempts do
+            runPreviousBranchIpcDowngradeRetryProbe ()
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(float (attempt * 25)))
+            attempt <- attempt + 1
+
+            try
+                retirePreviousBranchWatchIpc previousIpcFileName
+                |> ignore
+            with
+            | ex ->
+                logToAnsiConsole
+                    Colors.Important
+                    $"Grace Watch retry {attempt} could not retire previous branch IPC before transition completion: {Markup.Escape(ex.Message)}."
+
+            if File.Exists(previousIpcFileName) then publishGraceWatchResyncRequired ()
+
+            verified <- previousBranchWatchIpcRetiredOrNonIncremental previousIpcFileName
+
+        if not verified then
+            logToAnsiConsole
+                Colors.Error
+                $"Grace Watch could not verify previous branch IPC was retired or downgraded after {attempt} attempts; target branch IPC publication is deferred."
+
+        verified
+
     /// Publishes a target-branch non-incremental snapshot when old IPC retirement is temporarily blocked.
     let private publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc failure =
-        requestGraceWatchExplicitResync $"previous branch IPC retirement failed: {failure}"
+        let previousIpcFileName = IpcFileName()
 
         logToAnsiConsole
             Colors.Error
-            $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; publishing target branch resync IPC instead: {Markup.Escape(failure)}."
+            $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; verifying old IPC downgrade before target publication: {Markup.Escape(failure)}."
 
-        try
-            reloadConfigurationForTransitionCompletion ()
-            rebindUpdateMarkerWatcherAfterTransitionCompletion ()
-            publishNonIncrementalTransitionCompletionStatus $"previous branch IPC retirement failed: {failure}"
-        with
-        | ex ->
-            logToAnsiConsole
-                Colors.Error
-                $"Grace Watch could not publish target branch resync IPC after previous branch IPC retirement failed at {completedUtc:O}: {Markup.Escape(ex.Message)}."
+        if retryOrDowngradePreviousBranchWatchIpc previousIpcFileName failure then
+            try
+                reloadConfigurationForTransitionCompletion ()
+                rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+                publishNonIncrementalTransitionCompletionStatus $"previous branch IPC retirement failed: {failure}"
+            with
+            | ex ->
+                logToAnsiConsole
+                    Colors.Error
+                    $"Grace Watch could not publish target branch resync IPC after previous branch IPC retirement failed at {completedUtc:O}: {Markup.Escape(ex.Message)}."
 
     /// Completes a Grace-owned branch transition inside the serialized Watch publication boundary.
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
@@ -2034,8 +2099,12 @@ module Watch =
 
             let previousIpcRetired =
                 try
-                    retirePreviousBranchWatchIpc previousIpcFileName
-                    true
+                    let retired = retirePreviousBranchWatchIpc previousIpcFileName
+
+                    if not retired then
+                        publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc "previous branch IPC still existed after delete"
+
+                    retired
                 with
                 | ex ->
                     publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc ex.Message

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -521,6 +521,17 @@ module Watch =
     let internal resetBranchTransitionCompletionAfterRetireProbeForWatchTests () =
         lock branchTransitionCompletionProbeLock (fun () -> branchTransitionCompletionAfterRetireProbe <- ignore)
 
+    /// Removes stale source-branch Watch IPC before transition completion publishes under the target identity.
+    let mutable private retirePreviousBranchWatchIpcForTransitionCompletion = fun previousIpcFileName -> File.Delete(previousIpcFileName)
+
+    /// Installs the previous-branch IPC retirement operation used by transition-completion tests.
+    let internal setRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests retirePreviousBranchIpc =
+        retirePreviousBranchWatchIpcForTransitionCompletion <- retirePreviousBranchIpc
+
+    /// Restores previous-branch IPC retirement to the production file-delete behavior after Watch tests.
+    let internal resetRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests () =
+        retirePreviousBranchWatchIpcForTransitionCompletion <- fun previousIpcFileName -> File.Delete(previousIpcFileName)
+
     /// Reloads repository configuration after another Grace process changes the current branch.
     let private reloadConfigurationForTransitionCompletion () =
         resetConfiguration ()
@@ -1893,7 +1904,7 @@ module Watch =
     /// Removes the previous branch IPC snapshot so stale healthy status cannot survive a branch transition.
     let private retirePreviousBranchWatchIpc previousIpcFileName =
         if File.Exists(previousIpcFileName) then
-            File.Delete(previousIpcFileName)
+            retirePreviousBranchWatchIpcForTransitionCompletion previousIpcFileName
 
             logToAnsiConsole Colors.Important $"Grace Watch retired previous branch IPC before completing branch transition: {previousIpcFileName}."
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1530,6 +1530,9 @@ module Watch =
     /// Reports whether an explicit resync scan must run before incremental observation application resumes.
     let private isGraceWatchResyncPending () = currentGraceWatchResyncAttempt () <> 0L
 
+    /// Reports whether an explicit resync scan is pending for Watch confidence-boundary tests.
+    let internal isGraceWatchResyncPendingForWatchTests () = isGraceWatchResyncPending ()
+
     /// Reports whether an in-flight resync attempt still owns the recovery boundary.
     let private isGraceWatchResyncAttemptCurrent attempt =
         attempt <> 0L
@@ -1910,10 +1913,7 @@ module Watch =
 
     /// Publishes a target-branch non-incremental snapshot when old IPC retirement is temporarily blocked.
     let private publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc failure =
-        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
-        graceStatusHasChanged <- true
-
-        lastPublishedHasPendingWatchWork <- None
+        requestGraceWatchExplicitResync $"previous branch IPC retirement failed: {failure}"
 
         logToAnsiConsole
             Colors.Error

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -464,6 +464,8 @@ module Watch =
 
     let private updateMarkerWatcherRebindLock = obj ()
     let mutable private rebindUpdateMarkerWatcherForTransitionCompletion = ignore
+    let private branchTransitionCompletionProbeLock = obj ()
+    let mutable private branchTransitionCompletionAfterRetireProbe = ignore
 
     /// Installs the active update-marker watcher retarget operation used after branch identity changes.
     let private registerUpdateMarkerWatcherRebind rebind =
@@ -485,6 +487,19 @@ module Watch =
     /// Restores the default no-op update-marker watcher retarget operation after transition-completion tests.
     let internal resetUpdateMarkerWatcherRebindForWatchTests () =
         lock updateMarkerWatcherRebindLock (fun () -> rebindUpdateMarkerWatcherForTransitionCompletion <- ignore)
+
+    /// Runs the transition-boundary probe after old branch IPC retirement but before branch identity reload.
+    let private runBranchTransitionCompletionAfterRetireProbe () =
+        let probe = lock branchTransitionCompletionProbeLock (fun () -> branchTransitionCompletionAfterRetireProbe)
+        probe ()
+
+    /// Installs a transition-boundary probe used to prove publishers cannot race old branch IPC retirement.
+    let internal setBranchTransitionCompletionAfterRetireProbeForWatchTests probe =
+        lock branchTransitionCompletionProbeLock (fun () -> branchTransitionCompletionAfterRetireProbe <- probe)
+
+    /// Restores the transition-boundary probe to the production no-op behavior after Watch tests.
+    let internal resetBranchTransitionCompletionAfterRetireProbeForWatchTests () =
+        lock branchTransitionCompletionProbeLock (fun () -> branchTransitionCompletionAfterRetireProbe <- ignore)
 
     /// Reloads repository configuration after another Grace process changes the current branch.
     let private reloadConfigurationForTransitionCompletion () =
@@ -588,23 +603,22 @@ module Watch =
         with
         | _ -> DeletedPathStatusUnavailable
 
+    /// Reports whether a marker completion instant is recent enough to suppress delayed Watch callbacks.
+    let private isRecentGraceUpdateMarkerCompletion completedUtc =
+        completedUtc <> DateTime.MinValue
+        && DateTime.UtcNow - completedUtc
+           <= graceUpdateMarkerDeletedObservationWindow
+
     /// Reads the switch-owned completion instant that should govern delayed Watch callback suppression.
     let private tryRecentGraceUpdateMarkerCompletedUtc () =
-        let markerCompletedUtc =
+        let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
+
+        if isRecentGraceUpdateMarkerCompletion recordedUtc then
+            Some recordedUtc
+        else
             match tryReadGraceUpdateMarkerCompletedUtc () with
-            | Some completedUtc -> Some completedUtc
-            | None ->
-                let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
-
-                if recordedUtc <> DateTime.MinValue then Some recordedUtc else None
-
-        match markerCompletedUtc with
-        | Some completedUtc when
-            DateTime.UtcNow - completedUtc
-            <= graceUpdateMarkerDeletedObservationWindow
-            ->
-            Some completedUtc
-        | _ -> None
+            | Some completedUtc when isRecentGraceUpdateMarkerCompletion completedUtc -> Some completedUtc
+            | _ -> None
 
     /// Reports whether a missing path is already absent from the post-switch GraceStatus snapshot.
     let private completedSwitchRemovedPathFromGraceStatus fullPath =
@@ -1862,75 +1876,83 @@ module Watch =
 
             logToAnsiConsole Colors.Important $"Grace Watch retired previous branch IPC before completing branch transition: {previousIpcFileName}."
 
-    /// Completes a Grace-owned branch transition after the update marker is cleanly deleted.
+    /// Completes a Grace-owned branch transition inside the serialized Watch publication boundary.
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
-        let previousIpcFileName = IpcFileName()
+        lock watchStatusPublishLock (fun () ->
+            recordGraceUpdateMarkerCompletedUtc completedUtc
+            let previousIpcFileName = IpcFileName()
 
-        let previousIpcRetired =
-            try
-                retirePreviousBranchWatchIpc previousIpcFileName
-                true
-            with
-            | ex ->
-                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
-                graceStatusHasChanged <- true
-
-                lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
-
-                logToAnsiConsole
-                    Colors.Error
-                    $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; incremental observations will not resume: {Markup.Escape(ex.Message)}."
-
-                false
-
-        if previousIpcRetired then
-            let reloadedConfiguration =
+            let previousIpcRetired =
                 try
-                    reloadConfigurationForTransitionCompletion ()
-                    rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+                    retirePreviousBranchWatchIpc previousIpcFileName
                     true
                 with
                 | ex ->
                     setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
                     graceStatusHasChanged <- true
 
-                    lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
+                    lastPublishedHasPendingWatchWork <- None
 
                     logToAnsiConsole
                         Colors.Error
-                        $"Grace Watch could not reload configuration or rebind marker watcher after transition marker deletion at {completedUtc:O}; old branch IPC will not be republished: {Markup.Escape(ex.Message)}."
+                        $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; incremental observations will not resume: {Markup.Escape(ex.Message)}."
 
                     false
 
-            if reloadedConfiguration then
-                try
-                    let refreshedStatus =
-                        readGraceStatusFileForTransitionCompletion()
-                            .GetAwaiter()
-                            .GetResult()
+            if previousIpcRetired then
+                runBranchTransitionCompletionAfterRetireProbe ()
 
-                    graceStatus <- refreshedStatus
-                    updateGraceStatusDirectoryIds graceStatus
+                let reloadedConfiguration =
+                    try
+                        reloadConfigurationForTransitionCompletion ()
+                        rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+                        true
+                    with
+                    | ex ->
+                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+                        graceStatusHasChanged <- true
 
-                    if isTransitionCompletionConfigurationCoherent ()
-                       && isTransitionCompletionGraceStatusCoherent graceStatus then
-                        if
-                            currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
-                            && not (isGraceWatchResyncPending ())
-                        then
-                            publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
-                                updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
+                        lastPublishedHasPendingWatchWork <- None
 
-                            logToAnsiConsole
-                                Colors.Important
-                                $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                        logToAnsiConsole
+                            Colors.Error
+                            $"Grace Watch could not reload configuration or rebind marker watcher after transition marker deletion at {completedUtc:O}; old branch IPC will not be republished: {Markup.Escape(ex.Message)}."
+
+                        false
+
+                if reloadedConfiguration then
+                    try
+                        let refreshedStatus =
+                            readGraceStatusFileForTransitionCompletion()
+                                .GetAwaiter()
+                                .GetResult()
+
+                        graceStatus <- refreshedStatus
+                        updateGraceStatusDirectoryIds graceStatus
+
+                        if isTransitionCompletionConfigurationCoherent ()
+                           && isTransitionCompletionGraceStatusCoherent graceStatus then
+                            if
+                                currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                                && not (isGraceWatchResyncPending ())
+                            then
+                                let transitionPublicationVerified =
+                                    tryPublishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                                        updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
+
+                                if transitionPublicationVerified then
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                                else
+                                    requestGraceWatchExplicitResync "branch transition completion could not verify new branch IPC publication"
+                            else
+                                publishNonIncrementalTransitionCompletionStatus
+                                    $"runtime mode is {currentGraceWatchRuntimeMode ()} and resync pending is {isGraceWatchResyncPending ()}"
                         else
-                            publishNonIncrementalTransitionCompletionStatus
-                                $"runtime mode is {currentGraceWatchRuntimeMode ()} and resync pending is {isGraceWatchResyncPending ()}"
-                    else
-                        requestGraceWatchExplicitResync "branch transition completion reloaded incoherent configuration or GraceStatus"
-                with
-                | ex -> requestGraceWatchExplicitResync $"branch transition completion could not reload GraceStatus: {ex.Message}"
+                            requestGraceWatchExplicitResync "branch transition completion reloaded incoherent configuration or GraceStatus"
+                    with
+                    | ex -> requestGraceWatchExplicitResync $"branch transition completion could not reload GraceStatus: {ex.Message}")
 
     /// Combines status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
@@ -2034,6 +2056,7 @@ module Watch =
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
         readGraceStatusFileForTransitionCompletion <- readGraceStatusFile
+        resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         clearGraceUpdateMarkerDeletedUtc ()
@@ -2508,7 +2531,6 @@ module Watch =
             if updateNotInProgress () then
                 match tryReadGraceUpdateMarkerCompletedUtc () with
                 | Some completedUtc ->
-                    recordGraceUpdateMarkerCompletedUtc completedUtc
                     completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
                     logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
                 | None ->

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -253,12 +253,20 @@ module Watch =
     let updateInProgress () = File.Exists(updateInProgressFileName ())
     /// Coordinates update not in progress behavior for this CLI command path.
     let updateNotInProgress () = not <| updateInProgress ()
+
+    /// Reports whether the deleted callback path is an update marker path owned by any branch temp directory.
+    let private isUpdateMarkerPath (markerFileName: string) =
+        String.Equals(Path.GetFileName(markerFileName), Constants.UpdateInProgressFileName, StringComparison.OrdinalIgnoreCase)
+
     let private graceUpdateMarkerDeletionLock = obj ()
     let private graceUpdateMarkerDeletedObservationWindow = TimeSpan.FromSeconds(30.0)
     let mutable private lastGraceUpdateMarkerDeletedUtc = DateTime.MinValue
 
     /// Gets the completion sidecar written before the Grace update marker is removed.
     let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
+
+    /// Gets the completion sidecar paired with a specific update marker callback path.
+    let private updateMarkerCompletedFileNameForMarker markerFileName = markerFileName + ".completed"
 
     /// Records the completed Grace-owned update instant so delayed callbacks can be classified by switch authority.
     let private recordGraceUpdateMarkerCompletedUtc completedUtc =
@@ -276,14 +284,15 @@ module Watch =
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
 
+    /// Clears delayed-observation authority without deleting any branch-specific marker sidecar.
+    let private clearGraceUpdateMarkerDeletedObservation () = recordGraceUpdateMarkerCompletedUtc DateTime.MinValue
+
     /// Sets the recent Grace update marker deletion instant for deterministic Watch callback tests.
     let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc = recordGraceUpdateMarkerCompletedUtc deletedUtc
 
-    /// Reads the marker completion sidecar when a file callback arrives before Watch observes marker deletion.
-    let private tryReadGraceUpdateMarkerCompletedUtc () =
+    /// Reads a marker completion sidecar for the specific marker path that produced the callback.
+    let private tryReadGraceUpdateMarkerCompletedUtcFrom completedFileName =
         try
-            let completedFileName = updateMarkerCompletedFileName ()
-
             if File.Exists(completedFileName) then
                 match DateTime.TryParse(File.ReadAllText(completedFileName), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind) with
                 | true, completedUtc -> Some completedUtc
@@ -293,6 +302,17 @@ module Watch =
         with
         | :? IOException -> None
         | :? UnauthorizedAccessException -> None
+
+    /// Reads the marker completion sidecar when a file callback arrives before Watch observes marker deletion.
+    let private tryReadGraceUpdateMarkerCompletedUtc () =
+        updateMarkerCompletedFileName ()
+        |> tryReadGraceUpdateMarkerCompletedUtcFrom
+
+    /// Reads the completion instant for the marker whose deletion callback is being processed.
+    let private tryReadGraceUpdateMarkerCompletedUtcForMarker markerFileName =
+        markerFileName
+        |> updateMarkerCompletedFileNameForMarker
+        |> tryReadGraceUpdateMarkerCompletedUtcFrom
 
     /// Reports whether the completed sidecar was written for the marker that is currently still present.
     let private currentUpdateMarkerMatchesCompletedSidecar completedUtc =
@@ -504,6 +524,7 @@ module Watch =
     /// Reloads repository configuration after another Grace process changes the current branch.
     let private reloadConfigurationForTransitionCompletion () =
         resetConfiguration ()
+        clearShouldIgnoreCache ()
         Current() |> ignore
         configureWatchPathComparisonForCurrentRepository ()
 
@@ -1876,6 +1897,27 @@ module Watch =
 
             logToAnsiConsole Colors.Important $"Grace Watch retired previous branch IPC before completing branch transition: {previousIpcFileName}."
 
+    /// Publishes a target-branch non-incremental snapshot when old IPC retirement is temporarily blocked.
+    let private publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc failure =
+        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+        graceStatusHasChanged <- true
+
+        lastPublishedHasPendingWatchWork <- None
+
+        logToAnsiConsole
+            Colors.Error
+            $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; publishing target branch resync IPC instead: {Markup.Escape(failure)}."
+
+        try
+            reloadConfigurationForTransitionCompletion ()
+            rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+            publishNonIncrementalTransitionCompletionStatus $"previous branch IPC retirement failed: {failure}"
+        with
+        | ex ->
+            logToAnsiConsole
+                Colors.Error
+                $"Grace Watch could not publish target branch resync IPC after previous branch IPC retirement failed at {completedUtc:O}: {Markup.Escape(ex.Message)}."
+
     /// Completes a Grace-owned branch transition inside the serialized Watch publication boundary.
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
         lock watchStatusPublishLock (fun () ->
@@ -1888,15 +1930,7 @@ module Watch =
                     true
                 with
                 | ex ->
-                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
-                    graceStatusHasChanged <- true
-
-                    lastPublishedHasPendingWatchWork <- None
-
-                    logToAnsiConsole
-                        Colors.Error
-                        $"Grace Watch could not retire previous branch IPC after transition marker deletion at {completedUtc:O}; incremental observations will not resume: {Markup.Escape(ex.Message)}."
-
+                    publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc ex.Message
                     false
 
             if previousIpcRetired then
@@ -2056,6 +2090,7 @@ module Watch =
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
         readGraceStatusFileForTransitionCompletion <- readGraceStatusFile
+        clearShouldIgnoreCache ()
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
@@ -2527,14 +2562,14 @@ module Watch =
 
     /// Coordinates on grace update in progress deleted behavior for this CLI command path.
     let OnGraceUpdateInProgressDeleted (args: FileSystemEventArgs) =
-        if args.FullPath = updateInProgressFileName () then
-            if updateNotInProgress () then
-                match tryReadGraceUpdateMarkerCompletedUtc () with
+        if isUpdateMarkerPath args.FullPath then
+            if not (File.Exists(args.FullPath)) then
+                match tryReadGraceUpdateMarkerCompletedUtcForMarker args.FullPath with
                 | Some completedUtc ->
                     completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
                     logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
                 | None ->
-                    clearGraceUpdateMarkerDeletedUtc ()
+                    clearGraceUpdateMarkerDeletedObservation ()
                     logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -260,7 +260,7 @@ module Watch =
 
     let private graceUpdateMarkerDeletionLock = obj ()
     let private graceUpdateMarkerDeletedObservationWindow = TimeSpan.FromSeconds(30.0)
-    let mutable private lastGraceUpdateMarkerDeletedUtc = DateTime.MinValue
+    let private recentGraceUpdateMarkerCompletedUtc = List<DateTime>()
 
     /// Gets the completion sidecar written before the Grace update marker is removed.
     let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
@@ -270,12 +270,22 @@ module Watch =
 
     /// Records the completed Grace-owned update instant so delayed callbacks can be classified by switch authority.
     let private recordGraceUpdateMarkerCompletedUtc completedUtc =
-        lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc <- completedUtc)
+        lock graceUpdateMarkerDeletionLock (fun () ->
+            if completedUtc <> DateTime.MinValue then
+                let cutoffUtc =
+                    DateTime.UtcNow
+                    - graceUpdateMarkerDeletedObservationWindow
 
-    /// Clears the recent marker-deletion fact when a new Grace-owned update starts or tests reset Watch state.
-    let private clearGraceUpdateMarkerDeletedUtc () =
-        recordGraceUpdateMarkerCompletedUtc DateTime.MinValue
+                recentGraceUpdateMarkerCompletedUtc.RemoveAll(fun recordedUtc -> recordedUtc < cutoffUtc)
+                |> ignore
 
+                recentGraceUpdateMarkerCompletedUtc.Add(completedUtc))
+
+    /// Clears every recent marker-deletion fact when tests reset Watch state.
+    let private clearGraceUpdateMarkerDeletedUtcForReset () = lock graceUpdateMarkerDeletionLock (fun () -> recentGraceUpdateMarkerCompletedUtc.Clear())
+
+    /// Removes the current marker sidecar when a new marker supersedes stale sidecar evidence.
+    let private clearCurrentGraceUpdateMarkerCompletedSidecar () =
         try
             let completedFileName = updateMarkerCompletedFileName ()
 
@@ -284,11 +294,10 @@ module Watch =
         | :? IOException -> ()
         | :? UnauthorizedAccessException -> ()
 
-    /// Clears delayed-observation authority without deleting any branch-specific marker sidecar.
-    let private clearGraceUpdateMarkerDeletedObservation () = recordGraceUpdateMarkerCompletedUtc DateTime.MinValue
-
     /// Sets the recent Grace update marker deletion instant for deterministic Watch callback tests.
-    let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc = recordGraceUpdateMarkerCompletedUtc deletedUtc
+    let internal recordGraceUpdateMarkerDeletedUtcForTests deletedUtc =
+        clearGraceUpdateMarkerDeletedUtcForReset ()
+        recordGraceUpdateMarkerCompletedUtc deletedUtc
 
     /// Reads a marker completion sidecar for the specific marker path that produced the callback.
     let private tryReadGraceUpdateMarkerCompletedUtcFrom completedFileName =
@@ -643,11 +652,22 @@ module Watch =
 
     /// Reads the switch-owned completion instant that should govern delayed Watch callback suppression.
     let private tryRecentGraceUpdateMarkerCompletedUtc () =
-        let recordedUtc = lock graceUpdateMarkerDeletionLock (fun () -> lastGraceUpdateMarkerDeletedUtc)
+        let recordedUtc =
+            lock graceUpdateMarkerDeletionLock (fun () ->
+                let cutoffUtc =
+                    DateTime.UtcNow
+                    - graceUpdateMarkerDeletedObservationWindow
 
-        if isRecentGraceUpdateMarkerCompletion recordedUtc then
-            Some recordedUtc
-        else
+                recentGraceUpdateMarkerCompletedUtc.RemoveAll(fun completedUtc -> completedUtc < cutoffUtc)
+                |> ignore
+
+                recentGraceUpdateMarkerCompletedUtc
+                |> Seq.sortDescending
+                |> Seq.tryHead)
+
+        match recordedUtc with
+        | Some completedUtc when isRecentGraceUpdateMarkerCompletion completedUtc -> Some completedUtc
+        | _ ->
             match tryReadGraceUpdateMarkerCompletedUtc () with
             | Some completedUtc when isRecentGraceUpdateMarkerCompletion completedUtc -> Some completedUtc
             | _ -> None
@@ -2105,7 +2125,8 @@ module Watch =
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
-        clearGraceUpdateMarkerDeletedUtc ()
+        clearGraceUpdateMarkerDeletedUtcForReset ()
+        clearCurrentGraceUpdateMarkerCompletedSidecar ()
         watchPathComparison <- defaultWatchPathComparison ()
         watchPathComparisonOverride <- None
         watchPathComparisonConfiguredRoot <- None
@@ -2565,11 +2586,19 @@ module Watch =
                     | Some completedUtc -> currentUpdateMarkerMatchesCompletedSidecar completedUtc
                     | None -> false
 
-                if not hasCurrentCompletedSidecar then clearGraceUpdateMarkerDeletedUtc ()
+                if not hasCurrentCompletedSidecar then
+                    clearCurrentGraceUpdateMarkerCompletedSidecar ()
 
                 logToAnsiConsole Colors.Important $"Update is in progress from another Grace instance."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should already exist, but it doesn't."
+
+    /// Reports whether a marker deletion callback still owns branch transition completion authority.
+    let private deletedMarkerCanCompleteCurrentTransition markerFileName =
+        let currentMarkerFileName = updateInProgressFileName ()
+
+        String.Equals(markerFileName, currentMarkerFileName, StringComparison.OrdinalIgnoreCase)
+        || not (File.Exists(currentMarkerFileName))
 
     /// Coordinates on grace update in progress deleted behavior for this CLI command path.
     let OnGraceUpdateInProgressDeleted (args: FileSystemEventArgs) =
@@ -2577,11 +2606,16 @@ module Watch =
             if not (File.Exists(args.FullPath)) then
                 match tryReadGraceUpdateMarkerCompletedUtcForMarker args.FullPath with
                 | Some completedUtc ->
-                    completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
-                    logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
-                | None ->
-                    clearGraceUpdateMarkerDeletedObservation ()
-                    logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
+                    if deletedMarkerCanCompleteCurrentTransition args.FullPath then
+                        completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
+                        logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
+                    else
+                        recordGraceUpdateMarkerCompletedUtc completedUtc
+
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Ignored stale update marker deletion for {args.FullPath}; current marker {updateInProgressFileName ()} is still live."
+                | None -> logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -359,16 +359,46 @@ module Watch =
         | :? IOException -> false
         | :? UnauthorizedAccessException -> false
 
-    /// Proves a deleted marker sidecar was written for the marker instance Watch observed.
-    let private deletedMarkerMatchesCompletedSidecar markerFileName completedUtc =
+    /// Classifies whether a deleted marker sidecar can be trusted for branch transition authority.
+    type private DeletedMarkerSidecarAuthority =
+        | ObservedCurrentMarker
+        | ObservedStaleMarker
+        | UnobservedMarker
+
+    /// Proves whether a deleted marker sidecar was written for the marker instance Watch observed.
+    let private classifyDeletedMarkerCompletedSidecar markerFileName completedUtc =
         lock graceUpdateMarkerDeletionLock (fun () ->
             match observedGraceUpdateMarkerLastWriteUtc.TryGetValue(markerFileName) with
             | true, markerLastWriteUtc ->
                 observedGraceUpdateMarkerLastWriteUtc.Remove(markerFileName)
                 |> ignore
 
-                markerLastWriteUtc <= completedUtc
-            | false, _ -> false)
+                if markerLastWriteUtc <= completedUtc then
+                    ObservedCurrentMarker
+                else
+                    ObservedStaleMarker
+            | false, _ -> UnobservedMarker)
+
+    /// Reports whether a deleted marker path is the current transition marker Watch was expected to observe.
+    let private deletedMarkerIsCurrentMarker markerFileName = String.Equals(markerFileName, updateInProgressFileName (), StringComparison.OrdinalIgnoreCase)
+
+    /// Reports whether the on-disk repository config has moved beyond Watch's cached branch identity.
+    let private persistedConfigurationChangedSinceWatchCached () =
+        try
+            let cached = Current()
+
+            match tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection ->
+                let persisted = inspection.Configuration
+
+                cached.RepositoryId <> persisted.RepositoryId
+                || not (String.Equals(cached.RepositoryName, persisted.RepositoryName, StringComparison.OrdinalIgnoreCase))
+                || cached.BranchId <> persisted.BranchId
+                || not (String.Equals(cached.BranchName, persisted.BranchName, StringComparison.OrdinalIgnoreCase))
+                || not (String.Equals(cached.RootDirectory, persisted.RootDirectory, StringComparison.OrdinalIgnoreCase))
+            | Error _ -> false
+        with
+        | _ -> false
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.
     type private DeletedPathKind =
@@ -2655,20 +2685,34 @@ module Watch =
         if isUpdateMarkerPath args.FullPath then
             if not (File.Exists(args.FullPath)) then
                 match tryReadGraceUpdateMarkerCompletedUtcForMarker args.FullPath with
-                | Some completedUtc when deletedMarkerMatchesCompletedSidecar args.FullPath completedUtc ->
-                    if deletedMarkerCanCompleteCurrentTransition args.FullPath then
+                | Some completedUtc ->
+                    match classifyDeletedMarkerCompletedSidecar args.FullPath completedUtc with
+                    | ObservedCurrentMarker ->
+                        if deletedMarkerCanCompleteCurrentTransition args.FullPath then
+                            completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
+                            logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
+                        else
+                            recordGraceUpdateMarkerCompletedUtc completedUtc
+
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Ignored stale update marker deletion for {args.FullPath}; current marker {updateInProgressFileName ()} is still live."
+                    | UnobservedMarker when
+                        deletedMarkerIsCurrentMarker args.FullPath
+                        && isRecentGraceUpdateMarkerCompletion completedUtc
+                        && persistedConfigurationChangedSinceWatchCached ()
+                        ->
+                        requestGraceWatchExplicitResync "branch transition marker deletion had a fresh completion sidecar but no observed marker creation"
                         completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
-                        logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
-                    else
-                        recordGraceUpdateMarkerCompletedUtc completedUtc
 
                         logToAnsiConsole
                             Colors.Important
-                            $"Ignored stale update marker deletion for {args.FullPath}; current marker {updateInProgressFileName ()} is still live."
-                | Some _ ->
-                    logToAnsiConsole
-                        Colors.Important
-                        $"Update marker ended with a stale completed sidecar for {args.FullPath}; delayed observations will be processed normally."
+                            $"Update marker ended with an unobserved fresh completed sidecar for {args.FullPath}; grace watch is resynchronizing before incremental work resumes."
+                    | ObservedStaleMarker
+                    | UnobservedMarker ->
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Update marker ended with a stale completed sidecar for {args.FullPath}; delayed observations will be processed normally."
                 | None ->
                     forgetObservedGraceUpdateMarkerInstance args.FullPath
                     logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -460,6 +460,13 @@ module Watch =
     let mutable private readGraceStatusFileForDeletedPathClassification = readGraceStatusFile
 
     let mutable private readGraceStatusFileForPendingWorkTransition = readGraceStatusFile
+    let mutable private readGraceStatusFileForTransitionCompletion = readGraceStatusFile
+
+    /// Reloads repository configuration after another Grace process changes the current branch.
+    let private reloadConfigurationForTransitionCompletion () =
+        resetConfiguration ()
+        Current() |> ignore
+        configureWatchPathComparisonForCurrentRepository ()
 
     let mutable private enumerateFilesForDirectoryUpload = fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
 
@@ -638,6 +645,8 @@ module Watch =
 
     /// Coordinates set grace status for watch tests behavior for this CLI command path.
     let internal setGraceStatusForWatchTests status = graceStatus <- status
+    /// Replaces Watch's cached directory identity set after a trusted GraceStatus reload.
+    let internal updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
     /// Reads the in-memory Grace Status snapshot so transition-publication tests can prove state isolation.
     let internal graceStatusForWatchTests () = graceStatus
     /// Reads the in-memory Grace Status directory identities so transition-publication tests can prove state isolation.
@@ -659,9 +668,14 @@ module Watch =
             graceStatusHasChanged <- false
 
     /// Coordinates set read grace status file for watch tests behavior for this CLI command path.
-    let internal setReadGraceStatusFileForWatchTests readStatusFile = readGraceStatusFileForDeletedPathClassification <- readStatusFile
+    let internal setReadGraceStatusFileForWatchTests readStatusFile =
+        readGraceStatusFileForDeletedPathClassification <- readStatusFile
+        readGraceStatusFileForTransitionCompletion <- readStatusFile
+
     /// Sets the Grace Status reader used by pending-work transition tests.
     let internal setReadGraceStatusFileForPendingWorkTransitionForWatchTests readStatusFile = readGraceStatusFileForPendingWorkTransition <- readStatusFile
+    /// Sets the Grace Status reader used by branch-transition completion tests.
+    let internal setReadGraceStatusFileForTransitionCompletionForWatchTests readStatusFile = readGraceStatusFileForTransitionCompletion <- readStatusFile
     /// Reads set enumerate files for directory upload for watch tests data needed by the command workflow without changing remote state.
     let internal setEnumerateFilesForDirectoryUploadForWatchTests enumerateFiles = enumerateFilesForDirectoryUpload <- enumerateFiles
 
@@ -1774,6 +1788,98 @@ module Watch =
     /// Counts quarantined observations for tests that verify confidence loss does not replay stale work.
     let internal quarantinedWatchObservationCountForWatchTests () = Volatile.Read(&quarantinedWatchObservationCount)
 
+    /// Verifies a reloaded branch configuration has enough identity to own a branch-scoped Watch IPC file.
+    let private isTransitionCompletionConfigurationCoherent () =
+        let current = Current()
+
+        let hasRepositoryIdentity =
+            current.RepositoryId <> RepositoryId.Empty
+            || not (String.IsNullOrWhiteSpace(string current.RepositoryName))
+
+        let hasBranchIdentity =
+            current.BranchId <> BranchId.Empty
+            || not (String.IsNullOrWhiteSpace(string current.BranchName))
+
+        hasRepositoryIdentity
+        && hasBranchIdentity
+        && not (String.IsNullOrWhiteSpace current.RootDirectory)
+        && Directory.Exists(current.RootDirectory)
+
+    /// Verifies a reloaded GraceStatus can support a trusted incremental Watch snapshot after branch switch.
+    let private isTransitionCompletionGraceStatusCoherent (status: GraceStatus) =
+        let hasRootIdentity =
+            status.RootDirectoryId <> DirectoryVersionId.Empty
+            && not (String.IsNullOrWhiteSpace($"{status.RootDirectorySha256Hash}"))
+            && not (String.IsNullOrWhiteSpace($"{status.RootDirectoryBlake3Hash}"))
+
+        let mutable rootDirectoryVersion = LocalDirectoryVersion.Default
+
+        hasRootIdentity
+        && not (isNull status.Index)
+        && status.Index.TryGetValue(status.RootDirectoryId, &rootDirectoryVersion)
+        && rootDirectoryVersion.Sha256Hash = status.RootDirectorySha256Hash
+        && rootDirectoryVersion.Blake3Hash = status.RootDirectoryBlake3Hash
+
+    /// Publishes a branch-scoped non-incremental transition snapshot when Watch cannot safely resume.
+    let private publishNonIncrementalTransitionCompletionStatus context =
+        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+
+        publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+            match currentGraceWatchRuntimeMode () with
+            | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
+            | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some emptyDirectoryIds))
+
+        logToAnsiConsole Colors.Important $"Grace Watch published non-incremental IPC for branch transition completion: {context}."
+
+    /// Completes a Grace-owned branch transition after the update marker is cleanly deleted.
+    let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
+        let reloadedConfiguration =
+            try
+                reloadConfigurationForTransitionCompletion ()
+                true
+            with
+            | ex ->
+                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+                graceStatusHasChanged <- true
+
+                lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
+
+                logToAnsiConsole
+                    Colors.Error
+                    $"Grace Watch could not reload configuration after transition marker deletion at {completedUtc:O}; old branch IPC will not be republished: {Markup.Escape(ex.Message)}."
+
+                false
+
+        if reloadedConfiguration then
+            try
+                let refreshedStatus =
+                    readGraceStatusFileForTransitionCompletion()
+                        .GetAwaiter()
+                        .GetResult()
+
+                graceStatus <- refreshedStatus
+                updateGraceStatusDirectoryIds graceStatus
+
+                if isTransitionCompletionConfigurationCoherent ()
+                   && isTransitionCompletionGraceStatusCoherent graceStatus then
+                    if
+                        currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                        && not (isGraceWatchResyncPending ())
+                    then
+                        publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
+
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                    else
+                        publishNonIncrementalTransitionCompletionStatus
+                            $"runtime mode is {currentGraceWatchRuntimeMode ()} and resync pending is {isGraceWatchResyncPending ()}"
+                else
+                    requestGraceWatchExplicitResync "branch transition completion reloaded incoherent configuration or GraceStatus"
+            with
+            | ex -> requestGraceWatchExplicitResync $"branch transition completion could not reload GraceStatus: {ex.Message}"
+
     /// Combines status differences without applying the same filesystem observation twice.
     let private mergeStatusDifferences (first: List<FileSystemDifference>) (second: List<FileSystemDifference>) =
         let merged = List<FileSystemDifference>()
@@ -1875,6 +1981,7 @@ module Watch =
 
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
+        readGraceStatusFileForTransitionCompletion <- readGraceStatusFile
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         clearGraceUpdateMarkerDeletedUtc ()
@@ -2350,6 +2457,7 @@ module Watch =
                 match tryReadGraceUpdateMarkerCompletedUtc () with
                 | Some completedUtc ->
                     recordGraceUpdateMarkerCompletedUtc completedUtc
+                    completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
                     logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
                 | None ->
                     clearGraceUpdateMarkerDeletedUtc ()
@@ -2660,9 +2768,6 @@ module Watch =
             do! gzStream.DisposeAsync()
             graceStatus <- GraceStatus.Default
         }
-
-    /// Coordinates update grace status directory ids behavior for this CLI command path.
-    let updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
 
     /// Publishes a trusted Watch IPC snapshot only when incremental mode is currently safe for other processes.
     let private tryPublishGraceWatchInterprocessFileForCurrentConfidence trustedStatus directoryIds updateGraceWatchInterprocessFileClient context =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -261,6 +261,7 @@ module Watch =
     let private graceUpdateMarkerDeletionLock = obj ()
     let private graceUpdateMarkerDeletedObservationWindow = TimeSpan.FromSeconds(30.0)
     let private recentGraceUpdateMarkerCompletedUtc = List<DateTime>()
+    let private observedGraceUpdateMarkerLastWriteUtc = Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase)
 
     /// Gets the completion sidecar written before the Grace update marker is removed.
     let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
@@ -282,7 +283,10 @@ module Watch =
                 recentGraceUpdateMarkerCompletedUtc.Add(completedUtc))
 
     /// Clears every recent marker-deletion fact when tests reset Watch state.
-    let private clearGraceUpdateMarkerDeletedUtcForReset () = lock graceUpdateMarkerDeletionLock (fun () -> recentGraceUpdateMarkerCompletedUtc.Clear())
+    let private clearGraceUpdateMarkerDeletedUtcForReset () =
+        lock graceUpdateMarkerDeletionLock (fun () ->
+            recentGraceUpdateMarkerCompletedUtc.Clear()
+            observedGraceUpdateMarkerLastWriteUtc.Clear())
 
     /// Removes the current marker sidecar when a new marker supersedes stale sidecar evidence.
     let private clearCurrentGraceUpdateMarkerCompletedSidecar () =
@@ -323,14 +327,48 @@ module Watch =
         |> updateMarkerCompletedFileNameForMarker
         |> tryReadGraceUpdateMarkerCompletedUtcFrom
 
-    /// Reports whether the completed sidecar was written for the marker that is currently still present.
+    /// Records marker file freshness while the marker still exists so deletion cannot trust stale sidecars.
+    let private observeGraceUpdateMarkerInstance markerFileName =
+        try
+            if File.Exists(markerFileName) then
+                lock graceUpdateMarkerDeletionLock (fun () -> observedGraceUpdateMarkerLastWriteUtc[markerFileName] <- File.GetLastWriteTimeUtc(markerFileName))
+        with
+        | :? IOException -> ()
+        | :? UnauthorizedAccessException -> ()
+
+    /// Retires marker freshness state after a deletion callback consumes or rejects it.
+    let private forgetObservedGraceUpdateMarkerInstance markerFileName =
+        lock graceUpdateMarkerDeletionLock (fun () ->
+            observedGraceUpdateMarkerLastWriteUtc.Remove(markerFileName)
+            |> ignore)
+
+    /// Reports whether the completed sidecar was written for the current marker instance Watch observed.
     let private currentUpdateMarkerMatchesCompletedSidecar completedUtc =
         try
-            File.GetLastWriteTimeUtc(updateInProgressFileName ())
-            <= completedUtc
+            let currentMarkerFileName = updateInProgressFileName ()
+
+            if File.Exists(currentMarkerFileName) then
+                File.GetLastWriteTimeUtc(currentMarkerFileName)
+                <= completedUtc
+            else
+                lock graceUpdateMarkerDeletionLock (fun () ->
+                    match observedGraceUpdateMarkerLastWriteUtc.TryGetValue(currentMarkerFileName) with
+                    | true, markerLastWriteUtc -> markerLastWriteUtc <= completedUtc
+                    | false, _ -> false)
         with
         | :? IOException -> false
         | :? UnauthorizedAccessException -> false
+
+    /// Proves a deleted marker sidecar was written for the marker instance Watch observed.
+    let private deletedMarkerMatchesCompletedSidecar markerFileName completedUtc =
+        lock graceUpdateMarkerDeletionLock (fun () ->
+            match observedGraceUpdateMarkerLastWriteUtc.TryGetValue(markerFileName) with
+            | true, markerLastWriteUtc ->
+                observedGraceUpdateMarkerLastWriteUtc.Remove(markerFileName)
+                |> ignore
+
+                markerLastWriteUtc <= completedUtc
+            | false, _ -> false)
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.
     type private DeletedPathKind =
@@ -665,12 +703,21 @@ module Watch =
                 |> Seq.sortDescending
                 |> Seq.tryHead)
 
-        match recordedUtc with
-        | Some completedUtc when isRecentGraceUpdateMarkerCompletion completedUtc -> Some completedUtc
-        | _ ->
+        let currentSidecarUtc =
             match tryReadGraceUpdateMarkerCompletedUtc () with
-            | Some completedUtc when isRecentGraceUpdateMarkerCompletion completedUtc -> Some completedUtc
+            | Some completedUtc when
+                isRecentGraceUpdateMarkerCompletion completedUtc
+                && currentUpdateMarkerMatchesCompletedSidecar completedUtc
+                ->
+                Some completedUtc
             | _ -> None
+
+        match currentSidecarUtc, recordedUtc with
+        | Some currentCompletedUtc, Some recordedCompletedUtc when isRecentGraceUpdateMarkerCompletion recordedCompletedUtc ->
+            Some(max currentCompletedUtc recordedCompletedUtc)
+        | Some currentCompletedUtc, _ -> Some currentCompletedUtc
+        | None, Some recordedCompletedUtc when isRecentGraceUpdateMarkerCompletion recordedCompletedUtc -> Some recordedCompletedUtc
+        | None, _ -> None
 
     /// Reports whether a missing path is already absent from the post-switch GraceStatus snapshot.
     let private completedSwitchRemovedPathFromGraceStatus fullPath =
@@ -2579,6 +2626,9 @@ module Watch =
 
     /// Coordinates on grace update in progress created behavior for this CLI command path.
     let OnGraceUpdateInProgressCreated (args: FileSystemEventArgs) =
+        if isUpdateMarkerPath args.FullPath then
+            observeGraceUpdateMarkerInstance args.FullPath
+
         if args.FullPath = updateInProgressFileName () then
             if updateInProgress () then
                 let hasCurrentCompletedSidecar =
@@ -2605,7 +2655,7 @@ module Watch =
         if isUpdateMarkerPath args.FullPath then
             if not (File.Exists(args.FullPath)) then
                 match tryReadGraceUpdateMarkerCompletedUtcForMarker args.FullPath with
-                | Some completedUtc ->
+                | Some completedUtc when deletedMarkerMatchesCompletedSidecar args.FullPath completedUtc ->
                     if deletedMarkerCanCompleteCurrentTransition args.FullPath then
                         completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
                         logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
@@ -2615,7 +2665,13 @@ module Watch =
                         logToAnsiConsole
                             Colors.Important
                             $"Ignored stale update marker deletion for {args.FullPath}; current marker {updateInProgressFileName ()} is still live."
-                | None -> logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
+                | Some _ ->
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Update marker ended with a stale completed sidecar for {args.FullPath}; delayed observations will be processed normally."
+                | None ->
+                    forgetObservedGraceUpdateMarkerInstance args.FullPath
+                    logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."
 


### PR DESCRIPTION
## Summary

- Complete the Watch branch transition when the branch-switch update marker is deleted.
- Reload cached config and `GraceStatus`, update Watch's in-memory branch/root state, and publish through the refreshed
  branch-scoped IPC identity.
- Publish healthy incremental status only when the refreshed config/status are coherent; otherwise move Watch to resync
  without advertising the old branch.
- Cover the #535 carry-forward finding with tests for branch A to branch B transition without Watch restart, branch B
  IPC identity/path publication, incoherent transition refusal, and startup marker handling.

## Related Issue

References #495. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This advances WS5 by letting `grace watch` follow a clean same-process branch switch without restart. The change keeps
Watch's IPC status aligned with the branch that `grace switch` just wrote, so subsequent branch-switch preflight checks
inspect the correct branch-scoped status instead of stale pre-switch identity.

## Validation

- Targeted Fantomas passed for `src/Grace.CLI/Command/Watch.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs`.
- Focused Watch tests passed before formatting: 195/195.
- Focused Watch tests passed after formatting: 195/195.
- Final gate `pwsh ./scripts/validate.ps1 -Fast` passed with a 0-warning, 0-error build and fast tests green.
- `git diff --check` passed.

## Docs Impact

No docs changed. This changes internal Watch transition and IPC behavior under existing `grace watch` semantics without
changing public command syntax, options, examples, or documented user workflow.

## Explicit Deferrals

- #496: SignalR subscription refresh and WS5 ADR remain out of scope.
- Remote sync materialization remains Workstream 7.
- Durable journal authority remains Workstream 4.
- #494 marker timing, completion authority, suppression, and lease behavior are consumed as trusted inputs and are not
  reopened here.

## Review Status

- Current head: `348fb1dfa7529d6b5273eaabfeb437da0bdc1f09`.
- GitHub checks: `full:COMPLETED:SUCCESS` for `348fb1df`, completed 2026-07-04T17:32:16Z.
- Codex Code Review Bot current-head gate: 👍🏻 no-issues reaction on `348fb1df`; no current-head review threads.
- Latest completed Codex Code Review Bot review with findings: review `4629986952`, submitted
  2026-07-04T17:11:39Z on prior head `8b0331569ac8e3e84fa4a674cb688558d00d77d2`.
- Fresh finding from `4629986952` fixed by `348fb1dfa7529d6b5273eaabfeb437da0bdc1f09`:
  - `r3523572831`: previous-branch IPC downgrade/retire is now retried and verified before target-branch publication
    proceeds after old-IPC retire failure. Reply/resolution:
    [discussion_r3523591352](https://github.com/ScottArbeit/Grace/pull/538#discussion_r3523591352).
- Worker Wegener validation for `348fb1df`: targeted Fantomas passed; focused Watch tests passed 209/209;
  `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed; bot-prevention self-review passed.
- Older unresolved threads from `ec95775d` are stale relative to the current head and were not used to assign code work
  unless repeated on a current-head review. The current-head Codex pass did not repeat them.
- Stabilization ledger: [PR comment #4882521709](https://github.com/ScottArbeit/Grace/pull/538#issuecomment-4882521709)
  plus current-head update [#4882684402](https://github.com/ScottArbeit/Grace/pull/538#issuecomment-4882684402).
- Prevention line: #495 transition completion now treats fresh unobserved switch sidecars as transition confidence loss
  or target resync while preserving stale sidecar rejection, prefers active observed marker sidecar authority over older
  recorded completions, requires sidecar freshness for marker deletion completion, scopes branch-switch completion
  authority independently from unrelated later markers, ignores stale marker deletions during live current-branch
  markers, proves old-branch IPC retirement is lock-tolerant through a deterministic failure seam, invalidates stale
  ignore decisions on branch reload, schedules real scan-derived resync after retire-failure fallback, and verifies or
  retries old-branch IPC downgrade before target branch IPC publication.

### Current-Head Stabilization Status Map

- Previous-branch IPC downgrade after retire-failure fallback: implemented and proven.
  Code seam: `retryOrDowngradePreviousBranchWatchIpc`, `previousBranchWatchIpcRetiredOrNonIncremental`, and
  `publishNonIncrementalTransitionCompletionAfterRetireFailure`.
  Proof seam: `update marker deletion publishes target branch resync ipc when old branch ipc retirement fails`; focused
  Watch tests, `validate -Fast`, GitHub `full`, and Codex 👍🏻 on current head.
  Residual risk: none identified for #495.
- IPC writer swallowed-failure proof: implemented and proven.
  Code seam: verification after resync-required publication, retry probe, and bounded retry loop.
  Proof seam: regression locks the old IPC during the first downgrade write, releases it before retry, then verifies old
  branch IPC is non-usable/resynchronizing.
  Residual risk: permanent external lock defers target publication instead of trusting stale IPC.
- Fresh unobserved current-marker sidecar recovery: implemented and proven.
  Code seam: deletion sidecar freshness guard and non-authoritative sidecar fallback.
  Proof seam: missed/delayed marker-created callback with fresh switch sidecar requests/reaches target resync instead of
  leaving Watch serving the previous branch; focused Watch tests, `validate -Fast`, GitHub `full`, Codex 👍🏻.
  Residual risk: none identified.
- Active marker sidecar authority over older completions: implemented and proven.
  Code seam: delayed callback completion timestamp selection with observed current marker sidecar precedence.
  Proof seam: current sidecar suppresses Grace-owned writes before deletion handler runs despite older recorded
  completion; focused Watch tests, `validate -Fast`, GitHub `full`, Codex 👍🏻.
  Residual risk: none identified.
- Deleted-marker sidecar freshness: implemented and proven.
  Code seam: marker-instance observation freshness for deletion completion and observed-state cleanup on no-sidecar
  deletion.
  Proof seam: stale same-path sidecar without fresh observed marker no longer completes transition; focused Watch tests,
  `validate -Fast`, GitHub `full`, Codex 👍🏻.
  Residual risk: none identified.
- Leaf boundary: implemented and proven.
  Scope remained limited to #495 Watch transition completion; #496 SignalR refresh and remote materialization remain
  deferred.

## Residual Risks

- SignalR subscription refresh remains #496 scope.
- Remote sync materialization and durable journal authority remain outside WS5.4.
