### PR TITLE
OPS5: Add Grace.Operations.Worker ingestion loop

### DIFF
--- a/src/Grace.Aspire.AppHost/AssemblyInfo.cs
+++ b/src/Grace.Aspire.AppHost/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Grace.Operations.Tests")]

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -29,6 +29,7 @@ public partial class Program
     private const string OperationalFactsProcessorSubscriptionName = "operational-facts-processor";
     private const string OperationalFactsProcessorSubscriptionResourceName = "grace-operational-facts-processor-subscription";
     private const string OperationalFactsProcessorSubscriptionSettingName = "grace__azure_service_bus__operational_facts_processor_subscription";
+    private const string OperationsSqlConnectionStringSettingName = "grace__operations__sql__connectionstring";
 
     private static void Main(string[] args)
     {
@@ -297,6 +298,11 @@ public partial class Program
                             serviceBusSql.WithLifetime(ContainerLifetime.Session);
                         }
 
+                        var serviceBusSqlEndpoint = serviceBusSql.GetEndpoint("sql");
+                        var serviceBusSqlHostAndPort = serviceBusSqlEndpoint.Property(EndpointProperty.HostAndPort);
+                        var operationsSqlConnectionString = ReferenceExpression.Create(
+                            $"Server=tcp:{serviceBusSqlHostAndPort};Initial Catalog=GraceOperations;User ID=sa;Password={serviceBusSqlPassword};TrustServerCertificate=True;Encrypt=False;");
+
                         var serviceBusEmulatorResourceName = runSuffix is null ? "servicebus-emulator" : $"servicebus-emulator-{runSuffix}";
                         var serviceBusEmulator = builder.AddContainer(serviceBusEmulatorResourceName, "mcr.microsoft.com/azure-messaging/servicebus-emulator", "latest")
                             .WithContainerName(serviceBusEmulatorResourceName)
@@ -330,6 +336,24 @@ public partial class Program
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
                             .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscriptionName);
+
+                        _ = builder.AddProject("grace-operations-worker", "..\\Grace.Operations.Worker\\Grace.Operations.Worker.fsproj")
+                            .WithParentRelationship(serviceBusSql)
+                            .WithParentRelationship(serviceBusEmulator)
+                            .WithEnvironment("DOTNET_ENVIRONMENT", "Development")
+                            .WithEnvironment("OTLP_ENDPOINT_URL", otlpEndpoint)
+                            .WithEnvironment(
+                                EnvironmentVariables.AzureServiceBusConnectionString,
+                                ReferenceExpression.Create(
+                                    $"Endpoint=sb://{serviceBusHostAndPort};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+                                )
+                            )
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
+                            .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
+                            .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
+                            .WithEnvironment(OperationsSqlConnectionStringSettingName, operationsSqlConnectionString)
+                            .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Local")
+                            .WithOtlpExporter();
                     }
                     else
                     {
@@ -373,7 +397,13 @@ public partial class Program
 
                     var cosmosDatabaseName = GetRequiredSetting(configuration, EnvironmentVariables.AzureCosmosDBDatabaseName);
                     var cosmosContainerName = GetRequiredSetting(configuration, EnvironmentVariables.AzureCosmosDBContainerName);
+                    var serviceBusConnectionString = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusConnectionString);
                     var serviceBusNamespace = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusNamespace);
+                    if (string.IsNullOrWhiteSpace(serviceBusConnectionString) && string.IsNullOrWhiteSpace(serviceBusNamespace))
+                    {
+                        throw new InvalidOperationException(
+                            $"DebugAzure requires '{EnvironmentVariables.AzureServiceBusConnectionString}' or '{EnvironmentVariables.AzureServiceBusNamespace}' for operational usage ingestion.");
+                    }
                     var serviceBusTopic = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusTopic);
                     var operationalFactsTopic = GetRequiredSetting(configuration, EnvironmentVariables.AzureServiceBusOperationalFactsTopic);
                     EnsureDistinctServiceBusTopics(serviceBusTopic, operationalFactsTopic);
@@ -381,6 +411,7 @@ public partial class Program
                         GetRequiredSetting(configuration, OperationalFactsProcessorSubscriptionSettingName);
                     EnsureOperationalFactsProcessorSubscription(operationalFactsProcessorSubscription);
                     var serviceBusSubscription = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription);
+                    var operationsSqlConnectionString = GetRequiredSetting(configuration, OperationsSqlConnectionStringSettingName);
 
                     graceServer
                         .WithEnvironment(EnvironmentVariables.AzureStorageAccountName, azureStorageAccountName)
@@ -388,6 +419,7 @@ public partial class Program
                         .WithEnvironment(EnvironmentVariables.AzureCosmosDBEndpoint, cosmosdbEndpoint)
                         .WithEnvironment(EnvironmentVariables.AzureCosmosDBDatabaseName, cosmosDatabaseName)
                         .WithEnvironment(EnvironmentVariables.AzureCosmosDBContainerName, cosmosContainerName)
+                        .WithEnvironment(EnvironmentVariables.AzureServiceBusConnectionString, serviceBusConnectionString)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, serviceBusNamespace)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusTopic, serviceBusTopic)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopic)
@@ -395,6 +427,17 @@ public partial class Program
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscription)
                         .WithEnvironment(EnvironmentVariables.GraceLogDirectory, logDirectory)
                         .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Azure");
+
+                    _ = builder.AddProject("grace-operations-worker", "..\\Grace.Operations.Worker\\Grace.Operations.Worker.fsproj")
+                        .WithEnvironment("DOTNET_ENVIRONMENT", "Development")
+                        .WithEnvironment("OTLP_ENDPOINT_URL", otlpEndpoint)
+                        .WithEnvironment(EnvironmentVariables.AzureServiceBusConnectionString, serviceBusConnectionString)
+                        .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, serviceBusNamespace)
+                        .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopic)
+                        .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
+                        .WithEnvironment(OperationsSqlConnectionStringSettingName, operationsSqlConnectionString)
+                        .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Azure")
+                        .WithOtlpExporter();
 
                     Console.WriteLine("Grace.Server DebugAzure environment configured (no emulators started):");
                     Console.WriteLine("  - Azure Storage: using DefaultAzureCredential.");

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -299,9 +299,11 @@ public partial class Program
                         }
 
                         var serviceBusSqlEndpoint = serviceBusSql.GetEndpoint("sql");
-                        var serviceBusSqlHostAndPort = serviceBusSqlEndpoint.Property(EndpointProperty.HostAndPort);
+                        var serviceBusSqlHost = serviceBusSqlEndpoint.Property(EndpointProperty.Host);
+                        var serviceBusSqlPort = serviceBusSqlEndpoint.Property(EndpointProperty.Port);
+                        var serviceBusSqlDataSource = BuildSqlTcpDataSource(serviceBusSqlHost, serviceBusSqlPort);
                         var operationsSqlConnectionString = ReferenceExpression.Create(
-                            $"Server=tcp:{serviceBusSqlHostAndPort};Initial Catalog=GraceOperations;User ID=sa;Password={serviceBusSqlPassword};TrustServerCertificate=True;Encrypt=False;");
+                            $"Server={serviceBusSqlDataSource};Initial Catalog=GraceOperations;User ID=sa;Password={serviceBusSqlPassword};TrustServerCertificate=True;Encrypt=False;");
 
                         var serviceBusEmulatorResourceName = runSuffix is null ? "servicebus-emulator" : $"servicebus-emulator-{runSuffix}";
                         var serviceBusEmulator = builder.AddContainer(serviceBusEmulatorResourceName, "mcr.microsoft.com/azure-messaging/servicebus-emulator", "latest")
@@ -625,6 +627,28 @@ public partial class Program
             throw new InvalidOperationException(
                 $"DebugAzure requires existing Azure Service Bus topic '{EnvironmentVariables.AzureServiceBusOperationalFactsTopic}' to contain durable subscription '{OperationalFactsProcessorSubscriptionName}'. Set '{OperationalFactsProcessorSubscriptionSettingName}' to '{OperationalFactsProcessorSubscriptionName}' after creating that subscription.");
         }
+    }
+
+    internal static string BuildSqlTcpDataSource(object host, object port)
+    {
+        var hostValue = Convert.ToString(host)?.Trim();
+        var portValue = Convert.ToString(port)?.Trim();
+
+        if (string.IsNullOrWhiteSpace(hostValue))
+        {
+            throw new ArgumentException("SQL host is required.", nameof(host));
+        }
+
+        if (string.IsNullOrWhiteSpace(portValue))
+        {
+            throw new ArgumentException("SQL port is required.", nameof(port));
+        }
+
+        var normalizedHost = hostValue.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase)
+            ? hostValue.Substring(4)
+            : hostValue;
+
+        return $"tcp:{normalizedHost},{portValue}";
     }
 
     private static void AddOptionalEnvironment(

--- a/src/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations.Data/OperationsData.fs
@@ -78,6 +78,17 @@ module OperationsUsageSql =
     [<Literal>]
     let CreateSchema = "IF SCHEMA_ID(N'ops') IS NULL EXEC(N'CREATE SCHEMA ops');"
 
+    /// Creates the configured operations database when SQL Server does not already contain it.
+    [<Literal>]
+    let CreateDatabaseIfMissing =
+        """
+IF DB_ID(@DatabaseName) IS NULL
+BEGIN
+    DECLARE @CreateDatabaseSql nvarchar(max) = N'CREATE DATABASE ' + QUOTENAME(@DatabaseName);
+    EXEC(@CreateDatabaseSql);
+END;
+"""
+
     /// Creates `ops.RawUsageFact` with `UsageFactId` as the durable dedupe key.
     [<Literal>]
     let CreateRawUsageFactTable =
@@ -374,6 +385,70 @@ type SqlOperationsUsageTransactionScope(connectionString: string) =
                     do! rollbackIgnoringFailuresAsync transaction
                     return raise ex
             }
