### PR TITLE
OPS6: Add operations tracer-bullet proof

### DIFF
--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -280,7 +280,7 @@ public partial class Program
                             .WithEnvironment("ACCEPT_EULA", "Y")
                             .WithEnvironment("MSSQL_SA_PASSWORD", serviceBusSqlPassword)
                             //.WithLifetime(ContainerLifetime.Session)
-                            .WithEndpoint(targetPort: 1433, port: 21433, name: "sql", scheme: "tcp");
+                            .WithEndpoint(targetPort: 1433, name: "sql", scheme: "tcp");
                         if (isTestRun)
                         {
                             serviceBusSql.WithEnvironment("MSSQL_MEMORY_LIMIT_MB", "1024");
@@ -299,11 +299,6 @@ public partial class Program
                         }
 
                         var serviceBusSqlEndpoint = serviceBusSql.GetEndpoint("sql");
-                        var serviceBusSqlHost = serviceBusSqlEndpoint.Property(EndpointProperty.Host);
-                        var serviceBusSqlPort = serviceBusSqlEndpoint.Property(EndpointProperty.Port);
-                        var serviceBusSqlDataSource = BuildSqlTcpDataSource(serviceBusSqlHost, serviceBusSqlPort);
-                        var operationsSqlConnectionString = ReferenceExpression.Create(
-                            $"Server={serviceBusSqlDataSource};Initial Catalog=GraceOperations;User ID=sa;Password={serviceBusSqlPassword};TrustServerCertificate=True;Encrypt=False;");
 
                         var serviceBusEmulatorResourceName = runSuffix is null ? "servicebus-emulator" : $"servicebus-emulator-{runSuffix}";
                         var serviceBusEmulator = builder.AddContainer(serviceBusEmulatorResourceName, "mcr.microsoft.com/azure-messaging/servicebus-emulator", "latest")
@@ -353,7 +348,22 @@ public partial class Program
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusNamespace, "sbemulatorns")
                             .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopicName)
                             .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, OperationalFactsProcessorSubscriptionName)
-                            .WithEnvironment(OperationsSqlConnectionStringSettingName, operationsSqlConnectionString)
+                            .WithEnvironment(async context =>
+                            {
+                                var sqlEndpoint = await serviceBusSqlEndpoint.GetValueAsync(context.CancellationToken);
+                                if (string.IsNullOrWhiteSpace(sqlEndpoint))
+                                {
+                                    throw new InvalidOperationException("Service Bus SQL endpoint was not allocated for operations worker configuration.");
+                                }
+
+                                var sqlEndpointUri = new Uri(sqlEndpoint);
+                                var sqlDataSource = BuildSqlTcpDataSource(sqlEndpointUri.Host, sqlEndpointUri.Port);
+                                context.Logger.LogInformation(
+                                    "Configured operations worker SQL data source {SqlDataSource}.",
+                                    sqlDataSource);
+                                context.EnvironmentVariables[OperationsSqlConnectionStringSettingName] =
+                                    $"Server={sqlDataSource};Initial Catalog=GraceOperations;User ID=sa;Password={serviceBusSqlPassword};TrustServerCertificate=True;Encrypt=False;";
+                            })
                             .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Local")
                             .WithOtlpExporter();
                     }
@@ -647,6 +657,12 @@ public partial class Program
         var normalizedHost = hostValue.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase)
             ? hostValue.Substring(4)
             : hostValue;
+
+        if (normalizedHost.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || normalizedHost.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            normalizedHost = IPAddress.Loopback.ToString();
+        }
 
         return $"tcp:{normalizedHost},{portValue}";
     }

--- a/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -172,13 +172,13 @@ type OperationsWorkerIngestionTests() =
     /// Creates an already-processed persistence result for a fact.
     let alreadyProcessed fact = { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
 
-    /// Verifies AppHost SQL Server data sources use SqlClient comma-port syntax.
+    /// Verifies AppHost SQL Server data sources use SqlClient comma-port syntax and IPv4 loopback for local endpoints.
     [<Test>]
     member _.AppHostFormatsLocalSqlDataSourceWithCommaPort() =
         Assert.Multiple(
             Action (fun () ->
-                Assert.That(global.Program.BuildSqlTcpDataSource("localhost", 21433), Is.EqualTo("tcp:localhost,21433"))
-                Assert.That(global.Program.BuildSqlTcpDataSource("tcp:localhost", "21433"), Is.EqualTo("tcp:localhost,21433")))
+                Assert.That(global.Program.BuildSqlTcpDataSource("localhost", 21433), Is.EqualTo("tcp:127.0.0.1,21433"))
+                Assert.That(global.Program.BuildSqlTcpDataSource("tcp:localhost", "21433"), Is.EqualTo("tcp:127.0.0.1,21433")))
         )
 
     /// Verifies AppHost-style environment names resolve after Host configuration normalizes `__` to `:`.

--- a/src/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations.Worker/OperationsWorker.fs
@@ -7,6 +7,7 @@ open Grace.Operations.Data
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Usage
+open Microsoft.Data.SqlClient
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
@@ -397,6 +398,18 @@ type OperationsUsageWorkerService
         | None, Some fullyQualifiedNamespace -> ServiceBusClient(fullyQualifiedNamespace, credential.Value)
         | None, None -> invalidOp "Azure Service Bus connection string or namespace must be configured."
 