+
+/// Ensures the operations usage SQL schema exists before ingestion starts consuming durable messages.
+type OperationsUsageSchema(connectionString: string) =
+
+    /// Parses the configured SQL connection string so database bootstrap can run against `master` first.
+    let connectionStringBuilder = SqlConnectionStringBuilder(connectionString)
+
+    /// Identifies the target operations database when the connection string names one.
+    let targetDatabaseName =
+        if String.IsNullOrWhiteSpace connectionStringBuilder.InitialCatalog then
+            None
+        else
+            Some connectionStringBuilder.InitialCatalog
+
+    /// Builds a master-database connection string used to create the target operations database when needed.
+    let masterConnectionString =
+        let builder = SqlConnectionStringBuilder(connectionString)
+        builder.InitialCatalog <- "master"
+        builder.ConnectionString
+
+    /// Opens the SQL connection used for one schema initialization pass.
+    let openConnectionAsync databaseConnectionString cancellationToken =
+        task {
+            let connection = new SqlConnection(databaseConnectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Executes a schema command against the operations database.
+    let executeCommandAsync (connection: SqlConnection) commandText cancellationToken =
+        task {
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+            command.CommandText <- commandText
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Creates the configured operations database when the connection string points at a database that is absent.
+    let ensureDatabaseCreatedAsync cancellationToken =
+        task {
+            match targetDatabaseName with
+            | Some databaseName ->
+                use! connection = openConnectionAsync masterConnectionString cancellationToken
+                use command = connection.CreateCommand()
+                command.CommandType <- CommandType.Text
+                command.CommandText <- OperationsUsageSql.CreateDatabaseIfMissing
+
+                let parameter = command.Parameters.Add("@DatabaseName", SqlDbType.NVarChar, 128)
+                parameter.Value <- databaseName
+                let! _ = command.ExecuteNonQueryAsync cancellationToken
+                return ()
+            | None -> return ()
+        }
+
+    /// Creates the operations usage schema, raw fact table, and minute aggregate table when they are absent.
+    member _.EnsureCreatedAsync(cancellationToken: CancellationToken) =
+        task {
+            do! ensureDatabaseCreatedAsync cancellationToken
+            use! connection = openConnectionAsync connectionString cancellationToken
+            do! executeCommandAsync connection OperationsUsageSql.CreateSchema cancellationToken
+            do! executeCommandAsync connection OperationsUsageSql.CreateRawUsageFactTable cancellationToken
+            do! executeCommandAsync connection OperationsUsageSql.CreateUsageAggregateMinuteTable cancellationToken
+        }
 
 /// Persists usage facts through a transaction-scoped raw insert and aggregate projection.
 type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =

--- a/src/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations.Data/OperationsData.fs
@@ -119,6 +119,14 @@ module OperationsUsageSql =
     [<Literal>]
     let CaseSensitiveStoragePoolIdCollation = "Latin1_General_100_BIN2"
 
+    /// Limits correlation identifiers to the raw fact column width used by the operations store.
+    [<Literal>]
+    let CorrelationIdMaxLength = 200
+
+    /// Limits storage-pool identifiers to the aggregate key column width used by the operations store.
+    [<Literal>]
+    let StoragePoolIdMaxLength = 256
+
     /// Creates the operations schema when it is absent.
     [<Literal>]
     let CreateSchema = "IF SCHEMA_ID(N'ops') IS NULL EXEC(N'CREATE SCHEMA ops');"
@@ -282,36 +290,47 @@ module UsageFactPersistencePlan =
         match UsageFact.Validate fact with
         | Error errors -> Error errors
         | Ok () ->
-            let bucketStart = bucketObservedAt fact.ObservedAt
+            let errors = ResizeArray<string>()
 
-            let rawFact =
-                {
-                    UsageFactId = fact.UsageFactId
-                    CorrelationId = fact.CorrelationId
-                    FactKind = fact.FactKind
-                    OwnerId = fact.Scope.OwnerId
-                    OrganizationId = fact.Scope.OrganizationId
-                    RepositoryId = fact.Scope.RepositoryId
-                    StoragePoolId = fact.Resource.StoragePoolId
-                    Quantity = fact.Quantity
-                    ObservedAt = bucketStart
-                }
+            if fact.CorrelationId.Length > OperationsUsageSql.CorrelationIdMaxLength then
+                errors.Add($"CorrelationId must be {OperationsUsageSql.CorrelationIdMaxLength} characters or fewer for operations SQL storage.")
 
-            let aggregate =
-                {
-                    Key =
-                        {
-                            FactKind = fact.FactKind
-                            OwnerId = fact.Scope.OwnerId
-                            OrganizationId = fact.Scope.OrganizationId
-                            RepositoryId = fact.Scope.RepositoryId
-                            StoragePoolId = fact.Resource.StoragePoolId
-                            BucketStart = bucketStart
-                        }
-                    Quantity = fact.Quantity
-                }
+            if fact.Resource.StoragePoolId.Length > OperationsUsageSql.StoragePoolIdMaxLength then
+                errors.Add($"Resource.StoragePoolId must be {OperationsUsageSql.StoragePoolIdMaxLength} characters or fewer for operations SQL storage.")
 
-            Ok { RawFact = rawFact; Aggregate = aggregate }
+            if errors.Count > 0 then
+                Error(List.ofSeq errors)
+            else
+                let bucketStart = bucketObservedAt fact.ObservedAt
+
+                let rawFact =
+                    {
+                        UsageFactId = fact.UsageFactId
+                        CorrelationId = fact.CorrelationId
+                        FactKind = fact.FactKind
+                        OwnerId = fact.Scope.OwnerId
+                        OrganizationId = fact.Scope.OrganizationId
+                        RepositoryId = fact.Scope.RepositoryId
+                        StoragePoolId = fact.Resource.StoragePoolId
+                        Quantity = fact.Quantity
+                        ObservedAt = bucketStart
+                    }
+
+                let aggregate =
+                    {
+                        Key =
+                            {
+                                FactKind = fact.FactKind
+                                OwnerId = fact.Scope.OwnerId
+                                OrganizationId = fact.Scope.OrganizationId
+                                RepositoryId = fact.Scope.RepositoryId
+                                StoragePoolId = fact.Resource.StoragePoolId
+                                BucketStart = bucketStart
+                            }
+                        Quantity = fact.Quantity
+                    }
+
+                Ok { RawFact = rawFact; Aggregate = aggregate }
 
 /// Represents the commands available inside one durable operations usage transaction.
 type IOperationsUsageTransaction =
@@ -355,12 +374,12 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
     /// Adds the raw usage fact parameters expected by `OperationsUsageSql.TryInsertRawUsageFact`.
     let addRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
         addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
-        addStringParameter command "@CorrelationId" 200 rawFact.CorrelationId
+        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
         addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
         addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
         addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
         addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
-        addStringParameter command "@StoragePoolId" 256 rawFact.StoragePoolId
+        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
         addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
         addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
 
@@ -370,7 +389,7 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         addParameter command "@OwnerId" SqlDbType.UniqueIdentifier aggregate.Key.OwnerId
         addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier aggregate.Key.OrganizationId
         addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier aggregate.Key.RepositoryId
-        addStringParameter command "@StoragePoolId" 256 aggregate.Key.StoragePoolId
+        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength aggregate.Key.StoragePoolId
         addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
         addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
 

--- a/src/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations.Data/OperationsData.fs
@@ -54,6 +54,51 @@ type UsageFactPersistenceStatus =
 /// Reports the outcome of transactionally storing a usage fact.
 type UsageFactPersistenceResult = { Status: UsageFactPersistenceStatus; UsageFactId: UsageFactId; Aggregate: UsageAggregateMinute option }
 
+/// Chooses whether schema initialization may connect to `master` to create the operations database.
+type OperationsUsageSchemaBootstrapMode =
+
+    /// Opens only the configured target database, which supports least-privilege users without `master` access.
+    | TargetDatabaseOnly = 1
+
+    /// Opens `master` first to create the configured target database when an admin bootstrap caller opts in.
+    | CreateDatabaseIfMissing = 2
+
+/// Describes the SQL connections needed for an operations usage schema initialization pass.
+type internal OperationsUsageSchemaBootstrapPlan =
+    {
+        TargetDatabaseName: string option
+        SchemaConnectionString: string
+        DatabaseCreationConnectionString: string option
+    }
+
+/// Builds schema initialization plans without opening SQL connections.
+[<RequireQualifiedAccess>]
+module internal OperationsUsageSchemaBootstrapPlan =
+
+    /// Creates a plan that uses the target database by default and connects to `master` only for explicit bootstrap.
+    let create connectionString mode =
+        let builder = SqlConnectionStringBuilder(connectionString)
+
+        let targetDatabaseName =
+            if String.IsNullOrWhiteSpace builder.InitialCatalog then
+                None
+            else
+                Some builder.InitialCatalog
+
+        let databaseCreationConnectionString =
+            match mode, targetDatabaseName with
+            | OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing, Some _ ->
+                let masterBuilder = SqlConnectionStringBuilder(connectionString)
+                masterBuilder.InitialCatalog <- "master"
+                Some masterBuilder.ConnectionString
+            | _ -> None
+
+        {
+            TargetDatabaseName = targetDatabaseName
+            SchemaConnectionString = connectionString
+            DatabaseCreationConnectionString = databaseCreationConnectionString
+        }
+
 /// Provides SQL Server schema and command text for the operations usage fact tables.
 [<RequireQualifiedAccess>]
 module OperationsUsageSql =
@@ -387,23 +432,13 @@ type SqlOperationsUsageTransactionScope(connectionString: string) =
             }
 
 /// Ensures the operations usage SQL schema exists before ingestion starts consuming durable messages.
-type OperationsUsageSchema(connectionString: string) =
+type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsUsageSchemaBootstrapMode) =
 
-    /// Parses the configured SQL connection string so database bootstrap can run against `master` first.
-    let connectionStringBuilder = SqlConnectionStringBuilder(connectionString)
+    /// Describes whether this schema pass is target-only or explicit admin bootstrap.
+    let bootstrapMode = defaultArg bootstrapMode OperationsUsageSchemaBootstrapMode.TargetDatabaseOnly
 
-    /// Identifies the target operations database when the connection string names one.
-    let targetDatabaseName =
-        if String.IsNullOrWhiteSpace connectionStringBuilder.InitialCatalog then
-            None
-        else
-            Some connectionStringBuilder.InitialCatalog
-
-    /// Builds a master-database connection string used to create the target operations database when needed.
-    let masterConnectionString =
-        let builder = SqlConnectionStringBuilder(connectionString)
-        builder.InitialCatalog <- "master"
-        builder.ConnectionString
+    /// Captures the connection strings used by this schema pass without opening SQL connections.
+    let bootstrapPlan = OperationsUsageSchemaBootstrapPlan.create connectionString bootstrapMode
 
     /// Opens the SQL connection used for one schema initialization pass.
     let openConnectionAsync databaseConnectionString cancellationToken =
@@ -426,9 +461,9 @@ type OperationsUsageSchema(connectionString: string) =
     /// Creates the configured operations database when the connection string points at a database that is absent.
     let ensureDatabaseCreatedAsync cancellationToken =
         task {
-            match targetDatabaseName with
-            | Some databaseName ->
-                use! connection = openConnectionAsync masterConnectionString cancellationToken
+            match bootstrapPlan.DatabaseCreationConnectionString, bootstrapPlan.TargetDatabaseName with
+            | Some databaseCreationConnectionString, Some databaseName ->
+                use! connection = openConnectionAsync databaseCreationConnectionString cancellationToken
                 use command = connection.CreateCommand()
                 command.CommandType <- CommandType.Text
                 command.CommandText <- OperationsUsageSql.CreateDatabaseIfMissing
@@ -437,14 +472,14 @@ type OperationsUsageSchema(connectionString: string) =
                 parameter.Value <- databaseName
                 let! _ = command.ExecuteNonQueryAsync cancellationToken
                 return ()
-            | None -> return ()
+            | _ -> return ()
         }
 
     /// Creates the operations usage schema, raw fact table, and minute aggregate table when they are absent.
     member _.EnsureCreatedAsync(cancellationToken: CancellationToken) =
         task {
             do! ensureDatabaseCreatedAsync cancellationToken
-            use! connection = openConnectionAsync connectionString cancellationToken
+            use! connection = openConnectionAsync bootstrapPlan.SchemaConnectionString cancellationToken
             do! executeCommandAsync connection OperationsUsageSql.CreateSchema cancellationToken
             do! executeCommandAsync connection OperationsUsageSql.CreateRawUsageFactTable cancellationToken
             do! executeCommandAsync connection OperationsUsageSql.CreateUsageAggregateMinuteTable cancellationToken

--- a/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="OperationsSkeleton.Tests.fs" />
     <Compile Include="OperationsUsageStorage.Tests.fs" />
+    <Compile Include="OperationsWorkerIngestion.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -37,6 +38,8 @@
     <ProjectReference Include="..\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.Operations.Worker\Grace.Operations.Worker.fsproj" />
     <ProjectReference Include="..\Grace.Operations\Grace.Operations.fsproj" />
+    <ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
+    <ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj" />
     <ProjectReference Include="..\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.Operations.Worker\Grace.Operations.Worker.fsproj" />
     <ProjectReference Include="..\Grace.Operations\Grace.Operations.fsproj" />

--- a/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -222,6 +222,42 @@ type OperationsUsageStorageTests() =
 
         Assert.That(transactionScope, Is.InstanceOf<IOperationsUsageTransactionScope>())
 
+    /// Verifies default schema initialization uses the configured target database without requiring `master`.
+    [<Test>]
+    member _.DefaultSchemaBootstrapUsesTargetDatabaseConnectionOnly() =
+        let plan =
+            OperationsUsageSchemaBootstrapPlan.create
+                "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                OperationsUsageSchemaBootstrapMode.TargetDatabaseOnly
+
+        let schemaBuilder = Microsoft.Data.SqlClient.SqlConnectionStringBuilder(plan.SchemaConnectionString)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(plan.TargetDatabaseName, Is.EqualTo(Some "GraceOperations"))
+                Assert.That(schemaBuilder.InitialCatalog, Is.EqualTo("GraceOperations"))
+                Assert.That(plan.DatabaseCreationConnectionString, Is.EqualTo(None)))
+        )
+
+    /// Verifies database creation remains available only when an admin bootstrap mode is explicitly selected.
+    [<Test>]
+    member _.ExplicitSchemaBootstrapUsesMasterConnectionForDatabaseCreation() =
+        let plan =
+            OperationsUsageSchemaBootstrapPlan.create
+                "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing
+
+        let creationBuilder = Microsoft.Data.SqlClient.SqlConnectionStringBuilder(plan.DatabaseCreationConnectionString.Value)
+
+        let schemaBuilder = Microsoft.Data.SqlClient.SqlConnectionStringBuilder(plan.SchemaConnectionString)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(plan.TargetDatabaseName, Is.EqualTo(Some "GraceOperations"))
+                Assert.That(creationBuilder.InitialCatalog, Is.EqualTo("master"))
+                Assert.That(schemaBuilder.InitialCatalog, Is.EqualTo("GraceOperations")))
+        )
+
     /// Verifies a first usage fact inserts a raw row and increments the expected aggregate minute.
     [<Test>]
     member _.FirstFactStoresRawFactAndIncrementsMinuteAggregate() =

--- a/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -215,6 +215,37 @@ type OperationsUsageStorageTests() =
                 Assert.That(lowerPoolPlan.Aggregate.Key, Is.Not.EqualTo(mixedPoolPlan.Aggregate.Key)))
         )
 
+    /// Verifies facts that exceed SQL column widths are rejected before SQL Server can truncate them.
+    [<Test>]
+    member _.PersistencePlanRejectsSqlBoundStringOverflows() =
+        let overlongCorrelationId = CorrelationId(String('c', OperationsUsageSql.CorrelationIdMaxLength + 1))
+
+        let overlongStoragePoolId = StoragePoolId(String('s', OperationsUsageSql.StoragePoolIdMaxLength + 1))
+
+        let fact =
+            UsageFact.RepositoryStorageBytesMinute(
+                Guid.Parse("56565656-5656-5656-5656-565656565656"),
+                overlongCorrelationId,
+                OperationsUsageStorageTestData.ownerId,
+                OperationsUsageStorageTestData.organizationId,
+                OperationsUsageStorageTestData.repositoryId,
+                overlongStoragePoolId,
+                1L,
+                Instant.FromUtc(2026, 7, 4, 12, 37, 0)
+            )
+
+        match UsageFactPersistencePlan.tryCreate fact with
+        | Ok _ -> Assert.Fail("Overlong SQL-bound fact fields should be rejected before persistence.")
+        | Error errors ->
+            let errorText = String.Join("|", errors)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errorText, Does.Contain($"CorrelationId must be {OperationsUsageSql.CorrelationIdMaxLength} characters or fewer"))
+
+                    Assert.That(errorText, Does.Contain($"Resource.StoragePoolId must be {OperationsUsageSql.StoragePoolIdMaxLength} characters or fewer")))
+            )
+
     /// Verifies the production SQL transaction scope satisfies the store dependency.
     [<Test>]
     member _.SqlTransactionScopeImplementsOperationsUsageTransactionScope() =

--- a/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -157,6 +157,8 @@ type OperationsUsageStorageTests() =
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(OperationsUsageSql.CreateSchema, Does.Contain("CREATE SCHEMA ops"))
+                Assert.That(OperationsUsageSql.CreateDatabaseIfMissing, Does.Contain("DB_ID(@DatabaseName) IS NULL"))
+                Assert.That(OperationsUsageSql.CreateDatabaseIfMissing, Does.Contain("QUOTENAME(@DatabaseName)"))
                 Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("ops.RawUsageFact"))
                 Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("PRIMARY KEY CLUSTERED (UsageFactId)"))
                 Assert.That(OperationsUsageSql.TryInsertRawUsageFact, Does.Contain("WITH (UPDLOCK, HOLDLOCK)"))

--- a/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -110,6 +110,14 @@ type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Ta
             events.Add("store")
             storeAsync fact cancellationToken
 
+/// Fails if deterministic validation lets an invalid fact reach a storage transaction.
+type private FailingOperationsUsageTransactionScope() =
+
+    interface IOperationsUsageTransactionScope with
+
+        member _.ExecuteAsync<'T>(_operation, _cancellationToken) =
+            Task.FromException<'T>(InvalidOperationException("Invalid usage facts must be rejected before opening a storage transaction."))
+
 /// Covers the Grace operations worker usage fact ingestion loop.
 [<TestFixture>]
 type OperationsWorkerIngestionTests() =
@@ -131,6 +139,20 @@ type OperationsWorkerIngestionTests() =
 
         OperationsUsageIngestionProcessor(store, logger), store, RecordingMessageActions(events), events
 
+    /// Creates a processor backed by the real data-layer validation path.
+    let createProcessorWithRealStore () =
+        let events = List<string>()
+
+        let store =
+            OperationsUsageStore(FailingOperationsUsageTransactionScope())
+            |> OperationsUsageFactStoreAdapter
+
+        let logger =
+            NullLogger<OperationsUsageIngestionProcessor>
+                .Instance
+
+        OperationsUsageIngestionProcessor(store, logger), RecordingMessageActions(events), events
+
     /// Formats ordered fake events for overload-free assertions.
     let eventText (events: seq<string>) = String.Join("|", events)
 