+    /// Extracts the non-secret SQL data source for dependency diagnostics without logging credentials.
+    let sqlDataSource () =
+        try
+            let builder = SqlConnectionStringBuilder(settings.SqlConnectionString)
+
+            if String.IsNullOrWhiteSpace builder.DataSource then
+                "<missing>"
+            else
+                builder.DataSource
+        with
+        | _ -> "<unavailable>"
+
     /// Starts the Azure Service Bus processor after SQL schema initialization succeeds.
     let startProcessingAsync (cancellationToken: CancellationToken) =
         task {
@@ -472,7 +485,11 @@ type OperationsUsageWorkerService
                         | Some client -> do! client.DisposeAsync()
                         | None -> ()
 
-                        logger.LogWarning(ex, "Operations usage worker dependencies are not ready; pausing for five seconds before retrying.")
+                        logger.LogWarning(
+                            ex,
+                            "Operations usage worker dependencies are not ready for SQL data source {SqlDataSource}; pausing for five seconds before retrying.",
+                            sqlDataSource ()
+                        )
 
                         do! Task.Delay(TimeSpan.FromSeconds(5.0), cancellationToken)
         }

--- a/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
+++ b/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
@@ -27,6 +27,8 @@ module private AgentSessionTestHelpers =
                     ServiceBusTopic = serviceBusTopic
                     ServiceBusServerSubscription = serviceBusServerSubscription
                     ServiceBusTestSubscription = serviceBusTestSubscription
+                    OperationalFactsTopic = operationalFactsTopic
+                    OperationsSqlConnectionString = operationsSqlConnectionString
                 }
             | None ->
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -29,6 +29,8 @@ module private ApprovalTestHelpers =
                     ServiceBusTopic = serviceBusTopic
                     ServiceBusServerSubscription = serviceBusServerSubscription
                     ServiceBusTestSubscription = serviceBusTestSubscription
+                    OperationalFactsTopic = operationalFactsTopic
+                    OperationsSqlConnectionString = operationsSqlConnectionString
                 }
             | None ->
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -34,6 +34,8 @@ type TestHostState =
         ServiceBusTopic: string
         ServiceBusServerSubscription: string
         ServiceBusTestSubscription: string
+        OperationalFactsTopic: string
+        OperationsSqlConnectionString: string
     }
 
 /// Groups shared helpers for aspire test host.
@@ -41,6 +43,7 @@ module AspireTestHost =
     do AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> Environment.ExitCode <- 0)
 
     let private graceServerResourceName = "grace-server"
+    let private operationsWorkerResourceName = "grace-operations-worker"
     let private azuriteResourceName = "azurite"
     let private sharedStateLock = new SemaphoreSlim(1, 1)
     let mutable private sharedState: TestHostState option = None
@@ -1244,6 +1247,61 @@ module AspireTestHost =
                     let testSubscription = $"{subscription}-tests"
                     connection, topic, subscription, testSubscription
 
+            let! operationsWorkerEnv =
+                if shouldSkipServiceBus () then
+                    Task.FromResult Map.empty
+                else
+                    getEnvironmentVariablesAsync app operationsWorkerResourceName
+
+            let! serviceBusSqlEnv =
+                if shouldSkipServiceBus () then
+                    Task.FromResult Map.empty
+                else
+                    getEnvironmentVariablesAsync app serviceBusSqlResourceName
+
+            let! operationalFactsTopic, operationsSqlConnectionString =
+                if shouldSkipServiceBus () then
+                    Task.FromResult("", "")
+                else
+                    task {
+                        let topic =
+                            requireEnv operationsWorkerResourceName Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic operationsWorkerEnv
+
+                        let! dockerPortResult = runProcessAsync "docker" $"port {serviceBusSqlResourceName} 1433/tcp" (TimeSpan.FromSeconds(10.0))
+
+                        let sqlHost, sqlPort =
+                            if
+                                dockerPortResult.ExitCode = Some 0
+                                && not (String.IsNullOrWhiteSpace dockerPortResult.StdOut)
+                            then
+                                let dockerPortLines = dockerPortResult.StdOut.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+
+                                let firstLine = dockerPortLines[ 0 ].Trim()
+
+                                let separator = firstLine.LastIndexOf(':')
+
+                                if separator > 0 then
+                                    let host = firstLine.Substring(0, separator).Trim('[', ']')
+                                    let port = firstLine.Substring(separator + 1)
+
+                                    let host = if host = "0.0.0.0" || host = "::" then "127.0.0.1" else host
+
+                                    host, port
+                                else
+                                    let sqlEndpoint = app.GetEndpoint(serviceBusSqlResourceName, "sql")
+                                    sqlEndpoint.Host, string sqlEndpoint.Port
+                            else
+                                let sqlEndpoint = app.GetEndpoint(serviceBusSqlResourceName, "sql")
+                                sqlEndpoint.Host, string sqlEndpoint.Port
+
+                        let sqlPassword = requireEnv serviceBusSqlResourceName "MSSQL_SA_PASSWORD" serviceBusSqlEnv
+
+                        let sqlConnectionString =
+                            $"Server=tcp:{sqlHost},{sqlPort};Initial Catalog=GraceOperations;User ID=sa;Password={sqlPassword};TrustServerCertificate=True;Encrypt=False;Connection Timeout=3;"
+
+                        return topic, sqlConnectionString
+                    }
+
             let baseAddress = endpointUri.ToString().TrimEnd('/')
 
             let state =