@@ -149,6 +171,15 @@ type OperationsWorkerIngestionTests() =
 
     /// Creates an already-processed persistence result for a fact.
     let alreadyProcessed fact = { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
+
+    /// Verifies AppHost SQL Server data sources use SqlClient comma-port syntax.
+    [<Test>]
+    member _.AppHostFormatsLocalSqlDataSourceWithCommaPort() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(global.Program.BuildSqlTcpDataSource("localhost", 21433), Is.EqualTo("tcp:localhost,21433"))
+                Assert.That(global.Program.BuildSqlTcpDataSource("tcp:localhost", "21433"), Is.EqualTo("tcp:localhost,21433")))
+        )
 
     /// Verifies AppHost-style environment names resolve after Host configuration normalizes `__` to `:`.
     [<Test>]
@@ -189,6 +220,82 @@ type OperationsWorkerIngestionTests() =
 
                     Assert.That(value.MaxConcurrentCalls, Is.EqualTo(7))
                     Assert.That(value.PrefetchCount, Is.EqualTo(29)))
+            )
+        | Error errors -> Assert.Fail(String.Join("; ", errors))
+
+    /// Verifies DebugLocal opts into admin bootstrap so fresh local SQL containers get the operations database.
+    [<Test>]
+    member _.WorkerSettingsUseDatabaseCreationBootstrapForDebugLocal() =
+        let configuration =
+            configurationFromPairs [ KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic,
+                                         "operations-topic"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.ProcessorSubscriptionEnvironmentVariable,
+                                         OperationsWorkerSettings.DefaultProcessorSubscriptionName
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.SqlConnectionStringEnvironmentVariable,
+                                         "Server=tcp:localhost,21433;Database=GraceOperations;User ID=sa;Password=fake;TrustServerCertificate=True;Encrypt=False;"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                                         "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake;UseDevelopmentEmulator=true;"
+                                     )
+                                     KeyValuePair<string, string>(getConfigKey Constants.EnvironmentVariables.DebugEnvironment, "Local") ]
+
+        match OperationsWorkerSettings.fromConfiguration configuration with
+        | Ok value -> Assert.That(value.SchemaBootstrapMode, Is.EqualTo(OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing))
+        | Error errors -> Assert.Fail(String.Join("; ", errors))
+
+    /// Verifies non-local worker settings keep least-privilege target-only schema initialization.
+    [<Test>]
+    member _.WorkerSettingsKeepTargetOnlyBootstrapForDebugAzure() =
+        let configuration =
+            configurationFromPairs [ KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic,
+                                         "operations-topic"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.ProcessorSubscriptionEnvironmentVariable,
+                                         OperationsWorkerSettings.DefaultProcessorSubscriptionName
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.SqlConnectionStringEnvironmentVariable,
+                                         "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                                     )
+                                     KeyValuePair<string, string>(getConfigKey Constants.EnvironmentVariables.AzureServiceBusNamespace, "operations-bus")
+                                     KeyValuePair<string, string>(getConfigKey Constants.EnvironmentVariables.DebugEnvironment, "Azure") ]
+
+        match OperationsWorkerSettings.fromConfiguration configuration with
+        | Ok value -> Assert.That(value.SchemaBootstrapMode, Is.EqualTo(OperationsUsageSchemaBootstrapMode.TargetDatabaseOnly))
+        | Error errors -> Assert.Fail(String.Join("; ", errors))
+
+    /// Verifies worker-only managed identity settings accept short Service Bus namespace names.
+    [<Test>]
+    member _.WorkerSettingsNormalizeManagedIdentityNamespace() =
+        let configuration =
+            configurationFromPairs [ KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic,
+                                         "operations-topic"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.ProcessorSubscriptionEnvironmentVariable,
+                                         OperationsWorkerSettings.DefaultProcessorSubscriptionName
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.SqlConnectionStringEnvironmentVariable,
+                                         "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                                     )
+                                     KeyValuePair<string, string>(getConfigKey Constants.EnvironmentVariables.AzureServiceBusNamespace, "mybus") ]
+
+        match OperationsWorkerSettings.fromConfiguration configuration with
+        | Ok value ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(value.ServiceBusConnectionString, Is.EqualTo(None))
+                    Assert.That(value.ServiceBusFullyQualifiedNamespace, Is.EqualTo(Some "mybus.servicebus.windows.net")))
             )
         | Error errors -> Assert.Fail(String.Join("; ", errors))
 
@@ -308,6 +415,42 @@ type OperationsWorkerIngestionTests() =
                     Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
                     Assert.That(eventText events, Is.EqualTo("store|abandon"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon")))
+            )
+        }
+
+    /// Verifies usage facts that violate SQL-bound shape limits dead-letter instead of being retried.
+    [<Test>]
+    member _.SqlShapeValidationFailureIsDeadLettered() =
+        task {
+            let overlongCorrelationId = CorrelationId(String('c', OperationsUsageSql.CorrelationIdMaxLength + 1))
+
+            let overlongStoragePoolId = StoragePoolId(String('s', OperationsUsageSql.StoragePoolIdMaxLength + 1))
+
+            let fact =
+                UsageFact.RepositoryStorageBytesMinute(
+                    Guid.Parse("99999999-9999-9999-9999-999999999999"),
+                    overlongCorrelationId,
+                    OperationsWorkerIngestionTestData.ownerId,
+                    OperationsWorkerIngestionTestData.organizationId,
+                    OperationsWorkerIngestionTestData.repositoryId,
+                    overlongStoragePoolId,
+                    4096L,
+                    Instant.FromUtc(2026, 7, 4, 12, 39, 0)
+                )
+
+            let processor, actions, events = createProcessorWithRealStore ()
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:InvalidUsageFact")))
             )
         }
 

--- a/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -1,0 +1,289 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Operations.Worker
+open Grace.Shared
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Extensions.Logging.Abstractions
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Provides deterministic usage facts and envelopes for operations worker ingestion tests.
+module OperationsWorkerIngestionTestData =
+
+    /// Provides the owner used by worker ingestion facts.
+    let ownerId = OwnerId.Parse("11111111-1111-1111-1111-111111111111")
+
+    /// Provides the organization used by worker ingestion facts.
+    let organizationId = OrganizationId.Parse("22222222-2222-2222-2222-222222222222")
+
+    /// Provides the repository used by worker ingestion facts.
+    let repositoryId = RepositoryId.Parse("33333333-3333-3333-3333-333333333333")
+
+    /// Provides the storage pool used by worker ingestion facts.
+    let storagePoolId = StoragePoolId "storage-pool-main"
+
+    /// Creates a valid repository storage usage fact for ingestion tests.
+    let usageFact usageFactId =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"corr-{usageFactId}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            storagePoolId,
+            4096L,
+            Instant.FromUtc(2026, 7, 4, 12, 34, 0)
+        )
+
+    /// Serializes a usage fact through the shared Grace JSON options.
+    let serializeFact fact = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+
+    /// Builds the Service Bus application properties expected by the operations worker.
+    let applicationProperties () =
+        let properties = Dictionary<string, obj>()
+        properties[OperationalFactEnvelope.UsageFactMessageTypeProperty] <- box OperationalFactEnvelope.UsageFactMessageType
+        properties[OperationalFactEnvelope.UsageFactKindProperty] <- box "RepositoryStorageBytesMinute"
+        properties :> IReadOnlyDictionary<string, obj>
+
+    /// Creates a worker message for one operational fact payload.
+    let message body =
+        {
+            MessageId = "message-1"
+            CorrelationId = "message-correlation"
+            DeliveryCount = 2
+            Subject = OperationalFactEnvelope.UsageFactSubject
+            ApplicationProperties = applicationProperties ()
+            Body = body
+        }
+
+    /// Builds the aggregate projected by the data layer for a valid fact.
+    let aggregateFor fact =
+        match UsageFactPersistencePlan.tryCreate fact with
+        | Ok plan -> plan.Aggregate
+        | Error errors -> failwith (String.Join("; ", errors))
+
+/// Records message settlement chosen by the ingestion processor.
+type private RecordingMessageActions(events: List<string>) =
+    let settlements = ResizeArray<string * string option>()
+
+    /// Returns the settlements recorded by the fake actions.
+    member _.Settlements = settlements |> Seq.toList
+
+    interface IOperationsUsageMessageActions with
+
+        member _.CompleteAsync(_cancellationToken) =
+            events.Add("complete")
+            settlements.Add("complete", None)
+            Task.CompletedTask
+
+        member _.AbandonAsync(_cancellationToken) =
+            events.Add("abandon")
+            settlements.Add("abandon", None)
+            Task.CompletedTask
+
+        member _.DeadLetterAsync(reason, _description, _cancellationToken) =
+            events.Add("dead-letter")
+            settlements.Add("dead-letter", Some reason)
+            Task.CompletedTask
+
+/// Fakes the operations data-layer boundary for deterministic processor tests.
+type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>, events: List<string>) =
+    let storedFacts = ResizeArray<UsageFact>()
+
+    /// Returns the facts sent to the fake store.
+    member _.StoredFacts = storedFacts |> Seq.toList
+
+    interface IOperationsUsageFactStore with
+
+        member _.StoreUsageFactAsync(fact, cancellationToken) =
+            storedFacts.Add fact
+            events.Add("store")
+            storeAsync fact cancellationToken
+
+/// Covers the Grace operations worker usage fact ingestion loop.
+[<TestFixture>]
+type OperationsWorkerIngestionTests() =
+
+    /// Creates a processor with deterministic fake dependencies.
+    let createProcessor storeAsync =
+        let events = List<string>()
+        let store = StubUsageFactStore(storeAsync, events)
+
+        let logger =
+            NullLogger<OperationsUsageIngestionProcessor>
+                .Instance
+
+        OperationsUsageIngestionProcessor(store, logger), store, RecordingMessageActions(events), events
+
+    /// Formats ordered fake events for overload-free assertions.
+    let eventText (events: seq<string>) = String.Join("|", events)
+
+    /// Formats ordered settlement outcomes for overload-free assertions.
+    let settlementText settlements =
+        settlements
+        |> Seq.map (fun (action, reason) ->
+            match reason with
+            | Some value -> $"{action}:{value}"
+            | None -> action)
+        |> fun values -> String.Join("|", values)
+
+    /// Creates an accepted persistence result for a fact.
+    let accepted fact =
+        { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = fact.UsageFactId; Aggregate = Some(OperationsWorkerIngestionTestData.aggregateFor fact) }
+
+    /// Creates an already-processed persistence result for a fact.
+    let alreadyProcessed fact = { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
+
+    /// Verifies valid messages complete only after the data layer reports durable persistence.
+    [<Test>]
+    member _.ValidMessageIsPersistedBeforeCompletion() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+
+            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
+                    Assert.That(store.StoredFacts[0].UsageFactId, Is.EqualTo(fact.UsageFactId))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
+    /// Verifies duplicate durable processing still completes the Service Bus message.
+    [<Test>]
+    member _.DuplicateMessageCompletesAfterIdempotentStorageResult() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+            let processor, _store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(alreadyProcessed storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
+    /// Verifies malformed JSON dead-letters without calling the data layer.
+    [<Test>]
+    member _.MalformedJsonIsDeadLetteredWithoutStorage() =
+        task {
+            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                "{ not valid json"
+                |> Encoding.UTF8.GetBytes
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:MalformedUsageFactJson")))
+            )
+        }
+
+    /// Verifies future usage fact kinds dead-letter instead of being silently completed.
+    [<Test>]
+    member _.FutureUsageFactKindIsDeadLetteredWithoutStorage() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"))
+
+            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let unknownKindJson =
+                JsonSerializer
+                    .Serialize(fact, Constants.JsonSerializerOptions)
+                    .Replace("repositoryStorageBytesMinute", "futureUsageFactKind")
+
+            let message =
+                unknownKindJson
+                |> Encoding.UTF8.GetBytes
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:MalformedUsageFactJson")))
+            )
+        }
+
+    /// Verifies transient storage failures abandon the message for retry.
+    [<Test>]
+    member _.StorageFailureAbandonsMessageForRetry() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"))
+
+            let processor, store, actions, events =
+                createProcessor (fun _ _ -> Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure")))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
+                    Assert.That(eventText events, Is.EqualTo("store|abandon"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon")))
+            )
+        }
+
+    /// Verifies cancellation during storage leaves the message unsettled so Service Bus can redeliver it.
+    [<Test>]
+    member _.CancellationDuringStorageLeavesMessageUnsettled() =
+        task {
+            use cancellation = new CancellationTokenSource()
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"))
+
+            let processor, store, actions, events =
+                createProcessor (fun _ cancellationToken ->
+                    cancellation.Cancel()
+                    Task.FromCanceled<Result<UsageFactPersistenceResult, string list>>(cancellationToken))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, cancellation.Token)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
+                    Assert.That(eventText events, Is.EqualTo("store"))
+                    Assert.That(actions.Settlements, Is.Empty))
+            )
+        }