@@ -1255,10 +1313,13 @@ module AspireTestHost =
                     ServiceBusTopic = serviceBusTopic
                     ServiceBusServerSubscription = serviceBusSubscription
                     ServiceBusTestSubscription = serviceBusTestSubscription
+                    OperationalFactsTopic = operationalFactsTopic
+                    OperationsSqlConnectionString = operationsSqlConnectionString
                 }
 
             if not (shouldSkipServiceBus ()) then
                 do! waitForServiceBusReadyAsync serviceBusEmulatorResourceName serviceBusSqlResourceName state
+                do! waitForResourceHealthyAsync notificationService app operationsWorkerResourceName cts.Token
             else
                 Console.WriteLine("Skipping Service Bus functional readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
 

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -1319,7 +1319,9 @@ module AspireTestHost =
 
             if not (shouldSkipServiceBus ()) then
                 do! waitForServiceBusReadyAsync serviceBusEmulatorResourceName serviceBusSqlResourceName state
-                do! waitForResourceHealthyAsync notificationService app operationsWorkerResourceName cts.Token
+
+                use operationsWorkerReadinessCts = new CancellationTokenSource(defaultWaitTimeout)
+                do! waitForResourceHealthyAsync notificationService app operationsWorkerResourceName operationsWorkerReadinessCts.Token
             else
                 Console.WriteLine("Skipping Service Bus functional readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
 

--- a/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs
@@ -34,6 +34,8 @@ module private EventingIntegrationHelpers =
                 ServiceBusTopic = serviceBusTopic
                 ServiceBusServerSubscription = serviceBusServerSubscription
                 ServiceBusTestSubscription = serviceBusTestSubscription
+                OperationalFactsTopic = operationalFactsTopic
+                OperationsSqlConnectionString = operationsSqlConnectionString
             }
         | Microsoft.FSharp.Core.Option.None -> failwith "Aspire test host has not started."
 

--- a/src/Grace.Server.Tests/General.Server.Tests.fs
+++ b/src/Grace.Server.Tests/General.Server.Tests.fs
@@ -61,6 +61,8 @@ module Services =
     let mutable serviceBusTopic = String.Empty
     let mutable serviceBusServerSubscription = String.Empty
     let mutable serviceBusTestSubscription = String.Empty
+    let mutable operationalFactsTopic = String.Empty
+    let mutable operationsSqlConnectionString = String.Empty
     let mutable graceServerBaseAddress = String.Empty
     let mutable testUserId = String.Empty
     let mutable testUserClaims: string list = []
@@ -118,6 +120,8 @@ type Setup() =
             serviceBusTopic <- hostState.ServiceBusTopic
             serviceBusServerSubscription <- hostState.ServiceBusServerSubscription
             serviceBusTestSubscription <- hostState.ServiceBusTestSubscription
+            operationalFactsTopic <- hostState.OperationalFactsTopic
+            operationsSqlConnectionString <- hostState.OperationsSqlConnectionString
             testUserClaims <- [ "engineering"; "contributors" ]
 
             Client.DefaultRequestHeaders.Add("x-grace-user-id", testUserId)
@@ -127,6 +131,8 @@ type Setup() =
 
             logToTestConsole
                 $"Service Bus topic: {serviceBusTopic}; subscription: {serviceBusServerSubscription}; test subscription: {serviceBusTestSubscription}"
+
+            logToTestConsole $"Operational facts topic: {operationalFactsTopic}"
 
             let! drained = AspireTestHost.drainServiceBusAsync hostState
 

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AspireTestHost.Diagnostics.Tests.fs" />
     <Compile Include="OperationalFactsPublisher.AppHost.Tests.fs" />
     <Compile Include="General.Server.Tests.fs" />
+    <Compile Include="OperationsTracerBullet.Server.Tests.fs" />
     <Compile Include="Smoke.Server.Tests.fs" />
     <Compile Include="Slop.Server.Tests.fs" />
     <Compile Include="Owner.Server.Tests.fs" />
@@ -52,6 +53,7 @@
     <PackageReference Include="FsCheck" Version="3.3.3" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
     <PackageReference Include="FsUnit" Version="7.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
@@ -68,6 +70,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj" />
     <ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
     <ProjectReference Include="..\Grace.Server\Grace.Server.fsproj" />

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -131,6 +131,28 @@ type OperationsTracerBulletServerTests() =
                 |> Seq.toList
         }
 
+    /// Peeks message identities from the operations worker subscription without changing delivery state.
+    let peekOperationalMessageIdsAsync subQueue =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+
+            let receiverOptions =
+                match subQueue with
+                | Some queue -> ServiceBusReceiverOptions(SubQueue = queue, ReceiveMode = ServiceBusReceiveMode.PeekLock)
+                | None -> ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+
+            let receiver = client.CreateReceiver(operationalFactsTopic, operationsProcessorSubscriptionName, receiverOptions)
+
+            use _receiver = receiver
+            let! messages = receiver.PeekMessagesAsync(50)
+
+            return
+                messages
+                |> Seq.map (fun message -> message.MessageId)
+                |> Seq.toList
+        }
+
     /// Captures Service Bus delivery evidence for a failed operations SQL wait.
     let operationsServiceBusDiagnosticsAsync () =
         task {
@@ -162,14 +184,6 @@ type OperationsTracerBulletServerTests() =
             let connection = new SqlConnection(operationsSqlConnectionString)
             do! connection.OpenAsync()
             return connection
-        }
-
-    /// Ensures the dev/test SQL proof database and operations usage tables exist before publishing facts.
-    let ensureOperationsSchemaAsync () =
-        task {
-            let schema = OperationsUsageSchema(operationsSqlConnectionString, OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing)
-
-            do! schema.EnsureCreatedAsync(CancellationToken.None)
         }
 
     /// Adds a SQL parameter to a command without logging the value.
@@ -263,6 +277,48 @@ WHERE FactKind = @FactKind
                 )
         }
 
+    /// Waits until the operations worker has removed one expected message from its durable subscription.
+    let waitForOperationalMessageSettledAsync description messageId =
+        task {
+            let stopwatch = Stopwatch.StartNew()
+            let mutable settled = false
+            let mutable lastActiveMessages = List.empty
+            let mutable lastDeadLetterMessages = List.empty
+
+            while not settled && stopwatch.Elapsed < proofTimeout do
+                let! activeMessageIds = peekOperationalMessageIdsAsync None
+                let! deadLetterMessageIds = peekOperationalMessageIdsAsync (Some SubQueue.DeadLetter)
+
+                lastActiveMessages <- activeMessageIds
+                lastDeadLetterMessages <- deadLetterMessageIds
+
+                let hasMatchingMessage =
+                    activeMessageIds
+                    |> List.append deadLetterMessageIds
+                    |> List.exists (fun activeMessageId -> String.Equals(activeMessageId, messageId, StringComparison.Ordinal))
+
+                if hasMatchingMessage then
+                    do! Task.Delay(TimeSpan.FromSeconds(1.0))
+                else
+                    settled <- true
+
+            if not settled then
+                let format label messages =
+                    if List.isEmpty messages then
+                        $"{label}: <none>"
+                    else
+                        $"{label}:{Environment.NewLine}{String.Join(Environment.NewLine, messages)}"
+
+                let activeDiagnostics = format "Active operational messages" lastActiveMessages
+                let deadLetterDiagnostics = format "Dead-letter operational messages" lastDeadLetterMessages
+
+                raise (
+                    TimeoutException(
+                        $"{description} message '{messageId}' was not settled by the operations worker before timeout.{Environment.NewLine}{activeDiagnostics}{Environment.NewLine}{deadLetterDiagnostics}"
+                    )
+                )
+        }
+
     /// Waits for an invalid operational message to reach the worker's dead-letter queue.
     let waitForDeadLetterReasonAsync expectedReason =
         task {
@@ -311,13 +367,14 @@ WHERE FactKind = @FactKind
 
             Assert.That(fact.CorrelationId, Is.Not.EqualTo(fact.UsageFactId.ToString("D")))
 
-            do! ensureOperationsSchemaAsync ()
             do! sendOperationalMessageAsync (usageFactMessage (fact.UsageFactId.ToString("D")) fact)
             do! waitForUsageStateAsync "Initial published fact" 1L 4096L fact
 
-            let duplicateDelivery = usageFactMessage $"{fact.UsageFactId:D}-redelivery" fact
+            let duplicateMessageId = $"{fact.UsageFactId:D}-redelivery"
+            let duplicateDelivery = usageFactMessage duplicateMessageId fact
 
             do! sendOperationalMessageAsync duplicateDelivery
+            do! waitForOperationalMessageSettledAsync "Duplicate UsageFactId delivery" duplicateMessageId
             do! waitForUsageStateAsync "Duplicate UsageFactId delivery" 1L 4096L fact
 
             let futureFact = usageFact (Guid.Parse("53153153-2531-4531-8531-531531531531")) (CorrelationId "ops6-future-kind-correlation")

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -1,0 +1,356 @@
+namespace Grace.Server.Tests
+
+open Azure.Messaging.ServiceBus
+open Grace.Operations.Data
+open Grace.Server.Tests.Services
+open Grace.Shared
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Data.SqlClient
+open NodaTime
+open NUnit.Framework
+open System
+open System.Data
+open System.Diagnostics
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Proves the dev/test operational usage tracer bullet through Service Bus, worker ingestion, SQL raw storage, and aggregate projection.
+[<TestFixture>]
+type OperationsTracerBulletServerTests() =
+
+    /// Durable operations worker subscription created by AppHost for local tracer-bullet runs.
+    [<Literal>]
+    let operationsProcessorSubscriptionName = "operational-facts-processor"
+
+    /// JSON media type used for operational usage fact Service Bus messages.
+    [<Literal>]
+    let operationalJsonContentType = "application/json"
+
+    /// Service Bus subject used by operational usage fact messages.
+    [<Literal>]
+    let usageFactSubject = "GraceOperationalUsageFact"
+
+    /// Application property that identifies the operational fact contract carried by the message.
+    [<Literal>]
+    let usageFactMessageTypeProperty = "graceMessageType"
+
+    /// Application property value for operational usage fact messages.
+    [<Literal>]
+    let usageFactMessageType = "UsageFact"
+
+    /// Application property that records the specific usage fact kind without parsing the payload.
+    [<Literal>]
+    let usageFactKindProperty = "usageFactKind"
+
+    /// Bounded wait used while the worker consumes Service Bus messages and commits SQL rows.
+    let proofTimeout = TimeSpan.FromSeconds(45.0)
+
+    /// Builds a deterministic repository storage usage fact for the tracer-bullet proof.
+    let usageFact usageFactId correlationId =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            correlationId,
+            Guid.Parse(ownerId),
+            Guid.Parse(organizationId),
+            Guid.Parse(repositoryIds[0]),
+            StoragePoolId Constants.DefaultStoragePoolId,
+            4096L,
+            Instant.FromUtc(2026, 7, 4, 12, 34, 56)
+        )
+
+    /// Creates a Service Bus message that carries a usage fact through the same operational envelope consumed by the worker.
+    let usageFactMessage messageId (fact: UsageFact) =
+        let payload = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+        let message = ServiceBusMessage(payload)
+        message.ContentType <- operationalJsonContentType
+        message.Subject <- usageFactSubject
+        message.MessageId <- messageId
+        message.CorrelationId <- fact.CorrelationId
+
+        message.ApplicationProperties[ usageFactMessageTypeProperty ] <- usageFactMessageType
+
+        message.ApplicationProperties[ usageFactKindProperty ] <- fact.FactKind.ToString()
+
+        message
+
+    /// Sends one raw message directly to the operational facts topic for duplicate and invalid-payload proof.
+    let sendOperationalMessageAsync (message: ServiceBusMessage) =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+            let sender = client.CreateSender(operationalFactsTopic)
+
+            try
+                use cts = new CancellationTokenSource(TimeSpan.FromSeconds(10.0))
+                do! sender.SendMessageAsync(message, cts.Token)
+            finally
+                sender
+                    .DisposeAsync()
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult()
+        }
+
+    /// Describes a peeked Service Bus message without exposing the raw usage payload.
+    let describePeekedMessage (message: ServiceBusReceivedMessage) =
+        let usageKind =
+            match message.ApplicationProperties.TryGetValue usageFactKindProperty with
+            | true, value when not (isNull value) -> string value
+            | _ -> "<missing>"
+
+        let deadLetterReason =
+            if String.IsNullOrWhiteSpace message.DeadLetterReason then
+                "<none>"
+            else
+                message.DeadLetterReason
+
+        $"MessageId={message.MessageId}; CorrelationId={message.CorrelationId}; Subject={message.Subject}; UsageKind={usageKind}; DeliveryCount={message.DeliveryCount}; DeadLetterReason={deadLetterReason}"
+
+    /// Peeks messages from the operations worker subscription without changing delivery state.
+    let peekOperationalMessagesAsync subQueue =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+
+            let receiverOptions =
+                match subQueue with
+                | Some queue -> ServiceBusReceiverOptions(SubQueue = queue, ReceiveMode = ServiceBusReceiveMode.PeekLock)
+                | None -> ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+
+            let receiver = client.CreateReceiver(operationalFactsTopic, operationsProcessorSubscriptionName, receiverOptions)
+
+            use _receiver = receiver
+            let! messages = receiver.PeekMessagesAsync(5)
+
+            return
+                messages
+                |> Seq.map describePeekedMessage
+                |> Seq.toList
+        }
+
+    /// Captures Service Bus delivery evidence for a failed operations SQL wait.
+    let operationsServiceBusDiagnosticsAsync () =
+        task {
+            try
+                let! activeMessages = peekOperationalMessagesAsync None
+                let! deadLetterMessages = peekOperationalMessagesAsync (Some SubQueue.DeadLetter)
+
+                let format label messages =
+                    if List.isEmpty messages then
+                        $"{label}: <none>"
+                    else
+                        $"{label}:{Environment.NewLine}{String.Join(Environment.NewLine, messages)}"
+
+                return
+                    String.Join(
+                        Environment.NewLine,
+                        [
+                            format "Active operational messages" activeMessages
+                            format "Dead-letter operational messages" deadLetterMessages
+                        ]
+                    )
+            with
+            | ex -> return $"Service Bus diagnostics unavailable: {ex.GetType().FullName}: {ex.Message}"
+        }
+
+    /// Opens a SQL connection to the operations database configured for the AppHost worker.
+    let openOperationsSqlAsync () =
+        task {
+            let connection = new SqlConnection(operationsSqlConnectionString)
+            do! connection.OpenAsync()
+            return connection
+        }
+
+    /// Ensures the dev/test SQL proof database and operations usage tables exist before publishing facts.
+    let ensureOperationsSchemaAsync () =
+        task {
+            let schema = OperationsUsageSchema(operationsSqlConnectionString, OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing)
+
+            do! schema.EnsureCreatedAsync(CancellationToken.None)
+        }
+
+    /// Adds a SQL parameter to a command without logging the value.
+    let addParameter (command: SqlCommand) name sqlDbType value =
+        let parameter = command.Parameters.Add(name, sqlDbType)
+        parameter.Value <- value
+
+    /// Reads the raw fact count for one durable usage fact identity.
+    let rawFactCountAsync usageFactId =
+        task {
+            use! connection = openOperationsSqlAsync ()
+            use command = connection.CreateCommand()
+            command.CommandText <- $"SELECT COUNT_BIG(1) FROM {OperationsUsageSql.RawUsageFactTable} WHERE UsageFactId = @UsageFactId;"
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            let! scalar = command.ExecuteScalarAsync()
+            return Convert.ToInt64 scalar
+        }
+
+    /// Reads the minute aggregate quantity for the fact's repository resource and UTC bucket.
+    let aggregateQuantityAsync (fact: UsageFact) =
+        task {
+            use! connection = openOperationsSqlAsync ()
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                $"""
+SELECT COALESCE(SUM(Quantity), 0)
+FROM {OperationsUsageSql.UsageAggregateMinuteTable}
+WHERE FactKind = @FactKind
+  AND OwnerId = @OwnerId
+  AND OrganizationId = @OrganizationId
+  AND RepositoryId = @RepositoryId
+  AND StoragePoolId = @StoragePoolId
+  AND BucketStartUtc = @BucketStartUtc;
+"""
+
+            addParameter command "@FactKind" SqlDbType.Int (int fact.FactKind)
+            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier fact.Scope.OwnerId
+            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier fact.Scope.OrganizationId
+            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier fact.Scope.RepositoryId
+
+            let storagePoolParameter = command.Parameters.Add("@StoragePoolId", SqlDbType.NVarChar, OperationsUsageSql.StoragePoolIdMaxLength)
+
+            storagePoolParameter.Value <- fact.Resource.StoragePoolId
+            addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (fact.ObservedAt.ToDateTimeUtc())
+
+            let! scalar = command.ExecuteScalarAsync()
+            return Convert.ToInt64 scalar
+        }
+
+    /// Waits until SQL shows the expected raw count and aggregate quantity for the tracer-bullet fact.
+    let waitForUsageStateAsync description expectedRawCount expectedAggregateQuantity fact =
+        task {
+            let stopwatch = Stopwatch.StartNew()
+            let mutable matched = false
+            let mutable lastRawCount = -1L
+            let mutable lastAggregateQuantity = -1L
+            let mutable lastError = String.Empty
+
+            while not matched && stopwatch.Elapsed < proofTimeout do
+                try
+                    let! rawCount = rawFactCountAsync fact.UsageFactId
+                    let! aggregateQuantity = aggregateQuantityAsync fact
+                    lastRawCount <- rawCount
+                    lastAggregateQuantity <- aggregateQuantity
+                    lastError <- String.Empty
+
+                    if lastRawCount = expectedRawCount
+                       && lastAggregateQuantity = expectedAggregateQuantity then
+                        matched <- true
+                    else
+                        do! Task.Delay(TimeSpan.FromSeconds(1.0))
+                with
+                | ex ->
+                    lastError <- ex.Message
+                    do! Task.Delay(TimeSpan.FromSeconds(1.0))
+
+            if not matched then
+                let! serviceBusDiagnostics = operationsServiceBusDiagnosticsAsync ()
+
+                let errorSuffix =
+                    if String.IsNullOrWhiteSpace lastError then
+                        ""
+                    else
+                        $" Last SQL error: {lastError}"
+
+                raise (
+                    TimeoutException(
+                        $"{description} did not reach expected operations SQL state. Expected raw={expectedRawCount}, aggregate={expectedAggregateQuantity}; actual raw={lastRawCount}, aggregate={lastAggregateQuantity}.{errorSuffix}{Environment.NewLine}{serviceBusDiagnostics}"
+                    )
+                )
+        }
+
+    /// Waits for an invalid operational message to reach the worker's dead-letter queue.
+    let waitForDeadLetterReasonAsync expectedReason =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+
+            let receiver =
+                client.CreateReceiver(
+                    operationalFactsTopic,
+                    operationsProcessorSubscriptionName,
+                    ServiceBusReceiverOptions(SubQueue = SubQueue.DeadLetter, ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete)
+                )
+
+            use _receiver = receiver
+            let stopwatch = Stopwatch.StartNew()
+            let mutable found = false
+            let reasons = ResizeArray<string>()
+
+            while not found && stopwatch.Elapsed < proofTimeout do
+                let! message = receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(1.0))
+
+                if not (isNull message) then
+                    reasons.Add(message.DeadLetterReason)
+
+                    if message.DeadLetterReason = expectedReason then found <- true
+
+            if not found then
+                let reasonText = if reasons.Count = 0 then "<none>" else String.Join(", ", reasons)
+
+                raise (TimeoutException($"Timed out waiting for operations dead-letter reason '{expectedReason}'. Observed reasons: {reasonText}."))
+        }
+
+    /// Builds unsupported future-kind JSON while preserving the usage fact identity for SQL absence checks.
+    let futureKindJson (fact: UsageFact) =
+        JsonSerializer
+            .Serialize(fact, Constants.JsonSerializerOptions)
+            .Replace("repositoryStorageBytesMinute", "futureUsageFactKind")
+
+    /// Verifies the local dev/test source exercises publisher, Service Bus, worker, raw SQL, duplicate, and invalid payload behavior.
+    [<Test>]
+    member _.DevTestUsageFactPublishesThroughWorkerToRawSqlAndAggregateOnce() =
+        task {
+            let usageFactId = Guid.Parse("53153153-1531-4531-8531-531531531531")
+            let correlationId = CorrelationId "ops6-correlation-distinct-from-usage-fact-id"
+            let fact = usageFact usageFactId correlationId
+
+            Assert.That(fact.CorrelationId, Is.Not.EqualTo(fact.UsageFactId.ToString("D")))
+
+            do! ensureOperationsSchemaAsync ()
+            do! sendOperationalMessageAsync (usageFactMessage (fact.UsageFactId.ToString("D")) fact)
+            do! waitForUsageStateAsync "Initial published fact" 1L 4096L fact
+
+            let duplicateDelivery = usageFactMessage $"{fact.UsageFactId:D}-redelivery" fact
+
+            do! sendOperationalMessageAsync duplicateDelivery
+            do! waitForUsageStateAsync "Duplicate UsageFactId delivery" 1L 4096L fact
+
+            let futureFact = usageFact (Guid.Parse("53153153-2531-4531-8531-531531531531")) (CorrelationId "ops6-future-kind-correlation")
+
+            let futureMessage = ServiceBusMessage(BinaryData.FromString(futureKindJson futureFact))
+            futureMessage.ContentType <- operationalJsonContentType
+            futureMessage.Subject <- usageFactSubject
+            futureMessage.MessageId <- $"{futureFact.UsageFactId:D}-future-kind"
+            futureMessage.CorrelationId <- futureFact.CorrelationId
+
+            futureMessage.ApplicationProperties[ usageFactMessageTypeProperty ] <- usageFactMessageType
+
+            futureMessage.ApplicationProperties[ usageFactKindProperty ] <- "futureUsageFactKind"
+
+            do! sendOperationalMessageAsync futureMessage
+            do! waitForDeadLetterReasonAsync "MalformedUsageFactJson"
+
+            let malformedMessage = ServiceBusMessage(BinaryData.FromBytes(Encoding.UTF8.GetBytes("{ not valid json")))
+            malformedMessage.ContentType <- operationalJsonContentType
+            malformedMessage.Subject <- usageFactSubject
+            malformedMessage.MessageId <- "ops6-malformed-usage-fact"
+            malformedMessage.CorrelationId <- "ops6-malformed-correlation"
+
+            malformedMessage.ApplicationProperties[ usageFactMessageTypeProperty ] <- usageFactMessageType
+
+            do! sendOperationalMessageAsync malformedMessage
+            do! waitForDeadLetterReasonAsync "MalformedUsageFactJson"
+
+            let! rejectedRawCount = rawFactCountAsync futureFact.UsageFactId
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(rejectedRawCount, Is.EqualTo(0L))
+                    Assert.That(fact.ObservedAt, Is.EqualTo(Instant.FromUtc(2026, 7, 4, 12, 34))))
+            )
+        }