--- a/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -3,8 +3,10 @@ namespace Grace.Operations.Tests
 open Grace.Operations.Data
 open Grace.Operations.Worker
 open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Usage
+open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.Logging.Abstractions
 open NodaTime
 open NUnit.Framework
@@ -112,6 +114,12 @@ type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Ta
 [<TestFixture>]
 type OperationsWorkerIngestionTests() =
 
+    /// Builds host configuration from explicit keys so tests can model normalized environment variables.
+    let configurationFromPairs pairs =
+        ConfigurationBuilder()
+            .AddInMemoryCollection(pairs)
+            .Build()
+
     /// Creates a processor with deterministic fake dependencies.
     let createProcessor storeAsync =
         let events = List<string>()
@@ -141,6 +149,48 @@ type OperationsWorkerIngestionTests() =
 
     /// Creates an already-processed persistence result for a fact.
     let alreadyProcessed fact = { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
+
+    /// Verifies AppHost-style environment names resolve after Host configuration normalizes `__` to `:`.
+    [<Test>]
+    member _.WorkerSettingsReadNormalizedConfigurationKeys() =
+        let configuration =
+            configurationFromPairs [ KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic,
+                                         "operations-topic"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.ProcessorSubscriptionEnvironmentVariable,
+                                         OperationsWorkerSettings.DefaultProcessorSubscriptionName
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.SqlConnectionStringEnvironmentVariable,
+                                         "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                                         "Endpoint=sb://operations.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake"
+                                     )
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.MaxConcurrentCallsEnvironmentVariable, "7")
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.PrefetchCountEnvironmentVariable, "29") ]
+
+        let settings = OperationsWorkerSettings.fromConfiguration configuration
+
+        match settings with
+        | Ok value ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(value.TopicName, Is.EqualTo("operations-topic"))
+                    Assert.That(value.SubscriptionName, Is.EqualTo(OperationsWorkerSettings.DefaultProcessorSubscriptionName))
+
+                    Assert.That(
+                        value.SqlConnectionString,
+                        Is.EqualTo("Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;")
+                    )
+
+                    Assert.That(value.MaxConcurrentCalls, Is.EqualTo(7))
+                    Assert.That(value.PrefetchCount, Is.EqualTo(29)))
+            )
+        | Error errors -> Assert.Fail(String.Join("; ", errors))
 
     /// Verifies valid messages complete only after the data layer reports durable persistence.
     [<Test>]

--- a/src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
+++ b/src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <PublishReadyToRun>true</PublishReadyToRun>
+    <OutputType>Exe</OutputType>
     <Description>The worker boundary module for Grace operations.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
@@ -13,14 +14,21 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="OperationsWorker.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.Operations\Grace.Operations.fsproj" />
+    <ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
+    <ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Update="FSharp.Core" Version="10.1.301" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations.Worker/OperationsWorker.fs
@@ -88,6 +88,7 @@ type OperationsWorkerSettings =
         SqlConnectionString: string
         ServiceBusConnectionString: string option
         ServiceBusFullyQualifiedNamespace: string option
+        SchemaBootstrapMode: OperationsUsageSchemaBootstrapMode
         MaxConcurrentCalls: int
         PrefetchCount: int
     }
@@ -116,6 +117,23 @@ module OperationsWorkerSettings =
     [<Literal>]
     let PrefetchCountEnvironmentVariable = "grace__operations_worker__prefetch_count"
 
+    /// Converts short Service Bus namespace settings into the fully qualified host expected by Azure.Messaging.ServiceBus.
+    let private normalizeServiceBusNamespace (value: string) =
+        let trimmed = value.Trim()
+
+        let withoutScheme =
+            if trimmed.StartsWith("sb://", StringComparison.OrdinalIgnoreCase) then
+                trimmed.Substring(5)
+            else
+                trimmed
+
+        let normalizedNamespace = withoutScheme.Trim().TrimEnd('/')
+
+        if normalizedNamespace.Contains "." then
+            normalizedNamespace
+        else
+            $"{normalizedNamespace}.servicebus.windows.net"
+
     /// Returns a trimmed setting value when configuration contains a non-empty entry.
     let private optionalSetting (configuration: IConfiguration) name =
         [
@@ -139,6 +157,12 @@ module OperationsWorkerSettings =
             | _ -> defaultValue
         | None -> defaultValue
 
+    /// Allows local SQL emulator runs to create the operations database while keeping Azure connections least-privilege.
+    let private schemaBootstrapMode configuration =
+        match optionalSetting configuration Constants.EnvironmentVariables.DebugEnvironment with
+        | Some value when value.Equals("Local", StringComparison.OrdinalIgnoreCase) -> OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing
+        | _ -> OperationsUsageSchemaBootstrapMode.TargetDatabaseOnly
+
     /// Attempts managed-identity Service Bus discovery without letting unrelated Azure environment gaps abort validation.
     let private serviceBusNamespaceFromAzureEnvironment () =
         try
@@ -157,7 +181,9 @@ module OperationsWorkerSettings =
 
         let serviceBusConnectionString = optionalSetting configuration Constants.EnvironmentVariables.AzureServiceBusConnectionString
 
-        let serviceBusNamespace = optionalSetting configuration Constants.EnvironmentVariables.AzureServiceBusNamespace
+        let serviceBusNamespace =
+            optionalSetting configuration Constants.EnvironmentVariables.AzureServiceBusNamespace
+            |> Option.map normalizeServiceBusNamespace
 
         let errors = ResizeArray<string>()
 
@@ -195,6 +221,7 @@ module OperationsWorkerSettings =
                         | None ->
                             serviceBusNamespace
                             |> Option.orElseWith serviceBusNamespaceFromAzureEnvironment
+                    SchemaBootstrapMode = schemaBootstrapMode configuration
                     MaxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 4
                     PrefetchCount = positiveIntSetting configuration PrefetchCountEnvironmentVariable 16
                 }

--- a/src/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations.Worker/OperationsWorker.fs
@@ -5,6 +5,7 @@ open Azure.Identity
 open Azure.Messaging.ServiceBus
 open Grace.Operations.Data
 open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.Usage
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.Hosting
@@ -117,9 +118,12 @@ module OperationsWorkerSettings =
 
     /// Returns a trimmed setting value when configuration contains a non-empty entry.
     let private optionalSetting (configuration: IConfiguration) name =
-        let value = configuration[name]
-
-        if String.IsNullOrWhiteSpace value then None else Some(value.Trim())
+        [
+            configuration[getConfigKey name]
+            configuration[name]
+            Environment.GetEnvironmentVariable name
+        ]
+        |> List.tryPick (fun value -> if String.IsNullOrWhiteSpace value then None else Some(value.Trim()))
 
     /// Reads a setting or returns the supplied default.
     let private settingOrDefault configuration name defaultValue =
@@ -134,6 +138,14 @@ module OperationsWorkerSettings =
             | true, parsed when parsed > 0 -> parsed
             | _ -> defaultValue
         | None -> defaultValue