--- a/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
@@ -77,6 +77,8 @@ module private RestartDurabilityHelpers =
                 ServiceBusTopic = serviceBusTopic
                 ServiceBusServerSubscription = serviceBusServerSubscription
                 ServiceBusTestSubscription = serviceBusTestSubscription
+                OperationalFactsTopic = operationalFactsTopic
+                OperationsSqlConnectionString = operationsSqlConnectionString
             }
         | None ->
             Assert.Fail("Aspire test host was not started by the shared setup fixture.")

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -27,6 +27,8 @@ module private WebhookTestHelpers =
                     ServiceBusTopic = serviceBusTopic
                     ServiceBusServerSubscription = serviceBusServerSubscription
                     ServiceBusTestSubscription = serviceBusTestSubscription
+                    OperationalFactsTopic = operationalFactsTopic
+                    OperationsSqlConnectionString = operationsSqlConnectionString
                 }
             | None ->
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -141,6 +141,27 @@ and Service Bus readiness before running server integration tests. The
 `Grace.Server.Tests` profile today because the shared setup drains the Service
 Bus test subscription and verifies the Owner Created event.
 
+### Operations Usage Tracer Bullet
+
+`Grace.Server.Tests` includes a dev/test-only operations tracer bullet that
+publishes one repository-storage `UsageFact` to the dedicated operational facts
+topic, waits for `grace-operations-worker` to consume it, and queries the local
+`GraceOperations` SQL database for the raw fact and UTC minute aggregate. The
+test also injects a duplicate delivery with the same `UsageFactId` and verifies
+that the raw row and aggregate quantity remain single-counted.
+
+The tracer bullet is proof of the local operational usage pipeline only:
+
+- It uses the existing Aspire-local Service Bus emulator and SQL Server
+  container.
+- It keeps `UsageFactId` and `CorrelationId` distinct in the end-to-end
+  evidence.
+- It verifies malformed or unsupported usage payloads are dead-lettered and do
+  not become authoritative SQL usage.
+- It does not add customer-facing usage APIs, pricing, charge ledgers, billing
+  close, invoices, dashboards, Azure Cost Management ingestion, Azure Storage
+  diagnostic ingestion, or a durable outbox.
+
 ## Troubleshooting
 
 - **Port conflicts** – Update bindings inside


### PR DESCRIPTION
# OPS6: Add Dev Tracer-Bullet Publisher Path And End-To-End Proof

## Related issue

Related to #531. Part of #525.

## Why this matters

This slice proves the `Grace.Operations` spine as a working vertical slice instead of disconnected scaffolding. Grace
needs that exercised path before later pricing, charge-ledger, billing-close, dashboard, or customer-reporting specs can
trust operational usage facts.

## Summary

- Added a dev/test operations tracer-bullet proof under `Grace.Server.Tests`.
- Published a valid operational `UsageFact` through the operational facts Service Bus topic.
- Proved worker consumption, SQL raw fact persistence, duplicate protection, and minute aggregate projection.
- Proved malformed or unsupported future payloads do not become authoritative SQL usage.
- Kept `Grace.Server` free of `Grace.Operations.*` runtime references; only the test project queries operations SQL.
- Extended Aspire test-host state with operational facts topic and operations SQL connection details.
- Fixed local AppHost worker SQL endpoint formatting to use IPv4 loopback for SqlClient/Docker local connectivity.
- Added redacted worker dependency diagnostics that log SQL `DataSource` only, not credentials or full connection
  strings.
- Documented the Aspire-local operations usage tracer bullet and deferred future operations/billing areas.

## Diagnosis