+
+    /// Attempts managed-identity Service Bus discovery without letting unrelated Azure environment gaps abort validation.
+    let private serviceBusNamespaceFromAzureEnvironment () =
+        try
+            AzureEnvironment.tryGetServiceBusFullyQualifiedNamespace ()
+        with
+        | :? InvalidOperationException
+        | :? TypeInitializationException -> None
 
     /// Builds validated worker settings from configuration.
     let fromConfiguration (configuration: IConfiguration) =
@@ -163,9 +175,7 @@ module OperationsWorkerSettings =
 
         if serviceBusConnectionString.IsNone
            && serviceBusNamespace.IsNone
-           && AzureEnvironment
-               .tryGetServiceBusFullyQualifiedNamespace()
-               .IsNone then
+           && serviceBusNamespaceFromAzureEnvironment().IsNone then
             errors.Add(
                 $"{Constants.EnvironmentVariables.AzureServiceBusConnectionString} or {Constants.EnvironmentVariables.AzureServiceBusNamespace} is required."
             )
@@ -180,8 +190,11 @@ module OperationsWorkerSettings =
                     SqlConnectionString = sqlConnectionString.Value
                     ServiceBusConnectionString = serviceBusConnectionString
                     ServiceBusFullyQualifiedNamespace =
-                        serviceBusNamespace
-                        |> Option.orElse (AzureEnvironment.tryGetServiceBusFullyQualifiedNamespace ())
+                        match serviceBusConnectionString with
+                        | Some _ -> serviceBusNamespace
+                        | None ->
+                            serviceBusNamespace
+                            |> Option.orElseWith serviceBusNamespaceFromAzureEnvironment
                     MaxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 4
                     PrefetchCount = positiveIntSetting configuration PrefetchCountEnvironmentVariable 16
                 }

--- a/src/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations.Worker/OperationsWorker.fs
@@ -1,7 +1,467 @@
 namespace Grace.Operations.Worker
 
+open Azure.Core
+open Azure.Identity
+open Azure.Messaging.ServiceBus
+open Grace.Operations.Data
+open Grace.Shared
+open Grace.Types.Usage
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
+open NodaTime
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
 /// Identifies the Grace operations worker assembly before ingestion hosting is wired by a later slice.
 [<AbstractClass; Sealed>]
 type internal OperationsWorkerAssembly =
     class
     end