The initial focused tracer proof published a valid fact, but SQL stayed at `raw=0` and `aggregate=0`. Subscription
diagnostics showed the valid message remained active on `operational-facts-processor` with `DeliveryCount=0` and an
empty dead-letter queue.

Manual worker isolation showed the worker could start the processor when pointed at the live dynamic SQL and Service
Bus ports. The AppHost-launched worker was stuck before Service Bus processor startup because SQL schema initialization
timed out against `tcp:localhost,<allocated-port>`. Normalizing local SQL worker endpoints to
`tcp:127.0.0.1,<allocated-port>` fixed the local SqlClient/Docker loopback path, and the focused tracer proof then
passed end to end.

## Touched paths

- `src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs`
- `src/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs`
- `src/Grace.Operations.Worker/OperationsWorker.fs`
- `src/Grace.Server.Tests/AgentSession.Server.Tests.fs`
- `src/Grace.Server.Tests/Approval.Server.Tests.fs`
- `src/Grace.Server.Tests/AspireTestHost.fs`
- `src/Grace.Server.Tests/Eventing.Integration.Server.Tests.fs`
- `src/Grace.Server.Tests/General.Server.Tests.fs`
- `src/Grace.Server.Tests/Grace.Server.Tests.fsproj`
- `src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs`
- `src/Grace.Server.Tests/RestartDurability.Server.Tests.fs`
- `src/Grace.Server.Tests/Webhook.Server.Tests.fs`
- `src/docs/ASPIRE_SETUP.md`