+
+/// Holds the operational fact envelope constants shared with the publisher contract without depending on Grace.Actors.
+[<RequireQualifiedAccess>]
+module internal OperationalFactEnvelope =
+
+    /// Identifies the Service Bus subject used for immutable usage fact messages.
+    [<Literal>]
+    let UsageFactSubject = "GraceOperationalUsageFact"
+
+    /// Names the application property that classifies operational fact messages.
+    [<Literal>]
+    let UsageFactMessageTypeProperty = "graceMessageType"
+
+    /// Identifies the only operational fact message type consumed by this worker slice.
+    [<Literal>]
+    let UsageFactMessageType = "UsageFact"
+
+    /// Names the application property that records the usage fact kind for diagnostics and routing.
+    [<Literal>]
+    let UsageFactKindProperty = "usageFactKind"
+
+/// Carries the safe metadata and body bytes the ingestion processor needs from a Service Bus message.
+type OperationsUsageMessage =
+    {
+        MessageId: string
+        CorrelationId: string
+        DeliveryCount: int
+        Subject: string
+        ApplicationProperties: IReadOnlyDictionary<string, obj>
+        Body: byte array
+    }
+
+/// Settles an operational usage message only after the processor decides the durable outcome.
+type IOperationsUsageMessageActions =
+
+    /// Completes a message after durable SQL processing succeeds or proves the fact was already processed.
+    abstract CompleteAsync: cancellationToken: CancellationToken -> Task
+
+    /// Abandons a message when a transient failure should allow Service Bus retry delivery.
+    abstract AbandonAsync: cancellationToken: CancellationToken -> Task
+
+    /// Dead-letters a message that cannot become a valid usage fact through retry.
+    abstract DeadLetterAsync: reason: string * description: string * cancellationToken: CancellationToken -> Task
+
+/// Stores one usage fact through the operations data layer.
+type IOperationsUsageFactStore =
+
+    /// Persists the fact idempotently and returns the operations data-layer result.
+    abstract StoreUsageFactAsync: fact: UsageFact * cancellationToken: CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>
+
+/// Adapts the concrete operations data store to the worker's fakeable ingestion dependency.
+type OperationsUsageFactStoreAdapter(store: OperationsUsageStore) =
+
+    interface IOperationsUsageFactStore with
+
+        member _.StoreUsageFactAsync(fact, cancellationToken) = store.StoreUsageFactAsync(fact, cancellationToken)
+
+/// Reads Service Bus settings required by the operational usage ingestion worker.
+type OperationsWorkerSettings =
+    {
+        TopicName: string
+        SubscriptionName: string
+        SqlConnectionString: string
+        ServiceBusConnectionString: string option
+        ServiceBusFullyQualifiedNamespace: string option
+        MaxConcurrentCalls: int
+        PrefetchCount: int
+    }
+
+/// Resolves worker settings from host configuration and environment variables.
+[<RequireQualifiedAccess>]
+module OperationsWorkerSettings =
+
+    /// The durable subscription used by the operations worker for the operational facts topic.
+    [<Literal>]
+    let DefaultProcessorSubscriptionName = "operational-facts-processor"
+
+    /// The environment variable that confirms the durable operational facts processor subscription name.
+    [<Literal>]
+    let ProcessorSubscriptionEnvironmentVariable = "grace__azure_service_bus__operational_facts_processor_subscription"
+
+    /// The environment variable that contains the SQL connection string for operations usage storage.
+    [<Literal>]
+    let SqlConnectionStringEnvironmentVariable = "grace__operations__sql__connectionstring"
+
+    /// The environment variable that controls Service Bus processor concurrency for usage fact ingestion.
+    [<Literal>]
+    let MaxConcurrentCallsEnvironmentVariable = "grace__operations_worker__max_concurrent_calls"
+
+    /// The environment variable that controls Service Bus prefetch for usage fact ingestion.
+    [<Literal>]
+    let PrefetchCountEnvironmentVariable = "grace__operations_worker__prefetch_count"
+
+    /// Returns a trimmed setting value when configuration contains a non-empty entry.
+    let private optionalSetting (configuration: IConfiguration) name =
+        let value = configuration[name]
+
+        if String.IsNullOrWhiteSpace value then None else Some(value.Trim())
+
+    /// Reads a setting or returns the supplied default.
+    let private settingOrDefault configuration name defaultValue =
+        optionalSetting configuration name
+        |> Option.defaultValue defaultValue
+
+    /// Reads a positive integer setting or returns the supplied default.
+    let private positiveIntSetting configuration name defaultValue =
+        match optionalSetting configuration name with
+        | Some value ->
+            match Int32.TryParse value with
+            | true, parsed when parsed > 0 -> parsed
+            | _ -> defaultValue
+        | None -> defaultValue
+
+    /// Builds validated worker settings from configuration.
+    let fromConfiguration (configuration: IConfiguration) =
+        let topicName = settingOrDefault configuration Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic Constants.GraceOperationalFactsTopic
+
+        let subscriptionName = settingOrDefault configuration ProcessorSubscriptionEnvironmentVariable DefaultProcessorSubscriptionName
+
+        let sqlConnectionString = optionalSetting configuration SqlConnectionStringEnvironmentVariable
+
+        let serviceBusConnectionString = optionalSetting configuration Constants.EnvironmentVariables.AzureServiceBusConnectionString
+
+        let serviceBusNamespace = optionalSetting configuration Constants.EnvironmentVariables.AzureServiceBusNamespace
+
+        let errors = ResizeArray<string>()
+
+        if String.IsNullOrWhiteSpace topicName then
+            errors.Add($"{Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic} is required.")
+
+        if subscriptionName
+           <> DefaultProcessorSubscriptionName then
+            errors.Add(
+                $"{ProcessorSubscriptionEnvironmentVariable} must be '{DefaultProcessorSubscriptionName}' so the worker uses the durable operational facts processor subscription."
+            )
+
+        if sqlConnectionString.IsNone then
+            errors.Add($"{SqlConnectionStringEnvironmentVariable} is required.")
+
+        if serviceBusConnectionString.IsNone
+           && serviceBusNamespace.IsNone
+           && AzureEnvironment
+               .tryGetServiceBusFullyQualifiedNamespace()
+               .IsNone then
+            errors.Add(
+                $"{Constants.EnvironmentVariables.AzureServiceBusConnectionString} or {Constants.EnvironmentVariables.AzureServiceBusNamespace} is required."
+            )
+
+        if errors.Count > 0 then
+            Error(List.ofSeq errors)
+        else
+            Ok
+                {
+                    TopicName = topicName
+                    SubscriptionName = subscriptionName
+                    SqlConnectionString = sqlConnectionString.Value
+                    ServiceBusConnectionString = serviceBusConnectionString
+                    ServiceBusFullyQualifiedNamespace =
+                        serviceBusNamespace
+                        |> Option.orElse (AzureEnvironment.tryGetServiceBusFullyQualifiedNamespace ())
+                    MaxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 4
+                    PrefetchCount = positiveIntSetting configuration PrefetchCountEnvironmentVariable 16
+                }
+
+/// Handles one usage fact message through validation, SQL persistence, and explicit Service Bus settlement.
+type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger: ILogger<OperationsUsageIngestionProcessor>) =
+
+    /// Reads a string application property without exposing untrusted payload values in logs.
+    let tryGetStringProperty propertyName (properties: IReadOnlyDictionary<string, obj>) =
+        match properties.TryGetValue propertyName with
+        | true, (:? string as value) when not (String.IsNullOrWhiteSpace value) -> Some value
+        | true, value when not (isNull value) -> Some(string value)
+        | _ -> None
+
+    /// Builds a bounded diagnostic description without including the message body.
+    let describeErrors (errors: string list) = String.Join("; ", errors)
+
+    /// Dead-letters an invalid usage message with deterministic reason metadata.
+    let deadLetterAsync reason description (actions: IOperationsUsageMessageActions) cancellationToken =
+        actions.DeadLetterAsync(reason, description, cancellationToken)
+
+    /// Deserializes a usage fact using the shared Grace JSON contract options.
+    let deserializeUsageFact (body: byte array) =
+        use stream = new MemoryStream(body)
+        JsonSerializer.Deserialize<UsageFact>(stream, Constants.JsonSerializerOptions)
+
+    /// Processes a usage fact message and settles it only after the durable outcome is known.
+    member _.ProcessMessageAsync(message: OperationsUsageMessage, actions: IOperationsUsageMessageActions, cancellationToken: CancellationToken) =
+        task {
+            try
+                cancellationToken.ThrowIfCancellationRequested()
+
+                let messageType = tryGetStringProperty OperationalFactEnvelope.UsageFactMessageTypeProperty message.ApplicationProperties
+
+                if message.Subject
+                   <> OperationalFactEnvelope.UsageFactSubject
+                   || messageType
+                      <> Some OperationalFactEnvelope.UsageFactMessageType then
+                    logger.LogWarning(
+                        "Dead-lettering unsupported operational fact envelope. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Subject: {Subject}; MessageType: {MessageType}.",
+                        message.MessageId,
+                        message.CorrelationId,
+                        message.DeliveryCount,
+                        message.Subject,
+                        messageType |> Option.defaultValue "<missing>"
+                    )
+
+                    do!
+                        deadLetterAsync
+                            "UnsupportedOperationalFactEnvelope"
+                            "Message subject or graceMessageType is not supported by the operations usage worker."
+                            actions
+                            cancellationToken
+                else
+                    let usageFact = deserializeUsageFact message.Body
+
+                    match UsageFact.Validate usageFact with
+                    | Error errors ->
+                        logger.LogWarning(
+                            "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                            message.MessageId,
+                            message.CorrelationId,
+                            message.DeliveryCount,
+                            describeErrors errors
+                        )
+
+                        do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                    | Ok () ->
+                        let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
+
+                        match stored with
+                        | Error errors ->
+                            logger.LogWarning(
+                                "Dead-lettering UsageFact rejected by operations storage validation. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                                usageFact.UsageFactId,
+                                usageFact.CorrelationId,
+                                message.DeliveryCount,
+                                describeErrors errors
+                            )
+
+                            do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                        | Ok result ->
+                            logger.LogInformation(
+                                "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
+                                result.UsageFactId,
+                                usageFact.CorrelationId,
+                                message.DeliveryCount,
+                                result.Status,
+                                result.Aggregate
+                                |> Option.map (fun aggregate -> aggregate.Key.BucketStart)
+                                |> Option.defaultValue Instant.MinValue
+                            )
+
+                            do! actions.CompleteAsync cancellationToken
+            with
+            | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
+                logger.LogWarning(
+                    "Operational UsageFact processing was cancelled before message settlement. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}.",
+                    message.MessageId,
+                    message.CorrelationId,
+                    message.DeliveryCount
+                )
+            | :? JsonException as ex ->
+                logger.LogWarning(
+                    ex,
+                    "Dead-lettering malformed UsageFact JSON. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}.",
+                    message.MessageId,
+                    message.CorrelationId,
+                    message.DeliveryCount
+                )
+
+                do! deadLetterAsync "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
+            | ex ->
+                logger.LogError(
+                    ex,
+                    "Abandoning operational UsageFact message after transient processing failure. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}.",
+                    message.MessageId,
+                    message.CorrelationId,
+                    message.DeliveryCount
+                )
+
+                do! actions.AbandonAsync cancellationToken
+        }
+
+/// Adapts Azure Service Bus message settlement to the worker's fakeable action interface.
+type internal ServiceBusOperationsUsageMessageActions(args: ProcessMessageEventArgs) =
+
+    interface IOperationsUsageMessageActions with
+
+        member _.CompleteAsync(cancellationToken) = args.CompleteMessageAsync(args.Message, cancellationToken)
+
+        member _.AbandonAsync(cancellationToken) = args.AbandonMessageAsync(args.Message, cancellationToken = cancellationToken)
+
+        member _.DeadLetterAsync(reason, description, cancellationToken) =
+            args.DeadLetterMessageAsync(
+                args.Message,
+                deadLetterReason = reason,
+                deadLetterErrorDescription = description,
+                cancellationToken = cancellationToken
+            )
+
+/// Converts Service Bus messages into the processor's redacted, deterministic input shape.
+[<RequireQualifiedAccess>]
+module internal OperationsUsageServiceBusMessage =
+
+    /// Creates the ingestion processor message model from a received Service Bus message.
+    let fromReceivedMessage (message: ServiceBusReceivedMessage) =
+        {
+            MessageId = message.MessageId
+            CorrelationId = message.CorrelationId
+            DeliveryCount = message.DeliveryCount
+            Subject = message.Subject
+            ApplicationProperties = message.ApplicationProperties
+            Body = message.Body.ToArray()
+        }
+
+/// Runs the operational fact Service Bus processor for the Grace operations worker process.
+type OperationsUsageWorkerService
+    (
+        settings: OperationsWorkerSettings,
+        schema: OperationsUsageSchema,
+        processor: OperationsUsageIngestionProcessor,
+        logger: ILogger<OperationsUsageWorkerService>
+    ) =
+    let credential = lazy (DefaultAzureCredential() :> TokenCredential)
+    let mutable serviceBusClient: ServiceBusClient option = None
+    let mutable serviceBusProcessor: ServiceBusProcessor option = None
+
+    /// Creates a Service Bus client from connection string or managed identity settings.
+    let createClient () =
+        match settings.ServiceBusConnectionString, settings.ServiceBusFullyQualifiedNamespace with
+        | Some connectionString, _ -> ServiceBusClient(connectionString)
+        | None, Some fullyQualifiedNamespace -> ServiceBusClient(fullyQualifiedNamespace, credential.Value)
+        | None, None -> invalidOp "Azure Service Bus connection string or namespace must be configured."
+
+    /// Starts the Azure Service Bus processor after SQL schema initialization succeeds.
+    let startProcessingAsync (cancellationToken: CancellationToken) =
+        task {
+            if serviceBusProcessor.IsSome then
+                logger.LogDebug("Operations usage worker already running; skipping duplicate startup.")
+            else
+                let mutable ready = false
+
+                while not ready
+                      && not cancellationToken.IsCancellationRequested do
+                    let mutable createdClient = None
+                    let mutable createdProcessor = None
+
+                    try
+                        do! schema.EnsureCreatedAsync cancellationToken
+
+                        let client = createClient ()
+                        createdClient <- Some client
+
+                        let processorOptions =
+                            ServiceBusProcessorOptions(
+                                AutoCompleteMessages = false,
+                                MaxConcurrentCalls = settings.MaxConcurrentCalls,
+                                PrefetchCount = settings.PrefetchCount,
+                                Identifier = Environment.MachineName
+                            )
+
+                        let azureProcessor = client.CreateProcessor(settings.TopicName, settings.SubscriptionName, processorOptions)
+
+                        createdProcessor <- Some azureProcessor
+
+                        azureProcessor.add_ProcessMessageAsync (
+                            Func<ProcessMessageEventArgs, Task> (fun args ->
+                                let message = OperationsUsageServiceBusMessage.fromReceivedMessage args.Message
+                                let actions = ServiceBusOperationsUsageMessageActions args
+                                processor.ProcessMessageAsync(message, actions, args.CancellationToken))
+                        )
+
+                        azureProcessor.add_ProcessErrorAsync (
+                            Func<ProcessErrorEventArgs, Task> (fun args ->
+                                logger.LogError(
+                                    args.Exception,
+                                    "Operations usage Service Bus processor fault. ErrorSource: {ErrorSource}; EntityPath: {EntityPath}; FullyQualifiedNamespace: {FullyQualifiedNamespace}.",
+                                    args.ErrorSource,
+                                    args.EntityPath,
+                                    args.FullyQualifiedNamespace
+                                )
+
+                                Task.CompletedTask)
+                        )
+
+                        do! azureProcessor.StartProcessingAsync cancellationToken
+                        serviceBusClient <- Some client
+                        serviceBusProcessor <- Some azureProcessor
+                        createdClient <- None
+                        createdProcessor <- None
+
+                        logger.LogInformation(
+                            "Started operations usage worker for topic {TopicName} / subscription {SubscriptionName}.",
+                            settings.TopicName,
+                            settings.SubscriptionName
+                        )
+
+                        ready <- true
+                    with
+                    | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> ()
+                    | ex ->
+                        match createdProcessor with
+                        | Some processor -> do! processor.DisposeAsync()
+                        | None -> ()
+
+                        match createdClient with
+                        | Some client -> do! client.DisposeAsync()
+                        | None -> ()
+
+                        logger.LogWarning(ex, "Operations usage worker dependencies are not ready; pausing for five seconds before retrying.")
+
+                        do! Task.Delay(TimeSpan.FromSeconds(5.0), cancellationToken)
+        }
+
+    /// Stops the Azure Service Bus processor and releases its client.
+    let stopProcessingAsync cancellationToken =
+        task {
+            match serviceBusProcessor with
+            | Some processor ->
+                try
+                    do! processor.StopProcessingAsync cancellationToken
+                with
+                | ex -> logger.LogWarning(ex, "Operations usage processor stop failed; continuing with Dispose().")
+
+                do! processor.DisposeAsync()
+                serviceBusProcessor <- None
+            | None -> ()
+
+            match serviceBusClient with
+            | Some client ->
+                do! client.DisposeAsync()
+                serviceBusClient <- None
+            | None -> ()
+        }
+
+    interface IHostedService with
+
+        /// Starts operational usage ingestion.
+        member _.StartAsync(cancellationToken: CancellationToken) = startProcessingAsync cancellationToken
+
+        /// Stops operational usage ingestion.
+        member _.StopAsync(cancellationToken: CancellationToken) = stopProcessingAsync cancellationToken