## Validation

- Targeted Fantomas on touched F# files: passed/no changes.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `dotnet build --configuration Release src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj --filter "FullyQualifiedName~AppHostFormatsLocalSqlDataSourceWithCommaPort"`:
  passed.
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~OperationsTracerBulletServerTests"`:
  passed.
- `npx --yes markdownlint-cli2 "src/docs/ASPIRE_SETUP.md"`: passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed on `295ef13b`.
- GitHub Actions `full`: passed on `295ef13b`.

## Full-Gate History

The first local `validate -Full` run on `1067dc5d` was stopped after an unrecoverable Grace.Server.Tests restart
cascade. The first observed failure was `GraceServerProjectResourceRestartsAndReturnsHealthyResponses` failing to stop
`grace-server`; later unrelated HTTP and Service Bus event tests timed out after the shared server stayed unresponsive.

The issue-owned focused proof passed, and a fresh-host targeted `RestartDurability` slice passed 2/2. Current evidence
classified that local full-gate failure as an environment/Aspire restart cascade rather than a reproducible regression.
After the Codex review-fix commit `295ef13b`, local `pwsh ./scripts/validate.ps1 -Full` passed.

## Review Status

- Current head: `295ef13bfaf315bb7f11c8f253a7990ec89c4701`.
- Workers: Laplace completed implementation, diagnosis, validation, bot-prevention self-review, commit, and push; Hume
  fixed the first Codex review findings.
- Worker self-review:
  - `Grace.Server` still has no `Grace.Operations.*` runtime dependency.
  - `UsageFactId` and `CorrelationId` stay distinct in the proof.
  - Duplicate `UsageFactId` now waits for worker settlement before the unchanged SQL assertion, so the proof no longer
    wins the SQL poll race.
  - Malformed or unsupported future payloads do not become authoritative SQL usage.
  - Diagnostics do not log SQL credentials or message payload bodies.
- Codex Code Review Bot: first review on `1067dc5d` found duplicate-settlement, worker bootstrap, and readiness-timeout
  proof hardening issues; fixed in `295ef13b`.
- Review/fix evidence: replied on
  [discussion_r3523632267](https://github.com/ScottArbeit/Grace/pull/540#discussion_r3523632267),
  [discussion_r3523632294](https://github.com/ScottArbeit/Grace/pull/540#discussion_r3523632294), and
  [discussion_r3523632313](https://github.com/ScottArbeit/Grace/pull/540#discussion_r3523632313); all three
  conversations are resolved.
- Codex Code Review Bot: 👍 on `295ef13b`.

## Docs impact

Updated `src/docs/ASPIRE_SETUP.md` with the local operations usage tracer bullet, what it proves, and what remains
intentionally deferred.

## Explicit deferrals

- Customer usage APIs: deferred to the future usage API spec area.
- Pricing and charge ledger: deferred to the future billing and charge-ledger spec area.
- Billing close, invoices, and dashboards: deferred to the future billing and dashboard spec area.
- Azure Cost Management or Azure Storage diagnostic ingestion: deferred to the future external ingestion spec area.
- Durable outbox: deferred to the future operational reliability and outbox spec area.

## Residual risk

No residual risk was identified in the review-fix worker self-review.