--- a/src/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations.Worker/Program.fs
@@ -1,0 +1,46 @@
+namespace Grace.Operations.Worker
+
+open Grace.Operations.Data
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
+open System
+
+/// Starts the Grace operations worker host.
+module Program =
+
+    /// Configures and runs the operational usage ingestion worker process.
+    [<EntryPoint>]
+    let main args =
+        try
+            Host
+                .CreateDefaultBuilder(args)
+                .ConfigureServices(fun context services ->
+                    let settings =
+                        match OperationsWorkerSettings.fromConfiguration context.Configuration with
+                        | Ok value -> value
+                        | Error errors -> invalidOp (String.Join("; ", errors))
+
+                    services.AddSingleton(settings) |> ignore
+
+                    services.AddSingleton(OperationsUsageSchema(settings.SqlConnectionString))
+                    |> ignore
+
+                    services.AddSingleton<IOperationsUsageFactStore> (fun _ ->
+                        let transactionScope = SqlOperationsUsageTransactionScope(settings.SqlConnectionString)
+                        let store = OperationsUsageStore transactionScope
+                        OperationsUsageFactStoreAdapter(store) :> IOperationsUsageFactStore)
+                    |> ignore
+
+                    services.AddSingleton<OperationsUsageIngestionProcessor>()
+                    |> ignore
+
+                    services.AddHostedService<OperationsUsageWorkerService>()
+                    |> ignore)
+                .Build()
+                .Run()
+
+            0
+        with
+        | ex ->
+            Console.Error.WriteLine($"Grace operations worker failed to start: {ex.Message}")
+            1

--- a/src/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations.Worker/Program.fs
@@ -22,7 +22,7 @@ module Program =
 
                     services.AddSingleton(settings) |> ignore
 
-                    services.AddSingleton(OperationsUsageSchema(settings.SqlConnectionString))
+                    services.AddSingleton(OperationsUsageSchema(settings.SqlConnectionString, settings.SchemaBootstrapMode))
                     |> ignore
 
                     services.AddSingleton<IOperationsUsageFactStore> (fun _ ->

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -64,14 +64,24 @@ Open `http://localhost:18888` and confirm the following resources show
 - `redis` – Redis cache on port `6379`
 - `cosmos` – Cosmos DB emulator on port `8081`
 - `servicebus-sql` – SQL Server container required by the Service Bus emulator
+  and used locally for the `GraceOperations` SQL database
 - `servicebus-emulator` – Service Bus emulator (AMQP on `5672`, management
   endpoint on `5300`)
 - `grace-server` – HTTP `5000` / HTTPS `5001`
+- `grace-operations-worker` – operational usage fact ingestion worker for the
+  `grace-operational-facts` topic and durable `operational-facts-processor`
+  subscription
 
 Redis is provisioned by AppHost and its host/port are forwarded to
 `Grace.Server`. Current startup code does not enable Redis-backed SignalR, so
 Redis remains an explicit AppHost dependency pending a follow-up runtime
 decision rather than a prerequisite proven by the integration tests.
+
+The local operations worker creates the `ops` SQL schema and usage fact tables
+inside a `GraceOperations` database on the local SQL Server container before it
+starts the Service Bus processor. It completes a Service Bus message only after
+the operations data layer accepts the raw fact or reports that the fact was
+already processed.
 
 ## Smoke Tests
 
@@ -87,6 +97,9 @@ decision rather than a prerequisite proven by the integration tests.
    exporter.
 3. **Logs** – Within the same resource view, confirm log entries for Orleans
    startup and Aspire instrumentation.
+4. **Operations worker** – In the `grace-operations-worker` logs, confirm the
+   startup line for topic `grace-operational-facts` and subscription
+   `operational-facts-processor`.
 
 ## Service Bus Emulator Connection String
 

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -194,6 +194,20 @@ These capture failure classification, retryability, cleanup notes, and runtime m
   acknowledgement that the operational facts topic already has the durable `operational-facts-processor` subscription.
 - `grace__azure_service_bus__subscription`: Service Bus subscription name.
 
+### Operations Worker
+
+- `grace__operations__sql__connectionstring`: SQL Server connection string used by `Grace.Operations.Worker` for raw
+  usage facts and minute aggregates. Aspire local run mode points this at the local SQL Server container and database
+  `GraceOperations`.
+- `grace__operations_worker__max_concurrent_calls`: Optional Service Bus processor concurrency override. Defaults to
+  `4`.
+- `grace__operations_worker__prefetch_count`: Optional Service Bus processor prefetch override. Defaults to `16`.
+
+The operations worker reads from `grace__azure_service_bus__operational_facts_topic` and requires
+`grace__azure_service_bus__operational_facts_processor_subscription` to be exactly `operational-facts-processor`.
+Malformed or unsupported usage fact messages are dead-lettered; transient storage failures are abandoned for retry.
+Messages are completed only after SQL processing succeeds or the durable usage fact identity is already present.
+
 ### Redis
 
 - `grace__redis__host`: Redis host.


### PR DESCRIPTION
# OPS5: Add Grace.Operations.Worker Ingestion Loop

## Related issue

Related to #530. Part of #525.

## Why this matters

The operations worker is the runtime bridge from Grace activity to operations accounting. This slice makes usage-fact
retries safe and failures observable before later reporting, pricing, or billing work trusts the operations aggregate.

## Summary

- Added the executable `Grace.Operations.Worker` host.
- Added a Service Bus ingestion processor for operational `UsageFact` messages.
- Completed messages only after durable operations storage succeeds.
- Completed duplicate messages only after idempotent storage reports the fact was already processed.
- Dead-lettered malformed, invalid, and future-kind messages instead of silently treating them as successful.
- Abandoned messages on SQL/transient processing failures so Service Bus can retry.
- Left messages unsettled when cancellation interrupts storage processing.
- Added SQL database bootstrap before `ops` schema and table creation.
- Made SQL database creation explicit/admin-only so existing target-database connections do not require `master`.
- Resolved AppHost-style normalized worker configuration keys before startup validation.
- Wired `grace-operations-worker` into local and DebugAzure AppHost flows.
- Added deterministic worker ingestion tests for success, duplicate, invalid, failure, and cancellation paths.
- Documented worker runtime settings and local run expectations.

## Touched paths

- `src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs`
- `src/Grace.Operations.Data/OperationsData.fs`
- `src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`
- `src/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs`
- `src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs`
- `src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj`
- `src/Grace.Operations.Worker/OperationsWorker.fs`
- `src/Grace.Operations.Worker/Program.fs`
- `src/docs/ASPIRE_SETUP.md`
- `src/docs/ENVIRONMENT.md`

## Validation

- Targeted Fantomas on touched F# files: passed.
- `dotnet build src\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --configuration Release`: passed.
- `dotnet test --no-build --configuration Release src\Grace.Operations.Tests\Grace.Operations.Tests.fsproj`: passed.
- `npx --yes markdownlint-cli2 src/docs/ASPIRE_SETUP.md src/docs/ENVIRONMENT.md`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed.
- `git diff --check`: passed.
- GitHub Actions `full`: passed on `a1478327`.

## Review Status

- Current head: `a14783270b2394a95d6fa2a4de2bc8348c532622`.
- Workers: Singer implemented the ingestion loop and ran bot-prevention self-review; Gauss fixed the first Codex review
  findings; Bacon fixed the second Codex review findings.
- Worker self-review: fixed one runtime issue before commit; the operations SQL schema bootstrap now creates the target
  `GraceOperations` database from `master` before creating `ops` objects.
- Codex Code Review Bot: first review found worker configuration normalization and SQL bootstrap privilege issues on
  `1cebaa74`; fixed in `b7fc56ed`.
- Review stabilization: accepted findings recorded in
  [#530](https://github.com/ScottArbeit/Grace/issues/530#issuecomment-4882661310) and
  [PR #539](https://github.com/ScottArbeit/Grace/pull/539#issuecomment-4882661328).
- Review/fix evidence: replied on
  [discussion_r3523425406](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523425406) and
  [discussion_r3523425427](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523425427); both conversations
  are resolved.
- Second review found local SQL connection formatting, local database bootstrap, managed-identity namespace
  normalization, and deterministic SQL-shape dead-letter issues on `b7fc56ed`; assigned to fresh worker Bacon.
- Second review stabilization: accepted findings recorded in
  [#530](https://github.com/ScottArbeit/Grace/issues/530#issuecomment-4882866153) and
  [PR #539](https://github.com/ScottArbeit/Grace/pull/539#issuecomment-4882866149).
- Second review fix: local SQL container connection strings now use SqlClient comma-port syntax, local worker startup
  opts into database creation only for `grace__debug_environment=Local`, configured Service Bus namespaces are
  normalized before managed-identity client creation, and deterministic SQL-shape validation failures now dead-letter as
  invalid usage facts.
- Second review validation: targeted Fantomas passed; focused operations tests passed, 26/26; `validate -Full` passed;
  `git diff --check` passed.
- Second review/fix evidence: replied on
  [discussion_r3523458938](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523458938),
  [discussion_r3523459001](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523459001),
  [discussion_r3523459030](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523459030), and
  [discussion_r3523459061](https://github.com/ScottArbeit/Grace/pull/539#discussion_r3523459061); all four
  conversations are resolved.
- Codex Code Review Bot: 👍 on `a1478327`.

## Docs impact

Updated local Aspire and environment docs for operations worker settings and local run expectations.

## Residual risk

DebugAzure wiring compiles and local Aspire startup was covered by `validate -Full`, but this slice did not run against
real Azure Service Bus or Azure SQL credentials. Durable outbox, pricing, charge ledger, customer reports, and dashboard
UX remain out of scope for #530.
